### PR TITLE
[Owners] Support multiple init methods in codegen.

### DIFF
--- a/generated/niswitch/niswitch.proto
+++ b/generated/niswitch/niswitch.proto
@@ -573,9 +573,10 @@ message GetRelayPositionResponse {
 }
 
 message InitRequest {
-  string resource_name = 1;
-  bool id_query = 2;
-  bool reset_device = 3;
+  string session_name = 1;
+  string resource_name = 2;
+  bool id_query = 3;
+  bool reset_device = 4;
 }
 
 message InitResponse {
@@ -584,10 +585,11 @@ message InitResponse {
 }
 
 message InitWithOptionsRequest {
-  string resource_name = 1;
-  bool id_query = 2;
-  bool reset_device = 3;
-  string option_string = 4;
+  string session_name = 1;
+  string resource_name = 2;
+  bool id_query = 3;
+  bool reset_device = 4;
+  string option_string = 5;
 }
 
 message InitWithOptionsResponse {

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -786,11 +786,19 @@ namespace grpc {
       ViRsrc resource_name = (ViRsrc)request->resource_name().c_str();
       ViBoolean id_query = request->id_query();
       ViBoolean reset_device = request->reset_device();
-      ViSession vi {};
-      auto status = library_->init(resource_name, id_query, reset_device, &vi);
+
+      auto init_lambda = [&] () -> std::tuple<int, uint32_t> {
+        ViSession vi;
+        int status = library_->init(resource_name, id_query, reset_device, &vi);
+        return std::make_tuple(status, vi);
+      };
+      uint32_t session_id = 0;
+      const std::string& session_name = request->session_name();
+      auto cleanup_lambda = [&] (uint32_t id) { library_->close(id); };
+      int status = session_repository_->add_session(session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
       if (status == 0) {
-        response->mutable_vi()->set_id(vi);
+        response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
     }
@@ -811,11 +819,19 @@ namespace grpc {
       ViBoolean id_query = request->id_query();
       ViBoolean reset_device = request->reset_device();
       ViConstString option_string = request->option_string().c_str();
-      ViSession vi {};
-      auto status = library_->InitWithOptions(resource_name, id_query, reset_device, option_string, &vi);
+
+      auto init_lambda = [&] () -> std::tuple<int, uint32_t> {
+        ViSession vi;
+        int status = library_->InitWithOptions(resource_name, id_query, reset_device, option_string, &vi);
+        return std::make_tuple(status, vi);
+      };
+      uint32_t session_id = 0;
+      const std::string& session_name = request->session_name();
+      auto cleanup_lambda = [&] (uint32_t id) { library_->close(id); };
+      int status = session_repository_->add_session(session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
       if (status == 0) {
-        response->mutable_vi()->set_id(vi);
+        response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
     }

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -145,3 +145,6 @@ def get_ivi_dance_params(parameters):
   size_param = next(p for p in parameters if p['name'] == array_param['size']['value']) if array_param else None
   other_params = (p for p in parameters if p != array_param and p != size_param)
   return (size_param, array_param, other_params)
+
+def is_init_method(function_data):
+  return function_data.get('init_method', False)

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -1146,6 +1146,7 @@ functions = {
     },
     'InitWithOptions': {
         'codegen_method': 'public',
+        'init_method': True,
         'documentation': {
             'description': 'Creates a new IVI instrument driver session.'
         },

--- a/source/codegen/metadata/niscope/CHANGES.md
+++ b/source/codegen/metadata/niscope/CHANGES.md
@@ -97,3 +97,7 @@ should be implemented by hand in niscope_service.custom.cpp.
 
 Instances of `python-code` used for the `size` mechanism were updated to `custom-code` to reflect their implementations will be handled
 in the custom service handler implementations.
+
+The following functions were tagged with `'init_method': True,` to ensure their generated service handlers register the new session
+with the session_repository.
+- `InitWithOptions`

--- a/source/codegen/metadata/niscope/functions.py
+++ b/source/codegen/metadata/niscope/functions.py
@@ -1561,6 +1561,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'InitWithOptions': {
+        'init_method': True,
         'parameters': [
             {
                 'direction': 'in',

--- a/source/codegen/metadata/niswitch/CHANGES.md
+++ b/source/codegen/metadata/niswitch/CHANGES.md
@@ -64,3 +64,9 @@ The following APIs were newly added :
 The following APIs will not be implemented : 
 - ErrorQuery
 - RevisionQuery
+
+The following functions were tagged with `'init_method': True,` to ensure their generated service handlers register the new session
+with the session_repository.
+- `init`
+- `InitWithOptions`
+- `InitWithTopology`

--- a/source/codegen/metadata/niswitch/functions.py
+++ b/source/codegen/metadata/niswitch/functions.py
@@ -676,6 +676,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'init': {
+        'init_method': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -704,6 +705,7 @@ functions = {
         'returns': 'ViStatus',
     },
     'InitWithOptions': {
+        'init_method': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -737,6 +739,7 @@ functions = {
         'returns': 'ViStatus',
     },
     'InitWithTopology': {
+        'init_method': True,
         'parameters': [
             {
                 'direction': 'in',

--- a/source/codegen/proto.mako
+++ b/source/codegen/proto.mako
@@ -86,7 +86,7 @@ ${lookup.get_template(custom_template).render()}
 <%
   parameter_array = proto_helpers.filter_parameters_for_grpc_fields(functions[function]["parameters"])
   input_parameters = [p for p in parameter_array if common_helpers.is_input_parameter(p)]
-  if function == config['init_function']:
+  if common_helpers.is_init_method(functions[function]):
     session_name_param = {'direction': 'in','name': 'session_name','type': 'ViString'}
     input_parameters.insert(0, session_name_param)
   output_parameters = [p for p in parameter_array if common_helpers.is_output_parameter(p)]

--- a/source/codegen/service.cpp.mako
+++ b/source/codegen/service.cpp.mako
@@ -81,7 +81,7 @@ namespace grpc {
     try {
 % if common_helpers.has_unsupported_parameter(function_data):
       return ::grpc::Status(::grpc::UNIMPLEMENTED, "TODO: This server handler has not been implemented.");
-% elif function_name == config['init_function']:
+% elif common_helpers.is_init_method(function_data):
 ${gen_init_method_body(function_name=function_name, function_data=function_data, parameters=parameters)}
 % elif common_helpers.has_ivi_dance_param(parameters):
 ${gen_ivi_dance_method_body(function_name=function_name, function_data=function_data, parameters=parameters)}


### PR DESCRIPTION
# Justification
I noticed as we were adding more scope API methods an assumption in our codegen no longer holds.

Initially, we were anticipating just one method to initiate a `ViSession` per driver that was noted by name in the config.py file. Now that we're expanding functionality we can have multiple init methods per driver that need to be accounted for so the codegen'd service handler implementations properly register the newly created sessions with the `session_repository`.

# Implementation
- Added `'init_method': True,` to any function per driver that initiates a ViSession
- Keyed off this init_method field in service.cpp.mako to generate special handler implementations for the init methods to properly register with the session_repository

# Alternative
I considered doing this dynamically instead of having to manually update the metadata. I was thinking to filter functions that had a ViSession output paramater thinking any function with this would be an init function. Found that some functions like ni-switch's `GetAttributeViSession` would match that filter but is not an init function so this alternative wouldn't work.

# Testing
Existing ni_fake tests for init should continue to validate init functions' generated service handlers.
