### PR TITLE
[Owners] Add two fetch examples for ni-scope

### DIFF
--- a/examples/niscope/fetch-continuous.py
+++ b/examples/niscope/fetch-continuous.py
@@ -19,8 +19,8 @@
 # Generate the python API from the gRPC definition (.proto) files.
 # Note: The snippets below assume you are executing from the examples/niscope folder in the repo directory. 
 # If not, you will need to adjust the -I arguments so the compiler knows where to find the proto files.
-#   > py -m grpc_tools.protoc -I="../../source/protobuf" --python_out=. --grpc_python_out=. session.proto
-#   > py -m grpc_tools.protoc -I="../../generated/niscope" -I="../../source/protobuf" --python_out=. --grpc_python_out=. niscope.proto 
+#   > python -m grpc_tools.protoc -I="../../source/protobuf" --python_out=. --grpc_python_out=. session.proto
+#   > python -m grpc_tools.protoc -I="../../generated/niscope" -I="../../source/protobuf" --python_out=. --grpc_python_out=. niscope.proto 
 #
 # Refer to the NI-SCOPE gRPC Wiki to determine the valid channel and resource names for your NI-SCOPE module.
 # Link : https://github.com/ni/grpc-device/wiki/niScope_header

--- a/examples/niscope/fetch.py
+++ b/examples/niscope/fetch.py
@@ -14,8 +14,8 @@
 # Generate the python API from the gRPC definition (.proto) files
 # Note: The snippets below assume you are executing from the examples/niscope folder in the repo directory. 
 # If not, you will need to adjust the -I arguments so the compiler knows where to find the proto files.
-#   > py -m grpc_tools.protoc -I="../../source/protobuf" --python_out=. --grpc_python_out=. session.proto
-#   > py -m grpc_tools.protoc -I="../../generated/niscope" -I="../../source/protobuf" --python_out=. --grpc_python_out=. niscope.proto 
+#   > python -m grpc_tools.protoc -I="../../source/protobuf" --python_out=. --grpc_python_out=. session.proto
+#   > python -m grpc_tools.protoc -I="../../generated/niscope" -I="../../source/protobuf" --python_out=. --grpc_python_out=. niscope.proto 
 #
 # Refer to the NI-SCOPE gRPC Wiki to determine the valid channel and resource names for your NI-SCOPE module.
 # Link : https://github.com/ni/grpc-device/wiki/niScope_header


### PR DESCRIPTION
# Justification
[Task 1336772](https://ni.visualstudio.com/DevCentral/_workitems/edit/1336772)

We want to port a Fetch and FetchForever example to use with our gRPC implementation.

# Implementation
- Added `examples\niscope\fetch.py` that should resemble the core functionality in the [nimi-python fetch example](https://github.com/ni/nimi-python/blob/master/src/niscope/examples/niscope_fetch.py).
- Added `examples\niscope\fetch-continuous.py` that resembles the core functionality in the [nimi-python fetch-forever example](https://github.com/ni/nimi-python/blob/master/src/niscope/examples/niscope_fetch_forever.py

# Testing
Ran each python file against a locally running gRPC server.

fetch.py output:
![image](https://user-images.githubusercontent.com/77176215/111388563-824c3b00-867d-11eb-977b-6382e9ad3b71.png)

fetch-continuous.py output:
![image](https://user-images.githubusercontent.com/77176215/111673643-30c0bf00-87e9-11eb-9450-89015d459e2e.png)
