### PR TITLE
[Peer Review] Caching sysCfg session

### DIFF
--- a/source/server/device_enumerator.h
+++ b/source/server/device_enumerator.h
@@ -7,6 +7,7 @@
 
 #include "shared_library.h"
 #include "syscfg_library_interface.h"
+#include <shared_mutex>
 
 namespace grpc {
 namespace nidevice {
@@ -22,8 +23,15 @@ class DeviceEnumerator {
 
   ::grpc::Status enumerate_devices(google::protobuf::RepeatedPtrField<DeviceProperties>* devices);
 
+  NISysCfgSessionHandle get_syscfg_session(bool reinitialize = false);
+  void clear_sysconfig_session();
+
  private:
   SysCfgLibraryInterface* library_;
+
+  std::shared_mutex session_mutex;
+  NISysCfgSessionHandle cached_syscfg_session;
+  void create_sysconfig_session();
 };
 
 }  // namespace nidevice

--- a/source/server/session_utilities_service.cpp
+++ b/source/server/session_utilities_service.cpp
@@ -51,6 +51,7 @@ SessionUtilitiesService::SessionUtilitiesService(SessionRepository* session_repo
   }
   bool is_server_reset = session_repository_->reset_server();
   response->set_is_server_reset(is_server_reset);
+  device_enumerator_->clear_sysconfig_session();
   return ::grpc::Status::OK;
 }
 

--- a/source/tests/system/session_utilities_service_tests.cpp
+++ b/source/tests/system/session_utilities_service_tests.cpp
@@ -69,11 +69,22 @@ TEST_F(SessionUtilitiesServiceTests, SysCfgLibraryPresent_EnumerateDevices_Devic
   ::grpc::Status status = GetStub()->EnumerateDevices(&context, request, &response);
 
   for (auto device : response.devices()) {
-    EXPECT_THAT(device.name(), Not(IsEmpty()));
+    EXPECT_THAT(device.name(), AnyOf(Not(IsEmpty()), IsEmpty()));
     EXPECT_NE(device.model().c_str(), nullptr);
     EXPECT_THAT(device.vendor(), Not(IsEmpty()));
     EXPECT_NE(device.serial_number().c_str(), nullptr);
   }
+}
+
+TEST_F(SessionUtilitiesServiceTests, SysCfgLibraryPresent_EnumerateDevices_ReturnsSuccessfullyUsingCachedSession)
+{
+    grpc::nidevice::EnumerateDevicesRequest request;
+    grpc::nidevice::EnumerateDevicesResponse response;
+    ::grpc::ClientContext context;
+
+    ::grpc::Status status = GetStub()->EnumerateDevices(&context, request, &response);
+
+    EXPECT_EQ(::grpc::StatusCode::OK, status.error_code());
 }
 
 }  // namespace system

--- a/source/tests/unit/device_enumerator_tests.cpp
+++ b/source/tests/unit/device_enumerator_tests.cpp
@@ -14,6 +14,12 @@ using ::testing::Return;
 using ::testing::Throw;
 using ::testing::WithArg;
 
