### PR TITLE
Add SystemTestsRunner to artifacts

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -116,7 +116,6 @@ jobs:
         -C ${GITHUB_WORKSPACE}/build
         ni_grpc_device_server
         server_config.json
-        SystemTestsRunner
         -C ${GITHUB_WORKSPACE}
         LICENSE
         ThirdPartyNotices.txt
@@ -129,6 +128,29 @@ jobs:
         path: ni-grpc-device-server-linux-glibc2_23-x64.tar.gz
         retention-days: 5
 
+    - name: Tar Linux Test Binaries
+      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
+      run: >-
+        tar -cvzf ni-grpc-device-tests-linux-glibc2_23-x64.tar.gz
+        -C ${GITHUB_WORKSPACE}/build
+        certs/
+        IntegrationTestsRunner
+        libTestApi.so
+        SystemTestsRunner
+        test_mutual_tls_config.json
+        UnitTestsRunner
+        -C ${GITHUB_WORKSPACE}
+        LICENSE
+        ThirdPartyNotices.txt
+
+    - name: Upload Linux Test Binaries Artifact
+      uses: actions/upload-artifact@v2
+      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
+      with:
+        name: ni-grpc-device-tests-linux-glibc2_23-x64
+        path: ni-grpc-device-tests-linux-glibc2_23-x64.tar.gz
+        retention-days: 5
+
     - name: Upload Windows Server Binaries Artifact
       uses: actions/upload-artifact@v2
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}
@@ -137,7 +159,22 @@ jobs:
         path: |
           build/Release/ni_grpc_device_server.exe
           build/Release/server_config.json
+          LICENSE
+          ThirdPartyNotices.txt
+        retention-days: 5
+
+    - name: Upload Windows Test Binaries Artifact
+      uses: actions/upload-artifact@v2
+      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}
+      with:
+        name: ni-grpc-device-tests-windows-x64
+        path: |
+          build/Release/certs/
+          build/Release/IntegrationTestsRunner.exe
+          build/Release/TestApi.dll
           build/Release/SystemTestsRunner.exe
+          build/Release/test_mutual_tls_config.json
+          build/Release/UnitTestsRunner.exe
           LICENSE
           ThirdPartyNotices.txt
         retention-days: 5

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -116,6 +116,7 @@ jobs:
         -C ${GITHUB_WORKSPACE}/build
         ni_grpc_device_server
         server_config.json
+        SystemTestsRunner
         -C ${GITHUB_WORKSPACE}
         LICENSE
         ThirdPartyNotices.txt
@@ -136,6 +137,7 @@ jobs:
         path: |
           build/Release/ni_grpc_device_server.exe
           build/Release/server_config.json
+          build/Release/SystemTestsRunner.exe
           LICENSE
           ThirdPartyNotices.txt
         retention-days: 5

--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -134,16 +134,34 @@ jobs:
           message(FATAL_ERROR "Build failed")
         endif()
 
-    - name: Tar Development Build Files
-      if: ${{ github.ref == 'refs/heads/main' }}
+    - name: Tar Server Build Files
+      if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases') }}
       run: >-
         tar -cvzf ni-grpc-device-server-ni-linux-rt-x64.tar.gz
         -C ${GITHUB_WORKSPACE}/build
-        certs/
         ni_grpc_device_server
+        server_config.json
+        SystemTestsRunner
+        -C ${GITHUB_WORKSPACE}
+        LICENSE
+        ThirdPartyNotices.txt
+
+    - name: Upload Server Artifact
+      uses: actions/upload-artifact@v2
+      if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases') }}
+      with:
+        name: ni-grpc-device-server-ni-linux-rt-x64
+        path: ni-grpc-device-server-ni-linux-rt-x64.tar.gz
+        retention-days: 5
+
+    - name: Tar Test Build Files
+      if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases') }}
+      run: >-
+        tar -cvzf ni-grpc-device-tests-ni-linux-rt-x64.tar.gz
+        -C ${GITHUB_WORKSPACE}/build
+        certs/
         IntegrationTestsRunner
         libTestApi.so
-        server_config.json
         SystemTestsRunner
         test_mutual_tls_config.json
         UnitTestsRunner
@@ -151,22 +169,11 @@ jobs:
         LICENSE
         ThirdPartyNotices.txt
 
-    - name: Tar Release Build Files
-      if: ${{ startsWith(github.ref, 'refs/heads/releases') }}
-      run: >-
-        tar -cvzf ni-grpc-device-server-ni-linux-rt-x64.tar.gz
-        -C ${GITHUB_WORKSPACE}/build
-        ni_grpc_device_server
-        server_config.json
-        SystemTestsRunner
-        -C ${GITHUB_WORKSPACE}
-        LICENSE
-        ThirdPartyNotices.txt
-
-    - name: Upload Artifact
+    - name: Upload Tests Artifact
       uses: actions/upload-artifact@v2
       if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases') }}
       with:
-        name: ni-grpc-device-server-ni-linux-rt-x64
-        path: ni-grpc-device-server-ni-linux-rt-x64.tar.gz
+        name: ni-grpc-device-tests-ni-linux-rt-x64
+        path: ni-grpc-device-tests-ni-linux-rt-x64.tar.gz
         retention-days: 5
+

--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -158,6 +158,7 @@ jobs:
         -C ${GITHUB_WORKSPACE}/build
         ni_grpc_device_server
         server_config.json
+        SystemTestsRunner
         -C ${GITHUB_WORKSPACE}
         LICENSE
         ThirdPartyNotices.txt

--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -141,7 +141,6 @@ jobs:
         -C ${GITHUB_WORKSPACE}/build
         ni_grpc_device_server
         server_config.json
-        SystemTestsRunner
         -C ${GITHUB_WORKSPACE}
         LICENSE
         ThirdPartyNotices.txt


### PR DESCRIPTION
### What does this Pull Request accomplish?

This refactors the artifacts for all platforms that each has 2: one for the server and one for the tests.

### Why should this Pull Request be merged?

This will allow the CI testing (that is being triggered in https://github.com/ni/grpc-device/pull/226) to run the System Tests.

### What testing has been done?

Desktop run here: https://github.com/zhindes/grpc-device/actions/runs/958271879.
Linux RT run here: https://github.com/zhindes/grpc-device/actions/runs/958272207.
