### PR TITLE
use non-zero timeout in sync timestamp tests

### DIFF
--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -1470,7 +1470,7 @@ TEST_F(NiSyncDriver6683Test, GivenOneTrigger_ReadMultipleTriggerTimeStamp_Return
   CreateFutureTimeEvent(terminal, NISYNC_VAL_LEVEL_LOW, 0, 0, 0);
 
   ViStatus viStatusRead;
-  ViReal64 timeout = 0.0;
+  ViReal64 timeout = 1.0;
   const ViUInt32 timestampsToRead = 5;
   ViUInt32 timeSeconds[timestampsToRead] = {}, timeNanoseconds[timestampsToRead] = {};
   ViUInt16 timeFractionalNanoseconds[timestampsToRead] = {};
@@ -1510,7 +1510,7 @@ TEST_F(NiSyncDriver6683Test, GivenFiveTriggers_ReadMultipleTriggerTimeStamp_Retu
   }
 
   ViStatus viStatusRead;
-  ViReal64 timeout = 0.0;
+  ViReal64 timeout = 1.0;
   const ViUInt32 timestampsToRead = 5;
   ViUInt32 timeSeconds[timestampsToRead] = {}, timeNanoseconds[timestampsToRead] = {};
   ViUInt16 timeFractionalNanoseconds[timestampsToRead] = {};


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes sync failures in TimeStamp read tests by passing a non-zero timeout to the driver. With a 0.0 timeout, the read returns immediately with a timeout error.

### Why should this Pull Request be merged?

Fixes sync failures in TimeStamp read tests.

### What testing has been done?

```
admin@NI-PXIe-8880-03095FC1:~# ./SystemTestsRunner  --gtest_filter=*ReadMultipleTriggerTimeStamp*
Note: Google Test filter = *ReadMultipleTriggerTimeStamp*
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from NiSyncDriver6683Test
[ RUN      ] NiSyncDriver6683Test.GivenNoTrigger_ReadMultipleTriggerTimeStamp_ReturnsTimeoutError
[       OK ] NiSyncDriver6683Test.GivenNoTrigger_ReadMultipleTriggerTimeStamp_ReturnsTimeoutError (1231 ms)
[ RUN      ] NiSyncDriver6683Test.GivenOneTrigger_ReadMultipleTriggerTimeStamp_ReturnsOneTimeStampAndTimeoutError
[       OK ] NiSyncDriver6683Test.GivenOneTrigger_ReadMultipleTriggerTimeStamp_ReturnsOneTimeStampAndTimeoutError (1012 ms)
[ RUN      ] NiSyncDriver6683Test.GivenFiveTriggers_ReadMultipleTriggerTimeStamp_ReturnsFiveTimeStamps
[       OK ] NiSyncDriver6683Test.GivenFiveTriggers_ReadMultipleTriggerTimeStamp_ReturnsFiveTimeStamps (12 ms)
[----------] 3 tests from NiSyncDriver6683Test (2255 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (2256 ms total)
[  PASSED  ] 3 tests.
```
