### PR TITLE
Centralized creation of in-process device server for the system tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,6 +294,7 @@ add_custom_command(
 
 add_executable(SystemTestsRunner
     "source/tests/utilities/run_all_tests.cpp"
+    "source/tests/system/device_server.cpp"
     "source/tests/system/session_utilities_service_tests.cpp"
     "source/tests/system/nidcpower_driver_api_tests.cpp"
     "source/tests/system/nidcpower_session_tests.cpp"

--- a/source/tests/system/device_server.cpp
+++ b/source/tests/system/device_server.cpp
@@ -24,6 +24,7 @@ class DeviceServer : public DeviceServerInterface {
   ~DeviceServer() override {};
 
   // DeviceServerInterface overrides
+  void ResetServer() override;
   std::shared_ptr<::grpc::Channel> InProcessChannel() override;
 
  private:
@@ -65,6 +66,11 @@ DeviceServer::DeviceServer()
   builder.RegisterService(&nisync_service_);
   builder.RegisterService(&nidcpower_service_);
   server_ = builder.BuildAndStart();
+}
+
+void DeviceServer::ResetServer()
+{
+  session_repository_.reset_server();
 }
 
 std::shared_ptr<::grpc::Channel> DeviceServer::InProcessChannel()

--- a/source/tests/system/device_server.cpp
+++ b/source/tests/system/device_server.cpp
@@ -1,0 +1,86 @@
+#include "device_server.h"
+
+#include <server/device_enumerator.h>
+#include <server/session_utilities_service.h>
+#include <server/syscfg_library.h>
+#include <niscope/niscope_library.h>
+#include <niscope/niscope_service.h>
+#include <niswitch/niswitch_library.h>
+#include <niswitch/niswitch_service.h>
+#include <nisync/nisync_library.h>
+#include <nisync/nisync_service.h>
+#include <nidcpower/nidcpower_library.h>
+#include <nidcpower/nidcpower_service.h>
+
+namespace ni {
+namespace tests {
+namespace system {
+
+DeviceServerInterface::~DeviceServerInterface() {}
+
+class DeviceServer : public DeviceServerInterface {
+ public:
+  DeviceServer();
+  ~DeviceServer() override {};
+
+  // DeviceServerInterface overrides
+  std::shared_ptr<::grpc::Channel> InProcessChannel() override;
+
+ private:
+  nidevice_grpc::SessionRepository session_repository_;
+  nidevice_grpc::SysCfgLibrary syscfg_library_;
+  nidevice_grpc::DeviceEnumerator device_enumerator_;
+  nidevice_grpc::SessionUtilitiesService core_service_;
+  niscope_grpc::NiScopeLibrary niscope_library_;
+  niscope_grpc::NiScopeService niscope_service_;
+  niswitch_grpc::NiSwitchLibrary niswitch_library_;
+  niswitch_grpc::NiSwitchService niswitch_service_;
+  nisync_grpc::NiSyncLibrary nisync_library_;
+  nisync_grpc::NiSyncService nisync_service_;
+  nidcpower_grpc::NiDCPowerLibrary nidcpower_library_;
+  nidcpower_grpc::NiDCPowerService nidcpower_service_;
+
+  std::unique_ptr<::grpc::Server> server_;
+  std::shared_ptr<::grpc::Channel> channel_;
+};
+
+DeviceServer::DeviceServer()
+    : session_repository_(),
+      syscfg_library_(),
+      device_enumerator_(&syscfg_library_),
+      core_service_(&session_repository_, &device_enumerator_),
+      niscope_library_(),
+      niscope_service_(&niscope_library_, &session_repository_),
+      niswitch_library_(),
+      niswitch_service_(&niswitch_library_, &session_repository_),
+      nisync_library_(),
+      nisync_service_(&nisync_library_, &session_repository_),
+      nidcpower_library_(),
+      nidcpower_service_(&nidcpower_library_, &session_repository_)
+{
+  grpc::ServerBuilder builder;
+  builder.RegisterService(&core_service_);
+  builder.RegisterService(&niscope_service_);
+  builder.RegisterService(&niswitch_service_);
+  builder.RegisterService(&nisync_service_);
+  builder.RegisterService(&nidcpower_service_);
+  server_ = builder.BuildAndStart();
+}
+
+std::shared_ptr<::grpc::Channel> DeviceServer::InProcessChannel()
+{
+  if (!channel_) {
+    channel_ = server_->InProcessChannel(::grpc::ChannelArguments());
+  }
+  return channel_;
+}
+
+DeviceServerInterface* DeviceServerInterface::Singleton()
+{
+   static auto singleton = std::make_unique<DeviceServer>();
+   return singleton.get();
+}
+
+}  // namespace system
+}  // namespace tests
+}  // namespace ni

--- a/source/tests/system/device_server.h
+++ b/source/tests/system/device_server.h
@@ -1,0 +1,26 @@
+#ifndef NIDEVICE_GRPC_TESTS_DEVICE_SERVER
+#define NIDEVICE_GRPC_TESTS_DEVICE_SERVER
+
+#include <memory>
+
+namespace grpc {
+class Channel;
+}
+
+namespace ni {
+namespace tests {
+namespace system {
+
+class DeviceServerInterface {
+ public:
+  virtual ~DeviceServerInterface() = 0;
+  virtual std::shared_ptr<::grpc::Channel> InProcessChannel() = 0;
+
+  static DeviceServerInterface* Singleton();
+};
+
+}  // namespace system
+}  // namespace tests
+}  // namespace ni
+
+#endif  // NIDEVICE_GRPC_TESTS_DEVICE_SERVER

--- a/source/tests/system/device_server.h
+++ b/source/tests/system/device_server.h
@@ -14,6 +14,7 @@ namespace system {
 class DeviceServerInterface {
  public:
   virtual ~DeviceServerInterface() = 0;
+  virtual void ResetServer() = 0;
   virtual std::shared_ptr<::grpc::Channel> InProcessChannel() = 0;
 
   static DeviceServerInterface* Singleton();

--- a/source/tests/system/nidcpower_driver_api_tests.cpp
+++ b/source/tests/system/nidcpower_driver_api_tests.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "nidcpower/nidcpower_library.h"
+#include "device_server.h"
 #include "nidcpower/nidcpower_service.h"
 
 namespace ni {
@@ -14,16 +14,8 @@ const int kdcpowerDriverApiSuccess = 0;
 class NiDCPowerDriverApiTest : public ::testing::Test {
  protected:
   NiDCPowerDriverApiTest()
-  {
-    ::grpc::ServerBuilder builder;
-    session_repository_ = std::make_unique<nidevice_grpc::SessionRepository>();
-    nidcpower_library_ = std::make_unique<dcpower::NiDCPowerLibrary>();
-    nidcpower_service_ = std::make_unique<dcpower::NiDCPowerService>(nidcpower_library_.get(), session_repository_.get());
-    builder.RegisterService(nidcpower_service_.get());
-
-    server_ = builder.BuildAndStart();
-    ResetStub();
-  }
+      : nidcpower_stub_(dcpower::NiDCPower::NewStub(DeviceServerInterface::Singleton()->InProcessChannel()))
+  {}
 
   virtual ~NiDCPowerDriverApiTest() {}
 
@@ -35,12 +27,6 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   void TearDown() override
   {
     close_driver_session();
-  }
-
-  void ResetStub()
-  {
-    channel_ = server_->InProcessChannel(::grpc::ChannelArguments());
-    nidcpower_stub_ = dcpower::NiDCPower::NewStub(channel_);
   }
 
   std::unique_ptr<dcpower::NiDCPower::Stub>& GetStub()
@@ -309,13 +295,8 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   }
 
  private:
-  std::shared_ptr<::grpc::Channel> channel_;
   std::unique_ptr<::nidevice_grpc::Session> driver_session_;
   std::unique_ptr<dcpower::NiDCPower::Stub> nidcpower_stub_;
-  std::unique_ptr<nidevice_grpc::SessionRepository> session_repository_;
-  std::unique_ptr<dcpower::NiDCPowerLibrary> nidcpower_library_;
-  std::unique_ptr<dcpower::NiDCPowerService> nidcpower_service_;
-  std::unique_ptr<::grpc::Server> server_;
 };
 
 TEST_F(NiDCPowerDriverApiTest, PerformSelfTest_CompletesSuccessfuly)

--- a/source/tests/system/nidcpower_driver_api_tests.cpp
+++ b/source/tests/system/nidcpower_driver_api_tests.cpp
@@ -14,8 +14,11 @@ const int kdcpowerDriverApiSuccess = 0;
 class NiDCPowerDriverApiTest : public ::testing::Test {
  protected:
   NiDCPowerDriverApiTest()
-      : nidcpower_stub_(dcpower::NiDCPower::NewStub(DeviceServerInterface::Singleton()->InProcessChannel()))
-  {}
+      : device_server_(DeviceServerInterface::Singleton()),
+        nidcpower_stub_(dcpower::NiDCPower::NewStub(device_server_->InProcessChannel()))
+  {
+    device_server_->ResetServer();
+  }
 
   virtual ~NiDCPowerDriverApiTest() {}
 
@@ -295,6 +298,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   }
 
  private:
+  DeviceServerInterface* device_server_;
   std::unique_ptr<::nidevice_grpc::Session> driver_session_;
   std::unique_ptr<dcpower::NiDCPower::Stub> nidcpower_stub_;
 };

--- a/source/tests/system/nidcpower_session_tests.cpp
+++ b/source/tests/system/nidcpower_session_tests.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "nidcpower/nidcpower_library.h"
+#include "device_server.h"
 #include "nidcpower/nidcpower_service.h"
 
 namespace ni {
@@ -21,24 +21,10 @@ const char* kTestInvalidRsrc = "";
 class NiDCPowerSessionTest : public ::testing::Test {
  protected:
   NiDCPowerSessionTest()
-  {
-    ::grpc::ServerBuilder builder;
-    session_repository_ = std::make_unique<nidevice_grpc::SessionRepository>();
-    nidcpower_library_ = std::make_unique<dcpower::NiDCPowerLibrary>();
-    nidcpower_service_ = std::make_unique<dcpower::NiDCPowerService>(nidcpower_library_.get(), session_repository_.get());
-    builder.RegisterService(nidcpower_service_.get());
-
-    server_ = builder.BuildAndStart();
-    ResetStubs();
-  }
+      : nidcpower_stub_(dcpower::NiDCPower::NewStub(DeviceServerInterface::Singleton()->InProcessChannel()))
+  {}
 
   virtual ~NiDCPowerSessionTest() {}
-
-  void ResetStubs()
-  {
-    channel_ = server_->InProcessChannel(::grpc::ChannelArguments());
-    nidcpower_stub_ = dcpower::NiDCPower::NewStub(channel_);
-  }
 
   std::unique_ptr<dcpower::NiDCPower::Stub>& GetStub()
   {
@@ -90,12 +76,7 @@ class NiDCPowerSessionTest : public ::testing::Test {
   }
 
  private:
-  std::shared_ptr<::grpc::Channel> channel_;
   std::unique_ptr<dcpower::NiDCPower::Stub> nidcpower_stub_;
-  std::unique_ptr<nidevice_grpc::SessionRepository> session_repository_;
-  std::unique_ptr<dcpower::NiDCPowerLibrary> nidcpower_library_;
-  std::unique_ptr<dcpower::NiDCPowerService> nidcpower_service_;
-  std::unique_ptr<::grpc::Server> server_;
 };
 
 TEST_F(NiDCPowerSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDriverSession)

--- a/source/tests/system/nidcpower_session_tests.cpp
+++ b/source/tests/system/nidcpower_session_tests.cpp
@@ -21,8 +21,11 @@ const char* kTestInvalidRsrc = "";
 class NiDCPowerSessionTest : public ::testing::Test {
  protected:
   NiDCPowerSessionTest()
-      : nidcpower_stub_(dcpower::NiDCPower::NewStub(DeviceServerInterface::Singleton()->InProcessChannel()))
-  {}
+      : device_server_(DeviceServerInterface::Singleton()),
+        nidcpower_stub_(dcpower::NiDCPower::NewStub(device_server_->InProcessChannel()))
+  {
+    device_server_->ResetServer();
+  }
 
   virtual ~NiDCPowerSessionTest() {}
 
@@ -76,6 +79,7 @@ class NiDCPowerSessionTest : public ::testing::Test {
   }
 
  private:
+  DeviceServerInterface* device_server_;
   std::unique_ptr<dcpower::NiDCPower::Stub> nidcpower_stub_;
 };
 

--- a/source/tests/system/niscope_driver_api_tests.cpp
+++ b/source/tests/system/niscope_driver_api_tests.cpp
@@ -14,8 +14,11 @@ const int kScopeDriverApiSuccess = 0;
 class NiScopeDriverApiTest : public ::testing::Test {
  protected:
   NiScopeDriverApiTest()
-      : niscope_stub_(scope::NiScope::NewStub(DeviceServerInterface::Singleton()->InProcessChannel()))
-  {}
+      : device_server_(DeviceServerInterface::Singleton()),
+        niscope_stub_(scope::NiScope::NewStub(device_server_->InProcessChannel()))
+  {
+    device_server_->ResetServer();
+  }
 
   virtual ~NiScopeDriverApiTest() {}
 
@@ -210,6 +213,7 @@ class NiScopeDriverApiTest : public ::testing::Test {
   }
 
  private:
+  DeviceServerInterface* device_server_;
   std::unique_ptr<::nidevice_grpc::Session> driver_session_;
   std::unique_ptr<scope::NiScope::Stub> niscope_stub_;
 };

--- a/source/tests/system/niscope_driver_api_tests.cpp
+++ b/source/tests/system/niscope_driver_api_tests.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "niscope/niscope_library.h"
+#include "device_server.h"
 #include "niscope/niscope_service.h"
 
 namespace ni {
@@ -14,16 +14,8 @@ const int kScopeDriverApiSuccess = 0;
 class NiScopeDriverApiTest : public ::testing::Test {
  protected:
   NiScopeDriverApiTest()
-  {
-    ::grpc::ServerBuilder builder;
-    session_repository_ = std::make_unique<nidevice_grpc::SessionRepository>();
-    niscope_library_ = std::make_unique<scope::NiScopeLibrary>();
-    niscope_service_ = std::make_unique<scope::NiScopeService>(niscope_library_.get(), session_repository_.get());
-    builder.RegisterService(niscope_service_.get());
-
-    server_ = builder.BuildAndStart();
-    ResetStub();
-  }
+      : niscope_stub_(scope::NiScope::NewStub(DeviceServerInterface::Singleton()->InProcessChannel()))
+  {}
 
   virtual ~NiScopeDriverApiTest() {}
 
@@ -35,12 +27,6 @@ class NiScopeDriverApiTest : public ::testing::Test {
   void TearDown() override
   {
     close_driver_session();
-  }
-
-  void ResetStub()
-  {
-    channel_ = server_->InProcessChannel(::grpc::ChannelArguments());
-    niscope_stub_ = scope::NiScope::NewStub(channel_);
   }
 
   std::unique_ptr<scope::NiScope::Stub>& GetStub()
@@ -224,13 +210,8 @@ class NiScopeDriverApiTest : public ::testing::Test {
   }
 
  private:
-  std::shared_ptr<::grpc::Channel> channel_;
   std::unique_ptr<::nidevice_grpc::Session> driver_session_;
   std::unique_ptr<scope::NiScope::Stub> niscope_stub_;
-  std::unique_ptr<nidevice_grpc::SessionRepository> session_repository_;
-  std::unique_ptr<scope::NiScopeLibrary> niscope_library_;
-  std::unique_ptr<scope::NiScopeService> niscope_service_;
-  std::unique_ptr<::grpc::Server> server_;
 };
 
 TEST_F(NiScopeDriverApiTest, NiScopeSelfTest_SendRequest_SelfTestCompletesSuccessfully)

--- a/source/tests/system/niscope_session_tests.cpp
+++ b/source/tests/system/niscope_session_tests.cpp
@@ -21,8 +21,11 @@ const char* kInvalidResourceName = "";
 class NiScopeSessionTest : public ::testing::Test {
  protected:
   NiScopeSessionTest()
-      : niscope_stub_(scope::NiScope::NewStub(DeviceServerInterface::Singleton()->InProcessChannel()))
-  {}
+      : device_server_(DeviceServerInterface::Singleton()),
+        niscope_stub_(scope::NiScope::NewStub(device_server_->InProcessChannel()))
+  {
+    device_server_->ResetServer();
+  }
 
   virtual ~NiScopeSessionTest() {}
 
@@ -63,6 +66,7 @@ class NiScopeSessionTest : public ::testing::Test {
   }
 
  private:
+  DeviceServerInterface* device_server_;
   std::unique_ptr<scope::NiScope::Stub> niscope_stub_;
 };
 

--- a/source/tests/system/niswitch_driver_api_tests.cpp
+++ b/source/tests/system/niswitch_driver_api_tests.cpp
@@ -20,8 +20,11 @@ const char* fourthChannelName = "b0c6";
 class NiSwitchDriverApiTest : public ::testing::Test {
  protected:
   NiSwitchDriverApiTest()
-      : niswitch_stub_(niswitch::NiSwitch::NewStub(DeviceServerInterface::Singleton()->InProcessChannel()))
-  {}
+      : device_server_(DeviceServerInterface::Singleton()),
+        niswitch_stub_(niswitch::NiSwitch::NewStub(device_server_->InProcessChannel()))
+  {
+    device_server_->ResetServer();
+  }
 
   virtual ~NiSwitchDriverApiTest() {}
 
@@ -202,6 +205,7 @@ class NiSwitchDriverApiTest : public ::testing::Test {
   }
 
  private:
+  DeviceServerInterface* device_server_;
   std::unique_ptr<::nidevice_grpc::Session> driver_session_;
   std::unique_ptr<niswitch::NiSwitch::Stub> niswitch_stub_;
 };

--- a/source/tests/system/niswitch_driver_api_tests.cpp
+++ b/source/tests/system/niswitch_driver_api_tests.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "niswitch/niswitch_library.h"
+#include "device_server.h"
 #include "niswitch/niswitch_service.h"
 
 namespace ni {
@@ -20,16 +20,8 @@ const char* fourthChannelName = "b0c6";
 class NiSwitchDriverApiTest : public ::testing::Test {
  protected:
   NiSwitchDriverApiTest()
-  {
-    ::grpc::ServerBuilder builder;
-    session_repository_ = std::make_unique<nidevice_grpc::SessionRepository>();
-    niswitch_library_ = std::make_unique<niswitch::NiSwitchLibrary>();
-    niswitch_service_ = std::make_unique<niswitch::NiSwitchService>(niswitch_library_.get(), session_repository_.get());
-    builder.RegisterService(niswitch_service_.get());
-
-    server_ = builder.BuildAndStart();
-    ResetStub();
-  }
+      : niswitch_stub_(niswitch::NiSwitch::NewStub(DeviceServerInterface::Singleton()->InProcessChannel()))
+  {}
 
   virtual ~NiSwitchDriverApiTest() {}
 
@@ -41,12 +33,6 @@ class NiSwitchDriverApiTest : public ::testing::Test {
   void TearDown() override
   {
     close_driver_session();
-  }
-
-  void ResetStub()
-  {
-    channel_ = server_->InProcessChannel(::grpc::ChannelArguments());
-    niswitch_stub_ = niswitch::NiSwitch::NewStub(channel_);
   }
 
   std::unique_ptr<niswitch::NiSwitch::Stub>& GetStub()
@@ -216,13 +202,8 @@ class NiSwitchDriverApiTest : public ::testing::Test {
   }
 
  private:
-  std::shared_ptr<::grpc::Channel> channel_;
   std::unique_ptr<::nidevice_grpc::Session> driver_session_;
   std::unique_ptr<niswitch::NiSwitch::Stub> niswitch_stub_;
-  std::unique_ptr<nidevice_grpc::SessionRepository> session_repository_;
-  std::unique_ptr<niswitch::NiSwitchLibrary> niswitch_library_;
-  std::unique_ptr<niswitch::NiSwitchService> niswitch_service_;
-  std::unique_ptr<::grpc::Server> server_;
 };
 
 TEST_F(NiSwitchDriverApiTest, NiSwitchSelfTest_SendRequest_SelfTestCompletesSuccessfully)

--- a/source/tests/system/niswitch_session_tests.cpp
+++ b/source/tests/system/niswitch_session_tests.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "niswitch/niswitch_library.h"
+#include "device_server.h"
 #include "niswitch/niswitch_service.h"
 
 namespace ni {
@@ -21,24 +21,10 @@ const char* kTopology = "2529/2-Wire Dual 4x16 Matrix";
 class NiSwitchSessionTest : public ::testing::Test {
  protected:
   NiSwitchSessionTest()
-  {
-    ::grpc::ServerBuilder builder;
-    session_repository_ = std::make_unique<nidevice_grpc::SessionRepository>();
-    niswitch_library_ = std::make_unique<niswitch::NiSwitchLibrary>();
-    niswitch_service_ = std::make_unique<niswitch::NiSwitchService>(niswitch_library_.get(), session_repository_.get());
-    builder.RegisterService(niswitch_service_.get());
-
-    server_ = builder.BuildAndStart();
-    ResetStubs();
-  }
+      : niswitch_stub_(niswitch::NiSwitch::NewStub(DeviceServerInterface::Singleton()->InProcessChannel()))
+  {}
 
   virtual ~NiSwitchSessionTest() {}
-
-  void ResetStubs()
-  {
-    channel_ = server_->InProcessChannel(::grpc::ChannelArguments());
-    niswitch_stub_ = niswitch::NiSwitch::NewStub(channel_);
-  }
 
   std::unique_ptr<niswitch::NiSwitch::Stub>& GetStub()
   {
@@ -77,12 +63,7 @@ class NiSwitchSessionTest : public ::testing::Test {
   }
 
  private:
-  std::shared_ptr<::grpc::Channel> channel_;
   std::unique_ptr<niswitch::NiSwitch::Stub> niswitch_stub_;
-  std::unique_ptr<nidevice_grpc::SessionRepository> session_repository_;
-  std::unique_ptr<niswitch::NiSwitchLibrary> niswitch_library_;
-  std::unique_ptr<niswitch::NiSwitchService> niswitch_service_;
-  std::unique_ptr<::grpc::Server> server_;
 };
 
 TEST_F(NiSwitchSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDriverSession)

--- a/source/tests/system/niswitch_session_tests.cpp
+++ b/source/tests/system/niswitch_session_tests.cpp
@@ -21,8 +21,11 @@ const char* kTopology = "2529/2-Wire Dual 4x16 Matrix";
 class NiSwitchSessionTest : public ::testing::Test {
  protected:
   NiSwitchSessionTest()
-      : niswitch_stub_(niswitch::NiSwitch::NewStub(DeviceServerInterface::Singleton()->InProcessChannel()))
-  {}
+      : device_server_(DeviceServerInterface::Singleton()),
+        niswitch_stub_(niswitch::NiSwitch::NewStub(device_server_->InProcessChannel()))
+  {
+    device_server_->ResetServer();
+  }
 
   virtual ~NiSwitchSessionTest() {}
 
@@ -63,6 +66,7 @@ class NiSwitchSessionTest : public ::testing::Test {
   }
 
  private:
+  DeviceServerInterface* device_server_;
   std::unique_ptr<niswitch::NiSwitch::Stub> niswitch_stub_;
 };
 

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "nisync/nisync_library.h"
+#include "device_server.h"
 #include "nisync/nisync_service.h"
 
 namespace ni {
@@ -20,16 +20,8 @@ static const char* kInvalidTerminal = "Invalid";
 class NiSyncDriverApiTest : public ::testing::Test {
  protected:
   NiSyncDriverApiTest()
-  {
-    ::grpc::ServerBuilder builder;
-    session_repository_ = std::make_unique<nidevice_grpc::SessionRepository>();
-    nisync_library_ = std::make_unique<nisync::NiSyncLibrary>();
-    nisync_service_ = std::make_unique<nisync::NiSyncService>(nisync_library_.get(), session_repository_.get());
-    builder.RegisterService(nisync_service_.get());
-
-    server_ = builder.BuildAndStart();
-    ResetStubs();
-  }
+      : nisync_stub_(nisync::NiSync::NewStub(DeviceServerInterface::Singleton()->InProcessChannel()))
+  {}
 
   virtual ~NiSyncDriverApiTest() {}
 
@@ -41,12 +33,6 @@ class NiSyncDriverApiTest : public ::testing::Test {
   void TearDown() override
   {
     close_driver_session();
-  }
-
-  void ResetStubs()
-  {
-    channel_ = server_->InProcessChannel(::grpc::ChannelArguments());
-    nisync_stub_ = nisync::NiSync::NewStub(channel_);
   }
 
   std::unique_ptr<nisync::NiSync::Stub>& GetStub()
@@ -262,7 +248,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     *viStatusOut = response.status();
     return grpcStatus;
   }
- 
+
   ::grpc::Status call_SetAttributeViBoolean(ViConstString activeItem, ViAttr attribute, ViBoolean value, ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
@@ -344,13 +330,8 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
 private:
-  std::shared_ptr<::grpc::Channel> channel_;
   std::unique_ptr<::nidevice_grpc::Session> driver_session_;
   std::unique_ptr<nisync::NiSync::Stub> nisync_stub_;
-  std::unique_ptr<nidevice_grpc::SessionRepository> session_repository_;
-  std::unique_ptr<nisync::NiSyncLibrary> nisync_library_;
-  std::unique_ptr<nisync::NiSyncService> nisync_service_;
-  std::unique_ptr<::grpc::Server> server_;
 };
 
 TEST_F(NiSyncDriverApiTest, RevisionQuery_ReturnsNonEmptyRevisions)

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -20,8 +20,11 @@ static const char* kInvalidTerminal = "Invalid";
 class NiSyncDriverApiTest : public ::testing::Test {
  protected:
   NiSyncDriverApiTest()
-      : nisync_stub_(nisync::NiSync::NewStub(DeviceServerInterface::Singleton()->InProcessChannel()))
-  {}
+      : device_server_(DeviceServerInterface::Singleton()),
+        nisync_stub_(nisync::NiSync::NewStub(device_server_->InProcessChannel()))
+  {
+    device_server_->ResetServer();
+  }
 
   virtual ~NiSyncDriverApiTest() {}
 
@@ -330,6 +333,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
 private:
+  DeviceServerInterface* device_server_;
   std::unique_ptr<::nidevice_grpc::Session> driver_session_;
   std::unique_ptr<nisync::NiSync::Stub> nisync_stub_;
 };

--- a/source/tests/system/nisync_session_tests.cpp
+++ b/source/tests/system/nisync_session_tests.cpp
@@ -19,8 +19,11 @@ static const char* kInvalidRsrcName = "InvalidName";
 class NiSyncSessionTest : public ::testing::Test {
  protected:
   NiSyncSessionTest()
-      : nisync_stub_(nisync::NiSync::NewStub(DeviceServerInterface::Singleton()->InProcessChannel()))
-  {}
+      : device_server_(DeviceServerInterface::Singleton()),
+        nisync_stub_(nisync::NiSync::NewStub(device_server_->InProcessChannel()))
+  {
+    device_server_->ResetServer();
+  }
 
   virtual ~NiSyncSessionTest() {}
 
@@ -42,6 +45,7 @@ class NiSyncSessionTest : public ::testing::Test {
   }
 
  private:
+  DeviceServerInterface* device_server_;
   std::unique_ptr<nisync::NiSync::Stub> nisync_stub_;
 };
 

--- a/source/tests/system/nisync_session_tests.cpp
+++ b/source/tests/system/nisync_session_tests.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "nisync/nisync_library.h"
+#include "device_server.h"
 #include "nisync/nisync_service.h"
 
 namespace ni {
@@ -19,24 +19,10 @@ static const char* kInvalidRsrcName = "InvalidName";
 class NiSyncSessionTest : public ::testing::Test {
  protected:
   NiSyncSessionTest()
-  {
-    ::grpc::ServerBuilder builder;
-    session_repository_ = std::make_unique<nidevice_grpc::SessionRepository>();
-    nisync_library_ = std::make_unique<nisync::NiSyncLibrary>();
-    nisync_service_ = std::make_unique<nisync::NiSyncService>(nisync_library_.get(), session_repository_.get());
-    builder.RegisterService(nisync_service_.get());
-
-    server_ = builder.BuildAndStart();
-    ResetStubs();
-  }
+      : nisync_stub_(nisync::NiSync::NewStub(DeviceServerInterface::Singleton()->InProcessChannel()))
+  {}
 
   virtual ~NiSyncSessionTest() {}
-
-  void ResetStubs()
-  {
-    channel_ = server_->InProcessChannel(::grpc::ChannelArguments());
-    nisync_stub_ = nisync::NiSync::NewStub(channel_);
-  }
 
   std::unique_ptr<nisync::NiSync::Stub>& GetStub()
   {
@@ -56,12 +42,7 @@ class NiSyncSessionTest : public ::testing::Test {
   }
 
  private:
-  std::shared_ptr<::grpc::Channel> channel_;
   std::unique_ptr<nisync::NiSync::Stub> nisync_stub_;
-  std::unique_ptr<nidevice_grpc::SessionRepository> session_repository_;
-  std::unique_ptr<nisync::NiSyncLibrary> nisync_library_;
-  std::unique_ptr<nisync::NiSyncService> nisync_service_;
-  std::unique_ptr<::grpc::Server> server_;
 };
 
 TEST_F(NiSyncSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDriverSession)

--- a/source/tests/system/session_utilities_service_tests.cpp
+++ b/source/tests/system/session_utilities_service_tests.cpp
@@ -13,8 +13,11 @@ using ::testing::Not;
 class SessionUtilitiesServiceTests : public ::testing::Test {
  protected:
   SessionUtilitiesServiceTests()
-      : stub_(nidevice_grpc::SessionUtilities::NewStub(DeviceServerInterface::Singleton()->InProcessChannel()))
-  {}
+      : device_server_(DeviceServerInterface::Singleton()),
+        stub_(nidevice_grpc::SessionUtilities::NewStub(device_server_->InProcessChannel()))
+  {
+    device_server_->ResetServer();
+  }
 
   virtual ~SessionUtilitiesServiceTests() {}
 
@@ -24,6 +27,7 @@ class SessionUtilitiesServiceTests : public ::testing::Test {
   }
 
  private:
+  DeviceServerInterface* device_server_;
   std::unique_ptr<::nidevice_grpc::SessionUtilities::Stub> stub_;
 };
 

--- a/source/tests/system/session_utilities_service_tests.cpp
+++ b/source/tests/system/session_utilities_service_tests.cpp
@@ -1,7 +1,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "device_server.h"
 #include <server/session_utilities_service.h>
-#include <server/syscfg_library.h>
 
 namespace ni {
 namespace tests {
@@ -13,25 +13,10 @@ using ::testing::Not;
 class SessionUtilitiesServiceTests : public ::testing::Test {
  protected:
   SessionUtilitiesServiceTests()
-  {
-    ::grpc::ServerBuilder builder;
-    session_repository_ = std::make_unique<nidevice_grpc::SessionRepository>();
-    syscfg_library_ = std::make_unique<nidevice_grpc::SysCfgLibrary>();
-    device_enumerator_ = std::make_unique<nidevice_grpc::DeviceEnumerator>(syscfg_library_.get());
-    service_ = std::make_unique<nidevice_grpc::SessionUtilitiesService>(session_repository_.get(), device_enumerator_.get());
-    builder.RegisterService(service_.get());
-
-    server_ = builder.BuildAndStart();
-    ResetStub();
-  }
+      : stub_(nidevice_grpc::SessionUtilities::NewStub(DeviceServerInterface::Singleton()->InProcessChannel()))
+  {}
 
   virtual ~SessionUtilitiesServiceTests() {}
-
-  void ResetStub()
-  {
-    channel_ = server_->InProcessChannel(::grpc::ChannelArguments());
-    stub_ = nidevice_grpc::SessionUtilities::NewStub(channel_);
-  }
 
   std::unique_ptr<nidevice_grpc::SessionUtilities::Stub>& GetStub()
   {
@@ -39,13 +24,7 @@ class SessionUtilitiesServiceTests : public ::testing::Test {
   }
 
  private:
-  std::shared_ptr<::grpc::Channel> channel_;
   std::unique_ptr<::nidevice_grpc::SessionUtilities::Stub> stub_;
-  std::unique_ptr<nidevice_grpc::SessionRepository> session_repository_;
-  std::unique_ptr<nidevice_grpc::SysCfgLibrary> syscfg_library_;
-  std::unique_ptr<nidevice_grpc::DeviceEnumerator> device_enumerator_;
-  std::unique_ptr<nidevice_grpc::SessionUtilitiesService> service_;
-  std::unique_ptr<::grpc::Server> server_;
 };
 
 TEST_F(SessionUtilitiesServiceTests, SysCfgLibraryPresent_EnumerateDevices_ResponseContainsAtLeastOneDevice)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Centralized creation of in-process device server for the system tests

### Why should this Pull Request be merged?

Refactoring creation and lifetime management of device server to play nice with adding device auto discover being added in #192.

### What testing has been done?
Ran system tests on Linux RT system with PXIe-6674T `./SystemTestsRunner --gtest_filter=NiSync*`:
```
[----------] Global test environment tear-down
[==========] 26 tests from 2 test suites ran. (283 ms total)
[  PASSED  ] 25 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] NiSyncDriverApiTest.SendSoftwareTriggerOnInvalidTerminal_ReturnsInvalidSrcTerminal
```