### PR TITLE
Adding a workflow to create AzDO bugs from 'Issues' created on the repo

### DIFF
--- a/.github/workflows/sync_github_issues_to_azdo.yml
+++ b/.github/workflows/sync_github_issues_to_azdo.yml
@@ -1,0 +1,24 @@
+name: Sync issue to Azure DevOps work item
+
+on:
+  issues:
+    types:
+      [opened, edited, deleted, closed, reopened, labeled, unlabeled, assigned]
+
+jobs:
+  alert:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: danhellem/github-actions-issue-to-work-item@master
+        env:
+          ado_token: "${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}"
+          github_token: "${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}"
+          ado_organization: "ni"
+          ado_project: "DevCentral"
+          ado_area_path: "DevCentral\Product RnD\SWP\CBS\HW Config"
+          ado_wit: "Bug"
+          ado_new_state: "New"
+          ado_active_state: "Active"
+          ado_close_state: "Closed"
+          ado_bypassrules: true
+          log_level: 100

--- a/.github/workflows/sync_github_issues_to_azdo.yml
+++ b/.github/workflows/sync_github_issues_to_azdo.yml
@@ -15,7 +15,7 @@ jobs:
           github_token: "${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}"
           ado_organization: "ni"
           ado_project: "DevCentral"
-          ado_area_path: "DevCentral\Product RnD\\SWP\\CBS\\HW Config"
+          ado_area_path: "DevCentral\\Product RnD\\SWP\\CBS\\HW Config"
           ado_wit: "Bug"
           ado_new_state: "New"
           ado_active_state: "Active"

--- a/.github/workflows/sync_github_issues_to_azdo.yml
+++ b/.github/workflows/sync_github_issues_to_azdo.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
       - uses: danhellem/github-actions-issue-to-work-item@master
         env:
-          ado_token: "${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}"
-          github_token: "${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}"
+          ado_token: "${{ secrets.AZDO_Work_Item_Token }}"
+          github_token: "${{ secrets.GH_REPO_TOKEN }}"
           ado_organization: "ni"
           ado_project: "DevCentral"
           ado_area_path: "DevCentral\\Product RnD\\SWP\\CBS\\HW Config"

--- a/.github/workflows/sync_github_issues_to_azdo.yml
+++ b/.github/workflows/sync_github_issues_to_azdo.yml
@@ -15,7 +15,7 @@ jobs:
           github_token: "${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}"
           ado_organization: "ni"
           ado_project: "DevCentral"
-          ado_area_path: "DevCentral\Product RnD\SWP\CBS\HW Config"
+          ado_area_path: "DevCentral\Product RnD\\SWP\\CBS\\HW Config"
           ado_wit: "Bug"
           ado_new_state: "New"
           ado_active_state: "Active"


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR enables creation of bugs on AzDO (in the appropriate area path) when an issue on the grpc-device github repo is created.
A workflow was created using the steps outlined in this video: https://www.youtube.com/watch?v=I9ItftRT9dU
Using the yml script provided here: https://github.com/marketplace/actions/github-issues-to-azure-devops

(note: the other way - syncing any changes on AzDO back to github will not be done.)

### Why should this Pull Request be merged?

This avoids the below manual efforts:
1. Tracking issues opened on the grpc-device repo
2. Creating corresponding AzDO bugs so that they show up on domain dashboard & can be discussed during standups
3. Closing bugs after fixing the issue

### What testing has been done?
Unable to test this on the branch. Once merged, need to manually test the below scenarios:
Creating an  issue on github creates a bug in AzDO in the right project area path
Closing an issue on github closes the bug in AzDO
