### PR TITLE
[Owners] Cherry pick custom scope service fixes to releases/1.0 branch.

### DIFF
--- a/source/custom/niscope_service.custom.cpp
+++ b/source/custom/niscope_service.custom.cpp
@@ -455,7 +455,7 @@ void CheckStatus(int status)
     std::vector<niScope_coefficientInfo> coefficient_info(number_of_coefficient_sets, niScope_coefficientInfo());
     auto status = library_->GetNormalizationCoefficients(vi, channel_list, coefficient_info.size(), coefficient_info.data(), &number_of_coefficient_sets);
     response->set_status(status);
-    if (status != 0) {
+    if (status == 0) {
       response->set_number_of_coefficient_sets(number_of_coefficient_sets);
       Copy(coefficient_info, response->mutable_coefficient_info());
     }
@@ -488,7 +488,7 @@ void CheckStatus(int status)
     std::vector<niScope_coefficientInfo> coefficient_info(number_of_coefficient_sets, niScope_coefficientInfo());
     auto status = library_->GetScalingCoefficients(vi, channel_list, coefficient_info.size(), coefficient_info.data(), &number_of_coefficient_sets);
     response->set_status(status);
-    if (status != 0) {
+    if (status == 0) {
       response->set_number_of_coefficient_sets(number_of_coefficient_sets);
       Copy(coefficient_info, response->mutable_coefficient_info());
     }

--- a/source/tests/system/niscope_driver_api_tests.cpp
+++ b/source/tests/system/niscope_driver_api_tests.cpp
@@ -497,6 +497,46 @@ TEST_F(NiScopeDriverApiTest, NiScopeConfigureVertical_SendRequest_ConfigureCompl
   expect_api_success(response.status());
 }
 
+TEST_F(NiScopeDriverApiTest, NiScopeGetScalingCoefficients_SendRequest_NonZeroCoefficientsReturned)
+{
+  auto_setup();
+  ::grpc::ClientContext context;
+  scope::GetScalingCoefficientsRequest request;
+  request.mutable_vi()->set_id(GetSessionId());
+  request.set_channel_list("0, 1");
+  scope::GetScalingCoefficientsResponse response;
+
+  ::grpc::Status status = GetStub()->GetScalingCoefficients(&context, request, &response);
+
+  EXPECT_TRUE(status.ok());
+  expect_api_success(response.status());
+  EXPECT_EQ(2, response.coefficient_info_size());
+  EXPECT_EQ(0, response.coefficient_info(0).offset());
+  EXPECT_NE(0, response.coefficient_info(0).gain());
+  EXPECT_EQ(0, response.coefficient_info(0).reserved1());
+  EXPECT_EQ(0, response.coefficient_info(0).reserved2());
+}
+
+TEST_F(NiScopeDriverApiTest, NiScopeGetNormalizationCoefficients_SendRequest_NonZeroCoefficientsReturned)
+{
+  auto_setup();
+  ::grpc::ClientContext context;
+  scope::GetNormalizationCoefficientsRequest request;
+  request.mutable_vi()->set_id(GetSessionId());
+  request.set_channel_list("0, 1");
+  scope::GetNormalizationCoefficientsResponse response;
+
+  ::grpc::Status status = GetStub()->GetNormalizationCoefficients(&context, request, &response);
+
+  EXPECT_TRUE(status.ok());
+  expect_api_success(response.status());
+  EXPECT_EQ(2, response.coefficient_info_size());
+  EXPECT_EQ(0, response.coefficient_info(0).offset());
+  EXPECT_NE(0, response.coefficient_info(0).gain());
+  EXPECT_EQ(0, response.coefficient_info(0).reserved1());
+  EXPECT_EQ(0, response.coefficient_info(0).reserved2());
+}
+
 }  // namespace system
 }  // namespace tests
 }  // namespace ni


### PR DESCRIPTION
### What does this Pull Request accomplish?

Cherry-picks commit [65a3e7fd927](https://github.com/ni/grpc-device/commit/65a3e7fd927e8419578c102d9d8b4e921f570886) from main into the releases/1.0 branch.

### Why should this Pull Request be merged?

These changes fix the status check on `GetNormalizationCoefficients` and `GetScalingCoefficients` so that it sets the output fields on the response message upon success instead of upon failure.

Also, the releases/1.0 branch will be used to create a 1.0.1 Release to incorporate this bug fix.

### What testing has been done?

Build and tests pass locally.