### PR TITLE
Add SessionResourceRepository to support non-IVI sessions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,6 +266,7 @@ add_compile_definitions(TestApi TEST_API_BUILDING)
 
 add_executable(UnitTestsRunner
     "source/tests/utilities/run_all_tests.cpp"
+    "source/tests/unit/session_resource_repository_tests.cpp"
     "source/tests/unit/session_repository_tests.cpp"
     "source/tests/unit/device_enumerator_tests.cpp"
     "source/tests/unit/server_configuration_parser_tests.cpp"

--- a/generated/nidcpower/nidcpower_service.h
+++ b/generated/nidcpower/nidcpower_service.h
@@ -13,7 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
-#include <server/session_repository.h>
+#include <server/session_resource_repository.h>
 #include <server/shared_library.h>
 
 #include "nidcpower_library_interface.h"
@@ -22,8 +22,11 @@ namespace nidcpower_grpc {
 
 class NiDCPowerService final : public NiDCPower::Service {
 public:
-  NiDCPowerService(NiDCPowerLibraryInterface* library, nidevice_grpc::SessionRepository* session_repository);
+  using ResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViSession>>;
+
+  NiDCPowerService(NiDCPowerLibraryInterface* library, ResourceRepositorySharedPtr session_repository);
   virtual ~NiDCPowerService();
+  
   ::grpc::Status AbortWithChannels(::grpc::ServerContext* context, const AbortWithChannelsRequest* request, AbortWithChannelsResponse* response) override;
   ::grpc::Status CommitWithChannels(::grpc::ServerContext* context, const CommitWithChannelsRequest* request, CommitWithChannelsResponse* response) override;
   ::grpc::Status ConfigureDigitalEdgeMeasureTriggerWithChannels(::grpc::ServerContext* context, const ConfigureDigitalEdgeMeasureTriggerWithChannelsRequest* request, ConfigureDigitalEdgeMeasureTriggerWithChannelsResponse* response) override;
@@ -161,7 +164,7 @@ public:
   ::grpc::Status WaitForEvent(::grpc::ServerContext* context, const WaitForEventRequest* request, WaitForEventResponse* response) override;
 private:
   NiDCPowerLibraryInterface* library_;
-  nidevice_grpc::SessionRepository* session_repository_;
+  ResourceRepositorySharedPtr session_repository_;
   void Copy(const std::vector<ViBoolean>& input, google::protobuf::RepeatedField<bool>* output);
 };
 

--- a/generated/nidigitalpattern/nidigitalpattern_service.h
+++ b/generated/nidigitalpattern/nidigitalpattern_service.h
@@ -13,7 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
-#include <server/session_repository.h>
+#include <server/session_resource_repository.h>
 #include <server/shared_library.h>
 
 #include "nidigitalpattern_library_interface.h"
@@ -22,8 +22,11 @@ namespace nidigitalpattern_grpc {
 
 class NiDigitalService final : public NiDigital::Service {
 public:
-  NiDigitalService(NiDigitalLibraryInterface* library, nidevice_grpc::SessionRepository* session_repository);
+  using ResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViSession>>;
+
+  NiDigitalService(NiDigitalLibraryInterface* library, ResourceRepositorySharedPtr session_repository);
   virtual ~NiDigitalService();
+  
   ::grpc::Status Abort(::grpc::ServerContext* context, const AbortRequest* request, AbortResponse* response) override;
   ::grpc::Status AbortKeepAlive(::grpc::ServerContext* context, const AbortKeepAliveRequest* request, AbortKeepAliveResponse* response) override;
   ::grpc::Status ApplyLevelsAndTiming(::grpc::ServerContext* context, const ApplyLevelsAndTimingRequest* request, ApplyLevelsAndTimingResponse* response) override;
@@ -158,7 +161,7 @@ public:
   ::grpc::Status WriteSourceWaveformSiteUniqueU32(::grpc::ServerContext* context, const WriteSourceWaveformSiteUniqueU32Request* request, WriteSourceWaveformSiteUniqueU32Response* response) override;
 private:
   NiDigitalLibraryInterface* library_;
-  nidevice_grpc::SessionRepository* session_repository_;
+  ResourceRepositorySharedPtr session_repository_;
   void Copy(const std::vector<ViBoolean>& input, google::protobuf::RepeatedField<bool>* output);
   template <typename TEnum>
   void CopyBytesToEnums(const std::string& input, google::protobuf::RepeatedField<TEnum>* output);

--- a/generated/nidmm/nidmm_service.h
+++ b/generated/nidmm/nidmm_service.h
@@ -13,7 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
-#include <server/session_repository.h>
+#include <server/session_resource_repository.h>
 #include <server/shared_library.h>
 
 #include "nidmm_library_interface.h"
@@ -22,8 +22,11 @@ namespace nidmm_grpc {
 
 class NiDmmService final : public NiDmm::Service {
 public:
-  NiDmmService(NiDmmLibraryInterface* library, nidevice_grpc::SessionRepository* session_repository);
+  using ResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViSession>>;
+
+  NiDmmService(NiDmmLibraryInterface* library, ResourceRepositorySharedPtr session_repository);
   virtual ~NiDmmService();
+  
   ::grpc::Status Control4022(::grpc::ServerContext* context, const Control4022Request* request, Control4022Response* response) override;
   ::grpc::Status Abort(::grpc::ServerContext* context, const AbortRequest* request, AbortResponse* response) override;
   ::grpc::Status CheckAttributeViBoolean(::grpc::ServerContext* context, const CheckAttributeViBooleanRequest* request, CheckAttributeViBooleanResponse* response) override;
@@ -116,7 +119,7 @@ public:
   ::grpc::Status UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response) override;
 private:
   NiDmmLibraryInterface* library_;
-  nidevice_grpc::SessionRepository* session_repository_;
+  ResourceRepositorySharedPtr session_repository_;
 };
 
 } // namespace nidmm_grpc

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -665,7 +665,8 @@ namespace nifake_grpc {
       auto status = library_->GetAttributeViSession(vi, attribute_id, &session_out);
       response->set_status(status);
       if (status == 0) {
-        response->mutable_session_out()->set_id(session_out);
+        auto session_id = session_repository_->resolve_session_id(session_out);
+        response->mutable_session_out()->set_id(session_id);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -13,7 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
-#include <server/session_repository.h>
+#include <server/session_resource_repository.h>
 #include <server/shared_library.h>
 
 #include "nifake_library_interface.h"
@@ -22,8 +22,11 @@ namespace nifake_grpc {
 
 class NiFakeService final : public NiFake::Service {
 public:
-  NiFakeService(NiFakeLibraryInterface* library, nidevice_grpc::SessionRepository* session_repository);
+  using ResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViSession>>;
+
+  NiFakeService(NiFakeLibraryInterface* library, ResourceRepositorySharedPtr session_repository);
   virtual ~NiFakeService();
+  
   ::grpc::Status Abort(::grpc::ServerContext* context, const AbortRequest* request, AbortResponse* response) override;
   ::grpc::Status AcceptListOfDurationsInSeconds(::grpc::ServerContext* context, const AcceptListOfDurationsInSecondsRequest* request, AcceptListOfDurationsInSecondsResponse* response) override;
   ::grpc::Status AcceptViSessionArray(::grpc::ServerContext* context, const AcceptViSessionArrayRequest* request, AcceptViSessionArrayResponse* response) override;
@@ -82,7 +85,7 @@ public:
   ::grpc::Status ViInt16ArrayInputFunction(::grpc::ServerContext* context, const ViInt16ArrayInputFunctionRequest* request, ViInt16ArrayInputFunctionResponse* response) override;
 private:
   NiFakeLibraryInterface* library_;
-  nidevice_grpc::SessionRepository* session_repository_;
+  ResourceRepositorySharedPtr session_repository_;
   void Copy(const std::vector<ViBoolean>& input, google::protobuf::RepeatedField<bool>* output);
   template <typename TEnum>
   void CopyBytesToEnums(const std::string& input, google::protobuf::RepeatedField<TEnum>* output);

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -93,12 +93,12 @@ private:
   void Copy(const std::vector<CustomStruct>& input, google::protobuf::RepeatedPtrField<nifake_grpc::FakeCustomStruct>* output);
   CustomStruct ConvertMessage(const nifake_grpc::FakeCustomStruct& input);
   void Copy(const google::protobuf::RepeatedPtrField<nifake_grpc::FakeCustomStruct>& input, std::vector<CustomStruct>* output);
-  std::map<std::int32_t, std::string> mobileosnames_input_map_ { {1, "Android"},{2, "iOS"},{3, "None"}, };
-  std::map<std::string, std::int32_t> mobileosnames_output_map_ { {"Android", 1},{"iOS", 2},{"None", 3}, };
-  std::map<std::int32_t, float> floatenum_input_map_ { {1, 3.5f},{2, 4.5f},{3, 5.5f},{4, 6.5f},{5, 7.5f}, };
-  std::map<float, std::int32_t> floatenum_output_map_ { {3.5f, 1},{4.5f, 2},{5.5f, 3},{6.5f, 4},{7.5f, 5}, };
   std::map<std::int32_t, float> nifakereal64attributevaluesmapped_input_map_ { {1, 3.5f},{2, 4.5f},{3, 5.5f},{4, 6.5f},{5, 7.5f}, };
   std::map<float, std::int32_t> nifakereal64attributevaluesmapped_output_map_ { {3.5f, 1},{4.5f, 2},{5.5f, 3},{6.5f, 4},{7.5f, 5}, };
+  std::map<std::int32_t, float> floatenum_input_map_ { {1, 3.5f},{2, 4.5f},{3, 5.5f},{4, 6.5f},{5, 7.5f}, };
+  std::map<float, std::int32_t> floatenum_output_map_ { {3.5f, 1},{4.5f, 2},{5.5f, 3},{6.5f, 4},{7.5f, 5}, };
+  std::map<std::int32_t, std::string> mobileosnames_input_map_ { {1, "Android"},{2, "iOS"},{3, "None"}, };
+  std::map<std::string, std::int32_t> mobileosnames_output_map_ { {"Android", 1},{"iOS", 2},{"None", 3}, };
 };
 
 } // namespace nifake_grpc

--- a/generated/nifake_extension/nifake_extension_service.cpp
+++ b/generated/nifake_extension/nifake_extension_service.cpp
@@ -14,7 +14,7 @@
 
 namespace nifake_extension_grpc {
 
-  NiFakeExtensionService::NiFakeExtensionService(NiFakeExtensionLibraryInterface* library, nidevice_grpc::SessionRepository* session_repository)
+  NiFakeExtensionService::NiFakeExtensionService(NiFakeExtensionLibraryInterface* library, ResourceRepositorySharedPtr session_repository)
       : library_(library), session_repository_(session_repository)
   {
   }

--- a/generated/nifake_extension/nifake_extension_service.h
+++ b/generated/nifake_extension/nifake_extension_service.h
@@ -13,7 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
-#include <server/session_repository.h>
+#include <server/session_resource_repository.h>
 #include <server/shared_library.h>
 
 #include "nifake_extension_library_interface.h"
@@ -22,12 +22,15 @@ namespace nifake_extension_grpc {
 
 class NiFakeExtensionService final : public NiFakeExtension::Service {
 public:
-  NiFakeExtensionService(NiFakeExtensionLibraryInterface* library, nidevice_grpc::SessionRepository* session_repository);
+  using ResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViSession>>;
+
+  NiFakeExtensionService(NiFakeExtensionLibraryInterface* library, ResourceRepositorySharedPtr session_repository);
   virtual ~NiFakeExtensionService();
+  
   ::grpc::Status AddCoolFunctionality(::grpc::ServerContext* context, const AddCoolFunctionalityRequest* request, AddCoolFunctionalityResponse* response) override;
 private:
   NiFakeExtensionLibraryInterface* library_;
-  nidevice_grpc::SessionRepository* session_repository_;
+  ResourceRepositorySharedPtr session_repository_;
 };
 
 } // namespace nifake_extension_grpc

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -14,7 +14,7 @@
 
 namespace nifgen_grpc {
 
-  NiFgenService::NiFgenService(NiFgenLibraryInterface* library, nidevice_grpc::SessionRepository* session_repository)
+  NiFgenService::NiFgenService(NiFgenLibraryInterface* library, ResourceRepositorySharedPtr session_repository)
       : library_(library), session_repository_(session_repository)
   {
   }
@@ -1879,7 +1879,8 @@ namespace nifgen_grpc {
       auto status = library_->GetAttributeViSession(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
       if (status == 0) {
-        response->mutable_attribute_value()->set_id(attribute_value);
+        auto session_id = session_repository_->resolve_session_id(attribute_value);
+        response->mutable_attribute_value()->set_id(session_id);
       }
       return ::grpc::Status::OK;
     }
@@ -2349,14 +2350,14 @@ namespace nifgen_grpc {
       ViBoolean id_query = request->id_query();
       ViBoolean reset_device = request->reset_device();
 
-      auto init_lambda = [&] () -> std::tuple<int, uint32_t> {
+      auto init_lambda = [&] () {
         ViSession vi;
         int status = library_->Init(resource_name, id_query, reset_device, &vi);
         return std::make_tuple(status, vi);
       };
       uint32_t session_id = 0;
       const std::string& session_name = request->session_name();
-      auto cleanup_lambda = [&] (uint32_t id) { library_->Close(id); };
+      auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
       if (status == 0) {
@@ -2382,14 +2383,14 @@ namespace nifgen_grpc {
       ViBoolean reset_device = request->reset_device();
       ViConstString option_string = request->option_string().c_str();
 
-      auto init_lambda = [&] () -> std::tuple<int, uint32_t> {
+      auto init_lambda = [&] () {
         ViSession vi;
         int status = library_->InitWithOptions(resource_name, id_query, reset_device, option_string, &vi);
         return std::make_tuple(status, vi);
       };
       uint32_t session_id = 0;
       const std::string& session_name = request->session_name();
-      auto cleanup_lambda = [&] (uint32_t id) { library_->Close(id); };
+      auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
       if (status == 0) {
@@ -2415,14 +2416,14 @@ namespace nifgen_grpc {
       ViBoolean reset_device = request->reset_device();
       ViConstString option_string = request->option_string().c_str();
 
-      auto init_lambda = [&] () -> std::tuple<int, uint32_t> {
+      auto init_lambda = [&] () {
         ViSession vi;
         int status = library_->InitializeWithChannels(resource_name, channel_name, reset_device, option_string, &vi);
         return std::make_tuple(status, vi);
       };
       uint32_t session_id = 0;
       const std::string& session_name = request->session_name();
-      auto cleanup_lambda = [&] (uint32_t id) { library_->Close(id); };
+      auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
       if (status == 0) {

--- a/generated/nifgen/nifgen_service.h
+++ b/generated/nifgen/nifgen_service.h
@@ -13,7 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
-#include <server/session_repository.h>
+#include <server/session_resource_repository.h>
 #include <server/shared_library.h>
 
 #include "nifgen_library_interface.h"
@@ -22,8 +22,11 @@ namespace nifgen_grpc {
 
 class NiFgenService final : public NiFgen::Service {
 public:
-  NiFgenService(NiFgenLibraryInterface* library, nidevice_grpc::SessionRepository* session_repository);
+  using ResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViSession>>;
+
+  NiFgenService(NiFgenLibraryInterface* library, ResourceRepositorySharedPtr session_repository);
   virtual ~NiFgenService();
+  
   ::grpc::Status AbortGeneration(::grpc::ServerContext* context, const AbortGenerationRequest* request, AbortGenerationResponse* response) override;
   ::grpc::Status AdjustSampleClockRelativeDelay(::grpc::ServerContext* context, const AdjustSampleClockRelativeDelayRequest* request, AdjustSampleClockRelativeDelayResponse* response) override;
   ::grpc::Status AllocateNamedWaveform(::grpc::ServerContext* context, const AllocateNamedWaveformRequest* request, AllocateNamedWaveformResponse* response) override;
@@ -159,7 +162,7 @@ public:
   ::grpc::Status WriteNamedWaveformComplexI16(::grpc::ServerContext* context, const WriteNamedWaveformComplexI16Request* request, WriteNamedWaveformComplexI16Response* response) override;
 private:
   NiFgenLibraryInterface* library_;
-  nidevice_grpc::SessionRepository* session_repository_;
+  ResourceRepositorySharedPtr session_repository_;
   NIComplexNumber_struct ConvertMessage(const nifgen_grpc::NIComplexNumber& input);
   void Copy(const google::protobuf::RepeatedPtrField<nifgen_grpc::NIComplexNumber>& input, std::vector<NIComplexNumber_struct>* output);
   NIComplexI16_struct ConvertMessage(const nifgen_grpc::NIComplexInt32& input);

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -14,7 +14,7 @@
 
 namespace niscope_grpc {
 
-  NiScopeService::NiScopeService(NiScopeLibraryInterface* library, nidevice_grpc::SessionRepository* session_repository)
+  NiScopeService::NiScopeService(NiScopeLibraryInterface* library, ResourceRepositorySharedPtr session_repository)
       : library_(library), session_repository_(session_repository)
   {
   }
@@ -1575,7 +1575,8 @@ namespace niscope_grpc {
       auto status = library_->GetAttributeViSession(vi, channel_list, attribute_id, &value);
       response->set_status(status);
       if (status == 0) {
-        response->mutable_value()->set_id(value);
+        auto session_id = session_repository_->resolve_session_id(value);
+        response->mutable_value()->set_id(session_id);
       }
       return ::grpc::Status::OK;
     }
@@ -1894,14 +1895,14 @@ namespace niscope_grpc {
       ViBoolean id_query = request->id_query();
       ViBoolean reset_device = request->reset_device();
 
-      auto init_lambda = [&] () -> std::tuple<int, uint32_t> {
+      auto init_lambda = [&] () {
         ViSession vi;
         int status = library_->Init(resource_name, id_query, reset_device, &vi);
         return std::make_tuple(status, vi);
       };
       uint32_t session_id = 0;
       const std::string& session_name = request->session_name();
-      auto cleanup_lambda = [&] (uint32_t id) { library_->Close(id); };
+      auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
       if (status == 0) {
@@ -1927,14 +1928,14 @@ namespace niscope_grpc {
       ViBoolean reset_device = request->reset_device();
       ViConstString option_string = request->option_string().c_str();
 
-      auto init_lambda = [&] () -> std::tuple<int, uint32_t> {
+      auto init_lambda = [&] () {
         ViSession vi;
         int status = library_->InitWithOptions(resource_name, id_query, reset_device, option_string, &vi);
         return std::make_tuple(status, vi);
       };
       uint32_t session_id = 0;
       const std::string& session_name = request->session_name();
-      auto cleanup_lambda = [&] (uint32_t id) { library_->Close(id); };
+      auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
       if (status == 0) {

--- a/generated/niscope/niscope_service.h
+++ b/generated/niscope/niscope_service.h
@@ -13,7 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
-#include <server/session_repository.h>
+#include <server/session_resource_repository.h>
 #include <server/shared_library.h>
 
 #include "niscope_library_interface.h"
@@ -22,8 +22,11 @@ namespace niscope_grpc {
 
 class NiScopeService final : public NiScope::Service {
 public:
-  NiScopeService(NiScopeLibraryInterface* library, nidevice_grpc::SessionRepository* session_repository);
+  using ResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViSession>>;
+
+  NiScopeService(NiScopeLibraryInterface* library, ResourceRepositorySharedPtr session_repository);
   virtual ~NiScopeService();
+  
   ::grpc::Status Abort(::grpc::ServerContext* context, const AbortRequest* request, AbortResponse* response) override;
   ::grpc::Status AcquisitionStatus(::grpc::ServerContext* context, const AcquisitionStatusRequest* request, AcquisitionStatusResponse* response) override;
   ::grpc::Status ActualMeasWfmSize(::grpc::ServerContext* context, const ActualMeasWfmSizeRequest* request, ActualMeasWfmSizeResponse* response) override;
@@ -116,7 +119,7 @@ public:
   ::grpc::Status UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response) override;
 private:
   NiScopeLibraryInterface* library_;
-  nidevice_grpc::SessionRepository* session_repository_;
+  ResourceRepositorySharedPtr session_repository_;
   void Copy(const niScope_wfmInfo& input, niscope_grpc::WaveformInfo* output);
   void Copy(const std::vector<niScope_wfmInfo>& input, google::protobuf::RepeatedPtrField<niscope_grpc::WaveformInfo>* output);
   void Copy(const niScope_coefficientInfo& input, niscope_grpc::CoefficientInfo* output);

--- a/generated/niswitch/niswitch_service.h
+++ b/generated/niswitch/niswitch_service.h
@@ -13,7 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
-#include <server/session_repository.h>
+#include <server/session_resource_repository.h>
 #include <server/shared_library.h>
 
 #include "niswitch_library_interface.h"
@@ -22,8 +22,11 @@ namespace niswitch_grpc {
 
 class NiSwitchService final : public NiSwitch::Service {
 public:
-  NiSwitchService(NiSwitchLibraryInterface* library, nidevice_grpc::SessionRepository* session_repository);
+  using ResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViSession>>;
+
+  NiSwitchService(NiSwitchLibraryInterface* library, ResourceRepositorySharedPtr session_repository);
   virtual ~NiSwitchService();
+  
   ::grpc::Status AbortScan(::grpc::ServerContext* context, const AbortScanRequest* request, AbortScanResponse* response) override;
   ::grpc::Status CanConnect(::grpc::ServerContext* context, const CanConnectRequest* request, CanConnectResponse* response) override;
   ::grpc::Status CheckAttributeViBoolean(::grpc::ServerContext* context, const CheckAttributeViBooleanRequest* request, CheckAttributeViBooleanResponse* response) override;
@@ -88,7 +91,7 @@ public:
   ::grpc::Status WaitForScanComplete(::grpc::ServerContext* context, const WaitForScanCompleteRequest* request, WaitForScanCompleteResponse* response) override;
 private:
   NiSwitchLibraryInterface* library_;
-  nidevice_grpc::SessionRepository* session_repository_;
+  ResourceRepositorySharedPtr session_repository_;
 };
 
 } // namespace niswitch_grpc

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -14,7 +14,7 @@
 
 namespace nisync_grpc {
 
-  NiSyncService::NiSyncService(NiSyncLibraryInterface* library, nidevice_grpc::SessionRepository* session_repository)
+  NiSyncService::NiSyncService(NiSyncLibraryInterface* library, ResourceRepositorySharedPtr session_repository)
       : library_(library), session_repository_(session_repository)
   {
   }
@@ -35,14 +35,14 @@ namespace nisync_grpc {
       ViBoolean id_query = request->id_query();
       ViBoolean reset_device = request->reset_device();
 
-      auto init_lambda = [&] () -> std::tuple<int, uint32_t> {
+      auto init_lambda = [&] () {
         ViSession vi;
         int status = library_->Init(resource_name, id_query, reset_device, &vi);
         return std::make_tuple(status, vi);
       };
       uint32_t session_id = 0;
       const std::string& session_name = request->session_name();
-      auto cleanup_lambda = [&] (uint32_t id) { library_->Close(id); };
+      auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
       if (status == 0) {
@@ -1508,14 +1508,14 @@ namespace nisync_grpc {
       ViRsrc resource_name = (ViRsrc)request->resource_name().c_str();
       ViConstString password = request->password().c_str();
 
-      auto init_lambda = [&] () -> std::tuple<int, uint32_t> {
+      auto init_lambda = [&] () {
         ViSession vi;
         int status = library_->InitExtCal(resource_name, password, &vi);
         return std::make_tuple(status, vi);
       };
       uint32_t session_id = 0;
       const std::string& session_name = request->session_name();
-      auto cleanup_lambda = [&] (uint32_t id) { library_->Close(id); };
+      auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
       if (status == 0) {

--- a/generated/nisync/nisync_service.h
+++ b/generated/nisync/nisync_service.h
@@ -13,7 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
-#include <server/session_repository.h>
+#include <server/session_resource_repository.h>
 #include <server/shared_library.h>
 
 #include "nisync_library_interface.h"
@@ -22,8 +22,11 @@ namespace nisync_grpc {
 
 class NiSyncService final : public NiSync::Service {
 public:
-  NiSyncService(NiSyncLibraryInterface* library, nidevice_grpc::SessionRepository* session_repository);
+  using ResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViSession>>;
+
+  NiSyncService(NiSyncLibraryInterface* library, ResourceRepositorySharedPtr session_repository);
   virtual ~NiSyncService();
+  
   ::grpc::Status Init(::grpc::ServerContext* context, const InitRequest* request, InitResponse* response) override;
   ::grpc::Status Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response) override;
   ::grpc::Status ErrorMessage(::grpc::ServerContext* context, const ErrorMessageRequest* request, ErrorMessageResponse* response) override;
@@ -96,7 +99,7 @@ public:
   ::grpc::Status CalAdjustDDSInitialPhase(::grpc::ServerContext* context, const CalAdjustDDSInitialPhaseRequest* request, CalAdjustDDSInitialPhaseResponse* response) override;
 private:
   NiSyncLibraryInterface* library_;
-  nidevice_grpc::SessionRepository* session_repository_;
+  ResourceRepositorySharedPtr session_repository_;
 };
 
 } // namespace nisync_grpc

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -14,7 +14,7 @@
 
 namespace nitclk_grpc {
 
-  NiTClkService::NiTClkService(NiTClkLibraryInterface* library, nidevice_grpc::SessionRepository* session_repository)
+  NiTClkService::NiTClkService(NiTClkLibraryInterface* library, ResourceRepositorySharedPtr session_repository)
       : library_(library), session_repository_(session_repository)
   {
   }
@@ -115,7 +115,8 @@ namespace nitclk_grpc {
       auto status = library_->GetAttributeViSession(session, channel_name, attribute_id, &value);
       response->set_status(status);
       if (status == 0) {
-        response->mutable_value()->set_id(value);
+        auto session_id = session_repository_->resolve_session_id(value);
+        response->mutable_value()->set_id(session_id);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nitclk/nitclk_service.h
+++ b/generated/nitclk/nitclk_service.h
@@ -13,7 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
-#include <server/session_repository.h>
+#include <server/session_resource_repository.h>
 #include <server/shared_library.h>
 
 #include "nitclk_library_interface.h"
@@ -22,8 +22,11 @@ namespace nitclk_grpc {
 
 class NiTClkService final : public NiTClk::Service {
 public:
-  NiTClkService(NiTClkLibraryInterface* library, nidevice_grpc::SessionRepository* session_repository);
+  using ResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViSession>>;
+
+  NiTClkService(NiTClkLibraryInterface* library, ResourceRepositorySharedPtr session_repository);
   virtual ~NiTClkService();
+  
   ::grpc::Status ConfigureForHomogeneousTriggers(::grpc::ServerContext* context, const ConfigureForHomogeneousTriggersRequest* request, ConfigureForHomogeneousTriggersResponse* response) override;
   ::grpc::Status FinishSyncPulseSenderSynchronize(::grpc::ServerContext* context, const FinishSyncPulseSenderSynchronizeRequest* request, FinishSyncPulseSenderSynchronizeResponse* response) override;
   ::grpc::Status GetAttributeViReal64(::grpc::ServerContext* context, const GetAttributeViReal64Request* request, GetAttributeViReal64Response* response) override;
@@ -41,7 +44,7 @@ public:
   ::grpc::Status WaitUntilDone(::grpc::ServerContext* context, const WaitUntilDoneRequest* request, WaitUntilDoneResponse* response) override;
 private:
   NiTClkLibraryInterface* library_;
-  nidevice_grpc::SessionRepository* session_repository_;
+  ResourceRepositorySharedPtr session_repository_;
 };
 
 } // namespace nitclk_grpc

--- a/source/codegen/templates/service.cpp.mako
+++ b/source/codegen/templates/service.cpp.mako
@@ -29,7 +29,7 @@ if len(config["custom_types"]) > 0:
 
 namespace ${config["namespace_component"]}_grpc {
 
-  ${service_class_prefix}Service::${service_class_prefix}Service(${service_class_prefix}LibraryInterface* library, nidevice_grpc::SessionRepository* session_repository)
+  ${service_class_prefix}Service::${service_class_prefix}Service(${service_class_prefix}LibraryInterface* library, ResourceRepositorySharedPtr session_repository)
       : library_(library), session_repository_(session_repository)
   {
   }

--- a/source/server/core_server.cpp
+++ b/source/server/core_server.cpp
@@ -88,36 +88,39 @@ static void RunServer(const ServerConfiguration& config)
   nidevice_grpc::SessionUtilitiesService core_service(&session_repository, &device_enumerator);
   builder.RegisterService(&core_service);
 
+  using MIResourceRepository = nidevice_grpc::SessionResourceRepository<ViSession>;
+  auto mi_shared_resource_repository = std::make_shared<MIResourceRepository>(&session_repository);
+
   nidigitalpattern_grpc::NiDigitalLibrary nidigital_library;
-  nidigitalpattern_grpc::NiDigitalService nidigital_service(&nidigital_library, &session_repository);
+  nidigitalpattern_grpc::NiDigitalService nidigital_service(&nidigital_library, mi_shared_resource_repository);
   builder.RegisterService(&nidigital_service);
 
   niscope_grpc::NiScopeLibrary niscope_library;
-  niscope_grpc::NiScopeService niscope_service(&niscope_library, &session_repository);
+  niscope_grpc::NiScopeService niscope_service(&niscope_library, mi_shared_resource_repository);
   builder.RegisterService(&niscope_service);
 
   niswitch_grpc::NiSwitchLibrary niswitch_library;
-  niswitch_grpc::NiSwitchService niswitch_service(&niswitch_library, &session_repository);
+  niswitch_grpc::NiSwitchService niswitch_service(&niswitch_library, mi_shared_resource_repository);
   builder.RegisterService(&niswitch_service);
 
   nidmm_grpc::NiDmmLibrary nidmm_library;
-  nidmm_grpc::NiDmmService nidmm_service(&nidmm_library, &session_repository);
+  nidmm_grpc::NiDmmService nidmm_service(&nidmm_library, mi_shared_resource_repository);
   builder.RegisterService(&nidmm_service);
 
   nisync_grpc::NiSyncLibrary nisync_library;
-  nisync_grpc::NiSyncService nisync_service(&nisync_library, &session_repository);
+  nisync_grpc::NiSyncService nisync_service(&nisync_library, mi_shared_resource_repository);
   builder.RegisterService(&nisync_service);
 
   nitclk_grpc::NiTClkLibrary nitclk_library;
-  nitclk_grpc::NiTClkService nitclk_service(&nitclk_library, &session_repository);
+  nitclk_grpc::NiTClkService nitclk_service(&nitclk_library, mi_shared_resource_repository);
   builder.RegisterService(&nitclk_service);
   
   nidcpower_grpc::NiDCPowerLibrary nidcpower_library;
-  nidcpower_grpc::NiDCPowerService nidcpower_service(&nidcpower_library, &session_repository);
+  nidcpower_grpc::NiDCPowerService nidcpower_service(&nidcpower_library, mi_shared_resource_repository);
   builder.RegisterService(&nidcpower_service);
 
   nifgen_grpc::NiFgenLibrary nifgen_library;
-  nifgen_grpc::NiFgenService nifgen_service(&nifgen_library, &session_repository);
+  nifgen_grpc::NiFgenService nifgen_service(&nifgen_library, mi_shared_resource_repository);
   builder.RegisterService(&nifgen_service);
 
   // Assemble the server.

--- a/source/server/session_repository.cpp
+++ b/source/server/session_repository.cpp
@@ -27,12 +27,11 @@ int SessionRepository::add_session(
     return 0;
   }
   auto info = std::make_shared<SessionInfo>();
-  auto init_result = init_func();
-  int status = std::get<0>(init_result);
-  if (status != 0) {
+  auto status = init_func();
+  if (status) {
     return status;
   }
-  session_id = std::get<1>(init_result);
+  session_id = next_id();
   info->id = session_id;
   info->cleanup_func = cleanup_func;
   info->last_access_time = now;

--- a/source/server/session_repository.h
+++ b/source/server/session_repository.h
@@ -4,6 +4,7 @@
 #include <grpcpp/grpcpp.h>
 #include <session.grpc.pb.h>
 
+#include <atomic>
 #include <shared_mutex>
 
 #include "semaphore.h"
@@ -14,7 +15,7 @@ class SessionRepository {
  public:
   SessionRepository();
 
-  typedef std::function<std::tuple<int, uint32_t>()> InitFunc;
+  typedef std::function<int32_t()> InitFunc;
   typedef std::function<void(uint32_t)> CleanupSessionFunc;
 
   int add_session(const std::string& session_name, InitFunc init_func, CleanupSessionFunc cleanup_func, uint32_t& session_id);
@@ -55,6 +56,7 @@ class SessionRepository {
   bool close_sessions();
   void cleanup_session(const std::shared_ptr<SessionInfo>& session_info);
   bool release_reservation(const ReservationInfo* reservation_info);
+  uint32_t next_id() { return ++_next_id; }
 
   std::shared_mutex repository_lock_;
   // This map contains every session, including both named and unnamed ones.
@@ -62,8 +64,8 @@ class SessionRepository {
   // These entries point at SessionInfo objects that are also contained in sessions_.
   NamedSessionMap named_sessions_;
   ReservationMap reservations_;
+  std::atomic<uint32_t> _next_id;
 };
-
 }  // namespace nidevice_grpc
 
 #endif  // NIDEVICE_GRPC_SESSION_REPOSITORY

--- a/source/server/session_resource_repository.h
+++ b/source/server/session_resource_repository.h
@@ -1,0 +1,221 @@
+#pragma once
+
+#include <mutex>
+
+#include "session_repository.h"
+
+namespace nidevice_grpc {
+
+// Wraps SessionRepository to store a service-specific TResourceHandle associated with
+// each session.
+template <typename TResourceHandle>
+class SessionResourceRepository {
+ public:
+  typedef std::function<std::tuple<int, TResourceHandle>()> InitFunc;
+  typedef std::function<void(TResourceHandle)> CleanupSessionFunc;
+
+  SessionResourceRepository(SessionRepository* session_repository)
+      : session_repository_(session_repository)
+  {
+  }
+
+  int add_session(
+      const std::string& session_name,
+      InitFunc init_func,
+      CleanupSessionFunc cleanup_func,
+      uint32_t& session_id);
+
+  TResourceHandle access_session(uint32_t session_id, const std::string& session_name) const;
+  uint32_t resolve_session_id(TResourceHandle handle) const;
+
+  void remove_session(TResourceHandle handle);
+
+ private:
+  // Wraps init_func_ and caches the result as handle_.
+  // For passing into SessionRepository.add_session.
+  struct SessionResourceCreator {
+    const InitFunc& init_func_;
+    TResourceHandle handle_;
+    bool added_new_handle_;
+
+    SessionResourceCreator(const InitFunc& init_func)
+        : init_func_(init_func),
+          added_new_handle_(false),
+          handle_()
+    {
+    }
+
+    uint32_t init_resource_handle();
+  };
+
+  // A thread-safe bi-directional map of session_id to TResourceHandle.
+  class ResourceMap {
+   public:
+    void add(uint32_t session_id, TResourceHandle handle);
+
+    bool contains(uint32_t session_id) const;
+    TResourceHandle get_handle(uint32_t session_id) const;
+    uint32_t get_session_id(TResourceHandle handle) const;
+
+    uint32_t remove_handle(TResourceHandle handle);
+    TResourceHandle remove_session_id(uint32_t session_id);
+
+   private:
+    using SessionToResourceMap = std::map<uint32_t, TResourceHandle>;
+    using ResourceToSessionMap = std::map<TResourceHandle, uint32_t>;
+    using MapLock = std::lock_guard<std::recursive_mutex>;
+
+    SessionToResourceMap map_;
+    ResourceToSessionMap reverse_map_;
+    mutable std::recursive_mutex map_mutex_;
+  };
+
+  SessionRepository* session_repository_;
+  ResourceMap resource_map_;
+};
+
+template <typename TResourceHandle>
+int SessionResourceRepository<TResourceHandle>::add_session(
+    const std::string& session_name,
+    InitFunc init_func,
+    CleanupSessionFunc cleanup_func,
+    uint32_t& session_id)
+{
+  uint32_t session_from_repository = 0;
+
+  auto session_creator = SessionResourceCreator(init_func);
+  auto status = session_repository_->add_session(
+      session_name,
+      [&]() { return session_creator.init_resource_handle(); },
+      // By val capture to keep cleanup_func in memory.
+      [=](uint32_t id) {
+        auto handle = resource_map_.remove_session_id(id);
+        return cleanup_func(handle);
+      },
+      session_from_repository);
+
+  if (status) {
+    session_id = 0;
+    return status;
+  }
+
+  if (session_creator.added_new_handle_) {
+    resource_map_.add(session_from_repository, session_creator.handle_);
+  }
+
+  // session_name resolves to a session in a different resource repository.
+  // Report error.
+  if (!resource_map_.contains(session_from_repository)) {
+    session_id = 0;
+    const int kError_InvalidArg = 1;
+    return kError_InvalidArg;
+  }
+
+  session_id = session_from_repository;
+  return 0;
+}
+
+template <typename TResourceHandle>
+TResourceHandle SessionResourceRepository<TResourceHandle>::access_session(uint32_t session_id, const std::string& session_name) const
+{
+  auto id = session_repository_->access_session(session_id, session_name);
+  return resource_map_.get_handle(id);
+}
+
+template <typename TResourceHandle>
+uint32_t SessionResourceRepository<TResourceHandle>::resolve_session_id(TResourceHandle handle) const
+{
+  return resource_map_.get_session_id(handle);
+}
+
+template <typename TResourceHandle>
+void SessionResourceRepository<TResourceHandle>::remove_session(TResourceHandle handle)
+{
+  auto id = resource_map_.remove_handle(handle);
+  if (id) {
+    session_repository_->remove_session(id);
+  }
+}
+
+template <typename TResourceHandle>
+uint32_t SessionResourceRepository<TResourceHandle>::SessionResourceCreator::init_resource_handle()
+{
+  auto init_result = init_func_();
+  auto status = std::get<0>(init_result);
+  if (status) {
+    return status;
+  }
+
+  handle_ = std::get<1>(init_result);
+  added_new_handle_ = true;
+
+  return 0;
+}
+
+template <typename TResourceHandle>
+void SessionResourceRepository<TResourceHandle>::ResourceMap::add(uint32_t session_id, TResourceHandle handle)
+{
+  MapLock lock(map_mutex_);
+  map_[session_id] = handle;
+  reverse_map_[handle] = session_id;
+}
+
+template <typename TResourceHandle>
+bool SessionResourceRepository<TResourceHandle>::ResourceMap::contains(uint32_t session_id) const
+{
+  MapLock lock(map_mutex_);
+  auto found = map_.find(session_id);
+  return found != map_.end();
+}
+
+template <typename TResourceHandle>
+TResourceHandle SessionResourceRepository<TResourceHandle>::ResourceMap::get_handle(uint32_t session_id) const
+{
+  MapLock lock(map_mutex_);
+  auto resource_it = map_.find(session_id);
+  if (resource_it != map_.end()) {
+    return resource_it->second;
+  }
+  // Note: failed resolve will ultimately be reported as a bad resource by the driver
+  // on use.
+  return TResourceHandle();
+}
+
+template <typename TResourceHandle>
+uint32_t SessionResourceRepository<TResourceHandle>::ResourceMap::get_session_id(TResourceHandle handle) const
+{
+  MapLock lock(map_mutex_);
+  auto session_it = reverse_map_.find(handle);
+  if (session_it != reverse_map_.end()) {
+    return session_it->second;
+  }
+  // Note: failed resolve will ultimately be reported as a bad resource by the driver
+  // on use.
+  return 0;
+}
+
+template <typename TResourceHandle>
+uint32_t SessionResourceRepository<TResourceHandle>::ResourceMap::remove_handle(TResourceHandle handle)
+{
+  MapLock lock(map_mutex_);
+  auto session_id = get_session_id(handle);
+  if (session_id) {
+    map_.erase(session_id);
+    reverse_map_.erase(handle);
+  }
+  return session_id;
+}
+
+template <typename TResourceHandle>
+TResourceHandle SessionResourceRepository<TResourceHandle>::ResourceMap::remove_session_id(uint32_t session_id)
+{
+  MapLock lock(map_mutex_);
+  auto handle = get_handle(session_id);
+  if (handle != TResourceHandle()) {
+    map_.erase(session_id);
+    reverse_map_.erase(handle);
+  }
+  return handle;
+}
+
+}  // namespace nidevice_grpc

--- a/source/server/session_resource_repository.h
+++ b/source/server/session_resource_repository.h
@@ -1,6 +1,9 @@
-#pragma once
+#ifndef NIDEVICE_GRPC_SESSION_RESOURCE_REPOSITORY_H
+#define NIDEVICE_GRPC_SESSION_RESOURCE_REPOSITORY_H
 
 #include <mutex>
+#include <string>
+#include <unordered_map>
 
 #include "session_repository.h"
 
@@ -219,3 +222,5 @@ TResourceHandle SessionResourceRepository<TResourceHandle>::ResourceMap::remove_
 }
 
 }  // namespace nidevice_grpc
+
+#endif /* NIDEVICE_GRPC_SESSION_RESOURCE_REPOSITORY_H */

--- a/source/tests/integration/session_utilities_service_tests.cpp
+++ b/source/tests/integration/session_utilities_service_tests.cpp
@@ -402,7 +402,7 @@ TEST(SessionUtilitiesServiceTests, ReservationAndSession_ResetServer_UnreservesA
   uint32_t named_session_id;
   int status = session_repository.add_session(
       session_name,
-      []() { return std::make_tuple(0, 42); },
+      []() { return 0; },
       NULL,
       named_session_id);
   call_reserve(&service, session_name, "a");

--- a/source/tests/system/nidmm_driver_api_tests.cpp
+++ b/source/tests/system/nidmm_driver_api_tests.cpp
@@ -17,8 +17,10 @@ class NiDmmDriverApiTest : public ::testing::Test {
   {
     ::grpc::ServerBuilder builder;
     session_repository_ = std::make_unique<nidevice_grpc::SessionRepository>();
+    using ResourceRepository = nidevice_grpc::SessionResourceRepository<ViSession>;
+    auto resource_repository = std::make_shared<ResourceRepository>(session_repository_.get());
     nidmm_library_ = std::make_unique<dmm::NiDmmLibrary>();
-    nidmm_service_ = std::make_unique<dmm::NiDmmService>(nidmm_library_.get(), session_repository_.get());
+    nidmm_service_ = std::make_unique<dmm::NiDmmService>(nidmm_library_.get(), resource_repository);
     builder.RegisterService(nidmm_service_.get());
 
     server_ = builder.BuildAndStart();

--- a/source/tests/system/nidmm_session_tests.cpp
+++ b/source/tests/system/nidmm_session_tests.cpp
@@ -24,8 +24,10 @@ class NiDmmSessionTest : public ::testing::Test {
   {
     ::grpc::ServerBuilder builder;
     session_repository_ = std::make_unique<nidevice_grpc::SessionRepository>();
+    using ResourceRepository = nidevice_grpc::SessionResourceRepository<ViSession>;
+    auto resource_repository = std::make_shared<ResourceRepository>(session_repository_.get());
     nidmm_library_ = std::make_unique<dmm::NiDmmLibrary>();
-    nidmm_service_ = std::make_unique<dmm::NiDmmService>(nidmm_library_.get(), session_repository_.get());
+    nidmm_service_ = std::make_unique<dmm::NiDmmService>(nidmm_library_.get(), resource_repository);
     builder.RegisterService(nidmm_service_.get());
 
     server_ = builder.BuildAndStart();

--- a/source/tests/system/nifgen_driver_api_tests.cpp
+++ b/source/tests/system/nifgen_driver_api_tests.cpp
@@ -14,8 +14,8 @@ const int kFgenDriverApiSuccess = 0;
 class NiFgenDriverApiTest : public ::testing::Test {
  protected:
   NiFgenDriverApiTest()
-    : device_server_(DeviceServerInterface::Singleton()),
-      nifgen_stub_(fgen::NiFgen::NewStub(device_server_->InProcessChannel()))
+      : device_server_(DeviceServerInterface::Singleton()),
+        nifgen_stub_(fgen::NiFgen::NewStub(device_server_->InProcessChannel()))
   {
     device_server_->ResetServer();
   }
@@ -508,7 +508,7 @@ TEST_F(NiFgenDriverApiTest, SetAttributeViString_GetAttributeViString_ValueMatch
 TEST_F(NiFgenDriverApiTest, ConfigureTriggerMode_ConfiguresSuccessfully)
 {
   const char* channel_name = "0";
-  ViInt32 expected_value = 2; // NIFGEN_VAL_CONTINUOUS
+  ViInt32 expected_value = 2;  // NIFGEN_VAL_CONTINUOUS
   configure_trigger_mode(channel_name, fgen::TriggerMode::TRIGGER_MODE_NIFGEN_VAL_CONTINUOUS);
 
   ViInt32 actual_trigger_mode = get_int32_attribute(channel_name, fgen::NiFgenAttributes::NIFGEN_ATTRIBUTE_TRIGGER_MODE);
@@ -560,7 +560,7 @@ TEST_F(NiFgenDriverApiTest, AllocateNamedWaveform_WriteNamedWaveformF64_Waveform
 TEST_F(NiFgenDriverApiTest, ExportTriggerMode_ResetAndImportConfiguration_TriggerModeConfigurationIsImported)
 {
   const char* channel_name = "0";
-  ViInt32 expected_trigger_mode = 1; // NIFGEN_VAL_SINGLE
+  ViInt32 expected_trigger_mode = 1;  // NIFGEN_VAL_SINGLE
   configure_trigger_mode(channel_name, fgen::TriggerMode::TRIGGER_MODE_NIFGEN_VAL_SINGLE);
   auto exported_configuration_response = export_attribute_configuration_buffer();
 

--- a/source/tests/system/nifgen_session_tests.cpp
+++ b/source/tests/system/nifgen_session_tests.cpp
@@ -21,8 +21,8 @@ const char* kTestInvalidFgenRsrc = "";
 class NiFgenSessionTest : public ::testing::Test {
  protected:
   NiFgenSessionTest()
-    : device_server_(DeviceServerInterface::Singleton()),
-      nifgen_stub_(fgen::NiFgen::NewStub(device_server_->InProcessChannel()))
+      : device_server_(DeviceServerInterface::Singleton()),
+        nifgen_stub_(fgen::NiFgen::NewStub(device_server_->InProcessChannel()))
   {
     device_server_->ResetServer();
   }
@@ -73,8 +73,8 @@ class NiFgenSessionTest : public ::testing::Test {
   }
 
  private:
-   DeviceServerInterface* device_server_;
-   std::unique_ptr<fgen::NiFgen::Stub> nifgen_stub_;
+  DeviceServerInterface* device_server_;
+  std::unique_ptr<fgen::NiFgen::Stub> nifgen_stub_;
 };
 
 TEST_F(NiFgenSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDriverSession)

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -1571,8 +1571,9 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViSession_ReturnsSessionId)
 {
   nidevice_grpc::SessionRepository session_repository;
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  std::uint32_t session_id = create_session(library, service, kTestViSession);
   const ViInt32 kAttributeId = 1234;
   EXPECT_CALL(library, GetAttributeViSession(kTestViSession, kAttributeId, _))
       .WillOnce(
@@ -1596,10 +1597,11 @@ TEST(NiFakeServiceTests, NiFakeExtensionService_CallMethodWithSesionStartedByNIF
 {
   nidevice_grpc::SessionRepository session_repository;
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
   NiFakeExtensionMockLibrary extension_library;
-  nifake_extension_grpc::NiFakeExtensionService extension_service(&extension_library, &session_repository);
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  nifake_extension_grpc::NiFakeExtensionService extension_service(&extension_library, resource_repository);
+  std::uint32_t session_id = create_session(library, service, kTestViSession);
   const ViInt32 kParam = 1234;
   EXPECT_CALL(extension_library, AddCoolFunctionality(kTestViSession, kParam))
       .WillOnce(

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -33,29 +33,41 @@ using ::testing::SetArgPointee;
 using ::testing::SetArrayArgument;
 using ::testing::Throw;
 
+using FakeResourceRepository = nidevice_grpc::SessionResourceRepository<ViSession>;
+
 const std::uint32_t kTestViSession = 12345678;
 const std::uint32_t kDriverSuccess = 0;
 const std::uint32_t kDriverFailure = 1;
 const char* kTestChannelName = "channel";
 
-std::uint32_t create_session(nidevice_grpc::SessionRepository& session_repo, ViSession sessionToStore)
+std::int32_t create_session(
+    NiFakeMockLibrary& library,
+    nifake_grpc::NiFakeService& service,
+    const std::string& session_name,
+    std::uint32_t session_id)
 {
-  auto init_lambda = [&]() -> std::tuple<int, uint32_t> {
-    return std::make_tuple(0, sessionToStore);
-  };
-  uint32_t session_id;
-  session_repo.add_session("", init_lambda, NULL, session_id);
-  return session_id;
+  const char* resource_name = "Dev0";
+  const char* option_string = "Simulate = 1";
+  bool id_query = false, reset_device = true;
+  EXPECT_CALL(library, InitWithOptions(Pointee(*resource_name), id_query, reset_device, Pointee(*option_string), _))
+      .WillOnce(DoAll(SetArgPointee<4>(session_id), Return(kDriverSuccess)));
+
+  ::grpc::ServerContext context;
+  nifake_grpc::InitWithOptionsRequest request;
+  request.set_resource_name(resource_name);
+  request.set_id_query(id_query);
+  request.set_reset_device(reset_device);
+  request.set_option_string(option_string);
+  request.set_session_name(session_name.c_str());
+  nifake_grpc::InitWithOptionsResponse response;
+  ::grpc::Status status = service.InitWithOptions(&context, &request, &response);
+
+  return response.vi().id();
 }
 
-std::uint32_t create_session(std::string session_name, nidevice_grpc::SessionRepository& session_repo, ViSession sessionToStore)
+std::int32_t create_session(NiFakeMockLibrary& library, nifake_grpc::NiFakeService& service, std::uint32_t session_id)
 {
-  auto init_lambda = [&]() -> std::tuple<int, uint32_t> {
-    return std::make_tuple(0, sessionToStore);
-  };
-  uint32_t session_id;
-  session_repo.add_session(session_name, init_lambda, NULL, session_id);
-  return session_id;
+  return create_session(library, service, "sessionName", session_id);
 }
 
 // Init and Close function tests
@@ -63,7 +75,8 @@ TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsSucceeds_CreatesAndStoresS
 {
   nidevice_grpc::SessionRepository session_repository;
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
   const char* resource_name = "Dev0";
   const char* option_string = "Simulate = 1";
   bool id_query = false, reset_device = true;
@@ -84,15 +97,16 @@ TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsSucceeds_CreatesAndStoresS
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kDriverSuccess, response.status());
   nidevice_grpc::Session session = response.vi();
-  EXPECT_EQ(kTestViSession, session_repository.access_session(session.id(), ""));
-  EXPECT_EQ(kTestViSession, session_repository.access_session(0, session_name));
+  EXPECT_NE(0, session_repository.access_session(session.id(), ""));
+  EXPECT_NE(0, session_repository.access_session(0, session_name));
 }
 
 TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsFails_NoSessionIsStored)
 {
   nidevice_grpc::SessionRepository session_repository;
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
   const char* message = "Exception!";
   EXPECT_CALL(library, InitWithOptions)
       .WillOnce(DoAll(SetArgPointee<4>(kTestViSession), Throw(nidevice_grpc::LibraryLoadException(message))));
@@ -105,7 +119,6 @@ TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsFails_NoSessionIsStored)
   EXPECT_EQ(::grpc::StatusCode::NOT_FOUND, status.error_code());
   EXPECT_EQ(message, status.error_message());
   nidevice_grpc::Session session = response.vi();
-  EXPECT_NE(kTestViSession, session_repository.access_session(session.id(), ""));
   EXPECT_EQ(0, session_repository.access_session(session.id(), ""));
 }
 
@@ -113,7 +126,8 @@ TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsAndResetServer_SessionIsCl
 {
   nidevice_grpc::SessionRepository session_repository;
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
   const char* session_name = "sessionName";
   EXPECT_CALL(library, InitWithOptions)
       .WillOnce(DoAll(SetArgPointee<4>(kTestViSession), Return(kDriverSuccess)));
@@ -127,12 +141,11 @@ TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsAndResetServer_SessionIsCl
   ::grpc::Status init_status = service.InitWithOptions(&context, &request, &response);
   EXPECT_TRUE(init_status.ok());
   nidevice_grpc::Session session = response.vi();
-  EXPECT_EQ(kTestViSession, session_repository.access_session(session.id(), ""));
-  EXPECT_EQ(kTestViSession, session_repository.access_session(0, session_name));
+  EXPECT_NE(0, session_repository.access_session(session.id(), ""));
+  EXPECT_NE(0, session_repository.access_session(0, session_name));
   bool reset_status = session_repository.reset_server();
 
   EXPECT_TRUE(reset_status);
-  EXPECT_NE(kTestViSession, session_repository.access_session(session.id(), ""));
   EXPECT_EQ(0, session_repository.access_session(session.id(), ""));
 }
 
@@ -140,7 +153,8 @@ TEST(NiFakeServiceTests, NiFakeService_InitExtCalAndResetServer_SessionIsClosed)
 {
   nidevice_grpc::SessionRepository session_repository;
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
   const char* session_name = "sessionName";
   EXPECT_CALL(library, InitExtCal)
       .WillOnce(DoAll(SetArgPointee<2>(kTestViSession), Return(kDriverSuccess)));
@@ -154,8 +168,8 @@ TEST(NiFakeServiceTests, NiFakeService_InitExtCalAndResetServer_SessionIsClosed)
   ::grpc::Status init_status = service.InitExtCal(&context, &request, &response);
   EXPECT_TRUE(init_status.ok());
   nidevice_grpc::Session session = response.vi();
-  EXPECT_EQ(kTestViSession, session_repository.access_session(session.id(), ""));
-  EXPECT_EQ(kTestViSession, session_repository.access_session(0, session_name));
+  EXPECT_NE(0, session_repository.access_session(session.id(), ""));
+  EXPECT_NE(0, session_repository.access_session(0, session_name));
   bool reset_status = session_repository.reset_server();
 
   EXPECT_TRUE(reset_status);
@@ -167,7 +181,8 @@ TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsThenClose_SessionIsClosed)
 {
   nidevice_grpc::SessionRepository session_repository;
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
   std::string session_name = "sessionName";
   EXPECT_CALL(library, InitWithOptions)
       .WillOnce(DoAll(SetArgPointee<4>(kTestViSession), Return(kDriverSuccess)));
@@ -181,8 +196,8 @@ TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsThenClose_SessionIsClosed)
   ::grpc::Status init_status = service.InitWithOptions(&context, &init_request, &init_response);
   EXPECT_TRUE(init_status.ok());
   nidevice_grpc::Session session = init_response.vi();
-  EXPECT_EQ(kTestViSession, session_repository.access_session(session.id(), ""));
-  EXPECT_EQ(kTestViSession, session_repository.access_session(0, session_name));
+  EXPECT_NE(0, session_repository.access_session(session.id(), ""));
+  EXPECT_NE(0, session_repository.access_session(0, session_name));
   nifake_grpc::CloseRequest close_request;
   close_request.mutable_vi()->set_id(session.id());
   nifake_grpc::CloseResponse close_response;
@@ -190,7 +205,6 @@ TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsThenClose_SessionIsClosed)
 
   EXPECT_TRUE(close_status.ok());
   EXPECT_EQ(kDriverSuccess, close_response.status());
-  EXPECT_NE(kTestViSession, session_repository.access_session(session.id(), ""));
   EXPECT_EQ(0, session_repository.access_session(session.id(), ""));
 }
 
@@ -198,7 +212,8 @@ TEST(NiFakeServiceTests, NiFakeService_InitExtCalThenCloseExtCal_SessionIsClosed
 {
   nidevice_grpc::SessionRepository session_repository;
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
   std::string session_name = "sessionName";
   ViInt32 action = 1;
   EXPECT_CALL(library, InitExtCal)
@@ -213,8 +228,8 @@ TEST(NiFakeServiceTests, NiFakeService_InitExtCalThenCloseExtCal_SessionIsClosed
   ::grpc::Status init_status = service.InitExtCal(&context, &init_request, &init_response);
   EXPECT_TRUE(init_status.ok());
   nidevice_grpc::Session session = init_response.vi();
-  EXPECT_EQ(kTestViSession, session_repository.access_session(session.id(), ""));
-  EXPECT_EQ(kTestViSession, session_repository.access_session(0, session_name));
+  EXPECT_NE(0, session_repository.access_session(session.id(), ""));
+  EXPECT_NE(0, session_repository.access_session(0, session_name));
   nifake_grpc::CloseExtCalRequest close_request;
   close_request.mutable_vi()->set_id(session.id());
   close_request.set_action(action);
@@ -231,9 +246,10 @@ TEST(NiFakeServiceTests, NiFakeService_InitExtCalThenCloseExtCal_SessionIsClosed
 TEST(NiFakeServiceTests, NiFakeService_FunctionNotFound_DoesNotCallFunction)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   const char* message = "Exception!";
   EXPECT_CALL(library, GetABoolean)
       .WillOnce(Throw(nidevice_grpc::LibraryLoadException(message)));
@@ -251,9 +267,10 @@ TEST(NiFakeServiceTests, NiFakeService_FunctionNotFound_DoesNotCallFunction)
 TEST(NiFakeServiceTests, NiFakeService_FunctionCallErrors_ResponseValuesNotSet)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   bool a_boolean = true;
   EXPECT_CALL(library, GetABoolean(kTestViSession, _))
       .WillOnce(DoAll(SetArgPointee<1>(a_boolean), Return(kDriverFailure)));
@@ -272,9 +289,10 @@ TEST(NiFakeServiceTests, NiFakeService_FunctionCallErrors_ResponseValuesNotSet)
 TEST(NiFakeServiceTests, NiFakeService_GetABoolean_CallsGetABoolean)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   bool a_boolean = true;
   EXPECT_CALL(library, GetABoolean(kTestViSession, _))
       .WillOnce(DoAll(SetArgPointee<1>(a_boolean), Return(kDriverSuccess)));
@@ -294,9 +312,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetABoolean_CallsGetABoolean)
 TEST(NiFakeServiceTests, NiFakeService_Abort_CallsAbort)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   EXPECT_CALL(library, Abort(kTestViSession))
       .WillOnce(Return(kDriverSuccess));
 
@@ -313,9 +332,10 @@ TEST(NiFakeServiceTests, NiFakeService_Abort_CallsAbort)
 TEST(NiFakeServiceTests, NiFakeService_GetANumber_CallsGetANumber)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   std::int16_t a_number = 15;
   EXPECT_CALL(library, GetANumber(kTestViSession, _))
       .WillOnce(DoAll(SetArgPointee<1>(a_number), Return(kDriverSuccess)));
@@ -334,9 +354,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetANumber_CallsGetANumber)
 TEST(NiFakeServiceTests, NiFakeService_GetArraySizeForCustomCode_CallsGetArraySizeForCustomCode)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   std::int32_t array_size = 1000;
   EXPECT_CALL(library, GetArraySizeForCustomCode(kTestViSession, _))
       .WillOnce(DoAll(SetArgPointee<1>(array_size), Return(kDriverSuccess)));
@@ -355,9 +376,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetArraySizeForCustomCode_CallsGetArraySi
 TEST(NiFakeServiceTests, NiFakeService_GetAttributeViBoolean_CallsGetAttributeViBoolean)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   nifake_grpc::NiFakeAttributes attribute_id = nifake_grpc::NIFAKE_ATTRIBUTE_READ_WRITE_BOOL;
   bool attribute_value = true;
   EXPECT_CALL(library, GetAttributeViBoolean(kTestViSession, Pointee(*kTestChannelName), attribute_id, _))
@@ -379,9 +401,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViBoolean_CallsGetAttributeVi
 TEST(NiFakeServiceTests, NiFakeService_GetAttributeViInt32_CallsGetAttributeViInt32)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   nifake_grpc::NiFakeAttributes attribute_id = nifake_grpc::NIFAKE_ATTRIBUTE_READ_WRITE_INTEGER;
   std::int32_t attribute_value = 12345;
   EXPECT_CALL(library, GetAttributeViInt32(kTestViSession, Pointee(*kTestChannelName), attribute_id, _))
@@ -403,9 +426,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViInt32_CallsGetAttributeViIn
 TEST(NiFakeServiceTests, NiFakeService_GetAttributeViInt64_CallsGetAttributeViInt64)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   nifake_grpc::NiFakeAttributes attribute_id = nifake_grpc::NIFAKE_ATTRIBUTE_READ_WRITE_INT64;
   std::int64_t attribute_value = -12345;
   EXPECT_CALL(library, GetAttributeViInt64(kTestViSession, Pointee(*kTestChannelName), attribute_id, _))
@@ -427,9 +451,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViInt64_CallsGetAttributeViIn
 TEST(NiFakeServiceTests, NiFakeService_GetAttributeViReal64_CallsGetAttributeViReal64)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   nifake_grpc::NiFakeAttributes attribute_id = nifake_grpc::NIFAKE_ATTRIBUTE_READ_WRITE_DOUBLE;
   double attribute_value = 12.345;
   EXPECT_CALL(library, GetAttributeViReal64(kTestViSession, Pointee(*kTestChannelName), attribute_id, _))
@@ -451,9 +476,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViReal64_CallsGetAttributeViR
 TEST(NiFakeServiceTests, NiFakeService_GetCalDateAndTime_CallsGetCalDateAndTime)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   std::int32_t cal_type = 0;
   std::int32_t month = 1, day = 17, year = 2021, hour = 0, minute = 0;
   EXPECT_CALL(library, GetCalDateAndTime(kTestViSession, cal_type, _, _, _, _, _))
@@ -484,9 +510,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetCalDateAndTime_CallsGetCalDateAndTime)
 TEST(NiFakeServiceTests, NiFakeService_GetCalInterval_CallsGetCalInterval)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   nifake_grpc::NiFakeAttributes attribute_id = nifake_grpc::NIFAKE_ATTRIBUTE_READ_WRITE_DOUBLE;
   std::int32_t months = 24;
   EXPECT_CALL(library, GetCalInterval(kTestViSession, _))
@@ -506,9 +533,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetCalInterval_CallsGetCalInterval)
 TEST(NiFakeServiceTests, NiFakeService_GetEnumValue_CallsGetEnumValue)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   std::int32_t a_quantity = 123;
   std::int16_t a_turtle = NIFAKE_VAL_LEONARDO;
   EXPECT_CALL(library, GetEnumValue(kTestViSession, _, _))
@@ -530,9 +558,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetEnumValue_CallsGetEnumValue)
 TEST(NiFakeServiceTests, NiFakeService_GetEnumValueNotInEnum_CallsGetEnumValue)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   std::int32_t a_quantity = 123;
   std::int16_t a_turtle = 5;
   EXPECT_CALL(library, GetEnumValue(kTestViSession, _, _))
@@ -555,9 +584,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetEnumValueNotInEnum_CallsGetEnumValue)
 TEST(NiFakeServiceTests, NiFakeService_AcceptListOfDurationsInSeconds_CallsAcceptListOfDurationsInSeconds)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   const double delays[] = {1, 2, 3, 4, 5};
   std::int32_t expected_size = 5;
   EXPECT_CALL(library, AcceptListOfDurationsInSeconds(kTestViSession, expected_size, _))
@@ -580,9 +610,10 @@ TEST(NiFakeServiceTests, NiFakeService_AcceptListOfDurationsInSeconds_CallsAccep
 TEST(NiFakeServiceTests, NiFakeService_BoolArrayOutputFunction_CallsBoolArrayOutputFunction)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   ViInt32 number_of_elements = 3;
   ViBoolean an_array[] = {VI_FALSE, VI_TRUE, VI_TRUE};
   EXPECT_CALL(library, BoolArrayOutputFunction(kTestViSession, number_of_elements, _))
@@ -607,11 +638,12 @@ TEST(NiFakeServiceTests, NiFakeService_BoolArrayOutputFunction_CallsBoolArrayOut
 TEST(NiFakeServiceTests, NiFakeService_BoolArrayInputFunction_CallsBoolArrayInputFunction)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   ViInt32 number_of_elements = 3;
-  ViBoolean expected_array[] = { VI_FALSE, VI_TRUE, VI_TRUE };
+  ViBoolean expected_array[] = {VI_FALSE, VI_TRUE, VI_TRUE};
   EXPECT_CALL(library, BoolArrayInputFunction(kTestViSession, number_of_elements, _))
       .With(Args<2, 1>(ElementsAreArray(expected_array)))
       .WillOnce(Return(kDriverSuccess));
@@ -633,9 +665,10 @@ TEST(NiFakeServiceTests, NiFakeService_BoolArrayInputFunction_CallsBoolArrayInpu
 TEST(NiFakeServiceTests, NiFakeService_DoubleAllTheNums_CallsDoubleAllTheNums)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   const double numbers[] = {1, 2, 3, 4, 5};
   std::int32_t expected_size = 5;
   EXPECT_CALL(library, DoubleAllTheNums(kTestViSession, expected_size, _))
@@ -658,9 +691,10 @@ TEST(NiFakeServiceTests, NiFakeService_DoubleAllTheNums_CallsDoubleAllTheNums)
 TEST(NiFakeServiceTests, NiFakeService_GetAStringOfFixedMaximumSize_CallsGetAStringOfFixedMaximumSize)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   char output_string[256] = "Hello World!";
   EXPECT_CALL(library, GetAStringOfFixedMaximumSize(kTestViSession, _))
       .WillOnce(DoAll(
@@ -681,9 +715,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetAStringOfFixedMaximumSize_CallsGetAStr
 TEST(NiFakeServiceTests, NiFakeService_GetCustomTypeArray_CallsGetCustomTypeArray)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   ViInt32 number_of_elements = 3;
   std::vector<CustomStruct> cs(number_of_elements);
   EXPECT_CALL(library, GetCustomTypeArray(kTestViSession, number_of_elements, _))
@@ -704,9 +739,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetCustomTypeArray_CallsGetCustomTypeArra
 TEST(NiFakeServiceTests, NiFakeService_ImportAttributeConfigurationBuffer_CallsImportAttributeConfigurationBuffer)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   const std::int8_t char_array[] = {'a', 'b', 'c'};
   std::int32_t expected_size = 3;
   EXPECT_CALL(library, ImportAttributeConfigurationBuffer(kTestViSession, expected_size, _))
@@ -729,9 +765,10 @@ TEST(NiFakeServiceTests, NiFakeService_ImportAttributeConfigurationBuffer_CallsI
 TEST(NiFakeServiceTests, NiFakeService_MultipleArraysSameSize_CallsMultipleArraysSameSize)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   const double doubles[] = {0.2, -2.3, 4.5};
   std::int32_t expected_size = 3;
   EXPECT_CALL(library, MultipleArraysSameSize(kTestViSession, _, _, _, _, expected_size))
@@ -761,9 +798,10 @@ TEST(NiFakeServiceTests, NiFakeService_MultipleArraysSameSize_CallsMultipleArray
 TEST(NiFakeServiceTests, NiFakeService_ParametersAreMultipleTypes_CallsParametersAreMultipleTypes)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   bool a_boolean = true;
   std::int32_t an_int_32 = 35;
   std::int64_t an_int_64 = 42;
@@ -808,9 +846,10 @@ TEST(NiFakeServiceTests, NiFakeService_ParametersAreMultipleTypes_CallsParameter
 TEST(NiFakeServiceTests, NiFakeService_ParametersAreMultipleTypesWithRawValues_CallsParametersAreMultipleTypes)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   bool a_boolean = true;
   std::int32_t an_int_32 = 35;
   std::int64_t an_int_64 = 42;
@@ -854,9 +893,10 @@ TEST(NiFakeServiceTests, NiFakeService_ParametersAreMultipleTypesWithRawValues_C
 TEST(NiFakeServiceTests, NiFakeService_ParametersAreMultipleTypesWithRawValuesNotInEnum_CallsParametersAreMultipleTypes)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   bool a_boolean = true;
   std::int32_t an_int_32 = 35;
   std::int64_t an_int_64 = 42;
@@ -900,9 +940,10 @@ TEST(NiFakeServiceTests, NiFakeService_ParametersAreMultipleTypesWithRawValuesNo
 TEST(NiFakeServiceTests, NiFakeService_ReturnANumberAndAString_CallsReturnANumberAndAString)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   std::int16_t a_number = 42;
   char a_string[256] = "Hello World!";
   EXPECT_CALL(library, ReturnANumberAndAString(kTestViSession, _, _))
@@ -926,9 +967,10 @@ TEST(NiFakeServiceTests, NiFakeService_ReturnANumberAndAString_CallsReturnANumbe
 TEST(NiFakeServiceTests, NiFakeService_ReturnListOfDurationsInSeconds_CallsReturnListOfDurationsInSeconds)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   ViInt32 number_of_elements = 3;
   ViReal64 timedeltas[] = {1.0, 2, -3.0};
   EXPECT_CALL(library, ReturnListOfDurationsInSeconds(kTestViSession, number_of_elements, _))
@@ -953,9 +995,10 @@ TEST(NiFakeServiceTests, NiFakeService_ReturnListOfDurationsInSeconds_CallsRetur
 TEST(NiFakeServiceTests, NiFakeService_ReturnMultipleTypes_CallsReturnMultipleTypes)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   ViInt32 array_size = 3;
   ViBoolean a_boolean = false;
   ViInt32 an_int32 = 4;
@@ -1006,9 +1049,10 @@ TEST(NiFakeServiceTests, NiFakeService_ReturnMultipleTypes_CallsReturnMultipleTy
 TEST(NiFakeServiceTests, NiFakeService_WriteWaveform_CallsWriteWaveform)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   ViReal64 waveforms[] = {53.4, 42, -120.3};
   std::int32_t expected_number_of_samples = 3;
   EXPECT_CALL(library, WriteWaveform(kTestViSession, expected_number_of_samples, _))
@@ -1031,9 +1075,10 @@ TEST(NiFakeServiceTests, NiFakeService_WriteWaveform_CallsWriteWaveform)
 TEST(NiFakeServiceTests, NiFakeService_FetchWaveform_CallsFetchWaveform)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   ViInt32 request_number_of_samples = 4;
   ViReal64 actual_doubles[] = {53.4, 42, -120.3};
   ViInt32 actual_number_of_samples = 3;
@@ -1062,9 +1107,10 @@ TEST(NiFakeServiceTests, NiFakeService_FetchWaveform_CallsFetchWaveform)
 TEST(NiFakeServiceTests, NiFakeService_StringValuedEnumInputFunctionWithDefaultsWithInvalidEnumInput_ReturnsInvalidArgument)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   nifake_grpc::MobileOSNames a_mobile_o_s_name = nifake_grpc::MOBILE_O_S_NAMES_UNSPECIFIED;
   EXPECT_CALL(library, StringValuedEnumInputFunctionWithDefaults)
       .Times(0);
@@ -1083,9 +1129,10 @@ TEST(NiFakeServiceTests, NiFakeService_StringValuedEnumInputFunctionWithDefaults
 TEST(NiFakeServiceTests, NiFakeService_StringValuedEnumInputFunctionWithDefaultsWithValidEnumInput_CallsStringValuedEnumInputFunctionWithDefaults)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   nifake_grpc::MobileOSNames a_mobile_o_s_name = nifake_grpc::MOBILE_O_S_NAMES_ANDROID;
   const char* expected_enum_value = NIFAKE_VAL_ANDROID;
   EXPECT_CALL(library, StringValuedEnumInputFunctionWithDefaults(kTestViSession, Pointee(*expected_enum_value)))
@@ -1106,9 +1153,10 @@ TEST(NiFakeServiceTests, NiFakeService_StringValuedEnumInputFunctionWithDefaults
 TEST(NiFakeServiceTests, NiFakeService_ExportAttributeConfigurationBuffer_CallsExportAttributeConfigurationBuffer)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   ViInt8 config_buffer[] = {'A', 'B', 'C'};
   ViInt32 expected_size = 3;
   // ivi-dance call
@@ -1134,9 +1182,10 @@ TEST(NiFakeServiceTests, NiFakeService_ExportAttributeConfigurationBuffer_CallsE
 TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceString_CallsGetAnIviDanceString)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   ViChar char_array[] = {'H', 'E', 'L', 'L', 'O', '\0'};
   ViInt32 expected_size = sizeof(char_array);
   // ivi-dance call
@@ -1163,9 +1212,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceString_CallsGetAnIviDanceStr
 TEST(NiFakeServiceTests, NiFakeService_GetArrayUsingIviDance_CallsGetArrayUsingIviDance)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   ViReal64 doubles[] = {53.4, 42, -120.3};
   ViInt32 expected_size = 3;
   // ivi-dance call
@@ -1191,9 +1241,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetArrayUsingIviDance_CallsGetArrayUsingI
 TEST(NiFakeServiceTests, NiFakeService_GetAttributeViString_CallsGetAttributeViString)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  auto session_id = create_session(library, service, kTestViSession);
   nifake_grpc::NiFakeAttributes attributeId = nifake_grpc::NIFAKE_ATTRIBUTE_READ_WRITE_DOUBLE;
   ViChar attribute_char_array[] = {'H', 'E', 'L', 'L', 'O', '\0'};
   ViInt32 expected_size = sizeof(attribute_char_array);
@@ -1223,9 +1274,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViString_CallsGetAttributeViS
 TEST(NiFakeServiceTests, NiFakeService_GetViUInt8_CallsGetViUInt8)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  std::uint32_t session_id = create_session(library, service, kTestViSession);
   ViUInt8 a_ViUInt8_number = 0xFF;
   EXPECT_CALL(library, GetViUInt8(kTestViSession, _))
       .WillOnce(DoAll(SetArgPointee<1>(a_ViUInt8_number), Return(kDriverSuccess)));
@@ -1244,9 +1296,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetViUInt8_CallsGetViUInt8)
 TEST(NiFakeServiceTests, NiFakeService_ViUInt8ArrayInputFunction_CallsViUInt8ArrayInputFunction)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  std::uint32_t session_id = create_session(library, service, kTestViSession);
   ViInt32 number_of_elements = 3;
   ViUInt8 expected_array[] = {0, 127, 0xFF};
   EXPECT_CALL(library, ViUInt8ArrayInputFunction(kTestViSession, number_of_elements, _))
@@ -1272,9 +1325,10 @@ TEST(NiFakeServiceTests, NiFakeService_ViUInt8ArrayInputFunction_CallsViUInt8Arr
 TEST(NiFakeServiceTests, NiFakeService_ViUInt8ArrayOutputFunction_CallsViUInt8ArrayOutputFunction)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  std::uint32_t session_id = create_session(library, service, kTestViSession);
   ViInt32 number_of_elements = 3;
   ViUInt8 an_array[] = {0, 127, 0xFF};
   EXPECT_CALL(library, ViUInt8ArrayOutputFunction(kTestViSession, number_of_elements, _))
@@ -1298,9 +1352,10 @@ TEST(NiFakeServiceTests, NiFakeService_ViUInt8ArrayOutputFunction_CallsViUInt8Ar
 TEST(NiFakeServiceTests, NiFakeService_AcceptViUInt32Array_CallsAcceptViUInt32Array)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  std::uint32_t session_id = create_session(library, service, kTestViSession);
   std::uint32_t uint32_array[] = {0, 1, 0xFFFFFFFD, 0xFFFFFFFE, 0xFFFFFFFF};
   std::int32_t array_len = 5;
   EXPECT_CALL(library, AcceptViUInt32Array(kTestViSession, array_len, _))
@@ -1310,7 +1365,7 @@ TEST(NiFakeServiceTests, NiFakeService_AcceptViUInt32Array_CallsAcceptViUInt32Ar
   ::grpc::ServerContext context;
   nifake_grpc::AcceptViUInt32ArrayRequest request;
   request.mutable_vi()->set_id(session_id);
-  request.mutable_u_int32_array()->CopyFrom(google::protobuf::RepeatedField<google::protobuf::uint32>(uint32_array, uint32_array+5));
+  request.mutable_u_int32_array()->CopyFrom(google::protobuf::RepeatedField<google::protobuf::uint32>(uint32_array, uint32_array + 5));
   nifake_grpc::AcceptViUInt32ArrayResponse response;
   ::grpc::Status status = service.AcceptViUInt32Array(&context, &request, &response);
 
@@ -1321,9 +1376,10 @@ TEST(NiFakeServiceTests, NiFakeService_AcceptViUInt32Array_CallsAcceptViUInt32Ar
 TEST(NiFakeServiceTests, NiFakeService_GetViInt32Array_CallsGetViInt32Array)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  std::uint32_t session_id = create_session(library, service, kTestViSession);
   int array_len = 4;
   std::int32_t int32_array[] = {-2147483646, -2147483645, 2147483646, 2147483647};
   EXPECT_CALL(library, GetViInt32Array(kTestViSession, array_len, _))
@@ -1344,9 +1400,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetViInt32Array_CallsGetViInt32Array)
 TEST(NiFakeServiceTests, NiFakeService_GetViUInt32Array_CallsGetViUInt32Array)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  std::uint32_t session_id = create_session(library, service, kTestViSession);
   int array_len = 4;
   std::uint32_t uint32_array[] = {0, 1, 0xFFFFFFFE, 0xFFFFFFFF};
   EXPECT_CALL(library, GetViUInt32Array(kTestViSession, array_len, _))
@@ -1367,15 +1424,17 @@ TEST(NiFakeServiceTests, NiFakeService_GetViUInt32Array_CallsGetViUInt32Array)
 TEST(NiFakeServiceTests, NiFakeService_AcceptViSessionArray_CallsAcceptViSessionArray)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id1 = create_session("session1", session_repository, 12345671);
-  std::uint32_t session_id2 = create_session("session2", session_repository, 12345672);
-  std::uint32_t session_id3 = create_session("session3", session_repository, 12345673);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  std::array<ViSession, 3> vi_session_array{12345671, 12345672, 12345673};
+  std::uint32_t session_id1 = create_session(library, service, "session1", vi_session_array[0]);
+  std::uint32_t session_id2 = create_session(library, service, "session2", vi_session_array[1]);
+  std::uint32_t session_id3 = create_session(library, service, "session3", vi_session_array[2]);
+
   std::uint32_t session_count = 3;
-  ViSession session_array[] = {session_id1, session_id2, session_id3};
   EXPECT_CALL(library, AcceptViSessionArray(session_count, _))
-      .With(Args<1, 0>(ElementsAreArray(session_array)))
+      .With(Args<1, 0>(ElementsAreArray(vi_session_array)))
       .WillOnce(Return(kDriverSuccess));
 
   ::grpc::ServerContext context;
@@ -1395,11 +1454,12 @@ TEST(NiFakeServiceTests, NiFakeService_AcceptViSessionArray_CallsAcceptViSession
 TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArray_CallsGetAnIviDanceWithATwistArray)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  std::uint32_t session_id = create_session(library, service, kTestViSession);
   const char* a_string = "abc";
-  ViInt32 array_out[] = { 1, 2, 3 };
+  ViInt32 array_out[] = {1, 2, 3};
   ViInt32 expected_size = 3;
   // ivi-dance-with-a-twist call
   EXPECT_CALL(library, GetAnIviDanceWithATwistArray(kTestViSession, Pointee(*a_string), 0, nullptr, _))
@@ -1407,7 +1467,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArray_CallsGetAnIv
           SetArgPointee<4>(expected_size),
           Return(kDriverSuccess)));
   // follow up call with size returned from ivi-dance-with-a-twist setup.
-  EXPECT_CALL(library, GetAnIviDanceWithATwistArray(kTestViSession, Pointee(*a_string) , expected_size, _, _))
+  EXPECT_CALL(library, GetAnIviDanceWithATwistArray(kTestViSession, Pointee(*a_string), expected_size, _, _))
       .WillOnce(DoAll(
           SetArrayArgument<3>(array_out, array_out + expected_size),
           SetArgPointee<4>(expected_size),
@@ -1429,9 +1489,10 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArray_CallsGetAnIv
 TEST(NiFakeServiceTests, NiFakeService_AcceptViInt16Array_CallsAcceptViInt16Array)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  std::uint32_t session_id = create_session(library, service, kTestViSession);
   std::int16_t int16_array[] = {0, 1, -0x8000, 0x7FFF};
   std::int32_t array_len = 4;
   EXPECT_CALL(library, ViInt16ArrayInputFunction(kTestViSession, array_len, _))
@@ -1441,7 +1502,7 @@ TEST(NiFakeServiceTests, NiFakeService_AcceptViInt16Array_CallsAcceptViInt16Arra
   ::grpc::ServerContext context;
   nifake_grpc::ViInt16ArrayInputFunctionRequest request;
   request.mutable_vi()->set_id(session_id);
-  request.mutable_an_array()->CopyFrom(google::protobuf::RepeatedField<google::protobuf::int32>(int16_array, int16_array+4));
+  request.mutable_an_array()->CopyFrom(google::protobuf::RepeatedField<google::protobuf::int32>(int16_array, int16_array + 4));
   nifake_grpc::ViInt16ArrayInputFunctionResponse response;
   ::grpc::Status status = service.ViInt16ArrayInputFunction(&context, &request, &response);
 
@@ -1452,11 +1513,12 @@ TEST(NiFakeServiceTests, NiFakeService_AcceptViInt16Array_CallsAcceptViInt16Arra
 TEST(NiFakeServiceTests, NiFakeService_SetCustomTypeArray_CallsSetCustomTypeArray)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  std::uint32_t session_id = create_session(library, service, kTestViSession);
   ViInt32 number_of_elements = 2;
-  CustomStruct cs_array[] = { { 5, 8.0 },{ 15 , 19.7 } };
+  CustomStruct cs_array[] = {{5, 8.0}, {15, 19.7}};
   EXPECT_CALL(library, SetCustomTypeArray(kTestViSession, number_of_elements, _))
       .With(Args<2, 1>(ElementsAreArray(cs_array)))
       .WillOnce(Return(kDriverSuccess));
@@ -1464,8 +1526,7 @@ TEST(NiFakeServiceTests, NiFakeService_SetCustomTypeArray_CallsSetCustomTypeArra
   ::grpc::ServerContext context;
   nifake_grpc::SetCustomTypeArrayRequest request;
   request.mutable_vi()->set_id(session_id);
-  for (int i = 0; i < number_of_elements; i++)
-  {
+  for (int i = 0; i < number_of_elements; i++) {
     request.add_cs();
     request.mutable_cs(i)->set_struct_int(cs_array[i].structInt);
     request.mutable_cs(i)->set_struct_double(cs_array[i].structDouble);
@@ -1480,9 +1541,10 @@ TEST(NiFakeServiceTests, NiFakeService_SetCustomTypeArray_CallsSetCustomTypeArra
 TEST(NiFakeServiceTests, NiFakeService_GetArrayViUInt8WithEnum_CallsGetArrayViUInt8WithEnum)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::uint32_t session_id = create_session(session_repository, kTestViSession);
   NiFakeMockLibrary library;
-  nifake_grpc::NiFakeService service(&library, &session_repository);
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  std::uint32_t session_id = create_session(library, service, kTestViSession);
   int array_len = 3;
   ViUInt8 uint8_array[] = {nifake_grpc::Color::COLOR_RED, nifake_grpc::Color::COLOR_BLACK, nifake_grpc::Color::COLOR_BLUE};
   nifake_grpc::Color enum_array[] = {nifake_grpc::Color::COLOR_RED, nifake_grpc::Color::COLOR_BLACK, nifake_grpc::Color::COLOR_BLUE};
@@ -1502,7 +1564,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetArrayViUInt8WithEnum_CallsGetArrayViUI
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kDriverSuccess, response.status());
   EXPECT_THAT(response.u_int8_enum_array(), ElementsAreArray(enum_array, array_len));
-  EXPECT_EQ(std::string(uint8_array, uint8_array+array_len), response.u_int8_enum_array_raw());
+  EXPECT_EQ(std::string(uint8_array, uint8_array + array_len), response.u_int8_enum_array_raw());
 }
 
 TEST(NiFakeServiceTests, NiFakeService_GetAttributeViSession_ReturnsSessionId)

--- a/source/tests/unit/session_repository_tests.cpp
+++ b/source/tests/unit/session_repository_tests.cpp
@@ -12,7 +12,7 @@ TEST(SessionRepositoryTests, AddSessionWithNonZeroStatus_ReturnsStatusAndDoesNot
   uint32_t session_id = 42;
   int status = session_repository.add_session(
       "",
-      [session_id]() { return std::make_tuple(1, session_id); },
+      [session_id]() { return 1; },
       NULL,
       session_id);
 
@@ -26,12 +26,12 @@ TEST(SessionRepositoryTests, AddSession_StoresSessionWithGivenId)
   uint32_t session_id;
   int status = session_repository.add_session(
       "",
-      []() { return std::make_tuple(0, 42); },
+      []() { return 0; },
       NULL,
       session_id);
 
   EXPECT_EQ(status, 0);
-  EXPECT_EQ(session_id, 42);
+  EXPECT_NE(session_id, 0);
   EXPECT_EQ(session_repository.access_session(session_id, ""), session_id);
 }
 
@@ -42,12 +42,12 @@ TEST(SessionRepositoryTests, AddNamedSession_StoresSessionWithGivenIdAndName)
   uint32_t session_id;
   int status = session_repository.add_session(
       session_name,
-      []() { return std::make_tuple(0, 42); },
+      []() { return 0; },
       NULL,
       session_id);
 
   EXPECT_EQ(status, 0);
-  EXPECT_EQ(session_id, 42);
+  EXPECT_NE(session_id, 0);
   EXPECT_EQ(session_repository.access_session(session_id, ""), session_id);
   EXPECT_EQ(session_repository.access_session(0, session_name), session_id);
 }
@@ -58,7 +58,7 @@ TEST(SessionRepositoryTests, UnnamedSessionAdded_RemoveSession_RemovesSession)
   uint32_t session_id;
   session_repository.add_session(
       "",
-      []() { return std::make_tuple(0, 42); },
+      []() { return 0; },
       NULL,
       session_id);
 
@@ -74,7 +74,7 @@ TEST(SessionRepositoryTests, NamedSessionAdded_RemoveSession_RemovesSession)
   uint32_t session_id;
   int status = session_repository.add_session(
       session_name,
-      []() { return std::make_tuple(0, 42); },
+      []() { return 0; },
       NULL,
       session_id);
 
@@ -88,26 +88,26 @@ TEST(SessionRepositoryTests, NamedSessionAdded_AddSessionWithSameName_ReturnsFir
 {
   std::string session_name = "session_name";
   nidevice_grpc::SessionRepository session_repository;
-  uint32_t session_id;
+  uint32_t first_session_id;
   session_repository.add_session(
       session_name,
-      []() { return std::make_tuple(0, 42); },
+      []() { return 0; },
       NULL,
-      session_id);
+      first_session_id);
 
-  session_id = 0;
+  uint32_t second_session_id;
   bool init_called = false;
   session_repository.add_session(
       session_name,
       [init_called]() mutable {
         init_called = true;
-        return std::make_tuple(0, 52);
+        return 0;
       },
       NULL,
-      session_id);
+      second_session_id);
 
   EXPECT_FALSE(init_called);
-  EXPECT_EQ(session_id, 42);
+  EXPECT_EQ(first_session_id, second_session_id);
 }
 
 TEST(SessionRepositoryTests, NamedSessionAdded_ResetServer_RemovesSession)
@@ -117,7 +117,7 @@ TEST(SessionRepositoryTests, NamedSessionAdded_ResetServer_RemovesSession)
   uint32_t session_id;
   int status = session_repository.add_session(
       session_name,
-      []() { return std::make_tuple(0, 42); },
+      []() { return 0; },
       NULL,
       session_id);
 
@@ -134,7 +134,7 @@ TEST(SessionRepositoryTests, UnnamedSessionAdded_ResetServer_RemovesSession)
   uint32_t session_id;
   session_repository.add_session(
       "",
-      []() { return std::make_tuple(0, 42); },
+      []() { return 0; },
       NULL,
       session_id);
 
@@ -151,13 +151,13 @@ TEST(SessionRepositoryTests, NamedAndUnnamedSessionsAdded_ResetServer_RemovesBot
   uint32_t named_session_id;
   int status = session_repository.add_session(
       session_name,
-      []() { return std::make_tuple(0, 42); },
+      []() { return 0; },
       NULL,
       named_session_id);
   uint32_t unnamed_session_id;
   session_repository.add_session(
       "",
-      []() { return std::make_tuple(0, 42); },
+      []() { return 0; },
       NULL,
       unnamed_session_id);
 

--- a/source/tests/unit/session_resource_repository_tests.cpp
+++ b/source/tests/unit/session_resource_repository_tests.cpp
@@ -30,7 +30,6 @@ uint32_t add_session_resource(
 TEST(SessionResourceRepositoryTests, AddSessionResource_ResourceIsAdded)
 {
   SessionRepository repository;
-  ;
   SessionResourceRepository<uint64_t> resource_repository(
       &repository);
 
@@ -54,18 +53,20 @@ TEST(SessionResourceRepositoryTests, AddSessionResource_ResourceIsAdded)
   EXPECT_EQ(
       session_id,
       repository.access_session(0, kSessionName));
+  EXPECT_EQ(
+      session_id,
+      repository.access_session(session_id, ""));
 }
 
-TEST(SessionResourceRepositoryTests, SessionResource_RemoveSessionResource_ResourceIsRemoved)
+TEST(SessionResourceRepositoryTests, SessionResource_RemoveSession_ResourceIsRemoved)
 {
   SessionRepository repository;
-  ;
   SessionResourceRepository<uint16_t> resource_repository(
       &repository);
   const uint16_t kResourceHandle = 0x1234;
   auto session_id = add_session_resource(resource_repository, kResourceHandle);
 
-  resource_repository.remove_session(kResourceHandle);
+  repository.remove_session(session_id);
 
   EXPECT_EQ(
       kNoSession,
@@ -78,7 +79,6 @@ TEST(SessionResourceRepositoryTests, SessionResource_RemoveSessionResource_Resou
 TEST(SessionResourceRepositoryTests, SessionResource_RemoveFromResourceRepository_ResourceIsRemoved)
 {
   SessionRepository repository;
-  ;
   SessionResourceRepository<int64_t> resource_repository(
       &repository);
   const int64_t kResourceHandle = 68686868;
@@ -102,7 +102,6 @@ TEST(SessionResourceRepositoryTests, SessionResource_RemoveFromResourceRepositor
 TEST(SessionResourceRepositoryTests, SessionResource_ResetServer_ResourceIsRemoved)
 {
   SessionRepository repository;
-  ;
   SessionResourceRepository<int64_t> resource_repository(
       &repository);
   const int64_t kResourceHandle = -9847465247263584;
@@ -121,7 +120,6 @@ TEST(SessionResourceRepositoryTests, SessionResource_ResetServer_ResourceIsRemov
 TEST(SessionResourceRepositoryTests, SessionResource_ResetServer_CleanupIsCalled)
 {
   SessionRepository repository;
-  ;
   SessionResourceRepository<int64_t> resource_repository(
       &repository);
   bool cleanup_called = false;
@@ -141,7 +139,6 @@ TEST(SessionResourceRepositoryTests, SessionResource_ResetServer_CleanupIsCalled
 TEST(SessionResourceRepositoryTests, AddSessionResourceWithErrrOnInit_ResourceIsNotAdded)
 {
   SessionRepository repository;
-  ;
   SessionResourceRepository<int32_t> resource_repository(
       &repository);
 
@@ -160,7 +157,6 @@ TEST(SessionResourceRepositoryTests, AddSessionResourceWithErrrOnInit_ResourceIs
 TEST(SessionResourceRepositoryTests, MultipleResourceRepositories_AddResourceToEach_ResourcesAreAded)
 {
   SessionRepository repository;
-  ;
   SessionResourceRepository<int32_t> int_resource_repository(
       &repository);
   SessionResourceRepository<std::string> string_resource_repository(
@@ -186,7 +182,6 @@ TEST(SessionResourceRepositoryTests, MultipleResourceRepositories_AddResourceToE
 TEST(SessionResourceRepositoryTests, AddMultipleResources_ResourcesAreAdded)
 {
   SessionRepository repository;
-  ;
   SessionResourceRepository<int32_t> resource_repository(
       &repository);
 
@@ -210,7 +205,6 @@ TEST(SessionResourceRepositoryTests, AddMultipleResources_ResourcesAreAdded)
 TEST(SessionResourceRepositoryTests, AddSessionResource_AccessFromDifferentRepository_DoesNotReturnSession)
 {
   SessionRepository repository;
-  ;
   SessionResourceRepository<int32_t> resource_repository(
       &repository);
   SessionResourceRepository<int32_t> other_resource_repository(
@@ -229,15 +223,15 @@ TEST(SessionResourceRepositoryTests, AddSessionResource_AccessFromDifferentRepos
 TEST(SessionResourceRepositoryTests, AddSessionResource_AddSessionWithSameNameFromDifferentRepository_FailsWithoutCallingInit)
 {
   SessionRepository repository;
-  ;
   SessionResourceRepository<int32_t> resource_repository(
       &repository);
   SessionResourceRepository<int32_t> other_resource_repository(
       &repository);
   const int32_t kResourceHandle1 = -123456;
   uint32_t session_id;
+  const std::string kTestResource("test_resource");
   auto result = resource_repository.add_session(
-      "test_resource",
+      kTestResource,
       []() { return std::make_tuple(0, 5555); },
       [](int32_t handle) {},
       session_id);
@@ -247,12 +241,13 @@ TEST(SessionResourceRepositoryTests, AddSessionResource_AddSessionWithSameNameFr
   MockInitDelegate mock_init;
   uint32_t second_session_id;
   result = other_resource_repository.add_session(
-      "test_resource",
+      kTestResource,
       mock_init.AsStdFunction(),
       [](int32_t handle) { FAIL() << "Unexpected Cleanup"; },
       second_session_id);
 
   EXPECT_EQ(kNoSession, second_session_id);
+  EXPECT_NE(kNoError, result);
 }
 }  // namespace unit
 }  // namespace tests

--- a/source/tests/unit/session_resource_repository_tests.cpp
+++ b/source/tests/unit/session_resource_repository_tests.cpp
@@ -1,0 +1,259 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <server/session_repository.h>
+#include <server/session_resource_repository.h>
+
+using namespace nidevice_grpc;
+
+namespace ni {
+namespace tests {
+namespace unit {
+
+const uint32_t kNoSession = 0;
+const int32_t kNoError = 0;
+
+template <typename TResourceHandle>
+uint32_t add_session_resource(
+    SessionResourceRepository<TResourceHandle>& resource_repository,
+    const TResourceHandle& resource)
+{
+  uint32_t session_id;
+  auto result = resource_repository.add_session(
+      "",
+      [=]() { return std::make_tuple(kNoError, resource); },
+      [](TResourceHandle handle) {},
+      session_id);
+  EXPECT_EQ(kNoError, result);
+  return session_id;
+}
+
+TEST(SessionResourceRepositoryTests, AddSessionResource_ResourceIsAdded)
+{
+  SessionRepository repository;
+  ;
+  SessionResourceRepository<uint64_t> resource_repository(
+      &repository);
+
+  const uint64_t kResourceHandle = 0x1111222233334444;
+  const std::string kSessionName("session");
+  uint32_t session_id;
+  auto result = resource_repository.add_session(
+      kSessionName,
+      [=]() { return std::make_tuple(kNoError, kResourceHandle); },
+      [](uint64_t handle) {},
+      session_id);
+
+  EXPECT_EQ(kNoError, result);
+  EXPECT_NE(kNoSession, session_id);
+  EXPECT_EQ(
+      kResourceHandle,
+      resource_repository.access_session(session_id, ""));
+  EXPECT_EQ(
+      kResourceHandle,
+      resource_repository.access_session(0, kSessionName));
+  EXPECT_EQ(
+      session_id,
+      repository.access_session(0, kSessionName));
+}
+
+TEST(SessionResourceRepositoryTests, SessionResource_RemoveSessionResource_ResourceIsRemoved)
+{
+  SessionRepository repository;
+  ;
+  SessionResourceRepository<uint16_t> resource_repository(
+      &repository);
+  const uint16_t kResourceHandle = 0x1234;
+  auto session_id = add_session_resource(resource_repository, kResourceHandle);
+
+  resource_repository.remove_session(kResourceHandle);
+
+  EXPECT_EQ(
+      kNoSession,
+      resource_repository.access_session(session_id, ""));
+  EXPECT_EQ(
+      kNoSession,
+      repository.access_session(session_id, ""));
+}
+
+TEST(SessionResourceRepositoryTests, SessionResource_RemoveFromResourceRepository_ResourceIsRemoved)
+{
+  SessionRepository repository;
+  ;
+  SessionResourceRepository<int64_t> resource_repository(
+      &repository);
+  const int64_t kResourceHandle = 68686868;
+  auto session_id = add_session_resource(resource_repository, kResourceHandle);
+
+  // Remove from the SessionResourceRepository and ensure that it removes from the
+  // SessionRepository and SessionResourceRepository.
+  resource_repository.remove_session(kResourceHandle);
+
+  EXPECT_EQ(
+      kNoSession,
+      repository.access_session(session_id, ""));
+  EXPECT_EQ(
+      0L,
+      resource_repository.access_session(session_id, ""));
+  EXPECT_EQ(
+      kNoSession,
+      resource_repository.resolve_session_id(kResourceHandle));
+}
+
+TEST(SessionResourceRepositoryTests, SessionResource_ResetServer_ResourceIsRemoved)
+{
+  SessionRepository repository;
+  ;
+  SessionResourceRepository<int64_t> resource_repository(
+      &repository);
+  const int64_t kResourceHandle = -9847465247263584;
+  auto session_id = add_session_resource(resource_repository, kResourceHandle);
+
+  repository.reset_server();
+
+  EXPECT_EQ(
+      kNoSession,
+      resource_repository.access_session(session_id, ""));
+  EXPECT_EQ(
+      kNoSession,
+      resource_repository.resolve_session_id(kResourceHandle));
+}
+
+TEST(SessionResourceRepositoryTests, SessionResource_ResetServer_CleanupIsCalled)
+{
+  SessionRepository repository;
+  ;
+  SessionResourceRepository<int64_t> resource_repository(
+      &repository);
+  bool cleanup_called = false;
+  uint32_t session_id;
+  resource_repository.add_session(
+      "",
+      [=]() { return std::make_tuple(kNoError, 12345678); },
+      [&](int64_t) { cleanup_called = true; },
+      session_id);
+  EXPECT_FALSE(cleanup_called);
+
+  repository.reset_server();
+
+  EXPECT_TRUE(cleanup_called);
+}
+
+TEST(SessionResourceRepositoryTests, AddSessionResourceWithErrrOnInit_ResourceIsNotAdded)
+{
+  SessionRepository repository;
+  ;
+  SessionResourceRepository<int32_t> resource_repository(
+      &repository);
+
+  const int32_t kErrorCode = 9999;
+  uint32_t session_id;
+  auto result = resource_repository.add_session(
+      "",
+      [=]() { return std::make_tuple(kErrorCode, 5555); },
+      [](uint64_t handle) {},
+      session_id);
+
+  EXPECT_EQ(kErrorCode, result);
+  EXPECT_EQ(kNoSession, session_id);
+}
+
+TEST(SessionResourceRepositoryTests, MultipleResourceRepositories_AddResourceToEach_ResourcesAreAded)
+{
+  SessionRepository repository;
+  ;
+  SessionResourceRepository<int32_t> int_resource_repository(
+      &repository);
+  SessionResourceRepository<std::string> string_resource_repository(
+      &repository);
+
+  const int32_t kIntResourceHandle = -123456;
+  auto int_session_id = add_session_resource(
+      int_resource_repository,
+      kIntResourceHandle);
+  const std::string kStringResourceHandle("RESOURCE_HANDLE");
+  auto string_session_id = add_session_resource(
+      string_resource_repository,
+      kStringResourceHandle);
+
+  EXPECT_EQ(
+      kIntResourceHandle,
+      int_resource_repository.access_session(int_session_id, ""));
+  EXPECT_EQ(
+      kStringResourceHandle,
+      string_resource_repository.access_session(string_session_id, ""));
+}
+
+TEST(SessionResourceRepositoryTests, AddMultipleResources_ResourcesAreAdded)
+{
+  SessionRepository repository;
+  ;
+  SessionResourceRepository<int32_t> resource_repository(
+      &repository);
+
+  const int32_t kResourceHandle1 = -123456;
+  auto session_id_1 = add_session_resource(
+      resource_repository,
+      kResourceHandle1);
+  const int32_t kResourceHandle2 = 654321;
+  auto session_id_2 = add_session_resource(
+      resource_repository,
+      kResourceHandle2);
+
+  EXPECT_EQ(
+      kResourceHandle1,
+      resource_repository.access_session(session_id_1, ""));
+  EXPECT_EQ(
+      kResourceHandle2,
+      resource_repository.access_session(session_id_2, ""));
+}
+
+TEST(SessionResourceRepositoryTests, AddSessionResource_AccessFromDifferentRepository_DoesNotReturnSession)
+{
+  SessionRepository repository;
+  ;
+  SessionResourceRepository<int32_t> resource_repository(
+      &repository);
+  SessionResourceRepository<int32_t> other_resource_repository(
+      &repository);
+  const int32_t kResourceHandle1 = -123456;
+  auto session_id = add_session_resource(
+      resource_repository,
+      kResourceHandle1);
+
+  auto session_from_other_repository =
+      other_resource_repository.access_session(session_id, "");
+
+  EXPECT_EQ(kNoSession, session_from_other_repository);
+}
+
+TEST(SessionResourceRepositoryTests, AddSessionResource_AddSessionWithSameNameFromDifferentRepository_FailsWithoutCallingInit)
+{
+  SessionRepository repository;
+  ;
+  SessionResourceRepository<int32_t> resource_repository(
+      &repository);
+  SessionResourceRepository<int32_t> other_resource_repository(
+      &repository);
+  const int32_t kResourceHandle1 = -123456;
+  uint32_t session_id;
+  auto result = resource_repository.add_session(
+      "test_resource",
+      []() { return std::make_tuple(0, 5555); },
+      [](int32_t handle) {},
+      session_id);
+
+  const int32_t kErrorCode = 9999;
+  using MockInitDelegate = ::testing::MockFunction<std::tuple<int32_t, int32_t>(void)>;
+  MockInitDelegate mock_init;
+  uint32_t second_session_id;
+  result = other_resource_repository.add_session(
+      "test_resource",
+      mock_init.AsStdFunction(),
+      [](int32_t handle) { FAIL() << "Unexpected Cleanup"; },
+      second_session_id);
+
+  EXPECT_EQ(kNoSession, second_session_id);
+}
+}  // namespace unit
+}  // namespace tests
+}  // namespace ni


### PR DESCRIPTION
### What does this Pull Request accomplish?

Create a `SessionResourceRepository` class that wraps `SessionRepository` and allows storing driver-specific resource handles.

### Why should this Pull Request be merged?

DAQmx will be the first non-IVI driver. Up to now, the `SessionRepository` has stored the 32-bit `ViSession` directly.

For DAQmx, we need to support a pointer-sized `TaskHandle`. We also need to be able to store incompatible (and potentially conflicting) resource types independently.

This change supports the DAQmx requirement while still preserving the session management features of the `SessionRepository`.

Note that all MI drivers will share a single `SessionResourceRepository`. This is required for `TClk` timing and sync, which adds functionality to existing sessions.

### What testing has been done?

Ran and passed new auto-tests.
Ran and passed all system tests.
Used a prototype version of this in a prototype DAQ server.