### PR TITLE
[Owners] Introduce cancellation logic at the beginning of every service handler.

### DIFF
--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -46,6 +46,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::Abort(::grpc::ServerContext* context, const AbortRequest* request, AbortResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -62,6 +65,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::AcceptListOfDurationsInSeconds(::grpc::ServerContext* context, const AcceptListOfDurationsInSecondsRequest* request, AcceptListOfDurationsInSecondsResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -80,6 +86,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::BoolArrayOutputFunction(::grpc::ServerContext* context, const BoolArrayOutputFunctionRequest* request, BoolArrayOutputFunctionResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       return ::grpc::Status(::grpc::UNIMPLEMENTED, "TODO: This server handler has not been implemented.");
     }
@@ -92,6 +101,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::DoubleAllTheNums(::grpc::ServerContext* context, const DoubleAllTheNumsRequest* request, DoubleAllTheNumsResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -110,6 +122,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::EnumArrayOutputFunction(::grpc::ServerContext* context, const EnumArrayOutputFunctionRequest* request, EnumArrayOutputFunctionResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       return ::grpc::Status(::grpc::UNIMPLEMENTED, "TODO: This server handler has not been implemented.");
     }
@@ -122,6 +137,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::EnumInputFunctionWithDefaults(::grpc::ServerContext* context, const EnumInputFunctionWithDefaultsRequest* request, EnumInputFunctionWithDefaultsResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -139,6 +157,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::ExportAttributeConfigurationBuffer(::grpc::ServerContext* context, const ExportAttributeConfigurationBufferRequest* request, ExportAttributeConfigurationBufferResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -167,6 +188,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::FetchWaveform(::grpc::ServerContext* context, const FetchWaveformRequest* request, FetchWaveformResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -190,6 +214,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetABoolean(::grpc::ServerContext* context, const GetABooleanRequest* request, GetABooleanResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -210,6 +237,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetANumber(::grpc::ServerContext* context, const GetANumberRequest* request, GetANumberResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -230,6 +260,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetAStringOfFixedMaximumSize(::grpc::ServerContext* context, const GetAStringOfFixedMaximumSizeRequest* request, GetAStringOfFixedMaximumSizeResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -250,6 +283,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetAStringUsingPythonCode(::grpc::ServerContext* context, const GetAStringUsingPythonCodeRequest* request, GetAStringUsingPythonCodeResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       return ::grpc::Status(::grpc::UNIMPLEMENTED, "TODO: This server handler has not been implemented.");
     }
@@ -262,6 +298,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetAnIviDanceString(::grpc::ServerContext* context, const GetAnIviDanceStringRequest* request, GetAnIviDanceStringResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -290,6 +329,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetAnIviDanceWithATwistString(::grpc::ServerContext* context, const GetAnIviDanceWithATwistStringRequest* request, GetAnIviDanceWithATwistStringResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       return ::grpc::Status(::grpc::UNIMPLEMENTED, "TODO: This server handler has not been implemented.");
     }
@@ -302,6 +344,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetArrayForPythonCodeDouble(::grpc::ServerContext* context, const GetArrayForPythonCodeDoubleRequest* request, GetArrayForPythonCodeDoubleResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       return ::grpc::Status(::grpc::UNIMPLEMENTED, "TODO: This server handler has not been implemented.");
     }
@@ -314,6 +359,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetArraySizeForPythonCode(::grpc::ServerContext* context, const GetArraySizeForPythonCodeRequest* request, GetArraySizeForPythonCodeResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -334,6 +382,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetArrayUsingIviDance(::grpc::ServerContext* context, const GetArrayUsingIviDanceRequest* request, GetArrayUsingIviDanceResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -362,6 +413,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetAttributeViBoolean(::grpc::ServerContext* context, const GetAttributeViBooleanRequest* request, GetAttributeViBooleanResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -384,6 +438,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetAttributeViInt32(::grpc::ServerContext* context, const GetAttributeViInt32Request* request, GetAttributeViInt32Response* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -406,6 +463,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetAttributeViInt64(::grpc::ServerContext* context, const GetAttributeViInt64Request* request, GetAttributeViInt64Response* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -428,6 +488,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetAttributeViReal64(::grpc::ServerContext* context, const GetAttributeViReal64Request* request, GetAttributeViReal64Response* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -450,6 +513,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetAttributeViString(::grpc::ServerContext* context, const GetAttributeViStringRequest* request, GetAttributeViStringResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -480,6 +546,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetCalDateAndTime(::grpc::ServerContext* context, const GetCalDateAndTimeRequest* request, GetCalDateAndTimeResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -509,6 +578,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetCalInterval(::grpc::ServerContext* context, const GetCalIntervalRequest* request, GetCalIntervalResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -529,6 +601,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetCustomTypeArray(::grpc::ServerContext* context, const GetCustomTypeArrayRequest* request, GetCustomTypeArrayResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -550,6 +625,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetEnumValue(::grpc::ServerContext* context, const GetEnumValueRequest* request, GetEnumValueResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -572,6 +650,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::ImportAttributeConfigurationBuffer(::grpc::ServerContext* context, const ImportAttributeConfigurationBufferRequest* request, ImportAttributeConfigurationBufferResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -590,6 +671,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::InitWithOptions(::grpc::ServerContext* context, const InitWithOptionsRequest* request, InitWithOptionsResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       ViString resource_name = (ViString)request->resource_name().c_str();
       ViBoolean id_query = request->id_query();
@@ -620,6 +704,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::MultipleArrayTypes(::grpc::ServerContext* context, const MultipleArrayTypesRequest* request, MultipleArrayTypesResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       return ::grpc::Status(::grpc::UNIMPLEMENTED, "TODO: This server handler has not been implemented.");
     }
@@ -632,6 +719,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::MultipleArraysSameSize(::grpc::ServerContext* context, const MultipleArraysSameSizeRequest* request, MultipleArraysSameSizeResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -653,6 +743,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::OneInputFunction(::grpc::ServerContext* context, const OneInputFunctionRequest* request, OneInputFunctionResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -670,6 +763,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::ParametersAreMultipleTypes(::grpc::ServerContext* context, const ParametersAreMultipleTypesRequest* request, ParametersAreMultipleTypesResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -700,6 +796,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::PoorlyNamedSimpleFunction(::grpc::ServerContext* context, const PoorlyNamedSimpleFunctionRequest* request, PoorlyNamedSimpleFunctionResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -716,6 +815,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::Read(::grpc::ServerContext* context, const ReadRequest* request, ReadResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -737,6 +839,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::ReadFromChannel(::grpc::ServerContext* context, const ReadFromChannelRequest* request, ReadFromChannelResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -759,6 +864,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::ReturnANumberAndAString(::grpc::ServerContext* context, const ReturnANumberAndAStringRequest* request, ReturnANumberAndAStringResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -781,6 +889,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::ReturnDurationInSeconds(::grpc::ServerContext* context, const ReturnDurationInSecondsRequest* request, ReturnDurationInSecondsResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -801,6 +912,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::ReturnListOfDurationsInSeconds(::grpc::ServerContext* context, const ReturnListOfDurationsInSecondsRequest* request, ReturnListOfDurationsInSecondsResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -822,6 +936,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::ReturnMultipleTypes(::grpc::ServerContext* context, const ReturnMultipleTypesRequest* request, ReturnMultipleTypesResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -870,6 +987,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::StringValuedEnumInputFunctionWithDefaults(::grpc::ServerContext* context, const StringValuedEnumInputFunctionWithDefaultsRequest* request, StringValuedEnumInputFunctionWithDefaultsResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -893,6 +1013,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::TwoInputFunction(::grpc::ServerContext* context, const TwoInputFunctionRequest* request, TwoInputFunctionResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -911,6 +1034,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::Use64BitNumber(::grpc::ServerContext* context, const Use64BitNumberRequest* request, Use64BitNumberResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -932,6 +1058,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::WriteWaveform(::grpc::ServerContext* context, const WriteWaveformRequest* request, WriteWaveformResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -950,6 +1079,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -52,6 +52,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::Abort(::grpc::ServerContext* context, const AbortRequest* request, AbortResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -68,6 +71,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::AcquisitionStatus(::grpc::ServerContext* context, const AcquisitionStatusRequest* request, AcquisitionStatusResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -88,6 +94,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::AddWaveformProcessing(::grpc::ServerContext* context, const AddWaveformProcessingRequest* request, AddWaveformProcessingResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -106,6 +115,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::AutoSetup(::grpc::ServerContext* context, const AutoSetupRequest* request, AutoSetupResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -122,6 +134,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::CalSelfCalibrate(::grpc::ServerContext* context, const CalSelfCalibrateRequest* request, CalSelfCalibrateResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -140,6 +155,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ClearWaveformMeasurementStats(::grpc::ServerContext* context, const ClearWaveformMeasurementStatsRequest* request, ClearWaveformMeasurementStatsResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -158,6 +176,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ClearWaveformProcessing(::grpc::ServerContext* context, const ClearWaveformProcessingRequest* request, ClearWaveformProcessingResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -175,6 +196,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::Commit(::grpc::ServerContext* context, const CommitRequest* request, CommitResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -191,6 +215,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ConfigureChanCharacteristics(::grpc::ServerContext* context, const ConfigureChanCharacteristicsRequest* request, ConfigureChanCharacteristicsResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -210,6 +237,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ConfigureEqualizationFilterCoefficients(::grpc::ServerContext* context, const ConfigureEqualizationFilterCoefficientsRequest* request, ConfigureEqualizationFilterCoefficientsResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -229,6 +259,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ConfigureHorizontalTiming(::grpc::ServerContext* context, const ConfigureHorizontalTimingRequest* request, ConfigureHorizontalTimingResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -250,6 +283,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ConfigureTriggerDigital(::grpc::ServerContext* context, const ConfigureTriggerDigitalRequest* request, ConfigureTriggerDigitalResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -270,6 +306,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ConfigureTriggerEdge(::grpc::ServerContext* context, const ConfigureTriggerEdgeRequest* request, ConfigureTriggerEdgeResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -292,6 +331,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ConfigureTriggerHysteresis(::grpc::ServerContext* context, const ConfigureTriggerHysteresisRequest* request, ConfigureTriggerHysteresisResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -315,6 +357,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ConfigureTriggerImmediate(::grpc::ServerContext* context, const ConfigureTriggerImmediateRequest* request, ConfigureTriggerImmediateResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -331,6 +376,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ConfigureTriggerSoftware(::grpc::ServerContext* context, const ConfigureTriggerSoftwareRequest* request, ConfigureTriggerSoftwareResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -349,6 +397,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ConfigureTriggerVideo(::grpc::ServerContext* context, const ConfigureTriggerVideoRequest* request, ConfigureTriggerVideoResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -374,6 +425,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ConfigureTriggerWindow(::grpc::ServerContext* context, const ConfigureTriggerWindowRequest* request, ConfigureTriggerWindowResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -397,6 +451,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ConfigureVertical(::grpc::ServerContext* context, const ConfigureVerticalRequest* request, ConfigureVerticalResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -419,6 +476,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::Disable(::grpc::ServerContext* context, const DisableRequest* request, DisableResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -435,6 +495,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ExportAttributeConfigurationBuffer(::grpc::ServerContext* context, const ExportAttributeConfigurationBufferRequest* request, ExportAttributeConfigurationBufferResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -463,6 +526,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ExportAttributeConfigurationFile(::grpc::ServerContext* context, const ExportAttributeConfigurationFileRequest* request, ExportAttributeConfigurationFileResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -480,6 +546,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::Fetch(::grpc::ServerContext* context, const FetchRequest* request, FetchResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       return ::grpc::Status(::grpc::UNIMPLEMENTED, "TODO: This server handler has not been implemented.");
     }
@@ -492,6 +561,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::FetchArrayMeasurement(::grpc::ServerContext* context, const FetchArrayMeasurementRequest* request, FetchArrayMeasurementResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       return ::grpc::Status(::grpc::UNIMPLEMENTED, "TODO: This server handler has not been implemented.");
     }
@@ -504,6 +576,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::FetchBinary16(::grpc::ServerContext* context, const FetchBinary16Request* request, FetchBinary16Response* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       return ::grpc::Status(::grpc::UNIMPLEMENTED, "TODO: This server handler has not been implemented.");
     }
@@ -516,6 +591,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::FetchBinary32(::grpc::ServerContext* context, const FetchBinary32Request* request, FetchBinary32Response* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       return ::grpc::Status(::grpc::UNIMPLEMENTED, "TODO: This server handler has not been implemented.");
     }
@@ -528,6 +606,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::FetchBinary8(::grpc::ServerContext* context, const FetchBinary8Request* request, FetchBinary8Response* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       return ::grpc::Status(::grpc::UNIMPLEMENTED, "TODO: This server handler has not been implemented.");
     }
@@ -540,6 +621,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::FetchMeasurementStats(::grpc::ServerContext* context, const FetchMeasurementStatsRequest* request, FetchMeasurementStatsResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       return ::grpc::Status(::grpc::UNIMPLEMENTED, "TODO: This server handler has not been implemented.");
     }
@@ -552,6 +636,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::GetAttributeViBoolean(::grpc::ServerContext* context, const GetAttributeViBooleanRequest* request, GetAttributeViBooleanResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -574,6 +661,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::GetAttributeViInt32(::grpc::ServerContext* context, const GetAttributeViInt32Request* request, GetAttributeViInt32Response* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -596,6 +686,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::GetAttributeViInt64(::grpc::ServerContext* context, const GetAttributeViInt64Request* request, GetAttributeViInt64Response* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -618,6 +711,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::GetAttributeViReal64(::grpc::ServerContext* context, const GetAttributeViReal64Request* request, GetAttributeViReal64Response* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -640,6 +736,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::GetAttributeViString(::grpc::ServerContext* context, const GetAttributeViStringRequest* request, GetAttributeViStringResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -670,6 +769,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::GetEqualizationFilterCoefficients(::grpc::ServerContext* context, const GetEqualizationFilterCoefficientsRequest* request, GetEqualizationFilterCoefficientsResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -692,6 +794,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ImportAttributeConfigurationBuffer(::grpc::ServerContext* context, const ImportAttributeConfigurationBufferRequest* request, ImportAttributeConfigurationBufferResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -710,6 +815,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ImportAttributeConfigurationFile(::grpc::ServerContext* context, const ImportAttributeConfigurationFileRequest* request, ImportAttributeConfigurationFileResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -727,6 +835,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::InitWithOptions(::grpc::ServerContext* context, const InitWithOptionsRequest* request, InitWithOptionsResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       ViRsrc resource_name = (ViRsrc)request->resource_name().c_str();
       ViBoolean id_query = request->id_query();
@@ -757,6 +868,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::InitiateAcquisition(::grpc::ServerContext* context, const InitiateAcquisitionRequest* request, InitiateAcquisitionResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -773,6 +887,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -793,6 +910,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ProbeCompensationSignalStart(::grpc::ServerContext* context, const ProbeCompensationSignalStartRequest* request, ProbeCompensationSignalStartResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -809,6 +929,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ProbeCompensationSignalStop(::grpc::ServerContext* context, const ProbeCompensationSignalStopRequest* request, ProbeCompensationSignalStopResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -825,6 +948,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::Read(::grpc::ServerContext* context, const ReadRequest* request, ReadResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       return ::grpc::Status(::grpc::UNIMPLEMENTED, "TODO: This server handler has not been implemented.");
     }
@@ -837,6 +963,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ResetDevice(::grpc::ServerContext* context, const ResetDeviceRequest* request, ResetDeviceResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -853,6 +982,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ResetWithDefaults(::grpc::ServerContext* context, const ResetWithDefaultsRequest* request, ResetWithDefaultsResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -869,6 +1001,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::SendSoftwareTriggerEdge(::grpc::ServerContext* context, const SendSoftwareTriggerEdgeRequest* request, SendSoftwareTriggerEdgeResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -886,6 +1021,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::SetAttributeViBoolean(::grpc::ServerContext* context, const SetAttributeViBooleanRequest* request, SetAttributeViBooleanResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -905,6 +1043,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::SetAttributeViInt32(::grpc::ServerContext* context, const SetAttributeViInt32Request* request, SetAttributeViInt32Response* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -924,6 +1065,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::SetAttributeViInt64(::grpc::ServerContext* context, const SetAttributeViInt64Request* request, SetAttributeViInt64Response* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -943,6 +1087,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::SetAttributeViReal64(::grpc::ServerContext* context, const SetAttributeViReal64Request* request, SetAttributeViReal64Response* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -962,6 +1109,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::SetAttributeViString(::grpc::ServerContext* context, const SetAttributeViStringRequest* request, SetAttributeViStringResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -981,6 +1131,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -1001,6 +1154,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -1016,6 +1172,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ErrorMessage(::grpc::ServerContext* context, const ErrorMessageRequest* request, ErrorMessageResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -1037,6 +1196,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::Reset(::grpc::ServerContext* context, const ResetRequest* request, ResetResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -1053,6 +1215,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::SelfTest(::grpc::ServerContext* context, const SelfTestRequest* request, SelfTestResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -31,6 +31,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::AbortScan(::grpc::ServerContext* context, const AbortScanRequest* request, AbortScanResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -47,6 +50,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::CanConnect(::grpc::ServerContext* context, const CanConnectRequest* request, CanConnectResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -69,6 +75,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::Commit(::grpc::ServerContext* context, const CommitRequest* request, CommitResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -85,6 +94,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::Connect(::grpc::ServerContext* context, const ConnectRequest* request, ConnectResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -103,6 +115,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::ConnectMultiple(::grpc::ServerContext* context, const ConnectMultipleRequest* request, ConnectMultipleResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -120,6 +135,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::Disable(::grpc::ServerContext* context, const DisableRequest* request, DisableResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -136,6 +154,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::Disconnect(::grpc::ServerContext* context, const DisconnectRequest* request, DisconnectResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -154,6 +175,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::DisconnectAll(::grpc::ServerContext* context, const DisconnectAllRequest* request, DisconnectAllResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -170,6 +194,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::DisconnectMultiple(::grpc::ServerContext* context, const DisconnectMultipleRequest* request, DisconnectMultipleResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -187,6 +214,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::GetAttributeViBoolean(::grpc::ServerContext* context, const GetAttributeViBooleanRequest* request, GetAttributeViBooleanResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -209,6 +239,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::GetAttributeViInt32(::grpc::ServerContext* context, const GetAttributeViInt32Request* request, GetAttributeViInt32Response* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -231,6 +264,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::GetAttributeViReal64(::grpc::ServerContext* context, const GetAttributeViReal64Request* request, GetAttributeViReal64Response* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -253,6 +289,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::GetAttributeViString(::grpc::ServerContext* context, const GetAttributeViStringRequest* request, GetAttributeViStringResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -283,6 +322,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::GetChannelName(::grpc::ServerContext* context, const GetChannelNameRequest* request, GetChannelNameResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -312,6 +354,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::GetError(::grpc::ServerContext* context, const GetErrorRequest* request, GetErrorResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -342,6 +387,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::GetPath(::grpc::ServerContext* context, const GetPathRequest* request, GetPathResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -372,6 +420,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::GetRelayCount(::grpc::ServerContext* context, const GetRelayCountRequest* request, GetRelayCountResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -393,6 +444,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::GetRelayName(::grpc::ServerContext* context, const GetRelayNameRequest* request, GetRelayNameResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -422,6 +476,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::GetRelayPosition(::grpc::ServerContext* context, const GetRelayPositionRequest* request, GetRelayPositionResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -443,6 +500,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::InitWithTopology(::grpc::ServerContext* context, const InitWithTopologyRequest* request, InitWithTopologyResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       ViRsrc resource_name = (ViRsrc)request->resource_name().c_str();
       ViConstString topology = request->topology().c_str();
@@ -473,6 +533,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::InitiateScan(::grpc::ServerContext* context, const InitiateScanRequest* request, InitiateScanResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -489,6 +552,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -509,6 +575,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::RelayControl(::grpc::ServerContext* context, const RelayControlRequest* request, RelayControlResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -527,6 +596,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::ResetWithDefaults(::grpc::ServerContext* context, const ResetWithDefaultsRequest* request, ResetWithDefaultsResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -543,6 +615,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::RouteScanAdvancedOutput(::grpc::ServerContext* context, const RouteScanAdvancedOutputRequest* request, RouteScanAdvancedOutputResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -562,6 +637,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::RouteTriggerInput(::grpc::ServerContext* context, const RouteTriggerInputRequest* request, RouteTriggerInputResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -581,6 +659,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::SendSoftwareTrigger(::grpc::ServerContext* context, const SendSoftwareTriggerRequest* request, SendSoftwareTriggerResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -597,6 +678,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::SetAttributeViBoolean(::grpc::ServerContext* context, const SetAttributeViBooleanRequest* request, SetAttributeViBooleanResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -616,6 +700,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::SetAttributeViInt32(::grpc::ServerContext* context, const SetAttributeViInt32Request* request, SetAttributeViInt32Response* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -635,6 +722,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::SetAttributeViReal64(::grpc::ServerContext* context, const SetAttributeViReal64Request* request, SetAttributeViReal64Response* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -654,6 +744,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::SetAttributeViString(::grpc::ServerContext* context, const SetAttributeViStringRequest* request, SetAttributeViStringResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -673,6 +766,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::SetPath(::grpc::ServerContext* context, const SetPathRequest* request, SetPathResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -690,6 +786,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -710,6 +809,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::WaitForDebounce(::grpc::ServerContext* context, const WaitForDebounceRequest* request, WaitForDebounceResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -727,6 +829,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::WaitForScanComplete(::grpc::ServerContext* context, const WaitForScanCompleteRequest* request, WaitForScanCompleteResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -744,6 +849,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -759,6 +867,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::ErrorMessage(::grpc::ServerContext* context, const ErrorMessageRequest* request, ErrorMessageResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -780,6 +891,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::Reset(::grpc::ServerContext* context, const ResetRequest* request, ResetResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());
@@ -796,6 +910,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::SelfTest(::grpc::ServerContext* context, const SelfTestRequest* request, SelfTestResponse* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
       auto session = request->vi();
       ViSession vi = session_repository_->access_session(session.id(), session.name());

--- a/source/codegen/service.cpp.mako
+++ b/source/codegen/service.cpp.mako
@@ -75,6 +75,9 @@ namespace grpc {
   //---------------------------------------------------------------------
   ::grpc::Status ${service_class_prefix}Service::${method_name}(::grpc::ServerContext* context, const ${method_name}Request* request, ${method_name}Response* response)
   {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
     try {
 % if common_helpers.has_unsupported_parameter(function_data):
       return ::grpc::Status(::grpc::UNIMPLEMENTED, "TODO: This server handler has not been implemented.");


### PR DESCRIPTION
# Justification
[Task 1341087](https://ni.visualstudio.com/DevCentral/_workitems/edit/1341087)

Kevin brought up in a previous review that we should probably check for cancellation at the beginning of the service handlers. We do this for the session_utilities_service and should probably do it for our other services as well.

# Implementation
- Update service.cpp.mako to check if the server context `IsCancelled` and if so immediately return a cancelled grpc status
- Run generation so this code snippet for early returns on cancellation gets included for every generated service handler method.

# Testing
Relying on the build to catch errors.
