### PR TITLE
[Owners Review] Display Port Number in addition to server_address in exception handling

### DIFF
--- a/examples/nidcpower/measure-record.py
+++ b/examples/nidcpower/measure-record.py
@@ -196,7 +196,7 @@ try :
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
-        error_message = f"Failed to connect to server on {server_address}"
+        error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
         error_message = "The operation is not implemented or is not supported/enabled in this service"
     print(f"{error_message}")

--- a/examples/nidigitalpattern/configure-voltage-levels-and-termination-voltage.py
+++ b/examples/nidigitalpattern/configure-voltage-levels-and-termination-voltage.py
@@ -191,7 +191,7 @@ try:
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
-        error_message = f"Failed to connect to server on {server_address}"
+        error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
         error_message = "The operation is not implemented or is not supported/enabled in this service"
     print(f"{error_message}") 

--- a/examples/nidmm/continuous-acquire-graph-multiple-points.py
+++ b/examples/nidmm/continuous-acquire-graph-multiple-points.py
@@ -201,7 +201,7 @@ try:
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
-        error_message = f"Failed to connect to server on {server_address}"
+        error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
         error_message = "The operation is not implemented or is not supported/enabled in this service"
     print(f"{error_message}") 

--- a/examples/nifgen/basic-arbitrary-waveform.py
+++ b/examples/nifgen/basic-arbitrary-waveform.py
@@ -166,7 +166,7 @@ try:
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
-        error_message = f"Failed to connect to server on {server_address}"
+        error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
         error_message = "The operation is not implemented or is not supported/enabled in this service"
     print(f"{error_message}") 

--- a/examples/niscope/fetch-continuous.py
+++ b/examples/niscope/fetch-continuous.py
@@ -159,7 +159,7 @@ try :
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
-        error_message = f"Failed to connect to server on {server_address}"
+        error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
         error_message = "The operation is not implemented or is not supported/enabled in this service"
     print(f"{error_message}")

--- a/examples/niscope/fetch-continuous.py
+++ b/examples/niscope/fetch-continuous.py
@@ -134,30 +134,40 @@ try :
     # Fetch continuously until all samples are acquired.
     current_pos = 0
     samples_per_fetch = 100
-    while current_pos < total_samples:
 
-        # We fetch each channel at a time so we don't have to de-interleave afterwards.
-        # We do not keep the wfm_info returned from fetch.
-        for channel_name, waveform in zip(channel_list, waveforms):
-            fetch_response = client.Fetch(niscope_types.FetchRequest(
-                vi = vi,
-                channel_list = channel_name,
-                timeout = 500000,
-                num_samples = samples_per_fetch
-                ))
-            CheckForError(vi, fetch_response.status)
-            waveform[current_pos : current_pos + samples_per_fetch] = fetch_response.waveform
-            print(f'Fetching channel {channel_name}\'s waveform for indices {current_pos} to {current_pos + samples_per_fetch - 1}')
-        print()
-        current_pos += samples_per_fetch
+    try:
+        while current_pos < total_samples:
 
-    # Close session to NI-SCOPE module.
-    CheckForError(vi, (client.Close(niscope_types.CloseRequest(
-        vi = vi
-        ))).status)
-    channel.close()
+            # We fetch each channel at a time so we don't have to de-interleave afterwards.
+            # We do not keep the wfm_info returned from fetch.
+            for channel_name, waveform in zip(channel_list, waveforms):
+                fetch_response = client.Fetch(niscope_types.FetchRequest(
+                    vi = vi,
+                    channel_list = channel_name,
+                    timeout = 500000,
+                    num_samples = samples_per_fetch
+                    ))
+                CheckForError(vi, fetch_response.status)
+                waveform[current_pos : current_pos + samples_per_fetch] = fetch_response.waveform
+                print(f'Fetching channel {channel_name}\'s waveform for indices {current_pos} to {current_pos + samples_per_fetch - 1}')
+            print()
+            current_pos += samples_per_fetch
+            
+    except KeyboardInterrupt:
+        pass
 
 # If NI-SCOPE API throws an exception, print the error message.
