### PR TITLE
Fix helpers file to account for ViUInt16

### DIFF
--- a/source/codegen/proto_helpers.py
+++ b/source/codegen/proto_helpers.py
@@ -38,6 +38,8 @@ def get_grpc_type_from_ivi(type, is_array, driver_name_pascal):
     type = 'sint32'
   if 'ViInt64' in type:
     type = 'int64'
+  if 'ViUInt16' in type:
+    type = 'uint32'
   if 'ViUInt32' in type:
     type = 'uint32'
   if 'ViUInt64' in type:


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adding support to this repo for APIs to contain ViUInt16.

### Why should this Pull Request be merged?

Adding support to this repo for APIs to contain ViUInt16.  This is necessary for some of the time functions for NI-Sync.

### What testing has been done?

I am using this as a part of another PR ([link to PR](https://github.com/ni/grpc-device/pull/186)).
