### PR TITLE
Add syslog support to ni_grpc_device_server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,15 @@ foreach(api ${nidrivers})
   endif()
 endforeach()
 
+if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  set(SOURCE_OS
+    "source/server/linux/syslog_logging.cpp")
+else()
+  set(SOURCE_OS "")
+endif()
+
 add_executable(ni_grpc_device_server
+   ${SOURCE_OS}
    "source/server/core_server.cpp"
    "source/server/device_enumerator.cpp"
    "source/server/logging.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,13 +176,6 @@ foreach(api ${nidrivers})
   endif()
 endforeach()
 
-if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-  set(OSDEP_SOURCE
-    "source/server/linux/syslog_logging.cpp")
-else()
-  set(OSDEP_SOURCE "")
-endif()
-
 add_executable(ni_grpc_device_server
    ${OSDEP_SOURCE}
    "source/server/core_server.cpp"
@@ -198,6 +191,11 @@ add_executable(ni_grpc_device_server
    ${session_proto_srcs}
    ${session_grpc_srcs}
    ${nidriver_service_srcs})
+
+if(CMAKE_SYSTEM_NAME STREQUAL Linux)
+  target_sources(ni_grpc_device_server
+    PRIVATE "source/server/linux/syslog_logging.cpp")
+endif()
 
 target_link_libraries(ni_grpc_device_server
    ${_REFLECTION}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,7 @@ endforeach()
 add_executable(ni_grpc_device_server
    "source/server/core_server.cpp"
    "source/server/device_enumerator.cpp"
+   "source/server/logging.cpp"
    "source/server/semaphore.cpp"
    "source/server/server_configuration_parser.cpp"
    "source/server/server_security_configuration.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,14 +177,14 @@ foreach(api ${nidrivers})
 endforeach()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
-  set(SOURCE_OS
+  set(OSDEP_SOURCE
     "source/server/linux/syslog_logging.cpp")
 else()
-  set(SOURCE_OS "")
+  set(OSDEP_SOURCE "")
 endif()
 
 add_executable(ni_grpc_device_server
-   ${SOURCE_OS}
+   ${OSDEP_SOURCE}
    "source/server/core_server.cpp"
    "source/server/device_enumerator.cpp"
    "source/server/logging.cpp"

--- a/source/server/linux/syslog_logging.cpp
+++ b/source/server/linux/syslog_logging.cpp
@@ -5,7 +5,7 @@
 namespace nidevice_grpc {
 namespace Logging {
 
-static const char* syslog_identity = "ni_grpc_server";
+static const char* syslog_identity = "ni_grpc_device_server";
 
 void setup_syslog(bool is_daemon)
 {

--- a/source/server/linux/syslog_logging.cpp
+++ b/source/server/linux/syslog_logging.cpp
@@ -3,7 +3,6 @@
 #include <syslog.h>
 
 namespace nidevice_grpc {
-
 namespace logging {
 
 static const char* syslog_identity = "ni_grpc_device_server";
@@ -41,5 +40,4 @@ void log_syslog(Level level, const char* fmt, va_list args)
 }
 
 }  // namespace logging
-
 }  // namespace nidevice_grpc

--- a/source/server/linux/syslog_logging.cpp
+++ b/source/server/linux/syslog_logging.cpp
@@ -1,0 +1,44 @@
+#include "syslog_logging.h"
+
+#include <syslog.h>
+
+namespace nidevice_grpc {
+namespace Logging {
+
+static const char* syslog_identity = "ni_grpc_server";
+
+void setup_syslog(bool is_daemon)
+{
+  int syslog_options = LOG_PID;
+  int syslog_facility = 0;
+  if (is_daemon) {
+    syslog_facility = LOG_DAEMON;
+  } else {
+    // It's OK to fall back to the console if we're not a daemon.
+    syslog_options |= LOG_CONS;
+    syslog_facility |= LOG_USER;
+  }
+  openlog(syslog_identity, syslog_options, syslog_facility);
+}
+
+void log_syslog(Level level, const char* fmt, va_list args)
+{
+  int priority;
+  switch (level)
+  {
+    case Level_Info:
+      priority = LOG_INFO;
+      break;
+    case Level_Warning:
+      priority = LOG_WARNING;
+      break;
+    case Level_Error:
+      priority = LOG_ERR;
+      break;
+  }
+  vsyslog(priority, fmt, args);
+}
+
+} // Logging
+} // nidevice_grpc
+

--- a/source/server/linux/syslog_logging.cpp
+++ b/source/server/linux/syslog_logging.cpp
@@ -3,7 +3,8 @@
 #include <syslog.h>
 
 namespace nidevice_grpc {
-namespace Logging {
+
+namespace logging {
 
 static const char* syslog_identity = "ni_grpc_device_server";
 
@@ -13,7 +14,8 @@ void setup_syslog(bool is_daemon)
   int syslog_facility = 0;
   if (is_daemon) {
     syslog_facility = LOG_DAEMON;
-  } else {
+  }
+  else {
     // It's OK to fall back to the console if we're not a daemon.
     syslog_options |= LOG_CONS;
     syslog_facility |= LOG_USER;
@@ -24,8 +26,7 @@ void setup_syslog(bool is_daemon)
 void log_syslog(Level level, const char* fmt, va_list args)
 {
   int priority;
-  switch (level)
-  {
+  switch (level) {
     case Level_Info:
       priority = LOG_INFO;
       break;
@@ -39,6 +40,6 @@ void log_syslog(Level level, const char* fmt, va_list args)
   vsyslog(priority, fmt, args);
 }
 
-} // Logging
-} // nidevice_grpc
+}  // namespace logging
 
+}  // namespace nidevice_grpc

--- a/source/server/linux/syslog_logging.h
+++ b/source/server/linux/syslog_logging.h
@@ -1,0 +1,16 @@
+#ifndef NIDEVICE_GRPC_LINUX_SYSLOG_LOGGING_H
+#define NIDEVICE_GRPC_LINUX_SYSLOG_LOGGING_H
+
+#include "../logging.h"
+
+namespace nidevice_grpc {
+
+namespace Logging {
+
+void setup_syslog(bool is_daemon);
+void log_syslog(Level level, const char* fmt, va_list args);
+
+} // namespace Logging
+} // namespace nidevice_grpc
+
+#endif // NIDEVICE_GRPC_LINUX_SYSLOG_LOGGING_H

--- a/source/server/linux/syslog_logging.h
+++ b/source/server/linux/syslog_logging.h
@@ -4,14 +4,12 @@
 #include "../logging.h"
 
 namespace nidevice_grpc {
-
 namespace logging {
 
 void setup_syslog(bool is_daemon);
 void log_syslog(Level level, const char* fmt, va_list args);
 
 }  // namespace logging
-
 }  // namespace nidevice_grpc
 
 #endif  // NIDEVICE_GRPC_LINUX_SYSLOG_LOGGING_H

--- a/source/server/linux/syslog_logging.h
+++ b/source/server/linux/syslog_logging.h
@@ -5,12 +5,13 @@
 
 namespace nidevice_grpc {
 
-namespace Logging {
+namespace logging {
 
 void setup_syslog(bool is_daemon);
 void log_syslog(Level level, const char* fmt, va_list args);
 
-} // namespace Logging
-} // namespace nidevice_grpc
+}  // namespace logging
 
-#endif // NIDEVICE_GRPC_LINUX_SYSLOG_LOGGING_H
+}  // namespace nidevice_grpc
+
+#endif  // NIDEVICE_GRPC_LINUX_SYSLOG_LOGGING_H

--- a/source/server/logging.cpp
+++ b/source/server/logging.cpp
@@ -4,12 +4,12 @@
 #include <iostream>
 
 namespace nidevice_grpc {
-namespace Logging {
+
+namespace logging {
 
 void log_terminal(Level level, const char* fmt, va_list args)
 {
-  switch (level)
-  {
+  switch (level) {
     case Level_Info:
     // explicit fall-through
     case Level_Warning:
@@ -38,6 +38,6 @@ void log(Level level, const char* fmt, ...)
   va_end(args);
 }
 
-} // Logging
-} // nidevice_grpc
+}  // namespace logging
 
+}  // namespace nidevice_grpc

--- a/source/server/logging.cpp
+++ b/source/server/logging.cpp
@@ -25,11 +25,13 @@ void log_terminal(Level level, const char* fmt, va_list args)
 
 static log_fn_impl logger = &log_terminal;
 
-void set_logger(log_fn_impl impl) {
+void set_logger(log_fn_impl impl)
+{
   logger = impl;
 }
 
-void log(Level level, const char* fmt, ...) {
+void log(Level level, const char* fmt, ...)
+{
   va_list args;
   va_start(args, fmt);
   logger(level, fmt, args);

--- a/source/server/logging.cpp
+++ b/source/server/logging.cpp
@@ -1,0 +1,41 @@
+#include "logging.h"
+
+#include <cstdio>
+#include <iostream>
+
+namespace nidevice_grpc {
+namespace Logging {
+
+void log_terminal(Level level, const char* fmt, va_list args)
+{
+  switch (level)
+  {
+    case Level_Info:
+    // explicit fall-through
+    case Level_Warning:
+      vfprintf(stdout, fmt, args);
+      std::cout << std::endl;
+      break;
+    case Level_Error:
+      vfprintf(stderr, fmt, args);
+      std::cerr << std::endl;
+      break;
+  }
+}
+
+static log_fn_impl logger = &log_terminal;
+
+void set_logger(log_fn_impl impl) {
+  logger = impl;
+}
+
+void log(Level level, const char* fmt, ...) {
+  va_list args;
+  va_start(args, fmt);
+  logger(level, fmt, args);
+  va_end(args);
+}
+
+} // Logging
+} // nidevice_grpc
+

--- a/source/server/logging.cpp
+++ b/source/server/logging.cpp
@@ -4,7 +4,6 @@
 #include <iostream>
 
 namespace nidevice_grpc {
-
 namespace logging {
 
 void log_terminal(Level level, const char* fmt, va_list args)
@@ -39,5 +38,4 @@ void log(Level level, const char* fmt, ...)
 }
 
 }  // namespace logging
-
 }  // namespace nidevice_grpc

--- a/source/server/logging.h
+++ b/source/server/logging.h
@@ -4,7 +4,6 @@
 #include <cstdarg>
 
 namespace nidevice_grpc {
-
 namespace logging {
 
 enum Level {
@@ -20,7 +19,6 @@ void set_logger(log_fn_impl impl);
 void log(Level level, const char* fmt, ...);
 
 }  // namespace logging
-
 }  // namespace nidevice_grpc
 
 #endif  // NIDEVICE_GRPC_LOGGING_H

--- a/source/server/logging.h
+++ b/source/server/logging.h
@@ -1,0 +1,26 @@
+#ifndef NIDEVICE_GRPC_LOGGING_H
+#define NIDEVICE_GRPC_LOGGING_H
+
+#include <cstdarg>
+
+namespace nidevice_grpc {
+
+namespace Logging {
+
+enum Level {
+  Level_Info = 0,
+  Level_Warning,
+  Level_Error,
+};
+
+typedef void (*log_fn_impl)(Level level, const char* fmt, va_list args);
+
+
+// The logger defaults to the terminal (stdout and stderr)
+void set_logger(log_fn_impl impl);
+void log(Level level, const char* fmt, ...);
+
+} // namespace Logging
+} // namespace nidevice_grpc
+
+#endif // NIDEVICE_GRPC_LOGGING_H

--- a/source/server/logging.h
+++ b/source/server/logging.h
@@ -5,7 +5,7 @@
 
 namespace nidevice_grpc {
 
-namespace Logging {
+namespace logging {
 
 enum Level {
   Level_Info = 0,
@@ -15,12 +15,12 @@ enum Level {
 
 typedef void (*log_fn_impl)(Level level, const char* fmt, va_list args);
 
-
 // The logger defaults to the terminal (stdout and stderr)
 void set_logger(log_fn_impl impl);
 void log(Level level, const char* fmt, ...);
 
-} // namespace Logging
-} // namespace nidevice_grpc
+}  // namespace logging
 
-#endif // NIDEVICE_GRPC_LOGGING_H
+}  // namespace nidevice_grpc
+
+#endif  // NIDEVICE_GRPC_LOGGING_H


### PR DESCRIPTION
### What does this Pull Request accomplish?

This adds syslog support to ni_grpc_device_server. It does this by:
* Adding a simple logging interface to ni_grpc_device_server.
   * This should be used instead of direct stdout/stderr access.
   * The implementation uses a simple va_list-function that can be implemented for other logging.
   * There is a default stdout/stderr implementation
* Implemented a syslog logging function available on linux
* Added _slightly_ more robust command line option parsing with support for `--use-syslog`. I expect this may be replaced with a more generic daemon option in the future.

### Why should this Pull Request be merged?

This is early work towards making ni_grpc_device_server natively-daemonizable for on-boot configuration.

### What testing has been done?

Normal invocation and sad/happy paths:
```
admin@NI-PXIe-8880-03095FC1:~/grpc# ./ni_grpc_device_server
Server listening on port 31763
Security is configured with insecure credentials.
^C
admin@NI-PXIe-8880-03095FC1:~/grpc# ./ni_grpc_device_server foo
Failed to parse config: The server configuration file was not found at: foo
```

syslog invocation with sad/happy paths:
```
admin@NI-PXIe-8880-03095FC1:~/grpc# ./ni_grpc_device_server --use-syslog
^C
admin@NI-PXIe-8880-03095FC1:~/grpc# ./ni_grpc_device_server --use-syslog foo
admin@NI-PXIe-8880-03095FC1:~/grpc# tail /var/log/messages
...
2021-05-21T19:16:47.096+00:00 NI-PXIe-8880-03095FC1 ni_grpc_server[31221]: Server listening on port 31763
2021-05-21T19:16:47.096+00:00 NI-PXIe-8880-03095FC1 ni_grpc_server[31221]: Security is configured with insecure credentials.
2021-05-21T19:16:54.260+00:00 NI-PXIe-8880-03095FC1 ni_grpc_server[31255]: Failed to parse config: The server configuration file was not found at: foo
````

