### PR TITLE
Adding namespace component to metadata

### DIFF
--- a/source/codegen/handler_helpers.py
+++ b/source/codegen/handler_helpers.py
@@ -30,13 +30,8 @@ def sanitize_names(parameters):
             parameter['cppName'] = parameter['cppName'] + 'Parameter'
 
 def get_include_guard_name(config, suffix):
-    driver_full_namespace = config["grpc_package"]
-    include_guard_name = driver_full_namespace.replace(".", "_") + suffix
+    include_guard_name = 'ni_' + config['namespace_component'] + '_grpc' + suffix
     return include_guard_name.upper()
-
-def get_namespace_segments(config):
-    namespace = config["grpc_package"]
-    return namespace.split(".")
 
 def create_args(parameters):
     result = ''

--- a/source/codegen/library_wrapper.h.mako
+++ b/source/codegen/library_wrapper.h.mako
@@ -6,7 +6,6 @@ config = data['config']
 functions = data['functions']
 
 service_class_prefix = config["service_class_prefix"]
-driver_namespaces = handler_helpers.get_namespace_segments(config)
 include_guard_name = handler_helpers.get_include_guard_name(config, "_LIBRARY_WRAPPER_H")
 %>\
 //---------------------------------------------------------------------
@@ -22,9 +21,9 @@ include_guard_name = handler_helpers.get_include_guard_name(config, "_LIBRARY_WR
 #include <grpcpp/grpcpp.h>
 #include <${config["c_header"]}>
 
-% for namespace in driver_namespaces:
-namespace ${namespace} {
-% endfor
+namespace ni {
+namespace ${config["namespace_component"]} {
+namespace grpc {
 
 class ${service_class_prefix}LibraryWrapper {
  public:
@@ -44,7 +43,7 @@ class ${service_class_prefix}LibraryWrapper {
 %endfor
 };
 
-% for namespace in reversed(driver_namespaces):
-}  // namespace ${namespace}
-% endfor
+}  // namespace grpc
+}  // namespace ${config["namespace_component"]}
+}  // namespace ni
 #endif  // ${include_guard_name}

--- a/source/codegen/mock_library_wrapper.h.mako
+++ b/source/codegen/mock_library_wrapper.h.mako
@@ -6,8 +6,7 @@ config = data['config']
 functions = data['functions']
 
 service_class_prefix = config["service_class_prefix"]
-driver_namespaces = handler_helpers.get_namespace_segments(config)
-driver_namespace = '::'.join(str(namespace) for namespace in driver_namespaces)
+namespace_prefix = "ni::" + config["namespace_component"] + "::grpc"
 include_guard_name = handler_helpers.get_include_guard_name(config, "_MOCK_LIBRARY_WRAPPER_H")
 %>\
 //---------------------------------------------------------------------
@@ -28,10 +27,10 @@ include_guard_name = handler_helpers.get_include_guard_name(config, "_MOCK_LIBRA
 namespace ni {
 namespace tests {
 namespace unit {
-namespace ${config["unique_namespace_component"]} {
+namespace ${config["namespace_component"]} {
 namespace grpc {
 
-namespace driverNamespace = ${driver_namespace};
+namespace driverNamespace = ${namespace_prefix};
 
 class ${service_class_prefix}MockLibraryWrapper : public driverNamespace::${service_class_prefix}LibraryWrapper {
  public:
@@ -50,7 +49,7 @@ class ${service_class_prefix}MockLibraryWrapper : public driverNamespace::${serv
 };
 
 }  // namespace grpc
-}  // namespace ${config["unique_namespace_component"]}
+}  // namespace ${config["namespace_component"]}
 }  // namespace unit
 }  // namespace tests
 }  // namespace ni

--- a/source/codegen/proto.mako
+++ b/source/codegen/proto.mako
@@ -24,7 +24,7 @@ option java_package = "${config["java_package"]}";
 option java_outer_classname = "${service_class_prefix}";
 option csharp_namespace = "${config["csharp_namespace"]}";
 
-package ${config["grpc_package"]};
+package ni.${config["namespace_component"]}.grpc;
 
 service ${service_class_prefix} {
 % for function in common_helpers.filter_proto_rpc_functions(functions):

--- a/source/codegen/service.cpp.mako
+++ b/source/codegen/service.cpp.mako
@@ -8,8 +8,7 @@ enums = data['enums']
 functions = data['functions']
 
 service_class_prefix = config["service_class_prefix"]
-driver_namespaces = handler_helpers.get_namespace_segments(config)
-namespace_prefix = "::".join(driver_namespaces) + "::"
+namespace_prefix = "ni::" + config["namespace_component"] + "::grpc::"
 module_name = config["module_name"]
 c_function_prefix = config["c_function_prefix"]
 linux_library_name = config['library_info']['Linux']['64bit']['name']
@@ -29,9 +28,9 @@ windows_libary_name = config['library_info']['Windows']['64bit']['name']
 #include <atomic>
 
 ## Namespaces
-% for namespace in driver_namespaces:
-namespace ${namespace} {
-% endfor
+namespace ni {
+namespace ${config["namespace_component"]} {
+namespace grpc {
 
   namespace internal = ni::hardware::grpc::internal;
 
@@ -126,7 +125,7 @@ namespace ${namespace} {
     return ::grpc::Status::OK;
   }
 
-% endfor
-% for namespace in reversed(driver_namespaces):
-} // namespace ${namespace}
-% endfor
+%endfor
+} // namespace grpc
+} // namespace ${config["namespace_component"]}
+} // namespace ni

--- a/source/codegen/service.h.mako
+++ b/source/codegen/service.h.mako
@@ -6,7 +6,6 @@ config = data['config']
 functions = data['functions']
 
 service_class_prefix = config["service_class_prefix"]
-driver_namespaces = handler_helpers.get_namespace_segments(config)
 include_guard_name = handler_helpers.get_include_guard_name(config, "_SERVICE_H")
 %>\
 
@@ -29,9 +28,9 @@ include_guard_name = handler_helpers.get_include_guard_name(config, "_SERVICE_H"
 #include "core_server/hardware/grpc/internal/shared_library.h"
 #include "core_server/hardware/grpc/internal/session_repository.h"
 
-% for namespace in driver_namespaces:
-namespace ${namespace} {
-% endfor
+namespace ni {
+namespace ${config["namespace_component"]} {
+namespace grpc {
 
 class ${service_class_prefix}Service final : public ${service_class_prefix}::Service {
 public:
@@ -50,7 +49,7 @@ private:
   ni::hardware::grpc::internal::SessionRepository* session_repository_;
 };
 
-% for namespace in reversed(driver_namespaces):
-} // namespace ${namespace}
-% endfor
+} // namespace grpc
+} // namespace ${config["namespace_component"]}
+} // namespace ni
 #endif  // ${include_guard_name}

--- a/source/metadata/nifake/config.py
+++ b/source/metadata/nifake/config.py
@@ -5,10 +5,9 @@ config = {
     'c_header': 'niFake.h',
     'c_function_prefix': 'niFake_',
     'service_class_prefix': 'NiFake',
-    'grpc_package': 'ni.fake.grpc',
     'java_package': 'com.ni.fake.grpc',
     'csharp_namespace': 'NationalInstruments.Fake.Grpc',
-    'unique_namespace_component': 'fake',
+    'namespace_component': 'fake',
     'close_function': 'close',
     'context_manager_name': {
         'abort_function': 'Abort',


### PR DESCRIPTION
# Justification
Some generated files belong in a different namespace from the driver grpc namespace. This adds a value to the metadata that can be used to specify the driver-specific portion of the namespace in those scenarios and updates all generated files to use this approach.

# Implementation
* Added new `unique_namespace_component` to metadata
* Updated codegen files to use the new value

# Testing
Built and ran tests with the new value.