### PR TITLE
Add ReadAnalogF64 to DAQ service

### DIFF
--- a/generated/nidaqmx/nidaqmx.proto
+++ b/generated/nidaqmx/nidaqmx.proto
@@ -33,8 +33,8 @@ enum NiDAQmxAttributes {
 enum GroupBy {
   option allow_alias = true;
   GROUP_BY_UNSPECIFIED = 0;
-  GROUP_BY_GroupByChannel = 0;
-  GROUP_BY_GroupByScanNumber = 1;
+  GROUP_BY_GROUP_BY_CHANNEL = 0;
+  GROUP_BY_GROUP_BY_SCAN_NUMBER = 1;
 }
 
 enum InputTermCfgWithDefault {

--- a/generated/nidaqmx/nidaqmx.proto
+++ b/generated/nidaqmx/nidaqmx.proto
@@ -21,12 +21,20 @@ service NiDAQmx {
   rpc CreateDIChan(CreateDIChanRequest) returns (CreateDIChanResponse);
   rpc CreateDOChan(CreateDOChanRequest) returns (CreateDOChanResponse);
   rpc CreateTask(CreateTaskRequest) returns (CreateTaskResponse);
+  rpc ReadAnalogF64(ReadAnalogF64Request) returns (ReadAnalogF64Response);
   rpc StartTask(StartTaskRequest) returns (StartTaskResponse);
   rpc StopTask(StopTaskRequest) returns (StopTaskResponse);
 }
 
 enum NiDAQmxAttributes {
   NIDAQMX_ATTRIBUTE_UNSPECIFIED = 0;
+}
+
+enum GroupBy {
+  option allow_alias = true;
+  GROUP_BY_UNSPECIFIED = 0;
+  GROUP_BY_GroupByChannel = 0;
+  GROUP_BY_GroupByScanNumber = 1;
 }
 
 enum InputTermCfgWithDefault {
@@ -115,6 +123,23 @@ message CreateTaskRequest {
 message CreateTaskResponse {
   int32 status = 1;
   nidevice_grpc.Session task = 2;
+}
+
+message ReadAnalogF64Request {
+  nidevice_grpc.Session task = 1;
+  int32 num_samps_per_chan = 2;
+  double timeout = 3;
+  oneof fill_mode_enum {
+    GroupBy fill_mode = 4;
+    int32 fill_mode_raw = 5;
+  }
+  uint32 array_size_in_samps = 6;
+}
+
+message ReadAnalogF64Response {
+  int32 status = 1;
+  repeated double read_array = 2;
+  int32 samps_per_chan_read = 3;
 }
 
 message StartTaskRequest {

--- a/generated/nidaqmx/nidaqmx_library.cpp
+++ b/generated/nidaqmx/nidaqmx_library.cpp
@@ -26,6 +26,7 @@ NiDAQmxLibrary::NiDAQmxLibrary() : shared_library_(kLibraryName)
   function_pointers_.CreateDIChan = reinterpret_cast<CreateDIChanPtr>(shared_library_.get_function_pointer("DAQmxCreateDIChan"));
   function_pointers_.CreateDOChan = reinterpret_cast<CreateDOChanPtr>(shared_library_.get_function_pointer("DAQmxCreateDOChan"));
   function_pointers_.CreateTask = reinterpret_cast<CreateTaskPtr>(shared_library_.get_function_pointer("DAQmxCreateTask"));
+  function_pointers_.ReadAnalogF64 = reinterpret_cast<ReadAnalogF64Ptr>(shared_library_.get_function_pointer("DAQmxReadAnalogF64"));
   function_pointers_.StartTask = reinterpret_cast<StartTaskPtr>(shared_library_.get_function_pointer("DAQmxStartTask"));
   function_pointers_.StopTask = reinterpret_cast<StopTaskPtr>(shared_library_.get_function_pointer("DAQmxStopTask"));
 }
@@ -53,7 +54,7 @@ int32 NiDAQmxLibrary::ClearTask(TaskHandle task)
 #endif
 }
 
-int32 NiDAQmxLibrary::CreateAIVoltageChan(TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], int terminalConfig, float64 minVal, float64 maxVal, int units, const char customScaleName[])
+int32 NiDAQmxLibrary::CreateAIVoltageChan(TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], int32 terminalConfig, float64 minVal, float64 maxVal, int32 units, const char customScaleName[])
 {
   if (!function_pointers_.CreateAIVoltageChan) {
     throw nidevice_grpc::LibraryLoadException("Could not find DAQmxCreateAIVoltageChan.");
@@ -65,7 +66,7 @@ int32 NiDAQmxLibrary::CreateAIVoltageChan(TaskHandle task, const char physicalCh
 #endif
 }
 
-int32 NiDAQmxLibrary::CreateDIChan(TaskHandle task, const char lines[], const char nameToAssignToLines[], int lineGrouping)
+int32 NiDAQmxLibrary::CreateDIChan(TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping)
 {
   if (!function_pointers_.CreateDIChan) {
     throw nidevice_grpc::LibraryLoadException("Could not find DAQmxCreateDIChan.");
@@ -77,7 +78,7 @@ int32 NiDAQmxLibrary::CreateDIChan(TaskHandle task, const char lines[], const ch
 #endif
 }
 
-int32 NiDAQmxLibrary::CreateDOChan(TaskHandle task, const char lines[], const char nameToAssignToLines[], int lineGrouping)
+int32 NiDAQmxLibrary::CreateDOChan(TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping)
 {
   if (!function_pointers_.CreateDOChan) {
     throw nidevice_grpc::LibraryLoadException("Could not find DAQmxCreateDOChan.");
@@ -98,6 +99,18 @@ int32 NiDAQmxLibrary::CreateTask(const char sessionName[], TaskHandle* task)
   return DAQmxCreateTask(sessionName, task);
 #else
   return function_pointers_.CreateTask(sessionName, task);
+#endif
+}
+
+int32 NiDAQmxLibrary::ReadAnalogF64(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, float64 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved)
+{
+  if (!function_pointers_.ReadAnalogF64) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxReadAnalogF64.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxReadAnalogF64(task, numSampsPerChan, timeout, fillMode, readArray, arraySizeInSamps, sampsPerChanRead, reserved);
+#else
+  return function_pointers_.ReadAnalogF64(task, numSampsPerChan, timeout, fillMode, readArray, arraySizeInSamps, sampsPerChanRead, reserved);
 #endif
 }
 

--- a/generated/nidaqmx/nidaqmx_library.h
+++ b/generated/nidaqmx/nidaqmx_library.h
@@ -19,19 +19,21 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
 
   ::grpc::Status check_function_exists(std::string functionName);
   int32 ClearTask(TaskHandle task);
-  int32 CreateAIVoltageChan(TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], int terminalConfig, float64 minVal, float64 maxVal, int units, const char customScaleName[]);
-  int32 CreateDIChan(TaskHandle task, const char lines[], const char nameToAssignToLines[], int lineGrouping);
-  int32 CreateDOChan(TaskHandle task, const char lines[], const char nameToAssignToLines[], int lineGrouping);
+  int32 CreateAIVoltageChan(TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], int32 terminalConfig, float64 minVal, float64 maxVal, int32 units, const char customScaleName[]);
+  int32 CreateDIChan(TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping);
+  int32 CreateDOChan(TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping);
   int32 CreateTask(const char sessionName[], TaskHandle* task);
+  int32 ReadAnalogF64(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, float64 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
   int32 StartTask(TaskHandle task);
   int32 StopTask(TaskHandle task);
 
  private:
   using ClearTaskPtr = int32 (*)(TaskHandle task);
-  using CreateAIVoltageChanPtr = int32 (*)(TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], int terminalConfig, float64 minVal, float64 maxVal, int units, const char customScaleName[]);
-  using CreateDIChanPtr = int32 (*)(TaskHandle task, const char lines[], const char nameToAssignToLines[], int lineGrouping);
-  using CreateDOChanPtr = int32 (*)(TaskHandle task, const char lines[], const char nameToAssignToLines[], int lineGrouping);
+  using CreateAIVoltageChanPtr = int32 (*)(TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], int32 terminalConfig, float64 minVal, float64 maxVal, int32 units, const char customScaleName[]);
+  using CreateDIChanPtr = int32 (*)(TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping);
+  using CreateDOChanPtr = int32 (*)(TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping);
   using CreateTaskPtr = int32 (*)(const char sessionName[], TaskHandle* task);
+  using ReadAnalogF64Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, float64 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
   using StartTaskPtr = int32 (*)(TaskHandle task);
   using StopTaskPtr = int32 (*)(TaskHandle task);
 
@@ -41,6 +43,7 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
     CreateDIChanPtr CreateDIChan;
     CreateDOChanPtr CreateDOChan;
     CreateTaskPtr CreateTask;
+    ReadAnalogF64Ptr ReadAnalogF64;
     StartTaskPtr StartTask;
     StopTaskPtr StopTask;
   } FunctionLoadStatus;

--- a/generated/nidaqmx/nidaqmx_library_interface.h
+++ b/generated/nidaqmx/nidaqmx_library_interface.h
@@ -16,10 +16,11 @@ class NiDAQmxLibraryInterface {
   virtual ~NiDAQmxLibraryInterface() {}
 
   virtual int32 ClearTask(TaskHandle task) = 0;
-  virtual int32 CreateAIVoltageChan(TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], int terminalConfig, float64 minVal, float64 maxVal, int units, const char customScaleName[]) = 0;
-  virtual int32 CreateDIChan(TaskHandle task, const char lines[], const char nameToAssignToLines[], int lineGrouping) = 0;
-  virtual int32 CreateDOChan(TaskHandle task, const char lines[], const char nameToAssignToLines[], int lineGrouping) = 0;
+  virtual int32 CreateAIVoltageChan(TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], int32 terminalConfig, float64 minVal, float64 maxVal, int32 units, const char customScaleName[]) = 0;
+  virtual int32 CreateDIChan(TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping) = 0;
+  virtual int32 CreateDOChan(TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping) = 0;
   virtual int32 CreateTask(const char sessionName[], TaskHandle* task) = 0;
+  virtual int32 ReadAnalogF64(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, float64 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved) = 0;
   virtual int32 StartTask(TaskHandle task) = 0;
   virtual int32 StopTask(TaskHandle task) = 0;
 };

