### PR TITLE
Check in niFake.h and IVI headers

### DIFF
--- a/imports/includes/IviVisaType.h
+++ b/imports/includes/IviVisaType.h
@@ -1,0 +1,194 @@
+/****************************************************************************
+ * IviVisaType.h
+ *
+ * Copyright (c) Interchangeable Virtual Instruments Foundation 2006 - 2017.
+ * All Rights Reserved.
+ *
+ ****************************************************************************/
+#ifndef IVI_VISA_TYPE_H
+#define IVI_VISA_TYPE_H
+/* This defines the include guard of visatype.h for backward compatibility
+ * reasons. Please ensure that changes in this ifndef block are reflected
+ * in visatype.h when necessary.
+ */
+#ifndef __VISATYPE_HEADER__
+#define __VISATYPE_HEADER__
+#if defined(_WIN64)
+#define _VI_FAR
+#define _VI_FUNC            __fastcall
+#define _VI_FUNCC           __fastcall
+#define _VI_FUNCH           __fastcall
+#define _VI_SIGNED          signed
+#elif (defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)) && !defined(_NI_mswin16_)
+#define _VI_FAR
+#define _VI_FUNC            __stdcall
+#define _VI_FUNCC           __cdecl
+#define _VI_FUNCH           __stdcall
+#define _VI_SIGNED          signed
+#elif defined(_CVI_) && defined(_NI_i386_)
+#define _VI_FAR
+#define _VI_FUNC            _pascal
+#define _VI_FUNCC
+#define _VI_FUNCH           _pascal
+#define _VI_SIGNED          signed
+#elif (defined(_WINDOWS) || defined(_Windows)) && !defined(_NI_mswin16_)
+#define _VI_FAR             _far
+#define _VI_FUNC            _far _pascal _export
+#define _VI_FUNCC           _far _cdecl  _export
+#define _VI_FUNCH           _far _pascal
+#define _VI_SIGNED          signed
+#elif (defined(hpux) || defined(__hpux)) && (defined(__cplusplus) || defined(__cplusplus__))
+#define _VI_FAR
+#define _VI_FUNC
+#define _VI_FUNCC
+#define _VI_FUNCH
+#define _VI_SIGNED
+#else
+#define _VI_FAR
+#define _VI_FUNC
+#define _VI_FUNCC
+#define _VI_FUNCH
+#define _VI_SIGNED          signed
+#endif
+#define _VI_ERROR           (-2147483647L-1)  /* 0x80000000 */
+#define _VI_PTR             _VI_FAR *
+/*- VISA Types --------------------------------------------------------------*/
+#ifndef _VI_INT64_UINT64_DEFINED
+#if defined(_WIN64) || ((defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)) && !defined(_NI_mswin16_))
+#if (defined(_MSC_VER) && (_MSC_VER >= 1200)) || (defined(_CVI_) && (_CVI_ >= 700)) || (defined(__BORLANDC__) && (__BORLANDC__ >= 0x0520)) || defined(__LCC__) || (defined(__GNUC__) && (__GNUC__ >= 3)) || (defined(__clang__) && (__clang_major__ >= 3))
+typedef unsigned   __int64  ViUInt64;
+typedef _VI_SIGNED __int64  ViInt64;
+#define _VI_INT64_UINT64_DEFINED
+#if defined(_WIN64)
+#define _VISA_ENV_IS_64_BIT
+#else
+/* This is a 32-bit OS, not a 64-bit OS */
+#endif
+#endif
+#elif defined(__GNUC__) && (__GNUC__ >= 3)
+#include <limits.h>
+#include <sys/types.h>
+typedef u_int64_t           ViUInt64;
+typedef int64_t             ViInt64;
+#define _VI_INT64_UINT64_DEFINED
+#if defined(LONG_MAX) && (LONG_MAX > 0x7FFFFFFFL)
+#define _VISA_ENV_IS_64_BIT
+#else
+/* This is a 32-bit OS, not a 64-bit OS */
+#endif
+#else
+/* This platform does not support 64-bit types */
+#endif
+#endif
+#if defined(_VI_INT64_UINT64_DEFINED)
+typedef ViUInt64    _VI_PTR ViPUInt64;
+typedef ViUInt64    _VI_PTR ViAUInt64;
+typedef ViInt64     _VI_PTR ViPInt64;
+typedef ViInt64     _VI_PTR ViAInt64;
+#endif
+#if defined(LONG_MAX) && (LONG_MAX > 0x7FFFFFFFL)
+typedef unsigned int        ViUInt32;
+typedef _VI_SIGNED int      ViInt32;
+#else
+typedef unsigned long       ViUInt32;
+typedef _VI_SIGNED long     ViInt32;
+#endif
+typedef ViUInt32    _VI_PTR ViPUInt32;
+typedef ViUInt32    _VI_PTR ViAUInt32;
+typedef ViInt32     _VI_PTR ViPInt32;
+typedef ViInt32     _VI_PTR ViAInt32;
+typedef unsigned short      ViUInt16;
+typedef ViUInt16    _VI_PTR ViPUInt16;
+typedef ViUInt16    _VI_PTR ViAUInt16;
+typedef _VI_SIGNED short    ViInt16;
+typedef ViInt16     _VI_PTR ViPInt16;
+typedef ViInt16     _VI_PTR ViAInt16;
+typedef unsigned char       ViUInt8;
+typedef ViUInt8     _VI_PTR ViPUInt8;
+typedef ViUInt8     _VI_PTR ViAUInt8;
+typedef _VI_SIGNED char     ViInt8;
+typedef ViInt8      _VI_PTR ViPInt8;
+typedef ViInt8      _VI_PTR ViAInt8;
+typedef char                ViChar;
+typedef ViChar      _VI_PTR ViPChar;
+typedef ViChar      _VI_PTR ViAChar;
+typedef unsigned char       ViByte;
+typedef ViByte      _VI_PTR ViPByte;
+typedef ViByte      _VI_PTR ViAByte;
+typedef void        _VI_PTR ViAddr;
+typedef ViAddr      _VI_PTR ViPAddr;
+typedef ViAddr      _VI_PTR ViAAddr;
+typedef float               ViReal32;
+typedef ViReal32    _VI_PTR ViPReal32;
+typedef ViReal32    _VI_PTR ViAReal32;
+typedef double              ViReal64;
+typedef ViReal64    _VI_PTR ViPReal64;
+typedef ViReal64    _VI_PTR ViAReal64;
+typedef ViPByte             ViBuf;
+typedef const ViByte *      ViConstBuf;
+typedef ViPByte             ViPBuf;
+typedef ViPByte     _VI_PTR ViABuf;
+typedef ViPChar             ViString;
+#ifndef _VI_CONST_STRING_DEFINED
+typedef const ViChar *      ViConstString;
+#define _VI_CONST_STRING_DEFINED
+#endif
+typedef ViPChar             ViPString;
+typedef ViPChar     _VI_PTR ViAString;
+typedef ViString            ViRsrc;
+typedef ViConstString       ViConstRsrc;
+typedef ViString            ViPRsrc;
+typedef ViString    _VI_PTR ViARsrc;
+typedef ViUInt16            ViBoolean;
+typedef ViBoolean   _VI_PTR ViPBoolean;
+typedef ViBoolean   _VI_PTR ViABoolean;
+typedef ViInt32             ViStatus;
+typedef ViStatus    _VI_PTR ViPStatus;
+typedef ViStatus    _VI_PTR ViAStatus;
+typedef ViUInt32            ViVersion;
+typedef ViVersion   _VI_PTR ViPVersion;
+typedef ViVersion   _VI_PTR ViAVersion;
+typedef ViUInt32            ViObject;
+typedef ViObject    _VI_PTR ViPObject;
+typedef ViObject    _VI_PTR ViAObject;
+typedef ViObject            ViSession;
+typedef ViSession   _VI_PTR ViPSession;
+typedef ViSession   _VI_PTR ViASession;
+typedef ViUInt32             ViAttr;
+/*- Completion and Error Codes ----------------------------------------------*/
+#define VI_SUCCESS          (0L)
+/*- Other VISA Definitions --------------------------------------------------*/
+#define VI_NULL             (0)
+#define VI_TRUE             (1)
+#define VI_FALSE            (0)
+/*- Backward Compatibility Macros -------------------------------------------*/
+#define VISAFN              _VI_FUNC
+#define ViPtr               _VI_PTR
+#endif /* __VISATYPE_HEADER__ */
+/* This defines the include guard of vpptype.h for backward compatibility
+ * reasons. Please ensure that changes in this ifndef block are reflected
+ * in vpptype.h when necessary.
+ */
+#ifndef __VPPTYPE_HEADER__
+#define __VPPTYPE_HEADER__
+/*- Completion and Error Codes ----------------------------------------------*/
+#define VI_WARN_NSUP_ID_QUERY     (          0x3FFC0101L)
+#define VI_WARN_NSUP_RESET        (          0x3FFC0102L)
+#define VI_WARN_NSUP_SELF_TEST    (          0x3FFC0103L)
+#define VI_WARN_NSUP_ERROR_QUERY  (          0x3FFC0104L)
+#define VI_WARN_NSUP_REV_QUERY    (          0x3FFC0105L)
+#define VI_ERROR_PARAMETER1       (_VI_ERROR+0x3FFC0001L)
+#define VI_ERROR_PARAMETER2       (_VI_ERROR+0x3FFC0002L)
+#define VI_ERROR_PARAMETER3       (_VI_ERROR+0x3FFC0003L)
+#define VI_ERROR_PARAMETER4       (_VI_ERROR+0x3FFC0004L)
+#define VI_ERROR_PARAMETER5       (_VI_ERROR+0x3FFC0005L)
+#define VI_ERROR_PARAMETER6       (_VI_ERROR+0x3FFC0006L)
+#define VI_ERROR_PARAMETER7       (_VI_ERROR+0x3FFC0007L)
+#define VI_ERROR_PARAMETER8       (_VI_ERROR+0x3FFC0008L)
+#define VI_ERROR_FAIL_ID_QUERY    (_VI_ERROR+0x3FFC0011L)
+#define VI_ERROR_INV_RESPONSE     (_VI_ERROR+0x3FFC0012L)
+/*- Additional Definitions --------------------------------------------------*/
+#define VI_ON               (1)
+#define VI_OFF              (0)
+#endif /* __VPPTYPE_HEADER__ */
+#endif /* IVI_VISA_TYPE_H */

