### PR TITLE
[Peer Review] Add Windows artifact for merges to main

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -126,7 +126,7 @@ jobs:
 
     - name: Upload Windows Server Binaries Artifact
       uses: actions/upload-artifact@v2
-      if: "(runner.os == 'Windows')"
+      if: "(github.ref == 'refs/heads/main') && (runner.os == 'Windows')"
       with:
         name: ni-grpc-device-server-windows
         path: |

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -123,3 +123,13 @@ jobs:
         name: ni-grpc-device-server-linux-glibc2_23
         path: ni-grpc-device-server-linux-glibc2_23.tar
         retention-days: 5
+
+    - name: Upload Windows Server Binaries Artifact
+      uses: actions/upload-artifact@v2
+      if: "(runner.os == 'Windows')"
+      with:
+        name: ni-grpc-device-server-windows
+        path: |
+          build/Release/ni_grpc_device_server.exe
+          build/Release/server_config.json
+        retention-days: 5

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'releases/**'
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
@@ -109,7 +110,7 @@ jobs:
         endif()
 
     - name: Tar Linux Server Binaries
-      if: "(github.ref == 'refs/heads/main') && (runner.os == 'Linux')"
+      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       run: >-
         tar -cvf ni-grpc-device-server-linux-glibc2_23.tar
         -C ${GITHUB_WORKSPACE}/build
@@ -118,7 +119,7 @@ jobs:
 
     - name: Upload Linux Server Binaries Artifact
       uses: actions/upload-artifact@v2
-      if: "(github.ref == 'refs/heads/main') && (runner.os == 'Linux')"
+      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       with:
         name: ni-grpc-device-server-linux-glibc2_23
         path: ni-grpc-device-server-linux-glibc2_23.tar
@@ -126,7 +127,7 @@ jobs:
 
     - name: Upload Windows Server Binaries Artifact
       uses: actions/upload-artifact@v2
-      if: "(github.ref == 'refs/heads/main') && (runner.os == 'Windows')"
+      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}
       with:
         name: ni-grpc-device-server-windows
         path: |

--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'releases/**'
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
@@ -149,7 +150,7 @@ jobs:
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
-      if: "github.ref == 'refs/heads/main'"
+      if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases') }}
       with:
         name: NILinuxRealTime-x86_64
         path: NILinuxRealTime-x86_64.tar


### PR DESCRIPTION
### What does this Pull Request accomplish?
To facilitate releases, this PR adds Windows artifacts containing the server binary any time a merge to main occurs.

### Why should this Pull Request be merged?
To allow usage of the Windows artifacts for incremental usage and creating releases without requiring a local build.

### What testing has been done?
Ran a private workflow to ensure the artifact contains the right files. See [here](https://github.com/ni/grpc-device/actions/runs/808000693). 
