### PR TITLE
Add nifake GetAttributeViSesion test

### DIFF
--- a/generated/nifake/nifake.proto
+++ b/generated/nifake/nifake.proto
@@ -39,6 +39,7 @@ service NiFake {
   rpc GetAttributeViInt32(GetAttributeViInt32Request) returns (GetAttributeViInt32Response);
   rpc GetAttributeViInt64(GetAttributeViInt64Request) returns (GetAttributeViInt64Response);
   rpc GetAttributeViReal64(GetAttributeViReal64Request) returns (GetAttributeViReal64Response);
+  rpc GetAttributeViSession(GetAttributeViSessionRequest) returns (GetAttributeViSessionResponse);
   rpc GetAttributeViString(GetAttributeViStringRequest) returns (GetAttributeViStringResponse);
   rpc GetCalDateAndTime(GetCalDateAndTimeRequest) returns (GetCalDateAndTimeResponse);
   rpc GetCalInterval(GetCalIntervalRequest) returns (GetCalIntervalResponse);
@@ -359,6 +360,16 @@ message GetAttributeViReal64Request {
 message GetAttributeViReal64Response {
   int32 status = 1;
   double attribute_value = 2;
+}
+
+message GetAttributeViSessionRequest {
+  nidevice_grpc.Session vi = 1;
+  sint32 attribute_id = 2;
+}
+
+message GetAttributeViSessionResponse {
+  int32 status = 1;
+  nidevice_grpc.Session session_out = 2;
 }
 
 message GetAttributeViStringRequest {

--- a/generated/nifake/nifake_library.cpp
+++ b/generated/nifake/nifake_library.cpp
@@ -44,6 +44,7 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.GetAttributeViInt32 = reinterpret_cast<GetAttributeViInt32Ptr>(shared_library_.get_function_pointer("niFake_GetAttributeViInt32"));
   function_pointers_.GetAttributeViInt64 = reinterpret_cast<GetAttributeViInt64Ptr>(shared_library_.get_function_pointer("niFake_GetAttributeViInt64"));
   function_pointers_.GetAttributeViReal64 = reinterpret_cast<GetAttributeViReal64Ptr>(shared_library_.get_function_pointer("niFake_GetAttributeViReal64"));
+  function_pointers_.GetAttributeViSession = reinterpret_cast<GetAttributeViSessionPtr>(shared_library_.get_function_pointer("niFake_GetAttributeViSession"));
   function_pointers_.GetAttributeViString = reinterpret_cast<GetAttributeViStringPtr>(shared_library_.get_function_pointer("niFake_GetAttributeViString"));
   function_pointers_.GetCalDateAndTime = reinterpret_cast<GetCalDateAndTimePtr>(shared_library_.get_function_pointer("niFake_GetCalDateAndTime"));
   function_pointers_.GetCalInterval = reinterpret_cast<GetCalIntervalPtr>(shared_library_.get_function_pointer("niFake_GetCalInterval"));
@@ -371,6 +372,18 @@ ViStatus NiFakeLibrary::GetAttributeViReal64(ViSession vi, ViConstString channel
   return niFake_GetAttributeViReal64(vi, channelName, attributeId, attributeValue);
 #else
   return function_pointers_.GetAttributeViReal64(vi, channelName, attributeId, attributeValue);
+#endif
+}
+
+ViStatus NiFakeLibrary::GetAttributeViSession(ViSession vi, ViInt32 attributeId, ViSession* sessionOut)
+{
+  if (!function_pointers_.GetAttributeViSession) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_GetAttributeViSession.");
+  }
+#if defined(_MSC_VER)
+  return niFake_GetAttributeViSession(vi, attributeId, sessionOut);
+#else
+  return function_pointers_.GetAttributeViSession(vi, attributeId, sessionOut);
 #endif
 }
 

--- a/generated/nifake/nifake_library.h
+++ b/generated/nifake/nifake_library.h
@@ -41,6 +41,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus GetAttributeViInt32(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32* attributeValue);
   ViStatus GetAttributeViInt64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64* attributeValue);
   ViStatus GetAttributeViReal64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViReal64* attributeValue);
