### PR TITLE
Added support for niSync_ReadMultipleTriggerTimeStamp

### DIFF
--- a/generated/nisync/nisync.proto
+++ b/generated/nisync/nisync.proto
@@ -44,6 +44,7 @@ service NiSync {
   rpc EnableTimeStampTrigger(EnableTimeStampTriggerRequest) returns (EnableTimeStampTriggerResponse);
   rpc EnableTimeStampTriggerWithDecimation(EnableTimeStampTriggerWithDecimationRequest) returns (EnableTimeStampTriggerWithDecimationResponse);
   rpc ReadTriggerTimeStamp(ReadTriggerTimeStampRequest) returns (ReadTriggerTimeStampResponse);
+  rpc ReadMultipleTriggerTimeStamp(ReadMultipleTriggerTimeStampRequest) returns (ReadMultipleTriggerTimeStampResponse);
   rpc DisableTimeStampTrigger(DisableTimeStampTriggerRequest) returns (DisableTimeStampTriggerResponse);
   rpc CreateClock(CreateClockRequest) returns (CreateClockResponse);
   rpc ClearClock(ClearClockRequest) returns (ClearClockResponse);
@@ -486,6 +487,22 @@ message ReadTriggerTimeStampResponse {
   uint32 time_nanoseconds = 3;
   uint32 time_fractional_nanoseconds = 4;
   sint32 detected_edge = 5;
+}
+
+message ReadMultipleTriggerTimeStampRequest {
+  nidevice_grpc.Session vi = 1;
+  string terminal = 2;
+  uint32 timestamps_to_read = 3;
+  double timeout = 4;
+}
+
+message ReadMultipleTriggerTimeStampResponse {
+  int32 status = 1;
+  repeated uint32 time_seconds_buffer = 2;
+  repeated uint32 time_nanoseconds_buffer = 3;
+  repeated uint32 time_fractional_nanoseconds_buffer = 4;
+  repeated sint32 detected_edge_buffer = 5;
+  uint32 timestamps_read = 6;
 }
 
 message DisableTimeStampTriggerRequest {

--- a/generated/nisync/nisync_library.cpp
+++ b/generated/nisync/nisync_library.cpp
@@ -49,6 +49,7 @@ NiSyncLibrary::NiSyncLibrary() : shared_library_(kLibraryName)
   function_pointers_.EnableTimeStampTrigger = reinterpret_cast<EnableTimeStampTriggerPtr>(shared_library_.get_function_pointer("niSync_EnableTimeStampTrigger"));
   function_pointers_.EnableTimeStampTriggerWithDecimation = reinterpret_cast<EnableTimeStampTriggerWithDecimationPtr>(shared_library_.get_function_pointer("niSync_EnableTimeStampTriggerWithDecimation"));
   function_pointers_.ReadTriggerTimeStamp = reinterpret_cast<ReadTriggerTimeStampPtr>(shared_library_.get_function_pointer("niSync_ReadTriggerTimeStamp"));
+  function_pointers_.ReadMultipleTriggerTimeStamp = reinterpret_cast<ReadMultipleTriggerTimeStampPtr>(shared_library_.get_function_pointer("niSync_ReadMultipleTriggerTimeStamp"));
   function_pointers_.DisableTimeStampTrigger = reinterpret_cast<DisableTimeStampTriggerPtr>(shared_library_.get_function_pointer("niSync_DisableTimeStampTrigger"));
   function_pointers_.CreateClock = reinterpret_cast<CreateClockPtr>(shared_library_.get_function_pointer("niSync_CreateClock"));
   function_pointers_.ClearClock = reinterpret_cast<ClearClockPtr>(shared_library_.get_function_pointer("niSync_ClearClock"));
@@ -436,6 +437,18 @@ ViStatus NiSyncLibrary::ReadTriggerTimeStamp(ViSession vi, ViConstString termina
   return niSync_ReadTriggerTimeStamp(vi, terminal, timeout, timeSeconds, timeNanoseconds, timeFractionalNanoseconds, detectedEdge);
 #else
   return function_pointers_.ReadTriggerTimeStamp(vi, terminal, timeout, timeSeconds, timeNanoseconds, timeFractionalNanoseconds, detectedEdge);
+#endif
+}
+
+ViStatus NiSyncLibrary::ReadMultipleTriggerTimeStamp(ViSession vi, ViConstString terminal, ViUInt32 timestampsToRead, ViReal64 timeout, ViUInt32 timeSecondsBuffer[], ViUInt32 timeNanosecondsBuffer[], ViUInt16 timeFractionalNanosecondsBuffer[], ViInt32 detectedEdgeBuffer[], ViUInt32* timestampsRead)
+{
+  if (!function_pointers_.ReadMultipleTriggerTimeStamp) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niSync_ReadMultipleTriggerTimeStamp.");
+  }
+#if defined(_MSC_VER)
+  return niSync_ReadMultipleTriggerTimeStamp(vi, terminal, timestampsToRead, timeout, timeSecondsBuffer, timeNanosecondsBuffer, timeFractionalNanosecondsBuffer, detectedEdgeBuffer, timestampsRead);
+#else
+  return function_pointers_.ReadMultipleTriggerTimeStamp(vi, terminal, timestampsToRead, timeout, timeSecondsBuffer, timeNanosecondsBuffer, timeFractionalNanosecondsBuffer, detectedEdgeBuffer, timestampsRead);
 #endif
 }
 

--- a/generated/nisync/nisync_library.h
+++ b/generated/nisync/nisync_library.h
@@ -46,6 +46,7 @@ class NiSyncLibrary : public nisync_grpc::NiSyncLibraryInterface {
   ViStatus EnableTimeStampTrigger(ViSession vi, ViConstString terminal, ViInt32 activeEdge);
   ViStatus EnableTimeStampTriggerWithDecimation(ViSession vi, ViConstString terminal, ViInt32 activeEdge, ViUInt32 decimationCount);
   ViStatus ReadTriggerTimeStamp(ViSession vi, ViConstString terminal, ViReal64 timeout, ViUInt32* timeSeconds, ViUInt32* timeNanoseconds, ViUInt16* timeFractionalNanoseconds, ViInt32* detectedEdge);
+  ViStatus ReadMultipleTriggerTimeStamp(ViSession vi, ViConstString terminal, ViUInt32 timestampsToRead, ViReal64 timeout, ViUInt32 timeSecondsBuffer[], ViUInt32 timeNanosecondsBuffer[], ViUInt16 timeFractionalNanosecondsBuffer[], ViInt32 detectedEdgeBuffer[], ViUInt32* timestampsRead);
   ViStatus DisableTimeStampTrigger(ViSession vi, ViConstString terminal);
   ViStatus CreateClock(ViSession vi, ViConstString terminal, ViUInt32 highTicks, ViUInt32 lowTicks, ViUInt32 startTimeSeconds, ViUInt32 startTimeNanoseconds, ViUInt16 startTimeFractionalNanoseconds, ViUInt32 stopTimeSeconds, ViUInt32 stopTimeNanoseconds, ViUInt16 stopTimeFractionalNanoseconds);
   ViStatus ClearClock(ViSession vi, ViConstString terminal);
@@ -117,6 +118,7 @@ class NiSyncLibrary : public nisync_grpc::NiSyncLibraryInterface {
   using EnableTimeStampTriggerPtr = ViStatus (*)(ViSession vi, ViConstString terminal, ViInt32 activeEdge);
   using EnableTimeStampTriggerWithDecimationPtr = ViStatus (*)(ViSession vi, ViConstString terminal, ViInt32 activeEdge, ViUInt32 decimationCount);
   using ReadTriggerTimeStampPtr = ViStatus (*)(ViSession vi, ViConstString terminal, ViReal64 timeout, ViUInt32* timeSeconds, ViUInt32* timeNanoseconds, ViUInt16* timeFractionalNanoseconds, ViInt32* detectedEdge);
+  using ReadMultipleTriggerTimeStampPtr = ViStatus (*)(ViSession vi, ViConstString terminal, ViUInt32 timestampsToRead, ViReal64 timeout, ViUInt32 timeSecondsBuffer[], ViUInt32 timeNanosecondsBuffer[], ViUInt16 timeFractionalNanosecondsBuffer[], ViInt32 detectedEdgeBuffer[], ViUInt32* timestampsRead);
   using DisableTimeStampTriggerPtr = ViStatus (*)(ViSession vi, ViConstString terminal);
   using CreateClockPtr = ViStatus (*)(ViSession vi, ViConstString terminal, ViUInt32 highTicks, ViUInt32 lowTicks, ViUInt32 startTimeSeconds, ViUInt32 startTimeNanoseconds, ViUInt16 startTimeFractionalNanoseconds, ViUInt32 stopTimeSeconds, ViUInt32 stopTimeNanoseconds, ViUInt16 stopTimeFractionalNanoseconds);
   using ClearClockPtr = ViStatus (*)(ViSession vi, ViConstString terminal);
@@ -188,6 +190,7 @@ class NiSyncLibrary : public nisync_grpc::NiSyncLibraryInterface {
     EnableTimeStampTriggerPtr EnableTimeStampTrigger;
     EnableTimeStampTriggerWithDecimationPtr EnableTimeStampTriggerWithDecimation;
     ReadTriggerTimeStampPtr ReadTriggerTimeStamp;
+    ReadMultipleTriggerTimeStampPtr ReadMultipleTriggerTimeStamp;
     DisableTimeStampTriggerPtr DisableTimeStampTrigger;
     CreateClockPtr CreateClock;
     ClearClockPtr ClearClock;

--- a/generated/nisync/nisync_library_interface.h
+++ b/generated/nisync/nisync_library_interface.h
@@ -43,6 +43,7 @@ class NiSyncLibraryInterface {
   virtual ViStatus EnableTimeStampTrigger(ViSession vi, ViConstString terminal, ViInt32 activeEdge) = 0;
   virtual ViStatus EnableTimeStampTriggerWithDecimation(ViSession vi, ViConstString terminal, ViInt32 activeEdge, ViUInt32 decimationCount) = 0;
   virtual ViStatus ReadTriggerTimeStamp(ViSession vi, ViConstString terminal, ViReal64 timeout, ViUInt32* timeSeconds, ViUInt32* timeNanoseconds, ViUInt16* timeFractionalNanoseconds, ViInt32* detectedEdge) = 0;
+  virtual ViStatus ReadMultipleTriggerTimeStamp(ViSession vi, ViConstString terminal, ViUInt32 timestampsToRead, ViReal64 timeout, ViUInt32 timeSecondsBuffer[], ViUInt32 timeNanosecondsBuffer[], ViUInt16 timeFractionalNanosecondsBuffer[], ViInt32 detectedEdgeBuffer[], ViUInt32* timestampsRead) = 0;
   virtual ViStatus DisableTimeStampTrigger(ViSession vi, ViConstString terminal) = 0;
   virtual ViStatus CreateClock(ViSession vi, ViConstString terminal, ViUInt32 highTicks, ViUInt32 lowTicks, ViUInt32 startTimeSeconds, ViUInt32 startTimeNanoseconds, ViUInt16 startTimeFractionalNanoseconds, ViUInt32 stopTimeSeconds, ViUInt32 stopTimeNanoseconds, ViUInt16 stopTimeFractionalNanoseconds) = 0;
   virtual ViStatus ClearClock(ViSession vi, ViConstString terminal) = 0;

--- a/generated/nisync/nisync_mock_library.h
+++ b/generated/nisync/nisync_mock_library.h
@@ -45,6 +45,7 @@ class NiSyncMockLibrary : public nisync_grpc::NiSyncLibraryInterface {
   MOCK_METHOD(ViStatus, EnableTimeStampTrigger, (ViSession vi, ViConstString terminal, ViInt32 activeEdge), (override));
   MOCK_METHOD(ViStatus, EnableTimeStampTriggerWithDecimation, (ViSession vi, ViConstString terminal, ViInt32 activeEdge, ViUInt32 decimationCount), (override));
   MOCK_METHOD(ViStatus, ReadTriggerTimeStamp, (ViSession vi, ViConstString terminal, ViReal64 timeout, ViUInt32* timeSeconds, ViUInt32* timeNanoseconds, ViUInt16* timeFractionalNanoseconds, ViInt32* detectedEdge), (override));
+  MOCK_METHOD(ViStatus, ReadMultipleTriggerTimeStamp, (ViSession vi, ViConstString terminal, ViUInt32 timestampsToRead, ViReal64 timeout, ViUInt32 timeSecondsBuffer[], ViUInt32 timeNanosecondsBuffer[], ViUInt16 timeFractionalNanosecondsBuffer[], ViInt32 detectedEdgeBuffer[], ViUInt32* timestampsRead), (override));
   MOCK_METHOD(ViStatus, DisableTimeStampTrigger, (ViSession vi, ViConstString terminal), (override));
   MOCK_METHOD(ViStatus, CreateClock, (ViSession vi, ViConstString terminal, ViUInt32 highTicks, ViUInt32 lowTicks, ViUInt32 startTimeSeconds, ViUInt32 startTimeNanoseconds, ViUInt16 startTimeFractionalNanoseconds, ViUInt32 stopTimeSeconds, ViUInt32 stopTimeNanoseconds, ViUInt16 stopTimeFractionalNanoseconds), (override));
   MOCK_METHOD(ViStatus, ClearClock, (ViSession vi, ViConstString terminal), (override));

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -664,6 +664,40 @@ namespace nisync_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiSyncService::ReadMultipleTriggerTimeStamp(::grpc::ServerContext* context, const ReadMultipleTriggerTimeStampRequest* request, ReadMultipleTriggerTimeStampResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViConstString terminal = request->terminal().c_str();
+      ViUInt32 timestamps_to_read = request->timestamps_to_read();
+      ViReal64 timeout = request->timeout();
+      response->mutable_time_seconds_buffer()->Resize(timestamps_to_read, 0);
+      ViUInt32* time_seconds_buffer = reinterpret_cast<ViUInt32*>(response->mutable_time_seconds_buffer()->mutable_data());
+      response->mutable_time_nanoseconds_buffer()->Resize(timestamps_to_read, 0);
+      ViUInt32* time_nanoseconds_buffer = reinterpret_cast<ViUInt32*>(response->mutable_time_nanoseconds_buffer()->mutable_data());
+      response->mutable_time_fractional_nanoseconds_buffer()->Resize(timestamps_to_read, 0);
+      ViUInt16* time_fractional_nanoseconds_buffer = reinterpret_cast<ViUInt16*>(response->mutable_time_fractional_nanoseconds_buffer()->mutable_data());
+      response->mutable_detected_edge_buffer()->Resize(timestamps_to_read, 0);
+      ViInt32* detected_edge_buffer = reinterpret_cast<ViInt32*>(response->mutable_detected_edge_buffer()->mutable_data());
+      ViUInt32 timestamps_read {};
+      auto status = library_->ReadMultipleTriggerTimeStamp(vi, terminal, timestamps_to_read, timeout, time_seconds_buffer, time_nanoseconds_buffer, time_fractional_nanoseconds_buffer, detected_edge_buffer, &timestamps_read);
+      response->set_status(status);
+      if (status == 0) {
+        response->set_timestamps_read(timestamps_read);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiSyncService::DisableTimeStampTrigger(::grpc::ServerContext* context, const DisableTimeStampTriggerRequest* request, DisableTimeStampTriggerResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nisync/nisync_service.h
+++ b/generated/nisync/nisync_service.h
@@ -52,6 +52,7 @@ public:
   ::grpc::Status EnableTimeStampTrigger(::grpc::ServerContext* context, const EnableTimeStampTriggerRequest* request, EnableTimeStampTriggerResponse* response) override;
   ::grpc::Status EnableTimeStampTriggerWithDecimation(::grpc::ServerContext* context, const EnableTimeStampTriggerWithDecimationRequest* request, EnableTimeStampTriggerWithDecimationResponse* response) override;
   ::grpc::Status ReadTriggerTimeStamp(::grpc::ServerContext* context, const ReadTriggerTimeStampRequest* request, ReadTriggerTimeStampResponse* response) override;
+  ::grpc::Status ReadMultipleTriggerTimeStamp(::grpc::ServerContext* context, const ReadMultipleTriggerTimeStampRequest* request, ReadMultipleTriggerTimeStampResponse* response) override;
   ::grpc::Status DisableTimeStampTrigger(::grpc::ServerContext* context, const DisableTimeStampTriggerRequest* request, DisableTimeStampTriggerResponse* response) override;
   ::grpc::Status CreateClock(::grpc::ServerContext* context, const CreateClockRequest* request, CreateClockResponse* response) override;
   ::grpc::Status ClearClock(::grpc::ServerContext* context, const ClearClockRequest* request, ClearClockResponse* response) override;

--- a/source/codegen/metadata/nisync/functions.py
+++ b/source/codegen/metadata/nisync/functions.py
@@ -617,6 +617,72 @@ functions = {
         ],
         "returns": "ViStatus",
     },
+    "ReadMultipleTriggerTimeStamp": {
+        "parameters": [
+            {
+                "direction": "in",
+                "name": "vi",
+                "type": "ViSession",
+            },
+            {
+                "direction": "in",
+                "name": "terminal",
+                "type": "ViConstString",
+            },
+            {
+                "direction": "in",
+                "name": "timestampsToRead",
+                "type": "ViUInt32",
+            },
+            {
+                "direction": "in",
+                "name": "timeout",
+                "type": "ViReal64",
+            },
+            {
+                "direction": "out",
+                "name": "timeSecondsBuffer",
+                "type": "ViUInt32[]",
+                "size": {
+                    "mechanism": "passed-in",
+                    "value": "timestampsToRead",
+                },
+            },
+            {
+                "direction": "out",
+                "name": "timeNanosecondsBuffer",
+                "type": "ViUInt32[]",
+                "size": {
+                    "mechanism": "passed-in",
+                    "value": "timestampsToRead",
+                },
+            },
+            {
+                "direction": "out",
+                "name": "timeFractionalNanosecondsBuffer",
+                "type": "ViUInt16[]",
+                "size": {
+                    "mechanism": "passed-in",
+                    "value": "timestampsToRead",
+                },
+            },
+            {
+                "direction": "out",
+                "name": "detectedEdgeBuffer",
+                "type": "ViInt32[]",
+                "size": {
+                    "mechanism": "passed-in",
+                    "value": "timestampsToRead",
+                },
+            },
+            {
+                "direction": "out",
+                "name": "timestampsRead",
+                "type": "ViUInt32",
+            },
+        ],
+        "returns": "ViStatus",
+    },
     "DisableTimeStampTrigger": {
         "parameters": [
             {

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -229,7 +229,7 @@ one_of_case_prefix = f'{namespace_prefix}{function_name}Request::{PascalFieldNam
       if (${size} > 0) {
           ${parameter_name}.resize(${size}-1);
       }
-%     elif underlying_param_type == 'ViAddr':
+%     elif underlying_param_type in ['ViAddr', 'ViInt32', 'ViUInt32', 'ViUInt16']:
       response->mutable_${parameter_name}()->Resize(${size}, 0);
       ${underlying_param_type}* ${parameter_name} = reinterpret_cast<${underlying_param_type}*>(response->mutable_${parameter_name}()->mutable_data());
 %     else:

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -562,6 +562,88 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
+  ::grpc::Status call_EnableTimeStampTrigger(
+     ViConstString terminal,
+     ViInt32 activeEdge,
+     ViStatus* viStatusOut)
+  {
+    ::grpc::ClientContext clientContext;
+    nisync::EnableTimeStampTriggerRequest request;
+    nisync::EnableTimeStampTriggerResponse response;
+    request.set_terminal(terminal);
+    request.set_active_edge(activeEdge);
+    request.mutable_vi()->set_id(driver_session_->id());
+    auto grpcStatus = GetStub()->EnableTimeStampTrigger(&clientContext, request, &response);
+    *viStatusOut = response.status();
+    return grpcStatus;
+  }
+
+  ::grpc::Status call_ReadTriggerTimeStamp(
+     ViConstString terminal,
+     ViReal64 timeout,
+     ViUInt32* timeSeconds,
+     ViUInt32* timeNanoseconds,
+     ViUInt16* timeFractionalNanoseconds,
+     ViInt32* detectedEdge,
+     ViStatus* viStatusOut)
+  {
+    ::grpc::ClientContext clientContext;
+    nisync::ReadTriggerTimeStampRequest request;
+    nisync::ReadTriggerTimeStampResponse response;
+    request.set_terminal(terminal);
+    request.set_timeout(timeout);
+    request.mutable_vi()->set_id(driver_session_->id());
+    auto grpcStatus = GetStub()->ReadTriggerTimeStamp(&clientContext, request, &response);
+    *timeSeconds = response.time_seconds();
+    *timeNanoseconds = response.time_nanoseconds();
+    *timeFractionalNanoseconds = response.time_fractional_nanoseconds();
+    *detectedEdge = response.detected_edge();
+    *viStatusOut = response.status();
+    return grpcStatus;
+  }
+
+  ::grpc::Status call_ReadMultipleTriggerTimeStamp(
+     ViConstString terminal,
+     ViReal64 timeout,
+     ViUInt32 timestampsToRead,
+     ViUInt32* timeSecondsBuffer,
+     ViUInt32* timeNanosecondsBuffer,
+     ViUInt16* timeFractionalNanosecondsBuffer,
+     ViInt32* detectedEdgeBuffer,
+     ViUInt32* timestampsRead,
+     ViStatus* viStatusOut)
+  {
+    ::grpc::ClientContext clientContext;
+    nisync::ReadMultipleTriggerTimeStampRequest request;
+    nisync::ReadMultipleTriggerTimeStampResponse response;
+    request.set_terminal(terminal);
+    request.set_timeout(timeout);
+    request.set_timestamps_to_read(timestampsToRead);
+    request.mutable_vi()->set_id(driver_session_->id());
+    auto grpcStatus = GetStub()->ReadMultipleTriggerTimeStamp(&clientContext, request, &response);
+    *timestampsRead = response.timestamps_read();
+    memcpy(timeSecondsBuffer, response.time_seconds_buffer().data(), *timestampsRead);
+    memcpy(timeNanosecondsBuffer, response.time_nanoseconds_buffer().data(), *timestampsRead);
+    memcpy(timeFractionalNanosecondsBuffer, response.time_fractional_nanoseconds_buffer().data(), *timestampsRead);
+    memcpy(detectedEdgeBuffer, response.detected_edge_buffer().data(), *timestampsRead);
+    *viStatusOut = response.status();
+    return grpcStatus;
+  }
+
+  ::grpc::Status call_DisableTimeStampTrigger(
+     ViConstString terminal,
+     ViStatus* viStatusOut)
+  {
+    ::grpc::ClientContext clientContext;
+    nisync::DisableTimeStampTriggerRequest request;
+    nisync::DisableTimeStampTriggerResponse response;
+    request.set_terminal(terminal);
+    request.mutable_vi()->set_id(driver_session_->id());
+    auto grpcStatus = GetStub()->DisableTimeStampTrigger(&clientContext, request, &response);
+    *viStatusOut = response.status();
+    return grpcStatus;
+  }
+
   ViUInt32 GetCurrentBoardTimeSeconds()
   {
     ViStatus viStatus;


### PR DESCRIPTION
### What does this Pull Request accomplish?

Added support for niSync_ReadMultipleTriggerTimeStamp
- Added ReadMultipleTriggerTimeStamp to nisync/functions.py
- Updated `service_helpers.mako` to support arrays of `ViInt32`, `ViUInt32` and `ViUInt16`
- Added system tests to exercise ReadMultipleTriggerTimeStamp

Fixed test failures on Windows.

### Why should this Pull Request be merged?

This PR completes the support for functions available in the public NI-Sync C API.

### What testing has been done?

Ran `.\SystemTestsRunner.exe --gtest_filter=*TimeStamp*` on Windows
```
Note: Google Test filter = *TimeStamp*
[==========] Running 6 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 6 tests from NiSyncDriver6683Test
[ RUN      ] NiSyncDriver6683Test.EnableTimeStampTrigger_ReturnsSuccess
[       OK ] NiSyncDriver6683Test.EnableTimeStampTrigger_ReturnsSuccess (5406 ms)
[ RUN      ] NiSyncDriver6683Test.EnableTimeStampTriggerWithInvalidTerminal_ReturnsError
[       OK ] NiSyncDriver6683Test.EnableTimeStampTriggerWithInvalidTerminal_ReturnsError (10 ms)
[ RUN      ] NiSyncDriver6683Test.DisableTimeStampTriggerNotReserved_ReturnsError
[       OK ] NiSyncDriver6683Test.DisableTimeStampTriggerNotReserved_ReturnsError (9 ms)
[ RUN      ] NiSyncDriver6683Test.GivenNoTrigger_ReadTriggerTimeStamp_ReturnsTimeoutError
[       OK ] NiSyncDriver6683Test.GivenNoTrigger_ReadTriggerTimeStamp_ReturnsTimeoutError (126 ms)
[ RUN      ] NiSyncDriver6683Test.GivenNoTrigger_ReadMultipleTriggerTimeStamp_ReturnsTimeoutError
[       OK ] NiSyncDriver6683Test.GivenNoTrigger_ReadMultipleTriggerTimeStamp_ReturnsTimeoutError (138 ms)
[ RUN      ] NiSyncDriver6683Test.GivenFiveTriggers_ReadMultipleTriggerTimeStamp_ReturnsFiveTimeStamps
[       OK ] NiSyncDriver6683Test.GivenFiveTriggers_ReadMultipleTriggerTimeStamp_ReturnsFiveTimeStamps (19 ms)
[----------] 6 tests from NiSyncDriver6683Test (5714 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test suite ran. (5727 ms total)
[  PASSED  ] 6 tests.
```