-except grpc.RpcError as e:
-    error_message = e.details()
-    print(error_message)
+except grpc.RpcError as rpc_error:
+    error_message = rpc_error.details()
+    if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
+        error_message = f"Failed to connect to server on {server_address}"
+    elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
+        error_message = "The operation is not implemented or is not supported/enabled in this service"
+    print(f"{error_message}")
+
+finally:
+    if('vi' in vars() and vi.id != 0):
+        # close the session.
+        CheckForError(vi, (client.Close(niscope_types.CloseRequest(
+            vi = vi
+        ))).status)

--- a/examples/niscope/fetch-continuous.py
+++ b/examples/niscope/fetch-continuous.py
@@ -137,7 +137,6 @@ try :
 
     try:
         while current_pos < total_samples:
-
             # We fetch each channel at a time so we don't have to de-interleave afterwards.
             # We do not keep the wfm_info returned from fetch.
             for channel_name, waveform in zip(channel_list, waveforms):

--- a/examples/niscope/fetch.py
+++ b/examples/niscope/fetch.py
@@ -126,7 +126,7 @@ try :
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
-        error_message = f"Failed to connect to server on {server_address}"
+        error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
         error_message = "The operation is not implemented or is not supported/enabled in this service"
     print(f"{error_message}")

--- a/examples/niscope/fetch.py
+++ b/examples/niscope/fetch.py
@@ -122,13 +122,18 @@ try :
         print(f'Waveform {i} information:')
         print(f'{waveforms[i]}\n')
 
-    # Close session to NI-SCOPE module.
-    CheckForError(vi, (client.Close(niscope_types.CloseRequest(
-        vi = vi
-        ))).status)
-    channel.close()
-
 # If NI-SCOPE API throws an exception, print the error message.
-except grpc.RpcError as e:
-    error_message = e.details()
-    print(error_message)
+except grpc.RpcError as rpc_error:
+    error_message = rpc_error.details()
+    if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
+        error_message = f"Failed to connect to server on {server_address}"
+    elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
+        error_message = "The operation is not implemented or is not supported/enabled in this service"
+    print(f"{error_message}")
+
+finally:
+    if('vi' in vars() and vi.id != 0):
+        # close the session.
+        CheckForError(vi, (client.Close(niscope_types.CloseRequest(
+            vi = vi
+        ))).status)

--- a/examples/niscope/graph-measurement.py
+++ b/examples/niscope/graph-measurement.py
@@ -177,7 +177,7 @@ try:
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
-        error_message = f"Failed to connect to server on {server_address}"
+        error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
         error_message = "The operation is not implemented or is not supported/enabled in this service"
     print(f"{error_message}")

--- a/examples/niscope/graph-measurement.py
+++ b/examples/niscope/graph-measurement.py
@@ -51,11 +51,11 @@ def CheckForError (vi, status) :
         ThrowOnError (vi, status)
 
 def ThrowOnError (vi, error_code):
