### PR TITLE
Add Get/Set Attribute Methods for sync clock panel

### DIFF
--- a/generated/nisync/nisync.proto
+++ b/generated/nisync/nisync.proto
@@ -29,12 +29,17 @@ service NiSync {
   rpc SetAttributeViInt32(SetAttributeViInt32Request) returns (SetAttributeViInt32Response);
   rpc GetAttributeViString(GetAttributeViStringRequest) returns (GetAttributeViStringResponse);
   rpc SetAttributeViString(SetAttributeViStringRequest) returns (SetAttributeViStringResponse);
+  rpc GetAttributeViBoolean(GetAttributeViBooleanRequest) returns (GetAttributeViBooleanResponse);
+  rpc SetAttributeViBoolean(SetAttributeViBooleanRequest) returns (SetAttributeViBooleanResponse);
+  rpc GetAttributeViReal64(GetAttributeViReal64Request) returns (GetAttributeViReal64Response);
+  rpc SetAttributeViReal64(SetAttributeViReal64Request) returns (SetAttributeViReal64Response);
 }
 
 enum NiSyncAttributes {
   NISYNC_ATTRIBUTE_UNSPECIFIED = 0;
   NISYNC_ATTRIBUTE_INTF_NUM = 1150000;
   NISYNC_ATTRIBUTE_SERIAL_NUM = 1150001;
+  NISYNC_ATTRIBUTE_MODEL_CODE = 1150002;
   NISYNC_ATTRIBUTE_PFI0_THRESHOLD = 1150100;
   NISYNC_ATTRIBUTE_PFI1_THRESHOLD = 1150101;
   NISYNC_ATTRIBUTE_PFI2_THRESHOLD = 1150102;
@@ -279,6 +284,50 @@ message SetAttributeViStringRequest {
 }
 
 message SetAttributeViStringResponse {
+  int32 status = 1;
+}
+
+message GetAttributeViBooleanRequest {
+  nidevice_grpc.Session vi = 1;
+  string active_item = 2;
+  NiSyncAttributes attribute = 3;
+}
+
+message GetAttributeViBooleanResponse {
+  int32 status = 1;
+  bool value = 2;
+}
+
+message SetAttributeViBooleanRequest {
+  nidevice_grpc.Session vi = 1;
+  string active_item = 2;
+  NiSyncAttributes attribute = 3;
+  bool value = 4;
+}
+
+message SetAttributeViBooleanResponse {
+  int32 status = 1;
+}
+
+message GetAttributeViReal64Request {
+  nidevice_grpc.Session vi = 1;
+  string active_item = 2;
+  NiSyncAttributes attribute = 3;
+}
+
+message GetAttributeViReal64Response {
+  int32 status = 1;
+  double value = 2;
+}
+
+message SetAttributeViReal64Request {
+  nidevice_grpc.Session vi = 1;
+  string active_item = 2;
+  NiSyncAttributes attribute = 3;
+  double value = 4;
+}
+
+message SetAttributeViReal64Response {
   int32 status = 1;
 }
 

--- a/generated/nisync/nisync_library.cpp
+++ b/generated/nisync/nisync_library.cpp
@@ -34,6 +34,10 @@ NiSyncLibrary::NiSyncLibrary() : shared_library_(kLibraryName)
   function_pointers_.SetAttributeViInt32 = reinterpret_cast<SetAttributeViInt32Ptr>(shared_library_.get_function_pointer("niSync_SetAttributeViInt32"));
   function_pointers_.GetAttributeViString = reinterpret_cast<GetAttributeViStringPtr>(shared_library_.get_function_pointer("niSync_GetAttributeViString"));
   function_pointers_.SetAttributeViString = reinterpret_cast<SetAttributeViStringPtr>(shared_library_.get_function_pointer("niSync_SetAttributeViString"));
+  function_pointers_.GetAttributeViBoolean = reinterpret_cast<GetAttributeViBooleanPtr>(shared_library_.get_function_pointer("niSync_GetAttributeViBoolean"));
+  function_pointers_.SetAttributeViBoolean = reinterpret_cast<SetAttributeViBooleanPtr>(shared_library_.get_function_pointer("niSync_SetAttributeViBoolean"));
+  function_pointers_.GetAttributeViReal64 = reinterpret_cast<GetAttributeViReal64Ptr>(shared_library_.get_function_pointer("niSync_GetAttributeViReal64"));
+  function_pointers_.SetAttributeViReal64 = reinterpret_cast<SetAttributeViReal64Ptr>(shared_library_.get_function_pointer("niSync_SetAttributeViReal64"));
 }
 
 NiSyncLibrary::~NiSyncLibrary()
