### PR TITLE
[Owners] [Tiny] Fix enum name for few dmm attributes

### DIFF
--- a/source/codegen/metadata/nidmm/attributes.py
+++ b/source/codegen/metadata/nidmm/attributes.py
@@ -388,7 +388,7 @@ attributes = {
     1150120: {
         'access': 'read-write',
         'channel_based': False,
-        'enum': 'RTDType',
+        'enum': 'RtdType',
         'name': 'TEMP_RTD_TYPE',
         'resettable': False,
         'type': 'ViInt32'
@@ -581,7 +581,7 @@ attributes = {
         'access': 'read-write',
         'channel_based': False,
         'name': 'TRIGGER_COUNT',
-        'enum': 'TiggerCount',
+        'enum': 'TriggerCount',
         'resettable': False,
         'type': 'ViInt32'
     },


### PR DESCRIPTION
### What does this Pull Request accomplish?

There was typo in name of enums for some of the attributes in metadata file. Somehow our current codegen didn't catch that theses enums are not present in `enums.py` and fail. Changes I am making for per-type enum for attribute values fails build because they can't find matching enums.

### Why should this Pull Request be merged?

This changes fixes `attributes.py` metadata for DMM. There are no generated file changes since there are other attributes/functions using the correct enum name, which added them to the `.proto` file.

### What testing has been done?

No changes in generated files, so no testing required.
