### PR TITLE
Add ability to daemonize on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,6 @@ foreach(api ${nidrivers})
 endforeach()
 
 add_executable(ni_grpc_device_server
-   ${OSDEP_SOURCE}
    "source/server/core_server.cpp"
    "source/server/device_enumerator.cpp"
    "source/server/logging.cpp"
@@ -194,7 +193,8 @@ add_executable(ni_grpc_device_server
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   target_sources(ni_grpc_device_server
-    PRIVATE "source/server/linux/syslog_logging.cpp")
+    PRIVATE "source/server/linux/syslog_logging.cpp"
+    PRIVATE "source/server/linux/daemonize.cpp")
 endif()
 
 target_link_libraries(ni_grpc_device_server

--- a/source/server/core_server.cpp
+++ b/source/server/core_server.cpp
@@ -1,3 +1,4 @@
+#include <mutex>
 #include <nidcpower/nidcpower_library.h>
 #include <nidcpower/nidcpower_service.h>
 #include <nidmm/nidmm_library.h>
@@ -16,24 +17,29 @@
 #include "syscfg_library.h"
 
 #if defined(__GNUC__)
+  #include "linux/daemonize.h"
   #include "linux/syslog_logging.h"
 #endif
 
-static void RunServer(const std::string& config_file_path)
+struct ServerConfiguration
 {
-  grpc::EnableDefaultHealthCheckService(true);
-  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
+  std::string server_address;
+  std::string server_cert;
+  std::string server_key;
+  std::string root_cert;
+};
 
-  std::string server_address, server_cert, server_key, root_cert;
-
+static ServerConfiguration GetConfiguration(const std::string& config_file_path)
+{
+  ServerConfiguration config;
   try {
     nidevice_grpc::ServerConfigurationParser server_config_parser = config_file_path.empty()
         ? nidevice_grpc::ServerConfigurationParser()
         : nidevice_grpc::ServerConfigurationParser(config_file_path);
-    server_address = server_config_parser.parse_address();
-    server_cert = server_config_parser.parse_server_cert();
-    server_key = server_config_parser.parse_server_key();
-    root_cert = server_config_parser.parse_root_cert();
+    config.server_address = server_config_parser.parse_address();
+    config.server_cert = server_config_parser.parse_server_cert();
+    config.server_key = server_config_parser.parse_server_key();
+    config.root_cert = server_config_parser.parse_root_cert();
   }
   catch (const std::exception& ex) {
     nidevice_grpc::logging::log(
@@ -41,11 +47,31 @@ static void RunServer(const std::string& config_file_path)
         "Failed to parse config: %s", ex.what());
     exit(EXIT_FAILURE);
   }
+  return config;
+}
+
+static std::mutex server_mutex;
+static std::unique_ptr<grpc::Server> server;
+static bool shutdown = false;
+
+static void StopServer() 
+{
+  std::lock_guard<std::mutex> guard(server_mutex);
+  shutdown = true;
+  if (server) {
+    server->Shutdown();
+  }
+}
+
+static void RunServer(const ServerConfiguration& config)
+{
+  grpc::EnableDefaultHealthCheckService(true);
+  grpc::reflection::InitProtoReflectionServerBuilderPlugin();
 
   grpc::ServerBuilder builder;
   int listeningPort = 0;
-  nidevice_grpc::ServerSecurityConfiguration server_security_config(server_cert, server_key, root_cert);
-  builder.AddListeningPort(server_address, server_security_config.get_credentials(), &listeningPort);
+  nidevice_grpc::ServerSecurityConfiguration server_security_config(config.server_cert, config.server_key, config.root_cert);
+  builder.AddListeningPort(config.server_address, server_security_config.get_credentials(), &listeningPort);
   // Register services available on the server.
   nidevice_grpc::SessionRepository session_repository;
   nidevice_grpc::SysCfgLibrary syscfg_library;
@@ -74,12 +100,21 @@ static void RunServer(const std::string& config_file_path)
   builder.RegisterService(&nidcpower_service);
 
   // Assemble the server.
-  auto server = builder.BuildAndStart();
+  {
+    std::lock_guard<std::mutex> guard(server_mutex);
+    if (shutdown) {
+      nidevice_grpc::logging::log(
+          nidevice_grpc::logging::Level_Info,
+          "Asked to shutdown before creating the server");
+      return;
+    }
+    server = builder.BuildAndStart();
+  }
 
   if (!server) {
     nidevice_grpc::logging::log(
         nidevice_grpc::logging::Level_Error,
-        "Server failed to start on %s", server_address.c_str());
+        "Server failed to start on %s", config.server_address.c_str());
     exit(EXIT_FAILURE);
   }
 
@@ -108,20 +143,22 @@ static void RunServer(const std::string& config_file_path)
 struct Options {
   Options() :
 #if defined(__GNUC__)
-              use_syslog(false),
+              daemonize(false),
+	      use_syslog(false),
 #endif
               config_file_path()
   {
   }
 
 #if defined(__GNUC__)
+  bool daemonize;
   bool use_syslog;
 #endif
   std::string config_file_path;
 };
 
 #if defined(__GNUC__)
-const char* usage = "Usage: ni_grpc_device_server [--help] [--use-syslog] [config-file-path]";
+const char* usage = "Usage: ni_grpc_device_server [--help] [--daemonize] [--use-syslog] [config-file-path]";
 #else
 const char* usage = "Usage: ni_grpc_device_server [--help] [config-file-path]";
 #endif
@@ -131,14 +168,17 @@ Options parse_options(int argc, char** argv)
   Options options;
   for (int i = 1; i < argc; ++i) {
 #if defined(__GNUC__)
-    if (strcmp("--use-syslog", argv[i]) == 0) {
+    if (strcmp("--daemonize", argv[i]) == 0) {
+      options.daemonize = true;
+    }
+    else if (strcmp("--use-syslog", argv[i]) == 0) {
       options.use_syslog = true;
     }
     else
 #endif
     if (strcmp("--help", argv[i]) == 0 || strcmp("-h", argv[i]) == 0) {
       nidevice_grpc::logging::log(nidevice_grpc::logging::Level_Info, usage);
-      exit(0);
+      exit(EXIT_SUCCESS);
     }
     else if (i == argc - 1) {
       options.config_file_path = argv[i];
@@ -148,20 +188,36 @@ Options parse_options(int argc, char** argv)
       exit(EXIT_FAILURE);
     }
   }
+
+#if defined(__GNUC__)
+  if (options.daemonize && !options.use_syslog) {
+    nidevice_grpc::logging::log(nidevice_grpc::logging::Level_Error, "--daemonize requires --use-syslog");
+    exit(EXIT_FAILURE);
+  }
+#endif
+
   return options;
 }
 
 int main(int argc, char** argv)
 {
   auto options = parse_options(argc, argv);
+  auto config = GetConfiguration(options.config_file_path);
 #if defined(__GNUC__)
   if (options.use_syslog) {
-    // No daemon support, yet.
-    bool is_daemon = false;
-    nidevice_grpc::logging::setup_syslog(is_daemon);
+    nidevice_grpc::logging::setup_syslog(options.daemonize);
     nidevice_grpc::logging::set_logger(&nidevice_grpc::logging::log_syslog);
   }
+  
+  if (options.daemonize) {
+    if (!options.use_syslog) {
+      nidevice_grpc::logging::log(nidevice_grpc::logging::Level_Error, "--daemonize requires --use-syslog");
+      exit(EXIT_FAILURE);
+    }
+    nidevice_grpc::daemonize(&StopServer);
+  }
 #endif
-  RunServer(options.config_file_path);
-  return 0;
+
+  RunServer(config);
+  return EXIT_SUCCESS;
 }

--- a/source/server/core_server.cpp
+++ b/source/server/core_server.cpp
@@ -210,10 +210,6 @@ int main(int argc, char** argv)
   }
   
   if (options.daemonize) {
-    if (!options.use_syslog) {
-      nidevice_grpc::logging::log(nidevice_grpc::logging::Level_Error, "--daemonize requires --use-syslog");
-      exit(EXIT_FAILURE);
-    }
     nidevice_grpc::daemonize(&StopServer);
   }
 #endif

--- a/source/server/core_server.cpp
+++ b/source/server/core_server.cpp
@@ -144,7 +144,7 @@ struct Options {
   Options() :
 #if defined(__GNUC__)
               daemonize(false),
-	      use_syslog(false),
+              use_syslog(false),
               identity("ni_grpc_device_server"),
 #endif
               config_file_path()

--- a/source/server/linux/daemonize.cpp
+++ b/source/server/linux/daemonize.cpp
@@ -76,10 +76,8 @@ int create_pidfile() {
 }
 
 void daemonize(stop_callback signal_stop_) {
-  pid_t pid;
-
-  // Fork off the parent process
-  pid = fork();
+  // Fork off the parent process to get into the background
+  pid_t pid = fork();
   if (pid < 0) {
     logging::log(logging::Level_Error, "initial fork failed: %d (%s)", errno, strerror(errno));
     exit(EXIT_FAILURE);
@@ -90,13 +88,13 @@ void daemonize(stop_callback signal_stop_) {
     exit(EXIT_SUCCESS);
   }
 
-  // Yhe child process becomes session leader
+  // The child process becomes session leader to detach from the terminal
   if (setsid() < 0) {
     logging::log(logging::Level_Error, "setsid failed: %d (%s)", errno, strerror(errno));
     exit(EXIT_FAILURE);
   }
 
-  // Fork off for the second time
+  // Fork off for the second time to get rid of the session leader
   pid = fork();
   if (pid < 0) {
     logging::log(logging::Level_Error, "second fork failed: %d (%s)", errno, strerror(errno));
@@ -108,7 +106,7 @@ void daemonize(stop_callback signal_stop_) {
     exit(EXIT_SUCCESS);
   }
 
-  // Set new file permissions
+  // Clear umask to give daemon complete control of file permissions
   umask(0);
 
   // Change the working directory to the root directory

--- a/source/server/linux/daemonize.h
+++ b/source/server/linux/daemonize.h
@@ -1,11 +1,13 @@
 #ifndef NIDEVICE_GRPC_LINUX_DAEMONIZE_H
 #define NIDEVICE_GRPC_LINUX_DAEMONIZE_H
 
+#include <string>
+
 namespace nidevice_grpc {
 
 typedef void (*stop_callback)();
 
-void daemonize(stop_callback stop);
+void daemonize(stop_callback stop, const std::string& identity);
 
 }  // namespace nidevice_grpc
 

--- a/source/server/linux/daemonize.h
+++ b/source/server/linux/daemonize.h
@@ -1,0 +1,13 @@
+#ifndef NIDEVICE_GRPC_LINUX_DAEMONIZE_H
+#define NIDEVICE_GRPC_LINUX_DAEMONIZE_H
+
+namespace nidevice_grpc {
+
+typedef void (*stop_callback)();
+
+void daemonize(stop_callback stop);
+
+}  // namespace nidevice_grpc
+
+#endif  // NIDEVICE_GRPC_LINUX_DAEMONIZE_H
+

--- a/source/server/linux/syslog_logging.cpp
+++ b/source/server/linux/syslog_logging.cpp
@@ -5,9 +5,7 @@
 namespace nidevice_grpc {
 namespace logging {
 
-static const char* syslog_identity = "ni_grpc_device_server";
-
-void setup_syslog(bool is_daemon)
+void setup_syslog(bool is_daemon, const std::string& identity)
 {
   int syslog_options = LOG_PID;
   int syslog_facility = 0;
@@ -19,7 +17,7 @@ void setup_syslog(bool is_daemon)
     syslog_options |= LOG_CONS;
     syslog_facility |= LOG_USER;
   }
-  openlog(syslog_identity, syslog_options, syslog_facility);
+  openlog(identity.c_str(), syslog_options, syslog_facility);
 }
 
 void log_syslog(Level level, const char* fmt, va_list args)

--- a/source/server/linux/syslog_logging.h
+++ b/source/server/linux/syslog_logging.h
@@ -1,12 +1,14 @@
 #ifndef NIDEVICE_GRPC_LINUX_SYSLOG_LOGGING_H
 #define NIDEVICE_GRPC_LINUX_SYSLOG_LOGGING_H
 
+#include <string>
+
 #include "../logging.h"
 
 namespace nidevice_grpc {
 namespace logging {
 
-void setup_syslog(bool is_daemon);
+void setup_syslog(bool is_daemon, const std::string& identity);
 void log_syslog(Level level, const char* fmt, va_list args);
 
 }  // namespace logging


### PR DESCRIPTION
### What does this Pull Request accomplish?

These changes allow the server process to properly daemonize on Linux including:
* Executing the complicated dance necessary to daemonize: double fork, closing std handles, etc.
* Creating a pid file
* Handling common signals and stopping the server when necessary
   * Provided a callback that will poke the server to shutdown
* Separated server startup into a couple distinct sections
   * Parse options and load configuration
   * Redirect to syslog/daemonize
   * Run server

### Why should this Pull Request be merged?

NI Sync is installing the grpc server as a boot-daemon on Linux RT. It is "branded" as `ni-sync-remote` to make it clear what functionality it is providing. Hence the identity options.

### What testing has been done?

Tested on a local system with an improved sync init script. Here is interleaved commands and syslog output (via `tail -f`)

```
admin@NI-PXIe-8880-03095FC1:~/grpc# /etc/init.d/ni-sync-remote start
2021-05-26T16:18:06.829+00:00 NI-PXIe-8880-03095FC1 ni-sync-remote[17888]: Server listening on port 31763
2021-05-26T16:18:06.829+00:00 NI-PXIe-8880-03095FC1 ni-sync-remote[17888]: Security is configured with insecure credentials.
admin@NI-PXIe-8880-03095FC1:~/grpc# /etc/init.d/ni-sync-remote status;echo $?
0
admin@NI-PXIe-8880-03095FC1:~/grpc# cat /var/run/ni-sync-remote.pid
17888
...
admin@NI-PXIe-8880-03095FC1:~/grpc# /etc/init.d/ni-sync-remote stop
admin@NI-PXIe-8880-03095FC1:~/grpc# 2021-05-26T16:28:41.805+00:00 NI-PXIe-8880-03095FC1 ni-sync-remote[17888]: handling signal: 15 (terminate)
admin@NI-PXIe-8880-03095FC1:~/grpc# /etc/init.d/ni-sync-remote status;echo $?
3
```

