### PR TITLE
Updated NI-Sync tests to auto discover devices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,6 +308,7 @@ add_custom_command(
 add_executable(SystemTestsRunner
     "source/tests/utilities/run_all_tests.cpp"
     "source/tests/system/device_server.cpp"
+    "source/tests/system/enumerate_devices.cpp"
     "source/tests/system/session_utilities_service_tests.cpp"
     "source/tests/system/nidcpower_driver_api_tests.cpp"
     "source/tests/system/nidcpower_session_tests.cpp"

--- a/source/server/session_utilities_service.h
+++ b/source/server/session_utilities_service.h
@@ -1,3 +1,6 @@
+#ifndef NIDEVICE_GRPC_SESSION_UTILITIES_SERVICE
+#define NIDEVICE_GRPC_SESSION_UTILITIES_SERVICE
+
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/health_check_service_interface.h>
@@ -24,3 +27,5 @@ class SessionUtilitiesService final : public SessionUtilities::Service {
 };
 
 }  // namespace nidevice_grpc
+
+#endif  // NIDEVICE_GRPC_SESSION_UTILITIES_SERVICE

--- a/source/tests/system/enumerate_devices.cpp
+++ b/source/tests/system/enumerate_devices.cpp
@@ -1,0 +1,37 @@
+#include "enumerate_devices.h"
+
+#include <optional>
+#include <stdexcept>
+
+#include <server/session_utilities_service.h>
+#include "device_server.h"
+
+namespace ni {
+namespace tests {
+namespace system {
+
+const google::protobuf::RepeatedPtrField<nidevice_grpc::DeviceProperties> EnumerateDevices(bool clear_cache)
+{
+  static std::optional<google::protobuf::RepeatedPtrField<nidevice_grpc::DeviceProperties>> devices_cache;
+  if (!devices_cache || clear_cache) {
+    devices_cache.reset();
+
+    ::nidevice_grpc::SessionUtilities::Stub stub(DeviceServerInterface::Singleton()->InProcessChannel());
+
+    nidevice_grpc::EnumerateDevicesRequest request;
+    nidevice_grpc::EnumerateDevicesResponse response;
+    ::grpc::ClientContext context;
+
+    if (::grpc::StatusCode::OK != stub.EnumerateDevices(&context, request, &response).error_code()) {
+      throw std::runtime_error("Failed to enumerate devices");
+    }
+
+    devices_cache = response.devices();
+  }
+
+  return devices_cache.value();
+}
+
+}  // namespace system
+}  // namespace tests
+}  // namespace ni

--- a/source/tests/system/enumerate_devices.cpp
+++ b/source/tests/system/enumerate_devices.cpp
@@ -1,6 +1,5 @@
 #include "enumerate_devices.h"
 
-#include <optional>
 #include <stdexcept>
 
 #include <server/session_utilities_service.h>
@@ -12,9 +11,11 @@ namespace system {
 
 const google::protobuf::RepeatedPtrField<nidevice_grpc::DeviceProperties> EnumerateDevices(bool clear_cache)
 {
-  static std::optional<google::protobuf::RepeatedPtrField<nidevice_grpc::DeviceProperties>> devices_cache;
-  if (!devices_cache || clear_cache) {
-    devices_cache.reset();
+  static bool devices_are_cached = false;
+  static google::protobuf::RepeatedPtrField<nidevice_grpc::DeviceProperties> devices_cache;
+
+  if (!devices_are_cached || clear_cache) {
+    devices_are_cached = false;
 
     ::nidevice_grpc::SessionUtilities::Stub stub(DeviceServerInterface::Singleton()->InProcessChannel());
 
@@ -27,9 +28,10 @@ const google::protobuf::RepeatedPtrField<nidevice_grpc::DeviceProperties> Enumer
     }
 
     devices_cache = response.devices();
+    devices_are_cached = true;
   }
 
-  return devices_cache.value();
+  return devices_cache;
 }
 
 }  // namespace system

--- a/source/tests/system/enumerate_devices.cpp
+++ b/source/tests/system/enumerate_devices.cpp
@@ -27,7 +27,7 @@ const google::protobuf::RepeatedPtrField<nidevice_grpc::DeviceProperties> Enumer
       throw std::runtime_error("Failed to enumerate devices");
     }
 
