### PR TITLE
Response strings are 1 nul-character too big

### DIFF
--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -2347,7 +2347,7 @@ namespace nidcpower_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViStatus error_code = request->error_code();
-      std::string error_message(256-1, '\0');
+      std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       response->set_status(status);
       if (status == 0) {
@@ -2648,7 +2648,7 @@ namespace nidcpower_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      std::string info(256-1, '\0');
+      std::string info(256 - 1, '\0');
       auto status = library_->GetCalUserDefinedInfo(vi, (ViChar*)info.data());
       response->set_status(status);
       if (status == 0) {
@@ -3418,8 +3418,8 @@ namespace nidcpower_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      std::string instrument_driver_revision(256-1, '\0');
-      std::string firmware_revision(256-1, '\0');
+      std::string instrument_driver_revision(256 - 1, '\0');
+      std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
       if (status == 0) {
@@ -3444,7 +3444,7 @@ namespace nidcpower_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt16 self_test_result {};
-      std::string self_test_message(256-1, '\0');
+      std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
       if (status == 0) {

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -2347,7 +2347,7 @@ namespace nidcpower_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViStatus error_code = request->error_code();
-      std::string error_message(256, '\0');
+      std::string error_message(256-1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       response->set_status(status);
       if (status == 0) {
@@ -2622,7 +2622,10 @@ namespace nidcpower_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string attribute_value(buffer_size, '\0');
+      std::string attribute_value;
+      if (buffer_size > 0) {
+          attribute_value.resize(buffer_size-1);
+      }
       status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
       response->set_status(status);
       if (status == 0) {
@@ -2645,7 +2648,7 @@ namespace nidcpower_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      std::string info(256, '\0');
+      std::string info(256-1, '\0');
       auto status = library_->GetCalUserDefinedInfo(vi, (ViChar*)info.data());
       response->set_status(status);
       if (status == 0) {
@@ -2700,7 +2703,10 @@ namespace nidcpower_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string channel_name(buffer_size, '\0');
+      std::string channel_name;
+      if (buffer_size > 0) {
+          channel_name.resize(buffer_size-1);
+      }
       status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_name.data());
       response->set_status(status);
       if (status == 0) {
@@ -2732,7 +2738,10 @@ namespace nidcpower_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string channel_name(buffer_size, '\0');
+      std::string channel_name;
+      if (buffer_size > 0) {
+          channel_name.resize(buffer_size-1);
+      }
       status = library_->GetChannelNameFromString(vi, index, buffer_size, (ViChar*)channel_name.data());
       response->set_status(status);
       if (status == 0) {
@@ -2764,7 +2773,10 @@ namespace nidcpower_grpc {
       ViInt32 buffer_size = status;
 
       ViStatus code {};
-      std::string description(buffer_size, '\0');
+      std::string description;
+      if (buffer_size > 0) {
+          description.resize(buffer_size-1);
+      }
       status = library_->GetError(vi, &code, buffer_size, (ViChar*)description.data());
       response->set_status(status);
       if (status == 0) {
@@ -2873,7 +2885,10 @@ namespace nidcpower_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string coercion_record(buffer_size, '\0');
+      std::string coercion_record;
+      if (buffer_size > 0) {
+          coercion_record.resize(buffer_size-1);
+      }
       status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
       response->set_status(status);
       if (status == 0) {
@@ -2904,7 +2919,10 @@ namespace nidcpower_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string interchange_warning(buffer_size, '\0');
+      std::string interchange_warning;
+      if (buffer_size > 0) {
+          interchange_warning.resize(buffer_size-1);
+      }
       status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
       response->set_status(status);
       if (status == 0) {
@@ -3400,8 +3418,8 @@ namespace nidcpower_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      std::string instrument_driver_revision(256, '\0');
-      std::string firmware_revision(256, '\0');
+      std::string instrument_driver_revision(256-1, '\0');
+      std::string firmware_revision(256-1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
       if (status == 0) {
@@ -3426,7 +3444,7 @@ namespace nidcpower_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt16 self_test_result {};
-      std::string self_test_message(256, '\0');
+      std::string self_test_message(256-1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
       if (status == 0) {

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -1263,7 +1263,10 @@ namespace nidmm_grpc {
       }
       ViInt32 size = status;
 
-      std::string configuration(size, '\0');
+      std::string configuration;
+      if (size > 0) {
+          configuration.resize(size-1);
+      }
       status = library_->ExportAttributeConfigurationBuffer(vi, size, (ViInt8*)configuration.data());
       response->set_status(status);
       if (status == 0) {
@@ -1557,7 +1560,10 @@ namespace nidmm_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string attribute_value(buffer_size, '\0');
+      std::string attribute_value;
+      if (buffer_size > 0) {
+          attribute_value.resize(buffer_size-1);
+      }
       status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
       response->set_status(status);
       if (status == 0) {
@@ -1684,7 +1690,7 @@ namespace nidmm_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 buffer_size = request->buffer_size();
-      std::string info(256, '\0');
+      std::string info(256-1, '\0');
       auto status = library_->GetCalUserDefinedInfo(vi, buffer_size, (ViChar*)info.data());
       response->set_status(status);
       if (status == 0) {
@@ -1739,7 +1745,10 @@ namespace nidmm_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string channel_string(buffer_size, '\0');
+      std::string channel_string;
+      if (buffer_size > 0) {
+          channel_string.resize(buffer_size-1);
+      }
       status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_string.data());
       response->set_status(status);
       if (status == 0) {
@@ -1795,7 +1804,10 @@ namespace nidmm_grpc {
       ViInt32 buffer_size = status;
 
       ViStatus error_code {};
-      std::string description(buffer_size, '\0');
+      std::string description;
+      if (buffer_size > 0) {
+          description.resize(buffer_size-1);
+      }
       status = library_->GetError(vi, &error_code, buffer_size, (ViChar*)description.data());
       response->set_status(status);
       if (status == 0) {
@@ -1828,7 +1840,10 @@ namespace nidmm_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string error_message(buffer_size, '\0');
+      std::string error_message;
+      if (buffer_size > 0) {
+          error_message.resize(buffer_size-1);
+      }
       status = library_->GetErrorMessage(vi, error_code, buffer_size, (ViChar*)error_message.data());
       response->set_status(status);
       if (status == 0) {
@@ -1941,7 +1956,10 @@ namespace nidmm_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string coercion_record(buffer_size, '\0');
+      std::string coercion_record;
+      if (buffer_size > 0) {
+          coercion_record.resize(buffer_size-1);
+      }
       status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
       response->set_status(status);
       if (status == 0) {
@@ -1972,7 +1990,10 @@ namespace nidmm_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string interchange_warning(buffer_size, '\0');
+      std::string interchange_warning;
+      if (buffer_size > 0) {
+          interchange_warning.resize(buffer_size-1);
+      }
       status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
       response->set_status(status);
       if (status == 0) {
@@ -2530,8 +2551,8 @@ namespace nidmm_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      std::string instrument_driver_revision(256, '\0');
-      std::string firmware_revision(256, '\0');
+      std::string instrument_driver_revision(256-1, '\0');
+      std::string firmware_revision(256-1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
       if (status == 0) {
@@ -2575,7 +2596,7 @@ namespace nidmm_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt16 self_test_result {};
-      std::string self_test_message(256, '\0');
+      std::string self_test_message(256-1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
       if (status == 0) {

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -1263,10 +1263,7 @@ namespace nidmm_grpc {
       }
       ViInt32 size = status;
 
-      std::string configuration;
-      if (size > 0) {
-          configuration.resize(size-1);
-      }
+      std::string configuration(size, '\0');
       status = library_->ExportAttributeConfigurationBuffer(vi, size, (ViInt8*)configuration.data());
       response->set_status(status);
       if (status == 0) {

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -1687,7 +1687,7 @@ namespace nidmm_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 buffer_size = request->buffer_size();
-      std::string info(256-1, '\0');
+      std::string info(256 - 1, '\0');
       auto status = library_->GetCalUserDefinedInfo(vi, buffer_size, (ViChar*)info.data());
       response->set_status(status);
       if (status == 0) {
@@ -2548,8 +2548,8 @@ namespace nidmm_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      std::string instrument_driver_revision(256-1, '\0');
-      std::string firmware_revision(256-1, '\0');
+      std::string instrument_driver_revision(256 - 1, '\0');
+      std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
       if (status == 0) {
@@ -2593,7 +2593,7 @@ namespace nidmm_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt16 self_test_result {};
-      std::string self_test_message(256-1, '\0');
+      std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
       if (status == 0) {

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -313,7 +313,7 @@ namespace nifake_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      std::string a_string(256-1, '\0');
+      std::string a_string(256 - 1, '\0');
       auto status = library_->GetAStringOfFixedMaximumSize(vi, (ViChar*)a_string.data());
       response->set_status(status);
       if (status == 0) {
@@ -951,7 +951,7 @@ namespace nifake_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt16 a_number {};
-      std::string a_string(256-1, '\0');
+      std::string a_string(256 - 1, '\0');
       auto status = library_->ReturnANumberAndAString(vi, &a_number, (ViChar*)a_string.data());
       response->set_status(status);
       if (status == 0) {

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -218,10 +218,7 @@ namespace nifake_grpc {
       }
       ViInt32 size_in_bytes = status;
 
-      std::string configuration;
-      if (size_in_bytes > 0) {
-          configuration.resize(size_in_bytes-1);
-      }
+      std::string configuration(size_in_bytes, '\0');
       status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, (ViInt8*)configuration.data());
       response->set_status(status);
       if (status == 0) {

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -218,7 +218,10 @@ namespace nifake_grpc {
       }
       ViInt32 size_in_bytes = status;
 
-      std::string configuration(size_in_bytes, '\0');
+      std::string configuration;
+      if (size_in_bytes > 0) {
+          configuration.resize(size_in_bytes-1);
+      }
       status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, (ViInt8*)configuration.data());
       response->set_status(status);
       if (status == 0) {
@@ -313,7 +316,7 @@ namespace nifake_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      std::string a_string(256, '\0');
+      std::string a_string(256-1, '\0');
       auto status = library_->GetAStringOfFixedMaximumSize(vi, (ViChar*)a_string.data());
       response->set_status(status);
       if (status == 0) {
@@ -344,7 +347,10 @@ namespace nifake_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string a_string(buffer_size, '\0');
+      std::string a_string;
+      if (buffer_size > 0) {
+          a_string.resize(buffer_size-1);
+      }
       status = library_->GetAnIviDanceString(vi, buffer_size, (ViChar*)a_string.data());
       response->set_status(status);
       if (status == 0) {
@@ -546,7 +552,10 @@ namespace nifake_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string attribute_value(buffer_size, '\0');
+      std::string attribute_value;
+      if (buffer_size > 0) {
+          attribute_value.resize(buffer_size-1);
+      }
       status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
       response->set_status(status);
       if (status == 0) {
@@ -945,7 +954,7 @@ namespace nifake_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt16 a_number {};
-      std::string a_string(256, '\0');
+      std::string a_string(256-1, '\0');
       auto status = library_->ReturnANumberAndAString(vi, &a_number, (ViChar*)a_string.data());
       response->set_status(status);
       if (status == 0) {
@@ -1033,7 +1042,10 @@ namespace nifake_grpc {
       ViReal64 a_float_enum {};
       response->mutable_an_array()->Resize(array_size, 0);
       ViReal64* an_array = response->mutable_an_array()->mutable_data();
-      std::string a_string(string_size, '\0');
+      std::string a_string;
+      if (string_size > 0) {
+          a_string.resize(string_size-1);
+      }
       status = library_->ReturnMultipleTypes(vi, &a_boolean, &an_int32, &an_int64, &an_int_enum, &a_float, &a_float_enum, array_size, an_array, string_size, (ViChar*)a_string.data());
       response->set_status(status);
       if (status == 0) {

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -1272,10 +1272,7 @@ namespace niscope_grpc {
       }
       ViInt32 size_in_bytes = status;
 
-      std::string configuration;
-      if (size_in_bytes > 0) {
-          configuration.resize(size_in_bytes-1);
-      }
+      std::string configuration(size_in_bytes, '\0');
       status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, (ViInt8*)configuration.data());
       response->set_status(status);
       if (status == 0) {

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -1241,7 +1241,7 @@ namespace niscope_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViStatus error_code = request->error_code();
       ViChar* error_source = (ViChar*)request->error_source().c_str();
-      std::string error_description(642-1, '\0');
+      std::string error_description(642 - 1, '\0');
       auto status = library_->ErrorHandler(vi, error_code, error_source, (ViChar*)error_description.data());
       response->set_status(status);
       if (status == 0) {
@@ -1955,8 +1955,8 @@ namespace niscope_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      std::string driver_revision(256-1, '\0');
-      std::string firmware_revision(256-1, '\0');
+      std::string driver_revision(256 - 1, '\0');
+      std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
       if (status == 0) {
@@ -2027,7 +2027,7 @@ namespace niscope_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt16 self_test_result {};
-      std::string self_test_message(256-1, '\0');
+      std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
       if (status == 0) {

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -1241,7 +1241,7 @@ namespace niscope_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViStatus error_code = request->error_code();
       ViChar* error_source = (ViChar*)request->error_source().c_str();
-      std::string error_description(642, '\0');
+      std::string error_description(642-1, '\0');
       auto status = library_->ErrorHandler(vi, error_code, error_source, (ViChar*)error_description.data());
       response->set_status(status);
       if (status == 0) {
@@ -1272,7 +1272,10 @@ namespace niscope_grpc {
       }
       ViInt32 size_in_bytes = status;
 
-      std::string configuration(size_in_bytes, '\0');
+      std::string configuration;
+      if (size_in_bytes > 0) {
+          configuration.resize(size_in_bytes-1);
+      }
       status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, (ViInt8*)configuration.data());
       response->set_status(status);
       if (status == 0) {
@@ -1484,7 +1487,10 @@ namespace niscope_grpc {
       }
       ViInt32 buf_size = status;
 
-      std::string value(buf_size, '\0');
+      std::string value;
+      if (buf_size > 0) {
+          value.resize(buf_size-1);
+      }
       status = library_->GetAttributeViString(vi, channel_list, attribute_id, buf_size, (ViChar*)value.data());
       response->set_status(status);
       if (status == 0) {
@@ -1516,7 +1522,10 @@ namespace niscope_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string channel_string(buffer_size, '\0');
+      std::string channel_string;
+      if (buffer_size > 0) {
+          channel_string.resize(buffer_size-1);
+      }
       status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_string.data());
       response->set_status(status);
       if (status == 0) {
@@ -1548,7 +1557,10 @@ namespace niscope_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string name(buffer_size, '\0');
+      std::string name;
+      if (buffer_size > 0) {
+          name.resize(buffer_size-1);
+      }
       status = library_->GetChannelNameFromString(vi, index, buffer_size, (ViChar*)name.data());
       response->set_status(status);
       if (status == 0) {
@@ -1605,7 +1617,10 @@ namespace niscope_grpc {
       ViInt32 buffer_size = status;
 
       ViStatus error_code {};
-      std::string description(buffer_size, '\0');
+      std::string description;
+      if (buffer_size > 0) {
+          description.resize(buffer_size-1);
+      }
       status = library_->GetError(vi, &error_code, buffer_size, (ViChar*)description.data());
       response->set_status(status);
       if (status == 0) {
@@ -1638,7 +1653,10 @@ namespace niscope_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string error_message(buffer_size, '\0');
+      std::string error_message;
+      if (buffer_size > 0) {
+          error_message.resize(buffer_size-1);
+      }
       status = library_->GetErrorMessage(vi, error_code, buffer_size, (ViChar*)error_message.data());
       response->set_status(status);
       if (status == 0) {
@@ -1940,8 +1958,8 @@ namespace niscope_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      std::string driver_revision(256, '\0');
-      std::string firmware_revision(256, '\0');
+      std::string driver_revision(256-1, '\0');
+      std::string firmware_revision(256-1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
       if (status == 0) {
@@ -2012,7 +2030,7 @@ namespace niscope_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt16 self_test_result {};
-      std::string self_test_message(256, '\0');
+      std::string self_test_message(256-1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
       if (status == 0) {

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -466,7 +466,7 @@ namespace niswitch_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViStatus error_code = request->error_code();
-      std::string error_message(256-1, '\0');
+      std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       response->set_status(status);
       if (status == 0) {
@@ -490,7 +490,7 @@ namespace niswitch_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 error_code {};
-      std::string error_message(256-1, '\0');
+      std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorQuery(vi, &error_code, (ViChar*)error_message.data());
       response->set_status(status);
       if (status == 0) {
@@ -1204,8 +1204,8 @@ namespace niswitch_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      std::string instrument_driver_revision(256-1, '\0');
-      std::string firmware_revision(256-1, '\0');
+      std::string instrument_driver_revision(256 - 1, '\0');
+      std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
       if (status == 0) {
@@ -1355,7 +1355,7 @@ namespace niswitch_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt16 self_test_result {};
-      std::string self_test_message(256-1, '\0');
+      std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
       if (status == 0) {

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -466,7 +466,7 @@ namespace niswitch_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViStatus error_code = request->error_code();
-      std::string error_message(256, '\0');
+      std::string error_message(256-1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       response->set_status(status);
       if (status == 0) {
@@ -490,7 +490,7 @@ namespace niswitch_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 error_code {};
-      std::string error_message(256, '\0');
+      std::string error_message(256-1, '\0');
       auto status = library_->ErrorQuery(vi, &error_code, (ViChar*)error_message.data());
       response->set_status(status);
       if (status == 0) {
@@ -599,7 +599,10 @@ namespace niswitch_grpc {
       }
       ViInt32 array_size = status;
 
-      std::string attribute_value(array_size, '\0');
+      std::string attribute_value;
+      if (array_size > 0) {
+          attribute_value.resize(array_size-1);
+      }
       status = library_->GetAttributeViString(vi, channel_name, attribute_id, array_size, (ViChar*)attribute_value.data());
       response->set_status(status);
       if (status == 0) {
@@ -656,7 +659,10 @@ namespace niswitch_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string channel_name_buffer(buffer_size, '\0');
+      std::string channel_name_buffer;
+      if (buffer_size > 0) {
+          channel_name_buffer.resize(buffer_size-1);
+      }
       status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_name_buffer.data());
       response->set_status(status);
       if (status == 0) {
@@ -688,7 +694,10 @@ namespace niswitch_grpc {
       ViInt32 buffer_size = status;
 
       ViStatus code {};
-      std::string description(buffer_size, '\0');
+      std::string description;
+      if (buffer_size > 0) {
+          description.resize(buffer_size-1);
+      }
       status = library_->GetError(vi, &code, buffer_size, (ViChar*)description.data());
       response->set_status(status);
       if (status == 0) {
@@ -720,7 +729,10 @@ namespace niswitch_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string coercion_record(buffer_size, '\0');
+      std::string coercion_record;
+      if (buffer_size > 0) {
+          coercion_record.resize(buffer_size-1);
+      }
       status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
       response->set_status(status);
       if (status == 0) {
@@ -751,7 +763,10 @@ namespace niswitch_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string interchange_warning(buffer_size, '\0');
+      std::string interchange_warning;
+      if (buffer_size > 0) {
+          interchange_warning.resize(buffer_size-1);
+      }
       status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
       response->set_status(status);
       if (status == 0) {
@@ -784,7 +799,10 @@ namespace niswitch_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string path(buffer_size, '\0');
+      std::string path;
+      if (buffer_size > 0) {
+          path.resize(buffer_size-1);
+      }
       status = library_->GetPath(vi, channel1, channel2, buffer_size, (ViChar*)path.data());
       response->set_status(status);
       if (status == 0) {
@@ -840,7 +858,10 @@ namespace niswitch_grpc {
       }
       ViInt32 relay_name_buffer_size = status;
 
-      std::string relay_name_buffer(relay_name_buffer_size, '\0');
+      std::string relay_name_buffer;
+      if (relay_name_buffer_size > 0) {
+          relay_name_buffer.resize(relay_name_buffer_size-1);
+      }
       status = library_->GetRelayName(vi, index, relay_name_buffer_size, (ViChar*)relay_name_buffer.data());
       response->set_status(status);
       if (status == 0) {
@@ -1183,8 +1204,8 @@ namespace niswitch_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      std::string instrument_driver_revision(256, '\0');
-      std::string firmware_revision(256, '\0');
+      std::string instrument_driver_revision(256-1, '\0');
+      std::string firmware_revision(256-1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
       if (status == 0) {
@@ -1334,7 +1355,7 @@ namespace niswitch_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt16 self_test_result {};
-      std::string self_test_message(256, '\0');
+      std::string self_test_message(256-1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
       if (status == 0) {

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -86,7 +86,7 @@ namespace nisync_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViStatus error_code = request->error_code();
-      std::string error_message(256, '\0');
+      std::string error_message(256-1, '\0');
       auto status = library_->error_message(vi, error_code, (ViChar*)error_message.data());
       response->set_status(status);
       if (status == 0) {
@@ -148,7 +148,7 @@ namespace nisync_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt16 self_test_result {};
-      std::string self_test_message(256, '\0');
+      std::string self_test_message(256-1, '\0');
       auto status = library_->self_test(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
       if (status == 0) {
@@ -172,8 +172,8 @@ namespace nisync_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      std::string driver_revision(256, '\0');
-      std::string firmware_revision(256, '\0');
+      std::string driver_revision(256-1, '\0');
+      std::string firmware_revision(256-1, '\0');
       auto status = library_->revision_query(vi, (ViChar*)driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
       if (status == 0) {
@@ -1069,7 +1069,10 @@ namespace nisync_grpc {
       }
       ViUInt32 buffer_size = status;
 
-      std::string time_reference_names(buffer_size, '\0');
+      std::string time_reference_names;
+      if (buffer_size > 0) {
+          time_reference_names.resize(buffer_size-1);
+      }
       status = library_->GetTimeReferenceNames(vi, buffer_size, (ViChar*)time_reference_names.data());
       response->set_status(status);
       if (status == 0) {
@@ -1177,7 +1180,10 @@ namespace nisync_grpc {
       }
       ViInt32 buffer_size = status;
 
-      std::string value(buffer_size, '\0');
+      std::string value;
+      if (buffer_size > 0) {
+          value.resize(buffer_size-1);
+      }
       status = library_->GetAttributeViString(vi, active_item, attribute, buffer_size, (ViChar*)value.data());
       response->set_status(status);
       if (status == 0) {

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -86,7 +86,7 @@ namespace nisync_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViStatus error_code = request->error_code();
-      std::string error_message(256-1, '\0');
+      std::string error_message(256 - 1, '\0');
       auto status = library_->error_message(vi, error_code, (ViChar*)error_message.data());
       response->set_status(status);
       if (status == 0) {
@@ -148,7 +148,7 @@ namespace nisync_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt16 self_test_result {};
-      std::string self_test_message(256-1, '\0');
+      std::string self_test_message(256 - 1, '\0');
       auto status = library_->self_test(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
       if (status == 0) {
@@ -172,8 +172,8 @@ namespace nisync_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      std::string driver_revision(256-1, '\0');
-      std::string firmware_revision(256-1, '\0');
+      std::string driver_revision(256 - 1, '\0');
+      std::string firmware_revision(256 - 1, '\0');
       auto status = library_->revision_query(vi, (ViChar*)driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
       if (status == 0) {

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -218,12 +218,12 @@ one_of_case_prefix = f'{namespace_prefix}{function_name}Request::{PascalFieldNam
 %>\
 %     if common_helpers.is_struct(parameter) or underlying_param_type == 'ViBoolean':
       std::vector<${underlying_param_type}> ${parameter_name}(${size}, ${underlying_param_type}());
-## byte arrays are leveraging a string as a simple buffer wrapper
+## Byte arrays are leveraging a string as a buffer, so we don't need to take special consideration of the null terminator.
 %     elif service_helpers.is_string_arg(parameter) and parameter['type'] == 'ViInt8[]':
       std::string ${parameter_name}(${size}, '\0');
-## real strings leverages the underlying string buffer's null terminator as part of the size
+## Driver string APIs require room in the buffer for the null terminator. We need to account for that when sizing the string.
 %     elif service_helpers.is_string_arg(parameter) and common_helpers.get_size_mechanism(parameter) == 'fixed':
-      std::string ${parameter_name}(${size}-1, '\0');
+      std::string ${parameter_name}(${size} - 1, '\0');
 %     elif service_helpers.is_string_arg(parameter):
       std::string ${parameter_name};
       if (${size} > 0) {

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -218,8 +218,13 @@ one_of_case_prefix = f'{namespace_prefix}{function_name}Request::{PascalFieldNam
 %>\
 %     if common_helpers.is_struct(parameter) or underlying_param_type == 'ViBoolean':
       std::vector<${underlying_param_type}> ${parameter_name}(${size}, ${underlying_param_type}());
+%     elif service_helpers.is_string_arg(parameter) and common_helpers.get_size_mechanism(parameter) == 'fixed':
+      std::string ${parameter_name}(${size}-1, '\0');
 %     elif service_helpers.is_string_arg(parameter):
-      std::string ${parameter_name}(${size}, '\0');
+      std::string ${parameter_name};
+      if (${size} > 0) {
+          ${parameter_name}.resize(${size}-1);
+      }
 %     elif underlying_param_type == 'ViAddr':
       response->mutable_${parameter_name}()->Resize(${size}, 0);
       ${underlying_param_type}* ${parameter_name} = reinterpret_cast<${underlying_param_type}*>(response->mutable_${parameter_name}()->mutable_data());

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -218,6 +218,10 @@ one_of_case_prefix = f'{namespace_prefix}{function_name}Request::{PascalFieldNam
 %>\
 %     if common_helpers.is_struct(parameter) or underlying_param_type == 'ViBoolean':
       std::vector<${underlying_param_type}> ${parameter_name}(${size}, ${underlying_param_type}());
+## byte arrays are leveraging a string as a simple buffer wrapper
+%     elif service_helpers.is_string_arg(parameter) and parameter['type'] == 'ViInt8[]':
+      std::string ${parameter_name}(${size}, '\0');
+## real strings leverages the underlying string buffer's null terminator as part of the size
 %     elif service_helpers.is_string_arg(parameter) and common_helpers.get_size_mechanism(parameter) == 'fixed':
       std::string ${parameter_name}(${size}-1, '\0');
 %     elif service_helpers.is_string_arg(parameter):

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -892,6 +892,7 @@ TEST_F(NiSyncDriver6674Test, AttributeSet_GetAttributeViString_ReturnsValue)
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
   EXPECT_STREQ(expectedValue, value.c_str());
+  EXPECT_EQ(strlen(expectedValue), value.length());
 }
 
 TEST_F(NiSyncDriver6674Test, AttributeSet_GetAttributeViBoolean_ReturnsValue)

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -892,7 +892,6 @@ TEST_F(NiSyncDriver6674Test, AttributeSet_GetAttributeViString_ReturnsValue)
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
   EXPECT_STREQ(expectedValue, value.c_str());
-  EXPECT_EQ(strlen(expectedValue), value.length());
 }
 
 TEST_F(NiSyncDriver6674Test, AttributeSet_GetAttributeViBoolean_ReturnsValue)

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -981,7 +981,7 @@ TEST(NiFakeServiceTests, NiFakeService_ReturnMultipleTypes_CallsReturnMultipleTy
   EXPECT_EQ(a_float_enum, response.a_float_enum_raw());
   EXPECT_THAT(response.an_array(), ElementsAreArray(an_array, array_size));
   EXPECT_STREQ(response.a_string().c_str(), a_string);
-  EXPECT_EQ(response.a_string().length(), string_size-1);
+  EXPECT_EQ(response.a_string().length(), string_size - 1);
 }
 
 TEST(NiFakeServiceTests, NiFakeService_WriteWaveform_CallsWriteWaveform)
@@ -1091,7 +1091,7 @@ TEST(NiFakeServiceTests, NiFakeService_ExportAttributeConfigurationBuffer_CallsE
   NiFakeMockLibrary library;
   nifake_grpc::NiFakeService service(&library, &session_repository);
   ViInt8 config_buffer[] = {'A', 'B', 'C'};
-  ViInt32 expected_size = sizeof(config_buffer);
+  ViInt32 expected_size = 3;
   // ivi-dance call
   EXPECT_CALL(library, ExportAttributeConfigurationBuffer(kTestViSession, 0, nullptr))
       .WillOnce(Return(expected_size));
@@ -1138,7 +1138,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceString_CallsGetAnIviDanceStr
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kDriverSuccess, response.status());
   EXPECT_STREQ(response.a_string().c_str(), char_array);
-  EXPECT_EQ(response.a_string().length(), expected_size-1);
+  EXPECT_EQ(response.a_string().length(), expected_size - 1);
 }
 
 TEST(NiFakeServiceTests, NiFakeService_GetArrayUsingIviDance_CallsGetArrayUsingIviDance)
@@ -1198,7 +1198,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViString_CallsGetAttributeViS
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kDriverSuccess, response.status());
   EXPECT_STREQ(response.attribute_value().c_str(), attribute_char_array);
-  EXPECT_EQ(response.attribute_value().length(), expected_size-1);
+  EXPECT_EQ(response.attribute_value().length(), expected_size - 1);
 }
 
 }  // namespace unit

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -945,8 +945,8 @@ TEST(NiFakeServiceTests, NiFakeService_ReturnMultipleTypes_CallsReturnMultipleTy
   ViReal64 a_float = 7.2;
   ViReal64 a_float_enum = 6.5f;
   ViReal64 an_array[] = {1.0, 2, -3.0};
-  ViInt32 string_size = 6;
   char a_string[] = "Hello!";
+  ViInt32 string_size = sizeof(a_string);
   // ivi-dance call
   EXPECT_CALL(library, ReturnMultipleTypes(kTestViSession, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 0, nullptr, 0, nullptr))
       .WillOnce(Return(string_size));
@@ -980,7 +980,8 @@ TEST(NiFakeServiceTests, NiFakeService_ReturnMultipleTypes_CallsReturnMultipleTy
   EXPECT_EQ(nifake_grpc::FloatEnum::FLOAT_ENUM_SIX_POINT_FIVE, response.a_float_enum());
   EXPECT_EQ(a_float_enum, response.a_float_enum_raw());
   EXPECT_THAT(response.an_array(), ElementsAreArray(an_array, array_size));
-  EXPECT_THAT(response.a_string(), ElementsAreArray(a_string, string_size));
+  EXPECT_STREQ(response.a_string().c_str(), a_string);
+  EXPECT_EQ(response.a_string().length(), string_size-1);
 }
 
 TEST(NiFakeServiceTests, NiFakeService_WriteWaveform_CallsWriteWaveform)
@@ -1090,7 +1091,7 @@ TEST(NiFakeServiceTests, NiFakeService_ExportAttributeConfigurationBuffer_CallsE
   NiFakeMockLibrary library;
   nifake_grpc::NiFakeService service(&library, &session_repository);
   ViInt8 config_buffer[] = {'A', 'B', 'C'};
-  ViInt32 expected_size = 3;
+  ViInt32 expected_size = sizeof(config_buffer);
   // ivi-dance call
   EXPECT_CALL(library, ExportAttributeConfigurationBuffer(kTestViSession, 0, nullptr))
       .WillOnce(Return(expected_size));
@@ -1117,8 +1118,8 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceString_CallsGetAnIviDanceStr
   std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
   nifake_grpc::NiFakeService service(&library, &session_repository);
-  ViChar char_array[] = {'H', 'E', 'L', 'L', 'O'};
-  ViInt32 expected_size = 5;
+  ViChar char_array[] = {'H', 'E', 'L', 'L', 'O', '\0'};
+  ViInt32 expected_size = sizeof(char_array);
   // ivi-dance call
   EXPECT_CALL(library, GetAnIviDanceString(kTestViSession, 0, nullptr))
       .WillOnce(Return(expected_size));
@@ -1136,7 +1137,8 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceString_CallsGetAnIviDanceStr
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kDriverSuccess, response.status());
-  EXPECT_THAT(response.a_string(), ElementsAreArray(char_array, expected_size));
+  EXPECT_STREQ(response.a_string().c_str(), char_array);
+  EXPECT_EQ(response.a_string().length(), expected_size-1);
 }
 
 TEST(NiFakeServiceTests, NiFakeService_GetArrayUsingIviDance_CallsGetArrayUsingIviDance)
@@ -1174,8 +1176,8 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViString_CallsGetAttributeViS
   NiFakeMockLibrary library;
   nifake_grpc::NiFakeService service(&library, &session_repository);
   nifake_grpc::NiFakeAttributes attributeId = nifake_grpc::NIFAKE_ATTRIBUTE_READ_WRITE_DOUBLE;
-  ViChar attribute_char_array[] = {'H', 'E', 'L', 'L', 'O'};
-  ViInt32 expected_size = 5;
+  ViChar attribute_char_array[] = {'H', 'E', 'L', 'L', 'O', '\0'};
+  ViInt32 expected_size = sizeof(attribute_char_array);
   // ivi-dance call
   EXPECT_CALL(library, GetAttributeViString(kTestViSession, Pointee(*kTestChannelName), attributeId, 0, nullptr))
       .WillOnce(Return(expected_size));
@@ -1195,7 +1197,8 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViString_CallsGetAttributeViS
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kDriverSuccess, response.status());
-  EXPECT_THAT(response.attribute_value(), ElementsAreArray(attribute_char_array, expected_size));
+  EXPECT_STREQ(response.attribute_value().c_str(), attribute_char_array);
+  EXPECT_EQ(response.attribute_value().length(), expected_size-1);
 }
 
 }  // namespace unit


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes a bug in the service generator that is resulting in all out-strings being 1 nul-character too large. For example, if a string "foo" is returned from the library, we were returning "foo\0" (raw buffer is then "foo\0\0") over gRPC. This resulted in empty strings that were actually length 1 with a single character '\0'. This greatly confused LabVIEW.

### Why should this Pull Request be merged?

Fix a major string handling bug.

### What testing has been done?

Modified a sync test to validate the strlen in addition to str value. This was failing before my fix. Validated a string property node in NI-Sync is now correctly returning empty strings.