@@ -200,6 +204,54 @@ ViStatus NiSyncLibrary::SetAttributeViString(ViSession vi, ViConstString activeI
   return niSync_SetAttributeViString(vi, activeItem, attribute, value);
 #else
   return function_pointers_.SetAttributeViString(vi, activeItem, attribute, value);
+#endif
+}
+
+ViStatus NiSyncLibrary::GetAttributeViBoolean(ViSession vi, ViConstString activeItem, ViAttr attribute, ViBoolean* value)
+{
+  if (!function_pointers_.GetAttributeViBoolean) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niSync_GetAttributeViBoolean.");
+  }
+#if defined(_MSC_VER)
+  return niSync_GetAttributeViBoolean(vi, activeItem, attribute, value);
+#else
+  return function_pointers_.GetAttributeViBoolean(vi, activeItem, attribute, value);
+#endif
+}
+
+ViStatus NiSyncLibrary::SetAttributeViBoolean(ViSession vi, ViConstString activeItem, ViAttr attribute, ViBoolean value)
+{
+  if (!function_pointers_.SetAttributeViBoolean) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niSync_SetAttributeViBoolean.");
+  }
+#if defined(_MSC_VER)
+  return niSync_SetAttributeViBoolean(vi, activeItem, attribute, value);
+#else
+  return function_pointers_.SetAttributeViBoolean(vi, activeItem, attribute, value);
+#endif
+}
+
+ViStatus NiSyncLibrary::GetAttributeViReal64(ViSession vi, ViConstString activeItem, ViAttr attribute, ViReal64* value)
+{
+  if (!function_pointers_.GetAttributeViReal64) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niSync_GetAttributeViReal64.");
+  }
+#if defined(_MSC_VER)
+  return niSync_GetAttributeViReal64(vi, activeItem, attribute, value);
+#else
+  return function_pointers_.GetAttributeViReal64(vi, activeItem, attribute, value);
+#endif
+}
+
+ViStatus NiSyncLibrary::SetAttributeViReal64(ViSession vi, ViConstString activeItem, ViAttr attribute, ViReal64 value)
+{
+  if (!function_pointers_.SetAttributeViReal64) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niSync_SetAttributeViReal64.");
+  }
+#if defined(_MSC_VER)
+  return niSync_SetAttributeViReal64(vi, activeItem, attribute, value);
+#else
+  return function_pointers_.SetAttributeViReal64(vi, activeItem, attribute, value);
 #endif
 }
 

