### PR TITLE
Reimplement DAQmx callbacks with experimental callback service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,7 @@ endif()
 # Link test executable against gtest
 add_executable(IntegrationTestsRunner
     "source/tests/utilities/run_all_tests.cpp"
+    "source/tests/integration/ni_fake_non_ivi_service_tests_endtoend.cpp"
     "source/tests/integration/session_utilities_service_tests.cpp"
     "source/tests/integration/session_utilities_service_tests_endtoend.cpp"
     "source/server/device_enumerator.cpp"
@@ -247,7 +248,12 @@ add_executable(IntegrationTestsRunner
     "source/server/session_utilities_service.cpp"
     "source/server/shared_library.cpp"
     ${session_proto_srcs}
-    ${session_grpc_srcs})
+    ${session_grpc_srcs}
+    "${proto_srcs_dir}/nifake_non_ivi.pb.cc"
+    "${proto_srcs_dir}/nifake_non_ivi.grpc.pb.cc"
+    "${service_output_dir}/nifake_non_ivi/nifake_non_ivi_service.cpp"
+    "${custom_dir}/nifake_non_ivi_service.custom.cpp"
+)
 
     set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
     set(THREADS_PREFER_PTHREAD_FLAG TRUE)

--- a/generated/nidaqmx/nidaqmx_service.h
+++ b/generated/nidaqmx/nidaqmx_service.h
@@ -21,7 +21,7 @@
 
 namespace nidaqmx_grpc {
 
-class NiDAQmxService final : public NiDAQmx::Service {
+class NiDAQmxService final : public NiDAQmx::ExperimentalWithCallbackMethod_RegisterDoneEvent<NiDAQmx::Service> {
 public:
   using ResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<TaskHandle>>;
 
@@ -187,7 +187,7 @@ public:
   ::grpc::Status ReadDigitalU32(::grpc::ServerContext* context, const ReadDigitalU32Request* request, ReadDigitalU32Response* response) override;
   ::grpc::Status ReadDigitalU8(::grpc::ServerContext* context, const ReadDigitalU8Request* request, ReadDigitalU8Response* response) override;
   ::grpc::Status ReadRaw(::grpc::ServerContext* context, const ReadRawRequest* request, ReadRawResponse* response) override;
-  ::grpc::Status RegisterDoneEvent(::grpc::ServerContext* context, const RegisterDoneEventRequest* request, ::grpc::ServerWriter<RegisterDoneEventResponse>* writer) override;
+  ::grpc::experimental::ServerWriteReactor<RegisterDoneEventResponse>* RegisterDoneEvent(::grpc::CallbackServerContext* context, const RegisterDoneEventRequest* request) override;
   ::grpc::Status ReserveNetworkDevice(::grpc::ServerContext* context, const ReserveNetworkDeviceRequest* request, ReserveNetworkDeviceResponse* response) override;
   ::grpc::Status ResetDevice(::grpc::ServerContext* context, const ResetDeviceRequest* request, ResetDeviceResponse* response) override;
   ::grpc::Status SelfTestDevice(::grpc::ServerContext* context, const SelfTestDeviceRequest* request, SelfTestDeviceResponse* response) override;

--- a/generated/nifake_non_ivi/nifake_non_ivi.proto
+++ b/generated/nifake_non_ivi/nifake_non_ivi.proto
@@ -26,6 +26,7 @@ service NiFakeNonIvi {
   rpc InputArrayOfBytes(InputArrayOfBytesRequest) returns (InputArrayOfBytesResponse);
   rpc OutputArrayOfBytes(OutputArrayOfBytesRequest) returns (OutputArrayOfBytesResponse);
   rpc RegisterCallback(RegisterCallbackRequest) returns (RegisterCallbackResponse);
+  rpc ReadStream(ReadStreamRequest) returns (stream ReadStreamResponse);
   rpc InputTimestamp(InputTimestampRequest) returns (InputTimestampResponse);
   rpc OutputTimestamp(OutputTimestampRequest) returns (OutputTimestampResponse);
 }
@@ -117,6 +118,16 @@ message RegisterCallbackRequest {
 message RegisterCallbackResponse {
   int32 status = 1;
   int32 echo_data = 2;
+}
+
+message ReadStreamRequest {
+  int32 start = 1;
+  int32 stop = 2;
+}
+
+message ReadStreamResponse {
+  int32 status = 1;
+  int32 value = 2;
 }
 
 message InputTimestampRequest {

--- a/generated/nifake_non_ivi/nifake_non_ivi_library.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_library.cpp
@@ -30,6 +30,7 @@ NiFakeNonIviLibrary::NiFakeNonIviLibrary() : shared_library_(kLibraryName)
   function_pointers_.InputArrayOfBytes = reinterpret_cast<InputArrayOfBytesPtr>(shared_library_.get_function_pointer("niFakeNonIvi_InputArrayOfBytes"));
   function_pointers_.OutputArrayOfBytes = reinterpret_cast<OutputArrayOfBytesPtr>(shared_library_.get_function_pointer("niFakeNonIvi_OutputArrayOfBytes"));
   function_pointers_.RegisterCallback = reinterpret_cast<RegisterCallbackPtr>(shared_library_.get_function_pointer("niFakeNonIvi_RegisterCallback"));
+  function_pointers_.ReadStream = reinterpret_cast<ReadStreamPtr>(shared_library_.get_function_pointer("niFakeNonIvi_ReadStream"));
   function_pointers_.InputTimestamp = reinterpret_cast<InputTimestampPtr>(shared_library_.get_function_pointer("niFakeNonIvi_InputTimestamp"));
   function_pointers_.OutputTimestamp = reinterpret_cast<OutputTimestampPtr>(shared_library_.get_function_pointer("niFakeNonIvi_OutputTimestamp"));
 }
@@ -150,6 +151,18 @@ int32 NiFakeNonIviLibrary::RegisterCallback(myInt16 inputData, CallbackPtr callb
   return niFakeNonIvi_RegisterCallback(inputData, callbackFunction, callbackData);
 #else
   return function_pointers_.RegisterCallback(inputData, callbackFunction, callbackData);
+#endif
+}
+
+int32 NiFakeNonIviLibrary::ReadStream(int32 start, int32 stop, int32* value)
+{
+  if (!function_pointers_.ReadStream) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFakeNonIvi_ReadStream.");
+  }
+#if defined(_MSC_VER)
+  return niFakeNonIvi_ReadStream(start, stop, value);
+#else
+  return function_pointers_.ReadStream(start, stop, value);
 #endif
 }
 

--- a/generated/nifake_non_ivi/nifake_non_ivi_library.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_library.h
@@ -27,6 +27,7 @@ class NiFakeNonIviLibrary : public nifake_non_ivi_grpc::NiFakeNonIviLibraryInter
   int32 InputArrayOfBytes(const myUInt8 u8Array[]);
   int32 OutputArrayOfBytes(int32 numberOfU8Samples, myUInt8 u8Data[]);
   int32 RegisterCallback(myInt16 inputData, CallbackPtr callbackFunction, void* callbackData);
+  int32 ReadStream(int32 start, int32 stop, int32* value);
   int32 InputTimestamp(CVIAbsoluteTime when);
   int32 OutputTimestamp(CVIAbsoluteTime* when);
 
@@ -40,6 +41,7 @@ class NiFakeNonIviLibrary : public nifake_non_ivi_grpc::NiFakeNonIviLibraryInter
   using InputArrayOfBytesPtr = int32 (*)(const myUInt8 u8Array[]);
   using OutputArrayOfBytesPtr = int32 (*)(int32 numberOfU8Samples, myUInt8 u8Data[]);
   using RegisterCallbackPtr = int32 (*)(myInt16 inputData, CallbackPtr callbackFunction, void* callbackData);
+  using ReadStreamPtr = int32 (*)(int32 start, int32 stop, int32* value);
   using InputTimestampPtr = int32 (*)(CVIAbsoluteTime when);
   using OutputTimestampPtr = int32 (*)(CVIAbsoluteTime* when);
 
@@ -53,6 +55,7 @@ class NiFakeNonIviLibrary : public nifake_non_ivi_grpc::NiFakeNonIviLibraryInter
     InputArrayOfBytesPtr InputArrayOfBytes;
     OutputArrayOfBytesPtr OutputArrayOfBytes;
     RegisterCallbackPtr RegisterCallback;
+    ReadStreamPtr ReadStream;
     InputTimestampPtr InputTimestamp;
     OutputTimestampPtr OutputTimestamp;
   } FunctionLoadStatus;

--- a/generated/nifake_non_ivi/nifake_non_ivi_library_interface.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_library_interface.h
@@ -24,6 +24,7 @@ class NiFakeNonIviLibraryInterface {
   virtual int32 InputArrayOfBytes(const myUInt8 u8Array[]) = 0;
   virtual int32 OutputArrayOfBytes(int32 numberOfU8Samples, myUInt8 u8Data[]) = 0;
   virtual int32 RegisterCallback(myInt16 inputData, CallbackPtr callbackFunction, void* callbackData) = 0;
+  virtual int32 ReadStream(int32 start, int32 stop, int32* value) = 0;
   virtual int32 InputTimestamp(CVIAbsoluteTime when) = 0;
   virtual int32 OutputTimestamp(CVIAbsoluteTime* when) = 0;
 };

--- a/generated/nifake_non_ivi/nifake_non_ivi_mock_library.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_mock_library.h
@@ -26,6 +26,7 @@ class NiFakeNonIviMockLibrary : public nifake_non_ivi_grpc::NiFakeNonIviLibraryI
   MOCK_METHOD(int32, InputArrayOfBytes, (const myUInt8 u8Array[]), (override));
   MOCK_METHOD(int32, OutputArrayOfBytes, (int32 numberOfU8Samples, myUInt8 u8Data[]), (override));
   MOCK_METHOD(int32, RegisterCallback, (myInt16 inputData, CallbackPtr callbackFunction, void* callbackData), (override));
+  MOCK_METHOD(int32, ReadStream, (int32 start, int32 stop, int32* value), (override));
   MOCK_METHOD(int32, InputTimestamp, (CVIAbsoluteTime when), (override));
   MOCK_METHOD(int32, OutputTimestamp, (CVIAbsoluteTime* when), (override));
 };

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.h
@@ -21,7 +21,7 @@
 
 namespace nifake_non_ivi_grpc {
 
-class NiFakeNonIviService final : public NiFakeNonIvi::Service {
+class NiFakeNonIviService final : public NiFakeNonIvi::ExperimentalWithCallbackMethod_ReadStream<NiFakeNonIvi::Service> {
 public:
   using ResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<FakeHandle>>;
 
@@ -37,6 +37,7 @@ public:
   ::grpc::Status InputArrayOfBytes(::grpc::ServerContext* context, const InputArrayOfBytesRequest* request, InputArrayOfBytesResponse* response) override;
   ::grpc::Status OutputArrayOfBytes(::grpc::ServerContext* context, const OutputArrayOfBytesRequest* request, OutputArrayOfBytesResponse* response) override;
   ::grpc::Status RegisterCallback(::grpc::ServerContext* context, const RegisterCallbackRequest* request, RegisterCallbackResponse* response) override;
+  ::grpc::experimental::ServerWriteReactor<ReadStreamResponse>* ReadStream(::grpc::CallbackServerContext* context, const ReadStreamRequest* request) override;
   ::grpc::Status InputTimestamp(::grpc::ServerContext* context, const InputTimestampRequest* request, InputTimestampResponse* response) override;
   ::grpc::Status OutputTimestamp(::grpc::ServerContext* context, const OutputTimestampRequest* request, OutputTimestampResponse* response) override;
 private:

--- a/source/codegen/metadata/nifake_non_ivi/functions.py
+++ b/source/codegen/metadata/nifake_non_ivi/functions.py
@@ -199,6 +199,28 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'ReadStream': {
+        'codegen_method': 'CustomCode',
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'start',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'name': 'stop',
+                'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'name': 'value',
+                'type': 'int32'
+            }
+        ],
+        'stream_response': True,
+        'returns': 'int32'
+    },
     'InputTimestamp': {
         'parameters': [
             {

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -188,14 +188,27 @@ def is_custom_close_method(function_data):
 
 def requires_checked_conversion(parameters):
     return any([is_input_array_that_needs_coercion(p) for p in parameters])
-  
-
-def get_request_param(method_name, function_data):
-    return f'const {method_name}Request* request'
 
 
-def get_response_param(method_name, function_data):
-    is_streaming = common_helpers.has_streaming_response(function_data)
-    response_type = f'{method_name}Response'
-    return f'::grpc::ServerWriter<{response_type}>* writer' if is_streaming else f'{response_type}* response'
+def get_request_param(method_name):
+    return f'const {get_request_type(method_name)}* request'
 
+
+def get_request_type(method_name):
+    return f"{method_name}Request"
+
+
+def get_response_param(method_name):
+    return f'{get_response_type(method_name)}* response'
+
+
+def get_response_type(method_name):
+    return f'{method_name}Response'
+
+
+def get_async_functions(functions):
+    return {
+        name: data 
+        for name, data in functions.items() 
+        if common_helpers.has_streaming_response(data)
+    }

--- a/source/codegen/templates/service.cpp.mako
+++ b/source/codegen/templates/service.cpp.mako
@@ -110,8 +110,8 @@ namespace ${config["namespace_component"]}_grpc {
     function_data = functions[function_name]
     method_name = common_helpers.snake_to_pascal(function_name)
     parameters = function_data['parameters']
-    request_param = service_helpers.get_request_param(method_name, function_data)
-    response_param = service_helpers.get_response_param(method_name, function_data)
+    request_param = service_helpers.get_request_param(method_name)
+    response_param = service_helpers.get_response_param(method_name)
 %>\
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------

--- a/source/custom/nidaqmx_service.custom.cpp
+++ b/source/custom/nidaqmx_service.custom.cpp
@@ -49,7 +49,7 @@ NiDAQmxService::RegisterDoneEvent(::grpc::CallbackServerContext* context, const 
         }
       }
       catch (nidevice_grpc::LibraryLoadException& ex) {
-        Finish(::grpc::Status(::grpc::NOT_FOUND, ex.what()));
+        this->Finish(::grpc::Status(::grpc::NOT_FOUND, ex.what()));
       }
 
       return handler;

--- a/source/custom/nidaqmx_service.custom.cpp
+++ b/source/custom/nidaqmx_service.custom.cpp
@@ -1,6 +1,6 @@
 #include <nidaqmx/nidaqmx_service.h>
-#include <server/async_operation.h>
 #include <server/callback_router.h>
+#include <server/server_reactor.h>
 
 #include <memory>
 #include <thread>
@@ -18,7 +18,8 @@ NiDAQmxService::RegisterDoneEvent(::grpc::CallbackServerContext* context, const 
    public:
     RegisterDoneEventReactor(const RegisterDoneEventRequest& request, NiDAQmxLibraryInterface* library, const ResourceRepositorySharedPtr& session_repository)
     {
-      thread_ = start(request, library, session_repository);
+      this->set_producer(
+          start(request, library, session_repository));
     }
 
     std::unique_ptr<nidevice_grpc::CallbackRegistration> start(const RegisterDoneEventRequest& request, NiDAQmxLibraryInterface* library, const ResourceRepositorySharedPtr& session_repository)

--- a/source/custom/nidaqmx_service.custom.cpp
+++ b/source/custom/nidaqmx_service.custom.cpp
@@ -29,7 +29,7 @@ NiDAQmxService::RegisterDoneEvent(::grpc::CallbackServerContext* context, const 
         TaskHandle task = session_repository->access_session(task_grpc_session.id(), task_grpc_session.name());
         uInt32 options = request.options();
 
-        auto handler = DoneEventCallbackRouter::register_handler(
+        handler = DoneEventCallbackRouter::register_handler(
             [this](TaskHandle task, int32 callback_status) {
               RegisterDoneEventResponse callback_response;
               callback_response.set_status(callback_status);

--- a/source/custom/nidaqmx_service.custom.cpp
+++ b/source/custom/nidaqmx_service.custom.cpp
@@ -1,6 +1,8 @@
 #include <nidaqmx/nidaqmx_service.h>
+#include <server/async_operation.h>
 #include <server/callback_router.h>
 
+#include <memory>
 #include <thread>
 
 namespace nidaqmx_grpc {
@@ -9,40 +11,51 @@ using DoneEventCallbackRouter = nidevice_grpc::CallbackRouter<int32, TaskHandle,
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
-::grpc::Status
-NiDAQmxService::RegisterDoneEvent(::grpc::ServerContext* context, const RegisterDoneEventRequest* request, ::grpc::ServerWriter<RegisterDoneEventResponse>* writer)
+::grpc::experimental::ServerWriteReactor<RegisterDoneEventResponse>*
+NiDAQmxService::RegisterDoneEvent(::grpc::CallbackServerContext* context, const RegisterDoneEventRequest* request)
 {
-  if (context->IsCancelled()) {
-    return ::grpc::Status::CANCELLED;
-  }
-  try {
-    auto task_grpc_session = request->task();
-    TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
-    uInt32 options = request->options();
-
-    auto registration = DoneEventCallbackRouter::register_handler(
-        [writer](TaskHandle task, int32 callback_status) {
-          RegisterDoneEventResponse callback_response;
-          callback_response.set_status(callback_status);
-          writer->Write(callback_response);
-          return DAQmxSuccess;
-        });
-
-    auto status = library_->RegisterDoneEvent(task, options, DoneEventCallbackRouter::handle_callback, registration.token());
-
-    if (status) {
-      RegisterDoneEventResponse failed_to_register_response;
-      failed_to_register_response.set_status(status);
-      writer->Write(failed_to_register_response);
+  class RegisterDoneEventReactor : public nidevice_grpc::ServerWriterReactor<RegisterDoneEventResponse, nidevice_grpc::CallbackRegistration> {
+   public:
+    RegisterDoneEventReactor(const RegisterDoneEventRequest& request, NiDAQmxLibraryInterface* library, const ResourceRepositorySharedPtr& session_repository)
+    {
+      thread_ = start(request, library, session_repository);
     }
 
-    while (!context->IsCancelled()) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::unique_ptr<nidevice_grpc::CallbackRegistration> start(const RegisterDoneEventRequest& request, NiDAQmxLibraryInterface* library, const ResourceRepositorySharedPtr& session_repository)
+    {
+      std::unique_ptr<nidevice_grpc::CallbackRegistration> handler;
+      try {
+        auto task_grpc_session = request.task();
+        TaskHandle task = session_repository->access_session(task_grpc_session.id(), task_grpc_session.name());
+        uInt32 options = request.options();
+
+        auto handler = DoneEventCallbackRouter::register_handler(
+            [this](TaskHandle task, int32 callback_status) {
+              RegisterDoneEventResponse callback_response;
+              callback_response.set_status(callback_status);
+              queue_write(callback_response);
+              return DAQmxSuccess;
+            });
+
+        auto status = library->RegisterDoneEvent(task, options, DoneEventCallbackRouter::handle_callback, handler->token());
+
+        // SendInitialMetadata after the driver call so that WaitForInitialMetadata can be used to ensure that calls are serialized.
+        StartSendInitialMetadata();
+
+        if (status) {
+          RegisterDoneEventResponse failed_to_register_response;
+          failed_to_register_response.set_status(status);
+          queue_write(failed_to_register_response);
+        }
+      }
+      catch (nidevice_grpc::LibraryLoadException& ex) {
+        Finish(::grpc::Status(::grpc::NOT_FOUND, ex.what()));
+      }
+
+      return handler;
     }
-    return ::grpc::Status::OK;
-  }
-  catch (nidevice_grpc::LibraryLoadException& ex) {
-    return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-  }
+  };
+
+  return new RegisterDoneEventReactor(*request, library_, session_repository_);
 }
 }  // namespace nidaqmx_grpc

--- a/source/custom/nifake_non_ivi_service.custom.cpp
+++ b/source/custom/nifake_non_ivi_service.custom.cpp
@@ -1,7 +1,51 @@
 #include <nifake_non_ivi/nifake_non_ivi_service.h>
+#include <server/async_operation.h>
 #include <server/callback_router.h>
 
+#include <memory>
+#include <thread>
 namespace nifake_non_ivi_grpc {
+
+::grpc::experimental::ServerWriteReactor<ReadStreamResponse>* NiFakeNonIviService::ReadStream(::grpc::CallbackServerContext* context, const ReadStreamRequest* request)
+{
+  struct AutoJoinThread {
+    static std::unique_ptr<AutoJoinThread> make_auto_join(std::thread&& thread)
+    {
+      return std::make_unique<AutoJoinThread>(std::move(thread));
+    }
+    AutoJoinThread(std::thread&& thread) : thread_(std::move(thread))
+    {
+    }
+    ~AutoJoinThread() { thread_.join(); }
+    std::thread thread_;
+  };
+  class ReadStreamReactor : public nidevice_grpc::ServerWriterReactor<ReadStreamResponse, AutoJoinThread> {
+   public:
+    ReadStreamReactor(int32 start, int32 stop) : start_(start),
+                                                 stop_(stop)
+    {
+      thread_ = start_thread();
+    }
+
+    std::unique_ptr<AutoJoinThread> start_thread()
+    {
+      return AutoJoinThread::make_auto_join(std::thread([=]() {
+        ReadStreamResponse response;
+        for (auto i = start_; i <= stop_; ++i) {
+          response.set_value(i);
+          queue_write(response);
+        }
+      }));
+    }
+
+    int32 start_;
+    int32 stop_;
+  };
+
+  return new ReadStreamReactor(
+      request->start(),
+      request->stop());
+}
 
 // Note: this is a contrived callback implementation that depends on the callback being immediately called on register.
 // It is used to exercise the other levels of codegen associated with unpacking and forwarding callback params.
@@ -16,7 +60,7 @@ namespace nifake_non_ivi_grpc {
     auto registration = FakeCallbackRouter::register_handler([&](int32 val) { 
       response->set_echo_data(request->input_data());
       return 0; });
-    auto status = library_->RegisterCallback(request->input_data(), FakeCallbackRouter::handle_callback, registration.token());
+    auto status = library_->RegisterCallback(request->input_data(), FakeCallbackRouter::handle_callback, registration->token());
     response->set_status(status);
     return ::grpc::Status::OK;
   }

--- a/source/custom/nifake_non_ivi_service.custom.cpp
+++ b/source/custom/nifake_non_ivi_service.custom.cpp
@@ -21,8 +21,9 @@ namespace nifake_non_ivi_grpc {
   };
   class ReadStreamReactor : public nidevice_grpc::ServerWriterReactor<ReadStreamResponse, AutoJoinThread> {
    public:
-    ReadStreamReactor(int32 start, int32 stop) : start_(start),
-                                                 stop_(stop)
+    ReadStreamReactor(int32 start, int32 stop)
+        : start_(start),
+          stop_(stop)
     {
       thread_ = start_thread();
     }

--- a/source/server/async_operation.h
+++ b/source/server/async_operation.h
@@ -39,7 +39,7 @@ class ServerWriterReactor : public grpc::ServerWriteReactor<TResponse> {
   {
     LockGuard lock(mutex_);
     done_ = true;
-    Finish(::grpc::Status::OK);
+    this->Finish(::grpc::Status::OK);
   }
 
   void queue_write(const TResponse& response)
@@ -57,7 +57,7 @@ class ServerWriterReactor : public grpc::ServerWriteReactor<TResponse> {
     if (!done_ && write_ready_ && !pending_send_.empty()) {
       write_ready_ = false;
       auto& response = pending_send_.front();
-      StartWrite(&response);
+      this->StartWrite(&response);
     }
   }
 

--- a/source/server/async_operation.h
+++ b/source/server/async_operation.h
@@ -1,0 +1,65 @@
+#ifndef NIDEVICE_GRPC_DEVICE_ASYNC_OPERATION_H
+#define NIDEVICE_GRPC_DEVICE_ASYNC_OPERATION_H
+
+#include <grpcpp/alarm.h>
+#include <grpcpp/grpcpp.h>
+
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <queue>
+
+namespace nidevice_grpc {
+
+template <typename TResponse, typename TJoinable>
+class ServerWriterReactor : public grpc::ServerWriteReactor<TResponse> {
+  using LockGuard = std::lock_guard<std::recursive_mutex>;
+
+ public:
+  virtual ~ServerWriterReactor() {}
+
+  void OnDone() override
+  {
+    delete this;
+  }
+
+  void OnWriteDone(bool /*ok*/) override
+  {
+    LockGuard lock(mutex_);
+    write_ready = true;
+    pending_send_.pop();
+    next_write();
+  }
+
+  void OnCancel() override
+  {
+    Finish(::grpc::Status::OK);
+  }
+
+  void queue_write(const TResponse& response)
+  {
+    LockGuard lock(mutex_);
+    pending_send_.push(response);
+    next_write();
+  }
+
+  std::unique_ptr<TJoinable> thread_;
+
+ private:
+  void next_write()
+  {
+    LockGuard lock(mutex_);
+    if (write_ready && !pending_send_.empty()) {
+      write_ready = false;
+      auto& response = pending_send_.front();
+      StartWrite(&response);
+    }
+  }
+
+  std::recursive_mutex mutex_;
+  // This class relies on: std::deque does not invalidate on push/pop.
+  std::queue<TResponse, std::deque<TResponse>> pending_send_;
+  bool write_ready = true;
+};
+}  // namespace nidevice_grpc
+#endif  // NIDEVICE_GRPC_DEVICE_ASYNC_OPERATION_H

--- a/source/server/callback_router.h
+++ b/source/server/callback_router.h
@@ -8,6 +8,13 @@
 
 namespace nidevice_grpc {
 
+struct CallbackRegistration {
+  using Token = void*;
+
+  virtual ~CallbackRegistration() {}
+  virtual Token token() { return {}; }
+};
+
 // Allows registering Handlers taking TArgs... and exposes a static handle_callback
 // method that can be passed as a function pointer to C APIs.
 // This allows Handlers to be implemented with stateful lambdas, which are not convertible
@@ -16,26 +23,20 @@ template <typename TReturn, typename... TArgs>
 class CallbackRouter {
  public:
   using Handler = std::function<TReturn(TArgs...)>;
-  using Token = void*;
+  using Token = CallbackRegistration::Token;
 
-  // Move-only RAII type exposed through register_handler, to auto-unregister_handler when leaving scope.
-  class CallbackRegistration {
+  class CallbackRegistrationImpl : public CallbackRegistration {
+    using LockGuard = std::lock_guard<std::mutex>;
+
    public:
-    CallbackRegistration() : token_(0) {}
-    CallbackRegistration(Token token) : token_(token) {}
-    CallbackRegistration(const CallbackRegistration&) = delete;
-    CallbackRegistration& operator=(const CallbackRegistration&) = delete;
-    CallbackRegistration(CallbackRegistration&& rhs) : token_(rhs.token_) { rhs.token_ = reinterpret_cast<Token>(0); }
-    CallbackRegistration& operator=(CallbackRegistration&& rhs)
+    CallbackRegistrationImpl(Token token) : token_(token) {}
+    CallbackRegistrationImpl(const CallbackRegistrationImpl&) = delete;
+    CallbackRegistrationImpl& operator=(const CallbackRegistrationImpl&) = delete;
+    CallbackRegistrationImpl(CallbackRegistrationImpl&& rhs) = delete;
+    CallbackRegistrationImpl& operator=(CallbackRegistrationImpl&& rhs) = delete;
+    ~CallbackRegistrationImpl()
     {
-      std::swap(token_, rhs.token_);
-      return *this;
-    }
-    ~CallbackRegistration()
-    {
-      if (token_) {
-        instance().unregister_handler(token_);
-      }
+      instance().unregister_handler(token_);
     }
 
     Token token()
@@ -47,10 +48,10 @@ class CallbackRouter {
     Token token_;
   };
 
-  static CallbackRegistration register_handler(const Handler& handler)
+  static std::unique_ptr<CallbackRegistration> register_handler(const Handler& handler)
   {
     auto token = instance().allocate_token_for_handler(handler);
-    return {token};
+    return std::make_unique<CallbackRegistrationImpl>(token);
   }
 
   static TReturn handle_callback(TArgs... args, Token token)
@@ -75,24 +76,29 @@ class CallbackRouter {
   {
     LockGuard guard(mutex_);
     auto token = reinterpret_cast<Token>(callback_id_++);
-    handlers_[token] = handler;
+    handlers_[token] = std::make_shared<Handler>(handler);
     return token;
   }
 
   TReturn route_callback_to_handler(TArgs... args, Token token)
   {
-    Handler handler;
+    // shared_ptr in this method scope ensures that the callback is not deleted
+    // while it's being called.
+    auto handler_shared_ptr = get_handler(token);
+    Handler* handler_ptr = handler_shared_ptr.get();
+    if (!handler_ptr) return 0;
 
-    {
-      LockGuard guard(mutex_);
-      auto handler_it = handlers_.find(token);
-      if (handler_it == handlers_.end()) {
-        return 0;
-      }
-      handler = handler_it->second;
+    return (*handler_ptr)(args...);
+  }
+
+  std::shared_ptr<Handler> get_handler(Token token)
+  {
+    LockGuard guard(mutex_);
+    auto handler_it = handlers_.find(token);
+    if (handler_it == handlers_.end()) {
+      return {};
     }
-
-    return handler(args...);
+    return handler_it->second;
   }
 
   void unregister_handler(Token token)
@@ -102,7 +108,7 @@ class CallbackRouter {
   }
 
   using LockGuard = std::lock_guard<std::mutex>;
-  using HandlerMap = std::unordered_map<Token, Handler>;
+  using HandlerMap = std::unordered_map<Token, std::shared_ptr<Handler>>;
   std::atomic<size_t> callback_id_{0};
   std::mutex mutex_;
   HandlerMap handlers_;

--- a/source/server/callback_router.h
+++ b/source/server/callback_router.h
@@ -75,7 +75,7 @@ class CallbackRouter {
   Token allocate_token_for_handler(const Handler& handler)
   {
     LockGuard guard(mutex_);
-    auto token = reinterpret_cast<Token>(callback_id_++);
+    auto token = reinterpret_cast<Token>(++callback_id_);
     handlers_[token] = std::make_shared<Handler>(handler);
     return token;
   }

--- a/source/server/server_reactor.h
+++ b/source/server/server_reactor.h
@@ -26,12 +26,12 @@ class ServerWriterReactor : public grpc::ServerWriteReactor<TResponse> {
     delete this;
   }
 
-  void OnWriteDone(bool ok) override
+  void OnWriteDone(bool write_succeeded) override
   {
     LockGuard lock(mutex_);
     write_ready_ = true;
     pending_send_.pop();
-    if (ok) {
+    if (write_succeeded) {
       next_write();
     }
   }

--- a/source/tests/integration/ni_fake_non_ivi_service_tests_endtoend.cpp
+++ b/source/tests/integration/ni_fake_non_ivi_service_tests_endtoend.cpp
@@ -1,0 +1,235 @@
+#include <gtest/gtest.h>
+#include <nifake_non_ivi/nifake_non_ivi_mock_library.h>
+#include <nifake_non_ivi/nifake_non_ivi_service.h>
+
+#include <atomic>
+#include <memory>
+#include <thread>
+
+namespace ni {
+namespace tests {
+namespace integration {
+
+using namespace nifake_non_ivi_grpc;
+
+// Test NiFakeNonIviService using a client stub.
+class NiFakeNonIviServiceTests_EndToEnd : public ::testing::Test {
+ public:
+  using FakeResourceRepository = nidevice_grpc::SessionResourceRepository<FakeHandle>;
+  nidevice_grpc::SessionRepository session_repository_;
+  std::shared_ptr<FakeResourceRepository> resource_repository_;
+  ni::tests::unit::NiFakeNonIviMockLibrary library_;
+  NiFakeNonIviService service_;
+  std::unique_ptr<::grpc::Server> server_;
+  std::unique_ptr<NiFakeNonIvi::Stub> stub_;
+  std::atomic<bool> shutdown_{false};
+
+  NiFakeNonIviServiceTests_EndToEnd()
+      : session_repository_(),
+        resource_repository_(std::make_shared<FakeResourceRepository>(&session_repository_)),
+        library_(),
+        service_(&library_, resource_repository_),
+        server_(start_server()),
+        stub_(NiFakeNonIvi::NewStub(server_->InProcessChannel(::grpc::ChannelArguments())))
+  {
+  }
+
+  virtual ~NiFakeNonIviServiceTests_EndToEnd()
+  {
+    shutdown();
+  }
+
+  void shutdown()
+  {
+    if (!shutdown_) {
+      shutdown_ = true;
+      server_->Shutdown();
+    }
+  }
+
+  std::unique_ptr<::grpc::Server> start_server()
+  {
+    ::grpc::ServerBuilder builder;
+    builder.RegisterService(&service_);
+    return builder.BuildAndStart();
+  }
+
+  std::unique_ptr<NiFakeNonIvi::Stub>& stub()
+  {
+    return stub_;
+  }
+};
+
+TEST_F(NiFakeNonIviServiceTests_EndToEnd, ReadStream_ReturnsExpectedSequence)
+{
+  ::grpc::ClientContext context;
+  const auto START = 0;
+  const auto STOP = 100;
+  ReadStreamRequest request;
+  request.set_start(START);
+  request.set_stop(STOP);
+  auto reader = stub()->ReadStream(&context, request);
+
+  ReadStreamResponse response;
+  for (auto i = START; i <= STOP; ++i) {
+    reader->Read(&response);
+    EXPECT_EQ(response.value(), i);
+  }
+}
+
+TEST_F(NiFakeNonIviServiceTests_EndToEnd, ReadPartialStream_ReturnsExpectedSequence)
+{
+  ::grpc::ClientContext context;
+  const auto START = 0;
+  const auto STOP = 100;
+  ReadStreamRequest request;
+  request.set_start(START);
+  request.set_stop(STOP);
+  auto reader = stub()->ReadStream(&context, request);
+
+  ReadStreamResponse response;
+  for (auto i = START; i <= STOP / 2; ++i) {
+    reader->Read(&response);
+    EXPECT_EQ(response.value(), i);
+  }
+}
+
+TEST_F(NiFakeNonIviServiceTests_EndToEnd, ReadTwoStreamsAlternating_ReturnsExpectedSequences)
+{
+  ::grpc::ClientContext context;
+  const auto START = 0;
+  const auto STOP = 100;
+  const auto OFFSET = 100;
+  ReadStreamRequest request;
+  request.set_start(START);
+  request.set_stop(STOP);
+  auto reader = stub()->ReadStream(&context, request);
+  request.set_start(START + OFFSET);
+  request.set_stop(STOP + OFFSET);
+  ::grpc::ClientContext second_context;
+  auto second_reader = stub()->ReadStream(&second_context, request);
+  reader->WaitForInitialMetadata();
+
+  ReadStreamResponse response;
+  for (auto i = START; i <= STOP; ++i) {
+    reader->Read(&response);
+    EXPECT_EQ(response.value(), i);
+  }
+
+  for (auto i = START; i <= STOP; ++i) {
+    second_reader->Read(&response);
+    EXPECT_EQ(response.value(), i + OFFSET);
+  }
+}
+
+TEST_F(NiFakeNonIviServiceTests_EndToEnd, ReadPartialStream_ShutdownServerBeforeCancel_CleanShutdown)
+{
+  ::grpc::ClientContext context;
+  const auto START = 0;
+  const auto STOP = 100;
+  ReadStreamRequest request;
+  request.set_start(START);
+  request.set_stop(STOP);
+  auto reader = stub()->ReadStream(&context, request);
+  ReadStreamResponse response;
+  for (auto i = START; i <= STOP / 2; ++i) {
+    reader->Read(&response);
+    EXPECT_EQ(response.value(), i);
+  }
+
+  shutdown();
+}
+
+TEST_F(NiFakeNonIviServiceTests_EndToEnd, ReadStream_ShutdownServerBeforeCancel_CleanShutdown)
+{
+  ::grpc::ClientContext context;
+  const auto START = 0;
+  const auto STOP = 100;
+  ReadStreamRequest request;
+  request.set_start(START);
+  request.set_stop(STOP);
+  auto reader = stub()->ReadStream(&context, request);
+
+  ReadStreamResponse response;
+  for (auto i = START; i <= STOP; ++i) {
+    reader->Read(&response);
+    EXPECT_EQ(response.value(), i);
+  }
+
+  shutdown();
+}
+
+TEST_F(NiFakeNonIviServiceTests_EndToEnd, ReadTwoStreamsInterleaved_ReturnsExpectedSequences)
+{
+  ::grpc::ClientContext context;
+  const auto START = 0;
+  const auto STOP = 100;
+  const auto OFFSET = 100;
+  ReadStreamRequest request;
+  request.set_start(START);
+  request.set_stop(STOP);
+  auto reader = stub()->ReadStream(&context, request);
+  request.set_start(START + OFFSET);
+  request.set_stop(STOP + OFFSET);
+  ::grpc::ClientContext second_context;
+  auto second_reader = stub()->ReadStream(&second_context, request);
+  reader->WaitForInitialMetadata();
+
+  ReadStreamResponse response;
+  for (auto i = START; i <= STOP; ++i) {
+    reader->Read(&response);
+    EXPECT_EQ(response.value(), i);
+    second_reader->Read(&response);
+    EXPECT_EQ(response.value(), i + OFFSET);
+  }
+}
+
+TEST_F(NiFakeNonIviServiceTests_EndToEnd, StartReadStream_ShutdownBeforeRead_CleanShutdown)
+{
+  ::grpc::ClientContext context;
+  const auto START = 0;
+  const auto STOP = 10;
+  const auto OFFSET = 100;
+  ReadStreamRequest request;
+  request.set_start(START);
+  request.set_stop(STOP);
+  auto reader = stub()->ReadStream(&context, request);
+
+  reader.reset();
+}
+
+TEST_F(NiFakeNonIviServiceTests_EndToEnd, WaitForMetadata_Cancel_CleanShutdown)
+{
+  ::grpc::ClientContext context;
+  const auto START = 0;
+  const auto STOP = 10;
+  const auto OFFSET = 100;
+  ReadStreamRequest request;
+  request.set_start(START);
+  request.set_stop(STOP);
+  auto reader = stub()->ReadStream(&context, request);
+  reader->WaitForInitialMetadata();
+
+  reader.reset();
+}
+
+TEST_F(NiFakeNonIviServiceTests_EndToEnd, WaitForMetadata_ShutdownAndRead_CleanShutdown)
+{
+  ::grpc::ClientContext context;
+  const auto START = 0;
+  const auto STOP = 10;
+  const auto OFFSET = 100;
+  ReadStreamRequest request;
+  request.set_start(START);
+  request.set_stop(STOP);
+  auto reader = stub()->ReadStream(&context, request);
+  reader->WaitForInitialMetadata();
+
+  shutdown();
+  ReadStreamResponse response;
+  reader->Read(&response);
+}
+
+}  // namespace integration
+}  // namespace tests
+}  // namespace ni

--- a/source/tests/integration/ni_fake_non_ivi_service_tests_endtoend.cpp
+++ b/source/tests/integration/ni_fake_non_ivi_service_tests_endtoend.cpp
@@ -94,7 +94,7 @@ TEST_F(NiFakeNonIviServiceTests_EndToEnd, ReadPartialStream_ReturnsExpectedSeque
   }
 }
 
-TEST_F(NiFakeNonIviServiceTests_EndToEnd, ReadTwoStreamsAlternating_ReturnsExpectedSequences)
+TEST_F(NiFakeNonIviServiceTests_EndToEnd, ReadTwoStreamsConsecutively_ReturnsExpectedSequences)
 {
   ::grpc::ClientContext context;
   const auto START = 0;
@@ -189,7 +189,6 @@ TEST_F(NiFakeNonIviServiceTests_EndToEnd, StartReadStream_ShutdownBeforeRead_Cle
   ::grpc::ClientContext context;
   const auto START = 0;
   const auto STOP = 10;
-  const auto OFFSET = 100;
   ReadStreamRequest request;
   request.set_start(START);
   request.set_stop(STOP);
@@ -203,7 +202,6 @@ TEST_F(NiFakeNonIviServiceTests_EndToEnd, WaitForMetadata_Cancel_CleanShutdown)
   ::grpc::ClientContext context;
   const auto START = 0;
   const auto STOP = 10;
-  const auto OFFSET = 100;
   ReadStreamRequest request;
   request.set_start(START);
   request.set_stop(STOP);
@@ -218,7 +216,6 @@ TEST_F(NiFakeNonIviServiceTests_EndToEnd, WaitForMetadata_ShutdownAndRead_CleanS
   ::grpc::ClientContext context;
   const auto START = 0;
   const auto STOP = 10;
-  const auto OFFSET = 100;
   ReadStreamRequest request;
   request.set_start(START);
   request.set_stop(STOP);

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -924,8 +924,9 @@ TEST_F(NiDAQmxDriverApiTests, ChannelWithDoneEventRegistered_RunCompleteFiniteAc
   create_ai_voltage_chan(0.0, 1.0);
   ::grpc::ClientContext reader_context;
   auto reader = register_done_event(reader_context);
+  reader->WaitForInitialMetadata();
 
-  auto FINITE_SAMPLE_COUNT = 10UL;
+  const auto FINITE_SAMPLE_COUNT = 10UL;
   cfg_samp_clk_timing(
       create_cfg_samp_clk_timing_request(1000.0, Edge1::EDGE1_UNSPECIFIED, AcquisitionType::ACQUISITION_TYPE_FINITE_SAMPS, FINITE_SAMPLE_COUNT));
   start_task();
@@ -936,6 +937,31 @@ TEST_F(NiDAQmxDriverApiTests, ChannelWithDoneEventRegistered_RunCompleteFiniteAc
   RegisterDoneEventResponse response;
   reader->Read(&response);
   EXPECT_EQ(DAQmxSuccess, response.status());
+}
+
+TEST_F(NiDAQmxDriverApiTests, ChannelWithDoneEventRegisteredTwice_RunCompleteFiniteAcquisition_DoneEventResponseIsReceived)
+{
+  create_ai_voltage_chan(0.0, 1.0);
+  ::grpc::ClientContext reader_context;
+  auto reader = register_done_event(reader_context);
+  reader->WaitForInitialMetadata();
+  ::grpc::ClientContext second_reader_context;
+  auto second_reader = register_done_event(second_reader_context);
+  second_reader->WaitForInitialMetadata();
+
+  const auto FINITE_SAMPLE_COUNT = 10UL;
+  cfg_samp_clk_timing(
+      create_cfg_samp_clk_timing_request(1000.0, Edge1::EDGE1_UNSPECIFIED, AcquisitionType::ACQUISITION_TYPE_FINITE_SAMPS, FINITE_SAMPLE_COUNT));
+  start_task();
+  ReadAnalogF64Response read_response;
+  auto read_status = read_analog_f64(FINITE_SAMPLE_COUNT, FINITE_SAMPLE_COUNT, read_response);
+  EXPECT_SUCCESS(read_status, read_response);
+
+  RegisterDoneEventResponse response;
+  reader->Read(&response);
+  EXPECT_EQ(DAQmxSuccess, response.status());
+  second_reader->Read(&response);
+  EXPECT_EQ(DAQmxErrorDoneEventAlreadyRegistered, response.status());
 }
 
 TEST_F(NiDAQmxDriverApiTests, AIVoltageChannel_ConfigureInputBuffer_Succeeds)

--- a/source/tests/unit/callback_router_tests.cpp
+++ b/source/tests/unit/callback_router_tests.cpp
@@ -48,7 +48,7 @@ TEST(CallbackRouterTests, IntCallbackHandlerRegistered_HandleCallback_CallsHandl
   auto registration = IntCallbackRouter::register_handler(handler.AsStdFunction());
 
   EXPECT_CALLBACK(handler, CALLBACK_VAL);
-  auto result = IntCallbackRouter::handle_callback(CALLBACK_VAL, registration.token());
+  auto result = IntCallbackRouter::handle_callback(CALLBACK_VAL, registration->token());
 
   EXPECT_EQ(TEST_SUCCESS, result);
 }
@@ -60,10 +60,10 @@ TEST(CallbackRouterTests, IntCallbackHandlerRegistered_HandleCallbackMultipleTim
 
   const int32_t FIRST_CALLBACK_VAL = 0x1234;
   EXPECT_CALLBACK(handler, FIRST_CALLBACK_VAL);
-  auto first_result = IntCallbackRouter::handle_callback(FIRST_CALLBACK_VAL, registration.token());
+  auto first_result = IntCallbackRouter::handle_callback(FIRST_CALLBACK_VAL, registration->token());
   const int32_t SECOND_CALLBACK_VAL = 0xABAB;
   EXPECT_CALLBACK(handler, SECOND_CALLBACK_VAL);
-  auto second_result = IntCallbackRouter::handle_callback(SECOND_CALLBACK_VAL, registration.token());
+  auto second_result = IntCallbackRouter::handle_callback(SECOND_CALLBACK_VAL, registration->token());
 
   EXPECT_EQ(TEST_SUCCESS, first_result);
   EXPECT_EQ(TEST_SUCCESS, second_result);
@@ -77,12 +77,12 @@ TEST(CallbackRouterTests, BoolAndStringCallbackHandlerRegistered_HandleCallback_
   const bool CALLBACK_BOOL = true;
   const std::string CALLBACK_STRING = "HelloCallback";
   EXPECT_CALLBACK(handler, CALLBACK_BOOL, CALLBACK_STRING);
-  auto result = BoolAndStringCallbackRouter::handle_callback(CALLBACK_BOOL, CALLBACK_STRING, registration.token());
+  auto result = BoolAndStringCallbackRouter::handle_callback(CALLBACK_BOOL, CALLBACK_STRING, registration->token());
 
   EXPECT_EQ(TEST_SUCCESS, result);
 }
 
-TEST(CallbackRouterTests, BoolAndStringCallbackHandlerRegistered_HandleCallbackWithBogusToken_DoesNotCallHandler)
+TEST(CallbackRouterTests, BoolAndStringCallbackHandlerRegistered_HandleCallbackWithBogusAsyncOperationToken_DoesNotCallHandler)
 {
   auto registration = BoolAndStringCallbackRouter::register_handler(
       fail_on_callback);
@@ -103,7 +103,7 @@ TEST(CallbackRouterTests, MultipleHandlersRegistered_HandleOneCallback_SignalsCo
   const bool CALLBACK_BOOL = true;
   const std::string CALLBACK_STRING = "HelloSecondHandler";
   EXPECT_CALLBACK(handler, CALLBACK_BOOL, CALLBACK_STRING);
-  auto result = BoolAndStringCallbackRouter::handle_callback(CALLBACK_BOOL, CALLBACK_STRING, second_registration.token());
+  auto result = BoolAndStringCallbackRouter::handle_callback(CALLBACK_BOOL, CALLBACK_STRING, second_registration->token());
 
   EXPECT_EQ(TEST_SUCCESS, result);
 }
@@ -120,11 +120,11 @@ TEST(CallbackRouterTests, MultipleHandlersRegistered_HandleBothCallbacks_Signals
   const bool FIRST_CALLBACK_BOOL = false;
   const std::string FIRST_CALLBACK_STRING = "HelloFirstHandler";
   EXPECT_CALLBACK(first_handler, FIRST_CALLBACK_BOOL, FIRST_CALLBACK_STRING);
-  auto first_result = BoolAndStringCallbackRouter::handle_callback(FIRST_CALLBACK_BOOL, FIRST_CALLBACK_STRING, first_registration.token());
+  auto first_result = BoolAndStringCallbackRouter::handle_callback(FIRST_CALLBACK_BOOL, FIRST_CALLBACK_STRING, first_registration->token());
   const bool SECOND_CALLBACK_BOOL = true;
   const std::string SECOND_CALLBACK_STRING = "HelloSecondHandler";
   EXPECT_CALLBACK(second_handler, SECOND_CALLBACK_BOOL, SECOND_CALLBACK_STRING);
-  auto second_result = BoolAndStringCallbackRouter::handle_callback(SECOND_CALLBACK_BOOL, SECOND_CALLBACK_STRING, second_registration.token());
+  auto second_result = BoolAndStringCallbackRouter::handle_callback(SECOND_CALLBACK_BOOL, SECOND_CALLBACK_STRING, second_registration->token());
 
   EXPECT_EQ(TEST_SUCCESS, first_result);
   EXPECT_EQ(TEST_SUCCESS, second_result);
@@ -132,11 +132,11 @@ TEST(CallbackRouterTests, MultipleHandlersRegistered_HandleBothCallbacks_Signals
 
 TEST(CallbackRouterTests, CallbackRegisteredAndUnregistered_HandleCallback_DoesNotCallHandler)
 {
-  BoolAndStringCallbackRouter::Token token;
+  CallbackRegistration::Token token;
   {
     auto registration = BoolAndStringCallbackRouter::register_handler(
         fail_on_callback);
-    token = registration.token();
+    token = registration->token();
   }
 
   auto result = BoolAndStringCallbackRouter::handle_callback(false, "MessageToNoOne", token);


### PR DESCRIPTION
### What does this Pull Request accomplish?

Reimplement callbacks with experimental callback service.

The first pass implementation of DAQmx callbacks used synchronous streams. This has the problem of blocking a thread while the callback is registered and requiring polling to check for cancellation.

I attempted to use the traditional grpc async service API in #275. This API is difficult to use and my implementation had persistent race condition/quality issues.

Grpc recently "de-experimentalized" the async callback/reactor API for async services. This is much easier to implement than the previous API and a simple implementation is much more reliable than my previous attempt.

[Callback API proposal](https://github.com/grpc/proposal/blob/master/L67-cpp-callback-api.md)
[Callback example](https://github.com/grpc/grpc/blob/master/examples/cpp/route_guide/route_guide_callback_server.cc)

### Why should this Pull Request be merged?

Improve behavior and performance of `RegisterDoneEvent` callback.
Unblocks additional callbacks.
Adds integration testing for some of the async server glue code.

### What testing has been done?

Ran and passed all DAQ tests.
Ran and passed new tests 500+ times.