### PR TITLE
Fixed nidmm_service.cpp build

### DIFF
--- a/generated/nidmm/nidmm.proto
+++ b/generated/nidmm/nidmm.proto
@@ -1154,10 +1154,9 @@ message GetApertureTimeInfoRequest {
 
 message GetApertureTimeInfoResponse {
   int32 status = 1;
-  ApertureTime aperture_time = 2;
-  double aperture_time_raw = 3;
-  ApertureTimeUnits aperture_time_units = 4;
-  sint32 aperture_time_units_raw = 5;
+  double aperture_time = 2;
+  ApertureTimeUnits aperture_time_units = 3;
+  sint32 aperture_time_units_raw = 4;
 }
 
 message GetAttributeViBooleanRequest {

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -1425,8 +1425,7 @@ namespace nidmm_grpc {
       auto status = library_->GetApertureTimeInfo(vi, &aperture_time, &aperture_time_units);
       response->set_status(status);
       if (status == 0) {
-        response->set_aperture_time(static_cast<nidmm_grpc::ApertureTime>(aperture_time));
-        response->set_aperture_time_raw(aperture_time);
+        response->set_aperture_time(aperture_time);
         response->set_aperture_time_units(static_cast<nidmm_grpc::ApertureTimeUnits>(aperture_time_units));
         response->set_aperture_time_units_raw(aperture_time_units);
       }

--- a/source/codegen/metadata/nidmm/functions.py
+++ b/source/codegen/metadata/nidmm/functions.py
@@ -1042,7 +1042,6 @@ functions = {
             "name": "apertureTime",
             "direction": "out",
             "type": "ViReal64",
-            "enum": "ApertureTime"
         },
         {
             "name": "apertureTimeUnits",


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes nidmm_service.cpp build

### Why should this Pull Request be merged?

Building grpc-device processes the following error:
```
D:\Repos\grpc-device\generated\nidmm\nidmm_service.cpp(1428): error C2440: 'static_cast': cannot convert from 'ViReal64' to 'nidmm_grpc::ApertureTime' [D:\Repos\grpc-device\build\SystemTestsRunner.vcxpro
j]
```
### What testing has been done?

Built locally on Windows development machine.
