### PR TITLE
[Owners] Adding artifacts for client files to CI

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -151,6 +151,23 @@ jobs:
         path: ni-grpc-device-tests-linux-glibc2_23-x64.tar.gz
         retention-days: 5
 
+    - name: Stage Linux Client Files
+      if: ${{ (runner.os == 'Linux') }}
+      run: |
+        mkdir -p ${{ runner.temp }}/staging/proto
+        cp generated/**/*.proto source/protobuf/*.proto ${{ runner.temp }}/staging/proto
+        cp -r examples/ ${{ runner.temp }}/staging/
+        cp LICENSE ThirdPartyNotices.txt ${{ runner.temp }}/staging/
+        tar -cvzf ni-grpc-device-client.tar.gz -C ${{ runner.temp }}/staging/ --exclude *nifake* examples/ proto/ LICENSE ThirdPartyNotices.txt
+
+    - name: Upload Linux Client Files Artifact
+      uses: actions/upload-artifact@v2
+      if: ${{ (runner.os == 'Linux') }}
+      with:
+        name: ni-grpc-device-client-Linux
+        path: ni-grpc-device-client.tar.gz
+        retention-days: 5
+
     - name: Upload Windows Server Binaries Artifact
       uses: actions/upload-artifact@v2
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -152,7 +152,7 @@ jobs:
         retention-days: 5
 
     - name: Stage Linux Client Files
-      if: ${{ (runner.os == 'Linux') }}
+      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       run: |
         mkdir -p ${{ runner.temp }}/staging/proto
         cp generated/**/*.proto source/protobuf/*.proto ${{ runner.temp }}/staging/proto
@@ -162,7 +162,7 @@ jobs:
 
     - name: Upload Linux Client Files Artifact
       uses: actions/upload-artifact@v2
-      if: ${{ (runner.os == 'Linux') }}
+      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       with:
         name: ni-grpc-device-client-Linux
         path: ni-grpc-device-client.tar.gz

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -184,9 +184,9 @@ jobs:
       shell: powershell
       run: |
         mkdir "${{ runner.temp }}/staging/proto"
-        Copy-Item "source/*.proto", "generated/*.proto" -Exclude "*nifake*" -Destination "${{ runner.temp }}/staging/proto"
-        Copy-Item "examples/" -Recurse -Destination "${{ runner.temp }}/staging/"
-        Copy-Item "LICENSE","ThirdPartyNotices.txt" -Destination "${{ runner.temp }}/staging/"
+        Copy-Item "source/*.proto", "generated/*.proto" -Exclude "*nifake*" -Destination "${{ runner.temp }}/staging/proto/" -Verbose
+        Copy-Item "examples/" -Recurse -Destination "${{ runner.temp }}/staging/" -Verbose
+        Copy-Item "LICENSE","ThirdPartyNotices.txt" -Destination "${{ runner.temp }}/staging/" -Verbose
 
     - name: Upload Windows Client Files Artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -184,9 +184,9 @@ jobs:
       shell: powershell
       run: |
         mkdir "${{ runner.temp }}/staging/proto"
-        Copy-Item "source/*.proto", "generated/*.proto" -Exclude "*nifake*" -Destination "${{ runner.temp }}/staging/proto/" -Verbose
-        Copy-Item "examples/" -Recurse -Destination "${{ runner.temp }}/staging/" -Verbose
-        Copy-Item "LICENSE","ThirdPartyNotices.txt" -Destination "${{ runner.temp }}/staging/" -Verbose
+        Copy-Item "source/protobuf/*.proto", "generated/**/*.proto" -Exclude "*nifake*" -Destination "${{ runner.temp }}/staging/proto/"
+        Copy-Item "examples/" -Recurse -Destination "${{ runner.temp }}/staging/"
+        Copy-Item "LICENSE","ThirdPartyNotices.txt" -Destination "${{ runner.temp }}/staging/"
 
     - name: Upload Windows Client Files Artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -179,6 +179,26 @@ jobs:
           ThirdPartyNotices.txt
         retention-days: 5
 
+    - name: Stage Client Files
+      if: ${{ (runner.os == 'Windows') }}
+      shell: powershell
+      run: |
+        mkdir "${{ runner.temp }}/staging/proto", "${{ runner.temp }}/staging/examples"
+        Copy-Item "source/*.proto", "generated/*.proto" -Exclude "*nifake*" -Destination "${{ runner.temp }}/staging/proto"
+        Copy-Item "examples/" -Recurse -Destination "${{ runner.temp }}/staging/examples"
+
+    - name: Upload Windows Client Files Artifact
+      uses: actions/upload-artifact@v2
+      if: ${{ (runner.os == 'Windows') }}
+      with:
+        name: ni-grpc-device-client
+        path: |
+          ${{ runner.temp }}/**/proto
+          ${{ runner.temp }}/**/examples
+          LICENSE
+          ThirdPartyNotices.txt
+        retention-days: 5
+
   trigger_main_ci:
     name: Trigger Main CI
     needs: build

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -179,13 +179,14 @@ jobs:
           ThirdPartyNotices.txt
         retention-days: 5
 
-    - name: Stage Client Files
+    - name: Stage Windows Client Files
       if: ${{ (runner.os == 'Windows') }}
       shell: powershell
       run: |
-        mkdir "${{ runner.temp }}/staging/proto", "${{ runner.temp }}/staging/examples"
+        mkdir "${{ runner.temp }}/staging/proto"
         Copy-Item "source/*.proto", "generated/*.proto" -Exclude "*nifake*" -Destination "${{ runner.temp }}/staging/proto"
-        Copy-Item "examples/" -Recurse -Destination "${{ runner.temp }}/staging/examples"
+        Copy-Item "examples/" -Recurse -Destination "${{ runner.temp }}/staging/"
+        Copy-Item "LICENSE","ThirdPartyNotices.txt" -Destination "${{ runner.temp }}/staging/"
 
     - name: Upload Windows Client Files Artifact
       uses: actions/upload-artifact@v2
@@ -193,10 +194,7 @@ jobs:
       with:
         name: ni-grpc-device-client
         path: |
-          ${{ runner.temp }}/**/proto
-          ${{ runner.temp }}/**/examples
-          LICENSE
-          ThirdPartyNotices.txt
+          ${{ runner.temp }}/staging
         retention-days: 5
 
   trigger_main_ci:

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -197,7 +197,7 @@ jobs:
         retention-days: 5
 
     - name: Stage Windows Client Files
-      if: ${{ (runner.os == 'Windows') }}
+      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}
       shell: powershell
       run: |
         mkdir "${{ runner.temp }}/staging/proto"
@@ -207,7 +207,7 @@ jobs:
 
     - name: Upload Windows Client Files Artifact
       uses: actions/upload-artifact@v2
-      if: ${{ (runner.os == 'Windows') }}
+      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}
       with:
         name: ni-grpc-device-client
         path: |


### PR DESCRIPTION
### What does this Pull Request accomplish?
To make releases easier, it was requested that we add client files to the artifacts created by the CI for main and release branches. This change adds those artifacts.

### Why should this Pull Request be merged?
Saves time by reducing some of the manual cost of creating a release.

### What testing has been done?
Ran the workflows [here ](https://github.com/ni/grpc-device/actions/runs/1009178645) without the branch filters and confirmed the files were created as intended. 