-    error_message_request = niscope_types.ErrorMessageRequest(
+    error_message_request = niscope_types.GetErrorMessageRequest(
         vi = vi,
         error_code = error_code
         )
-    error_message_response = scope_service.ErrorMessage(error_message_request)
+    error_message_response = scope_service.GetErrorMessage(error_message_request)
     raise Exception (error_message_response.error_message)
 
 # Read in cmd args

--- a/examples/niscope/graph-measurement.py
+++ b/examples/niscope/graph-measurement.py
@@ -42,11 +42,21 @@ options = "Simulate=1, DriverSetup=Model:5164; BoardType:PXIe; MemorySize:161061
 
 channels = "0"
 
-def CheckStatus(scope_service, vi, result):
-    if (result.status != 0):
-        error_result = scope_service.GetErrorMessage(niscope_types.GetErrorMessageRequest(vi = vi, error_code = result.status))
-        print(error_result.error_message)
-        exit()
+# Checks for errors. If any, throws an exception to stop the execution.
+any_error = False
+def CheckForError (vi, status) :
+    global any_error
+    if(status != 0 and not any_error):
+        any_error = True
+        ThrowOnError (vi, status)
+
+def ThrowOnError (vi, error_code):
+    error_message_request = niscope_types.ErrorMessageRequest(
+        vi = vi,
+        error_code = error_code
+        )
+    error_message_response = scope_service.ErrorMessage(error_message_request)
+    raise Exception (error_message_response.error_message)
 
 # Read in cmd args
 if len(sys.argv) >= 2:
@@ -62,109 +72,119 @@ if len(sys.argv) >= 4:
 channel = grpc.insecure_channel(f"{server_address}:{server_port}")
 scope_service = grpc_scope.NiScopeStub(channel)
 
-# Initialize the scope
-init_result = scope_service.InitWithOptions(niscope_types.InitWithOptionsRequest(
-    session_name = "demo",
-    resource_name = resource, 
-    id_query = False, 
-    option_string = options
-    ))
-vi = init_result.vi
-CheckStatus(scope_service, vi, init_result)
-
-# Configure Vertical
-vertical_result = scope_service.ConfigureVertical(niscope_types.ConfigureVerticalRequest(
-    vi = vi,
-    channel_list = channels,
-    range = 10.0,
-    offset = 0,
-    coupling = niscope_types.VerticalCoupling.VERTICAL_COUPLING_NISCOPE_VAL_DC,
-    enabled = True,
-    probe_attenuation = 1
-    ))
-CheckStatus(scope_service, vi, vertical_result)
-
-# Configure Horizontal Timing
-config_result = scope_service.ConfigureHorizontalTiming(niscope_types.ConfigureHorizontalTimingRequest(
-    vi = vi,
-    min_sample_rate = 1000000,
-    min_num_pts = 1000,
-    ref_position = 50,
-    num_records = 1,
-    enforce_realtime = True
-    ))
-CheckStatus(scope_service, vi, config_result)
-
-# Setup an Edge Trigger
-result = scope_service.SetAttributeViInt32(niscope_types.SetAttributeViInt32Request(
-    vi = vi,
-    attribute_id = niscope_types.NiScopeAttributes.NISCOPE_ATTRIBUTE_TRIGGER_TYPE,
-    value = niscope_types.NiScopeInt32AttributeValues.NISCOPE_INT32_TRIGGER_TYPE_VAL_EDGE_TRIGGER
-))
-CheckStatus(scope_service, vi, result)
-
-conf_trigger_edge_result = scope_service.ConfigureTriggerEdge(niscope_types.ConfigureTriggerEdgeRequest(
-    vi = vi,
-    trigger_source = channels,
-    level = 0.00,
-    slope = niscope_types.TriggerSlope.TRIGGER_SLOPE_NISCOPE_VAL_POSITIVE,
-    trigger_coupling = niscope_types.TriggerCoupling.TRIGGER_COUPLING_NISCOPE_VAL_DC,
-    holdoff = 0.0
-))
-CheckStatus(scope_service, vi, conf_trigger_edge_result)
-
-result = scope_service.SetAttributeViInt32(niscope_types.SetAttributeViInt32Request(
-    vi = vi,
-    channel_list = channels,
-    attribute_id = niscope_types.NiScopeAttributes.NISCOPE_ATTRIBUTE_MEAS_REF_LEVEL_UNITS,
-    value = niscope_types.NiScopeInt32AttributeValues.NISCOPE_INT32_REF_LEVEL_UNITS_VAL_PERCENTAGE
-))
-CheckStatus(scope_service, vi, result)
-
-# Setup a plot to draw the captured waveform
-fig = plt.gcf()
-fig.show()
-fig.canvas.draw()
-
-print("\nReading values in loop. CTRL+C to stop.\n")
 try:
-    while True:
-        # Clear the plot and setup the axis
-        plt.clf()
-        plt.axis([0, 100, -6, 6])
-        # Read a waveform from the scope
-        read_result = scope_service.Read(niscope_types.ReadRequest(
-            vi = vi,
-            channel_list = channels,
-            timeout = 1,
-            num_samples = 10000
+    # Initialize the scope
+    init_result = scope_service.InitWithOptions(niscope_types.InitWithOptionsRequest(
+        session_name = "demo",
+        resource_name = resource, 
+        id_query = False, 
+        option_string = options
         ))
-        CheckStatus(scope_service, vi, read_result)
-        values = read_result.waveform[0:10]
-        print(values)
+    vi = init_result.vi
+    CheckForError(vi, init_result.status)
 
-        # Update the plot with the new waveform
-        plt.plot(read_result.waveform[0:100])
-        fig.canvas.draw()
-        plt.pause(0.001)
-
-        # Fetch the measured average frequency
-        fetch_result = scope_service.FetchMeasurementStats(niscope_types.FetchMeasurementStatsRequest(
-            vi = vi,
-            channel_list = channels,
-            timeout = 1,
-            scalar_meas_function = niscope_types.ScalarMeasurement.SCALAR_MEASUREMENT_NISCOPE_VAL_AVERAGE_FREQUENCY
+    # Configure Vertical
+    vertical_result = scope_service.ConfigureVertical(niscope_types.ConfigureVerticalRequest(
+        vi = vi,
+        channel_list = channels,
+        range = 10.0,
+        offset = 0,
+        coupling = niscope_types.VerticalCoupling.VERTICAL_COUPLING_NISCOPE_VAL_DC,
+        enabled = True,
+        probe_attenuation = 1
         ))
-        CheckStatus(scope_service, vi, fetch_result)
-        print("Average Frequency: " + str("%.2f" % round(fetch_result.result[0], 2)) + " Hz")
-        print("")
+    CheckForError(vi, vertical_result.status)
 
-        time.sleep(0.1)
-except KeyboardInterrupt:
-    pass
+    # Configure Horizontal Timing
+    config_result = scope_service.ConfigureHorizontalTiming(niscope_types.ConfigureHorizontalTimingRequest(
+        vi = vi,
+        min_sample_rate = 1000000,
+        min_num_pts = 1000,
+        ref_position = 50,
+        num_records = 1,
+        enforce_realtime = True
+        ))
+    CheckForError(vi, config_result.status)
 
-# Close
-scope_service.Close(niscope_types.CloseRequest(
-    vi = vi
-))
-channel.close()
+    # Setup an Edge Trigger
+    result = scope_service.SetAttributeViInt32(niscope_types.SetAttributeViInt32Request(
+        vi = vi,
+        attribute_id = niscope_types.NiScopeAttributes.NISCOPE_ATTRIBUTE_TRIGGER_TYPE,
+        value = niscope_types.NiScopeInt32AttributeValues.NISCOPE_INT32_TRIGGER_TYPE_VAL_EDGE_TRIGGER
+    ))
+    CheckForError(vi, result.status)
+
+    conf_trigger_edge_result = scope_service.ConfigureTriggerEdge(niscope_types.ConfigureTriggerEdgeRequest(
+        vi = vi,
+        trigger_source = channels,
+        level = 0.00,
+        slope = niscope_types.TriggerSlope.TRIGGER_SLOPE_NISCOPE_VAL_POSITIVE,
+        trigger_coupling = niscope_types.TriggerCoupling.TRIGGER_COUPLING_NISCOPE_VAL_DC,
+        holdoff = 0.0
+    ))
+    CheckForError(vi, conf_trigger_edge_result.status)
+
+    result = scope_service.SetAttributeViInt32(niscope_types.SetAttributeViInt32Request(
+        vi = vi,
+        channel_list = channels,
+        attribute_id = niscope_types.NiScopeAttributes.NISCOPE_ATTRIBUTE_MEAS_REF_LEVEL_UNITS,
+        value = niscope_types.NiScopeInt32AttributeValues.NISCOPE_INT32_REF_LEVEL_UNITS_VAL_PERCENTAGE
+    ))
+    CheckForError(vi, result.status)
+
+    # Setup a plot to draw the captured waveform
+    fig = plt.gcf()
+    fig.show()
+    fig.canvas.draw()
+
+    print("\nReading values in loop. CTRL+C to stop.\n")
+    try:
+        while True:
+            # Clear the plot and setup the axis
+            plt.clf()
+            plt.axis([0, 100, -6, 6])
+            # Read a waveform from the scope
+            read_result = scope_service.Read(niscope_types.ReadRequest(
+                vi = vi,
+                channel_list = channels,
+                timeout = 1,
+                num_samples = 10000
+            ))
+            CheckForError(vi, read_result.status)
+            values = read_result.waveform[0:10]
+            print(values)
+
+            # Update the plot with the new waveform
+            plt.plot(read_result.waveform[0:100])
+            fig.canvas.draw()
+            plt.pause(0.001)
+
+            # Fetch the measured average frequency
+            fetch_result = scope_service.FetchMeasurementStats(niscope_types.FetchMeasurementStatsRequest(
+                vi = vi,
+                channel_list = channels,
+                timeout = 1,
+                scalar_meas_function = niscope_types.ScalarMeasurement.SCALAR_MEASUREMENT_NISCOPE_VAL_AVERAGE_FREQUENCY
+            ))
+            CheckForError(vi, fetch_result.status)
+            print("Average Frequency: " + str("%.2f" % round(fetch_result.result[0], 2)) + " Hz")
+            print("")
+
+            time.sleep(0.1)
+    except KeyboardInterrupt:
+        pass
+
+except grpc.RpcError as rpc_error:
+    error_message = rpc_error.details()
+    if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
+        error_message = f"Failed to connect to server on {server_address}"
+    elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
+        error_message = "The operation is not implemented or is not supported/enabled in this service"
+    print(f"{error_message}")
+
+finally:
+    if('vi' in vars() and vi.id != 0):
+        # close the session.
+        CheckForError(vi, (scope_service.Close(niscope_types.CloseRequest(
+            vi = vi
+        ))).status)

--- a/examples/niscope/plot-read-waveform.py
+++ b/examples/niscope/plot-read-waveform.py
@@ -47,11 +47,11 @@ def CheckForError (vi, status) :
         ThrowOnError (vi, status)
 
 def ThrowOnError (vi, error_code):
-    error_message_request = niscope_types.ErrorMessageRequest(
+    error_message_request = niscope_types.GetErrorMessageRequest(
         vi = vi,
         error_code = error_code
         )
-    error_message_response = scope_service.ErrorMessage(error_message_request)
+    error_message_response = scope_service.GetErrorMessage(error_message_request)
     raise Exception (error_message_response.error_message)
 
 # Read in cmd args

--- a/examples/niscope/plot-read-waveform.py
+++ b/examples/niscope/plot-read-waveform.py
@@ -38,11 +38,21 @@ options = "Simulate=1, DriverSetup=Model:5164; BoardType:PXIe; MemorySize:161061
 
 channels = "0"
 
-def CheckStatus(scope_service, vi, result):
-    if (result.status != 0):
-        error_result = scope_service.GetErrorMessage(niscope_types.GetErrorMessageRequest(vi = vi, error_code = result.status))
-        print(error_result.error_message)
-        exit()
+# Checks for errors. If any, throws an exception to stop the execution.
+any_error = False
+def CheckForError (vi, status) :
+    global any_error
+    if(status != 0 and not any_error):
+        any_error = True
+        ThrowOnError (vi, status)
+
+def ThrowOnError (vi, error_code):
+    error_message_request = niscope_types.ErrorMessageRequest(
+        vi = vi,
+        error_code = error_code
+        )
+    error_message_response = scope_service.ErrorMessage(error_message_request)
+    raise Exception (error_message_response.error_message)
 
 # Read in cmd args
 if len(sys.argv) >= 2:
@@ -58,68 +68,79 @@ if len(sys.argv) >= 4:
 channel = grpc.insecure_channel(f"{server_address}:{server_port}")
 scope_service = grpc_scope.NiScopeStub(channel)
 
-# Initialize the scope
-init_result = scope_service.InitWithOptions(niscope_types.InitWithOptionsRequest(
-    session_name = "demo",
-    resource_name = resource, 
-    id_query = False, 
-    option_string = options
+try:
+    # Initialize the scope
+    init_result = scope_service.InitWithOptions(niscope_types.InitWithOptionsRequest(
+        session_name = "demo",
+        resource_name = resource, 
+        id_query = False, 
+        option_string = options
+        ))
+    vi = init_result.vi
+    CheckForError(vi, init_result.status)
+
+    # Configure horizontal timing
+    config_result = scope_service.ConfigureHorizontalTiming(niscope_types.ConfigureHorizontalTimingRequest(
+        vi = vi,
+        min_sample_rate = 1000000,
+        min_num_pts = 100000,
+        ref_position = 50,
+        num_records = 1,
+        enforce_realtime = True
     ))
-vi = init_result.vi
-CheckStatus(scope_service, vi, init_result)
+    CheckForError(vi, config_result.status)
 
-# Configure horizontal timing
-config_result = scope_service.ConfigureHorizontalTiming(niscope_types.ConfigureHorizontalTimingRequest(
-    vi = vi,
-    min_sample_rate = 1000000,
-    min_num_pts = 100000,
-    ref_position = 50,
-    num_records = 1,
-    enforce_realtime = True
-))
-CheckStatus(scope_service, vi, config_result)
+    # Configure vertical timing
+    vertical_result = scope_service.ConfigureVertical(niscope_types.ConfigureVerticalRequest(
+        vi = vi,
+        channel_list = channels,
+        range = 10.0,
+        offset = 0,
+        coupling = niscope_types.VerticalCoupling.VERTICAL_COUPLING_NISCOPE_VAL_DC,
+        enabled = True,
+        probe_attenuation = 1
+    ))
+    CheckForError(vi, vertical_result.status)
 
-# Configure vertical timing
-vertical_result = scope_service.ConfigureVertical(niscope_types.ConfigureVerticalRequest(
-    vi = vi,
-    channel_list = channels,
-    range = 10.0,
-    offset = 0,
-    coupling = niscope_types.VerticalCoupling.VERTICAL_COUPLING_NISCOPE_VAL_DC,
-    enabled = True,
-    probe_attenuation = 1
-))
-CheckStatus(scope_service, vi, vertical_result)
+    confTrigger_edge_result = scope_service.ConfigureTriggerEdge(niscope_types.ConfigureTriggerEdgeRequest(
+        vi = vi,
+        trigger_source = channels,
+        level = 0.00,
+        trigger_coupling = niscope_types.TriggerCoupling.TRIGGER_COUPLING_NISCOPE_VAL_DC,
+        slope = niscope_types.TriggerSlope.TRIGGER_SLOPE_NISCOPE_VAL_POSITIVE
+    ))
+    CheckForError(vi, confTrigger_edge_result.status)
 
-confTrigger_edge_result = scope_service.ConfigureTriggerEdge(niscope_types.ConfigureTriggerEdgeRequest(
-    vi = vi,
-    trigger_source = channels,
-    level = 0.00,
-    trigger_coupling = niscope_types.TriggerCoupling.TRIGGER_COUPLING_NISCOPE_VAL_DC,
-    slope = niscope_types.TriggerSlope.TRIGGER_SLOPE_NISCOPE_VAL_POSITIVE
-))
-CheckStatus(scope_service, vi, confTrigger_edge_result)
+    result = scope_service.SetAttributeViInt32(niscope_types.SetAttributeViInt32Request(
+        vi = vi,
+        channel_list = channels,
+        attribute_id = niscope_types.NiScopeAttributes.NISCOPE_ATTRIBUTE_MEAS_REF_LEVEL_UNITS,
+        value = niscope_types.NiScopeInt32AttributeValues.NISCOPE_INT32_REF_LEVEL_UNITS_VAL_VOLTS
+    ))
+    CheckForError(vi, result.status)
 
-result = scope_service.SetAttributeViInt32(niscope_types.SetAttributeViInt32Request(
-    vi = vi,
-    channel_list = channels,
-    attribute_id = niscope_types.NiScopeAttributes.NISCOPE_ATTRIBUTE_MEAS_REF_LEVEL_UNITS,
-    value = niscope_types.NiScopeInt32AttributeValues.NISCOPE_INT32_REF_LEVEL_UNITS_VAL_VOLTS
-))
-CheckStatus(scope_service, vi, result)
+    # Read a waveform from the scope
+    read_result = scope_service.Read(niscope_types.ReadRequest(
+        vi = vi,
+        channel_list = channels,
+        timeout = 10000,
+        num_samples = 100000
+    ))
+    CheckForError(vi, read_result.status)
+    values = read_result.waveform[0:10]
+    print(values)
 
-# Read a waveform from the scope
-read_result = scope_service.Read(niscope_types.ReadRequest(
-    vi = vi,
-    channel_list = channels,
-    timeout = 10000,
-    num_samples = 100000
-))
-CheckStatus(scope_service, vi, read_result)
-values = read_result.waveform[0:10]
-print(values)
+except grpc.RpcError as rpc_error:
+    error_message = rpc_error.details()
+    if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
+        error_message = f"Failed to connect to server on {server_address}"
+    elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
+        error_message = "The operation is not implemented or is not supported/enabled in this service"
+    print(f"{error_message}")
 
-scope_service.Close(niscope_types.CloseRequest(
-    vi = vi
-))
-channel.close()
+finally:
+    if('vi' in vars() and vi.id != 0):
+        # close the session.
+        CheckForError(vi, (scope_service.Close(niscope_types.CloseRequest(
+            vi = vi
+        ))).status)

--- a/examples/niscope/plot-read-waveform.py
+++ b/examples/niscope/plot-read-waveform.py
@@ -133,7 +133,7 @@ try:
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
-        error_message = f"Failed to connect to server on {server_address}"
+        error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
         error_message = "The operation is not implemented or is not supported/enabled in this service"
     print(f"{error_message}")

--- a/examples/niswitch/controlling-an-individual-relay.py
+++ b/examples/niswitch/controlling-an-individual-relay.py
@@ -97,14 +97,18 @@ try :
         ))).status)
     print("Wait for debounce to complete.")
 
-    # Close NI-SWITCH session.
-    CheckForError(vi, (niswitch_client.Close(niswitch_types.CloseRequest(
-        vi = vi
-        ))).status)
-
 # If NI-SWITCH API throws an exception, print the error message  
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
         error_message = f"Failed to connect to server on {server_address}"
-    print(f"{error_message}") 
+    elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
+        error_message = "The operation is not implemented or is not supported/enabled in this service"
+    print(f"{error_message}")
+
+finally:
+    if('vi' in vars() and vi.id != 0):
+        # close the session.
+        CheckForError(vi, (niswitch_client.Close(niswitch_types.CloseRequest(
+            vi = vi
+        ))).status)

--- a/examples/niswitch/controlling-an-individual-relay.py
+++ b/examples/niswitch/controlling-an-individual-relay.py
@@ -101,7 +101,7 @@ try :
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
-        error_message = f"Failed to connect to server on {server_address}"
+        error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
         error_message = "The operation is not implemented or is not supported/enabled in this service"
     print(f"{error_message}")

--- a/examples/niswitch/software-scanning.py
+++ b/examples/niswitch/software-scanning.py
@@ -127,7 +127,7 @@ try :
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
-        error_message = f"Failed to connect to server on {server_address}"
+        error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
         error_message = "The operation is not implemented or is not supported/enabled in this service"
     print(f"{error_message}") 

--- a/examples/niswitch/software-scanning.py
+++ b/examples/niswitch/software-scanning.py
@@ -123,14 +123,18 @@ try :
         ))).status)
     print("Scanning completed.")
 
