### PR TITLE
[Owners] Adding bigobj flag to fix Debug compile errors for ni_fake_service_tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,7 +227,6 @@ add_library(TestApi SHARED
     "source/tests/utilities/test_api.cpp")
 add_compile_definitions(TestApi TEST_API_BUILDING)
 
-# Hardcode ni-fake sources in right now to get it building the unit tests.
 add_executable(UnitTestsRunner
     "source/tests/utilities/run_all_tests.cpp"
     "source/tests/unit/session_utilities_service_tests.cpp"
@@ -249,6 +248,12 @@ add_executable(UnitTestsRunner
     "${service_output_dir}/nifake/nifake_service.cpp"
     "${proto_srcs_dir}/nifake.pb.cc"
     "${proto_srcs_dir}/nifake.grpc.pb.cc")
+
+# ni_fake_service_tests.cpp exceeds the MSVC limit for the number of sections in an obj file defined by PE-COFF.
+# This disables that requirement for just the ni_fake_service_tests.cpp file.
+if(MSVC)
+  set_source_files_properties("source/tests/unit/ni_fake_service_tests.cpp" PROPERTIES COMPILE_FLAGS /bigobj)
+endif()
 
 target_include_directories(UnitTestsRunner
     PRIVATE "${service_output_dir}/nifake")


### PR DESCRIPTION
# Justification
MSVC limits the number of sections in obj files per the PE-COFF standard and to maintain backwards compatibility with older MSVC versions. The `ni_fake_service_tests.cpp` file is hitting this limit during Debug builds and preventing compilation of the `UnitTestRunner` for debugging. This change adds the `/bigobj` flag for `ni_fake_service_tests.cpp` to ensure the build will work.

See [/bigobj (Increase Number of Sections in .Obj file) ](https://docs.microsoft.com/en-us/cpp/build/reference/bigobj-increase-number-of-sections-in-dot-obj-file?view=msvc-160)for more information.

# Implementation
* Added `/bigobj` compiler flag for source file `ni_fake_service_tests.cpp` when compiler is MSVC

This approach will apply the flag **only** for compilation of the file in question. Alternatives include:
* Splitting the test source into multiple source files to reduce the number of sections in the obj file. I've rejected this idea for now as multiple ongoing PRs are adding tests to the file.
* Adding the `/bigobj` flag globally. I've rejected this idea because it seems like we should be aware of which files have this problem and adding the flag globally would prevent future instances of the issue from being noticed. 

# Testing
Built and ran tests in Debug mode on Windows. 