### PR TITLE
Cherry-pick license files in artifacts to releases/1.0

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -112,25 +112,30 @@ jobs:
     - name: Tar Linux Server Binaries
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       run: >-
-        tar -cvf ni-grpc-device-server-linux-glibc2_23.tar
+        tar -cvzf ni-grpc-device-server-linux-glibc2_23-x64.tar.gz
         -C ${GITHUB_WORKSPACE}/build
         ni_grpc_device_server
         server_config.json
+        -C ${GITHUB_WORKSPACE}
+        LICENSE
+        ThirdPartyNotices.txt
 
     - name: Upload Linux Server Binaries Artifact
       uses: actions/upload-artifact@v2
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       with:
-        name: ni-grpc-device-server-linux-glibc2_23
-        path: ni-grpc-device-server-linux-glibc2_23.tar
+        name: ni-grpc-device-server-linux-glibc2_23-x64
+        path: ni-grpc-device-server-linux-glibc2_23-x64.tar.gz
         retention-days: 5
 
     - name: Upload Windows Server Binaries Artifact
       uses: actions/upload-artifact@v2
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}
       with:
-        name: ni-grpc-device-server-windows
+        name: ni-grpc-device-server-windows-x64
         path: |
           build/Release/ni_grpc_device_server.exe
           build/Release/server_config.json
+          LICENSE
+          ThirdPartyNotices.txt
         retention-days: 5

--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -134,10 +134,10 @@ jobs:
           message(FATAL_ERROR "Build failed")
         endif()
 
-    - name: Tar Build Files
-      if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases') }}
+    - name: Tar Development Build Files
+      if: ${{ github.ref == 'refs/heads/main' }}
       run: >-
-        tar -cvf NILinuxRealTime-x86_64.tar
+        tar -cvzf ni-grpc-device-server-ni-linux-rt-x64.tar.gz
         -C ${GITHUB_WORKSPACE}/build
         certs/
         ni_grpc_device_server
@@ -147,11 +147,25 @@ jobs:
         SystemTestsRunner
         test_mutual_tls_config.json
         UnitTestsRunner
+        -C ${GITHUB_WORKSPACE}
+        LICENSE
+        ThirdPartyNotices.txt
+
+    - name: Tar Release Build Files
+      if: ${{ startsWith(github.ref, 'refs/heads/releases') }}
+      run: >-
+        tar -cvzf ni-grpc-device-server-ni-linux-rt-x64.tar.gz
+        -C ${GITHUB_WORKSPACE}/build
+        ni_grpc_device_server
+        server_config.json
+        -C ${GITHUB_WORKSPACE}
+        LICENSE
+        ThirdPartyNotices.txt
 
     - name: Upload Artifact
       uses: actions/upload-artifact@v2
       if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases') }}
       with:
-        name: NILinuxRealTime-x86_64
-        path: NILinuxRealTime-x86_64.tar
+        name: ni-grpc-device-server-ni-linux-rt-x64
+        path: ni-grpc-device-server-ni-linux-rt-x64.tar.gz
         retention-days: 5


### PR DESCRIPTION
### What does this Pull Request accomplish?
Cherry-pick of #185 to the `releases/1.0` branch.

### Why should this Pull Request be merged?
Facilitates easier release creation.

### What testing has been done?
Confirmed presence of license files in workflow artifacts from #185 merge.
See [here](https://github.com/ni/grpc-device/actions/runs/820915518) and [here](https://github.com/ni/grpc-device/actions/runs/820915519). 
