### PR TITLE
[Owners] Update digital pattern and tclk system tests to use device_server

### DIFF
--- a/source/tests/system/device_server.cpp
+++ b/source/tests/system/device_server.cpp
@@ -11,6 +11,10 @@
 #include <nisync/nisync_service.h>
 #include <nidcpower/nidcpower_library.h>
 #include <nidcpower/nidcpower_service.h>
+#include <nidigitalpattern/nidigitalpattern_library.h>
+#include <nidigitalpattern/nidigitalpattern_service.h>
+#include <nitclk/nitclk_library.h>
+#include <nitclk/nitclk_service.h>
 
 namespace ni {
 namespace tests {
@@ -40,6 +44,10 @@ class DeviceServer : public DeviceServerInterface {
   nisync_grpc::NiSyncService nisync_service_;
   nidcpower_grpc::NiDCPowerLibrary nidcpower_library_;
   nidcpower_grpc::NiDCPowerService nidcpower_service_;
+  nidigitalpattern_grpc::NiDigitalLibrary nidigital_library_;
+  nidigitalpattern_grpc::NiDigitalService nidigital_service_;
+  nitclk_grpc::NiTClkLibrary nitclk_library_;
+  nitclk_grpc::NiTClkService nitclk_service_;
 
   std::unique_ptr<::grpc::Server> server_;
   std::shared_ptr<::grpc::Channel> channel_;
@@ -57,7 +65,11 @@ DeviceServer::DeviceServer()
       nisync_library_(),
       nisync_service_(&nisync_library_, &session_repository_),
       nidcpower_library_(),
-      nidcpower_service_(&nidcpower_library_, &session_repository_)
+      nidcpower_service_(&nidcpower_library_, &session_repository_),
+      nidigital_library_(),
+      nidigital_service_(&nidigital_library_, &session_repository_),
+      nitclk_library_(),
+      nitclk_service_(&nitclk_library_, &session_repository_)
 {
   grpc::ServerBuilder builder;
   builder.RegisterService(&core_service_);
@@ -65,6 +77,8 @@ DeviceServer::DeviceServer()
   builder.RegisterService(&niswitch_service_);
   builder.RegisterService(&nisync_service_);
   builder.RegisterService(&nidcpower_service_);
+  builder.RegisterService(&nidigital_service_);
+  builder.RegisterService(&nitclk_service_);
   server_ = builder.BuildAndStart();
 }
 

--- a/source/tests/system/nidigital_session_tests.cpp
+++ b/source/tests/system/nidigital_session_tests.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include "nidigitalpattern/nidigitalpattern_library.h"
+#include "device_server.h"
 #include "nidigitalpattern/nidigitalpattern_service.h"
 
 namespace ni {
@@ -19,24 +19,13 @@ const char* kDigitalInvalidResourceName = "";
 class NiDigitalSessionTest : public ::testing::Test {
  protected:
   NiDigitalSessionTest()
+    : device_server_(DeviceServerInterface::Singleton()),
+      nidigital_stub_(digital::NiDigital::NewStub(device_server_->InProcessChannel()))
   {
-    ::grpc::ServerBuilder builder;
-    session_repository_ = std::make_unique<nidevice_grpc::SessionRepository>();
-    nidigital_library_ = std::make_unique<digital::NiDigitalLibrary>();
-    nidigital_service_ = std::make_unique<digital::NiDigitalService>(nidigital_library_.get(), session_repository_.get());
-    builder.RegisterService(nidigital_service_.get());
-
-    server_ = builder.BuildAndStart();
-    ResetStubs();
+    device_server_->ResetServer();
   }
 
   virtual ~NiDigitalSessionTest() {}
-
-  void ResetStubs()
-  {
-    channel_ = server_->InProcessChannel(::grpc::ChannelArguments());
-    nidigital_stub_ = digital::NiDigital::NewStub(channel_);
-  }
 
   std::unique_ptr<digital::NiDigital::Stub>& GetStub()
   {
@@ -58,12 +47,8 @@ class NiDigitalSessionTest : public ::testing::Test {
   }
 
  private:
-  std::shared_ptr<::grpc::Channel> channel_;
-  std::unique_ptr<digital::NiDigital::Stub> nidigital_stub_;
-  std::unique_ptr<nidevice_grpc::SessionRepository> session_repository_;
-  std::unique_ptr<digital::NiDigitalLibrary> nidigital_library_;
-  std::unique_ptr<digital::NiDigitalService> nidigital_service_;
-  std::unique_ptr<::grpc::Server> server_;
+   DeviceServerInterface* device_server_;
+   std::unique_ptr<digital::NiDigital::Stub> nidigital_stub_;
 };
 
 TEST_F(NiDigitalSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDriverSession)

--- a/source/tests/system/nidigital_session_tests.cpp
+++ b/source/tests/system/nidigital_session_tests.cpp
@@ -47,8 +47,8 @@ class NiDigitalSessionTest : public ::testing::Test {
   }
 
  private:
-   DeviceServerInterface* device_server_;
-   std::unique_ptr<digital::NiDigital::Stub> nidigital_stub_;
+  DeviceServerInterface* device_server_;
+  std::unique_ptr<digital::NiDigital::Stub> nidigital_stub_;
 };
 
 TEST_F(NiDigitalSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDriverSession)


### PR DESCRIPTION
### What does this Pull Request accomplish?

DeviceServer was introduced for system tests in [PR 196](https://github.com/ni/grpc-device/pull/196). This PR updates digital pattern and tclk system tests to use centralized device server.

### Why should this Pull Request be merged?

System tests follow common pattern used by other system tests for lifetime management of session sever.

### What testing has been done?

- Digital pattern and tclk system tests pass