### PR TITLE
[Owners] Add some System level tests for ni-scope acquisition and measurement functions.

### DIFF
--- a/source/tests/system/niscope_driver_api_tests.cpp
+++ b/source/tests/system/niscope_driver_api_tests.cpp
@@ -124,10 +124,11 @@ class NiScopeDriverApiTest : public ::testing::Test {
 
   void expect_api_success(int error_status)
   {
-    EXPECT_EQ(kScopeDriverApiSuccess, error_status);
-    if (kScopeDriverApiSuccess == error_status) {
-      return;
-    }
+    EXPECT_EQ(kScopeDriverApiSuccess, error_status) << get_error_message(error_status);
+  }
+
+  std::string get_error_message(int error_status)
+  {
     ::grpc::ClientContext context;
     scope::GetErrorMessageRequest request;
     request.mutable_vi()->set_id(GetSessionId());
@@ -137,7 +138,7 @@ class NiScopeDriverApiTest : public ::testing::Test {
     ::grpc::Status status = GetStub()->GetErrorMessage(&context, request, &response);
     EXPECT_TRUE(status.ok());
     EXPECT_EQ(kScopeDriverApiSuccess, response.status());
-    EXPECT_STREQ("", response.error_message().c_str());
+    return response.error_message();
   }
 
   void auto_setup()


### PR DESCRIPTION
# Justification
[Task 1253989](https://ni.visualstudio.com/DevCentral/_workitems/edit/1253989)

We want a few system level tests to cover some of the data acquisition and measurement functions present for the NiScope service.

# Implementation
Added tests that cover for Data Acquisition
- `Read`
- `FetchBinary8`
- `FetchBinary16`
- `InitiateAcquisition`

And the following test for one of the Measurement Functions
- `FetchArrayMeasurement`

# Testing
Ran the tests locally with ni-scope installed and they all pass.
