### PR TITLE
Fix Windows build

### DIFF
--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -1425,7 +1425,7 @@ namespace nidmm_grpc {
       auto status = library_->GetApertureTimeInfo(vi, &aperture_time, &aperture_time_units);
       response->set_status(status);
       if (status == 0) {
-        response->set_aperture_time(static_cast<nidmm_grpc::ApertureTime>(aperture_time));
+        response->set_aperture_time(static_cast<nidmm_grpc::ApertureTime>(static_cast<int>(aperture_time)));
         response->set_aperture_time_raw(aperture_time);
         response->set_aperture_time_units(static_cast<nidmm_grpc::ApertureTimeUnits>(aperture_time_units));
         response->set_aperture_time_units_raw(aperture_time_units);

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -263,6 +263,8 @@ one_of_case_prefix = f'{namespace_prefix}{function_name}Request::{PascalFieldNam
         if(${iterator_name} != ${map_name}.end()) {
           response->set_${parameter_name}(static_cast<${namespace_prefix}${parameter["enum"]}>(${iterator_name}->second));
         }
+%     elif parameter['type'] == 'ViReal64':
+        response->set_${parameter_name}(static_cast<${namespace_prefix}${parameter["enum"]}>(static_cast<int>(${parameter_name})));
 %     else:
         response->set_${parameter_name}(static_cast<${namespace_prefix}${parameter["enum"]}>(${parameter_name}));
 %     endif


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes the Windows build. It currently fails because `static_cast`ing from floating-point to an enum isn't allowed. You gotta stop by the underlying enum type on the way.

### Why should this Pull Request be merged?

Fix the Windows build.

### What testing has been done?

It builds on both Linux and Windows.
