### PR TITLE
[Owners] [Tiny] [Refactoring] Renaming session_utilities_service_tests to session_utilities_service_tests_endtoend in integration folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,7 +207,7 @@ add_subdirectory(third_party/gtest ${CMAKE_CURRENT_BINARY_DIR}/gtest EXCLUDE_FRO
 # Link test executable against gtest
 add_executable(IntegrationTestsRunner
     "source/tests/utilities/run_all_tests.cpp"
-    "source/tests/integration/in_process_server_client_tests.cpp"
+    "source/tests/integration/session_utilities_service_tests_endtoend.cpp"
     "source/server/device_enumerator.cpp"
     "source/server/semaphore.cpp"
     "source/server/session_repository.cpp"

--- a/source/tests/integration/session_utilities_service_tests_endtoend.cpp
+++ b/source/tests/integration/session_utilities_service_tests_endtoend.cpp
@@ -13,9 +13,9 @@ namespace integration {
 using ::testing::NiceMock;
 using ::testing::Throw;
 
-class InProcessServerClientTests : public ::testing::Test {
+class SessionUtilitiesServiceTests_EndToEnd : public ::testing::Test {
  public:
-  virtual ~InProcessServerClientTests() {}
+  virtual ~SessionUtilitiesServiceTests_EndToEnd() {}
 
   void SetUp() override
   {
@@ -89,7 +89,7 @@ class InProcessServerClientTests : public ::testing::Test {
   }
 
  protected:
-  InProcessServerClientTests() {}
+  SessionUtilitiesServiceTests_EndToEnd() {}
 
  private:
   std::shared_ptr<::grpc::Channel> channel_;
@@ -101,7 +101,7 @@ class InProcessServerClientTests : public ::testing::Test {
   std::unique_ptr<::grpc::Server> server_;
 };
 
-TEST_F(InProcessServerClientTests, SessionUtilitiesServiceClient_RequestIsServerRunning_ResponseIsTrue)
+TEST_F(SessionUtilitiesServiceTests_EndToEnd, SessionUtilitiesServiceClient_RequestIsServerRunning_ResponseIsTrue)
 {
   grpc::nidevice::IsReservedByClientRequest request;
   grpc::nidevice::IsReservedByClientResponse response;
@@ -113,7 +113,7 @@ TEST_F(InProcessServerClientTests, SessionUtilitiesServiceClient_RequestIsServer
   EXPECT_TRUE(s.ok());
 }
 
-TEST_F(InProcessServerClientTests, ClientTimesOutWaitingForReservation_FreeReservation_DoesNotReserve)
+TEST_F(SessionUtilitiesServiceTests_EndToEnd, ClientTimesOutWaitingForReservation_FreeReservation_DoesNotReserve)
 {
   auto status_a = call_reserve("foo", "a");
   auto status_b = call_reserve("foo", "b", std::chrono::system_clock::now() + std::chrono::milliseconds(5));
@@ -126,7 +126,7 @@ TEST_F(InProcessServerClientTests, ClientTimesOutWaitingForReservation_FreeReser
   EXPECT_EQ(status_b.error_code(), ::grpc::DEADLINE_EXCEEDED);
 }
 
-TEST_F(InProcessServerClientTests, MultipleClientsTimeOutWaitingForReservation_FreeReservation_DoNotReserve)
+TEST_F(SessionUtilitiesServiceTests_EndToEnd, MultipleClientsTimeOutWaitingForReservation_FreeReservation_DoNotReserve)
 {
   call_reserve("foo", "a");
   call_reserve("foo", "b", std::chrono::system_clock::now() + std::chrono::milliseconds(5));
@@ -138,7 +138,7 @@ TEST_F(InProcessServerClientTests, MultipleClientsTimeOutWaitingForReservation_F
   EXPECT_FALSE(call_is_reserved("foo", "c"));
 }
 
-TEST_F(InProcessServerClientTests, ClientTimesOutWaitingForReservationWithOtherClientWaitingBehind_FreeReservation_ReservesLastClient)
+TEST_F(SessionUtilitiesServiceTests_EndToEnd, ClientTimesOutWaitingForReservationWithOtherClientWaitingBehind_FreeReservation_ReservesLastClient)
 {
   call_reserve("foo", "a");
   call_reserve("foo", "b", std::chrono::system_clock::now() + std::chrono::milliseconds(5));
@@ -158,7 +158,7 @@ TEST_F(InProcessServerClientTests, ClientTimesOutWaitingForReservationWithOtherC
   EXPECT_TRUE(call_is_reserved("foo", "c"));
 }
 
-TEST_F(InProcessServerClientTests, SysCfgLibraryNotPresent_ClientCallsEnumerateDevices_ReturnsNotFoundGrpcStatusError)
+TEST_F(SessionUtilitiesServiceTests_EndToEnd, SysCfgLibraryNotPresent_ClientCallsEnumerateDevices_ReturnsNotFoundGrpcStatusError)
 {
   grpc::nidevice::EnumerateDevicesRequest request;
   grpc::nidevice::EnumerateDevicesResponse response;


### PR DESCRIPTION
# Justification
In the review of previous PR, there was a comment to move some tests to integration tests which used more than one component. PR #113 does that. But this PR will rename session_utilities_service_tests to in_process_server_client_tests in integration folder so that in the next PR (#113 ) , session_utilities_service_tests from unit tests can be moved to integration tests

Task: https://ni.visualstudio.com/DevCentral/_workitems/edit/1352987

# Implementation
 Renaming session_utilities_service_tests to in_process_server_client_tests in integration folder

# Testing
Tests pass
