### PR TITLE
Cache Host OS gRPC support to speed up NILRT builds

### DIFF
--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -1,6 +1,6 @@
 name: NI Linux Real-Time Build
 
-on: [push]
+on: [push, workflow_dispatch]
 
 env:
   CMAKE_VERSION: 3.18.3


### PR DESCRIPTION
# Justification
Currently, NILRT CC builds are taking twice as long as native builds due to requiring Host OS support for protoc and similar gRPC dependencies. This change caches the built dependencies to cut that time out of the build time.

# Implementation
* Added step to cache build directory for gRPC
  * If the cache is present, the workflow will skip configuring and building the support for the Host OS
  * If the commit ID of the gRPC dependency changes, the cache ID will change and force a rebuild
* Added the `workflow_dispatch` trigger to allow manually running the workflow from the Actions page in the future. This will make sure we can test this type of behavior with any future changes without requiring additional pushes to trigger a new run.

Adding caching for the nilrt toolchain was considered as well but ultimately discarded. The installed toolchain files are ~2 GB and the limit on cached files for private GitHub repos is 5 GB. Additionally, the time required to download and install the toolchain is on the order of ~1-3 minutes and not a big impact on the build time.

# Testing
Ran the workflow twice. Upon the second run, the workflow completed in under 20 minutes.