### PR TITLE
[Peer Review] Update LICENSE to show up as MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,6 @@
 MIT License
 
 Copyright (c) 2021 National Instruments Corp.
-NI-Digital Pattern Driver, NI-DMM, NI-DCPower, NI-FGEN, NI-SCOPE, NI-SWITCH, NI Switch Executive,
-NI-ModInst, NI-TClk are trademarks of National Instruments.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
# Justification
The license link in the right rail of the repo doesn't show up as an MIT License:
![image](https://user-images.githubusercontent.com/77176215/112046985-ad6dd900-8b1a-11eb-810e-81a8c7213b91.png)

It also doesn't appear in the repo's short description linked from the NI organization.
![image](https://user-images.githubusercontent.com/77176215/112047068-c8d8e400-8b1a-11eb-978c-40f7c68a4d2d.png)

# Implementation
I believe this is because of the extra blurb added to the LICENSE file about NI-SCOPE, NI-SWITCH, etc. trademarks.
Removing that blurb to have GitHub recognize the license as a proper MIT License. This update makes our LICENSE match other NI repositories with the MIT license.

# Testing
Will have to see when it is pushed into main.
