### PR TITLE
[Tiny] [Owners] Added r prefix to path string in Digital pattern example

### DIFF
--- a/examples/nidigitalpattern/configure-voltage-levels-and-termination-voltage.py
+++ b/examples/nidigitalpattern/configure-voltage-levels-and-termination-voltage.py
@@ -41,7 +41,7 @@ session_name = "NI-Digital-Pattern-Driver-Session"
 resource = "PXI1Slot2"
 options = "Simulate=1, DriverSetup=Model:6570"
 # Provide the absolute path to the folder on the server machine containing the .pinmap, .specs, .digitiming & .digipat files.
-directory_path = ""
+directory_path = r""
 if directory_path == "":
     print("\nProvide the absolute path to the folder on the server machine containing the .pinmap, .specs, .digitiming & .digipat files to the dirctory_path variable in the source code.")
     exit(1)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Added r prefix to the pinmap, specs, digitiming directory path string in the Digital Pattern example This is for running the example on windows, so that users can paste the absolute path of the directory having those files

### Why should this Pull Request be merged?

Added r prefix to the path string

### What testing has been done?

Example tested on local machine