+  ViStatus GetAttributeViSession(ViSession vi, ViInt32 attributeId, ViSession* sessionOut);
   ViStatus GetAttributeViString(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 bufferSize, ViChar attributeValue[]);
   ViStatus GetCalDateAndTime(ViSession vi, ViInt32 calType, ViInt32* month, ViInt32* day, ViInt32* year, ViInt32* hour, ViInt32* minute);
   ViStatus GetCalInterval(ViSession vi, ViInt32* months);
@@ -107,6 +108,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using GetAttributeViInt32Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32* attributeValue);
   using GetAttributeViInt64Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64* attributeValue);
   using GetAttributeViReal64Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViReal64* attributeValue);
+  using GetAttributeViSessionPtr = ViStatus (*)(ViSession vi, ViInt32 attributeId, ViSession* sessionOut);
   using GetAttributeViStringPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 bufferSize, ViChar attributeValue[]);
   using GetCalDateAndTimePtr = ViStatus (*)(ViSession vi, ViInt32 calType, ViInt32* month, ViInt32* day, ViInt32* year, ViInt32* hour, ViInt32* minute);
   using GetCalIntervalPtr = ViStatus (*)(ViSession vi, ViInt32* months);
@@ -173,6 +175,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     GetAttributeViInt32Ptr GetAttributeViInt32;
     GetAttributeViInt64Ptr GetAttributeViInt64;
     GetAttributeViReal64Ptr GetAttributeViReal64;
+    GetAttributeViSessionPtr GetAttributeViSession;
     GetAttributeViStringPtr GetAttributeViString;
     GetCalDateAndTimePtr GetCalDateAndTime;
     GetCalIntervalPtr GetCalInterval;

--- a/generated/nifake/nifake_library_interface.h
+++ b/generated/nifake/nifake_library_interface.h
@@ -38,6 +38,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus GetAttributeViInt32(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32* attributeValue) = 0;
   virtual ViStatus GetAttributeViInt64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64* attributeValue) = 0;
   virtual ViStatus GetAttributeViReal64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViReal64* attributeValue) = 0;
+  virtual ViStatus GetAttributeViSession(ViSession vi, ViInt32 attributeId, ViSession* sessionOut) = 0;
   virtual ViStatus GetAttributeViString(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 bufferSize, ViChar attributeValue[]) = 0;
   virtual ViStatus GetCalDateAndTime(ViSession vi, ViInt32 calType, ViInt32* month, ViInt32* day, ViInt32* year, ViInt32* hour, ViInt32* minute) = 0;
   virtual ViStatus GetCalInterval(ViSession vi, ViInt32* months) = 0;

--- a/generated/nifake/nifake_mock_library.h
+++ b/generated/nifake/nifake_mock_library.h
@@ -40,6 +40,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, GetAttributeViInt32, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32* attributeValue), (override));
   MOCK_METHOD(ViStatus, GetAttributeViInt64, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64* attributeValue), (override));
   MOCK_METHOD(ViStatus, GetAttributeViReal64, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViReal64* attributeValue), (override));
