### PR TITLE
Changed nisync lower_case_with_underscores function names to CamelCase

### DIFF
--- a/generated/nisync/nisync_library.cpp
+++ b/generated/nisync/nisync_library.cpp
@@ -21,13 +21,13 @@ NiSyncLibrary::NiSyncLibrary() : shared_library_(kLibraryName)
   if (!loaded) {
     return;
   }
-  function_pointers_.init = reinterpret_cast<initPtr>(shared_library_.get_function_pointer("niSync_init"));
-  function_pointers_.close = reinterpret_cast<closePtr>(shared_library_.get_function_pointer("niSync_close"));
-  function_pointers_.error_message = reinterpret_cast<error_messagePtr>(shared_library_.get_function_pointer("niSync_error_message"));
-  function_pointers_.reset = reinterpret_cast<resetPtr>(shared_library_.get_function_pointer("niSync_reset"));
+  function_pointers_.Init = reinterpret_cast<InitPtr>(shared_library_.get_function_pointer("niSync_init"));
+  function_pointers_.Close = reinterpret_cast<ClosePtr>(shared_library_.get_function_pointer("niSync_close"));
+  function_pointers_.ErrorMessage = reinterpret_cast<ErrorMessagePtr>(shared_library_.get_function_pointer("niSync_error_message"));
+  function_pointers_.Reset = reinterpret_cast<ResetPtr>(shared_library_.get_function_pointer("niSync_reset"));
   function_pointers_.PersistConfig = reinterpret_cast<PersistConfigPtr>(shared_library_.get_function_pointer("niSync_PersistConfig"));
-  function_pointers_.self_test = reinterpret_cast<self_testPtr>(shared_library_.get_function_pointer("niSync_self_test"));
-  function_pointers_.revision_query = reinterpret_cast<revision_queryPtr>(shared_library_.get_function_pointer("niSync_revision_query"));
+  function_pointers_.SelfTest = reinterpret_cast<SelfTestPtr>(shared_library_.get_function_pointer("niSync_self_test"));
+  function_pointers_.RevisionQuery = reinterpret_cast<RevisionQueryPtr>(shared_library_.get_function_pointer("niSync_revision_query"));
   function_pointers_.ConnectTrigTerminals = reinterpret_cast<ConnectTrigTerminalsPtr>(shared_library_.get_function_pointer("niSync_ConnectTrigTerminals"));
   function_pointers_.DisconnectTrigTerminals = reinterpret_cast<DisconnectTrigTerminalsPtr>(shared_library_.get_function_pointer("niSync_DisconnectTrigTerminals"));
   function_pointers_.ConnectSWTrigToTerminal = reinterpret_cast<ConnectSWTrigToTerminalPtr>(shared_library_.get_function_pointer("niSync_ConnectSWTrigToTerminal"));
@@ -104,51 +104,51 @@ NiSyncLibrary::~NiSyncLibrary()
     : ::grpc::Status(::grpc::NOT_FOUND, "Could not find the function " + functionName);
 }
 
