### PR TITLE
[Peer Review] Cache Implementation for storing niSysCfgSession handle.

### DIFF
--- a/source/core_server/hardware/grpc/internal/session_repository.cpp
+++ b/source/core_server/hardware/grpc/internal/session_repository.cpp
@@ -83,20 +83,20 @@ void SessionRepository::remove_session(uint64_t id)
   }
 }
 
-// This method caches the NISysCfgSession into cached_SysCfgSession field.
+// This method caches the NISysCfgSession into cached_syscfg_session field.
 // This takes an optional reinitialize boolean as input which can be used to enforce initialization when needed.
-// This method takes a unique lock to access cached_SysCfgSession and returns if its not null otherwise creates a new session
-// when reinitialize is true or cached_SysCfgSession is null and returns it.
+// This method takes a unique lock to access cached_syscfg_session and returns if its not null otherwise creates a new session
+// when reinitialize is true or cached_syscfg_session is null and returns it.
 // This method doesn't check for return of null session after failed initialization.
-NISysCfgSessionHandle SessionRepository::getSysCfgSession(bool reinitialize = false)
+NISysCfgSessionHandle SessionRepository::get_syscfg_session(bool reinitialize = false)
 {
   std::unique_lock<std::shared_mutex> lock(session_mutex);
-  if (!reinitialize && cached_SysCfgSession != nullptr) {
-      return cached_SysCfgSession;
+  if (!reinitialize && cached_syscfg_session != nullptr) {
+    return cached_syscfg_session;
   }
   else {
-    NISysCfgInitializeSession("localhost", NULL, NULL, NISysCfgLocaleDefault, NISysCfgBoolTrue, 10000, NULL, &cached_SysCfgSession);
-    return cached_SysCfgSession;
+    NISysCfgInitializeSession("localhost", NULL, NULL, NISysCfgLocaleDefault, NISysCfgBoolTrue, 10000, NULL, &cached_syscfg_session);
+    return cached_syscfg_session;
    }
 }
 

--- a/source/core_server/hardware/grpc/internal/session_repository.h
+++ b/source/core_server/hardware/grpc/internal/session_repository.h
@@ -7,7 +7,7 @@
 #include <shared_mutex>
 
 #include "hardware/grpc/internal/semaphore.h"
-#include "../../imports/includes/nisyscfg.h"
+#include <nisyscfg.h>
 
 namespace ni {
 namespace hardware {
@@ -24,7 +24,7 @@ class SessionRepository {
   uint64_t access_session(uint64_t session_id, const std::string& session_name);
   void remove_session(uint64_t id);
 
-  NISysCfgSessionHandle getSysCfgSession(bool reinitialize);
+  NISysCfgSessionHandle get_syscfg_session(bool reinitialize);
 
   bool reserve(
       const ::grpc::ServerContext* context,
@@ -69,7 +69,7 @@ class SessionRepository {
   ReservationMap reservations_;
 
   std::shared_mutex session_mutex;
-  NISysCfgSessionHandle cached_SysCfgSession;
+  NISysCfgSessionHandle cached_syscfg_session;
 
 };
 


### PR DESCRIPTION
# Justification
In order to speed up the access time of niSysCfgSession properties, we have found that it is helpful to cache niSysCfgSession handle into a field. This handle is shared among the clients which access this server.

# Implementation
Have introduced a getSysCfgSession(bool ) API which takes a bool reinitialize for reinitialization. The behavior is if the niSysCfgSession is null or reinitialize is true, it always initializes the session and returns session handle. Otherwise it returns the cached session handle.

# Testing
TODO: TO BE DONE
