### PR TITLE
Updating tar to use yaml line-folding

### DIFF
--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -135,15 +135,16 @@ jobs:
 
     - name: Tar Build Files
       if: "github.ref == 'refs/heads/main'"
-      run: tar -cvf NILinuxRealTime-x86_64.tar \
-        ${GITHUB_WORKSPACE}/build/certs/ \
-        ${GITHUB_WORKSPACE}/build/core_server \
-        ${GITHUB_WORKSPACE}/build/CTestTestfile.cmake \
-        ${GITHUB_WORKSPACE}/build/IntegrationTestsRunner \
-        ${GITHUB_WORKSPACE}/build/libTestApi.so \
-        ${GITHUB_WORKSPACE}/build/server_config.json \
-        ${GITHUB_WORKSPACE}/build/SystemTestsRunner \
-        ${GITHUB_WORKSPACE}/build/test_mutual_tls_config.json \
+      run: >-
+        tar -cvf NILinuxRealTime-x86_64.tar
+        ${GITHUB_WORKSPACE}/build/certs/
+        ${GITHUB_WORKSPACE}/build/core_server
+        ${GITHUB_WORKSPACE}/build/CTestTestfile.cmake
+        ${GITHUB_WORKSPACE}/build/IntegrationTestsRunner
+        ${GITHUB_WORKSPACE}/build/libTestApi.so
+        ${GITHUB_WORKSPACE}/build/server_config.json
+        ${GITHUB_WORKSPACE}/build/SystemTestsRunner
+        ${GITHUB_WORKSPACE}/build/test_mutual_tls_config.json
         ${GITHUB_WORKSPACE}/build/UnitTestsRunner
 
     - name: Upload Artifact


### PR DESCRIPTION
# Justification
tar step for NILRT is failing as yaml folds new lines into spaces.

# Implementation
Update workflow to use line folding.

# Testing
This will not be tested until merged as the step only runs on pushes to main. 
