### PR TITLE
[Owners] Create download section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ For more detailed information on the server and API design refer to the [wiki](h
 
 ### Download the Server
 1. Navigate to the [Releases](https://github.com/ni/grpc-device/releases)
-2. Download the latest Server Release `.tar.gz` or `.zip` for the desired platform.
-3. Extract the contents of the `.tar.gz` or `.zip` to a directory with read and write permissions.
+2. Download the latest Server Release `.tgz` or `.zip` for the desired platform.
+3. Extract the contents of the `.tgz` or `.zip` to a directory with read and write permissions.
 4. [Run the server](#running-the-grpc-server)
 
 ### Download the Client Files


### PR DESCRIPTION
# Justification
The purpose of this is to add a placeholder for installation instructions in the readme.

See [this thread in Teams](https://teams.microsoft.com/l/message/19:ece6acb612224f7ba63953b92a16b42f@thread.skype/1616127076293?tenantId=87ba1f9a-44cd-43a6-b008-6fdb45a5204e&groupId=a75d3b19-c24b-4bc8-866d-a6c1a703b3fd&parentMessageId=1615953055424&teamName=HW%20Configuration%20Domain&channelName=HW%20Config%20Bock&createdTime=1616127076293).
