### PR TITLE
loosen double comparison for sync tests

### DIFF
--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -1038,7 +1038,10 @@ TEST_F(NiSyncDriver6674Test, AttributeSet_GetAttributeViReal64_ReturnsValue)
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
-  EXPECT_DOUBLE_EQ(expectedValue, value);
+  // 6674T has up to 16.8mV of resolution for PFI threshold. We'll loosen our
+  // validation to a bit more than twice that to ensure we aren't testing
+  // driver implementation details.
+  EXPECT_NEAR(expectedValue, value, 50e-3);
 }
 
 TEST_F(NiSyncDriver6674Test, MeasureFrequencyExOnTerminalWithNoFrequency_ReturnsNoFrequency)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Loosens the double comparison of the sync tests. EXPECT_DOUBLE_EQ compares within 4 LUTs, which isn't enough for compiler differences between Windows and Linux. Here is how it was failing on Windows:

```
D:\a\grpc-device\grpc-device\source\tests\system\nisync_driver_api_tests.cpp:1041
Expected equality of these values:
  expectedValue
    Which is: 2.2999999999999998
  value
    Which is: 2.3004000000000002
```

Loosen the comparison to a bit over twice the resolution of the device.

### Why should this Pull Request be merged?

Fix tests on Windows.

### What testing has been done?

It builds.
