### PR TITLE
[Owners Review] Bug fix in graph_measurement betterproto example

### DIFF
--- a/examples/niscope/graph-measurement-betterproto.py
+++ b/examples/niscope/graph-measurement-betterproto.py
@@ -119,7 +119,7 @@ async def ConfigureGrpcScope(scope_service: niscope_grpc.NiScopeStub, channel, v
     set_trigger_result = await scope_service.set_attribute_vi_int32(
         vi = vi,
         attribute_id = niscope_grpc.NiScopeAttributes.NISCOPE_ATTRIBUTE_TRIGGER_TYPE,
-        value = niscope_grpc.NiScopeInt32AttributeValues.NISCOPE_INT32_TRIGGER_TYPE_VAL_EDGE_TRIGGER
+        value_raw = niscope_grpc.NiScopeInt32AttributeValues.NISCOPE_INT32_TRIGGER_TYPE_VAL_EDGE_TRIGGER
     )
     await CheckStatus(scope_service, vi, set_trigger_result)
 
@@ -137,7 +137,7 @@ async def ConfigureGrpcScope(scope_service: niscope_grpc.NiScopeStub, channel, v
         vi = vi,
         channel_list = channels,
         attribute_id = niscope_grpc.NiScopeAttributes.NISCOPE_ATTRIBUTE_MEAS_REF_LEVEL_UNITS,
-        value = niscope_grpc.NiScopeInt32AttributeValues.NISCOPE_INT32_REF_LEVEL_UNITS_VAL_PERCENTAGE
+        value_raw = niscope_grpc.NiScopeInt32AttributeValues.NISCOPE_INT32_REF_LEVEL_UNITS_VAL_PERCENTAGE
     )
     await CheckStatus(scope_service, vi, set_units_result)
 

--- a/examples/niscope/plot-read-waveform-betterproto.py
+++ b/examples/niscope/plot-read-waveform-betterproto.py
@@ -110,7 +110,7 @@ async def PerformAcquire():
         level = 0.00,
         holdoff = 0.0,
         trigger_coupling_raw = niscope_grpc.TriggerCoupling.TRIGGER_COUPLING_NISCOPE_VAL_DC,
-        slope = niscope_grpc.TriggerSlope.TRIGGER_SLOPE_NISCOPE_VAL_POSITIVE
+        slope_raw = niscope_grpc.TriggerSlope.TRIGGER_SLOPE_NISCOPE_VAL_POSITIVE
     )
     await CheckStatus(scope_service, vi, confTrigger_edge_result)
 
@@ -118,7 +118,7 @@ async def PerformAcquire():
         vi = vi,
         channel_list = channels,
         attribute_id = niscope_grpc.NiScopeAttributes.NISCOPE_ATTRIBUTE_MEAS_REF_LEVEL_UNITS,
-        value = niscope_grpc.NiScopeInt32AttributeValues.NISCOPE_INT32_REF_LEVEL_UNITS_VAL_PERCENTAGE
+        value_raw = niscope_grpc.NiScopeInt32AttributeValues.NISCOPE_INT32_REF_LEVEL_UNITS_VAL_PERCENTAGE
     )
     await CheckStatus(scope_service, vi, set_result)
 


### PR DESCRIPTION
### Justification
This PR fixes the [bug](https://ni.visualstudio.com/DevCentral/_workitems/edit/1512638) in graph_measurement betterproto example. 

### Implementation
1. Why did the bug arise?
Recently SetAttribute APIs were modified to include `raw_values` which are included inside `oneof` in the proto file. The Better Protobuf compiler has a bug generating helpers for gRPC messages with oneof types. The problem is that zero-value messages in a oneof group take priority based on order and overwrite other set values. Therefore, only the last field, the field that has '_raw` appended to the name, can be properly set without wrapper modification.
**The original example did not use _raw field at the places where SetAttribute APIs were used which was causing this issue.**
On changing those fields to raw type resolves the issue.

Note: The wiki already contains a highlight about the betterproto bug related to oneof gRPC types. https://github.com/ni/grpc-device/wiki/Creating-a-gRPC-Client#creating-a-python-grpc-client

### Testing
Verified that the bug was resolved.
