### PR TITLE
Cancel previous builds on the current branch on push.

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -26,7 +26,7 @@ jobs:
           }
 
     steps:
-    - name: Cancel Workflow Action(s)
+    - name: Cancel Build(s)
       uses: styfle/cancel-workflow-action@0.7.0
       with:
         access_token: ${{ github.token }}


### PR DESCRIPTION
### Justification
The builds are currently about 10 or so minutes. Seems reasonable if there are pushes onto a branch then previously queued or running builds for previous pushes will be cancelled since the most recent build results should be all that's needed.

### Implementation
Add to the .yml an initial step to cancel builds using a cancel-workflow-action.
This should cancel any current github actions running for the branch that were triggered by previous pushes.
Documentation can be found [here](https://github.com/styfle/cancel-workflow-action#how-does-it-work)

### Testing
Pushed and confirmed previously started build 