-    devices_cache = response.devices();
+    devices_cache.CopyFrom(response.devices());
     devices_are_cached = true;
   }
 

--- a/source/tests/system/enumerate_devices.h
+++ b/source/tests/system/enumerate_devices.h
@@ -1,0 +1,16 @@
+#ifndef NIDEVICE_GRPC_TESTS_ENUMERATE_DEVICES
+#define NIDEVICE_GRPC_TESTS_ENUMERATE_DEVICES
+
+#include <server/device_enumerator.h>
+
+namespace ni {
+namespace tests {
+namespace system {
+
+const google::protobuf::RepeatedPtrField<nidevice_grpc::DeviceProperties> EnumerateDevices(bool clear_cache = false);
+
+}  // namespace system
+}  // namespace tests
+}  // namespace ni
+
+#endif  // NIDEVICE_GRPC_TESTS_ENUMERATE_DEVICES

--- a/source/tests/system/nisync_session_tests.cpp
+++ b/source/tests/system/nisync_session_tests.cpp
@@ -2,6 +2,7 @@
 
 #include "device_server.h"
 #include "nisync/nisync_service.h"
+#include "enumerate_devices.h"
 
 namespace ni {
 namespace tests {
@@ -10,19 +11,33 @@ namespace system {
 namespace nisync = nisync_grpc;
 
 static const int kSyncDeviceNotFound = -1074118634;
-// Update the value of 'kTestRsrcName' to the name of your NI-Sync device.
-static const char* kTestRsrcName = "Dev1";
 static const char* kTestSessionName = "TestSession";
 static const char* kEmptySessionName = "";
 static const char* kInvalidRsrcName = "InvalidName";
 
 class NiSyncSessionTest : public ::testing::Test {
  protected:
+  std::string test_resource_name;
+
   NiSyncSessionTest()
       : device_server_(DeviceServerInterface::Singleton()),
         nisync_stub_(nisync::NiSync::NewStub(device_server_->InProcessChannel()))
   {
     device_server_->ResetServer();
+  }
+
+  void SetUp() override
+  {
+    for(const auto& device : EnumerateDevices()) {
+      if ((device.model() == "NI PXI-6683H") || (device.model() == "NI PXIe-6674T")) {
+        test_resource_name = device.name();
+        break;
+      }
+    }
+
+    if (test_resource_name.empty()) {
+      GTEST_SKIP() << "No device found";
+    }
   }
 
   virtual ~NiSyncSessionTest() {}
@@ -52,7 +67,7 @@ class NiSyncSessionTest : public ::testing::Test {
 TEST_F(NiSyncSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDriverSession)
 {
   nisync::InitResponse response;
-  ::grpc::Status status = call_init(kTestRsrcName, kTestSessionName, &response);
+  ::grpc::Status status = call_init(test_resource_name.c_str(), kTestSessionName, &response);
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
@@ -62,7 +77,7 @@ TEST_F(NiSyncSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDrive
 TEST_F(NiSyncSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesDriverSession)
 {
   nisync::InitResponse response;
-  ::grpc::Status status = call_init(kTestRsrcName, kEmptySessionName, &response);
+  ::grpc::Status status = call_init(test_resource_name.c_str(), kEmptySessionName, &response);
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
@@ -82,7 +97,7 @@ TEST_F(NiSyncSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
 TEST_F(NiSyncSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
 {
   nisync::InitResponse init_response;
-  call_init(kTestRsrcName, kEmptySessionName, &init_response);
+  call_init(test_resource_name.c_str(), kEmptySessionName, &init_response);
   nidevice_grpc::Session session = init_response.vi();
   EXPECT_EQ(0, init_response.status());
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Updates NI-Sync tests to auto discover devices

### Why should this Pull Request be merged?

This will allow the NI-Sync system tests to be run on any system without modifying the device name.

### What testing has been done?

Ran system tests on Linux RT system with PXIe-6674T `./SystemTestsRunner --gtest_filter=NiSync*`:
```
[==========] 26 tests from 2 test suites ran. (1437 ms total)
[  PASSED  ] 24 tests.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] NiSyncDriverApiTest.SendSoftwareTriggerOnInvalidTerminal_ReturnsInvalidSrcTerminal
[  FAILED  ] NiSyncDriverApiTest.AttributeSet_GetAttributeViReal64_ReturnsValue
```
See comment section for complete log.