### PR TITLE
[Owners] Updating CMake to search for python3 instead of assuming default python version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,14 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 #----------------------------------------------------------------------
+# Find python3 for the build system
+#----------------------------------------------------------------------
+find_package(Python3 COMPONENTS Interpreter)
+if(NOT ${Python3_FOUND})
+  message(WARNING "Python3 not found. Python3 is required for code generation.")
+endif()
+
+#----------------------------------------------------------------------
 # Include generated *.pb.h files
 #----------------------------------------------------------------------
 set(proto_srcs_dir "${CMAKE_CURRENT_BINARY_DIR}/proto")
@@ -91,7 +99,7 @@ foreach(api ${nidrivers})
     ${service_output_dir}/${api}/${api}.proto
     ${service_output_dir}/${api}/${api}_service.cpp
     ${service_output_dir}/${api}/${api}_service.h)
-  set(gen_command COMMAND python ${codegen_dir}/generate_service.py ${metadata_dir}/${api}/ -o ${service_output_dir}/)
+  set(gen_command COMMAND ${Python3_EXECUTABLE} ${codegen_dir}/generate_service.py ${metadata_dir}/${api}/ -o ${service_output_dir}/)
   if (NOT api STREQUAL "nifake")
     set(nidriver_service_srcs
       ${nidriver_service_srcs}


### PR DESCRIPTION
# Justification
If a user has a different version of python as the default, our build will fail. Some OSes and systems require a different default version of python for everything to play nicely, and users shouldn't have to change their defaults just to build our binaries. This change makes it so that CMake takes care of finding python3. 

# Implementation
- Added FindPython3 functionality through CMake's `find_package` command.

# Testing
Built on Ubuntu with different default versions of python. In both cases, python3 was correctly used by the build. The following output was seen during configuration:
```bash
-- Found Python3: /usr/bin/python3.8 (found version "3.8.5") found components: Interpreter 
```
