### PR TITLE
Add basic feature toggles to server configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,7 @@ endforeach()
 add_executable(ni_grpc_device_server
    "source/server/core_server.cpp"
    "source/server/device_enumerator.cpp"
+   "source/server/feature_toggles.cpp"
    "source/server/logging.cpp"
    "source/server/semaphore.cpp"
    "source/server/server_configuration_parser.cpp"
@@ -273,6 +274,7 @@ add_executable(UnitTestsRunner
     "source/tests/unit/shared_library_tests.cpp"
     "source/tests/unit/syscfg_library_tests.cpp"
     "source/server/device_enumerator.cpp"
+    "source/server/feature_toggles.cpp"
     "source/server/semaphore.cpp"
     "source/server/server_configuration_parser.cpp"
     "source/server/server_security_configuration.cpp"

--- a/source/server/core_server.cpp
+++ b/source/server/core_server.cpp
@@ -1,10 +1,13 @@
 #include <mutex>
+
 #include <nidcpower/nidcpower_library.h>
 #include <nidcpower/nidcpower_service.h>
 #include <nidigitalpattern/nidigitalpattern_library.h>
 #include <nidigitalpattern/nidigitalpattern_service.h>
 #include <nidmm/nidmm_library.h>
 #include <nidmm/nidmm_service.h>
+#include <nifgen/nifgen_library.h>
+#include <nifgen/nifgen_service.h>
 #include <niscope/niscope_library.h>
 #include <niscope/niscope_service.h>
 #include <niswitch/niswitch_library.h>
@@ -13,9 +16,8 @@
 #include <nisync/nisync_service.h>
 #include <nitclk/nitclk_library.h>
 #include <nitclk/nitclk_service.h>
-#include <nifgen/nifgen_library.h>
-#include <nifgen/nifgen_service.h>
 
+#include "feature_toggles.h"
 #include "logging.h"
 #include "server_configuration_parser.h"
 #include "server_security_configuration.h"
@@ -27,12 +29,12 @@
   #include "linux/syslog_logging.h"
 #endif
 
-struct ServerConfiguration
-{
+struct ServerConfiguration {
   std::string server_address;
   std::string server_cert;
   std::string server_key;
   std::string root_cert;
+  nidevice_grpc::FeatureToggles feature_toggles;
 };
 
 static ServerConfiguration GetConfiguration(const std::string& config_file_path)
@@ -46,6 +48,7 @@ static ServerConfiguration GetConfiguration(const std::string& config_file_path)
     config.server_cert = server_config_parser.parse_server_cert();
     config.server_key = server_config_parser.parse_server_key();
     config.root_cert = server_config_parser.parse_root_cert();
+    config.feature_toggles = server_config_parser.parse_feature_toggles();
   }
   catch (const std::exception& ex) {
     nidevice_grpc::logging::log(
@@ -241,7 +244,7 @@ int main(int argc, char** argv)
     nidevice_grpc::logging::setup_syslog(options.daemonize, options.identity);
     nidevice_grpc::logging::set_logger(&nidevice_grpc::logging::log_syslog);
   }
-  
+
   if (options.daemonize) {
     nidevice_grpc::daemonize(&StopServer, options.identity);
   }

--- a/source/server/feature_toggles.cpp
+++ b/source/server/feature_toggles.cpp
@@ -1,12 +1,14 @@
 #include "feature_toggles.h"
 
 namespace nidevice_grpc {
-bool FeatureToggles::is_enabled(const std::string& feature_name) const
+FeatureToggles::FeatureState FeatureToggles::get_feature_state(const std::string& feature_name) const
 {
   auto found = map_.find(feature_name);
   if (found != map_.end()) {
-    return found->second;
+    return found->second 
+    ? FeatureState::kEnabled 
+    : FeatureState::kDisabled;
   }
-  return false;
+  return FeatureState::kUnspecified;
 }
 }  // namespace nidevice_grpc

--- a/source/server/feature_toggles.cpp
+++ b/source/server/feature_toggles.cpp
@@ -1,0 +1,12 @@
+#include "feature_toggles.h"
+
+namespace nidevice_grpc {
+bool FeatureToggles::is_enabled(const std::string& feature_name) const
+{
+  auto found = map_.find(feature_name);
+  if (found != map_.end()) {
+    return found->second;
+  }
+  return false;
+}
+}  // namespace nidevice_grpc

--- a/source/server/feature_toggles.h
+++ b/source/server/feature_toggles.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+namespace nidevice_grpc {
+
+using FeatureToggleConfigurationMap = std::unordered_map<std::string, bool>;
+class FeatureToggles {
+ public:
+  FeatureToggles() {}
+  FeatureToggles(FeatureToggleConfigurationMap&& map) : map_(map) {}
+  bool is_enabled(const std::string& feature_name) const;
+
+ private:
+  FeatureToggleConfigurationMap map_;
+};
+}  // namespace nidevice_grpc

--- a/source/server/feature_toggles.h
+++ b/source/server/feature_toggles.h
@@ -7,9 +7,14 @@ namespace nidevice_grpc {
 using FeatureToggleConfigurationMap = std::unordered_map<std::string, bool>;
 class FeatureToggles {
  public:
+  enum class FeatureState {
+    kDisabled,
+    kEnabled,
+    kUnspecified
+  };
   FeatureToggles() {}
   FeatureToggles(FeatureToggleConfigurationMap&& map) : map_(map) {}
-  bool is_enabled(const std::string& feature_name) const;
+  FeatureState get_feature_state(const std::string& feature_name) const;
 
  private:
   FeatureToggleConfigurationMap map_;

--- a/source/server/feature_toggles.h
+++ b/source/server/feature_toggles.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef NIDEVICE_GRPC_FEATURE_TOGGLES_H
+#define NIDEVICE_GRPC_FEATURE_TOGGLES_H
 
 #include <string>
 #include <unordered_map>
@@ -20,3 +21,6 @@ class FeatureToggles {
   FeatureToggleConfigurationMap map_;
 };
 }  // namespace nidevice_grpc
+
+
+#endif /* NIDEVICE_GRPC_FEATURE_TOGGLES_H */

--- a/source/server/server_configuration_parser.h
+++ b/source/server/server_configuration_parser.h
@@ -4,6 +4,8 @@
 #include <fstream>
 #include <nlohmann/json.hpp>
 
+#include "feature_toggles.h"
+
 namespace nidevice_grpc {
 
 static const char* kConfigFileNotFoundMessage = "The server configuration file was not found at: ";
@@ -14,6 +16,7 @@ static const char* kUnspecifiedPortMessage = "The server port must be specified 
 static const char* kValueTypeNotStringMessage = "The following key must be specified in the server's configuration file as a string enclosed with double quotes: ";
 static const char* kFileNotFoundMessage = "The following certificate file was not found: ";
 static const char* kInvalidExePathMessage = "The server was unable to resolve the current executable path.";
+static const char* kInvalidFeatureToggleMessage = "Feature Toggles must be specified as boolean fields in the form \"feature_toggles\": { \"feature1\": true, \"feature2\": false }. \n\n";
 static const char* kDefaultAddressPrefix = "[::]:";
 
 class ServerConfigurationParser {
@@ -29,6 +32,7 @@ class ServerConfigurationParser {
   std::string parse_server_cert() const;
   std::string parse_server_key() const;
   std::string parse_root_cert() const;
+  FeatureToggles parse_feature_toggles() const;
 
   struct ConfigFileNotFoundException : public std::runtime_error {
     ConfigFileNotFoundException(const std::string& config_file_path);
@@ -60,6 +64,10 @@ class ServerConfigurationParser {
 
   struct InvalidExePathException : public std::runtime_error {
     InvalidExePathException();
+  };
+
+  struct InvalidFeatureToggleException : std::runtime_error {
+    InvalidFeatureToggleException(const std::string& type_error_details);
   };
 
  private:

--- a/source/tests/unit/server_configuration_parser_tests.cpp
+++ b/source/tests/unit/server_configuration_parser_tests.cpp
@@ -357,6 +357,7 @@ TEST(ServerConfigurationParserTests, JsonConfigWithMissingRootCertFile_ParseRoot
     EXPECT_THAT(ex.what(), testing::HasSubstr(nidevice_grpc::kFileNotFoundMessage));
   }
 }
+
 TEST(ServerConfigurationParserTests, JsonConfigWithEnabledFeature_ParseFeatureToggles_FeatureIsEnabled)
 {
   nlohmann::json config_json = nlohmann::json::parse(R"(


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add support for feature toggles to the server configuration json file format so that features can be explicitly enabled and disabled.

### Why should this Pull Request be merged?

DAQmx feature development will not be ready for release until significant work is completed and multiple internal features are complete.

Adding the concept of feature toggles allows us to use an NI-standard mainline model for development.

### What testing has been done?

Ran and passed new tests.
Manual testing with a server with valid and invalid configuration.