### PR TITLE
Improve server code readability

### DIFF
--- a/source/core_server/hardware/grpc/internal/session_repository.h
+++ b/source/core_server/hardware/grpc/internal/session_repository.h
@@ -35,7 +35,7 @@ namespace internal
          std::string client_id;
          std::unique_ptr<internal::Semaphore> lock;
          std::chrono::steady_clock::time_point creation_time;
-         // the number of clients that have asked to reserve this reservation, but have not yet acquired the lock.
+         // The number of clients that have asked to reserve this reservation, but have not yet acquired the lock.
          int client_count;
       };
 
@@ -47,16 +47,16 @@ namespace internal
          SessionRepository::CleanupSessionProc cleanup_proc;
       };
 
-      // named sessions point at SessionInfo objects that are also contained in the SessionMap.
       using NamedSessionMap = std::map<std::string, std::shared_ptr<SessionInfo>>;
-      // this map contains every session, including both named and unnamed ones.
-      using SessionMap = std::map<google::protobuf::int64, std::shared_ptr<SessionInfo>>;
+      using SessionMap = std::map<uint64_t, std::shared_ptr<SessionInfo>>;
       using ReservationMap = std::map<std::string, std::shared_ptr<ReservationInfo>>;
 
       std::shared_ptr<ReservationInfo> find_or_create_reservation(const std::string& reservation_id, const std::string& client_id);
 
       std::shared_mutex repository_lock_;
+      // This map contains every session, including both named and unnamed ones.
       SessionMap sessions_;
+      // These entries point at SessionInfo objects that are also contained in sessions_.
       NamedSessionMap named_sessions_;
       ReservationMap reservations_;
    };


### PR DESCRIPTION
# Justification
Some of the server code is hard to follow, so we want to improve the readability of it.

# Implementation
Added comments for many of the session_repository methods and members to help clarify what they do, and the intentions of the parameters and return values.

# Testing
N/A
