### PR TITLE
[Owners] Change tar extension for release files in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ There are two ways to start the server:
     
     `.\ni_grpc_device_server.exe`
     
-   **Note:** It is also possible to start the server by double-clicking the executable. Starting the server through a command prompt, however, allows for observation of startup errors.
+   **Note:** It is also possible to start the server by double-clicking the executable. Starting the server through a command prompt, however, allows for observation of [startup errors](#common-server-startup-errors).
    
     **Linux and Linux RT**
     


### PR DESCRIPTION
### What does this Pull Request accomplish?

1. Change the `.tgz` extension to `.tar.gz` for references to release files. 
2. Use actual filenames for client release files
3. Implement PO feedback on launching server via double-click of EXE