-    # Close NI-SWITCH session.
-    CheckForError(vi, (niswitch_client.Close(niswitch_types.CloseRequest(
-        vi = vi
-        ))).status)
-
 # If NI-SWITCH API throws an exception, print the error message  
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
         error_message = f"Failed to connect to server on {server_address}"
+    elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
+        error_message = "The operation is not implemented or is not supported/enabled in this service"
     print(f"{error_message}") 
+
+finally:
+    if('vi' in vars() and vi.id != 0):
+        # close the session.
+        CheckForError(vi, (niswitch_client.Close(niswitch_types.CloseRequest(
+            vi = vi
+        ))).status)

--- a/examples/nitclk/multi-device-configured-acquisition-tclk.py
+++ b/examples/nitclk/multi-device-configured-acquisition-tclk.py
@@ -295,7 +295,7 @@ try:
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
-        error_message = f"Failed to connect to server on {server_address}"
+        error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
         error_message = "The operation is not implemented or is not supported/enabled in this service"
     print(f"{error_message}")

--- a/examples/nitclk/synchronize-tclk.py
+++ b/examples/nitclk/synchronize-tclk.py
@@ -154,7 +154,7 @@ try:
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
-        error_message = f"Failed to connect to server on {server_address}"
+        error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
         error_message = "The operation is not implemented or is not supported/enabled in this service"
     print(error_message) 

