### PR TITLE
[Owners] Add some attribute and configuration system level tests for ni-scope.

### DIFF
--- a/source/tests/system/niscope_driver_api_tests.cpp
+++ b/source/tests/system/niscope_driver_api_tests.cpp
@@ -374,7 +374,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeSetViInt32Attribute_SendRequest_GetViInt32At
   EXPECT_EQ(expected_value, get_attribute_value);
 }
 
-TEST_F(NiScopeDriverApiTest, NiScopeSetViInt64Attribute_SendRequest_GetViInt32AttributeMatches)
+TEST_F(NiScopeDriverApiTest, NiScopeSetViInt64Attribute_SendRequest_GetViInt64AttributeMatches)
 {
   const char* channel_list = "";
   // TODO: ViInt64 attributes in niScope.h missing in niscope.proto. Do we want to add them?
@@ -398,7 +398,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeSetViInt64Attribute_SendRequest_GetViInt32At
   EXPECT_EQ(expected_value, get_attribute_value);
 }
 
-TEST_F(NiScopeDriverApiTest, NiScopeSetViReal64Attribute_SendRequest_GetViInt32AttributeMatches)
+TEST_F(NiScopeDriverApiTest, NiScopeSetViReal64Attribute_SendRequest_GetViReal64AttributeMatches)
 {
   const char* channel_list = "";
   const scope::NiScopeAttributes attribute_to_set = scope::NiScopeAttributes::NISCOPE_ATTRIBUTE_REF_CLK_RATE;


### PR DESCRIPTION
# Justification
[Task 1253976](https://ni.visualstudio.com/DevCentral/_workitems/edit/1253976)

We wanted to add some system level tests around setting and getting attributes along with a few tests for configuration methods on ni scope.

# Implementation
- Added set and get attribute tests, one for each attribute type (excluding ViSession as there weren't any ViSession attributes in NiScope)
- Added two configuration tests for `ConfigureHorizontalTiming` and `ConfigureVertical`
    - There is already some basic testing with a few other config methods like `AutoSetup`, `ActualMeasWfmSize`, `ActualNumWfms`, etc. that are used within pre-existing system tests. Between those and the new ones I felt it was a decent amount of coverage for these types of methods.

# Testing
New tests pass on local Windows machine with ni scope installed.