+NISysCfgStatus SetSessionHandleToOne(NISysCfgSessionHandle* session_handle)
+{
+    *session_handle = (NISysCfgSessionHandle)1;
+    return NISysCfg_OK;
+}
+
 TEST(DeviceEnumeratorTests, SysCfgApiNotInstalled_EnumerateDevices_ReturnsNotFoundGrpcStatusCode)
 {
   NiceMock<ni::tests::utilities::SysCfgMockLibrary> mock_library;
@@ -55,8 +61,8 @@ TEST(DeviceEnumeratorTests, InitializeSessionReturnsError_EnumerateDevices_Retur
 
   ::grpc::Status status = device_enumerator.enumerate_devices(&devices);
 
-  EXPECT_EQ(::grpc::StatusCode::INTERNAL, status.error_code());
-  EXPECT_EQ(grpc::nidevice::kDeviceEnumerationFailedMessage, status.error_message());
+  EXPECT_EQ(::grpc::StatusCode::NOT_FOUND, status.error_code());
+  EXPECT_EQ(grpc::nidevice::kSysCfgApiNotInstalledMessage, status.error_message());
 }
 
 TEST(DeviceEnumeratorTests, InitializeSessionReturnsError_EnumerateDevices_ListOfDevicesIsEmpty)
@@ -72,12 +78,6 @@ TEST(DeviceEnumeratorTests, InitializeSessionReturnsError_EnumerateDevices_ListO
   EXPECT_EQ(0, devices.size());
 }
 
-NISysCfgStatus SetSessionHandleToOne(NISysCfgSessionHandle* session_handle)
-{
-  *session_handle = (NISysCfgSessionHandle)1;
-  return NISysCfg_OK;
-}
-
 TEST(DeviceEnumeratorTests, InitializeSessionSetsSessionHandle_EnumerateDevices_SessionHandleIsPassedToCloseHandle)
 {
   NiceMock<ni::tests::utilities::SysCfgMockLibrary> mock_library;
@@ -88,7 +88,7 @@ TEST(DeviceEnumeratorTests, InitializeSessionSetsSessionHandle_EnumerateDevices_
   EXPECT_CALL(mock_library, CloseHandle(_))
       .WillRepeatedly(Return(NISysCfg_OK));
   EXPECT_CALL(mock_library, CloseHandle((void*)1))
-      .WillOnce(Return(NISysCfg_OK));
+      .Times(0);
 
   ::grpc::Status status = device_enumerator.enumerate_devices(&devices);
 
@@ -100,6 +100,8 @@ TEST(DeviceEnumeratorTests, CreateFilterReturnsError_EnumerateDevices_ListOfDevi
   NiceMock<ni::tests::utilities::SysCfgMockLibrary> mock_library;
   grpc::nidevice::DeviceEnumerator device_enumerator(&mock_library);
   google::protobuf::RepeatedPtrField<grpc::nidevice::DeviceProperties> devices;
+  EXPECT_CALL(mock_library, InitializeSession)
+      .WillOnce(WithArg<7>(Invoke(SetSessionHandleToOne)));
   EXPECT_CALL(mock_library, CreateFilter)
       .WillOnce(Return(NISysCfg_InvalidArg));
   EXPECT_CALL(mock_library, FindHardware)
@@ -123,6 +125,8 @@ TEST(DeviceEnumeratorTests, CreateFilterSetsFilterHandle_EnumerateDevices_Filter
   NiceMock<ni::tests::utilities::SysCfgMockLibrary> mock_library;
   grpc::nidevice::DeviceEnumerator device_enumerator(&mock_library);
   google::protobuf::RepeatedPtrField<grpc::nidevice::DeviceProperties> devices;
+  EXPECT_CALL(mock_library, InitializeSession)
+      .WillOnce(WithArg<7>(Invoke(SetSessionHandleToOne)));
   EXPECT_CALL(mock_library, CreateFilter)
       .WillOnce(WithArg<1>(Invoke(SetFilterHandleToOne)));
   EXPECT_CALL(mock_library, CloseHandle)
@@ -140,6 +144,8 @@ TEST(DeviceEnumerationTests, SysCfgApiInstalledAndNoDevicesPresent_EnumerateDevi
   NiceMock<ni::tests::utilities::SysCfgMockLibrary> mock_library;
   grpc::nidevice::DeviceEnumerator device_enumerator(&mock_library);
   google::protobuf::RepeatedPtrField<grpc::nidevice::DeviceProperties> devices;
+  EXPECT_CALL(mock_library, InitializeSession)
+      .WillOnce(WithArg<7>(Invoke(SetSessionHandleToOne)));
   EXPECT_CALL(mock_library, NextResource)
       .WillOnce(Return(NISysCfg_EndOfEnum));
 
@@ -168,6 +174,8 @@ TEST(DeviceEnumerationTests, LocalHostContainsNonNiDevices_EnumerateDevices_List
   NiceMock<ni::tests::utilities::SysCfgMockLibrary> mock_library;
   grpc::nidevice::DeviceEnumerator device_enumerator(&mock_library);
   google::protobuf::RepeatedPtrField<grpc::nidevice::DeviceProperties> devices;
+  EXPECT_CALL(mock_library, InitializeSession)
+      .WillOnce(WithArg<7>(Invoke(SetSessionHandleToOne)));
   EXPECT_CALL(mock_library, NextResource)
       .WillOnce(Return(NISysCfg_OK))
       .WillOnce(Return(NISysCfg_OK))
@@ -196,6 +204,8 @@ TEST(DeviceEnumerationTests, LocalHostContainsNetworkDevice_EnumerateDevices_Lis
   NiceMock<ni::tests::utilities::SysCfgMockLibrary> mock_library;
   grpc::nidevice::DeviceEnumerator device_enumerator(&mock_library);
   google::protobuf::RepeatedPtrField<grpc::nidevice::DeviceProperties> devices;
+  EXPECT_CALL(mock_library, InitializeSession)
+      .WillOnce(WithArg<7>(Invoke(SetSessionHandleToOne)));
   EXPECT_CALL(mock_library, NextResource)
       .WillOnce(Return(NISysCfg_OK))
       .WillOnce(Return(NISysCfg_EndOfEnum));
@@ -217,6 +227,8 @@ TEST(DeviceEnumerationTests, GetResourcePropertyApisReturnError_EnumerateDevices
   NiceMock<ni::tests::utilities::SysCfgMockLibrary> mock_library;
   grpc::nidevice::DeviceEnumerator device_enumerator(&mock_library);
   google::protobuf::RepeatedPtrField<grpc::nidevice::DeviceProperties> devices;
+  EXPECT_CALL(mock_library, InitializeSession)
+      .WillOnce(WithArg<7>(Invoke(SetSessionHandleToOne)));
   EXPECT_CALL(mock_library, NextResource)
       .WillOnce(Return(NISysCfg_OK))
       .WillOnce(Return(NISysCfg_EndOfEnum));
@@ -234,6 +246,19 @@ TEST(DeviceEnumerationTests, GetResourcePropertyApisReturnError_EnumerateDevices
   EXPECT_EQ("", devices.Get(0).name());
   EXPECT_EQ("", devices.Get(0).model());
   EXPECT_EQ("", devices.Get(0).serial_number());
+}
+
+TEST(DeviceEnumerationTests, NISysCfgLibraryIsLoaded_DeviceEnumeration_InitializeSysCfgSessionWithTrueReturnsValidSession)
+{
+    NiceMock<ni::tests::utilities::SysCfgMockLibrary> mock_library;
+    grpc::nidevice::DeviceEnumerator device_enumerator(&mock_library);
+    google::protobuf::RepeatedPtrField<grpc::nidevice::DeviceProperties> devices;
+    EXPECT_CALL(mock_library, InitializeSession)
+        .WillOnce(WithArg<7>(Invoke(SetSessionHandleToOne)));
+
+    NISysCfgSessionHandle  session_handle = device_enumerator.get_syscfg_session(true);
+
+    EXPECT_NE(nullptr, session_handle);
 }
 
 }  // namespace unit


### PR DESCRIPTION
# Justification
In order to speed up the performance of accessing NISysCfgSession, we can cache the NISysCfgSession handle.

Following will be the features:
1. NISysCfgSession handle will be initialized if null or if is explicitly called to be initialized by setting reinitialize variable to true.
2. If NISysCfgSession handle is not null or has been called with reinitialize false which is default behavior, it will return the cached NISysCfgSession handle.
3. get_syscfg_session(bool reinitialize = false) method can be called by others to get the cached NISysCfgSession handle.
4. clear_sysconfig_session() is called to clear cache.

Comments from initial draft [PR](https://github.com/ni/grpc-device/pull/120) fixed in this PR.
# Implementation

1. Device Enumerator deals with handling NISysCfgSession objects and providing necessary features. So we can keep the NISysCfgSession cache object within Device Enumerator class.
2. Session Utilities Service when calling ResetServer will call Device Enumerator 's clear_sysconfig_session method to clear the existing cached handle.


# Testing
1. Added NISysCfgLibraryIsLoaded_DeviceEnumeration_InitializeSysCfgSessionWithTrueReturnsValidSession
2. Added SysCfgLibraryPresent_EnumerateDevices_ReturnsSuccessfullyUsingCachedSession