### PR TITLE
Add DAQ Task Control and Configuration methods

### DIFF
--- a/generated/nidaqmx/nidaqmx.proto
+++ b/generated/nidaqmx/nidaqmx.proto
@@ -16,17 +16,22 @@ package nidaqmx_grpc;
 import "session.proto";
 
 service NiDAQmx {
+  rpc AddGlobalChansToTask(AddGlobalChansToTaskRequest) returns (AddGlobalChansToTaskResponse);
   rpc ClearTask(ClearTaskRequest) returns (ClearTaskResponse);
   rpc CreateAIVoltageChan(CreateAIVoltageChanRequest) returns (CreateAIVoltageChanResponse);
   rpc CreateAOVoltageChan(CreateAOVoltageChanRequest) returns (CreateAOVoltageChanResponse);
   rpc CreateDIChan(CreateDIChanRequest) returns (CreateDIChanResponse);
   rpc CreateDOChan(CreateDOChanRequest) returns (CreateDOChanResponse);
   rpc CreateTask(CreateTaskRequest) returns (CreateTaskResponse);
+  rpc GetNthTaskChannel(GetNthTaskChannelRequest) returns (GetNthTaskChannelResponse);
+  rpc GetNthTaskDevice(GetNthTaskDeviceRequest) returns (GetNthTaskDeviceResponse);
+  rpc IsTaskDone(IsTaskDoneRequest) returns (IsTaskDoneResponse);
   rpc ReadAnalogF64(ReadAnalogF64Request) returns (ReadAnalogF64Response);
   rpc ReadDigitalU16(ReadDigitalU16Request) returns (ReadDigitalU16Response);
   rpc ReadDigitalU8(ReadDigitalU8Request) returns (ReadDigitalU8Response);
   rpc StartTask(StartTaskRequest) returns (StartTaskResponse);
   rpc StopTask(StopTaskRequest) returns (StopTaskResponse);
+  rpc WaitUntilTaskDone(WaitUntilTaskDoneRequest) returns (WaitUntilTaskDoneResponse);
   rpc WriteAnalogF64(WriteAnalogF64Request) returns (WriteAnalogF64Response);
   rpc WriteDigitalU16(WriteDigitalU16Request) returns (WriteDigitalU16Response);
   rpc WriteDigitalU8(WriteDigitalU8Request) returns (WriteDigitalU8Response);
@@ -63,6 +68,15 @@ enum VoltageUnits2 {
   VOLTAGE_UNITS2_UNSPECIFIED = 0;
   VOLTAGE_UNITS2_VOLTS = 10348;
   VOLTAGE_UNITS2_FROM_CUSTOM_SCALE = 10065;
+}
+
+message AddGlobalChansToTaskRequest {
+  nidevice_grpc.Session task = 1;
+  string channel_names = 2;
+}
+
+message AddGlobalChansToTaskResponse {
+  int32 status = 1;
 }
 
 message ClearTaskRequest {
@@ -148,6 +162,37 @@ message CreateTaskResponse {
   nidevice_grpc.Session task = 2;
 }
 
+message GetNthTaskChannelRequest {
+  nidevice_grpc.Session task = 1;
+  uint32 index = 2;
+  int32 buffer_size = 3;
+}
+
+message GetNthTaskChannelResponse {
+  int32 status = 1;
+  string buffer = 2;
+}
+
+message GetNthTaskDeviceRequest {
+  nidevice_grpc.Session task = 1;
+  uint32 index = 2;
+  int32 buffer_size = 3;
+}
+
+message GetNthTaskDeviceResponse {
+  int32 status = 1;
+  string buffer = 2;
+}
+
+message IsTaskDoneRequest {
+  nidevice_grpc.Session task = 1;
+}
+
+message IsTaskDoneResponse {
+  int32 status = 1;
+  bool is_task_done = 2;
+}
+
 message ReadAnalogF64Request {
   nidevice_grpc.Session task = 1;
   int32 num_samps_per_chan = 2;
@@ -212,6 +257,15 @@ message StopTaskRequest {
 }
 
 message StopTaskResponse {
+  int32 status = 1;
+}
+
+message WaitUntilTaskDoneRequest {
+  nidevice_grpc.Session task = 1;
+  double time_to_wait = 2;
+}
+
+message WaitUntilTaskDoneResponse {
   int32 status = 1;
 }
 

--- a/generated/nidaqmx/nidaqmx.proto
+++ b/generated/nidaqmx/nidaqmx.proto
@@ -31,6 +31,7 @@ service NiDAQmx {
   rpc ReadDigitalU8(ReadDigitalU8Request) returns (ReadDigitalU8Response);
   rpc StartTask(StartTaskRequest) returns (StartTaskResponse);
   rpc StopTask(StopTaskRequest) returns (StopTaskResponse);
+  rpc TaskControl(TaskControlRequest) returns (TaskControlResponse);
   rpc WaitUntilTaskDone(WaitUntilTaskDoneRequest) returns (WaitUntilTaskDoneResponse);
   rpc WriteAnalogF64(WriteAnalogF64Request) returns (WriteAnalogF64Response);
   rpc WriteDigitalU16(WriteDigitalU16Request) returns (WriteDigitalU16Response);
@@ -62,6 +63,18 @@ enum LineGrouping {
   LINE_GROUPING_UNSPECIFIED = 0;
   LINE_GROUPING_CHAN_FOR_ALL_LINES = 1;
   LINE_GROUPING_CHAN_PER_LINE = 0;
+}
+
+enum TaskControlAction {
+  option allow_alias = true;
+  TASK_CONTROL_ACTION_UNSPECIFIED = 0;
+  TASK_CONTROL_ACTION_TASK_START = 0;
+  TASK_CONTROL_ACTION_TASK_STOP = 1;
+  TASK_CONTROL_ACTION_TASK_VERIFY = 2;
+  TASK_CONTROL_ACTION_TASK_COMMIT = 3;
+  TASK_CONTROL_ACTION_TASK_RESERVE = 4;
+  TASK_CONTROL_ACTION_TASK_UNRESERVE = 5;
+  TASK_CONTROL_ACTION_TASK_ABORT = 6;
 }
 
 enum VoltageUnits2 {
@@ -257,6 +270,18 @@ message StopTaskRequest {
 }
 
 message StopTaskResponse {
+  int32 status = 1;
+}
+
+message TaskControlRequest {
+  nidevice_grpc.Session task = 1;
+  oneof action_enum {
+    TaskControlAction action = 2;
+    int32 action_raw = 3;
+  }
+}
+
+message TaskControlResponse {
   int32 status = 1;
 }
 

--- a/generated/nidaqmx/nidaqmx.proto
+++ b/generated/nidaqmx/nidaqmx.proto
@@ -237,7 +237,7 @@ message ReadDigitalU16Request {
 message ReadDigitalU16Response {
   int32 status = 1;
   repeated uint32 read_array = 2;
-  int32 samps_per_chan = 3;
+  int32 samps_per_chan_read = 3;
 }
 
 message ReadDigitalU8Request {
@@ -314,10 +314,13 @@ message WriteAnalogF64Response {
 message WriteDigitalU16Request {
   nidevice_grpc.Session task = 1;
   int32 num_samps_per_chan = 2;
-  int32 auto_start = 3;
+  bool auto_start = 3;
   double timeout = 4;
-  int32 data_layout = 5;
-  repeated uint32 write_array = 6;
+  oneof data_layout_enum {
+    GroupBy data_layout = 5;
+    int32 data_layout_raw = 6;
+  }
+  repeated uint32 write_array = 7;
 }
 
 message WriteDigitalU16Response {

--- a/generated/nidaqmx/nidaqmx_library.cpp
+++ b/generated/nidaqmx/nidaqmx_library.cpp
@@ -36,6 +36,7 @@ NiDAQmxLibrary::NiDAQmxLibrary() : shared_library_(kLibraryName)
   function_pointers_.ReadDigitalU8 = reinterpret_cast<ReadDigitalU8Ptr>(shared_library_.get_function_pointer("DAQmxReadDigitalU8"));
   function_pointers_.StartTask = reinterpret_cast<StartTaskPtr>(shared_library_.get_function_pointer("DAQmxStartTask"));
   function_pointers_.StopTask = reinterpret_cast<StopTaskPtr>(shared_library_.get_function_pointer("DAQmxStopTask"));
+  function_pointers_.TaskControl = reinterpret_cast<TaskControlPtr>(shared_library_.get_function_pointer("DAQmxTaskControl"));
   function_pointers_.WaitUntilTaskDone = reinterpret_cast<WaitUntilTaskDonePtr>(shared_library_.get_function_pointer("DAQmxWaitUntilTaskDone"));
   function_pointers_.WriteAnalogF64 = reinterpret_cast<WriteAnalogF64Ptr>(shared_library_.get_function_pointer("DAQmxWriteAnalogF64"));
   function_pointers_.WriteDigitalU16 = reinterpret_cast<WriteDigitalU16Ptr>(shared_library_.get_function_pointer("DAQmxWriteDigitalU16"));
@@ -230,6 +231,18 @@ int32 NiDAQmxLibrary::StopTask(TaskHandle task)
   return DAQmxStopTask(task);
 #else
   return function_pointers_.StopTask(task);
+#endif
+}
+
+int32 NiDAQmxLibrary::TaskControl(TaskHandle task, int32 action)
+{
+  if (!function_pointers_.TaskControl) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxTaskControl.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxTaskControl(task, action);
+#else
+  return function_pointers_.TaskControl(task, action);
 #endif
 }
 

--- a/generated/nidaqmx/nidaqmx_library.cpp
+++ b/generated/nidaqmx/nidaqmx_library.cpp
@@ -186,15 +186,15 @@ int32 NiDAQmxLibrary::ReadAnalogF64(TaskHandle task, int32 numSampsPerChan, floa
 #endif
 }
 
-int32 NiDAQmxLibrary::ReadDigitalU16(TaskHandle task, int32 numSampsPerChan, double timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChan, bool32* reserved)
+int32 NiDAQmxLibrary::ReadDigitalU16(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved)
 {
   if (!function_pointers_.ReadDigitalU16) {
     throw nidevice_grpc::LibraryLoadException("Could not find DAQmxReadDigitalU16.");
   }
 #if defined(_MSC_VER)
-  return DAQmxReadDigitalU16(task, numSampsPerChan, timeout, fillMode, readArray, arraySizeInSamps, sampsPerChan, reserved);
+  return DAQmxReadDigitalU16(task, numSampsPerChan, timeout, fillMode, readArray, arraySizeInSamps, sampsPerChanRead, reserved);
 #else
-  return function_pointers_.ReadDigitalU16(task, numSampsPerChan, timeout, fillMode, readArray, arraySizeInSamps, sampsPerChan, reserved);
+  return function_pointers_.ReadDigitalU16(task, numSampsPerChan, timeout, fillMode, readArray, arraySizeInSamps, sampsPerChanRead, reserved);
 #endif
 }
 
@@ -270,7 +270,7 @@ int32 NiDAQmxLibrary::WriteAnalogF64(TaskHandle task, int32 numSampsPerChan, boo
 #endif
 }
 
-int32 NiDAQmxLibrary::WriteDigitalU16(TaskHandle task, int32 numSampsPerChan, int32 autoStart, double timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved)
+int32 NiDAQmxLibrary::WriteDigitalU16(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved)
 {
   if (!function_pointers_.WriteDigitalU16) {
     throw nidevice_grpc::LibraryLoadException("Could not find DAQmxWriteDigitalU16.");

--- a/generated/nidaqmx/nidaqmx_library.cpp
+++ b/generated/nidaqmx/nidaqmx_library.cpp
@@ -21,17 +21,22 @@ NiDAQmxLibrary::NiDAQmxLibrary() : shared_library_(kLibraryName)
   if (!loaded) {
     return;
   }
+  function_pointers_.AddGlobalChansToTask = reinterpret_cast<AddGlobalChansToTaskPtr>(shared_library_.get_function_pointer("DAQmxAddGlobalChansToTask"));
   function_pointers_.ClearTask = reinterpret_cast<ClearTaskPtr>(shared_library_.get_function_pointer("DAQmxClearTask"));
   function_pointers_.CreateAIVoltageChan = reinterpret_cast<CreateAIVoltageChanPtr>(shared_library_.get_function_pointer("DAQmxCreateAIVoltageChan"));
   function_pointers_.CreateAOVoltageChan = reinterpret_cast<CreateAOVoltageChanPtr>(shared_library_.get_function_pointer("DAQmxCreateAOVoltageChan"));
   function_pointers_.CreateDIChan = reinterpret_cast<CreateDIChanPtr>(shared_library_.get_function_pointer("DAQmxCreateDIChan"));
   function_pointers_.CreateDOChan = reinterpret_cast<CreateDOChanPtr>(shared_library_.get_function_pointer("DAQmxCreateDOChan"));
   function_pointers_.CreateTask = reinterpret_cast<CreateTaskPtr>(shared_library_.get_function_pointer("DAQmxCreateTask"));
+  function_pointers_.GetNthTaskChannel = reinterpret_cast<GetNthTaskChannelPtr>(shared_library_.get_function_pointer("DAQmxGetNthTaskChannel"));
+  function_pointers_.GetNthTaskDevice = reinterpret_cast<GetNthTaskDevicePtr>(shared_library_.get_function_pointer("DAQmxGetNthTaskDevice"));
+  function_pointers_.IsTaskDone = reinterpret_cast<IsTaskDonePtr>(shared_library_.get_function_pointer("DAQmxIsTaskDone"));
   function_pointers_.ReadAnalogF64 = reinterpret_cast<ReadAnalogF64Ptr>(shared_library_.get_function_pointer("DAQmxReadAnalogF64"));
   function_pointers_.ReadDigitalU16 = reinterpret_cast<ReadDigitalU16Ptr>(shared_library_.get_function_pointer("DAQmxReadDigitalU16"));
   function_pointers_.ReadDigitalU8 = reinterpret_cast<ReadDigitalU8Ptr>(shared_library_.get_function_pointer("DAQmxReadDigitalU8"));
   function_pointers_.StartTask = reinterpret_cast<StartTaskPtr>(shared_library_.get_function_pointer("DAQmxStartTask"));
   function_pointers_.StopTask = reinterpret_cast<StopTaskPtr>(shared_library_.get_function_pointer("DAQmxStopTask"));
+  function_pointers_.WaitUntilTaskDone = reinterpret_cast<WaitUntilTaskDonePtr>(shared_library_.get_function_pointer("DAQmxWaitUntilTaskDone"));
   function_pointers_.WriteAnalogF64 = reinterpret_cast<WriteAnalogF64Ptr>(shared_library_.get_function_pointer("DAQmxWriteAnalogF64"));
   function_pointers_.WriteDigitalU16 = reinterpret_cast<WriteDigitalU16Ptr>(shared_library_.get_function_pointer("DAQmxWriteDigitalU16"));
   function_pointers_.WriteDigitalU8 = reinterpret_cast<WriteDigitalU8Ptr>(shared_library_.get_function_pointer("DAQmxWriteDigitalU8"));
@@ -46,6 +51,18 @@ NiDAQmxLibrary::~NiDAQmxLibrary()
   return shared_library_.function_exists(functionName.c_str())
     ? ::grpc::Status::OK
     : ::grpc::Status(::grpc::NOT_FOUND, "Could not find the function " + functionName);
+}
+
+int32 NiDAQmxLibrary::AddGlobalChansToTask(TaskHandle task, const char channelNames[])
+{
+  if (!function_pointers_.AddGlobalChansToTask) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxAddGlobalChansToTask.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxAddGlobalChansToTask(task, channelNames);
+#else
+  return function_pointers_.AddGlobalChansToTask(task, channelNames);
+#endif
 }
 
 int32 NiDAQmxLibrary::ClearTask(TaskHandle task)
@@ -120,6 +137,42 @@ int32 NiDAQmxLibrary::CreateTask(const char sessionName[], TaskHandle* task)
 #endif
 }
 
+int32 NiDAQmxLibrary::GetNthTaskChannel(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize)
+{
+  if (!function_pointers_.GetNthTaskChannel) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxGetNthTaskChannel.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxGetNthTaskChannel(task, index, buffer, bufferSize);
+#else
+  return function_pointers_.GetNthTaskChannel(task, index, buffer, bufferSize);
+#endif
+}
+
+int32 NiDAQmxLibrary::GetNthTaskDevice(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize)
+{
+  if (!function_pointers_.GetNthTaskDevice) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxGetNthTaskDevice.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxGetNthTaskDevice(task, index, buffer, bufferSize);
+#else
+  return function_pointers_.GetNthTaskDevice(task, index, buffer, bufferSize);
+#endif
+}
+
+int32 NiDAQmxLibrary::IsTaskDone(TaskHandle task, bool32* isTaskDone)
+{
+  if (!function_pointers_.IsTaskDone) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxIsTaskDone.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxIsTaskDone(task, isTaskDone);
+#else
+  return function_pointers_.IsTaskDone(task, isTaskDone);
+#endif
+}
+
 int32 NiDAQmxLibrary::ReadAnalogF64(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, float64 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved)
 {
   if (!function_pointers_.ReadAnalogF64) {
@@ -177,6 +230,18 @@ int32 NiDAQmxLibrary::StopTask(TaskHandle task)
   return DAQmxStopTask(task);
 #else
   return function_pointers_.StopTask(task);
+#endif
+}
+
+int32 NiDAQmxLibrary::WaitUntilTaskDone(TaskHandle task, float64 timeToWait)
+{
+  if (!function_pointers_.WaitUntilTaskDone) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxWaitUntilTaskDone.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxWaitUntilTaskDone(task, timeToWait);
+#else
+  return function_pointers_.WaitUntilTaskDone(task, timeToWait);
 #endif
 }
 

--- a/generated/nidaqmx/nidaqmx_library.h
+++ b/generated/nidaqmx/nidaqmx_library.h
@@ -29,14 +29,14 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   int32 GetNthTaskDevice(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize);
   int32 IsTaskDone(TaskHandle task, bool32* isTaskDone);
   int32 ReadAnalogF64(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, float64 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
-  int32 ReadDigitalU16(TaskHandle task, int32 numSampsPerChan, double timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChan, bool32* reserved);
+  int32 ReadDigitalU16(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
   int32 ReadDigitalU8(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
   int32 StartTask(TaskHandle task);
   int32 StopTask(TaskHandle task);
   int32 TaskControl(TaskHandle task, int32 action);
   int32 WaitUntilTaskDone(TaskHandle task, float64 timeToWait);
   int32 WriteAnalogF64(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const float64 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
-  int32 WriteDigitalU16(TaskHandle task, int32 numSampsPerChan, int32 autoStart, double timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
+  int32 WriteDigitalU16(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
   int32 WriteDigitalU8(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
 
  private:
@@ -51,14 +51,14 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   using GetNthTaskDevicePtr = int32 (*)(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize);
   using IsTaskDonePtr = int32 (*)(TaskHandle task, bool32* isTaskDone);
   using ReadAnalogF64Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, float64 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
-  using ReadDigitalU16Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, double timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChan, bool32* reserved);
+  using ReadDigitalU16Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
   using ReadDigitalU8Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
   using StartTaskPtr = int32 (*)(TaskHandle task);
   using StopTaskPtr = int32 (*)(TaskHandle task);
   using TaskControlPtr = int32 (*)(TaskHandle task, int32 action);
   using WaitUntilTaskDonePtr = int32 (*)(TaskHandle task, float64 timeToWait);
   using WriteAnalogF64Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const float64 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
-  using WriteDigitalU16Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, int32 autoStart, double timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
+  using WriteDigitalU16Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
   using WriteDigitalU8Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
 
   typedef struct FunctionPointers {

--- a/generated/nidaqmx/nidaqmx_library.h
+++ b/generated/nidaqmx/nidaqmx_library.h
@@ -18,49 +18,64 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   virtual ~NiDAQmxLibrary();
 
   ::grpc::Status check_function_exists(std::string functionName);
+  int32 AddGlobalChansToTask(TaskHandle task, const char channelNames[]);
   int32 ClearTask(TaskHandle task);
   int32 CreateAIVoltageChan(TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], int32 terminalConfig, float64 minVal, float64 maxVal, int32 units, const char customScaleName[]);
   int32 CreateAOVoltageChan(TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], float64 minVal, float64 maxVal, int32 units, const char customScaleName[]);
   int32 CreateDIChan(TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping);
   int32 CreateDOChan(TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping);
   int32 CreateTask(const char sessionName[], TaskHandle* task);
+  int32 GetNthTaskChannel(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize);
+  int32 GetNthTaskDevice(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize);
+  int32 IsTaskDone(TaskHandle task, bool32* isTaskDone);
   int32 ReadAnalogF64(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, float64 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
   int32 ReadDigitalU16(TaskHandle task, int32 numSampsPerChan, double timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChan, bool32* reserved);
   int32 ReadDigitalU8(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
   int32 StartTask(TaskHandle task);
   int32 StopTask(TaskHandle task);
+  int32 WaitUntilTaskDone(TaskHandle task, float64 timeToWait);
   int32 WriteAnalogF64(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const float64 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
   int32 WriteDigitalU16(TaskHandle task, int32 numSampsPerChan, int32 autoStart, double timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
   int32 WriteDigitalU8(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
 
  private:
+  using AddGlobalChansToTaskPtr = int32 (*)(TaskHandle task, const char channelNames[]);
   using ClearTaskPtr = int32 (*)(TaskHandle task);
   using CreateAIVoltageChanPtr = int32 (*)(TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], int32 terminalConfig, float64 minVal, float64 maxVal, int32 units, const char customScaleName[]);
   using CreateAOVoltageChanPtr = int32 (*)(TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], float64 minVal, float64 maxVal, int32 units, const char customScaleName[]);
   using CreateDIChanPtr = int32 (*)(TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping);
   using CreateDOChanPtr = int32 (*)(TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping);
   using CreateTaskPtr = int32 (*)(const char sessionName[], TaskHandle* task);
+  using GetNthTaskChannelPtr = int32 (*)(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize);
+  using GetNthTaskDevicePtr = int32 (*)(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize);
+  using IsTaskDonePtr = int32 (*)(TaskHandle task, bool32* isTaskDone);
   using ReadAnalogF64Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, float64 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
   using ReadDigitalU16Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, double timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChan, bool32* reserved);
   using ReadDigitalU8Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
   using StartTaskPtr = int32 (*)(TaskHandle task);
   using StopTaskPtr = int32 (*)(TaskHandle task);
+  using WaitUntilTaskDonePtr = int32 (*)(TaskHandle task, float64 timeToWait);
   using WriteAnalogF64Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const float64 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
   using WriteDigitalU16Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, int32 autoStart, double timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
   using WriteDigitalU8Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
 
   typedef struct FunctionPointers {
+    AddGlobalChansToTaskPtr AddGlobalChansToTask;
     ClearTaskPtr ClearTask;
     CreateAIVoltageChanPtr CreateAIVoltageChan;
     CreateAOVoltageChanPtr CreateAOVoltageChan;
     CreateDIChanPtr CreateDIChan;
     CreateDOChanPtr CreateDOChan;
     CreateTaskPtr CreateTask;
+    GetNthTaskChannelPtr GetNthTaskChannel;
+    GetNthTaskDevicePtr GetNthTaskDevice;
+    IsTaskDonePtr IsTaskDone;
     ReadAnalogF64Ptr ReadAnalogF64;
     ReadDigitalU16Ptr ReadDigitalU16;
     ReadDigitalU8Ptr ReadDigitalU8;
     StartTaskPtr StartTask;
     StopTaskPtr StopTask;
+    WaitUntilTaskDonePtr WaitUntilTaskDone;
     WriteAnalogF64Ptr WriteAnalogF64;
     WriteDigitalU16Ptr WriteDigitalU16;
     WriteDigitalU8Ptr WriteDigitalU8;

--- a/generated/nidaqmx/nidaqmx_library.h
+++ b/generated/nidaqmx/nidaqmx_library.h
@@ -33,6 +33,7 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   int32 ReadDigitalU8(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
   int32 StartTask(TaskHandle task);
   int32 StopTask(TaskHandle task);
+  int32 TaskControl(TaskHandle task, int32 action);
   int32 WaitUntilTaskDone(TaskHandle task, float64 timeToWait);
   int32 WriteAnalogF64(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const float64 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
   int32 WriteDigitalU16(TaskHandle task, int32 numSampsPerChan, int32 autoStart, double timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
@@ -54,6 +55,7 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   using ReadDigitalU8Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved);
   using StartTaskPtr = int32 (*)(TaskHandle task);
   using StopTaskPtr = int32 (*)(TaskHandle task);
+  using TaskControlPtr = int32 (*)(TaskHandle task, int32 action);
   using WaitUntilTaskDonePtr = int32 (*)(TaskHandle task, float64 timeToWait);
   using WriteAnalogF64Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const float64 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
   using WriteDigitalU16Ptr = int32 (*)(TaskHandle task, int32 numSampsPerChan, int32 autoStart, double timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
@@ -75,6 +77,7 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
     ReadDigitalU8Ptr ReadDigitalU8;
     StartTaskPtr StartTask;
     StopTaskPtr StopTask;
+    TaskControlPtr TaskControl;
     WaitUntilTaskDonePtr WaitUntilTaskDone;
     WriteAnalogF64Ptr WriteAnalogF64;
     WriteDigitalU16Ptr WriteDigitalU16;

--- a/generated/nidaqmx/nidaqmx_library_interface.h
+++ b/generated/nidaqmx/nidaqmx_library_interface.h
@@ -30,6 +30,7 @@ class NiDAQmxLibraryInterface {
   virtual int32 ReadDigitalU8(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved) = 0;
   virtual int32 StartTask(TaskHandle task) = 0;
   virtual int32 StopTask(TaskHandle task) = 0;
+  virtual int32 TaskControl(TaskHandle task, int32 action) = 0;
   virtual int32 WaitUntilTaskDone(TaskHandle task, float64 timeToWait) = 0;
   virtual int32 WriteAnalogF64(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const float64 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;
   virtual int32 WriteDigitalU16(TaskHandle task, int32 numSampsPerChan, int32 autoStart, double timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;

--- a/generated/nidaqmx/nidaqmx_library_interface.h
+++ b/generated/nidaqmx/nidaqmx_library_interface.h
@@ -15,17 +15,22 @@ class NiDAQmxLibraryInterface {
  public:
   virtual ~NiDAQmxLibraryInterface() {}
 
+  virtual int32 AddGlobalChansToTask(TaskHandle task, const char channelNames[]) = 0;
   virtual int32 ClearTask(TaskHandle task) = 0;
   virtual int32 CreateAIVoltageChan(TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], int32 terminalConfig, float64 minVal, float64 maxVal, int32 units, const char customScaleName[]) = 0;
   virtual int32 CreateAOVoltageChan(TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], float64 minVal, float64 maxVal, int32 units, const char customScaleName[]) = 0;
   virtual int32 CreateDIChan(TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping) = 0;
   virtual int32 CreateDOChan(TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping) = 0;
   virtual int32 CreateTask(const char sessionName[], TaskHandle* task) = 0;
+  virtual int32 GetNthTaskChannel(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize) = 0;
+  virtual int32 GetNthTaskDevice(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize) = 0;
+  virtual int32 IsTaskDone(TaskHandle task, bool32* isTaskDone) = 0;
   virtual int32 ReadAnalogF64(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, float64 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved) = 0;
   virtual int32 ReadDigitalU16(TaskHandle task, int32 numSampsPerChan, double timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChan, bool32* reserved) = 0;
   virtual int32 ReadDigitalU8(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved) = 0;
   virtual int32 StartTask(TaskHandle task) = 0;
   virtual int32 StopTask(TaskHandle task) = 0;
+  virtual int32 WaitUntilTaskDone(TaskHandle task, float64 timeToWait) = 0;
   virtual int32 WriteAnalogF64(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const float64 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;
   virtual int32 WriteDigitalU16(TaskHandle task, int32 numSampsPerChan, int32 autoStart, double timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;
   virtual int32 WriteDigitalU8(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;

--- a/generated/nidaqmx/nidaqmx_library_interface.h
+++ b/generated/nidaqmx/nidaqmx_library_interface.h
@@ -26,14 +26,14 @@ class NiDAQmxLibraryInterface {
   virtual int32 GetNthTaskDevice(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize) = 0;
   virtual int32 IsTaskDone(TaskHandle task, bool32* isTaskDone) = 0;
   virtual int32 ReadAnalogF64(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, float64 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved) = 0;
-  virtual int32 ReadDigitalU16(TaskHandle task, int32 numSampsPerChan, double timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChan, bool32* reserved) = 0;
+  virtual int32 ReadDigitalU16(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved) = 0;
   virtual int32 ReadDigitalU8(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved) = 0;
   virtual int32 StartTask(TaskHandle task) = 0;
   virtual int32 StopTask(TaskHandle task) = 0;
   virtual int32 TaskControl(TaskHandle task, int32 action) = 0;
   virtual int32 WaitUntilTaskDone(TaskHandle task, float64 timeToWait) = 0;
   virtual int32 WriteAnalogF64(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const float64 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;
-  virtual int32 WriteDigitalU16(TaskHandle task, int32 numSampsPerChan, int32 autoStart, double timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;
+  virtual int32 WriteDigitalU16(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;
   virtual int32 WriteDigitalU8(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;
 };
 

--- a/generated/nidaqmx/nidaqmx_mock_library.h
+++ b/generated/nidaqmx/nidaqmx_mock_library.h
@@ -32,6 +32,7 @@ class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   MOCK_METHOD(int32, ReadDigitalU8, (TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved), (override));
   MOCK_METHOD(int32, StartTask, (TaskHandle task), (override));
   MOCK_METHOD(int32, StopTask, (TaskHandle task), (override));
+  MOCK_METHOD(int32, TaskControl, (TaskHandle task, int32 action), (override));
   MOCK_METHOD(int32, WaitUntilTaskDone, (TaskHandle task, float64 timeToWait), (override));
   MOCK_METHOD(int32, WriteAnalogF64, (TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const float64 writeArray[], int32* sampsPerChanWritten, bool32* reserved), (override));
   MOCK_METHOD(int32, WriteDigitalU16, (TaskHandle task, int32 numSampsPerChan, int32 autoStart, double timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved), (override));

--- a/generated/nidaqmx/nidaqmx_mock_library.h
+++ b/generated/nidaqmx/nidaqmx_mock_library.h
@@ -28,14 +28,14 @@ class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   MOCK_METHOD(int32, GetNthTaskDevice, (TaskHandle task, uInt32 index, char buffer[], int32 bufferSize), (override));
   MOCK_METHOD(int32, IsTaskDone, (TaskHandle task, bool32* isTaskDone), (override));
   MOCK_METHOD(int32, ReadAnalogF64, (TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, float64 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved), (override));
-  MOCK_METHOD(int32, ReadDigitalU16, (TaskHandle task, int32 numSampsPerChan, double timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChan, bool32* reserved), (override));
+  MOCK_METHOD(int32, ReadDigitalU16, (TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved), (override));
   MOCK_METHOD(int32, ReadDigitalU8, (TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved), (override));
   MOCK_METHOD(int32, StartTask, (TaskHandle task), (override));
   MOCK_METHOD(int32, StopTask, (TaskHandle task), (override));
   MOCK_METHOD(int32, TaskControl, (TaskHandle task, int32 action), (override));
   MOCK_METHOD(int32, WaitUntilTaskDone, (TaskHandle task, float64 timeToWait), (override));
   MOCK_METHOD(int32, WriteAnalogF64, (TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const float64 writeArray[], int32* sampsPerChanWritten, bool32* reserved), (override));
-  MOCK_METHOD(int32, WriteDigitalU16, (TaskHandle task, int32 numSampsPerChan, int32 autoStart, double timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved), (override));
+  MOCK_METHOD(int32, WriteDigitalU16, (TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved), (override));
   MOCK_METHOD(int32, WriteDigitalU8, (TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved), (override));
 };
 

--- a/generated/nidaqmx/nidaqmx_mock_library.h
+++ b/generated/nidaqmx/nidaqmx_mock_library.h
@@ -17,17 +17,22 @@ namespace unit {
 
 class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
  public:
+  MOCK_METHOD(int32, AddGlobalChansToTask, (TaskHandle task, const char channelNames[]), (override));
   MOCK_METHOD(int32, ClearTask, (TaskHandle task), (override));
   MOCK_METHOD(int32, CreateAIVoltageChan, (TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], int32 terminalConfig, float64 minVal, float64 maxVal, int32 units, const char customScaleName[]), (override));
   MOCK_METHOD(int32, CreateAOVoltageChan, (TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], float64 minVal, float64 maxVal, int32 units, const char customScaleName[]), (override));
   MOCK_METHOD(int32, CreateDIChan, (TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping), (override));
   MOCK_METHOD(int32, CreateDOChan, (TaskHandle task, const char lines[], const char nameToAssignToLines[], int32 lineGrouping), (override));
   MOCK_METHOD(int32, CreateTask, (const char sessionName[], TaskHandle* task), (override));
+  MOCK_METHOD(int32, GetNthTaskChannel, (TaskHandle task, uInt32 index, char buffer[], int32 bufferSize), (override));
+  MOCK_METHOD(int32, GetNthTaskDevice, (TaskHandle task, uInt32 index, char buffer[], int32 bufferSize), (override));
+  MOCK_METHOD(int32, IsTaskDone, (TaskHandle task, bool32* isTaskDone), (override));
   MOCK_METHOD(int32, ReadAnalogF64, (TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, float64 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved), (override));
   MOCK_METHOD(int32, ReadDigitalU16, (TaskHandle task, int32 numSampsPerChan, double timeout, int32 fillMode, uInt16 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChan, bool32* reserved), (override));
   MOCK_METHOD(int32, ReadDigitalU8, (TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved), (override));
   MOCK_METHOD(int32, StartTask, (TaskHandle task), (override));
   MOCK_METHOD(int32, StopTask, (TaskHandle task), (override));
+  MOCK_METHOD(int32, WaitUntilTaskDone, (TaskHandle task, float64 timeToWait), (override));
   MOCK_METHOD(int32, WriteAnalogF64, (TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const float64 writeArray[], int32* sampsPerChanWritten, bool32* reserved), (override));
   MOCK_METHOD(int32, WriteDigitalU16, (TaskHandle task, int32 numSampsPerChan, int32 autoStart, double timeout, int32 dataLayout, const uInt16 writeArray[], int32* sampsPerChanWritten, bool32* reserved), (override));
   MOCK_METHOD(int32, WriteDigitalU8, (TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved), (override));

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -398,7 +398,7 @@ namespace nidaqmx_grpc {
       auto task_grpc_session = request->task();
       TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
-      double timeout = request->timeout();
+      float64 timeout = request->timeout();
       int32 fill_mode;
       switch (request->fill_mode_enum_case()) {
         case nidaqmx_grpc::ReadDigitalU16Request::FillModeEnumCase::kFillMode: {
@@ -418,8 +418,8 @@ namespace nidaqmx_grpc {
       uInt32 array_size_in_samps = request->array_size_in_samps();
       auto reserved = nullptr;
       std::vector<uInt16> read_array(array_size_in_samps);
-      int32 samps_per_chan {};
-      auto status = library_->ReadDigitalU16(task, num_samps_per_chan, timeout, fill_mode, read_array.data(), array_size_in_samps, &samps_per_chan, reserved);
+      int32 samps_per_chan_read {};
+      auto status = library_->ReadDigitalU16(task, num_samps_per_chan, timeout, fill_mode, read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
       response->set_status(status);
       if (status == 0) {
         response->mutable_read_array()->Clear();
@@ -431,7 +431,7 @@ namespace nidaqmx_grpc {
           [](auto x) { 
               return x;
           });
-        response->set_samps_per_chan(samps_per_chan);
+        response->set_samps_per_chan_read(samps_per_chan_read);
       }
       return ::grpc::Status::OK;
     }
@@ -633,9 +633,24 @@ namespace nidaqmx_grpc {
       auto task_grpc_session = request->task();
       TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
-      int32 auto_start = request->auto_start();
-      double timeout = request->timeout();
-      int32 data_layout = request->data_layout();
+      bool32 auto_start = request->auto_start();
+      float64 timeout = request->timeout();
+      int32 data_layout;
+      switch (request->data_layout_enum_case()) {
+        case nidaqmx_grpc::WriteDigitalU16Request::DataLayoutEnumCase::kDataLayout: {
+          data_layout = static_cast<int32>(request->data_layout());
+          break;
+        }
+        case nidaqmx_grpc::WriteDigitalU16Request::DataLayoutEnumCase::kDataLayoutRaw: {
+          data_layout = static_cast<int32>(request->data_layout_raw());
+          break;
+        }
+        case nidaqmx_grpc::WriteDigitalU16Request::DataLayoutEnumCase::DATA_LAYOUT_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for data_layout was not specified or out of range");
+          break;
+        }
+      }
+
       auto write_array_raw = request->write_array();
       auto write_array = std::vector<uInt16>();
       write_array.reserve(write_array_raw.size());

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -25,6 +25,26 @@ namespace nidaqmx_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::AddGlobalChansToTask(::grpc::ServerContext* context, const AddGlobalChansToTaskRequest* request, AddGlobalChansToTaskResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto task_grpc_session = request->task();
+      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      auto channel_names = request->channel_names().c_str();
+      auto status = library_->AddGlobalChansToTask(task, channel_names);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiDAQmxService::ClearTask(::grpc::ServerContext* context, const ClearTaskRequest* request, ClearTaskResponse* response)
   {
     if (context->IsCancelled()) {
@@ -245,6 +265,85 @@ namespace nidaqmx_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::GetNthTaskChannel(::grpc::ServerContext* context, const GetNthTaskChannelRequest* request, GetNthTaskChannelResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto task_grpc_session = request->task();
+      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      uInt32 index = request->index();
+      int32 buffer_size = request->buffer_size();
+      std::string buffer;
+      if (buffer_size > 0) {
+          buffer.resize(buffer_size-1);
+      }
+      auto status = library_->GetNthTaskChannel(task, index, (char*)buffer.data(), buffer_size);
+      response->set_status(status);
+      if (status == 0) {
+        response->set_buffer(buffer);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::GetNthTaskDevice(::grpc::ServerContext* context, const GetNthTaskDeviceRequest* request, GetNthTaskDeviceResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto task_grpc_session = request->task();
+      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      uInt32 index = request->index();
+      int32 buffer_size = request->buffer_size();
+      std::string buffer;
+      if (buffer_size > 0) {
+          buffer.resize(buffer_size-1);
+      }
+      auto status = library_->GetNthTaskDevice(task, index, (char*)buffer.data(), buffer_size);
+      response->set_status(status);
+      if (status == 0) {
+        response->set_buffer(buffer);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::IsTaskDone(::grpc::ServerContext* context, const IsTaskDoneRequest* request, IsTaskDoneResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto task_grpc_session = request->task();
+      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      bool32 is_task_done {};
+      auto status = library_->IsTaskDone(task, &is_task_done);
+      response->set_status(status);
+      if (status == 0) {
+        response->set_is_task_done(is_task_done);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiDAQmxService::ReadAnalogF64(::grpc::ServerContext* context, const ReadAnalogF64Request* request, ReadAnalogF64Response* response)
   {
     if (context->IsCancelled()) {
@@ -416,6 +515,26 @@ namespace nidaqmx_grpc {
       auto task_grpc_session = request->task();
       TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
       auto status = library_->StopTask(task);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::WaitUntilTaskDone(::grpc::ServerContext* context, const WaitUntilTaskDoneRequest* request, WaitUntilTaskDoneResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto task_grpc_session = request->task();
+      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      float64 time_to_wait = request->time_to_wait();
+      auto status = library_->WaitUntilTaskDone(task, time_to_wait);
       response->set_status(status);
       return ::grpc::Status::OK;
     }

--- a/generated/nidaqmx/nidaqmx_service.h
+++ b/generated/nidaqmx/nidaqmx_service.h
@@ -28,17 +28,22 @@ public:
   NiDAQmxService(NiDAQmxLibraryInterface* library, ResourceRepositorySharedPtr session_repository);
   virtual ~NiDAQmxService();
   
+  ::grpc::Status AddGlobalChansToTask(::grpc::ServerContext* context, const AddGlobalChansToTaskRequest* request, AddGlobalChansToTaskResponse* response) override;
   ::grpc::Status ClearTask(::grpc::ServerContext* context, const ClearTaskRequest* request, ClearTaskResponse* response) override;
   ::grpc::Status CreateAIVoltageChan(::grpc::ServerContext* context, const CreateAIVoltageChanRequest* request, CreateAIVoltageChanResponse* response) override;
   ::grpc::Status CreateAOVoltageChan(::grpc::ServerContext* context, const CreateAOVoltageChanRequest* request, CreateAOVoltageChanResponse* response) override;
   ::grpc::Status CreateDIChan(::grpc::ServerContext* context, const CreateDIChanRequest* request, CreateDIChanResponse* response) override;
   ::grpc::Status CreateDOChan(::grpc::ServerContext* context, const CreateDOChanRequest* request, CreateDOChanResponse* response) override;
   ::grpc::Status CreateTask(::grpc::ServerContext* context, const CreateTaskRequest* request, CreateTaskResponse* response) override;
+  ::grpc::Status GetNthTaskChannel(::grpc::ServerContext* context, const GetNthTaskChannelRequest* request, GetNthTaskChannelResponse* response) override;
+  ::grpc::Status GetNthTaskDevice(::grpc::ServerContext* context, const GetNthTaskDeviceRequest* request, GetNthTaskDeviceResponse* response) override;
+  ::grpc::Status IsTaskDone(::grpc::ServerContext* context, const IsTaskDoneRequest* request, IsTaskDoneResponse* response) override;
   ::grpc::Status ReadAnalogF64(::grpc::ServerContext* context, const ReadAnalogF64Request* request, ReadAnalogF64Response* response) override;
   ::grpc::Status ReadDigitalU16(::grpc::ServerContext* context, const ReadDigitalU16Request* request, ReadDigitalU16Response* response) override;
   ::grpc::Status ReadDigitalU8(::grpc::ServerContext* context, const ReadDigitalU8Request* request, ReadDigitalU8Response* response) override;
   ::grpc::Status StartTask(::grpc::ServerContext* context, const StartTaskRequest* request, StartTaskResponse* response) override;
   ::grpc::Status StopTask(::grpc::ServerContext* context, const StopTaskRequest* request, StopTaskResponse* response) override;
+  ::grpc::Status WaitUntilTaskDone(::grpc::ServerContext* context, const WaitUntilTaskDoneRequest* request, WaitUntilTaskDoneResponse* response) override;
   ::grpc::Status WriteAnalogF64(::grpc::ServerContext* context, const WriteAnalogF64Request* request, WriteAnalogF64Response* response) override;
   ::grpc::Status WriteDigitalU16(::grpc::ServerContext* context, const WriteDigitalU16Request* request, WriteDigitalU16Response* response) override;
   ::grpc::Status WriteDigitalU8(::grpc::ServerContext* context, const WriteDigitalU8Request* request, WriteDigitalU8Response* response) override;

--- a/generated/nidaqmx/nidaqmx_service.h
+++ b/generated/nidaqmx/nidaqmx_service.h
@@ -43,6 +43,7 @@ public:
   ::grpc::Status ReadDigitalU8(::grpc::ServerContext* context, const ReadDigitalU8Request* request, ReadDigitalU8Response* response) override;
   ::grpc::Status StartTask(::grpc::ServerContext* context, const StartTaskRequest* request, StartTaskResponse* response) override;
   ::grpc::Status StopTask(::grpc::ServerContext* context, const StopTaskRequest* request, StopTaskResponse* response) override;
+  ::grpc::Status TaskControl(::grpc::ServerContext* context, const TaskControlRequest* request, TaskControlResponse* response) override;
   ::grpc::Status WaitUntilTaskDone(::grpc::ServerContext* context, const WaitUntilTaskDoneRequest* request, WaitUntilTaskDoneResponse* response) override;
   ::grpc::Status WriteAnalogF64(::grpc::ServerContext* context, const WriteAnalogF64Request* request, WriteAnalogF64Response* response) override;
   ::grpc::Status WriteDigitalU16(::grpc::ServerContext* context, const WriteDigitalU16Request* request, WriteDigitalU16Response* response) override;

--- a/source/codegen/metadata/nidaqmx/config.py
+++ b/source/codegen/metadata/nidaqmx/config.py
@@ -13,6 +13,7 @@ config = {
     'type_to_grpc_type': {
         'TaskHandle': 'nidevice_grpc.Session',
         'const char[]': 'string',
+        'char[]': 'string',
         'float64': 'double',
         'bool32': 'bool',
         'int32': 'int32',

--- a/source/codegen/metadata/nidaqmx/enums.py
+++ b/source/codegen/metadata/nidaqmx/enums.py
@@ -47,6 +47,38 @@ enums = {
             }
         ]
     },
+    'TaskControlAction': {
+        'values': [
+            {
+                'name': 'TASK_START',
+                'value': 0
+            },
+            {
+                'name': 'TASK_STOP',
+                'value': 1
+            },
+            {
+                'name': 'TASK_VERIFY',
+                'value': 2
+            },
+            {
+                'name': 'TASK_COMMIT',
+                'value': 3
+            },
+            {
+                'name': 'TASK_RESERVE',
+                'value': 4
+            },
+            {
+                'name': 'TASK_UNRESERVE',
+                'value': 5
+            },
+            {
+                'name': 'TASK_ABORT',
+                'value': 6
+            }
+        ]
+    },
     'VoltageUnits2': {
         'values': [
             {

--- a/source/codegen/metadata/nidaqmx/functions.py
+++ b/source/codegen/metadata/nidaqmx/functions.py
@@ -433,6 +433,22 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'TaskControl': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'task',
+                'type': 'TaskHandle'
+            },
+            {
+                'direction': 'in',
+                'enum': 'TaskControlAction',
+                'name': 'action',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
     'WaitUntilTaskDone': {
         'parameters': [
             {

--- a/source/codegen/metadata/nidaqmx/functions.py
+++ b/source/codegen/metadata/nidaqmx/functions.py
@@ -1,4 +1,19 @@
 functions = {
+    'AddGlobalChansToTask': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'task',
+                'type': 'TaskHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'channelNames',
+                'type': 'const char[]'
+            }
+        ],
+        'returns': 'int32'
+    },
     'ClearTask': {
         'parameters': [
             {
@@ -166,6 +181,79 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'GetNthTaskChannel': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'task',
+                'type': 'TaskHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'index',
+                'type': 'uInt32'
+            },
+            {
+                'direction': 'out',
+                'name': 'buffer',
+                'size': {
+                    'mechanism': 'passed-in',
+                    'value': 'bufferSize'
+                },
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'bufferSize',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'GetNthTaskDevice': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'task',
+                'type': 'TaskHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'index',
+                'type': 'uInt32'
+            },
+            {
+                'direction': 'out',
+                'name': 'buffer',
+                'size': {
+                    'mechanism': 'passed-in',
+                    'value': 'bufferSize'
+                },
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'bufferSize',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'IsTaskDone': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'task',
+                'type': 'TaskHandle'
+            },
+            {
+                'direction': 'out',
+                'name': 'isTaskDone',
+                'type': 'bool32'
+            }
+        ],
+        'returns': 'int32'
+    },
     'ReadAnalogF64': {
         'parameters': [
             {
@@ -213,7 +301,7 @@ functions = {
                 'include_in_proto': False,
                 'name': 'reserved',
                 'pass_null': True,
-                'type': 'bool32',
+                'type': 'bool32'
             }
         ],
         'returns': 'int32'
@@ -341,6 +429,21 @@ functions = {
                 'direction': 'in',
 	            'name': 'task',
                 'type': 'TaskHandle'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'WaitUntilTaskDone': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'task',
+                'type': 'TaskHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'timeToWait',
+                'type': 'float64'
             }
         ],
         'returns': 'int32'

--- a/source/codegen/metadata/nidaqmx/functions.py
+++ b/source/codegen/metadata/nidaqmx/functions.py
@@ -311,44 +311,42 @@ functions = {
             {
                 'direction': 'in',
                 'name': 'task',
-                'type': 'TaskHandle',
-                'grpc_type': 'nidevice_grpc.Session'
+                'type': 'TaskHandle'
             },
             {
                 'direction': 'in',
                 'name': 'numSampsPerChan',
-                'type': 'int32',
+                'type': 'int32'
             },
             {
                 'direction': 'in',
                 'name': 'timeout',
-                'type': 'double',
+                'type': 'float64'
             },
             {
                 'direction': 'in',
                 'enum': 'GroupBy',
                 'name': 'fillMode',
-                'type': 'int32',
+                'type': 'int32'
             },
             {
+                'coerced': True,
                 'direction': 'out',
                 'name': 'readArray',
-                'type': 'uInt16[]',
-                'coerced': True,
                 'size': {
                     'mechanism': 'passed-in',
                     'value': 'arraySizeInSamps'
-                }
+                },
+                'type': 'uInt16[]'
             },
             {
                 'direction': 'in',
                 'name': 'arraySizeInSamps',
-                'type': 'uInt32',
-                'grpc_type': 'uint32'
+                'type': 'uInt32'
             },
             {
                 'direction': 'out',
-                'name': 'sampsPerChan',
+                'name': 'sampsPerChanRead',
                 'type': 'int32'
             },
             {
@@ -356,10 +354,10 @@ functions = {
                 'include_in_proto': False,
                 'name': 'reserved',
                 'pass_null': True,
-                'type': 'bool32',
+                'type': 'bool32'
             }
         ],
-        'returns': 'int32',
+        'returns': 'int32'
     },
     'ReadDigitalU8': {
         'parameters': [
@@ -427,7 +425,7 @@ functions = {
         'parameters': [
             {
                 'direction': 'in',
-	            'name': 'task',
+                'name': 'task',
                 'type': 'TaskHandle'
             }
         ],
@@ -466,7 +464,7 @@ functions = {
     },
     'WriteAnalogF64': {
         'parameters': [
-	        {
+            {
                 'direction': 'in',
                 'name': 'task',
                 'type': 'TaskHandle'
@@ -483,13 +481,13 @@ functions = {
             },
             {
                 'direction': 'in',
-            	'name': 'timeout',
+                'name': 'timeout',
                 'type': 'float64'
             },
             {
                 'direction': 'in',
                 'enum': 'GroupBy',
-	            'name': 'dataLayout',
+                'name': 'dataLayout',
                 'type': 'int32'
             },
             {
@@ -505,9 +503,9 @@ functions = {
             {
                 'direction': 'in',
                 'include_in_proto': False,
-	            'name': 'reserved',
+                'name': 'reserved',
                 'pass_null': True,
-                'type': 'bool32',
+                'type': 'bool32'
             }
         ],
         'returns': 'int32'
@@ -517,34 +515,34 @@ functions = {
             {
                 'direction': 'in',
                 'name': 'task',
-                'type': 'TaskHandle',
-                'grpc_type': 'nidevice_grpc.Session'
+                'type': 'TaskHandle'
             },
             {
                 'direction': 'in',
                 'name': 'numSampsPerChan',
-                'type': 'int32',
+                'type': 'int32'
             },
             {
                 'direction': 'in',
                 'name': 'autoStart',
-                'type': 'int32',
+                'type': 'bool32'
             },
             {
                 'direction': 'in',
                 'name': 'timeout',
-                'type': 'double',
+                'type': 'float64'
             },
             {
                 'direction': 'in',
+                'enum': 'GroupBy',
                 'name': 'dataLayout',
-                'type': 'int32',
+                'type': 'int32'
             },
             {
+                'coerced': True,
                 'direction': 'in',
                 'name': 'writeArray',
-                'type': 'const uInt16[]',
-                'coerced': True
+                'type': 'const uInt16[]'
             },
             {
                 'direction': 'out',
@@ -556,10 +554,10 @@ functions = {
                 'include_in_proto': False,
                 'name': 'reserved',
                 'pass_null': True,
-                'type': 'bool32',
+                'type': 'bool32'
             }
         ],
-        'returns': 'int32',
+        'returns': 'int32'
     },
     'WriteDigitalU8': {
         'parameters': [
@@ -608,5 +606,5 @@ functions = {
             }
         ],
         'returns': 'int32'
-    },
+    }
 }

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -218,8 +218,6 @@ ${initialize_standard_input_param(function_name, parameter)}\
 %>\
 % if c_type in ['ViConstString', 'const char[]']:
       auto ${parameter_name} = ${request_snippet}.c_str();\
-% elif c_type == 'ViString' or c_type == 'ViRsrc':
-      ${c_type} ${parameter_name} = (${c_type})${request_snippet}.c_str();\
 % elif common_helpers.is_string_arg(parameter):
       ${c_type_pointer} ${parameter_name} = (${c_type_pointer})${request_snippet}.c_str();\
 % elif c_type == 'ViSession[]':


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add methods from the Task Control and Configuration API to the DAQ service.

Does not include methods with callbacks or timestamps. Support for those will be added separately.

### Why should this Pull Request be merged?

Incremental progress towards DAQ grpc-device support.

### What testing has been done?

Ran and passed all DAQ auto-tests.