### PR TITLE
Sort set from get_function_enums

### DIFF
--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -93,12 +93,12 @@ private:
   void Copy(const std::vector<CustomStruct>& input, google::protobuf::RepeatedPtrField<nifake_grpc::FakeCustomStruct>* output);
   CustomStruct ConvertMessage(const nifake_grpc::FakeCustomStruct& input);
   void Copy(const google::protobuf::RepeatedPtrField<nifake_grpc::FakeCustomStruct>& input, std::vector<CustomStruct>* output);
-  std::map<std::int32_t, float> nifakereal64attributevaluesmapped_input_map_ { {1, 3.5f},{2, 4.5f},{3, 5.5f},{4, 6.5f},{5, 7.5f}, };
-  std::map<float, std::int32_t> nifakereal64attributevaluesmapped_output_map_ { {3.5f, 1},{4.5f, 2},{5.5f, 3},{6.5f, 4},{7.5f, 5}, };
   std::map<std::int32_t, float> floatenum_input_map_ { {1, 3.5f},{2, 4.5f},{3, 5.5f},{4, 6.5f},{5, 7.5f}, };
   std::map<float, std::int32_t> floatenum_output_map_ { {3.5f, 1},{4.5f, 2},{5.5f, 3},{6.5f, 4},{7.5f, 5}, };
   std::map<std::int32_t, std::string> mobileosnames_input_map_ { {1, "Android"},{2, "iOS"},{3, "None"}, };
   std::map<std::string, std::int32_t> mobileosnames_output_map_ { {"Android", 1},{"iOS", 2},{"None", 3}, };
+  std::map<std::int32_t, float> nifakereal64attributevaluesmapped_input_map_ { {1, 3.5f},{2, 4.5f},{3, 5.5f},{4, 6.5f},{5, 7.5f}, };
+  std::map<float, std::int32_t> nifakereal64attributevaluesmapped_output_map_ { {3.5f, 1},{4.5f, 2},{5.5f, 3},{6.5f, 4},{7.5f, 5}, };
 };
 
 } // namespace nifake_grpc

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -117,7 +117,7 @@ def get_function_enums(functions):
         function_enums.add(parameter['enum'])
       if 'mapped-enum' in parameter:
         function_enums.add(parameter['mapped-enum'])
-  return function_enums
+  return sorted(function_enums)
 
 def has_viboolean_array_param(functions):
   '''Returns True if atleast one function has parameter of type ViBoolean[]'''


### PR DESCRIPTION
### What does this Pull Request accomplish?

Ensure that the enum names are ordered when they are used in codegen for the header file.

In python, `dict`s are ordered but `set`s are not.

### Why should this Pull Request be merged?

This prevents non-deterministic codegen and spurious diffs.

### What testing has been done?

Ran codegen with expected result.