-ViStatus NiSyncLibrary::init(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi)
+ViStatus NiSyncLibrary::Init(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi)
 {
-  if (!function_pointers_.init) {
+  if (!function_pointers_.Init) {
     throw nidevice_grpc::LibraryLoadException("Could not find niSync_init.");
   }
 #if defined(_MSC_VER)
   return niSync_init(resourceName, idQuery, resetDevice, vi);
 #else
-  return function_pointers_.init(resourceName, idQuery, resetDevice, vi);
+  return function_pointers_.Init(resourceName, idQuery, resetDevice, vi);
 #endif
 }
 
-ViStatus NiSyncLibrary::close(ViSession vi)
+ViStatus NiSyncLibrary::Close(ViSession vi)
 {
-  if (!function_pointers_.close) {
+  if (!function_pointers_.Close) {
     throw nidevice_grpc::LibraryLoadException("Could not find niSync_close.");
   }
 #if defined(_MSC_VER)
   return niSync_close(vi);
 #else
-  return function_pointers_.close(vi);
+  return function_pointers_.Close(vi);
 #endif
 }
 
-ViStatus NiSyncLibrary::error_message(ViSession vi, ViStatus errorCode, ViChar errorMessage[256])
+ViStatus NiSyncLibrary::ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[256])
 {
-  if (!function_pointers_.error_message) {
+  if (!function_pointers_.ErrorMessage) {
     throw nidevice_grpc::LibraryLoadException("Could not find niSync_error_message.");
   }
 #if defined(_MSC_VER)
   return niSync_error_message(vi, errorCode, errorMessage);
 #else
-  return function_pointers_.error_message(vi, errorCode, errorMessage);
+  return function_pointers_.ErrorMessage(vi, errorCode, errorMessage);
 #endif
 }
 
-ViStatus NiSyncLibrary::reset(ViSession vi)
+ViStatus NiSyncLibrary::Reset(ViSession vi)
 {
-  if (!function_pointers_.reset) {
+  if (!function_pointers_.Reset) {
     throw nidevice_grpc::LibraryLoadException("Could not find niSync_reset.");
   }
 #if defined(_MSC_VER)
   return niSync_reset(vi);
 #else
-  return function_pointers_.reset(vi);
+  return function_pointers_.Reset(vi);
 #endif
 }
 
@@ -164,27 +164,27 @@ ViStatus NiSyncLibrary::PersistConfig(ViSession vi)
 #endif
 }
 
-ViStatus NiSyncLibrary::self_test(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256])
+ViStatus NiSyncLibrary::SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256])
 {
-  if (!function_pointers_.self_test) {
+  if (!function_pointers_.SelfTest) {
     throw nidevice_grpc::LibraryLoadException("Could not find niSync_self_test.");
   }
 #if defined(_MSC_VER)
   return niSync_self_test(vi, selfTestResult, selfTestMessage);
 #else
-  return function_pointers_.self_test(vi, selfTestResult, selfTestMessage);
+  return function_pointers_.SelfTest(vi, selfTestResult, selfTestMessage);
 #endif
 }
 
-ViStatus NiSyncLibrary::revision_query(ViSession vi, ViChar driverRevision[256], ViChar firmwareRevision[256])
+ViStatus NiSyncLibrary::RevisionQuery(ViSession vi, ViChar driverRevision[256], ViChar firmwareRevision[256])
 {
-  if (!function_pointers_.revision_query) {
+  if (!function_pointers_.RevisionQuery) {
     throw nidevice_grpc::LibraryLoadException("Could not find niSync_revision_query.");
   }
 #if defined(_MSC_VER)
   return niSync_revision_query(vi, driverRevision, firmwareRevision);
 #else
-  return function_pointers_.revision_query(vi, driverRevision, firmwareRevision);
+  return function_pointers_.RevisionQuery(vi, driverRevision, firmwareRevision);
 #endif
 }
 

--- a/generated/nisync/nisync_library.h
+++ b/generated/nisync/nisync_library.h
@@ -18,13 +18,13 @@ class NiSyncLibrary : public nisync_grpc::NiSyncLibraryInterface {
   virtual ~NiSyncLibrary();
 
   ::grpc::Status check_function_exists(std::string functionName);
-  ViStatus init(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi);
-  ViStatus close(ViSession vi);
-  ViStatus error_message(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]);
-  ViStatus reset(ViSession vi);
+  ViStatus Init(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi);
+  ViStatus Close(ViSession vi);
+  ViStatus ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]);
+  ViStatus Reset(ViSession vi);
   ViStatus PersistConfig(ViSession vi);
-  ViStatus self_test(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]);
-  ViStatus revision_query(ViSession vi, ViChar driverRevision[256], ViChar firmwareRevision[256]);
+  ViStatus SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]);
+  ViStatus RevisionQuery(ViSession vi, ViChar driverRevision[256], ViChar firmwareRevision[256]);
   ViStatus ConnectTrigTerminals(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal, ViConstString syncClock, ViInt32 invert, ViInt32 updateEdge);
   ViStatus DisconnectTrigTerminals(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal);
   ViStatus ConnectSWTrigToTerminal(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal, ViConstString syncClock, ViInt32 invert, ViInt32 updateEdge, ViReal64 delay);