--- a/examples/session/enumerate-device.py
+++ b/examples/session/enumerate-device.py
@@ -59,7 +59,7 @@ try :
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
-        error_message = f"Failed to connect to server on {server_address}"
+        error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
         error_message = "The operation is not implemented or is not supported/enabled in this service"
     print(f"{error_message}")

--- a/examples/session/enumerate-device.py
+++ b/examples/session/enumerate-device.py
@@ -59,5 +59,7 @@ try :
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
-        error_message = f"Failed to connect to the server on {server_address}."
+        error_message = f"Failed to connect to server on {server_address}"
+    elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
+        error_message = "The operation is not implemented or is not supported/enabled in this service"
     print(f"{error_message}")

--- a/examples/session/session-reservation.py
+++ b/examples/session/session-reservation.py
@@ -167,6 +167,10 @@ try :
     print(f'All sessions have been closed and reservations have been cleared.\n')
 
 # If NI-SCOPE API or Session API throws an exception, print the error message.
-except grpc.RpcError as e:
-    error_message = e.details()
-    print(error_message)
+except grpc.RpcError as rpc_error:
+    error_message = rpc_error.details()
+    if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
+        error_message = f"Failed to connect to server on {server_address}"
+    elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
+        error_message = "The operation is not implemented or is not supported/enabled in this service"
+    print(f"{error_message}")

--- a/examples/session/session-reservation.py
+++ b/examples/session/session-reservation.py
@@ -170,7 +170,7 @@ try :
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE :
-        error_message = f"Failed to connect to server on {server_address}"
+        error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
         error_message = "The operation is not implemented or is not supported/enabled in this service"
     print(f"{error_message}")


### PR DESCRIPTION
### What does this Pull Request accomplish?

port number is also displayed in addition to the server_address as part of the message in the case when client fails to connect to the server.

### Why should this Pull Request be merged?

If the client fails to connect to the server when either server is not running or client puts wrong server_address or port_number, the client gets a proper message indicating server_adress and port_number both.

For eg.
![image](https://user-images.githubusercontent.com/78592845/123079138-44f40800-d439-11eb-8626-e7d465fe0d47.png)


### What testing has been done?

Manual
