### PR TITLE
[Owners] [Tiny] Showing message for no devices connected to localhost (device enumeration example)

### DIFF
--- a/examples/session/enumerate-device.py
+++ b/examples/session/enumerate-device.py
@@ -22,8 +22,8 @@ import session_pb2_grpc as grpc_session
 
 # Helper to print the devices 
 def print_devices(devices) :
-    if len(devices) == 0:
-        print("Currently no devices are connected to the server machine.")
+    if not devices:
+        print("No devices are connected.")
         return
     print("\n-----------------------------------------------------------------------------------------------------\n")
     print("  List of devices connected to the server: \n")


### PR DESCRIPTION
# Justification
Showing proper message when list of devices is empty.

# Implementation
The devices parameter is an instance of RepeatedCompositeFieldContainer. That container did not have empty method. So checking for len of devices being 0 and displaying the message as shown below:

![no devices](https://user-images.githubusercontent.com/77618357/111773444-30e9b900-88d4-11eb-8ed7-c50b26c4edfb.PNG)


# Testing
Manually verified
