### PR TITLE
[Owners] Updating Desktop Builds to use Ubuntu 16.04

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -112,8 +112,9 @@ jobs:
       if: "(github.ref == 'refs/heads/main') && (runner.os == 'Linux')"
       run: >-
         tar -cvf ni-grpc-device-server-linux-glibc2_23.tar
-        ${GITHUB_WORKSPACE}/build/ni_grpc_device_server
-        ${GITHUB_WORKSPACE}/build/server_config.json
+        -C ${GITHUB_WORKSPACE}/build
+        ni_grpc_device_server
+        server_config.json
 
     - name: Upload Linux Server Binaries Artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -23,13 +23,13 @@ jobs:
         - {
             name: "Windows Build", artifact: "Windows.tar.xz",
             os: windows-latest,
-            build_type: "Release", cc: "gcc", cxx: "g++",
+            build_type: "Release", cc: "gcc-9", cxx: "g++-9",
             cmake_platform: "-A x64"
           }
         - {
             name: "Ubuntu Build", artifact: "Linux.tar.xz",
-            os: ubuntu-latest,
-            build_type: "Release", cc: "gcc", cxx: "g++",
+            os: ubuntu-16.04,
+            build_type: "Release", cc: "gcc-9", cxx: "g++-9",
             cmake_platform: ""
           }
 
@@ -107,3 +107,18 @@ jobs:
         if (NOT result EQUAL 0)
             message(FATAL_ERROR "Running tests failed!")
         endif()
+
+    - name: Tar Linux Server Binaries
+      if: "(github.ref == 'refs/heads/main') && (runner.os == 'Linux')"
+      run: >-
+        tar -cvf ni-grpc-device-server-linux-glibc2_23.tar
+        ${GITHUB_WORKSPACE}/build/ni_grpc_device_server
+        ${GITHUB_WORKSPACE}/build/server_config.json
+
+    - name: Upload Linux Server Binaries Artifact
+      uses: actions/upload-artifact@v2
+      if: "(github.ref == 'refs/heads/main') && (runner.os == 'Linux')"
+      with:
+        name: ni-grpc-device-server-linux-glibc2_23
+        path: ni-grpc-device-server-linux-glibc2_23.tar
+        retention-days: 5

--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -137,15 +137,15 @@ jobs:
       if: "github.ref == 'refs/heads/main'"
       run: >-
         tar -cvf NILinuxRealTime-x86_64.tar
-        ${GITHUB_WORKSPACE}/build/certs/
-        ${GITHUB_WORKSPACE}/build/ni_grpc_device_server
-        ${GITHUB_WORKSPACE}/build/CTestTestfile.cmake
-        ${GITHUB_WORKSPACE}/build/IntegrationTestsRunner
-        ${GITHUB_WORKSPACE}/build/libTestApi.so
-        ${GITHUB_WORKSPACE}/build/server_config.json
-        ${GITHUB_WORKSPACE}/build/SystemTestsRunner
-        ${GITHUB_WORKSPACE}/build/test_mutual_tls_config.json
-        ${GITHUB_WORKSPACE}/build/UnitTestsRunner
+        -C ${GITHUB_WORKSPACE}/build
+        certs/
+        ni_grpc_device_server
+        IntegrationTestsRunner
+        libTestApi.so
+        server_config.json
+        SystemTestsRunner
+        test_mutual_tls_config.json
+        UnitTestsRunner
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Updates our Linux Desktop builds to use the Ubuntu 16.04 runners. 
- Explicitly use gcc-9 which is the version we've been using so far
- Adds steps to upload the server and config file as an artifact for Linux Desktop workflows in main (e.g., merges)

### Why should this Pull Request be merged?

Due to GLIBC compatibility issues, we should build on an older LTS version of Ubuntu instead of 20.04. This should help alleviate compatibility issues as newer GLIBC versions are backwards compatible. Additionally, uploading the artifact built on these systems helps ensure that any testing we do uses the exports of our build. 

### What testing has been done?

This requires a workflow run to validate. That is, the completion of a workflow should indicate success.