### PR TITLE
[Owners] Adding an example using the session reservation API.

### DIFF
--- a/examples/session/session-reservation.py
+++ b/examples/session/session-reservation.py
@@ -15,8 +15,8 @@
 # Generate the python API from the gRPC definition (.proto) files.
 # Note: The snippets below assume you are executing from the examples/session folder in the repo directory. 
 # If not, you will need to adjust the -I arguments so the compiler knows where to find the proto files.
-#   > py -m grpc_tools.protoc -I="../../source/protobuf" --python_out=. --grpc_python_out=. session.proto
-#   > py -m grpc_tools.protoc -I="../../generated/niscope" -I="../../source/protobuf" --python_out=. --grpc_python_out=. niscope.proto 
+#   > python -m grpc_tools.protoc -I="../../source/protobuf" --python_out=. --grpc_python_out=. session.proto
+#   > python -m grpc_tools.protoc -I="../../generated/niscope" -I="../../source/protobuf" --python_out=. --grpc_python_out=. niscope.proto 
 #
 # Refer to the NI-SCOPE gRPC Wiki to determine the valid channel and resource names for your NI-SCOPE module.
 # Link : https://github.com/ni/grpc-device/wiki/niScope_header


### PR DESCRIPTION
# Justification
[Task 1351601](https://ni.visualstudio.com/DevCentral/_workitems/edit/1351601)

We wanted an example of using the session.proto's reservation methods. The example should initialize a session using one of the drivers (I went with NI-SCOPE) and use the session API's reservation methods to demonstrate the capabilities there.

# Implementation
- Added `session-reservation.py` to `examples\session` 
- Followed similar patterns as other examples for naming, exceptions, and accepting args for IP address and port

# Testing
Ran against server running locally.

Simple text output when run:
![image](https://user-images.githubusercontent.com/77176215/111670933-644e1a00-87e6-11eb-9e25-6730778557e7.png)
