### PR TITLE
Add RevisionQuery support to Sync for Advanced Test Panel

### DIFF
--- a/generated/nisync/nisync.proto
+++ b/generated/nisync/nisync.proto
@@ -18,6 +18,7 @@ import "session.proto";
 service NiSync {
   rpc Init(InitRequest) returns (InitResponse);
   rpc Close(CloseRequest) returns (CloseResponse);
+  rpc RevisionQuery(RevisionQueryRequest) returns (RevisionQueryResponse);
   rpc SendSoftwareTrigger(SendSoftwareTriggerRequest) returns (SendSoftwareTriggerResponse);
   rpc ConnectClkTerminals(ConnectClkTerminalsRequest) returns (ConnectClkTerminalsResponse);
   rpc DisconnectClkTerminals(DisconnectClkTerminalsRequest) returns (DisconnectClkTerminalsResponse);
@@ -166,6 +167,16 @@ message CloseRequest {
 
 message CloseResponse {
   int32 status = 1;
+}
+
+message RevisionQueryRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message RevisionQueryResponse {
+  int32 status = 1;
+  string driver_revision = 2;
+  string firmware_revision = 3;
 }
 
 message SendSoftwareTriggerRequest {

--- a/generated/nisync/nisync_library.cpp
+++ b/generated/nisync/nisync_library.cpp
@@ -23,6 +23,7 @@ NiSyncLibrary::NiSyncLibrary() : shared_library_(kLibraryName)
   }
   function_pointers_.init = reinterpret_cast<initPtr>(shared_library_.get_function_pointer("niSync_init"));
   function_pointers_.close = reinterpret_cast<closePtr>(shared_library_.get_function_pointer("niSync_close"));
+  function_pointers_.RevisionQuery = reinterpret_cast<RevisionQueryPtr>(shared_library_.get_function_pointer("niSync_revision_query"));
   function_pointers_.SendSoftwareTrigger = reinterpret_cast<SendSoftwareTriggerPtr>(shared_library_.get_function_pointer("niSync_SendSoftwareTrigger"));
   function_pointers_.ConnectClkTerminals = reinterpret_cast<ConnectClkTerminalsPtr>(shared_library_.get_function_pointer("niSync_ConnectClkTerminals"));
   function_pointers_.DisconnectClkTerminals = reinterpret_cast<DisconnectClkTerminalsPtr>(shared_library_.get_function_pointer("niSync_DisconnectClkTerminals"));
@@ -73,6 +74,18 @@ ViStatus NiSyncLibrary::close(ViSession vi)
   return niSync_close(vi);
 #else
   return function_pointers_.close(vi);
+#endif
+}
+
+ViStatus NiSyncLibrary::RevisionQuery(ViSession vi, ViChar driverRevision[256], ViChar firmwareRevision[256])
+{
+  if (!function_pointers_.RevisionQuery) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niSync_revision_query.");
+  }
+#if defined(_MSC_VER)
+  return niSync_revision_query(vi, driverRevision, firmwareRevision);
+#else
+  return function_pointers_.RevisionQuery(vi, driverRevision, firmwareRevision);
 #endif
 }
 

