### PR TITLE
Clean up exceptions in DAQ betterproto examples

### DIFF
--- a/examples/nidaqmx/analog-input-betterproto.py
+++ b/examples/nidaqmx/analog-input-betterproto.py
@@ -30,6 +30,7 @@ import asyncio
 from nidevice import nidaqmx_grpc
 import sys
 from grpclib.client import Channel
+from grpclib.exceptions import GRPCError
 
 
 server_address = "localhost"
@@ -98,6 +99,13 @@ async def main():
 
         print(f"Acquired {response.samps_per_chan_read} samples.")
         print(f"First 5 samples: {response.read_array[:5]}")
+    except GRPCError as e:
+        if e.status.name == "UNIMPLEMENTED":
+            print("The operation is not implemented or is not supported/enabled in this service")
+        else:
+            print(f"GRPCError: {str(e)}")
+    except Exception as e:
+        print(str(e))
     finally:
         if task:
             await daq_service.stop_task(task=task)

--- a/examples/nidaqmx/digital-input-betterproto.py
+++ b/examples/nidaqmx/digital-input-betterproto.py
@@ -30,6 +30,7 @@ import asyncio
 from nidevice import nidaqmx_grpc
 import sys
 from grpclib.client import Channel
+from grpclib.exceptions import GRPCError
 
 server_address = "localhost"
 server_port = "31763"
@@ -76,6 +77,13 @@ async def main():
         await raise_if_error(response)
 
         print(f"Data acquired: {hex(response.read_array[0])}")
+    except GRPCError as e:
+        if e.status.name == "UNIMPLEMENTED":
+            print("The operation is not implemented or is not supported/enabled in this service")
+        else:
+            print(f"GRPCError: {str(e)}")
+    except Exception as e:
+        print(str(e))
     finally:
         if task:
             await daq_service.stop_task(task=task)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fix DAQ `betterproto` examples to print better exceptions, especially in common error cases.

Note that `betterproto` does not report `GRPCError`s for connection failures. Those are reported as `OSError` or `TimeouError`, which do not provide much structure.

Sample output:

Connection errors (different cases):
```
> python digital-input-betterproto.py localhost 31763 "gRPCSystemTestDAQ/port0"                                                                                                                                                               
Multiple exceptions: [Errno 10061] Connect call failed ('::1', 31763, 0, 0), [Errno 10061] Connect call failed ('127.0.0.1', 31763)

> python digital-input-betterproto.py 0.0.0.0 31763 "gRPCSystemTestDAQ/port0"                                                                                                                                                                 
[Errno 10049] Connect call failed ('0.0.0.0', 31763)

> python digital-input-betterproto.py 10.0.62.17 31763 "gRPCSystemTestDAQ/port0"
[Errno 10060] Connect call failed ('10.0.62.17', 31763)
```

UNIMPLEMENTED error:
```
> python digital-input-betterproto.py 10.0.62.17 31763 "gRPCSystemTestDAQ/port0"
The operation is not implemented or is not supported/enabled in this service
```

Other GRPC error:
```
> python digital-input-betterproto.py 10.0.62.17 31763 "gRPCSystemTestDAQ/port0"
GRPCError: (<Status.SOMETHINGELSE: 12345>, None, None)
```

Error from DAQ/`raise_if_error`:
```
> python digital-input-betterproto.py 10.0.62.17 31763 "gRPCSystemTestDAQ/not-a-port"
Error: Device identifier is invalid.
```

### Why should this Pull Request be merged?

Simple implementation to provide reasonable errors for betterproto examples.

### What testing has been done?

Ran examples in various success and failure cases.