### PR TITLE
fix nisync.h sign extension issue

### DIFF
--- a/imports/include/nisync.h
+++ b/imports/include/nisync.h
@@ -817,8 +817,8 @@ ViStatus _VI_FUNC niSync_Get1588Time(ViSession vi,
 /****************************************************************************
  *------------------------ Error And Completion Codes ----------------------*
  ****************************************************************************/
-#define NISYNC_WARN_BASE                        0x3FFA4000
-#define NISYNC_ERROR_BASE                       0xBFFA4000 /* IVI_SPECIFIC_PUBLIC_ATTR_BASE */
+#define NISYNC_WARN_BASE                        (ViStatus)(0x3FFA4000)
+#define NISYNC_ERROR_BASE                       (ViStatus)(0xBFFA4000) /* IVI_SPECIFIC_PUBLIC_ATTR_BASE */
 
 // NISYNC_WARN_BASE + 6x is reserved for calibration warnings.
 #define NISYNC_WARN_CAL_UNCALIBRATED            (NISYNC_WARN_BASE + 60)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes the nisync.h header so it has the correct Status codes. Previously it wasn't sign-extending error codes appropriately.

### Why should this Pull Request be merged?

To fix error code constants.

### What testing has been done?

Ran new sync system tests that were failing previously.
