### PR TITLE
Making sure nilrt build files are packaged in release branches

### DIFF
--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -135,7 +135,7 @@ jobs:
         endif()
 
     - name: Tar Build Files
-      if: "github.ref == 'refs/heads/main'"
+      if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases') }}
       run: >-
         tar -cvf NILinuxRealTime-x86_64.tar
         -C ${GITHUB_WORKSPACE}/build


### PR DESCRIPTION
### What does this Pull Request accomplish?
When adding release branch artifacts, I neglected to update the step for nilrt builds to package the files into a tarball. This change rectifies that.

### Why should this Pull Request be merged?
Ensures proper artifact generation on release branches.

### What testing has been done?
N/A, but see the previous failure [here](https://github.com/ni/grpc-device/actions/runs/811016448).
