### PR TITLE
Clean up Sync Tests so they run and pass 100% on Linux RT

### DIFF
--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -587,14 +587,14 @@ class NiSyncDriver6674Test : public NiSyncDriverApiTest
 {
 public:
   NiSyncDriver6674Test() : NiSyncDriverApiTest() {}
-  virtual const char* get_model_name() const { return "NI PXIe-6674T"; }
+  const char* get_model_name() const override { return "NI PXIe-6674T"; }
 };
 
 class NiSyncDriver6683Test : public NiSyncDriverApiTest
 {
 public:
   NiSyncDriver6683Test() : NiSyncDriverApiTest() {}
-  virtual const char* get_model_name() const { return "NI PXI-6683H"; }
+  const char* get_model_name() const override { return "NI PXI-6683H"; }
 };
 
 TEST_F(NiSyncDriver6674Test, RevisionQuery_ReturnsNonEmptyRevisions)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Cleans up Sync tests so they run and pass 100% on Linux RT. A few changes:
* Parameterize the required device in the test fixture
* Handle Linux-vs-Windows behavior inconsistencies
* Skip tests of functionality that aren't supported on Linux RT, yet

### Why should this Pull Request be merged?

So that all of our tests pass!

### What testing has been done?

Ran on a system with a 6674T:

```
admin@yam:~/grpc# ./SystemTestsRunner --gtest_filter=NiSync*
...
[==========] 44 tests from 3 test suites ran. (1393 ms total)
[  PASSED  ] 26 tests.
[  SKIPPED ] 18 tests, listed below:
...
```

Ran on a system with a 6683H:
```
admin@NI-PXIe-8880-03095FC1:~/grpc# ./SystemTestsRunner --gtest_filter=NiSync*
...
[==========] 44 tests from 3 test suites ran. (41827 ms total)
[  PASSED  ] 21 tests.
[  SKIPPED ] 23 tests, listed below:
...
```
