### PR TITLE
Fix sync 8021as test on Windows

### DIFF
--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -1228,7 +1228,12 @@ TEST_F(NiSyncDriver6683Test, SetTimeReference8021AS_ReturnsSuccess)
   auto grpcStatus = call_SetTimeReference8021AS(&viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
+  #if defined(_MSC_VER)
+  // SetTimeReference8021AS is only supported on Linux RT targets.
+  EXPECT_EQ(NISYNC_ERROR_FEATURE_NOT_SUPPORTED, viStatus);
+  #else
   EXPECT_EQ(VI_SUCCESS, viStatus);
+  #endif
 }
 
 TEST_F(NiSyncDriver6683Test, CreateClearFutureTimeEvent_ReturnsSuccess)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes Sync 8021AS, so that i passed on Windows. 802.1AS is only supported on Linux, so simply expect the feature not supported error on Windows.

### Why should this Pull Request be merged?

Fix the test.

### What testing has been done?

```
C:\Users\Administrator\Desktop>SystemTestsRunner.exe --gtest_filter=*8021AS*
Note: Google Test filter = *8021AS*
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from NiSyncDriver6683Test
[ RUN      ] NiSyncDriver6683Test.SetTimeReference8021AS_ReturnsSuccess
[       OK ] NiSyncDriver6683Test.SetTimeReference8021AS_ReturnsSuccess (1758 ms)
[----------] 1 test from NiSyncDriver6683Test (1759 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1773 ms total)
[  PASSED  ] 1 test.
```