+  MOCK_METHOD(ViStatus, GetAttributeViSession, (ViSession vi, ViInt32 attributeId, ViSession* sessionOut), (override));
   MOCK_METHOD(ViStatus, GetAttributeViString, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 bufferSize, ViChar attributeValue[]), (override));
   MOCK_METHOD(ViStatus, GetCalDateAndTime, (ViSession vi, ViInt32 calType, ViInt32* month, ViInt32* day, ViInt32* year, ViInt32* hour, ViInt32* minute), (override));
   MOCK_METHOD(ViStatus, GetCalInterval, (ViSession vi, ViInt32* months), (override));

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -652,6 +652,30 @@ namespace nifake_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::GetAttributeViSession(::grpc::ServerContext* context, const GetAttributeViSessionRequest* request, GetAttributeViSessionResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViInt32 attribute_id = request->attribute_id();
+      ViSession session_out {};
+      auto status = library_->GetAttributeViSession(vi, attribute_id, &session_out);
+      response->set_status(status);
+      if (status == 0) {
+        response->mutable_session_out()->set_id(session_out);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetAttributeViString(::grpc::ServerContext* context, const GetAttributeViStringRequest* request, GetAttributeViStringResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -47,6 +47,7 @@ public:
   ::grpc::Status GetAttributeViInt32(::grpc::ServerContext* context, const GetAttributeViInt32Request* request, GetAttributeViInt32Response* response) override;
   ::grpc::Status GetAttributeViInt64(::grpc::ServerContext* context, const GetAttributeViInt64Request* request, GetAttributeViInt64Response* response) override;
   ::grpc::Status GetAttributeViReal64(::grpc::ServerContext* context, const GetAttributeViReal64Request* request, GetAttributeViReal64Response* response) override;
+  ::grpc::Status GetAttributeViSession(::grpc::ServerContext* context, const GetAttributeViSessionRequest* request, GetAttributeViSessionResponse* response) override;
   ::grpc::Status GetAttributeViString(::grpc::ServerContext* context, const GetAttributeViStringRequest* request, GetAttributeViStringResponse* response) override;
   ::grpc::Status GetCalDateAndTime(::grpc::ServerContext* context, const GetCalDateAndTimeRequest* request, GetCalDateAndTimeResponse* response) override;
   ::grpc::Status GetCalInterval(::grpc::ServerContext* context, const GetCalIntervalRequest* request, GetCalIntervalResponse* response) override;

--- a/source/codegen/metadata/nifake/CHANGES.md
+++ b/source/codegen/metadata/nifake/CHANGES.md
@@ -25,7 +25,8 @@ The following functions, not originally in nimi-python metadata, were newly adde
   - This function allows testing of ViUInt8[] output parameters that use enum
 - Changed `'GetAnIviDanceWithATwistString'` to `'GetAnIviDanceWithATwistArray'` and updated the parameters
     -  This function allows testing of ivi-dance-with-a-twist mechanism
- 
+- `'GetAttributeViSession'`
+    - This function allows testing `ViSession` out parameters from non-open methods.
 The following functions were tagged with `'init_method': True,` to ensure their generated service handlers register the new session
 with the session_repository.
 - `InitWithOptions`

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -912,6 +912,26 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'GetAttributeViSession': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'in',
+                'name': 'attributeId',
+                'type': 'ViInt32'
+            },
+            {
+                'direction': 'out',
+                'name': 'sessionOut',
+                'type': 'ViSession'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'GetAttributeViString': {
         'codegen_method': 'public',
         'documentation': {

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -1503,6 +1503,31 @@ TEST(NiFakeServiceTests, NiFakeService_GetArrayViUInt8WithEnum_CallsGetArrayViUI
   EXPECT_EQ(std::string(uint8_array, uint8_array+array_len), response.u_int8_enum_array_raw());
 }
 
+TEST(NiFakeServiceTests, NiFakeService_GetAttributeViSession_ReturnsSessionId)
+{
+  nidevice_grpc::SessionRepository session_repository;
+  NiFakeMockLibrary library;
+  nifake_grpc::NiFakeService service(&library, &session_repository);
+  std::uint32_t session_id = create_session(session_repository, kTestViSession);
+  const ViInt32 kAttributeId = 1234;
+  EXPECT_CALL(library, GetAttributeViSession(kTestViSession, kAttributeId, _))
+      .WillOnce(
+          DoAll(
+              SetArgPointee<2>(kTestViSession),
+              Return(kDriverSuccess)));
+
+  ::grpc::ServerContext context;
+  nifake_grpc::GetAttributeViSessionRequest request;
+  request.mutable_vi()->set_id(session_id);
+  request.set_attribute_id(kAttributeId);
+  nifake_grpc::GetAttributeViSessionResponse response;
+  auto status = service.GetAttributeViSession(&context, &request, &response);
+
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(kDriverSuccess, response.status());
+  EXPECT_EQ(session_id, response.session_out().id());
+}
+
 }  // namespace unit
 }  // namespace tests
 }  // namespace ni


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add a test covering for an `ViSession` out parameter from a non-open method.

### Why should this Pull Request be merged?

A similar method exists on many of the MI drivers.

I'm working on changes to the `SessionRepository`. A version of my change broke multiple `TClk` tests but no unit or integration tests.

### What testing has been done?

Ran and passed included test.
Confirmed how it was broken and can be fixed with the same fixes that worked for `TClk`.