--- a/generated/nidaqmx/nidaqmx_mock_library.h
+++ b/generated/nidaqmx/nidaqmx_mock_library.h
@@ -18,10 +18,11 @@ namespace unit {
 class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
  public:
   MOCK_METHOD(int32, ClearTask, (TaskHandle task), (override));
-  MOCK_METHOD(int32, CreateAIVoltageChan, (TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], int terminalConfig, float64 minVal, float64 maxVal, int units, const char customScaleName[]), (override));
-  MOCK_METHOD(int32, CreateDIChan, (TaskHandle task, const char lines[], const char nameToAssignToLines[], int lineGrouping), (override));
-  MOCK_METHOD(int32, CreateDOChan, (TaskHandle task, const char lines[], const char nameToAssignToLines[], int lineGrouping), (override));
+  MOCK_METHOD(int32, CreateAIVoltageChan, (TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], int32 terminalConfig, float64 minVal, float64 maxVal, int32 units, const char customScaleName[]), (override));
+  MOCK_METHOD(int32, CreateDIChan, (TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping), (override));
+  MOCK_METHOD(int32, CreateDOChan, (TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping), (override));
   MOCK_METHOD(int32, CreateTask, (const char sessionName[], TaskHandle* task), (override));
+  MOCK_METHOD(int32, ReadAnalogF64, (TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, float64 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved), (override));
   MOCK_METHOD(int32, StartTask, (TaskHandle task), (override));
   MOCK_METHOD(int32, StopTask, (TaskHandle task), (override));
 };

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -55,14 +55,14 @@ namespace nidaqmx_grpc {
       TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
-      int terminal_config;
+      int32 terminal_config;
       switch (request->terminal_config_enum_case()) {
         case nidaqmx_grpc::CreateAIVoltageChanRequest::TerminalConfigEnumCase::kTerminalConfig: {
-          terminal_config = static_cast<int>(request->terminal_config());
+          terminal_config = static_cast<int32>(request->terminal_config());
           break;
         }
         case nidaqmx_grpc::CreateAIVoltageChanRequest::TerminalConfigEnumCase::kTerminalConfigRaw: {
-          terminal_config = static_cast<int>(request->terminal_config_raw());
+          terminal_config = static_cast<int32>(request->terminal_config_raw());
           break;
         }
         case nidaqmx_grpc::CreateAIVoltageChanRequest::TerminalConfigEnumCase::TERMINAL_CONFIG_ENUM_NOT_SET: {
@@ -73,14 +73,14 @@ namespace nidaqmx_grpc {
 
       float64 min_val = request->min_val();
       float64 max_val = request->max_val();
-      int units;
+      int32 units;
       switch (request->units_enum_case()) {
         case nidaqmx_grpc::CreateAIVoltageChanRequest::UnitsEnumCase::kUnits: {
-          units = static_cast<int>(request->units());
+          units = static_cast<int32>(request->units());
           break;
         }
         case nidaqmx_grpc::CreateAIVoltageChanRequest::UnitsEnumCase::kUnitsRaw: {
-          units = static_cast<int>(request->units_raw());
+          units = static_cast<int32>(request->units_raw());
           break;
         }
         case nidaqmx_grpc::CreateAIVoltageChanRequest::UnitsEnumCase::UNITS_ENUM_NOT_SET: {
@@ -111,14 +111,14 @@ namespace nidaqmx_grpc {
       TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
       auto lines = request->lines().c_str();
       auto name_to_assign_to_lines = request->name_to_assign_to_lines().c_str();
-      int line_grouping;
+      int32 line_grouping;
       switch (request->line_grouping_enum_case()) {
         case nidaqmx_grpc::CreateDIChanRequest::LineGroupingEnumCase::kLineGrouping: {
-          line_grouping = static_cast<int>(request->line_grouping());
+          line_grouping = static_cast<int32>(request->line_grouping());
           break;
         }
         case nidaqmx_grpc::CreateDIChanRequest::LineGroupingEnumCase::kLineGroupingRaw: {
-          line_grouping = static_cast<int>(request->line_grouping_raw());
+          line_grouping = static_cast<int32>(request->line_grouping_raw());
           break;
         }
         case nidaqmx_grpc::CreateDIChanRequest::LineGroupingEnumCase::LINE_GROUPING_ENUM_NOT_SET: {
@@ -148,14 +148,14 @@ namespace nidaqmx_grpc {
       TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
       auto lines = request->lines().c_str();
       auto name_to_assign_to_lines = request->name_to_assign_to_lines().c_str();
-      int line_grouping;
+      int32 line_grouping;
       switch (request->line_grouping_enum_case()) {
         case nidaqmx_grpc::CreateDOChanRequest::LineGroupingEnumCase::kLineGrouping: {
-          line_grouping = static_cast<int>(request->line_grouping());
+          line_grouping = static_cast<int32>(request->line_grouping());
           break;
         }
         case nidaqmx_grpc::CreateDOChanRequest::LineGroupingEnumCase::kLineGroupingRaw: {
-          line_grouping = static_cast<int>(request->line_grouping_raw());
+          line_grouping = static_cast<int32>(request->line_grouping_raw());
           break;
         }
         case nidaqmx_grpc::CreateDOChanRequest::LineGroupingEnumCase::LINE_GROUPING_ENUM_NOT_SET: {
@@ -195,6 +195,50 @@ namespace nidaqmx_grpc {
       response->set_status(status);
       if (status == 0) {
         response->mutable_task()->set_id(session_id);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::ReadAnalogF64(::grpc::ServerContext* context, const ReadAnalogF64Request* request, ReadAnalogF64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto task_grpc_session = request->task();
+      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      int32 num_samps_per_chan = request->num_samps_per_chan();
+      float64 timeout = request->timeout();
+      int32 fill_mode;
+      switch (request->fill_mode_enum_case()) {
+        case nidaqmx_grpc::ReadAnalogF64Request::FillModeEnumCase::kFillMode: {
+          fill_mode = static_cast<int32>(request->fill_mode());
+          break;
+        }
+        case nidaqmx_grpc::ReadAnalogF64Request::FillModeEnumCase::kFillModeRaw: {
+          fill_mode = static_cast<int32>(request->fill_mode_raw());
+          break;
+        }
+        case nidaqmx_grpc::ReadAnalogF64Request::FillModeEnumCase::FILL_MODE_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for fill_mode was not specified or out of range");
+          break;
+        }
+      }
+
+      uInt32 array_size_in_samps = request->array_size_in_samps();
+      response->mutable_read_array()->Resize(array_size_in_samps, 0);
+      float64* read_array = response->mutable_read_array()->mutable_data();
+      int32 samps_per_chan_read {};
+      auto status = library_->ReadAnalogF64(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, nullptr);
+      response->set_status(status);
+      if (status == 0) {
+        response->set_samps_per_chan_read(samps_per_chan_read);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -232,10 +232,11 @@ namespace nidaqmx_grpc {
       }
 
       uInt32 array_size_in_samps = request->array_size_in_samps();
+      auto reserved = nullptr;
       response->mutable_read_array()->Resize(array_size_in_samps, 0);
       float64* read_array = response->mutable_read_array()->mutable_data();
       int32 samps_per_chan_read {};
-      auto status = library_->ReadAnalogF64(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, nullptr);
+      auto status = library_->ReadAnalogF64(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
       response->set_status(status);
       if (status == 0) {
         response->set_samps_per_chan_read(samps_per_chan_read);

--- a/generated/nidaqmx/nidaqmx_service.h
+++ b/generated/nidaqmx/nidaqmx_service.h
@@ -32,6 +32,7 @@ public:
   ::grpc::Status CreateDIChan(::grpc::ServerContext* context, const CreateDIChanRequest* request, CreateDIChanResponse* response) override;
   ::grpc::Status CreateDOChan(::grpc::ServerContext* context, const CreateDOChanRequest* request, CreateDOChanResponse* response) override;
   ::grpc::Status CreateTask(::grpc::ServerContext* context, const CreateTaskRequest* request, CreateTaskResponse* response) override;
+  ::grpc::Status ReadAnalogF64(::grpc::ServerContext* context, const ReadAnalogF64Request* request, ReadAnalogF64Response* response) override;
   ::grpc::Status StartTask(::grpc::ServerContext* context, const StartTaskRequest* request, StartTaskResponse* response) override;
   ::grpc::Status StopTask(::grpc::ServerContext* context, const StopTaskRequest* request, StopTaskResponse* response) override;
 private:

--- a/generated/nifake/nifake.proto
+++ b/generated/nifake/nifake.proto
@@ -22,6 +22,7 @@ service NiFake {
   rpc AcceptViUInt32Array(AcceptViUInt32ArrayRequest) returns (AcceptViUInt32ArrayResponse);
   rpc BoolArrayOutputFunction(BoolArrayOutputFunctionRequest) returns (BoolArrayOutputFunctionResponse);
   rpc BoolArrayInputFunction(BoolArrayInputFunctionRequest) returns (BoolArrayInputFunctionResponse);
+  rpc CommandWithReservedParam(CommandWithReservedParamRequest) returns (CommandWithReservedParamResponse);
   rpc DoubleAllTheNums(DoubleAllTheNumsRequest) returns (DoubleAllTheNumsResponse);
   rpc EnumArrayOutputFunction(EnumArrayOutputFunctionRequest) returns (EnumArrayOutputFunctionResponse);
   rpc EnumInputFunctionWithDefaults(EnumInputFunctionWithDefaultsRequest) returns (EnumInputFunctionWithDefaultsResponse);
@@ -196,6 +197,14 @@ message BoolArrayInputFunctionRequest {
 }
 
 message BoolArrayInputFunctionResponse {
+  int32 status = 1;
+}
+
+message CommandWithReservedParamRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message CommandWithReservedParamResponse {
   int32 status = 1;
 }
 

--- a/generated/nifake/nifake_library.cpp
+++ b/generated/nifake/nifake_library.cpp
@@ -27,6 +27,7 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.AcceptViUInt32Array = reinterpret_cast<AcceptViUInt32ArrayPtr>(shared_library_.get_function_pointer("niFake_AcceptViUInt32Array"));
   function_pointers_.BoolArrayOutputFunction = reinterpret_cast<BoolArrayOutputFunctionPtr>(shared_library_.get_function_pointer("niFake_BoolArrayOutputFunction"));
   function_pointers_.BoolArrayInputFunction = reinterpret_cast<BoolArrayInputFunctionPtr>(shared_library_.get_function_pointer("niFake_BoolArrayInputFunction"));
+  function_pointers_.CommandWithReservedParam = reinterpret_cast<CommandWithReservedParamPtr>(shared_library_.get_function_pointer("niFake_CommandWithReservedParam"));
   function_pointers_.DoubleAllTheNums = reinterpret_cast<DoubleAllTheNumsPtr>(shared_library_.get_function_pointer("niFake_DoubleAllTheNums"));
   function_pointers_.EnumArrayOutputFunction = reinterpret_cast<EnumArrayOutputFunctionPtr>(shared_library_.get_function_pointer("niFake_EnumArrayOutputFunction"));
   function_pointers_.EnumInputFunctionWithDefaults = reinterpret_cast<EnumInputFunctionWithDefaultsPtr>(shared_library_.get_function_pointer("niFake_EnumInputFunctionWithDefaults"));
@@ -168,6 +169,18 @@ ViStatus NiFakeLibrary::BoolArrayInputFunction(ViSession vi, ViInt32 numberOfEle
   return niFake_BoolArrayInputFunction(vi, numberOfElements, anArray);
 #else
   return function_pointers_.BoolArrayInputFunction(vi, numberOfElements, anArray);
+#endif
+}
+
+ViStatus NiFakeLibrary::CommandWithReservedParam(ViSession vi, ViBoolean* reserved)
+{
+  if (!function_pointers_.CommandWithReservedParam) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_CommandWithReservedParam.");
+  }
+#if defined(_MSC_VER)
+  return niFake_CommandWithReservedParam(vi, reserved);
+#else
+  return function_pointers_.CommandWithReservedParam(vi, reserved);
 #endif
 }
 

--- a/generated/nifake/nifake_library.h
+++ b/generated/nifake/nifake_library.h
@@ -24,6 +24,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus AcceptViUInt32Array(ViSession vi, ViInt32 arrayLen, ViUInt32 uInt32Array[]);
   ViStatus BoolArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]);
   ViStatus BoolArrayInputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]);
+  ViStatus CommandWithReservedParam(ViSession vi, ViBoolean* reserved);
   ViStatus DoubleAllTheNums(ViSession vi, ViInt32 numberCount, ViReal64 numbers[]);
   ViStatus EnumArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViInt16 anArray[]);
   ViStatus EnumInputFunctionWithDefaults(ViSession vi, ViInt16 aTurtle);
@@ -91,6 +92,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using AcceptViUInt32ArrayPtr = ViStatus (*)(ViSession vi, ViInt32 arrayLen, ViUInt32 uInt32Array[]);
   using BoolArrayOutputFunctionPtr = ViStatus (*)(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]);
   using BoolArrayInputFunctionPtr = ViStatus (*)(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]);
+  using CommandWithReservedParamPtr = ViStatus (*)(ViSession vi, ViBoolean* reserved);
   using DoubleAllTheNumsPtr = ViStatus (*)(ViSession vi, ViInt32 numberCount, ViReal64 numbers[]);
   using EnumArrayOutputFunctionPtr = ViStatus (*)(ViSession vi, ViInt32 numberOfElements, ViInt16 anArray[]);
   using EnumInputFunctionWithDefaultsPtr = ViStatus (*)(ViSession vi, ViInt16 aTurtle);
@@ -158,6 +160,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     AcceptViUInt32ArrayPtr AcceptViUInt32Array;
     BoolArrayOutputFunctionPtr BoolArrayOutputFunction;
     BoolArrayInputFunctionPtr BoolArrayInputFunction;
+    CommandWithReservedParamPtr CommandWithReservedParam;
     DoubleAllTheNumsPtr DoubleAllTheNums;
     EnumArrayOutputFunctionPtr EnumArrayOutputFunction;
     EnumInputFunctionWithDefaultsPtr EnumInputFunctionWithDefaults;

--- a/generated/nifake/nifake_library_interface.h
+++ b/generated/nifake/nifake_library_interface.h
@@ -21,6 +21,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus AcceptViUInt32Array(ViSession vi, ViInt32 arrayLen, ViUInt32 uInt32Array[]) = 0;
   virtual ViStatus BoolArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]) = 0;
   virtual ViStatus BoolArrayInputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]) = 0;
+  virtual ViStatus CommandWithReservedParam(ViSession vi, ViBoolean* reserved) = 0;
   virtual ViStatus DoubleAllTheNums(ViSession vi, ViInt32 numberCount, ViReal64 numbers[]) = 0;
   virtual ViStatus EnumArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViInt16 anArray[]) = 0;
   virtual ViStatus EnumInputFunctionWithDefaults(ViSession vi, ViInt16 aTurtle) = 0;

--- a/generated/nifake/nifake_mock_library.h
+++ b/generated/nifake/nifake_mock_library.h
@@ -23,6 +23,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, AcceptViUInt32Array, (ViSession vi, ViInt32 arrayLen, ViUInt32 uInt32Array[]), (override));
   MOCK_METHOD(ViStatus, BoolArrayOutputFunction, (ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]), (override));
   MOCK_METHOD(ViStatus, BoolArrayInputFunction, (ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]), (override));
+  MOCK_METHOD(ViStatus, CommandWithReservedParam, (ViSession vi, ViBoolean* reserved), (override));
   MOCK_METHOD(ViStatus, DoubleAllTheNums, (ViSession vi, ViInt32 numberCount, ViReal64 numbers[]), (override));
   MOCK_METHOD(ViStatus, EnumArrayOutputFunction, (ViSession vi, ViInt32 numberOfElements, ViInt16 anArray[]), (override));
   MOCK_METHOD(ViStatus, EnumInputFunctionWithDefaults, (ViSession vi, ViInt16 aTurtle), (override));

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -211,6 +211,25 @@ namespace nifake_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::CommandWithReservedParam(::grpc::ServerContext* context, const CommandWithReservedParamRequest* request, CommandWithReservedParamResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      auto status = library_->CommandWithReservedParam(vi, nullptr);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::DoubleAllTheNums(::grpc::ServerContext* context, const DoubleAllTheNumsRequest* request, DoubleAllTheNumsResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -219,7 +219,8 @@ namespace nifake_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      auto status = library_->CommandWithReservedParam(vi, nullptr);
+      auto reserved = nullptr;
+      auto status = library_->CommandWithReservedParam(vi, reserved);
       response->set_status(status);
       return ::grpc::Status::OK;
     }

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -33,6 +33,7 @@ public:
   ::grpc::Status AcceptViUInt32Array(::grpc::ServerContext* context, const AcceptViUInt32ArrayRequest* request, AcceptViUInt32ArrayResponse* response) override;
   ::grpc::Status BoolArrayOutputFunction(::grpc::ServerContext* context, const BoolArrayOutputFunctionRequest* request, BoolArrayOutputFunctionResponse* response) override;
   ::grpc::Status BoolArrayInputFunction(::grpc::ServerContext* context, const BoolArrayInputFunctionRequest* request, BoolArrayInputFunctionResponse* response) override;
+  ::grpc::Status CommandWithReservedParam(::grpc::ServerContext* context, const CommandWithReservedParamRequest* request, CommandWithReservedParamResponse* response) override;
   ::grpc::Status DoubleAllTheNums(::grpc::ServerContext* context, const DoubleAllTheNumsRequest* request, DoubleAllTheNumsResponse* response) override;
   ::grpc::Status EnumArrayOutputFunction(::grpc::ServerContext* context, const EnumArrayOutputFunctionRequest* request, EnumArrayOutputFunctionResponse* response) override;
   ::grpc::Status EnumInputFunctionWithDefaults(::grpc::ServerContext* context, const EnumInputFunctionWithDefaultsRequest* request, EnumInputFunctionWithDefaultsResponse* response) override;

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -1,8 +1,14 @@
 def is_output_parameter(parameter):
-    return "out" in parameter["direction"]
+  return "out" in parameter["direction"]
 
 def is_input_parameter(parameter):
-    return "in" in parameter["direction"]
+  return "in" in parameter["direction"]
+
+def is_pass_null_parameter(parameter):
+  return "pass_null" in parameter["direction"]
+
+def is_pointer_parameter(parameter):
+  return is_output_parameter(parameter) or is_pass_null_parameter(parameter)
 
 def is_array(dataType):
   return dataType.endswith("[]")

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -5,7 +5,7 @@ def is_input_parameter(parameter):
   return "in" in parameter["direction"]
 
 def is_pass_null_parameter(parameter):
-  return "pass_null" in parameter["direction"]
+  return parameter.get('pass_null', False)
 
 def is_pointer_parameter(parameter):
   return is_output_parameter(parameter) or is_pass_null_parameter(parameter)

--- a/source/codegen/metadata/nidaqmx/config.py
+++ b/source/codegen/metadata/nidaqmx/config.py
@@ -14,7 +14,10 @@ config = {
         'TaskHandle': 'nidevice_grpc.Session',
         'const char[]': 'string',
         'float64': 'double',
-        'int': 'int32'
+        'float64[]': 'repeated double',
+        'int32': 'int32',
+        'uInt32': 'uint32',
+        'bool32': 'bool'
     },
     'driver_name': 'NI-DAQMX',
     'extra_errors_used': [

--- a/source/codegen/metadata/nidaqmx/enums.py
+++ b/source/codegen/metadata/nidaqmx/enums.py
@@ -1,13 +1,12 @@
 enums = {
     'GroupBy': {
-        'name': 'GroupBy',
         'values': [
             {
-                'name': 'GroupByChannel',
+                'name': 'GROUP_BY_CHANNEL',
                 'value': 0
             },
             {
-                'name': 'GroupByScanNumber',
+                'name': 'GROUP_BY_SCAN_NUMBER',
                 'value': 1
             }
         ]

--- a/source/codegen/metadata/nidaqmx/enums.py
+++ b/source/codegen/metadata/nidaqmx/enums.py
@@ -1,4 +1,17 @@
 enums = {
+    'GroupBy': {
+        'name': 'GroupBy',
+        'values': [
+            {
+                'name': 'GroupByChannel',
+                'value': 0
+            },
+            {
+                'name': 'GroupByScanNumber',
+                'value': 1
+            }
+        ]
+    },
     'InputTermCfgWithDefault': {
         'values': [
             {

--- a/source/codegen/metadata/nidaqmx/functions.py
+++ b/source/codegen/metadata/nidaqmx/functions.py
@@ -168,8 +168,10 @@ functions = {
                 'type': 'int32'
             },
             {
-                'direction': 'pass_null',
+                'direction': 'in',
+                'include_in_proto': False,
                 'name': 'reserved',
+                'pass_null': True,
                 'type': 'bool32',
             }
         ],

--- a/source/codegen/metadata/nidaqmx/functions.py
+++ b/source/codegen/metadata/nidaqmx/functions.py
@@ -30,7 +30,7 @@ functions = {
                 'direction': 'in',
                 'enum': 'InputTermCfgWithDefault',
                 'name': 'terminalConfig',
-                'type': 'int'
+                'type': 'int32'
             },
             {
                 'direction': 'in',
@@ -46,7 +46,7 @@ functions = {
                 'direction': 'in',
                 'enum': 'VoltageUnits2',
                 'name': 'units',
-                'type': 'int'
+                'type': 'int32'
             },
             {
                 'direction': 'in',
@@ -77,7 +77,7 @@ functions = {
                 'direction': 'in',
                 'enum': 'LineGrouping',
                 'name': 'lineGrouping',
-                'type': 'int'
+                'type': 'int32'
             }
         ],
         'returns': 'int32'
@@ -103,7 +103,7 @@ functions = {
                 'direction': 'in',
                 'enum': 'LineGrouping',
                 'name': 'lineGrouping',
-                'type': 'int'
+                'type': 'int32'
             }
         ],
         'returns': 'int32'
@@ -121,6 +121,56 @@ functions = {
                 'direction': 'out',
                 'name': 'task',
                 'type': 'TaskHandle'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'ReadAnalogF64': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'task',
+                'type': 'TaskHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'numSampsPerChan',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'name': 'timeout',
+                'type': 'float64'
+            },
+            {
+                'direction': 'in',
+                'enum': 'GroupBy',
+                'name': 'fillMode',
+                'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'name': 'readArray',
+                'size': {
+                    'mechanism': 'passed-in',
+                    'value': 'arraySizeInSamps'
+                },
+                'type': 'float64[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'arraySizeInSamps',
+                'type': 'uInt32'
+            },
+            {
+                'direction': 'out',
+                'name': 'sampsPerChanRead',
+                'type': 'int32'
+            },
+            {
+                'direction': 'pass_null',
+                'name': 'reserved',
+                'type': 'bool32',
             }
         ],
         'returns': 'int32'

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -183,8 +183,10 @@ functions = {
                 'type': 'ViSession'
             },
             {
-                'direction': 'pass_null',
+                'direction': 'in',
+                'include_in_proto': False,
                 'name': 'reserved',
+                'pass_null': True,
                 'type': 'ViBoolean'
             }
         ],

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -175,6 +175,21 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'CommandWithReservedParam': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'direction': 'pass_null',
+                'name': 'reserved',
+                'type': 'ViBoolean'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'DoubleAllTheNums': {
         'documentation': {
             'description': 'Test for buffer with converter'

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -21,6 +21,8 @@ def create_args(parameters):
         result = f'{result}{parameter_name}.data(), '
       elif parameter.get('is_size_param', False) and is_twist_mechanism:
         result = f'{result}{twist_value_name}, '
+      elif common_helpers.is_pass_null_parameter(parameter):
+        result = f'{result}nullptr, '
       else:
         if is_array and common_helpers.is_struct(parameter):
           parameter_name = parameter_name + ".data()"
@@ -73,7 +75,7 @@ def create_param(parameter):
     if common_helpers.is_array(type):
         array_size = get_array_param_size(parameter)
         return f'{type[:-2]} {name}[{array_size}]'
-    elif common_helpers.is_output_parameter(parameter):
+    elif common_helpers.is_pointer_parameter(parameter):
         return f'{type}* {name}'
     else:
         return f'{type} {name}'

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -21,8 +21,6 @@ def create_args(parameters):
         result = f'{result}{parameter_name}.data(), '
       elif parameter.get('is_size_param', False) and is_twist_mechanism:
         result = f'{result}{twist_value_name}, '
-      elif common_helpers.is_pass_null_parameter(parameter):
-        result = f'{result}nullptr, '
       else:
         if is_array and common_helpers.is_struct(parameter):
           parameter_name = parameter_name + ".data()"

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -201,7 +201,7 @@ ${initialize_standard_input_param(function_name, parameter)}\
 
 ## Initialize a 'pass_null' param.
 <%def name="initialize_pass_null_param(parameter)">\
-      auto ${parameter["name"]} = nullptr;\
+      auto ${common_helpers.camel_to_snake(parameter['cppName'])} = nullptr;\
 </%def>
 
 ## Initialize an input parameter for an API call.

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -122,6 +122,8 @@ ${initialize_input_param(function_name, parameter)}
 ${initialize_enum_input_param(function_name, parameter)}\
 % elif "determine_size_from" in parameter:
 ${initialize_len_input_param(parameter)}\
+% elif common_helpers.is_pass_null_parameter(parameter):
+${initialize_pass_null_param(parameter)}\
 % else:
 ${initialize_standard_input_param(function_name, parameter)}\
 % endif
@@ -195,6 +197,11 @@ ${initialize_standard_input_param(function_name, parameter)}\
   field_name = common_helpers.camel_to_snake(parameter["determine_size_from"])
 %>\
       ${parameter['type']} ${parameter_name} = request->${field_name}().size();\
+</%def>
+
+## Initialize a 'pass_null' param.
+<%def name="initialize_pass_null_param(parameter)">\
+      auto ${parameter["name"]} = nullptr;\
 </%def>
 
 ## Initialize an input parameter for an API call.

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -153,7 +153,7 @@ class NiDAQmxDriverApiTests : public Test {
     set_request_session_id(request);
     request.set_num_samps_per_chan(100);
     request.set_array_size_in_samps(100);
-    request.set_fill_mode(GroupBy::GROUP_BY_GroupByChannel);
+    request.set_fill_mode(GroupBy::GROUP_BY_GROUP_BY_CHANNEL);
     return stub()->ReadAnalogF64(&context, request, &response);
   }
 

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -8,7 +8,6 @@
 
 using namespace ::testing;
 using namespace nidaqmx_grpc;
-using namespace ::testing;
 using google::protobuf::uint32;
 
 namespace ni {
@@ -98,7 +97,7 @@ class NiDAQmxDriverApiTests : public Test {
     CreateAIVoltageChanRequest request;
     set_request_session_id(request);
     request.set_physical_channel("Dev1/ai0");
-    request.set_name_to_assign_to_channel("channel1");
+    request.set_name_to_assign_to_channel("ai0");
     request.set_terminal_config(InputTermCfgWithDefault::INPUT_TERM_CFG_WITH_DEFAULT_CFG_DEFAULT);
     request.set_min_val(min_val);
     request.set_max_val(max_val);

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -1,4 +1,5 @@
-#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>  // For EXPECT matchers.
 
 #include "device_server.h"
 #include "enumerate_devices.h"
@@ -7,11 +8,13 @@
 
 using namespace ::testing;
 using namespace nidaqmx_grpc;
+using namespace ::testing;
+using google::protobuf::uint32;
 
 namespace ni {
 namespace tests {
 namespace system {
-class NiDAQmxDriverApiTests : public ::testing::Test {
+class NiDAQmxDriverApiTests : public Test {
  protected:
   NiDAQmxDriverApiTests()
       : device_server_(DeviceServerInterface::Singleton()),
@@ -89,7 +92,7 @@ class NiDAQmxDriverApiTests : public ::testing::Test {
     return stub()->ClearTask(&context, request, &response);
   }
 
-  ::grpc::Status create_ai_voltage_chan(CreateAIVoltageChanResponse& response)
+  ::grpc::Status create_ai_voltage_chan(double min_val, double max_val, CreateAIVoltageChanResponse& response)
   {
     ::grpc::ClientContext context;
     CreateAIVoltageChanRequest request;
@@ -97,8 +100,8 @@ class NiDAQmxDriverApiTests : public ::testing::Test {
     request.set_physical_channel("Dev1/ai0");
     request.set_name_to_assign_to_channel("channel1");
     request.set_terminal_config(InputTermCfgWithDefault::INPUT_TERM_CFG_WITH_DEFAULT_CFG_DEFAULT);
-    request.set_min_val(-10.0);
-    request.set_max_val(10.0);
+    request.set_min_val(min_val);
+    request.set_max_val(max_val);
     request.set_units(VoltageUnits2::VOLTAGE_UNITS2_VOLTS);
     return stub()->CreateAIVoltageChan(&context, request, &response);
   }
@@ -141,6 +144,20 @@ class NiDAQmxDriverApiTests : public ::testing::Test {
     return stub()->StopTask(&context, request, &response);
   }
 
+  ::grpc::Status read_analog_f64(
+      int32 samps_per_chan,
+      uint32 array_size_in_samps,
+      ReadAnalogF64Response& response)
+  {
+    ::grpc::ClientContext context;
+    ReadAnalogF64Request request;
+    set_request_session_id(request);
+    request.set_num_samps_per_chan(100);
+    request.set_array_size_in_samps(100);
+    request.set_fill_mode(GroupBy::GROUP_BY_GroupByChannel);
+    return stub()->ReadAnalogF64(&context, request, &response);
+  }
+
   std::unique_ptr<NiDAQmx::Stub>& stub()
   {
     return nidaqmx_stub_;
@@ -167,7 +184,7 @@ class NiDAQmxDriverApiTests : public ::testing::Test {
 TEST_F(NiDAQmxDriverApiTests, CreateAIVoltageChannel_Succeeds)
 {
   CreateAIVoltageChanResponse response;
-  auto status = create_ai_voltage_chan(response);
+  auto status = create_ai_voltage_chan(-1.0, 1.0, response);
 
   EXPECT_SUCCESS(status, response);
 }
@@ -188,17 +205,25 @@ TEST_F(NiDAQmxDriverApiTests, CreateDOChannel_Succeeds)
   EXPECT_SUCCESS(status, response);
 }
 
-TEST_F(NiDAQmxDriverApiTests, AIVoltageChannel_StartTaskStopTask_Succeeds)
+TEST_F(NiDAQmxDriverApiTests, AIVoltageChannel_ReadAIData_ReturnsDataInExpectedRange)
 {
+  const double AI_MIN = 1.0;
+  const double AI_MAX = 10.0;
   CreateAIVoltageChanResponse create_channel_response;
-  create_ai_voltage_chan(create_channel_response);
+  create_ai_voltage_chan(AI_MIN, AI_MAX, create_channel_response);
 
   StartTaskResponse start_response;
   auto start_status = start_task(start_response);
+  ReadAnalogF64Response read_response;
+  auto read_status = read_analog_f64(100, 100, read_response);
   StopTaskResponse stop_response;
   auto stop_status = stop_task(stop_response);
 
+  EXPECT_EQ(read_response.read_array_size(), 100);
+  EXPECT_THAT(read_response.read_array(), Each(Not(Lt(AI_MIN))));
+  EXPECT_THAT(read_response.read_array(), Each(Not(Gt(AI_MAX))));
   EXPECT_SUCCESS(start_status, start_response);
+  EXPECT_SUCCESS(read_status, read_response);
   EXPECT_SUCCESS(stop_status, stop_response);
 }
 }  // namespace system

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -151,8 +151,8 @@ class NiDAQmxDriverApiTests : public Test {
     ::grpc::ClientContext context;
     ReadAnalogF64Request request;
     set_request_session_id(request);
-    request.set_num_samps_per_chan(100);
-    request.set_array_size_in_samps(100);
+    request.set_num_samps_per_chan(samps_per_chan);
+    request.set_array_size_in_samps(array_size_in_samps);
     request.set_fill_mode(GroupBy::GROUP_BY_GROUP_BY_CHANNEL);
     return stub()->ReadAnalogF64(&context, request, &response);
   }

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -1619,6 +1619,28 @@ TEST(NiFakeServiceTests, NiFakeExtensionService_CallMethodWithSesionStartedByNIF
   EXPECT_EQ(kDriverSuccess, response.status());
 }
 
+TEST(NiFakeServiceTests, NiFakeService_CallMethodWithReservedPassNullParam_PassesNull)
+{
+  nidevice_grpc::SessionRepository session_repository;
+  NiFakeMockLibrary library;
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  std::uint32_t session_id = create_session(library, service, kTestViSession);
+  EXPECT_CALL(library, CommandWithReservedParam(kTestViSession, nullptr))
+      .WillOnce(
+          DoAll(
+              Return(kDriverSuccess)));
+
+  ::grpc::ServerContext context;
+  nifake_grpc::CommandWithReservedParamRequest request;
+  request.mutable_vi()->set_id(session_id);
+  nifake_grpc::CommandWithReservedParamResponse response;
+  auto status = service.CommandWithReservedParam(&context, &request, &response);
+
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(kDriverSuccess, response.status());
+}
+
 }  // namespace unit
 }  // namespace tests
 }  // namespace ni


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds ReadAnalogF64 to DAQ service.

### Why should this Pull Request be merged?

Enables very basic analog acquisition in DAQ.

### What testing has been done?

Ran and passed all DAQ tests.