### PR TITLE
Update README.md to include build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,14 @@ Clone the repo and update submodules, this will pull the gRPC components and all
 
 ### Prerequisites
 
-Install the following packages:
-- `git`
-- `git-perltools` - needed for `git submodule`
-- `cmake`
+For Debian/Ubuntu, install git and cmake:
+```
+> sudo apt-get update
+> sudo apt-get install git
+> sudo apt-get install cmake
+```
 
-Example on NI Linux RT
+For NI Linux RT, install git, git-perltools, and cmake:
 ```
 > opkg update
 > opkg install git


### PR DESCRIPTION
# Justification
We need to include general information about the build process and how to install/use the server and client.

# Implementation
I copied the README.md from the [grpc-labview](github.com/ni/grpc-labview) repo and made modifications from there.
The build steps should be fairly similar between the two except for the requirement on LabVIEW.