--- a/generated/nisync/nisync_library.h
+++ b/generated/nisync/nisync_library.h
@@ -20,6 +20,7 @@ class NiSyncLibrary : public nisync_grpc::NiSyncLibraryInterface {
   ::grpc::Status check_function_exists(std::string functionName);
   ViStatus init(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi);
   ViStatus close(ViSession vi);
+  ViStatus RevisionQuery(ViSession vi, ViChar driverRevision[256], ViChar firmwareRevision[256]);
   ViStatus SendSoftwareTrigger(ViSession vi, ViConstString srcTerminal);
   ViStatus ConnectClkTerminals(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal);
   ViStatus DisconnectClkTerminals(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal);
@@ -40,6 +41,7 @@ class NiSyncLibrary : public nisync_grpc::NiSyncLibraryInterface {
  private:
   using initPtr = ViStatus (*)(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi);
   using closePtr = ViStatus (*)(ViSession vi);
+  using RevisionQueryPtr = ViStatus (*)(ViSession vi, ViChar driverRevision[256], ViChar firmwareRevision[256]);
   using SendSoftwareTriggerPtr = ViStatus (*)(ViSession vi, ViConstString srcTerminal);
   using ConnectClkTerminalsPtr = ViStatus (*)(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal);
   using DisconnectClkTerminalsPtr = ViStatus (*)(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal);
@@ -60,6 +62,7 @@ class NiSyncLibrary : public nisync_grpc::NiSyncLibraryInterface {
   typedef struct FunctionPointers {
     initPtr init;
     closePtr close;
+    RevisionQueryPtr RevisionQuery;
     SendSoftwareTriggerPtr SendSoftwareTrigger;
     ConnectClkTerminalsPtr ConnectClkTerminals;
     DisconnectClkTerminalsPtr DisconnectClkTerminals;

--- a/generated/nisync/nisync_library_interface.h
+++ b/generated/nisync/nisync_library_interface.h
@@ -17,6 +17,7 @@ class NiSyncLibraryInterface {
 
   virtual ViStatus init(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi) = 0;
   virtual ViStatus close(ViSession vi) = 0;
+  virtual ViStatus RevisionQuery(ViSession vi, ViChar driverRevision[256], ViChar firmwareRevision[256]) = 0;
   virtual ViStatus SendSoftwareTrigger(ViSession vi, ViConstString srcTerminal) = 0;
   virtual ViStatus ConnectClkTerminals(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal) = 0;
   virtual ViStatus DisconnectClkTerminals(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal) = 0;

--- a/generated/nisync/nisync_mock_library.h
+++ b/generated/nisync/nisync_mock_library.h
@@ -19,6 +19,7 @@ class NiSyncMockLibrary : public nisync_grpc::NiSyncLibraryInterface {
  public:
   MOCK_METHOD(ViStatus, init, (ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi), (override));
   MOCK_METHOD(ViStatus, close, (ViSession vi), (override));
+  MOCK_METHOD(ViStatus, RevisionQuery, (ViSession vi, ViChar driverRevision[256], ViChar firmwareRevision[256]), (override));
   MOCK_METHOD(ViStatus, SendSoftwareTrigger, (ViSession vi, ViConstString srcTerminal), (override));
   MOCK_METHOD(ViStatus, ConnectClkTerminals, (ViSession vi, ViConstString srcTerminal, ViConstString destTerminal), (override));
   MOCK_METHOD(ViStatus, DisconnectClkTerminals, (ViSession vi, ViConstString srcTerminal, ViConstString destTerminal), (override));

--- a/generated/nisync/nisync_service.h
+++ b/generated/nisync/nisync_service.h
@@ -26,6 +26,7 @@ public:
   virtual ~NiSyncService();
   ::grpc::Status Init(::grpc::ServerContext* context, const InitRequest* request, InitResponse* response) override;
   ::grpc::Status Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response) override;
+  ::grpc::Status RevisionQuery(::grpc::ServerContext* context, const RevisionQueryRequest* request, RevisionQueryResponse* response) override;
   ::grpc::Status SendSoftwareTrigger(::grpc::ServerContext* context, const SendSoftwareTriggerRequest* request, SendSoftwareTriggerResponse* response) override;
   ::grpc::Status ConnectClkTerminals(::grpc::ServerContext* context, const ConnectClkTerminalsRequest* request, ConnectClkTerminalsResponse* response) override;
   ::grpc::Status DisconnectClkTerminals(::grpc::ServerContext* context, const DisconnectClkTerminalsRequest* request, DisconnectClkTerminalsResponse* response) override;

--- a/source/codegen/metadata/nisync/functions.py
+++ b/source/codegen/metadata/nisync/functions.py
@@ -16,6 +16,35 @@ functions = {
         ],
         "returns": "ViStatus",
     },
+    'RevisionQuery':{
+        'cname' : 'niSync_revision_query',
+        'parameters':[
+            {
+                'name':'vi',
+                'direction':'in',
+                'type':'ViSession'
+            },
+            {
+                'name':'driverRevision',
+                'direction':'out',
+                'type':'ViChar[]',
+                'size':{
+                    'mechanism':'fixed',
+                    'value':256
+                }
+            },
+            {
+                'name':'firmwareRevision',
+                'direction':'out',
+                'type':'ViChar[]',
+                'size':{
+                    'mechanism':'fixed',
+                    'value':256
+                }
+            }
+        ],
+        'returns':'ViStatus'
+    },
     "SendSoftwareTrigger": {
         "parameters": [
             {

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -353,7 +353,7 @@ private:
   std::unique_ptr<::grpc::Server> server_;
 };
 
-TEST_F(NiSyncDriverApiTest, RevisionQuery)
+TEST_F(NiSyncDriverApiTest, RevisionQuery_ReturnsNonEmptyRevisions)
 {
   ViStatus viStatus;
   std::string driverRevision, firmwareRevision;


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add RevisionQuery support to Sync for Advanced Test Panel. I based this off of the existing `RevisionQuery` method that Scope has implemented.

### Why should this Pull Request be merged?

So that the Sync Advanced Test Panel Works

### What testing has been done?

New test passes:
```
admin@NI-PXIe-8861-031B3401:~# ./SystemTestsRunner --gtest_filter="*RevisionQuery*"
Note: Google Test filter = *RevisionQuery*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from NiSyncDriverApiTest
[ RUN      ] NiSyncDriverApiTest.RevisionQuery
[       OK ] NiSyncDriverApiTest.RevisionQuery (13 ms)
[----------] 1 test from NiSyncDriverApiTest (13 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (13 ms total)
[  PASSED  ] 1 test.
```
