### PR TITLE
[Owners] Update switch example port

### DIFF
--- a/examples/niswitch/software-scanning.py
+++ b/examples/niswitch/software-scanning.py
@@ -25,7 +25,7 @@ import niSwitch_pb2 as switchTypes
 import niSwitch_pb2_grpc as gRPCSwitch
 
 # This is the location (ipaddress or machine name):(port) of the niDevice server
-serverAddress = "localhost:50051"
+serverAddress = "localhost:31763"
 
 # Resource name and options for a simulated 2529 switch. Change them according to the switch model.
 resource = "Switch1"


### PR DESCRIPTION
# Justification
In https://github.com/ni/ni-driver-apis-grpc/pull/85 I missed a comment from Jonathan that the NI Switch Python example hard codes the server port.

The purpose of this PR is to update that port to match the new default.

# Implementation
Changed to the port in the example to `31763`