--- a/imports/includes/niFake.h
+++ b/imports/includes/niFake.h
@@ -1,0 +1,530 @@
+/*
+    **** THIS FILE IS GENERATED. ANY CHANGES WILL BE OVERWRITTEN! ****
+    Command-line: /P/MI/shared/hapigen/hapigen/export/1.2/1.2.0f0/tools/linux/i386/hapigen_render --processed-metadata-path /P/MI/shared/hapigen/hapigen_cheader_plugin/trunk/1.2/objects/export/test_output/linux/system_test_cheader_expanded_metadata.hapigen_processed --template-path ./objects/export/templates/ivi_based_public_header.h.mako --output-path ./objects/export/test_output/niFake.h --template-search-path /P/MI/shared/hapigen/hapigen/export/1.2/1.2.0f0/templates --template-search-path /P/MI/shared/hapigen/hapigen_cheader_plugin/trunk/1.2/objects/export/templates
+*/
+
+#ifndef __NIFAKE_HEADER
+#define __NIFAKE_HEADER
+
+/******************************************************************************/
+/*                               Include Files                                */
+/******************************************************************************/
+
+#define IVI_DO_NOT_INCLUDE_VISA_HEADERS
+#include <IviVisaType.h>
+#undef IVI_DO_NOT_INCLUDE_VISA_HEADERS
+
+#ifdef _CVI_
+#pragma EnableLibraryRuntimeChecking
+#endif
+
+/****************************************************************************
+ *----------------- Instrument Driver Revision Information -----------------*
+ ****************************************************************************/
+#define NIFAKE_MAJOR_VERSION                                   1                               // Instrument driver major version
+#define NIFAKE_MINOR_VERSION                                   2                               // Instrument driver minor version
+#define NIFAKE_UPDATE_VERSION                                  0                               // Instrument driver update version
+
+
+#define NIFAKE_ATTR_BASE                                       1000000                         // 1000000 (0xf4240)
+#define NIFAKE_ATTR_PRIVATE_BASE                               (NIFAKE_ATTR_BASE + 100L)       // 1000100 (0xf42a4)
+#define NIFAKE_MAX_MESSAGE_BUF_SIZE                            256                             // 256 (0x100)
+#define NIFAKE_FLAG0                                           (1L << 0)                       // 1 (0x1)
+#define NIFAKE_FLAG1                                           (1L << 1)                       // 2 (0x2)
+#define NIFAKE_FLAG2                                           (1L << 2)                       // 4 (0x4)
+#define NIFAKE_FLAG3                                           (1L << 3)                       // 8 (0x8)
+#define NIFAKE_FLAG4                                           (1L << 4)                       // 16 (0x10)
+#define NIFAKE_FLAG5                                           (1L << 5)                       // 32 (0x20)
+#define NIFAKE_FLAG6                                           (1L << 6)                       // 64 (0x40)
+#define NIFAKE_FLAG7                                           (1L << 7)                       // 128 (0x80)
+#define NIFAKE_FLAG8                                           (1L << 8)                       // 256 (0x100)
+#define NIFAKE_FLAG_FLAG3                                      (1L << NIFAKE_FLAG3)            // 256 (0x100)
+#define NIFAKE_FLAG_COMBO0                                     (NIFAKE_FLAG0 | NIFAKE_FLAG1)   // 3 (0x3)
+#define NIFAKE_FLAG_COMBO1                                     (NIFAKE_FLAG1 | NIFAKE_FLAG4)   // 18 (0x12)
+#define NIFAKE_FLOAT_DEFINE                                    42.0
+#define NIFAKE_INT_DEFINE                                      42                              // 42 (0x2a)
+
+// Values
+// Beautiful Color
+#define NIFAKE_VAL_PINK                                        44                              // 44 (0x2c)
+#define NIFAKE_VAL_AQUA                                        43                              // 43 (0x2b)
+#define NIFAKE_VAL_GREEN                                       45                              // 45 (0x2d)
+#define NIFAKE_VAL_BLACK                                       42                              // 42 (0x2a)
+
+// Test comment
+// Values used in
+//     NIFAKE_ATTR_READ_WRITE_COLOR
+#define NIFAKE_VAL_RED                                         1                               // 1 (0x1)
+#define NIFAKE_VAL_BLUE                                        (NIFAKE_VAL_RED + 1L)           // 2 (0x2)
+#define NIFAKE_VAL_YELLOW                                      5                               // 5 (0x5)
+// #define NIFAKE_VAL_BLACK                                    DEFINED ABOVE (42)              // 42 (0x2a)
+
+// Values used in
+//     NIFAKE_ATTR_FLOAT_ENUM, niFake_ParametersAreMultipleTypes, niFake_ReturnMultipleTypes
+#define NIFAKE_VAL_THREE_POINT_FIVE                            3.5
+#define NIFAKE_VAL_FOUR_POINT_FIVE                             4.5
+#define NIFAKE_VAL_FIVE_POINT_FIVE                             5.5
+#define NIFAKE_VAL_SIX_POINT_FIVE                              6.5
+#define NIFAKE_VAL_SEVEN_POINT_FIVE                            7.5
+
+// Values used in
+//     niFake_StringValuedEnumInputFunctionWithDefaults
+#define NIFAKE_VAL_ANDROID                                     "Android"
+#define NIFAKE_VAL_IOS                                         "iOS"
+#define NIFAKE_VAL_NONE                                        "None"
+
+// Values used in
+//     niFake_EnumArrayOutputFunction, niFake_EnumInputFunctionWithDefaults, niFake_GetEnumValue,
+//     niFake_ParametersAreMultipleTypes, niFake_ReturnMultipleTypes
+#define NIFAKE_VAL_LEONARDO                                    0                               // 0 (0x0)
+#define NIFAKE_VAL_DONATELLO                                   1                               // 1 (0x1)
+#define NIFAKE_VAL_RAPHAEL                                     2                               // 2 (0x2)
+#define NIFAKE_VAL_MICHELANGELO                                3                               // 3 (0x3)
+
+// Attributes
+#define NIFAKE_ATTR_READ_WRITE_BOOL                            (NIFAKE_ATTR_BASE + 0L)         // 1000000 (0xf4240), ViBoolean
+#define NIFAKE_ATTR_READ_WRITE_DOUBLE                          (NIFAKE_ATTR_BASE + 1L)         // 1000001 (0xf4241), ViReal64
+#define NIFAKE_ATTR_READ_WRITE_STRING                          (NIFAKE_ATTR_BASE + 2L)         // 1000002 (0xf4242), ViString
+#define NIFAKE_ATTR_READ_WRITE_COLOR                           (NIFAKE_ATTR_BASE + 3L)         // 1000003 (0xf4243), ViInt32
+#define NIFAKE_ATTR_READ_WRITE_INTEGER                         (NIFAKE_ATTR_BASE + 4L)         // 1000004 (0xf4244), ViInt32
+// Test comment
+#define NIFAKE_ATTR_FLOAT_ENUM                                 (NIFAKE_ATTR_BASE + 5L)         // 1000005 (0xf4245), ViReal64
+#define NIFAKE_ATTR_READ_WRITE_INT64                           (NIFAKE_ATTR_BASE + 6L)         // 1000006 (0xf4246), ViInt64
+#define NIFAKE_ATTR_READ_WRITE_DOUBLE_WITH_CONVERTER           (NIFAKE_ATTR_BASE + 7L)         // 1000007 (0xf4247), ViReal64
+#define NIFAKE_ATTR_READ_WRITE_INTEGER_WITH_CONVERTER          (NIFAKE_ATTR_BASE + 8L)         // 1000008 (0xf4248), ViInt32
+#define NIFAKE_ATTR_READ_WRITE_DOUBLE_WITH_REPEATED_CAPABILITY (NIFAKE_ATTR_BASE + 9L)         // 1000009 (0xf4249), ViReal64,   multi-channel
+#define NIFAKE_ATTR_READ_WRITE_STRING_REPEATED_CAPABILITY      (NIFAKE_ATTR_BASE + 10L)        // 1000010 (0xf424a), ViString
+
+#pragma pack(push,8)
+// Test comment
+#if !defined(_NIStruct)
+#define _NIStruct
+struct CustomStruct
+{
+    ViInt32 structInt;
+    ViReal64 structDouble;
+};
+#endif // !defined(_NIStruct)
+
+#pragma pack(pop)
+
+// Functions
+ViStatus _VI_FUNC niFake_Abort(
+   ViSession vi);
+
+ViStatus _VI_FUNC niFake_BoolArrayOutputFunction(
+   ViSession vi,
+   ViInt32 numberOfElements,
+   ViBoolean anArray[]);
+
+ViStatus _VI_FUNC niFake_ClearError(
+   ViSession vi);
+
+ViStatus _VI_FUNC niFake_close(
+   ViSession vi);
+
+ViStatus _VI_FUNC niFake_EnumArrayOutputFunction(
+   ViSession vi,
+   ViInt32 numberOfElements,
+   ViInt16 anArray[]);
+
+ViStatus _VI_FUNC niFake_EnumInputFunctionWithDefaults(
+   ViSession vi,
+   ViInt16 aTurtle);
+
+ViStatus _VI_FUNC niFake_StringValuedEnumInputFunctionWithDefaults(
+   ViSession vi,
+   ViConstString aMobileOSName);
+
+ViStatus _VI_FUNC niFake_error_message(
+   ViSession vi,
+   ViStatus errorCode,
+   ViChar errorMessage[NIFAKE_MAX_MESSAGE_BUF_SIZE]);
+
+ViStatus _VI_FUNC niFake_FetchWaveform(
+   ViSession vi,
+   ViInt32 numberOfSamples,
+   ViReal64 waveformData[],
+   ViInt32* actualNumberOfSamples);
+
+ViStatus _VI_FUNC niFake_GetABoolean(
+   ViSession vi,
+   ViBoolean* aBoolean);
+
+ViStatus _VI_FUNC niFake_GetANumber(
+   ViSession vi,
+   ViInt16* aNumber);
+
+ViStatus _VI_FUNC niFake_GetAStringOfFixedMaximumSize(
+   ViSession vi,
+   ViChar aString[NIFAKE_MAX_MESSAGE_BUF_SIZE]);
+
+ViStatus _VI_FUNC niFake_GetAStringUsingPythonCode(
+   ViSession vi,
+   ViInt16 aNumber,
+   ViChar aString[]);
+
+// Test comment
+ViStatus _VI_FUNC niFake_GetAnIviDanceString(
+   ViSession vi,
+   ViInt32 bufferSize,
+   ViChar aString[]);
+
+ViStatus _VI_FUNC niFake_GetArrayForPythonCodeDouble(
+   ViSession vi,
+   ViInt32 numberOfElements[],
+   ViReal64 arrayOut[]);
+
+ViStatus _VI_FUNC niFake_GetArraySizeForPythonCode(
+   ViSession vi,
+   ViInt32* sizeOut);
+
+ViStatus _VI_FUNC niFake_GetArrayUsingIviDance(
+   ViSession vi,
+   ViInt32 arraySize,
+   ViReal64 arrayOut[]);
+
+ViStatus _VI_FUNC niFake_GetAttributeViBoolean(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViBoolean* attributeValue);
+
+ViStatus _VI_FUNC niFake_GetAttributeViInt32(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViInt32* attributeValue);
+
+ViStatus _VI_FUNC niFake_GetAttributeViInt64(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViInt64* attributeValue);
+
+ViStatus _VI_FUNC niFake_GetAttributeViReal64(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViReal64* attributeValue);
+
+ViStatus _VI_FUNC niFake_GetAttributeViSession(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViSession* attributeValue);
+
+ViStatus _VI_FUNC niFake_GetAttributeViString(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViInt32 bufferSize,
+   ViChar attributeValue[]);
+
+ViStatus _VI_FUNC niFake_GetCalDateAndTime(
+   ViSession vi,
+   ViInt32 calType,
+   ViInt32* month,
+   ViInt32* day,
+   ViInt32* year,
+   ViInt32* hour,
+   ViInt32* minute);
+
+ViStatus _VI_FUNC niFake_GetCalInterval(
+   ViSession vi,
+   ViInt32* months);
+
+ViStatus _VI_FUNC niFake_GetEnumValue(
+   ViSession vi,
+   ViInt32* aQuantity,
+   ViInt16* aTurtle);
+
+ViStatus _VI_FUNC niFake_GetError(
+   ViSession vi,
+   ViStatus* errorCode,
+   ViInt32 bufferSize,
+   ViChar description[]);
+
+ViStatus _VI_FUNC niFake_GetErrorMessage(
+   ViSession vi,
+   ViStatus errorCode,
+   ViInt32 bufferSize,
+   ViChar errorMessage[]);
+
+ViStatus _VI_FUNC niFake_InitWithOptions(
+   ViString resourceName,
+   ViBoolean idQuery,
+   ViBoolean resetDevice,
+   ViConstString optionString,
+   ViSession* vi);
+
+ViStatus _VI_FUNC niFake_Initiate(
+   ViSession vi);
+
+ViStatus _VI_FUNC niFake_LockSession(
+   ViSession vi,
+   ViBoolean* callerHasLock);
+
+ViStatus _VI_FUNC niFake_UnlockSession(
+   ViSession vi,
+   ViBoolean* callerHasLock);
+
+ViStatus _VI_FUNC niFake_MultipleArrayTypes(
+   ViSession vi,
+   ViInt32 outputArraySize,
+   ViReal64 outputArray[],
+   ViReal64 outputArrayOfFixedLength[3],
+   ViInt32 inputArraySizes,
+   ViReal64 inputArrayOfFloats[],
+   ViInt16 inputArrayOfIntegers[]);
+
+ViStatus _VI_FUNC niFake_MultipleArraysSameSize(
+   ViSession vi,
+   ViReal64 values1[],
+   ViReal64 values2[],
+   ViReal64 values3[],
+   ViReal64 values4[],
+   ViInt32 size);
+
+ViStatus _VI_FUNC niFake_OneInputFunction(
+   ViSession vi,
+   ViInt32 aNumber);
+
+ViStatus _VI_FUNC niFake_ParametersAreMultipleTypes(
+   ViSession vi,
+   ViBoolean aBoolean,
+   ViInt32 anInt32,
+   ViInt64 anInt64,
+   ViInt16 anIntEnum,
+   ViReal64 aFloat,
+   ViReal64 aFloatEnum,
+   ViInt32 stringSize,
+   ViConstString aString[]);
+
+ViStatus _VI_FUNC niFake_PoorlyNamedSimpleFunction(
+   ViSession vi);
+
+ViStatus _VI_FUNC niFake_Read(
+   ViSession vi,
+   ViReal64 maximumTime,
+   ViReal64* reading);
+
+ViStatus _VI_FUNC niFake_ReadFromChannel(
+   ViSession vi,
+   ViConstString channelName,
+   ViInt32 maximumTime,
+   ViReal64* reading);
+
+ViStatus _VI_FUNC niFake_ReturnANumberAndAString(
+   ViSession vi,
+   ViInt16* aNumber,
+   ViChar aString[NIFAKE_MAX_MESSAGE_BUF_SIZE]);
+
+ViStatus _VI_FUNC niFake_ReturnMultipleTypes(
+   ViSession vi,
+   ViBoolean* aBoolean,
+   ViInt32* anInt32,
+   ViInt64* anInt64,
+   ViInt16* anIntEnum,
+   ViReal64* aFloat,
+   ViReal64* aFloatEnum,
+   ViInt32 arraySize,
+   ViReal64 anArray[],
+   ViInt32 stringSize,
+   ViChar aString[]);
+
+ViStatus _VI_FUNC niFake_self_test(
+   ViSession vi,
+   ViInt16* selfTestResult,
+   ViChar selfTestMessage[NIFAKE_MAX_MESSAGE_BUF_SIZE]);
+
+ViStatus _VI_FUNC niFake_SetAttributeViBoolean(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViBoolean attributeValue);
+
+ViStatus _VI_FUNC niFake_SetAttributeViInt32(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViInt32 attributeValue);
+
+ViStatus _VI_FUNC niFake_SetAttributeViInt64(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViInt64 attributeValue);
+
+ViStatus _VI_FUNC niFake_SetAttributeViReal64(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViReal64 attributeValue);
+
+ViStatus _VI_FUNC niFake_SetAttributeViSession(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViSession attributeValue);
+
+ViStatus _VI_FUNC niFake_SetAttributeViString(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViConstString attributeValue);
+
+ViStatus _VI_FUNC niFake_TwoInputFunction(
+   ViSession vi,
+   ViReal64 aNumber,
+   ViString aString);
+
+ViStatus _VI_FUNC niFake_Use64BitNumber(
+   ViSession vi,
+   ViInt64 input,
+   ViInt64* output);
+
+ViStatus _VI_FUNC niFake_WriteWaveform(
+   ViSession vi,
+   ViInt32 numberOfSamples,
+   ViReal64 waveform[]);
+
+ViStatus _VI_FUNC niFake_SetCustomType(
+   ViSession vi,
+   struct CustomStruct* cs);
+
+ViStatus _VI_FUNC niFake_SetCustomTypeArray(
+   ViSession vi,
+   ViInt32 numberOfElements,
+   struct CustomStruct cs[]);
+
+ViStatus _VI_FUNC niFake_GetCustomType(
+   ViSession vi,
+   struct CustomStruct* cs);
+
+ViStatus _VI_FUNC niFake_GetCustomTypeArray(
+   ViSession vi,
+   ViInt32 numberOfElements,
+   struct CustomStruct cs[]);
+
+ViStatus _VI_FUNC niFake_GetArrayForPythonCodeCustomType(
+   ViSession vi,
+   ViInt32 numberOfElements[],
+   struct CustomStruct arrayOut[]);
+
+ViStatus _VI_FUNC niFake_ResetAttribute(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId);
+
+ViStatus _VI_FUNC niFake_GetAttributeWithOptionsViInt32(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViInt32 retrievalMode,
+   ViInt32* attributeValue);
+
+ViStatus _VI_FUNC niFake_GetAttributeWithOptionsViReal64(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViInt32 retrievalMode,
+   ViReal64* attributeValue);
+
+ViStatus _VI_FUNC niFake_GetAttributeWithOptionsViString(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViInt32 retrievalMode,
+   ViInt32 bufferSize,
+   ViChar attributeValue[]);
+
+ViStatus _VI_FUNC niFake_OneOutputFunction(
+   ViSession vi,
+   ViInt16* aNumber);
+
+ViStatus _VI_FUNC niFake_GetAnIviDanceWithATwistString(
+   ViSession vi,
+   ViInt32 bufferSize,
+   ViChar aString[],
+   ViInt32* actualSize);
+
+ViStatus _VI_FUNC niFake_InitializeWithChannels(
+   ViRsrc resourceName,
+   ViConstString channels,
+   ViBoolean reset,
+   ViConstString optionString,
+   ViSession* newVi);
+
+ViStatus _VI_FUNC niFake_GetChannelName(
+   ViSession vi,
+   ViInt32 index,
+   ViInt32 nameSize,
+   ViChar name[]);
+
+ViStatus _VI_FUNC niFake_GetAttributeWithOptionsViInt64(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViInt32 retrievalMode,
+   ViInt64* attributeValue);
+
+ViStatus _VI_FUNC niFake_GetAttributeWithOptionsViSession(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViInt32 retrievalMode,
+   ViSession* attributeValue);
+
+ViStatus _VI_FUNC niFake_GetAttributeWithOptionsViBoolean(
+   ViSession vi,
+   ViConstString channelName,
+   ViAttr attributeId,
+   ViInt32 retrievalMode,
+   ViBoolean* attributeValue);
+
+ViStatus _VI_FUNC niFake_AttributeWasSetByUser(
+   ViSession vi,
+   ViConstString repCapName,
+   ViAttr attributeId,
+   ViBoolean* wasSetByUser);
+
+ViStatus _VI_FUNC niFake_DisableParentSessionAutoClose(
+   ViSession vi);
+
+ViStatus _VI_FUNC niFake_DoubleAllTheNums(
+   ViSession vi,
+   ViInt32 numberCount,
+   ViReal64 numbers[]);
+
+ViStatus _VI_FUNC niFake_AcceptListOfDurationsInSeconds(
+   ViSession vi,
+   ViInt32 count,
+   ViReal64 delays[]);
+
+ViStatus _VI_FUNC niFake_ReturnDurationInSeconds(
+   ViSession vi,
+   ViReal64 timedelta);
+
+ViStatus _VI_FUNC niFake_ReturnListOfDurationsInSeconds(
+   ViSession vi,
+   ViInt32 numberOfElements,
+   ViReal64 timedeltas[]);
+
+ViStatus _VI_FUNC niFake_ImportAttributeConfigurationBuffer(
+   ViSession vi,
+   ViInt32 sizeInBytes,
+   ViInt8 configuration[]);
+
+ViStatus _VI_FUNC niFake_ExportAttributeConfigurationBuffer(
+   ViSession vi,
+   ViInt32 sizeInBytes,
+   ViInt8 configuration[]);
+
+
+// Errors and Warnings
+
+#include "niFakeObsolete.h"
+
+#endif /* __NIFAKE_HEADER */
+