--- a/generated/nisync/nisync_library.h
+++ b/generated/nisync/nisync_library.h
@@ -31,6 +31,10 @@ class NiSyncLibrary : public nisync_grpc::NiSyncLibraryInterface {
   ViStatus SetAttributeViInt32(ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32 value);
   ViStatus GetAttributeViString(ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32 bufferSize, ViChar value[]);
   ViStatus SetAttributeViString(ViSession vi, ViConstString activeItem, ViAttr attribute, ViConstString value);
+  ViStatus GetAttributeViBoolean(ViSession vi, ViConstString activeItem, ViAttr attribute, ViBoolean* value);
+  ViStatus SetAttributeViBoolean(ViSession vi, ViConstString activeItem, ViAttr attribute, ViBoolean value);
+  ViStatus GetAttributeViReal64(ViSession vi, ViConstString activeItem, ViAttr attribute, ViReal64* value);
+  ViStatus SetAttributeViReal64(ViSession vi, ViConstString activeItem, ViAttr attribute, ViReal64 value);
 
  private:
   using initPtr = ViStatus (*)(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi);
@@ -46,6 +50,10 @@ class NiSyncLibrary : public nisync_grpc::NiSyncLibraryInterface {
   using SetAttributeViInt32Ptr = ViStatus (*)(ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32 value);
   using GetAttributeViStringPtr = ViStatus (*)(ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32 bufferSize, ViChar value[]);
   using SetAttributeViStringPtr = ViStatus (*)(ViSession vi, ViConstString activeItem, ViAttr attribute, ViConstString value);
+  using GetAttributeViBooleanPtr = ViStatus (*)(ViSession vi, ViConstString activeItem, ViAttr attribute, ViBoolean* value);
+  using SetAttributeViBooleanPtr = ViStatus (*)(ViSession vi, ViConstString activeItem, ViAttr attribute, ViBoolean value);
+  using GetAttributeViReal64Ptr = ViStatus (*)(ViSession vi, ViConstString activeItem, ViAttr attribute, ViReal64* value);
+  using SetAttributeViReal64Ptr = ViStatus (*)(ViSession vi, ViConstString activeItem, ViAttr attribute, ViReal64 value);
 
   typedef struct FunctionPointers {
     initPtr init;
@@ -61,6 +69,10 @@ class NiSyncLibrary : public nisync_grpc::NiSyncLibraryInterface {
     SetAttributeViInt32Ptr SetAttributeViInt32;
     GetAttributeViStringPtr GetAttributeViString;
     SetAttributeViStringPtr SetAttributeViString;
+    GetAttributeViBooleanPtr GetAttributeViBoolean;
+    SetAttributeViBooleanPtr SetAttributeViBoolean;
+    GetAttributeViReal64Ptr GetAttributeViReal64;
+    SetAttributeViReal64Ptr SetAttributeViReal64;
   } FunctionLoadStatus;
 
   nidevice_grpc::SharedLibrary shared_library_;

--- a/generated/nisync/nisync_library_interface.h
+++ b/generated/nisync/nisync_library_interface.h
@@ -28,6 +28,10 @@ class NiSyncLibraryInterface {
   virtual ViStatus SetAttributeViInt32(ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32 value) = 0;
   virtual ViStatus GetAttributeViString(ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32 bufferSize, ViChar value[]) = 0;
   virtual ViStatus SetAttributeViString(ViSession vi, ViConstString activeItem, ViAttr attribute, ViConstString value) = 0;
+  virtual ViStatus GetAttributeViBoolean(ViSession vi, ViConstString activeItem, ViAttr attribute, ViBoolean* value) = 0;
+  virtual ViStatus SetAttributeViBoolean(ViSession vi, ViConstString activeItem, ViAttr attribute, ViBoolean value) = 0;
+  virtual ViStatus GetAttributeViReal64(ViSession vi, ViConstString activeItem, ViAttr attribute, ViReal64* value) = 0;
+  virtual ViStatus SetAttributeViReal64(ViSession vi, ViConstString activeItem, ViAttr attribute, ViReal64 value) = 0;
 };
 
 }  // namespace nisync_grpc

--- a/generated/nisync/nisync_mock_library.h
+++ b/generated/nisync/nisync_mock_library.h
@@ -30,6 +30,10 @@ class NiSyncMockLibrary : public nisync_grpc::NiSyncLibraryInterface {
   MOCK_METHOD(ViStatus, SetAttributeViInt32, (ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32 value), (override));
   MOCK_METHOD(ViStatus, GetAttributeViString, (ViSession vi, ViConstString activeItem, ViAttr attribute, ViInt32 bufferSize, ViChar value[]), (override));
   MOCK_METHOD(ViStatus, SetAttributeViString, (ViSession vi, ViConstString activeItem, ViAttr attribute, ViConstString value), (override));
+  MOCK_METHOD(ViStatus, GetAttributeViBoolean, (ViSession vi, ViConstString activeItem, ViAttr attribute, ViBoolean* value), (override));
+  MOCK_METHOD(ViStatus, SetAttributeViBoolean, (ViSession vi, ViConstString activeItem, ViAttr attribute, ViBoolean value), (override));
+  MOCK_METHOD(ViStatus, GetAttributeViReal64, (ViSession vi, ViConstString activeItem, ViAttr attribute, ViReal64* value), (override));
+  MOCK_METHOD(ViStatus, SetAttributeViReal64, (ViSession vi, ViConstString activeItem, ViAttr attribute, ViReal64 value), (override));
 };
 
 }  // namespace unit

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -328,5 +328,99 @@ namespace nisync_grpc {
     }
   }
 
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiSyncService::GetAttributeViBoolean(::grpc::ServerContext* context, const GetAttributeViBooleanRequest* request, GetAttributeViBooleanResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViConstString active_item = request->active_item().c_str();
+      ViAttr attribute = request->attribute();
+      ViBoolean value {};
+      auto status = library_->GetAttributeViBoolean(vi, active_item, attribute, &value);
+      response->set_status(status);
+      if (status == 0) {
+        response->set_value(value);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiSyncService::SetAttributeViBoolean(::grpc::ServerContext* context, const SetAttributeViBooleanRequest* request, SetAttributeViBooleanResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViConstString active_item = request->active_item().c_str();
+      ViAttr attribute = request->attribute();
+      ViBoolean value = request->value();
+      auto status = library_->SetAttributeViBoolean(vi, active_item, attribute, value);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiSyncService::GetAttributeViReal64(::grpc::ServerContext* context, const GetAttributeViReal64Request* request, GetAttributeViReal64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViConstString active_item = request->active_item().c_str();
+      ViAttr attribute = request->attribute();
+      ViReal64 value {};
+      auto status = library_->GetAttributeViReal64(vi, active_item, attribute, &value);
+      response->set_status(status);
+      if (status == 0) {
+        response->set_value(value);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiSyncService::SetAttributeViReal64(::grpc::ServerContext* context, const SetAttributeViReal64Request* request, SetAttributeViReal64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViConstString active_item = request->active_item().c_str();
+      ViAttr attribute = request->attribute();
+      ViReal64 value = request->value();
+      auto status = library_->SetAttributeViReal64(vi, active_item, attribute, value);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
 } // namespace nisync_grpc
 

--- a/generated/nisync/nisync_service.h
+++ b/generated/nisync/nisync_service.h
@@ -37,6 +37,10 @@ public:
   ::grpc::Status SetAttributeViInt32(::grpc::ServerContext* context, const SetAttributeViInt32Request* request, SetAttributeViInt32Response* response) override;
   ::grpc::Status GetAttributeViString(::grpc::ServerContext* context, const GetAttributeViStringRequest* request, GetAttributeViStringResponse* response) override;
   ::grpc::Status SetAttributeViString(::grpc::ServerContext* context, const SetAttributeViStringRequest* request, SetAttributeViStringResponse* response) override;
+  ::grpc::Status GetAttributeViBoolean(::grpc::ServerContext* context, const GetAttributeViBooleanRequest* request, GetAttributeViBooleanResponse* response) override;
+  ::grpc::Status SetAttributeViBoolean(::grpc::ServerContext* context, const SetAttributeViBooleanRequest* request, SetAttributeViBooleanResponse* response) override;
+  ::grpc::Status GetAttributeViReal64(::grpc::ServerContext* context, const GetAttributeViReal64Request* request, GetAttributeViReal64Response* response) override;
+  ::grpc::Status SetAttributeViReal64(::grpc::ServerContext* context, const SetAttributeViReal64Request* request, SetAttributeViReal64Response* response) override;
 private:
   NiSyncLibraryInterface* library_;
   nidevice_grpc::SessionRepository* session_repository_;

--- a/source/codegen/metadata/nisync/CHANGES.md
+++ b/source/codegen/metadata/nisync/CHANGES.md
@@ -27,3 +27,6 @@ Removed the following deprecated attributes.
 - TIMEREF_CLK_ADJ_OFFSET
 - GPS_UTC_OFFSET
 - IRIG_TAI_OFFSET
+
+Added the following internal attribute.
+- MODEL_CODE

--- a/source/codegen/metadata/nisync/attributes.py
+++ b/source/codegen/metadata/nisync/attributes.py
@@ -6,6 +6,9 @@ attributes = {
     1150001: {
         'name': 'SERIAL_NUM'
     },
+    1150002: {
+        'name': 'MODEL_CODE'
+    },
     1150100: {
         'name': 'PFI0_THRESHOLD'
     },

--- a/source/codegen/metadata/nisync/functions.py
+++ b/source/codegen/metadata/nisync/functions.py
@@ -295,4 +295,104 @@ functions = {
         ],
         "returns": "ViStatus"
     },
+    "GetAttributeViBoolean": {
+        "parameters": [
+            {
+                "direction": "in",
+                "name": "vi",
+                "type": "ViSession"
+            },
+            {
+                "direction": "in",
+                "name": "activeItem",
+                "type": "ViConstString"
+            },
+            {
+                "direction": "in",
+                "name": "attribute",
+                "type": "ViAttr"
+            },
+            {
+                "direction": "out",
+                "name": "value",
+                "type": "ViBoolean"
+            }
+        ],
+        "returns": "ViStatus"
+    },
+    "SetAttributeViBoolean": {
+        "parameters": [
+            {
+                "direction": "in",
+                "name": "vi",
+                "type": "ViSession"
+            },
+            {
+                "direction": "in",
+                "name": "activeItem",
+                "type": "ViConstString"
+            },
+            {
+                "direction": "in",
+                "name": "attribute",
+                "type": "ViAttr"
+            },
+            {
+                "direction": "in",
+                "name": "value",
+                "type": "ViBoolean"
+            }
+        ],
+        "returns": "ViStatus"
+    },
+    "GetAttributeViReal64": {
+        "parameters": [
+            {
+                "direction": "in",
+                "name": "vi",
+                "type": "ViSession"
+            },
+            {
+                "direction": "in",
+                "name": "activeItem",
+                "type": "ViConstString"
+            },
+            {
+                "direction": "in",
+                "name": "attribute",
+                "type": "ViAttr"
+            },
+            {
+                "direction": "out",
+                "name": "value",
+                "type": "ViReal64"
+            }
+        ],
+        "returns": "ViStatus"
+    },
+    "SetAttributeViReal64": {
+        "parameters": [
+            {
+                "direction": "in",
+                "name": "vi",
+                "type": "ViSession"
+            },
+            {
+                "direction": "in",
+                "name": "activeItem",
+                "type": "ViConstString"
+            },
+            {
+                "direction": "in",
+                "name": "attribute",
+                "type": "ViAttr"
+            },
+            {
+                "direction": "in",
+                "name": "value",
+                "type": "ViReal64"
+            }
+        ],
+        "returns": "ViStatus"
+    },
 }

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -248,6 +248,62 @@ class NiSyncDriverApiTest : public ::testing::Test {
     *viStatusOut = response.status();
     return grpcStatus;
   }
+ 
+  ::grpc::Status call_SetAttributeViBoolean(ViConstString activeItem, ViAttr attribute, ViBoolean value, ViStatus* viStatusOut)
+  {
+    ::grpc::ClientContext clientContext;
+    nisync::SetAttributeViBooleanRequest request;
+    nisync::SetAttributeViBooleanResponse response;
+    request.set_active_item(activeItem);
+    request.set_attribute(static_cast<nisync::NiSyncAttributes>(attribute));
+    request.set_value(value);
+    request.mutable_vi()->set_id(driver_session_->id());
+    auto grpcStatus = GetStub()->SetAttributeViBoolean(&clientContext, request, &response);
+    *viStatusOut = response.status();
+    return grpcStatus;
+  }
+
+  ::grpc::Status call_GetAttributeViBoolean(ViConstString activeItem, ViAttr attribute, ViBoolean* valueOut, ViStatus* viStatusOut)
+  {
+    ::grpc::ClientContext clientContext;
+    nisync::GetAttributeViBooleanRequest request;
+    nisync::GetAttributeViBooleanResponse response;
+    request.set_active_item(activeItem);
+    request.set_attribute(static_cast<nisync::NiSyncAttributes>(attribute));
+    request.mutable_vi()->set_id(driver_session_->id());
+    auto grpcStatus = GetStub()->GetAttributeViBoolean(&clientContext, request, &response);
+    *valueOut = response.value();
+    *viStatusOut = response.status();
+    return grpcStatus;
+  }
+
+  ::grpc::Status call_SetAttributeViReal64(ViConstString activeItem, ViAttr attribute, ViReal64 value, ViStatus* viStatusOut)
+  {
+    ::grpc::ClientContext clientContext;
+    nisync::SetAttributeViReal64Request request;
+    nisync::SetAttributeViReal64Response response;
+    request.set_active_item(activeItem);
+    request.set_attribute(static_cast<nisync::NiSyncAttributes>(attribute));
+    request.set_value(value);
+    request.mutable_vi()->set_id(driver_session_->id());
+    auto grpcStatus = GetStub()->SetAttributeViReal64(&clientContext, request, &response);
+    *viStatusOut = response.status();
+    return grpcStatus;
+  }
+
+  ::grpc::Status call_GetAttributeViReal64(ViConstString activeItem, ViAttr attribute, ViReal64* valueOut, ViStatus* viStatusOut)
+  {
+    ::grpc::ClientContext clientContext;
+    nisync::GetAttributeViReal64Request request;
+    nisync::GetAttributeViReal64Response response;
+    request.set_active_item(activeItem);
+    request.set_attribute(static_cast<nisync::NiSyncAttributes>(attribute));
+    request.mutable_vi()->set_id(driver_session_->id());
+    auto grpcStatus = GetStub()->GetAttributeViReal64(&clientContext, request, &response);
+    *valueOut = response.value();
+    *viStatusOut = response.status();
+    return grpcStatus;
+  }
 
 private:
   std::shared_ptr<::grpc::Channel> channel_;
@@ -539,6 +595,44 @@ TEST_F(NiSyncDriverApiTest, AttributeSet_GetAttributeViString_ReturnsValue)
   EXPECT_EQ(VI_SUCCESS, viStatus);
   EXPECT_STREQ(expectedValue, value.c_str());
 }
+
+TEST_F(NiSyncDriverApiTest, AttributeSet_GetAttributeViBoolean_ReturnsValue)
+{
+  ViStatus viStatus;
+  auto activeItem = "";
+  ViAttr attribute = NISYNC_ATTR_CLKIN_ATTENUATION_DISABLE;
+  ViBoolean expectedValue = VI_TRUE;
+  auto grpcStatus = call_SetAttributeViBoolean(activeItem, attribute, expectedValue, &viStatus);
+  EXPECT_TRUE(grpcStatus.ok());
+  EXPECT_EQ(VI_SUCCESS, viStatus);
+
+  ViBoolean value;
+  grpcStatus = call_GetAttributeViBoolean(activeItem, attribute, &value, &viStatus);
+
+  EXPECT_TRUE(grpcStatus.ok());
+  EXPECT_EQ(VI_SUCCESS, viStatus);
+  EXPECT_EQ(expectedValue, value);
+}
+
+TEST_F(NiSyncDriverApiTest, AttributeSet_GetAttributeViReal64_ReturnsValue)
+{
+  ViStatus viStatus;
+  auto activeItem = "";
+  ViAttr attribute = NISYNC_ATTR_PFI0_THRESHOLD;
+  ViReal64 expectedValue = 2.3;
+  auto grpcStatus = call_SetAttributeViReal64(activeItem, attribute, expectedValue, &viStatus);
+  EXPECT_TRUE(grpcStatus.ok());
+  EXPECT_EQ(VI_SUCCESS, viStatus);
+
+  ViReal64 value;
+  grpcStatus = call_GetAttributeViReal64(activeItem, attribute, &value, &viStatus);
+
+  EXPECT_TRUE(grpcStatus.ok());
+  EXPECT_EQ(VI_SUCCESS, viStatus);
+  EXPECT_DOUBLE_EQ(expectedValue, value);
+}
+
+
 
 }  // namespace system
 }  // namespace tests


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds the following methods for sync clock panel:
* niSync_GetAttributeViBoolean
* niSync_GetAttributeViReal64
* niSync_SetAttributeViBoolean
* niSync_SetAttributeViReal64

### Why should this Pull Request be merged?

These attribute methods are used by the sync routing panel for Linux RT.

### What testing has been done?

Ran the SystemTests on a 6674T on an RT Target:
```
admin@NI-PXIe-8861-031B3401:~# ./SystemTestsRunner --gtest_filter=*AttributeSet_GetAttributeVi*_ReturnsValue*
Note: Google Test filter = *AttributeSet_GetAttributeVi*_ReturnsValue*
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from NiSyncDriverApiTest
[ RUN      ] NiSyncDriverApiTest.AttributeSet_GetAttributeViInt32_ReturnsValue
[       OK ] NiSyncDriverApiTest.AttributeSet_GetAttributeViInt32_ReturnsValue (13 ms)
[ RUN      ] NiSyncDriverApiTest.AttributeSet_GetAttributeViString_ReturnsValue
[       OK ] NiSyncDriverApiTest.AttributeSet_GetAttributeViString_ReturnsValue (12 ms)
[ RUN      ] NiSyncDriverApiTest.AttributeSet_GetAttributeViBoolean_ReturnsValue
[       OK ] NiSyncDriverApiTest.AttributeSet_GetAttributeViBoolean_ReturnsValue (12 ms)
[ RUN      ] NiSyncDriverApiTest.AttributeSet_GetAttributeViReal64_ReturnsValue
[       OK ] NiSyncDriverApiTest.AttributeSet_GetAttributeViReal64_ReturnsValue (14 ms)
[----------] 4 tests from NiSyncDriverApiTest (51 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (51 ms total)
[  PASSED  ] 4 tests.
```