@@ -90,13 +90,13 @@ class NiSyncLibrary : public nisync_grpc::NiSyncLibraryInterface {
   ViStatus CalAdjustDDSInitialPhase(ViSession vi, ViReal64 measuredPhase, ViReal64* oldPhase);
 
  private:
-  using initPtr = ViStatus (*)(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi);
-  using closePtr = ViStatus (*)(ViSession vi);
-  using error_messagePtr = ViStatus (*)(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]);
-  using resetPtr = ViStatus (*)(ViSession vi);
+  using InitPtr = ViStatus (*)(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi);
+  using ClosePtr = ViStatus (*)(ViSession vi);
+  using ErrorMessagePtr = ViStatus (*)(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]);
+  using ResetPtr = ViStatus (*)(ViSession vi);
   using PersistConfigPtr = ViStatus (*)(ViSession vi);
-  using self_testPtr = ViStatus (*)(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]);
-  using revision_queryPtr = ViStatus (*)(ViSession vi, ViChar driverRevision[256], ViChar firmwareRevision[256]);
+  using SelfTestPtr = ViStatus (*)(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]);
+  using RevisionQueryPtr = ViStatus (*)(ViSession vi, ViChar driverRevision[256], ViChar firmwareRevision[256]);
   using ConnectTrigTerminalsPtr = ViStatus (*)(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal, ViConstString syncClock, ViInt32 invert, ViInt32 updateEdge);
   using DisconnectTrigTerminalsPtr = ViStatus (*)(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal);
   using ConnectSWTrigToTerminalPtr = ViStatus (*)(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal, ViConstString syncClock, ViInt32 invert, ViInt32 updateEdge, ViReal64 delay);
@@ -162,13 +162,13 @@ class NiSyncLibrary : public nisync_grpc::NiSyncLibraryInterface {
   using CalAdjustDDSInitialPhasePtr = ViStatus (*)(ViSession vi, ViReal64 measuredPhase, ViReal64* oldPhase);
 
   typedef struct FunctionPointers {
-    initPtr init;
-    closePtr close;
-    error_messagePtr error_message;
-    resetPtr reset;
+    InitPtr Init;
+    ClosePtr Close;
+    ErrorMessagePtr ErrorMessage;
+    ResetPtr Reset;
     PersistConfigPtr PersistConfig;
-    self_testPtr self_test;
-    revision_queryPtr revision_query;
+    SelfTestPtr SelfTest;
+    RevisionQueryPtr RevisionQuery;
     ConnectTrigTerminalsPtr ConnectTrigTerminals;
     DisconnectTrigTerminalsPtr DisconnectTrigTerminals;
     ConnectSWTrigToTerminalPtr ConnectSWTrigToTerminal;

--- a/generated/nisync/nisync_library_interface.h
+++ b/generated/nisync/nisync_library_interface.h
@@ -15,13 +15,13 @@ class NiSyncLibraryInterface {
  public:
   virtual ~NiSyncLibraryInterface() {}
 
-  virtual ViStatus init(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi) = 0;
-  virtual ViStatus close(ViSession vi) = 0;
-  virtual ViStatus error_message(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]) = 0;
-  virtual ViStatus reset(ViSession vi) = 0;
+  virtual ViStatus Init(ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi) = 0;
+  virtual ViStatus Close(ViSession vi) = 0;
+  virtual ViStatus ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]) = 0;
+  virtual ViStatus Reset(ViSession vi) = 0;
   virtual ViStatus PersistConfig(ViSession vi) = 0;
-  virtual ViStatus self_test(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]) = 0;
-  virtual ViStatus revision_query(ViSession vi, ViChar driverRevision[256], ViChar firmwareRevision[256]) = 0;
+  virtual ViStatus SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]) = 0;
+  virtual ViStatus RevisionQuery(ViSession vi, ViChar driverRevision[256], ViChar firmwareRevision[256]) = 0;
   virtual ViStatus ConnectTrigTerminals(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal, ViConstString syncClock, ViInt32 invert, ViInt32 updateEdge) = 0;
   virtual ViStatus DisconnectTrigTerminals(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal) = 0;
   virtual ViStatus ConnectSWTrigToTerminal(ViSession vi, ViConstString srcTerminal, ViConstString destTerminal, ViConstString syncClock, ViInt32 invert, ViInt32 updateEdge, ViReal64 delay) = 0;