--- a/imports/includes/niFakeObsolete.h
+++ b/imports/includes/niFakeObsolete.h
@@ -1,0 +1,68 @@
+/*
+    **** THIS FILE IS GENERATED. ANY CHANGES WILL BE OVERWRITTEN! ****
+    Command-line: /P/MI/shared/hapigen/hapigen/export/1.2/1.2.0f0/tools/linux/i386/hapigen_render --processed-metadata-path /P/MI/shared/hapigen/hapigen_cheader_plugin/trunk/1.2/objects/export/test_output/linux/system_test_cheader_expanded_metadata.hapigen_processed --template-path ./objects/export/templates/ivi_based_obsolete_header.h.mako --output-path ./objects/export/test_output/niFakeObsolete.h --template-search-path /P/MI/shared/hapigen/hapigen/export/1.2/1.2.0f0/templates --template-search-path /P/MI/shared/hapigen/hapigen_cheader_plugin/trunk/1.2/objects/export/templates
+*/
+
+#ifndef __NIFAKEOBSOLETE_HEADER
+#define __NIFAKEOBSOLETE_HEADER
+
+#ifdef _CVI_
+#pragma EnableLibraryRuntimeChecking
+#endif
+
+
+// Values
+// Values used in
+//     NIFAKE_ATTR_READ_WRITE_COLOR_OBSOLETE, niFake_EnumArrayOutputFunctionObsolete
+#define NIFAKE_VAL_RED                                         1                               // 1 (0x1)
+#define NIFAKE_VAL_BLUE                                        (NIFAKE_VAL_RED + 1L)           // 2 (0x2)
+#define NIFAKE_VAL_YELLOW                                      5                               // 5 (0x5)
+#define NIFAKE_VAL_BLACK                                       42                              // 42 (0x2a)
+
+// Attributes
+#define NIFAKE_ATTR_READ_WRITE_BOOL_OBSOLETE                   (NIFAKE_ATTR_BASE + 50L)        // 1000050 (0xf4272), ViBoolean
+#define NIFAKE_ATTR_READ_WRITE_COLOR_OBSOLETE                  (NIFAKE_ATTR_BASE + 53L)        // 1000053 (0xf4275), ViInt32
+
+
+
+// Functions
+ViStatus _VI_FUNC niFake_EnumArrayOutputFunctionObsolete(
+   ViSession vi,
+   ViInt32 numberOfElements,
+   ViInt16 anArray[]);
+
+ViStatus _VI_FUNC niFake_DoubleAllTheNums(
+   ViSession vi,
+   ViInt32 numberCount,
+   ViReal64 numbers[]);
+
+ViStatus _VI_FUNC niFake_AcceptListOfDurationsInSeconds(
+   ViSession vi,
+   ViInt32 count,
+   ViReal64 delays[]);
+
+ViStatus _VI_FUNC niFake_ReturnDurationInSeconds(
+   ViSession vi,
+   ViReal64 timedelta);
+
+ViStatus _VI_FUNC niFake_ReturnListOfDurationsInSeconds(
+   ViSession vi,
+   ViInt32 numberOfElements,
+   ViReal64 timedeltas[]);
+
+ViStatus _VI_FUNC niFake_ImportAttributeConfigurationBuffer(
+   ViSession vi,
+   ViInt32 sizeInBytes,
+   ViInt8 configuration[]);
+
+ViStatus _VI_FUNC niFake_ExportAttributeConfigurationBuffer(
+   ViSession vi,
+   ViInt32 sizeInBytes,
+   ViInt8 configuration[]);
+
+
+// Errors and Warnings
+
+
+#endif /* __NIFAKEOBSOLETE_HEADER */
+


### PR DESCRIPTION
# Justification
This is staging for using IVI types in the generated code.

# Implementation
- Copied `IviVisaType.h` version 220f0
- Copied `niFake*.h` version 1.2.0f0.

# Testing
N/A