### PR TITLE
Exclude System tests from Run Tests step

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -100,7 +100,7 @@ jobs:
         ProcessorCount(N)
 
         execute_process(
-          COMMAND ctest -j ${N} -C $ENV{BUILD_TYPE} --output-on-failure
+          COMMAND ctest -j ${N} -C $ENV{BUILD_TYPE} -E System --output-on-failure
           WORKING_DIRECTORY build
           RESULT_VARIABLE result
         )


### PR DESCRIPTION
# Justification
We don't want to run system tests during the "Run Tests" step on our GitHub build

# Implementation
use "-E System" to exclude system tests

# Testing
Tested command locally.