### PR TITLE
[Owners] Adding NIFake Unit Tests for existing enum logic

### DIFF
--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -692,6 +692,7 @@ TEST(NiFakeServiceTests, NiFakeService_StringValuedEnumInputFunctionWithDefaults
   ::grpc::Status status = service.StringValuedEnumInputFunctionWithDefaults(&context, &request, &response);
 
   EXPECT_EQ(::grpc::INVALID_ARGUMENT, status.error_code());
+  EXPECT_EQ(NULL, response.status());
 }
 
 TEST(NiFakeServiceTests, NiFakeService_StringValuedEnumInputFunctionWithDefaultsWithValidEnumInput_CallsStringValuedEnumInputFunctionWithDefaults)


### PR DESCRIPTION
# Justification
This change adds unit testing for enum code generation logic that already exists for NIFake. 

# Implementation
* Added a test for `GetEnumValue`
* Added two tests for getting a non-integer enum
  * One invalid case
  * One valid (working) case

**Note:** The other non-integer enum is already tested by `NiFakeService_ParametersAreMultipleTypes_CallsParametersAreMultipleTypes`. Currently, there are no functions exposed which include setting an enum. 

# Testing
Build and ran all tests.
