### PR TITLE
Add MeasureEx

### DIFF
--- a/generated/nisync/nisync.proto
+++ b/generated/nisync/nisync.proto
@@ -25,6 +25,7 @@ service NiSync {
   rpc DisconnectSWTrigFromTerminal(DisconnectSWTrigFromTerminalRequest) returns (DisconnectSWTrigFromTerminalResponse);
   rpc ConnectTrigTerminals(ConnectTrigTerminalsRequest) returns (ConnectTrigTerminalsResponse);
   rpc DisconnectTrigTerminals(DisconnectTrigTerminalsRequest) returns (DisconnectTrigTerminalsResponse);
+  rpc MeasureFrequencyEx(MeasureFrequencyExRequest) returns (MeasureFrequencyExResponse);
   rpc GetAttributeViInt32(GetAttributeViInt32Request) returns (GetAttributeViInt32Response);
   rpc SetAttributeViInt32(SetAttributeViInt32Request) returns (SetAttributeViInt32Response);
   rpc GetAttributeViString(GetAttributeViStringRequest) returns (GetAttributeViStringResponse);
@@ -236,6 +237,20 @@ message DisconnectTrigTerminalsRequest {
 
 message DisconnectTrigTerminalsResponse {
   int32 status = 1;
+}
+
+message MeasureFrequencyExRequest {
+  nidevice_grpc.Session vi = 1;
+  string src_terminal = 2;
+  double duration = 3;
+  uint32 decimation_count = 4;
+}
+
+message MeasureFrequencyExResponse {
+  int32 status = 1;
+  double actual_duration = 2;
+  double frequency = 3;
+  double frequency_error = 4;
 }
 
 message GetAttributeViInt32Request {

--- a/generated/nisync/nisync_library.cpp
+++ b/generated/nisync/nisync_library.cpp
@@ -30,6 +30,7 @@ NiSyncLibrary::NiSyncLibrary() : shared_library_(kLibraryName)
   function_pointers_.DisconnectSWTrigFromTerminal = reinterpret_cast<DisconnectSWTrigFromTerminalPtr>(shared_library_.get_function_pointer("niSync_DisconnectSWTrigFromTerminal"));
   function_pointers_.ConnectTrigTerminals = reinterpret_cast<ConnectTrigTerminalsPtr>(shared_library_.get_function_pointer("niSync_ConnectTrigTerminals"));
   function_pointers_.DisconnectTrigTerminals = reinterpret_cast<DisconnectTrigTerminalsPtr>(shared_library_.get_function_pointer("niSync_DisconnectTrigTerminals"));
+  function_pointers_.MeasureFrequencyEx = reinterpret_cast<MeasureFrequencyExPtr>(shared_library_.get_function_pointer("niSync_MeasureFrequencyEx"));
   function_pointers_.GetAttributeViInt32 = reinterpret_cast<GetAttributeViInt32Ptr>(shared_library_.get_function_pointer("niSync_GetAttributeViInt32"));
   function_pointers_.SetAttributeViInt32 = reinterpret_cast<SetAttributeViInt32Ptr>(shared_library_.get_function_pointer("niSync_SetAttributeViInt32"));
   function_pointers_.GetAttributeViString = reinterpret_cast<GetAttributeViStringPtr>(shared_library_.get_function_pointer("niSync_GetAttributeViString"));
@@ -152,6 +153,18 @@ ViStatus NiSyncLibrary::DisconnectTrigTerminals(ViSession vi, ViConstString srcT
   return niSync_DisconnectTrigTerminals(vi, srcTerminal, destTerminal);
 #else
   return function_pointers_.DisconnectTrigTerminals(vi, srcTerminal, destTerminal);
+#endif
+}
+
+ViStatus NiSyncLibrary::MeasureFrequencyEx(ViSession vi, ViConstString srcTerminal, ViReal64 duration, ViUInt32 decimationCount, ViReal64* actualDuration, ViReal64* frequency, ViReal64* frequencyError)
+{
+  if (!function_pointers_.MeasureFrequencyEx) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niSync_MeasureFrequencyEx.");
+  }
+#if defined(_MSC_VER)
+  return niSync_MeasureFrequencyEx(vi, srcTerminal, duration, decimationCount, actualDuration, frequency, frequencyError);
+#else
+  return function_pointers_.MeasureFrequencyEx(vi, srcTerminal, duration, decimationCount, actualDuration, frequency, frequencyError);
 #endif
 }
 

--- a/generated/nisync/nisync_library.h
+++ b/generated/nisync/nisync_library.h
@@ -27,6 +27,7 @@ class NiSyncLibrary : public nisync_grpc::NiSyncLibraryInterface {
   ViStatus DisconnectSWTrigFromTerminal(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal);
   ViStatus ConnectTrigTerminals(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal, ViConstString syncClock, ViInt32 invert, ViInt32 updateEdge);
   ViStatus DisconnectTrigTerminals(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal);
+  ViStatus MeasureFrequencyEx(ViSession vi, ViConstString srcTerminal, ViReal64 duration, ViUInt32 decimationCount, ViReal64* actualDuration, ViReal64* frequency, ViReal64* frequencyError);
   ViStatus GetAttributeViInt32(ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32* value);
   ViStatus SetAttributeViInt32(ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32 value);
   ViStatus GetAttributeViString(ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32 bufferSize, ViChar value[]);
@@ -42,6 +43,7 @@ class NiSyncLibrary : public nisync_grpc::NiSyncLibraryInterface {
   using DisconnectSWTrigFromTerminalPtr = ViStatus (*)(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal);
   using ConnectTrigTerminalsPtr = ViStatus (*)(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal, ViConstString syncClock, ViInt32 invert, ViInt32 updateEdge);
   using DisconnectTrigTerminalsPtr = ViStatus (*)(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal);
+  using MeasureFrequencyExPtr = ViStatus (*)(ViSession vi, ViConstString srcTerminal, ViReal64 duration, ViUInt32 decimationCount, ViReal64* actualDuration, ViReal64* frequency, ViReal64* frequencyError);
   using GetAttributeViInt32Ptr = ViStatus (*)(ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32* value);
   using SetAttributeViInt32Ptr = ViStatus (*)(ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32 value);
   using GetAttributeViStringPtr = ViStatus (*)(ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32 bufferSize, ViChar value[]);
@@ -57,6 +59,7 @@ class NiSyncLibrary : public nisync_grpc::NiSyncLibraryInterface {
     DisconnectSWTrigFromTerminalPtr DisconnectSWTrigFromTerminal;
     ConnectTrigTerminalsPtr ConnectTrigTerminals;
     DisconnectTrigTerminalsPtr DisconnectTrigTerminals;
+    MeasureFrequencyExPtr MeasureFrequencyEx;
     GetAttributeViInt32Ptr GetAttributeViInt32;
     SetAttributeViInt32Ptr SetAttributeViInt32;
     GetAttributeViStringPtr GetAttributeViString;

--- a/generated/nisync/nisync_library_interface.h
+++ b/generated/nisync/nisync_library_interface.h
@@ -24,6 +24,7 @@ class NiSyncLibraryInterface {
   virtual ViStatus DisconnectSWTrigFromTerminal(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal) = 0;
   virtual ViStatus ConnectTrigTerminals(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal, ViConstString syncClock, ViInt32 invert, ViInt32 updateEdge) = 0;
   virtual ViStatus DisconnectTrigTerminals(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal) = 0;
+  virtual ViStatus MeasureFrequencyEx(ViSession vi, ViConstString srcTerminal, ViReal64 duration, ViUInt32 decimationCount, ViReal64* actualDuration, ViReal64* frequency, ViReal64* frequencyError) = 0;
   virtual ViStatus GetAttributeViInt32(ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32* value) = 0;
   virtual ViStatus SetAttributeViInt32(ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32 value) = 0;
   virtual ViStatus GetAttributeViString(ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32 bufferSize, ViChar value[]) = 0;

--- a/generated/nisync/nisync_mock_library.h
+++ b/generated/nisync/nisync_mock_library.h
@@ -26,6 +26,7 @@ class NiSyncMockLibrary : public nisync_grpc::NiSyncLibraryInterface {
   MOCK_METHOD(ViStatus, DisconnectSWTrigFromTerminal, (ViSession vi, ViConstString srcTerminal, ViConstString destTerminal), (override));
   MOCK_METHOD(ViStatus, ConnectTrigTerminals, (ViSession vi, ViConstString srcTerminal, ViConstString destTerminal, ViConstString syncClock, ViInt32 invert, ViInt32 updateEdge), (override));
   MOCK_METHOD(ViStatus, DisconnectTrigTerminals, (ViSession vi, ViConstString srcTerminal, ViConstString destTerminal), (override));
+  MOCK_METHOD(ViStatus, MeasureFrequencyEx, (ViSession vi, ViConstString srcTerminal, ViReal64 duration, ViUInt32 decimationCount, ViReal64* actualDuration, ViReal64* frequency, ViReal64* frequencyError), (override));
   MOCK_METHOD(ViStatus, GetAttributeViInt32, (ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32* value), (override));
   MOCK_METHOD(ViStatus, SetAttributeViInt32, (ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32 value), (override));
   MOCK_METHOD(ViStatus, GetAttributeViString, (ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32 bufferSize, ViChar value[]), (override));

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -228,6 +228,36 @@ namespace nisync_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiSyncService::MeasureFrequencyEx(::grpc::ServerContext* context, const MeasureFrequencyExRequest* request, MeasureFrequencyExResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViConstString src_terminal = request->src_terminal().c_str();
+      ViReal64 duration = request->duration();
+      ViUInt32 decimation_count = request->decimation_count();
+      ViReal64 actual_duration {};
+      ViReal64 frequency {};
+      ViReal64 frequency_error {};
+      auto status = library_->MeasureFrequencyEx(vi, src_terminal, duration, decimation_count, &actual_duration, &frequency, &frequency_error);
+      response->set_status(status);
+      if (status == 0) {
+        response->set_actual_duration(actual_duration);
+        response->set_frequency(frequency);
+        response->set_frequency_error(frequency_error);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiSyncService::GetAttributeViInt32(::grpc::ServerContext* context, const GetAttributeViInt32Request* request, GetAttributeViInt32Response* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nisync/nisync_service.h
+++ b/generated/nisync/nisync_service.h
@@ -33,6 +33,7 @@ public:
   ::grpc::Status DisconnectSWTrigFromTerminal(::grpc::ServerContext* context, const DisconnectSWTrigFromTerminalRequest* request, DisconnectSWTrigFromTerminalResponse* response) override;
   ::grpc::Status ConnectTrigTerminals(::grpc::ServerContext* context, const ConnectTrigTerminalsRequest* request, ConnectTrigTerminalsResponse* response) override;
   ::grpc::Status DisconnectTrigTerminals(::grpc::ServerContext* context, const DisconnectTrigTerminalsRequest* request, DisconnectTrigTerminalsResponse* response) override;
+  ::grpc::Status MeasureFrequencyEx(::grpc::ServerContext* context, const MeasureFrequencyExRequest* request, MeasureFrequencyExResponse* response) override;
   ::grpc::Status GetAttributeViInt32(::grpc::ServerContext* context, const GetAttributeViInt32Request* request, GetAttributeViInt32Response* response) override;
   ::grpc::Status SetAttributeViInt32(::grpc::ServerContext* context, const SetAttributeViInt32Request* request, SetAttributeViInt32Response* response) override;
   ::grpc::Status GetAttributeViString(::grpc::ServerContext* context, const GetAttributeViStringRequest* request, GetAttributeViStringResponse* response) override;

--- a/source/codegen/metadata/nisync/functions.py
+++ b/source/codegen/metadata/nisync/functions.py
@@ -186,6 +186,46 @@ functions = {
         ],
         "returns": "ViStatus"
     },
+    "MeasureFrequencyEx": {
+        "parameters": [
+            {
+                "direction": "in",
+                "name": "vi",
+                "type": "ViSession"
+            },
+            {
+                "direction": "in",
+                "name": "srcTerminal",
+                "type": "ViConstString"
+            },
+            {
+                "direction": "in",
+                "name": "duration",
+                "type": "ViReal64"
+            },
+            {
+                "direction": "in",
+                "name": "decimationCount",
+                "type": "ViUInt32"
+            },
+            {
+                "direction": "out",
+                "name": "actualDuration",
+                "type": "ViReal64"
+            },
+            {
+                "direction": "out",
+                "name": "frequency",
+                "type": "ViReal64"
+            },
+            {
+                "direction": "out",
+                "name": "frequencyError",
+                "type": "ViReal64"
+            }
+        ],
+        "returns": "ViStatus"
+    },    
     "GetAttributeViInt32": {
         "parameters": [
             {

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -557,17 +557,34 @@ TEST_F(NiSyncDriverApiTest, AttributeSet_GetAttributeViString_ReturnsValue)
   EXPECT_STREQ(expectedValue, value.c_str());
 }
 
-TEST_F(NiSyncDriverApiTest, MeasureFrequencyEx_ReturnsSuccess)
+TEST_F(NiSyncDriverApiTest, MeasureFrequencyExOnTerminalWithNoFrequency_ReturnsNoFrequency)
 {
   ViStatus viStatus;
   ViConstString srcTerminal = NISYNC_VAL_PFI0;
-  ViReal64 duration = 1; // duration is in seconds
+  ViReal64 duration = 0.1; // duration is in seconds
   ViUInt32 decimationCount = 0; // ignored for 6674
   ViReal64 actualDuration, frequency, frequencyError;
   auto grpcStatus = call_MeasureFrequencyEx(srcTerminal, duration, decimationCount, &actualDuration, &frequency, &frequencyError, &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
+  EXPECT_EQ(0, actualDuration);
+  EXPECT_EQ(0, frequency);
+}
+
+TEST_F(NiSyncDriverApiTest, MeasureFrequencyExOnOscillatorWithFrequency_ReturnsFrequency)
+{
+  ViStatus viStatus;
+  ViConstString srcTerminal = NISYNC_VAL_OSCILLATOR;
+  ViReal64 duration = 0.1; // duration is in seconds
+  ViUInt32 decimationCount = 0; // ignored for 6674
+  ViReal64 actualDuration, frequency, frequencyError;
+  auto grpcStatus = call_MeasureFrequencyEx(srcTerminal, duration, decimationCount, &actualDuration, &frequency, &frequencyError, &viStatus);
+
+  EXPECT_TRUE(grpcStatus.ok());
+  EXPECT_EQ(VI_SUCCESS, viStatus);
+  EXPECT_GT(actualDuration, 0);  
+  EXPECT_GT(frequency, 0);
 }
 
 }  // namespace system

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -249,7 +249,14 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_MeasureFrequencyEx(ViConstString srcTerminal, ViReal64 duration, ViUInt32 decimationCount, ViReal64* actualDurationOut, ViReal64* frequencyOut, ViReal64* frequencyErrorOut, ViStatus* viStatusOut)
+  ::grpc::Status call_MeasureFrequencyEx(
+     ViConstString srcTerminal,
+     ViReal64 duration,
+     ViUInt32 decimationCount,
+     ViReal64* actualDurationOut,
+     ViReal64* frequencyOut,
+     ViReal64* frequencyErrorOut,
+     ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::MeasureFrequencyExRequest request;

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -656,7 +656,49 @@ TEST_F(NiSyncDriverApiTest, AttributeSet_GetAttributeViReal64_ReturnsValue)
   EXPECT_DOUBLE_EQ(expectedValue, value);
 }
 
+TEST_F(NiSyncDriverApiTest, MeasureFrequencyExOnTerminalWithNoFrequency_ReturnsNoFrequency)
+{
+  ViStatus viStatus;
+  ViConstString srcTerminal = NISYNC_VAL_PFI0;
+  ViReal64 duration = 0.1; // duration is in seconds
+  ViUInt32 decimationCount = 0; // ignored for 6674
+  ViReal64 actualDuration, frequency, frequencyError;
+  auto grpcStatus = call_MeasureFrequencyEx(
+     srcTerminal, 
+     duration, 
+     decimationCount, 
+     &actualDuration, 
+     &frequency, 
+     &frequencyError, 
+     &viStatus);
 
+  EXPECT_TRUE(grpcStatus.ok());
+  EXPECT_EQ(VI_SUCCESS, viStatus);
+  EXPECT_EQ(0, actualDuration);
+  EXPECT_EQ(0, frequency);
+}
+
+TEST_F(NiSyncDriverApiTest, MeasureFrequencyExOnOscillatorWithFrequency_ReturnsFrequency)
+{
+  ViStatus viStatus;
+  ViConstString srcTerminal = NISYNC_VAL_OSCILLATOR;
+  ViReal64 duration = 0.1; // duration is in seconds
+  ViUInt32 decimationCount = 0; // ignored for 6674
+  ViReal64 actualDuration, frequency, frequencyError;
+  auto grpcStatus = call_MeasureFrequencyEx(
+     srcTerminal, 
+     duration, 
+     decimationCount, 
+     &actualDuration, 
+     &frequency, 
+     &frequencyError, 
+     &viStatus);
+
+  EXPECT_TRUE(grpcStatus.ok());
+  EXPECT_EQ(VI_SUCCESS, viStatus);
+  EXPECT_GT(actualDuration, 0);  
+  EXPECT_GT(frequency, 0);
+}
 
 }  // namespace system
 }  // namespace tests

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -564,7 +564,14 @@ TEST_F(NiSyncDriverApiTest, MeasureFrequencyExOnTerminalWithNoFrequency_ReturnsN
   ViReal64 duration = 0.1; // duration is in seconds
   ViUInt32 decimationCount = 0; // ignored for 6674
   ViReal64 actualDuration, frequency, frequencyError;
-  auto grpcStatus = call_MeasureFrequencyEx(srcTerminal, duration, decimationCount, &actualDuration, &frequency, &frequencyError, &viStatus);
+  auto grpcStatus = call_MeasureFrequencyEx(
+     srcTerminal, 
+     duration, 
+     decimationCount, 
+     &actualDuration, 
+     &frequency, 
+     &frequencyError, 
+     &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
@@ -579,7 +586,14 @@ TEST_F(NiSyncDriverApiTest, MeasureFrequencyExOnOscillatorWithFrequency_ReturnsF
   ViReal64 duration = 0.1; // duration is in seconds
   ViUInt32 decimationCount = 0; // ignored for 6674
   ViReal64 actualDuration, frequency, frequencyError;
-  auto grpcStatus = call_MeasureFrequencyEx(srcTerminal, duration, decimationCount, &actualDuration, &frequency, &frequencyError, &viStatus);
+  auto grpcStatus = call_MeasureFrequencyEx(
+     srcTerminal, 
+     duration, 
+     decimationCount, 
+     &actualDuration, 
+     &frequency, 
+     &frequencyError, 
+     &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add the method `niSync_MeasureFrequencyEx` for the measure test panel for NI-Sync.

### Why should this Pull Request be merged?

Adding methods need for the measure test panel for NI-Sync.

### What testing has been done?

[ RUN      ] NiSyncDriverApiTest.MeasureFrequencyExOnTerminalWithNoFrequency_ReturnsNoFrequency
[       OK ] NiSyncDriverApiTest.MeasureFrequencyExOnTerminalWithNoFrequency_ReturnsNoFrequency (106 ms)
[ RUN      ] NiSyncDriverApiTest.MeasureFrequencyExOnOscillatorWithFrequency_ReturnsFrequency
[       OK ] NiSyncDriverApiTest.MeasureFrequencyExOnOscillatorWithFrequency_ReturnsFrequency (105 ms)
[----------] 18 tests from NiSyncDriverApiTest (750 ms total)
