### PR TITLE
Fixed nisync's ReadMultipleTriggerTimeStamp timeout behavior

### DIFF
--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -664,40 +664,6 @@ namespace nisync_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiSyncService::ReadMultipleTriggerTimeStamp(::grpc::ServerContext* context, const ReadMultipleTriggerTimeStampRequest* request, ReadMultipleTriggerTimeStampResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViConstString terminal = request->terminal().c_str();
-      ViUInt32 timestamps_to_read = request->timestamps_to_read();
-      ViReal64 timeout = request->timeout();
-      response->mutable_time_seconds_buffer()->Resize(timestamps_to_read, 0);
-      ViUInt32* time_seconds_buffer = reinterpret_cast<ViUInt32*>(response->mutable_time_seconds_buffer()->mutable_data());
-      response->mutable_time_nanoseconds_buffer()->Resize(timestamps_to_read, 0);
-      ViUInt32* time_nanoseconds_buffer = reinterpret_cast<ViUInt32*>(response->mutable_time_nanoseconds_buffer()->mutable_data());
-      response->mutable_time_fractional_nanoseconds_buffer()->Resize(timestamps_to_read, 0);
-      ViUInt16* time_fractional_nanoseconds_buffer = reinterpret_cast<ViUInt16*>(response->mutable_time_fractional_nanoseconds_buffer()->mutable_data());
-      response->mutable_detected_edge_buffer()->Resize(timestamps_to_read, 0);
-      ViInt32* detected_edge_buffer = reinterpret_cast<ViInt32*>(response->mutable_detected_edge_buffer()->mutable_data());
-      ViUInt32 timestamps_read {};
-      auto status = library_->ReadMultipleTriggerTimeStamp(vi, terminal, timestamps_to_read, timeout, time_seconds_buffer, time_nanoseconds_buffer, time_fractional_nanoseconds_buffer, detected_edge_buffer, &timestamps_read);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_timestamps_read(timestamps_read);
-      }
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiSyncService::DisableTimeStampTrigger(::grpc::ServerContext* context, const DisableTimeStampTriggerRequest* request, DisableTimeStampTriggerResponse* response)
   {
     if (context->IsCancelled()) {

--- a/source/codegen/metadata/nisync/CHANGES.md
+++ b/source/codegen/metadata/nisync/CHANGES.md
@@ -9,3 +9,8 @@ Removed the following deprecated attributes.
 
 Added the following internal attribute.
 - MODEL_CODE
+
+## functions.py
+
+The following functions were tagged as 'codegen_method':'CustomCode':
+- ReadMultipleTriggerTimeStamp

--- a/source/codegen/metadata/nisync/functions.py
+++ b/source/codegen/metadata/nisync/functions.py
@@ -624,6 +624,7 @@ functions = {
         "returns": "ViStatus",
     },
     "ReadMultipleTriggerTimeStamp": {
+        "codegen_method": "CustomCode",
         "parameters": [
             {
                 "direction": "in",

--- a/source/custom/nisync_service.custom.cpp
+++ b/source/custom/nisync_service.custom.cpp
@@ -1,2 +1,39 @@
+#include <nisync/nisync_service.h>
+
 namespace nisync_grpc {
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiSyncService::ReadMultipleTriggerTimeStamp(::grpc::ServerContext* context, const ReadMultipleTriggerTimeStampRequest* request, ReadMultipleTriggerTimeStampResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto vi_grpc_session = request->vi();
+    ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+    ViConstString terminal = request->terminal().c_str();
+    ViUInt32 timestamps_to_read = request->timestamps_to_read();
+    ViReal64 timeout = request->timeout();
+    response->mutable_time_seconds_buffer()->Resize(timestamps_to_read, 0);
+    ViUInt32* time_seconds_buffer = reinterpret_cast<ViUInt32*>(response->mutable_time_seconds_buffer()->mutable_data());
+    response->mutable_time_nanoseconds_buffer()->Resize(timestamps_to_read, 0);
+    ViUInt32* time_nanoseconds_buffer = reinterpret_cast<ViUInt32*>(response->mutable_time_nanoseconds_buffer()->mutable_data());
+    response->mutable_time_fractional_nanoseconds_buffer()->Resize(timestamps_to_read, 0);
+    ViUInt16* time_fractional_nanoseconds_buffer = reinterpret_cast<ViUInt16*>(response->mutable_time_fractional_nanoseconds_buffer()->mutable_data());
+    response->mutable_detected_edge_buffer()->Resize(timestamps_to_read, 0);
+    ViInt32* detected_edge_buffer = reinterpret_cast<ViInt32*>(response->mutable_detected_edge_buffer()->mutable_data());
+    ViUInt32 timestamps_read {};
+    auto status = library_->ReadMultipleTriggerTimeStamp(vi, terminal, timestamps_to_read, timeout, time_seconds_buffer, time_nanoseconds_buffer, time_fractional_nanoseconds_buffer, detected_edge_buffer, &timestamps_read);
+    response->set_status(status);
+    if (status == VI_SUCCESS || status == NISYNC_ERROR_DRIVER_TIMEOUT) {
+      response->set_timestamps_read(timestamps_read);
+    }
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::LibraryLoadException& ex) {
+    return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+  }
+}
+
 }  // namespace nisync_grpc


### PR DESCRIPTION
### What does this Pull Request accomplish?

Allows ReadMultipleTriggerTimeStamp to set timestamps_read when the operation times out.

This build on #203

### Why should this Pull Request be merged?

If the timeout duration is reached before the number time stamps read equals timestamps_to_read, ReadMultipleTriggerTimeStamp will return the number of read time stamps along and a timeout error. This normal operating behavior.

### What testing has been done?

Ran `.\SystemTestsRunner.exe --gtest_filter=*TimeStamp*` on Windows
```
Note: Google Test filter = *TimeStamp*
[==========] Running 7 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 7 tests from NiSyncDriver6683Test
[ RUN      ] NiSyncDriver6683Test.EnableTimeStampTrigger_ReturnsSuccess
[       OK ] NiSyncDriver6683Test.EnableTimeStampTrigger_ReturnsSuccess (1846 ms)
[ RUN      ] NiSyncDriver6683Test.EnableTimeStampTriggerWithInvalidTerminal_ReturnsError
[       OK ] NiSyncDriver6683Test.EnableTimeStampTriggerWithInvalidTerminal_ReturnsError (9 ms)
[ RUN      ] NiSyncDriver6683Test.DisableTimeStampTriggerNotReserved_ReturnsError
[       OK ] NiSyncDriver6683Test.DisableTimeStampTriggerNotReserved_ReturnsError (10 ms)
[ RUN      ] NiSyncDriver6683Test.GivenNoTrigger_ReadTriggerTimeStamp_ReturnsTimeoutError
[       OK ] NiSyncDriver6683Test.GivenNoTrigger_ReadTriggerTimeStamp_ReturnsTimeoutError (129 ms)
[ RUN      ] NiSyncDriver6683Test.GivenNoTrigger_ReadMultipleTriggerTimeStamp_ReturnsTimeoutError
[       OK ] NiSyncDriver6683Test.GivenNoTrigger_ReadMultipleTriggerTimeStamp_ReturnsTimeoutError (127 ms)
[ RUN      ] NiSyncDriver6683Test.GivenOneTrigger_ReadMultipleTriggerTimeStamp_ReturnsOneTimeStampAndTimeoutError
[       OK ] NiSyncDriver6683Test.GivenOneTrigger_ReadMultipleTriggerTimeStamp_ReturnsOneTimeStampAndTimeoutError(31 ms)
[ RUN      ] NiSyncDriver6683Test.GivenFiveTriggers_ReadMultipleTriggerTimeStamp_ReturnsFiveTimeStamps
[       OK ] NiSyncDriver6683Test.GivenFiveTriggers_ReadMultipleTriggerTimeStamp_ReturnsFiveTimeStamps (16 ms)
[----------] 7 tests from NiSyncDriver6683Test (2174 ms total)

[----------] Global test environment tear-down
[==========] 7 tests from 1 test suite ran. (2178 ms total)
[  PASSED  ] 7 tests.
```