--- a/generated/nisync/nisync_mock_library.h
+++ b/generated/nisync/nisync_mock_library.h
@@ -17,13 +17,13 @@ namespace unit {
 
 class NiSyncMockLibrary : public nisync_grpc::NiSyncLibraryInterface {
  public:
-  MOCK_METHOD(ViStatus, init, (ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi), (override));
-  MOCK_METHOD(ViStatus, close, (ViSession vi), (override));
-  MOCK_METHOD(ViStatus, error_message, (ViSession vi, ViStatus errorCode, ViChar errorMessage[256]), (override));
-  MOCK_METHOD(ViStatus, reset, (ViSession vi), (override));
+  MOCK_METHOD(ViStatus, Init, (ViRsrc resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViSession* vi), (override));
+  MOCK_METHOD(ViStatus, Close, (ViSession vi), (override));
+  MOCK_METHOD(ViStatus, ErrorMessage, (ViSession vi, ViStatus errorCode, ViChar errorMessage[256]), (override));
+  MOCK_METHOD(ViStatus, Reset, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, PersistConfig, (ViSession vi), (override));
-  MOCK_METHOD(ViStatus, self_test, (ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]), (override));
-  MOCK_METHOD(ViStatus, revision_query, (ViSession vi, ViChar driverRevision[256], ViChar firmwareRevision[256]), (override));
+  MOCK_METHOD(ViStatus, SelfTest, (ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]), (override));
+  MOCK_METHOD(ViStatus, RevisionQuery, (ViSession vi, ViChar driverRevision[256], ViChar firmwareRevision[256]), (override));
   MOCK_METHOD(ViStatus, ConnectTrigTerminals, (ViSession vi, ViConstString srcTerminal, ViConstString destTerminal, ViConstString syncClock, ViInt32 invert, ViInt32 updateEdge), (override));
   MOCK_METHOD(ViStatus, DisconnectTrigTerminals, (ViSession vi, ViConstString srcTerminal, ViConstString destTerminal), (override));
   MOCK_METHOD(ViStatus, ConnectSWTrigToTerminal, (ViSession vi, ViConstString srcTerminal, ViConstString destTerminal, ViConstString syncClock, ViInt32 invert, ViInt32 updateEdge, ViReal64 delay), (override));

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -37,12 +37,12 @@ namespace nisync_grpc {
 
       auto init_lambda = [&] () -> std::tuple<int, uint32_t> {
         ViSession vi;
-        int status = library_->init(resource_name, id_query, reset_device, &vi);
+        int status = library_->Init(resource_name, id_query, reset_device, &vi);
         return std::make_tuple(status, vi);
       };
       uint32_t session_id = 0;
       const std::string& session_name = request->session_name();
-      auto cleanup_lambda = [&] (uint32_t id) { library_->close(id); };
+      auto cleanup_lambda = [&] (uint32_t id) { library_->Close(id); };
       int status = session_repository_->add_session(session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
       if (status == 0) {
@@ -65,8 +65,7 @@ namespace nisync_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi);
-      auto status = library_->close(vi);
+      auto status = library_->Close(vi);
       response->set_status(status);
       return ::grpc::Status::OK;
     }
@@ -87,7 +86,7 @@ namespace nisync_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViStatus error_code = request->error_code();
       std::string error_message(256 - 1, '\0');
-      auto status = library_->error_message(vi, error_code, (ViChar*)error_message.data());
+      auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       response->set_status(status);
       if (status == 0) {
         response->set_error_message(error_message);
@@ -109,7 +108,7 @@ namespace nisync_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      auto status = library_->reset(vi);
+      auto status = library_->Reset(vi);
       response->set_status(status);
       return ::grpc::Status::OK;
     }
@@ -149,7 +148,7 @@ namespace nisync_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt16 self_test_result {};
       std::string self_test_message(256 - 1, '\0');
-      auto status = library_->self_test(vi, &self_test_result, (ViChar*)self_test_message.data());
+      auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
       if (status == 0) {
         response->set_self_test_result(self_test_result);
@@ -174,7 +173,7 @@ namespace nisync_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       std::string driver_revision(256 - 1, '\0');
       std::string firmware_revision(256 - 1, '\0');
-      auto status = library_->revision_query(vi, (ViChar*)driver_revision.data(), (ViChar*)firmware_revision.data());
+      auto status = library_->RevisionQuery(vi, (ViChar*)driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
       if (status == 0) {
         response->set_driver_revision(driver_revision);
@@ -1549,7 +1548,7 @@ namespace nisync_grpc {
       };
       uint32_t session_id = 0;
       const std::string& session_name = request->session_name();
-      auto cleanup_lambda = [&] (uint32_t id) { library_->close(id); };
+      auto cleanup_lambda = [&] (uint32_t id) { library_->Close(id); };
       int status = session_repository_->add_session(session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
       if (status == 0) {

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -65,6 +65,7 @@ namespace nisync_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      session_repository_->remove_session(vi);
       auto status = library_->Close(vi);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/source/codegen/metadata/nisync/CHANGES.md
+++ b/source/codegen/metadata/nisync/CHANGES.md
@@ -1,27 +1,6 @@
 # Changes in metadata from the nimi-python metadata
 
-## functions.py
-
-The following functions were tagged with `'init_method': True,` to ensure their generated service handlers register the new session
-with the session_repository.
-- `init`
-
-The following function parameters were changes to camel case so the generated name would be snake case.
-- `idQuery` parameter in `init`
-
-The following function parameters were changed to generate the correct parameter type.
-- `value` parameter in `GetAttributeViString`
-```
-            "direction": "out",
-            "name": "value",
-            'size': {
-                'mechanism': 'ivi-dance',
-                'value': 'bufferSize'
-            },
-            'type': 'ViChar[]'
-```
-
-Renamed parameter `terminalName` to `activeItem` in `GetAttribute*` and `SetAttribute*` functions.
+## attributes.py
 
 Removed the following deprecated attributes.
 - TIMEREF_CLK_ADJ_OFFSET

--- a/source/codegen/metadata/nisync/config.py
+++ b/source/codegen/metadata/nisync/config.py
@@ -7,7 +7,7 @@ config = {
     "java_package": "com.ni.grpc.sync",
     "csharp_namespace": "NationalInstruments.Grpc.Sync",
     "namespace_component": "nisync",
-    "close_function": "close",
+    "close_function": "Close",
     "context_manager_name": {
         "abort_function": "Abort",
         "initiate_function": "InitiateAcquisition",

--- a/source/codegen/metadata/nisync/functions.py
+++ b/source/codegen/metadata/nisync/functions.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 functions = {
-    "init": {
+    "Init": {
+        "cname": "niSync_init",
         "init_method": True,
         "parameters": [
             {
@@ -26,7 +27,8 @@ functions = {
         ],
         "returns": "ViStatus",
     },
-    "close": {
+    "Close": {
+        "cname": "niSync_close",
         "parameters": [
             {
                 "direction": "in",
@@ -36,7 +38,8 @@ functions = {
         ],
         "returns": "ViStatus",
     },
-    "error_message": {
+    "ErrorMessage": {
+        "cname": "niSync_error_message",
         "parameters": [
             {
                 "direction": "in",
@@ -60,7 +63,8 @@ functions = {
         ],
         "returns": "ViStatus",
     },
-    "reset": {
+    "Reset": {
+        "cname": "niSync_reset",
         "parameters": [
             {
                 "direction": "in",
@@ -80,7 +84,8 @@ functions = {
         ],
         "returns": "ViStatus",
     },
-    "self_test": {
+    "SelfTest": {
+        "cname": "niSync_self_test",
         "parameters": [
             {
                 "direction": "in",
@@ -104,7 +109,8 @@ functions = {
         ],
         "returns": "ViStatus",
     },
-    "revision_query": {
+    "RevisionQuery": {
+        "cname": "niSync_revision_query",
         "parameters": [
             {
                 "direction": "in",


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Changed lower_case_with_underscores function names to CamelCase
  This is a follow up to PR #200 
- Updated nisync CHANGES.md since functions.py is codegen'ed and checked in without modification

### Why should this Pull Request be merged?

The NiSyncLibraryInterface function names follow a consistent naming convention.

### What testing has been done?

Built locally on Windows machine.
