### PR TITLE
Adding Build Workflow for NI Linux Real-Time Cross Compile

### DIFF
--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -5,31 +5,33 @@ on: [push]
 env:
   CMAKE_VERSION: 3.18.3
   BUILD_TYPE: Release
-  
+
 jobs:
   build-nilrt:
     name: NILRT Cross Compile with GCC 6.3.0
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Cancel Build(s)
       uses: styfle/cancel-workflow-action@0.7.0
       with:
         access_token: ${{ github.token }}
-    
+
     - name: Checkout Repo
       uses: actions/checkout@v2
-    
+
+    # The URL used to download this toolchain may change in the future as
+    # improvements to hosting and exports of the NILRT toolchain are made.
     - name: Install NI Linux RT CC Toolchain
       run: |
         wget -nv https://download.ni.com/support/softlib/labview/labview_rt/2018/Linux%20Toolchains/linux/oecore-x86_64-core2-64-toolchain-6.0.sh
         sudo chmod a+x ./oecore-x86_64-core2-64-toolchain-6.0.sh
         sudo ./oecore-x86_64-core2-64-toolchain-6.0.sh -y -d ${GITHUB_WORKSPACE}/nilrt-toolchain/
         echo "${GITHUB_WORKSPACE}/nilrt-toolchain/sysroots/x86_64-nilrtsdk-linux/usr/bin/x86_64-nilrt-linux" >> ${GITHUB_PATH}
-      
+
     - name: Update Submodules
       run: git submodule update --init --recursive
-      
+
     - name: Configure Host OS gRPC Support
       shell: cmake -P {0}
       run: |
@@ -47,10 +49,10 @@ jobs:
         if (NOT result EQUAL 0)
           message(FATAL_ERROR "Bad exit status")
         endif()
-      
+
     - name: Build and Install Host OS gRPC Support
       run: sudo cmake --build ${GITHUB_WORKSPACE}/third_party/grpc/build --target install
-        
+
     - name: Configure Cross Compile
       shell: cmake -P {0}
       run: |
@@ -67,7 +69,7 @@ jobs:
         if (NOT result EQUAL 0)
           message(FATAL_ERROR "Bad exit status")
         endif()
-    
+
     - name: Cross Compile
       shell: cmake -P {0}
       run: |
@@ -84,10 +86,10 @@ jobs:
           message("::error::${error_message}")
           message(FATAL_ERROR "Build failed")
         endif()
-    
+
     - name: Tar build files
       run: tar -cvf NILinuxRealTime-x86_64.tar ${GITHUB_WORKSPACE}/build/
-    
+
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       with:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This repo contains necessary C++ code and .proto files needed to build a gRPC se
 
 ## Build Status
 ![Linux Build](https://github.com/ni/ni-driver-apis-grpc/workflows/Build%20Matrix/badge.svg)
+![NI Linux Real-Time Build](https://github.com/ni/ni-driver-apis-grpc/workflows/NI%20Linux%20Real-Time%20Build/badge.svg)
 
 ## Note: This project is not yet complete
 * The gRPC server is not yet complete.

--- a/scripts/cmake/nilrt-x86_64.cmake
+++ b/scripts/cmake/nilrt-x86_64.cmake
@@ -1,23 +1,34 @@
+#----------------------------------------------------------------------
 # CMake toolchain file for cross-compiling for NI Linux Real-Time
+#----------------------------------------------------------------------
 set(CMAKE_SYSTEM_NAME Linux)
 set(CMAKE_SYSTEM_PROCESSOR x86_64)
 
-# root path for toolchains
+#----------------------------------------------------------------------
+# Path variables for toolchains
+#----------------------------------------------------------------------
 find_program(COMPILER_PATH x86_64-nilrt-linux-gcc)
 get_filename_component(toolchain_path ${COMPILER_PATH}/../../../../.. REALPATH DIRECTORY)
+set(include_path core2-64-nilrt-linux/usr/include/c++/6.3.0)
 
-# compilers
+#----------------------------------------------------------------------
+# Compilers
+#----------------------------------------------------------------------
 set(CMAKE_C_COMPILER x86_64-nilrt-linux-gcc)
 set(CMAKE_CXX_COMPILER x86_64-nilrt-linux-g++)
 
-# compiler flags
+#----------------------------------------------------------------------
+# Default compiler flags
+#----------------------------------------------------------------------
 set(CMAKE_SYSROOT ${toolchain_path}/core2-64-nilrt-linux)
-set(CMAKE_<LANG>_STANDARD_INCLUDE_DIRECTORIES ${toolchain_path}/core2-64-nilrt-linux/usr/include/c++/6.3.0 ${toolchain_path}/core2-64-nilrt-linux/usr/include/c++/6.3.0/x86_64-nilrt-linux)
+set(CMAKE_<LANG>_STANDARD_INCLUDE_DIRECTORIES ${toolchain_path}/${include_path} ${toolchain_path}/${include_path}/x86_64-nilrt-linux)
 set(CMAKE_<LANG>_FLAGS "-Wall -fmessage-length=0")
 set(CMAKE_<LANG>_FLAGS_DEBUG "-O0 -g3")
 set(CMAKE_<LANG>_FLAGS_RELEASE "-O3")
 
-# define search behavior
+#----------------------------------------------------------------------
+# Define proper search behavior for cross compilation
+#----------------------------------------------------------------------
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)


### PR DESCRIPTION
### Justification
Adding a workflow to build the repo using the latest public version of the NI Linux Real-Time Cross Compile Toolchain for x64 targets. This will ensure changes don't break NILRT builds and provide artifacts that can be downloaded from each workflow with built binaries for NILRT x64 devices.

### Implementation
* Added a CMake Toolchain file (`scripts/cmake/nilrt-x86_64.cmake`) to specify cross compile behavior for CMake.
* Added a new workflow to build the repo for NILRT targets upon a push. This workflow:
  * Downloads and installs the toolchain from online.
  * Builds and installs gRPC for the Host OS
    * This is required to build for the Target OS as the protocol buffer compiler and related dependencies (`protoc`) are required to finish building and are typically created as part of the build.
  * Configures the build to cross compile using `scripts/cmake/nilrt-x86_64.cmake`
  * Cross compiles
  * Uploads the build folder from the cross compilation preserving file permissions and hierarchy in a tarball as an artifact

The artifact can be downloaded and extracted to the root directory on a Linux RT Target. The file system hierarchy is preserved, which is necessary due to the test paths for `ctest` being hard coded. For example, `/home/runner/work/ni-driver-apis-grpc/ni-driver-apis-grpc/build` would be the full path from the tarball where `ctest` can be run.

### Testing
* Completed a successful run of the new workflow.
* Copied the artifact from the workflow to a Linux RT target and ran ctest to confirm all tests passed. 
![image](https://user-images.githubusercontent.com/5367780/105776627-876af480-5f2e-11eb-929d-6106f067aa9b.png)
