### PR TITLE
Add DAQmx Advanced functions to grpc-device

### DIFF
--- a/generated/nidaqmx/nidaqmx.proto
+++ b/generated/nidaqmx/nidaqmx.proto
@@ -17,8 +17,11 @@ import "session.proto";
 import "google/protobuf/timestamp.proto";
 
 service NiDAQmx {
+  rpc AddCDAQSyncConnection(AddCDAQSyncConnectionRequest) returns (AddCDAQSyncConnectionResponse);
   rpc AddGlobalChansToTask(AddGlobalChansToTaskRequest) returns (AddGlobalChansToTaskResponse);
   rpc AddNetworkDevice(AddNetworkDeviceRequest) returns (AddNetworkDeviceResponse);
+  rpc AreConfiguredCDAQSyncPortsDisconnected(AreConfiguredCDAQSyncPortsDisconnectedRequest) returns (AreConfiguredCDAQSyncPortsDisconnectedResponse);
+  rpc AutoConfigureCDAQSyncConnections(AutoConfigureCDAQSyncConnectionsRequest) returns (AutoConfigureCDAQSyncConnectionsResponse);
   rpc CalculateReversePolyCoeff(CalculateReversePolyCoeffRequest) returns (CalculateReversePolyCoeffResponse);
   rpc CfgAnlgEdgeRefTrig(CfgAnlgEdgeRefTrigRequest) returns (CfgAnlgEdgeRefTrigResponse);
   rpc CfgAnlgEdgeStartTrig(CfgAnlgEdgeStartTrigRequest) returns (CfgAnlgEdgeStartTrigResponse);
@@ -43,8 +46,10 @@ service NiDAQmx {
   rpc CfgWatchdogAOExpirStates(CfgWatchdogAOExpirStatesRequest) returns (CfgWatchdogAOExpirStatesResponse);
   rpc CfgWatchdogCOExpirStates(CfgWatchdogCOExpirStatesRequest) returns (CfgWatchdogCOExpirStatesResponse);
   rpc CfgWatchdogDOExpirStates(CfgWatchdogDOExpirStatesRequest) returns (CfgWatchdogDOExpirStatesResponse);
+  rpc ClearTEDS(ClearTEDSRequest) returns (ClearTEDSResponse);
   rpc ClearTask(ClearTaskRequest) returns (ClearTaskResponse);
   rpc ConfigureLogging(ConfigureLoggingRequest) returns (ConfigureLoggingResponse);
+  rpc ConfigureTEDS(ConfigureTEDSRequest) returns (ConfigureTEDSResponse);
   rpc ConnectTerms(ConnectTermsRequest) returns (ConnectTermsResponse);
   rpc ControlWatchdogTask(ControlWatchdogTaskRequest) returns (ControlWatchdogTaskResponse);
   rpc CreateAIAccel4WireDCVoltageChan(CreateAIAccel4WireDCVoltageChanRequest) returns (CreateAIAccel4WireDCVoltageChanResponse);
@@ -130,6 +135,10 @@ service NiDAQmx {
   rpc CreateWatchdogTimerTask(CreateWatchdogTimerTaskRequest) returns (CreateWatchdogTimerTaskResponse);
   rpc CreateWatchdogTimerTaskEx(CreateWatchdogTimerTaskExRequest) returns (CreateWatchdogTimerTaskExResponse);
   rpc DeleteNetworkDevice(DeleteNetworkDeviceRequest) returns (DeleteNetworkDeviceResponse);
+  rpc DeleteSavedGlobalChan(DeleteSavedGlobalChanRequest) returns (DeleteSavedGlobalChanResponse);
+  rpc DeleteSavedScale(DeleteSavedScaleRequest) returns (DeleteSavedScaleResponse);
+  rpc DeleteSavedTask(DeleteSavedTaskRequest) returns (DeleteSavedTaskResponse);
+  rpc DeviceSupportsCal(DeviceSupportsCalRequest) returns (DeviceSupportsCalResponse);
   rpc DisableRefTrig(DisableRefTrigRequest) returns (DisableRefTrigResponse);
   rpc DisableStartTrig(DisableStartTrigRequest) returns (DisableStartTrigResponse);
   rpc DisconnectTerms(DisconnectTermsRequest) returns (DisconnectTermsResponse);
@@ -138,7 +147,9 @@ service NiDAQmx {
   rpc GetAIChanCalExpDate(GetAIChanCalExpDateRequest) returns (GetAIChanCalExpDateResponse);
   rpc GetArmStartTrigTimestampVal(GetArmStartTrigTimestampValRequest) returns (GetArmStartTrigTimestampValResponse);
   rpc GetArmStartTrigTrigWhen(GetArmStartTrigTrigWhenRequest) returns (GetArmStartTrigTrigWhenResponse);
+  rpc GetAutoConfiguredCDAQSyncConnections(GetAutoConfiguredCDAQSyncConnectionsRequest) returns (GetAutoConfiguredCDAQSyncConnectionsResponse);
   rpc GetDigitalLogicFamilyPowerUpState(GetDigitalLogicFamilyPowerUpStateRequest) returns (GetDigitalLogicFamilyPowerUpStateResponse);
+  rpc GetDisconnectedCDAQSyncPorts(GetDisconnectedCDAQSyncPortsRequest) returns (GetDisconnectedCDAQSyncPortsResponse);
   rpc GetErrorString(GetErrorStringRequest) returns (GetErrorStringResponse);
   rpc GetExtendedErrorInfo(GetExtendedErrorInfoRequest) returns (GetExtendedErrorInfoResponse);
   rpc GetFirstSampClkWhen(GetFirstSampClkWhenRequest) returns (GetFirstSampClkWhenResponse);
@@ -147,6 +158,7 @@ service NiDAQmx {
   rpc GetNthTaskDevice(GetNthTaskDeviceRequest) returns (GetNthTaskDeviceResponse);
   rpc GetNthTaskReadChannel(GetNthTaskReadChannelRequest) returns (GetNthTaskReadChannelResponse);
   rpc GetRefTrigTimestampVal(GetRefTrigTimestampValRequest) returns (GetRefTrigTimestampValResponse);
+  rpc GetSelfCalLastDateAndTime(GetSelfCalLastDateAndTimeRequest) returns (GetSelfCalLastDateAndTimeResponse);
   rpc GetStartTrigTimestampVal(GetStartTrigTimestampValRequest) returns (GetStartTrigTimestampValResponse);
   rpc GetStartTrigTrigWhen(GetStartTrigTrigWhenRequest) returns (GetStartTrigTrigWhenResponse);
   rpc GetSyncPulseTimeWhen(GetSyncPulseTimeWhenRequest) returns (GetSyncPulseTimeWhenResponse);
@@ -177,8 +189,13 @@ service NiDAQmx {
   rpc ReadDigitalU8(ReadDigitalU8Request) returns (ReadDigitalU8Response);
   rpc ReadRaw(ReadRawRequest) returns (ReadRawResponse);
   rpc RegisterDoneEvent(RegisterDoneEventRequest) returns (stream RegisterDoneEventResponse);
+  rpc RemoveCDAQSyncConnection(RemoveCDAQSyncConnectionRequest) returns (RemoveCDAQSyncConnectionResponse);
   rpc ReserveNetworkDevice(ReserveNetworkDeviceRequest) returns (ReserveNetworkDeviceResponse);
   rpc ResetDevice(ResetDeviceRequest) returns (ResetDeviceResponse);
+  rpc SaveGlobalChan(SaveGlobalChanRequest) returns (SaveGlobalChanResponse);
+  rpc SaveScale(SaveScaleRequest) returns (SaveScaleResponse);
+  rpc SaveTask(SaveTaskRequest) returns (SaveTaskResponse);
+  rpc SelfCal(SelfCalRequest) returns (SelfCalResponse);
   rpc SelfTestDevice(SelfTestDeviceRequest) returns (SelfTestDeviceResponse);
   rpc SetAIChanCalCalDate(SetAIChanCalCalDateRequest) returns (SetAIChanCalCalDateResponse);
   rpc SetAIChanCalExpDate(SetAIChanCalExpDateRequest) returns (SetAIChanCalExpDateResponse);
@@ -193,6 +210,7 @@ service NiDAQmx {
   rpc TaskControl(TaskControlRequest) returns (TaskControlResponse);
   rpc TristateOutputTerm(TristateOutputTermRequest) returns (TristateOutputTermResponse);
   rpc UnreserveNetworkDevice(UnreserveNetworkDeviceRequest) returns (UnreserveNetworkDeviceResponse);
+  rpc WaitForNextSampleClock(WaitForNextSampleClockRequest) returns (WaitForNextSampleClockResponse);
   rpc WaitForValidTimestamp(WaitForValidTimestampRequest) returns (WaitForValidTimestampResponse);
   rpc WaitUntilTaskDone(WaitUntilTaskDoneRequest) returns (WaitUntilTaskDoneResponse);
   rpc WriteAnalogF64(WriteAnalogF64Request) returns (WriteAnalogF64Response);
@@ -213,6 +231,8 @@ service NiDAQmx {
   rpc WriteDigitalU32(WriteDigitalU32Request) returns (WriteDigitalU32Response);
   rpc WriteDigitalU8(WriteDigitalU8Request) returns (WriteDigitalU8Response);
   rpc WriteRaw(WriteRawRequest) returns (WriteRawResponse);
+  rpc WriteToTEDSFromArray(WriteToTEDSFromArrayRequest) returns (WriteToTEDSFromArrayResponse);
+  rpc WriteToTEDSFromFile(WriteToTEDSFromFileRequest) returns (WriteToTEDSFromFileResponse);
 }
 
 enum NiDAQmxAttributes {
@@ -589,6 +609,13 @@ enum ResistanceUnits2 {
   RESISTANCE_UNITS2_FROM_CUSTOM_SCALE = 10065;
 }
 
+enum SaveOptions {
+  SAVE_OPTIONS_UNSPECIFIED = 0;
+  SAVE_OPTIONS_OVERWRITE = 1;
+  SAVE_OPTIONS_ALLOW_INTERACTIVE_EDITING = 2;
+  SAVE_OPTIONS_ALLOW_INTERACTIVE_DELETION = 4;
+}
+
 enum Signal {
   SIGNAL_UNSPECIFIED = 0;
   SIGNAL_AI_CONVERT_CLOCK = 12484;
@@ -789,6 +816,21 @@ enum WindowTriggerCondition1 {
   WINDOW_TRIGGER_CONDITION1_LEAVING_WIN = 10208;
 }
 
+enum WriteBasicTEDSOptions {
+  WRITE_BASIC_TEDS_OPTIONS_UNSPECIFIED = 0;
+  WRITE_BASIC_TEDS_OPTIONS_WRITE_TO_EEPROM = 12538;
+  WRITE_BASIC_TEDS_OPTIONS_WRITE_TO_PROM = 12539;
+  WRITE_BASIC_TEDS_OPTIONS_DO_NOT_WRITE = 12540;
+}
+
+message AddCDAQSyncConnectionRequest {
+  string port_list = 1;
+}
+
+message AddCDAQSyncConnectionResponse {
+  int32 status = 1;
+}
+
 message AddGlobalChansToTaskRequest {
   nidevice_grpc.Session task = 1;
   string channel_names = 2;
@@ -809,6 +851,25 @@ message AddNetworkDeviceRequest {
 message AddNetworkDeviceResponse {
   int32 status = 1;
   string device_name_out = 2;
+}
+
+message AreConfiguredCDAQSyncPortsDisconnectedRequest {
+  string chassis_devices_ports = 1;
+  double timeout = 2;
+}
+
+message AreConfiguredCDAQSyncPortsDisconnectedResponse {
+  int32 status = 1;
+  bool disconnected_ports_exist = 2;
+}
+
+message AutoConfigureCDAQSyncConnectionsRequest {
+  string chassis_devices_ports = 1;
+  double timeout = 2;
+}
+
+message AutoConfigureCDAQSyncConnectionsResponse {
+  int32 status = 1;
 }
 
 message CalculateReversePolyCoeffRequest {
@@ -1164,6 +1225,14 @@ message CfgWatchdogDOExpirStatesResponse {
   int32 status = 1;
 }
 
+message ClearTEDSRequest {
+  string physical_channel = 1;
+}
+
+message ClearTEDSResponse {
+  int32 status = 1;
+}
+
 message ClearTaskRequest {
   nidevice_grpc.Session task = 1;
 }
@@ -1187,6 +1256,15 @@ message ConfigureLoggingRequest {
 }
 
 message ConfigureLoggingResponse {
+  int32 status = 1;
+}
+
+message ConfigureTEDSRequest {
+  string physical_channel = 1;
+  string file_path = 2;
+}
+
+message ConfigureTEDSResponse {
   int32 status = 1;
 }
 
@@ -3241,6 +3319,39 @@ message DeleteNetworkDeviceResponse {
   int32 status = 1;
 }
 
+message DeleteSavedGlobalChanRequest {
+  string channel_name = 1;
+}
+
+message DeleteSavedGlobalChanResponse {
+  int32 status = 1;
+}
+
+message DeleteSavedScaleRequest {
+  string scale_name = 1;
+}
+
+message DeleteSavedScaleResponse {
+  int32 status = 1;
+}
+
+message DeleteSavedTaskRequest {
+  string task_name = 1;
+}
+
+message DeleteSavedTaskResponse {
+  int32 status = 1;
+}
+
+message DeviceSupportsCalRequest {
+  string device_name = 1;
+}
+
+message DeviceSupportsCalResponse {
+  int32 status = 1;
+  bool cal_supported = 2;
+}
+
 message DisableRefTrigRequest {
   nidevice_grpc.Session task = 1;
 }
@@ -3325,6 +3436,15 @@ message GetArmStartTrigTrigWhenResponse {
   google.protobuf.Timestamp data = 2;
 }
 
+message GetAutoConfiguredCDAQSyncConnectionsRequest {
+  uint32 port_list_size = 1;
+}
+
+message GetAutoConfiguredCDAQSyncConnectionsResponse {
+  int32 status = 1;
+  string port_list = 2;
+}
+
 message GetDigitalLogicFamilyPowerUpStateRequest {
   string device_name = 1;
 }
@@ -3332,6 +3452,15 @@ message GetDigitalLogicFamilyPowerUpStateRequest {
 message GetDigitalLogicFamilyPowerUpStateResponse {
   int32 status = 1;
   int32 logic_family = 2;
+}
+
+message GetDisconnectedCDAQSyncPortsRequest {
+  uint32 port_list_size = 1;
+}
+
+message GetDisconnectedCDAQSyncPortsResponse {
+  int32 status = 1;
+  string port_list = 2;
 }
 
 message GetErrorStringRequest {
@@ -3411,6 +3540,19 @@ message GetRefTrigTimestampValRequest {
 message GetRefTrigTimestampValResponse {
   int32 status = 1;
   google.protobuf.Timestamp data = 2;
+}
+
+message GetSelfCalLastDateAndTimeRequest {
+  string device_name = 1;
+}
+
+message GetSelfCalLastDateAndTimeResponse {
+  int32 status = 1;
+  uint32 year = 2;
+  uint32 month = 3;
+  uint32 day = 4;
+  uint32 hour = 5;
+  uint32 minute = 6;
 }
 
 message GetStartTrigTimestampValRequest {
@@ -3822,6 +3964,14 @@ message RegisterDoneEventResponse {
   int32 status = 1;
 }
 
+message RemoveCDAQSyncConnectionRequest {
+  string port_list = 1;
+}
+
+message RemoveCDAQSyncConnectionResponse {
+  int32 status = 1;
+}
+
 message ReserveNetworkDeviceRequest {
   string device_name = 1;
   bool override_reservation = 2;
@@ -3836,6 +3986,57 @@ message ResetDeviceRequest {
 }
 
 message ResetDeviceResponse {
+  int32 status = 1;
+}
+
+message SaveGlobalChanRequest {
+  nidevice_grpc.Session task = 1;
+  string channel_name = 2;
+  string save_as = 3;
+  string author = 4;
+  oneof options_enum {
+    SaveOptions options = 5;
+    uint32 options_raw = 6;
+  }
+}
+
+message SaveGlobalChanResponse {
+  int32 status = 1;
+}
+
+message SaveScaleRequest {
+  string scale_name = 1;
+  string save_as = 2;
+  string author = 3;
+  oneof options_enum {
+    SaveOptions options = 4;
+    uint32 options_raw = 5;
+  }
+}
+
+message SaveScaleResponse {
+  int32 status = 1;
+}
+
+message SaveTaskRequest {
+  nidevice_grpc.Session task = 1;
+  string save_as = 2;
+  string author = 3;
+  oneof options_enum {
+    SaveOptions options = 4;
+    uint32 options_raw = 5;
+  }
+}
+
+message SaveTaskResponse {
+  int32 status = 1;
+}
+
+message SelfCalRequest {
+  string device_name = 1;
+}
+
+message SelfCalResponse {
   int32 status = 1;
 }
 
@@ -3974,6 +4175,16 @@ message UnreserveNetworkDeviceRequest {
 
 message UnreserveNetworkDeviceResponse {
   int32 status = 1;
+}
+
+message WaitForNextSampleClockRequest {
+  nidevice_grpc.Session task = 1;
+  double timeout = 2;
+}
+
+message WaitForNextSampleClockResponse {
+  int32 status = 1;
+  bool is_late = 2;
 }
 
 message WaitForValidTimestampRequest {
@@ -4275,5 +4486,32 @@ message WriteRawRequest {
 message WriteRawResponse {
   int32 status = 1;
   int32 samps_per_chan_written = 2;
+}
+
+message WriteToTEDSFromArrayRequest {
+  string physical_channel = 1;
+  bytes bit_stream = 2;
+  uint32 array_size = 3;
+  oneof basic_teds_options_enum {
+    WriteBasicTEDSOptions basic_teds_options = 4;
+    int32 basic_teds_options_raw = 5;
+  }
+}
+
+message WriteToTEDSFromArrayResponse {
+  int32 status = 1;
+}
+
+message WriteToTEDSFromFileRequest {
+  string physical_channel = 1;
+  string file_path = 2;
+  oneof basic_teds_options_enum {
+    WriteBasicTEDSOptions basic_teds_options = 3;
+    int32 basic_teds_options_raw = 4;
+  }
+}
+
+message WriteToTEDSFromFileResponse {
+  int32 status = 1;
 }
 

--- a/generated/nidaqmx/nidaqmx_library.cpp
+++ b/generated/nidaqmx/nidaqmx_library.cpp
@@ -21,8 +21,11 @@ NiDAQmxLibrary::NiDAQmxLibrary() : shared_library_(kLibraryName)
   if (!loaded) {
     return;
   }
+  function_pointers_.AddCDAQSyncConnection = reinterpret_cast<AddCDAQSyncConnectionPtr>(shared_library_.get_function_pointer("DAQmxAddCDAQSyncConnection"));
   function_pointers_.AddGlobalChansToTask = reinterpret_cast<AddGlobalChansToTaskPtr>(shared_library_.get_function_pointer("DAQmxAddGlobalChansToTask"));
   function_pointers_.AddNetworkDevice = reinterpret_cast<AddNetworkDevicePtr>(shared_library_.get_function_pointer("DAQmxAddNetworkDevice"));
+  function_pointers_.AreConfiguredCDAQSyncPortsDisconnected = reinterpret_cast<AreConfiguredCDAQSyncPortsDisconnectedPtr>(shared_library_.get_function_pointer("DAQmxAreConfiguredCDAQSyncPortsDisconnected"));
+  function_pointers_.AutoConfigureCDAQSyncConnections = reinterpret_cast<AutoConfigureCDAQSyncConnectionsPtr>(shared_library_.get_function_pointer("DAQmxAutoConfigureCDAQSyncConnections"));
   function_pointers_.CalculateReversePolyCoeff = reinterpret_cast<CalculateReversePolyCoeffPtr>(shared_library_.get_function_pointer("DAQmxCalculateReversePolyCoeff"));
   function_pointers_.CfgAnlgEdgeRefTrig = reinterpret_cast<CfgAnlgEdgeRefTrigPtr>(shared_library_.get_function_pointer("DAQmxCfgAnlgEdgeRefTrig"));
   function_pointers_.CfgAnlgEdgeStartTrig = reinterpret_cast<CfgAnlgEdgeStartTrigPtr>(shared_library_.get_function_pointer("DAQmxCfgAnlgEdgeStartTrig"));
@@ -47,8 +50,10 @@ NiDAQmxLibrary::NiDAQmxLibrary() : shared_library_(kLibraryName)
   function_pointers_.CfgWatchdogAOExpirStates = reinterpret_cast<CfgWatchdogAOExpirStatesPtr>(shared_library_.get_function_pointer("DAQmxCfgWatchdogAOExpirStates"));
   function_pointers_.CfgWatchdogCOExpirStates = reinterpret_cast<CfgWatchdogCOExpirStatesPtr>(shared_library_.get_function_pointer("DAQmxCfgWatchdogCOExpirStates"));
   function_pointers_.CfgWatchdogDOExpirStates = reinterpret_cast<CfgWatchdogDOExpirStatesPtr>(shared_library_.get_function_pointer("DAQmxCfgWatchdogDOExpirStates"));
+  function_pointers_.ClearTEDS = reinterpret_cast<ClearTEDSPtr>(shared_library_.get_function_pointer("DAQmxClearTEDS"));
   function_pointers_.ClearTask = reinterpret_cast<ClearTaskPtr>(shared_library_.get_function_pointer("DAQmxClearTask"));
   function_pointers_.ConfigureLogging = reinterpret_cast<ConfigureLoggingPtr>(shared_library_.get_function_pointer("DAQmxConfigureLogging"));
+  function_pointers_.ConfigureTEDS = reinterpret_cast<ConfigureTEDSPtr>(shared_library_.get_function_pointer("DAQmxConfigureTEDS"));
   function_pointers_.ConnectTerms = reinterpret_cast<ConnectTermsPtr>(shared_library_.get_function_pointer("DAQmxConnectTerms"));
   function_pointers_.ControlWatchdogTask = reinterpret_cast<ControlWatchdogTaskPtr>(shared_library_.get_function_pointer("DAQmxControlWatchdogTask"));
   function_pointers_.CreateAIAccel4WireDCVoltageChan = reinterpret_cast<CreateAIAccel4WireDCVoltageChanPtr>(shared_library_.get_function_pointer("DAQmxCreateAIAccel4WireDCVoltageChan"));
@@ -134,6 +139,10 @@ NiDAQmxLibrary::NiDAQmxLibrary() : shared_library_(kLibraryName)
   function_pointers_.CreateWatchdogTimerTask = reinterpret_cast<CreateWatchdogTimerTaskPtr>(shared_library_.get_function_pointer("DAQmxCreateWatchdogTimerTask"));
   function_pointers_.CreateWatchdogTimerTaskEx = reinterpret_cast<CreateWatchdogTimerTaskExPtr>(shared_library_.get_function_pointer("DAQmxCreateWatchdogTimerTaskEx"));
   function_pointers_.DeleteNetworkDevice = reinterpret_cast<DeleteNetworkDevicePtr>(shared_library_.get_function_pointer("DAQmxDeleteNetworkDevice"));
+  function_pointers_.DeleteSavedGlobalChan = reinterpret_cast<DeleteSavedGlobalChanPtr>(shared_library_.get_function_pointer("DAQmxDeleteSavedGlobalChan"));
+  function_pointers_.DeleteSavedScale = reinterpret_cast<DeleteSavedScalePtr>(shared_library_.get_function_pointer("DAQmxDeleteSavedScale"));
+  function_pointers_.DeleteSavedTask = reinterpret_cast<DeleteSavedTaskPtr>(shared_library_.get_function_pointer("DAQmxDeleteSavedTask"));
+  function_pointers_.DeviceSupportsCal = reinterpret_cast<DeviceSupportsCalPtr>(shared_library_.get_function_pointer("DAQmxDeviceSupportsCal"));
   function_pointers_.DisableRefTrig = reinterpret_cast<DisableRefTrigPtr>(shared_library_.get_function_pointer("DAQmxDisableRefTrig"));
   function_pointers_.DisableStartTrig = reinterpret_cast<DisableStartTrigPtr>(shared_library_.get_function_pointer("DAQmxDisableStartTrig"));
   function_pointers_.DisconnectTerms = reinterpret_cast<DisconnectTermsPtr>(shared_library_.get_function_pointer("DAQmxDisconnectTerms"));
@@ -142,7 +151,9 @@ NiDAQmxLibrary::NiDAQmxLibrary() : shared_library_(kLibraryName)
   function_pointers_.GetAIChanCalExpDate = reinterpret_cast<GetAIChanCalExpDatePtr>(shared_library_.get_function_pointer("DAQmxGetAIChanCalExpDate"));
   function_pointers_.GetArmStartTrigTimestampVal = reinterpret_cast<GetArmStartTrigTimestampValPtr>(shared_library_.get_function_pointer("DAQmxGetArmStartTrigTimestampVal"));
   function_pointers_.GetArmStartTrigTrigWhen = reinterpret_cast<GetArmStartTrigTrigWhenPtr>(shared_library_.get_function_pointer("DAQmxGetArmStartTrigTrigWhen"));
+  function_pointers_.GetAutoConfiguredCDAQSyncConnections = reinterpret_cast<GetAutoConfiguredCDAQSyncConnectionsPtr>(shared_library_.get_function_pointer("DAQmxGetAutoConfiguredCDAQSyncConnections"));
   function_pointers_.GetDigitalLogicFamilyPowerUpState = reinterpret_cast<GetDigitalLogicFamilyPowerUpStatePtr>(shared_library_.get_function_pointer("DAQmxGetDigitalLogicFamilyPowerUpState"));
+  function_pointers_.GetDisconnectedCDAQSyncPorts = reinterpret_cast<GetDisconnectedCDAQSyncPortsPtr>(shared_library_.get_function_pointer("DAQmxGetDisconnectedCDAQSyncPorts"));
   function_pointers_.GetErrorString = reinterpret_cast<GetErrorStringPtr>(shared_library_.get_function_pointer("DAQmxGetErrorString"));
   function_pointers_.GetExtendedErrorInfo = reinterpret_cast<GetExtendedErrorInfoPtr>(shared_library_.get_function_pointer("DAQmxGetExtendedErrorInfo"));
   function_pointers_.GetFirstSampClkWhen = reinterpret_cast<GetFirstSampClkWhenPtr>(shared_library_.get_function_pointer("DAQmxGetFirstSampClkWhen"));
@@ -151,6 +162,7 @@ NiDAQmxLibrary::NiDAQmxLibrary() : shared_library_(kLibraryName)
   function_pointers_.GetNthTaskDevice = reinterpret_cast<GetNthTaskDevicePtr>(shared_library_.get_function_pointer("DAQmxGetNthTaskDevice"));
   function_pointers_.GetNthTaskReadChannel = reinterpret_cast<GetNthTaskReadChannelPtr>(shared_library_.get_function_pointer("DAQmxGetNthTaskReadChannel"));
   function_pointers_.GetRefTrigTimestampVal = reinterpret_cast<GetRefTrigTimestampValPtr>(shared_library_.get_function_pointer("DAQmxGetRefTrigTimestampVal"));
+  function_pointers_.GetSelfCalLastDateAndTime = reinterpret_cast<GetSelfCalLastDateAndTimePtr>(shared_library_.get_function_pointer("DAQmxGetSelfCalLastDateAndTime"));
   function_pointers_.GetStartTrigTimestampVal = reinterpret_cast<GetStartTrigTimestampValPtr>(shared_library_.get_function_pointer("DAQmxGetStartTrigTimestampVal"));
   function_pointers_.GetStartTrigTrigWhen = reinterpret_cast<GetStartTrigTrigWhenPtr>(shared_library_.get_function_pointer("DAQmxGetStartTrigTrigWhen"));
   function_pointers_.GetSyncPulseTimeWhen = reinterpret_cast<GetSyncPulseTimeWhenPtr>(shared_library_.get_function_pointer("DAQmxGetSyncPulseTimeWhen"));
@@ -181,8 +193,13 @@ NiDAQmxLibrary::NiDAQmxLibrary() : shared_library_(kLibraryName)
   function_pointers_.ReadDigitalU8 = reinterpret_cast<ReadDigitalU8Ptr>(shared_library_.get_function_pointer("DAQmxReadDigitalU8"));
   function_pointers_.ReadRaw = reinterpret_cast<ReadRawPtr>(shared_library_.get_function_pointer("DAQmxReadRaw"));
   function_pointers_.RegisterDoneEvent = reinterpret_cast<RegisterDoneEventPtr>(shared_library_.get_function_pointer("DAQmxRegisterDoneEvent"));
+  function_pointers_.RemoveCDAQSyncConnection = reinterpret_cast<RemoveCDAQSyncConnectionPtr>(shared_library_.get_function_pointer("DAQmxRemoveCDAQSyncConnection"));
   function_pointers_.ReserveNetworkDevice = reinterpret_cast<ReserveNetworkDevicePtr>(shared_library_.get_function_pointer("DAQmxReserveNetworkDevice"));
   function_pointers_.ResetDevice = reinterpret_cast<ResetDevicePtr>(shared_library_.get_function_pointer("DAQmxResetDevice"));
+  function_pointers_.SaveGlobalChan = reinterpret_cast<SaveGlobalChanPtr>(shared_library_.get_function_pointer("DAQmxSaveGlobalChan"));
+  function_pointers_.SaveScale = reinterpret_cast<SaveScalePtr>(shared_library_.get_function_pointer("DAQmxSaveScale"));
+  function_pointers_.SaveTask = reinterpret_cast<SaveTaskPtr>(shared_library_.get_function_pointer("DAQmxSaveTask"));
+  function_pointers_.SelfCal = reinterpret_cast<SelfCalPtr>(shared_library_.get_function_pointer("DAQmxSelfCal"));
   function_pointers_.SelfTestDevice = reinterpret_cast<SelfTestDevicePtr>(shared_library_.get_function_pointer("DAQmxSelfTestDevice"));
   function_pointers_.SetAIChanCalCalDate = reinterpret_cast<SetAIChanCalCalDatePtr>(shared_library_.get_function_pointer("DAQmxSetAIChanCalCalDate"));
   function_pointers_.SetAIChanCalExpDate = reinterpret_cast<SetAIChanCalExpDatePtr>(shared_library_.get_function_pointer("DAQmxSetAIChanCalExpDate"));
@@ -197,6 +214,7 @@ NiDAQmxLibrary::NiDAQmxLibrary() : shared_library_(kLibraryName)
   function_pointers_.TaskControl = reinterpret_cast<TaskControlPtr>(shared_library_.get_function_pointer("DAQmxTaskControl"));
   function_pointers_.TristateOutputTerm = reinterpret_cast<TristateOutputTermPtr>(shared_library_.get_function_pointer("DAQmxTristateOutputTerm"));
   function_pointers_.UnreserveNetworkDevice = reinterpret_cast<UnreserveNetworkDevicePtr>(shared_library_.get_function_pointer("DAQmxUnreserveNetworkDevice"));
+  function_pointers_.WaitForNextSampleClock = reinterpret_cast<WaitForNextSampleClockPtr>(shared_library_.get_function_pointer("DAQmxWaitForNextSampleClock"));
   function_pointers_.WaitForValidTimestamp = reinterpret_cast<WaitForValidTimestampPtr>(shared_library_.get_function_pointer("DAQmxWaitForValidTimestamp"));
   function_pointers_.WaitUntilTaskDone = reinterpret_cast<WaitUntilTaskDonePtr>(shared_library_.get_function_pointer("DAQmxWaitUntilTaskDone"));
   function_pointers_.WriteAnalogF64 = reinterpret_cast<WriteAnalogF64Ptr>(shared_library_.get_function_pointer("DAQmxWriteAnalogF64"));
@@ -217,6 +235,8 @@ NiDAQmxLibrary::NiDAQmxLibrary() : shared_library_(kLibraryName)
   function_pointers_.WriteDigitalU32 = reinterpret_cast<WriteDigitalU32Ptr>(shared_library_.get_function_pointer("DAQmxWriteDigitalU32"));
   function_pointers_.WriteDigitalU8 = reinterpret_cast<WriteDigitalU8Ptr>(shared_library_.get_function_pointer("DAQmxWriteDigitalU8"));
   function_pointers_.WriteRaw = reinterpret_cast<WriteRawPtr>(shared_library_.get_function_pointer("DAQmxWriteRaw"));
+  function_pointers_.WriteToTEDSFromArray = reinterpret_cast<WriteToTEDSFromArrayPtr>(shared_library_.get_function_pointer("DAQmxWriteToTEDSFromArray"));
+  function_pointers_.WriteToTEDSFromFile = reinterpret_cast<WriteToTEDSFromFilePtr>(shared_library_.get_function_pointer("DAQmxWriteToTEDSFromFile"));
 }
 
 NiDAQmxLibrary::~NiDAQmxLibrary()
@@ -228,6 +248,18 @@ NiDAQmxLibrary::~NiDAQmxLibrary()
   return shared_library_.function_exists(functionName.c_str())
     ? ::grpc::Status::OK
     : ::grpc::Status(::grpc::NOT_FOUND, "Could not find the function " + functionName);
+}
+
+int32 NiDAQmxLibrary::AddCDAQSyncConnection(const char portList[])
+{
+  if (!function_pointers_.AddCDAQSyncConnection) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxAddCDAQSyncConnection.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxAddCDAQSyncConnection(portList);
+#else
+  return function_pointers_.AddCDAQSyncConnection(portList);
+#endif
 }
 
 int32 NiDAQmxLibrary::AddGlobalChansToTask(TaskHandle task, const char channelNames[])
@@ -251,6 +283,30 @@ int32 NiDAQmxLibrary::AddNetworkDevice(const char ipAddress[], const char device
   return DAQmxAddNetworkDevice(ipAddress, deviceName, attemptReservation, timeout, deviceNameOut, deviceNameOutBufferSize);
 #else
   return function_pointers_.AddNetworkDevice(ipAddress, deviceName, attemptReservation, timeout, deviceNameOut, deviceNameOutBufferSize);
+#endif
+}
+
+int32 NiDAQmxLibrary::AreConfiguredCDAQSyncPortsDisconnected(const char chassisDevicesPorts[], float64 timeout, bool32* disconnectedPortsExist)
+{
+  if (!function_pointers_.AreConfiguredCDAQSyncPortsDisconnected) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxAreConfiguredCDAQSyncPortsDisconnected.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxAreConfiguredCDAQSyncPortsDisconnected(chassisDevicesPorts, timeout, disconnectedPortsExist);
+#else
+  return function_pointers_.AreConfiguredCDAQSyncPortsDisconnected(chassisDevicesPorts, timeout, disconnectedPortsExist);
+#endif
+}
+
+int32 NiDAQmxLibrary::AutoConfigureCDAQSyncConnections(const char chassisDevicesPorts[], float64 timeout)
+{
+  if (!function_pointers_.AutoConfigureCDAQSyncConnections) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxAutoConfigureCDAQSyncConnections.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxAutoConfigureCDAQSyncConnections(chassisDevicesPorts, timeout);
+#else
+  return function_pointers_.AutoConfigureCDAQSyncConnections(chassisDevicesPorts, timeout);
 #endif
 }
 
@@ -542,6 +598,18 @@ int32 NiDAQmxLibrary::CfgWatchdogDOExpirStates(TaskHandle task, const char chann
 #endif
 }
 
+int32 NiDAQmxLibrary::ClearTEDS(const char physicalChannel[])
+{
+  if (!function_pointers_.ClearTEDS) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxClearTEDS.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxClearTEDS(physicalChannel);
+#else
+  return function_pointers_.ClearTEDS(physicalChannel);
+#endif
+}
+
 int32 NiDAQmxLibrary::ClearTask(TaskHandle task)
 {
   if (!function_pointers_.ClearTask) {
@@ -563,6 +631,18 @@ int32 NiDAQmxLibrary::ConfigureLogging(TaskHandle task, const char filePath[], i
   return DAQmxConfigureLogging(task, filePath, loggingMode, groupName, operation);
 #else
   return function_pointers_.ConfigureLogging(task, filePath, loggingMode, groupName, operation);
+#endif
+}
+
+int32 NiDAQmxLibrary::ConfigureTEDS(const char physicalChannel[], const char filePath[])
+{
+  if (!function_pointers_.ConfigureTEDS) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxConfigureTEDS.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxConfigureTEDS(physicalChannel, filePath);
+#else
+  return function_pointers_.ConfigureTEDS(physicalChannel, filePath);
 #endif
 }
 
@@ -1586,6 +1666,54 @@ int32 NiDAQmxLibrary::DeleteNetworkDevice(const char deviceName[])
 #endif
 }
 
+int32 NiDAQmxLibrary::DeleteSavedGlobalChan(const char channelName[])
+{
+  if (!function_pointers_.DeleteSavedGlobalChan) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxDeleteSavedGlobalChan.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxDeleteSavedGlobalChan(channelName);
+#else
+  return function_pointers_.DeleteSavedGlobalChan(channelName);
+#endif
+}
+
+int32 NiDAQmxLibrary::DeleteSavedScale(const char scaleName[])
+{
+  if (!function_pointers_.DeleteSavedScale) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxDeleteSavedScale.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxDeleteSavedScale(scaleName);
+#else
+  return function_pointers_.DeleteSavedScale(scaleName);
+#endif
+}
+
+int32 NiDAQmxLibrary::DeleteSavedTask(const char taskName[])
+{
+  if (!function_pointers_.DeleteSavedTask) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxDeleteSavedTask.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxDeleteSavedTask(taskName);
+#else
+  return function_pointers_.DeleteSavedTask(taskName);
+#endif
+}
+
+int32 NiDAQmxLibrary::DeviceSupportsCal(const char deviceName[], bool32* calSupported)
+{
+  if (!function_pointers_.DeviceSupportsCal) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxDeviceSupportsCal.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxDeviceSupportsCal(deviceName, calSupported);
+#else
+  return function_pointers_.DeviceSupportsCal(deviceName, calSupported);
+#endif
+}
+
 int32 NiDAQmxLibrary::DisableRefTrig(TaskHandle task)
 {
   if (!function_pointers_.DisableRefTrig) {
@@ -1682,6 +1810,18 @@ int32 NiDAQmxLibrary::GetArmStartTrigTrigWhen(TaskHandle task, CVIAbsoluteTime* 
 #endif
 }
 
+int32 NiDAQmxLibrary::GetAutoConfiguredCDAQSyncConnections(char portList[], uInt32 portListSize)
+{
+  if (!function_pointers_.GetAutoConfiguredCDAQSyncConnections) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxGetAutoConfiguredCDAQSyncConnections.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxGetAutoConfiguredCDAQSyncConnections(portList, portListSize);
+#else
+  return function_pointers_.GetAutoConfiguredCDAQSyncConnections(portList, portListSize);
+#endif
+}
+
 int32 NiDAQmxLibrary::GetDigitalLogicFamilyPowerUpState(const char deviceName[], int32* logicFamily)
 {
   if (!function_pointers_.GetDigitalLogicFamilyPowerUpState) {
@@ -1691,6 +1831,18 @@ int32 NiDAQmxLibrary::GetDigitalLogicFamilyPowerUpState(const char deviceName[],
   return DAQmxGetDigitalLogicFamilyPowerUpState(deviceName, logicFamily);
 #else
   return function_pointers_.GetDigitalLogicFamilyPowerUpState(deviceName, logicFamily);
+#endif
+}
+
+int32 NiDAQmxLibrary::GetDisconnectedCDAQSyncPorts(char portList[], uInt32 portListSize)
+{
+  if (!function_pointers_.GetDisconnectedCDAQSyncPorts) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxGetDisconnectedCDAQSyncPorts.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxGetDisconnectedCDAQSyncPorts(portList, portListSize);
+#else
+  return function_pointers_.GetDisconnectedCDAQSyncPorts(portList, portListSize);
 #endif
 }
 
@@ -1787,6 +1939,18 @@ int32 NiDAQmxLibrary::GetRefTrigTimestampVal(TaskHandle task, CVIAbsoluteTime* d
   return DAQmxGetRefTrigTimestampVal(task, data);
 #else
   return function_pointers_.GetRefTrigTimestampVal(task, data);
+#endif
+}
+
+int32 NiDAQmxLibrary::GetSelfCalLastDateAndTime(const char deviceName[], uInt32* year, uInt32* month, uInt32* day, uInt32* hour, uInt32* minute)
+{
+  if (!function_pointers_.GetSelfCalLastDateAndTime) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxGetSelfCalLastDateAndTime.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxGetSelfCalLastDateAndTime(deviceName, year, month, day, hour, minute);
+#else
+  return function_pointers_.GetSelfCalLastDateAndTime(deviceName, year, month, day, hour, minute);
 #endif
 }
 
@@ -2150,6 +2314,18 @@ int32 NiDAQmxLibrary::RegisterDoneEvent(TaskHandle task, uInt32 options, DAQmxDo
 #endif
 }
 
+int32 NiDAQmxLibrary::RemoveCDAQSyncConnection(const char portList[])
+{
+  if (!function_pointers_.RemoveCDAQSyncConnection) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxRemoveCDAQSyncConnection.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxRemoveCDAQSyncConnection(portList);
+#else
+  return function_pointers_.RemoveCDAQSyncConnection(portList);
+#endif
+}
+
 int32 NiDAQmxLibrary::ReserveNetworkDevice(const char deviceName[], bool32 overrideReservation)
 {
   if (!function_pointers_.ReserveNetworkDevice) {
@@ -2171,6 +2347,54 @@ int32 NiDAQmxLibrary::ResetDevice(const char deviceName[])
   return DAQmxResetDevice(deviceName);
 #else
   return function_pointers_.ResetDevice(deviceName);
+#endif
+}
+
+int32 NiDAQmxLibrary::SaveGlobalChan(TaskHandle task, const char channelName[], const char saveAs[], const char author[], uInt32 options)
+{
+  if (!function_pointers_.SaveGlobalChan) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxSaveGlobalChan.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxSaveGlobalChan(task, channelName, saveAs, author, options);
+#else
+  return function_pointers_.SaveGlobalChan(task, channelName, saveAs, author, options);
+#endif
+}
+
+int32 NiDAQmxLibrary::SaveScale(const char scaleName[], const char saveAs[], const char author[], uInt32 options)
+{
+  if (!function_pointers_.SaveScale) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxSaveScale.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxSaveScale(scaleName, saveAs, author, options);
+#else
+  return function_pointers_.SaveScale(scaleName, saveAs, author, options);
+#endif
+}
+
+int32 NiDAQmxLibrary::SaveTask(TaskHandle task, const char saveAs[], const char author[], uInt32 options)
+{
+  if (!function_pointers_.SaveTask) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxSaveTask.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxSaveTask(task, saveAs, author, options);
+#else
+  return function_pointers_.SaveTask(task, saveAs, author, options);
+#endif
+}
+
+int32 NiDAQmxLibrary::SelfCal(const char deviceName[])
+{
+  if (!function_pointers_.SelfCal) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxSelfCal.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxSelfCal(deviceName);
+#else
+  return function_pointers_.SelfCal(deviceName);
 #endif
 }
 
@@ -2339,6 +2563,18 @@ int32 NiDAQmxLibrary::UnreserveNetworkDevice(const char deviceName[])
   return DAQmxUnreserveNetworkDevice(deviceName);
 #else
   return function_pointers_.UnreserveNetworkDevice(deviceName);
+#endif
+}
+
+int32 NiDAQmxLibrary::WaitForNextSampleClock(TaskHandle task, float64 timeout, bool32* isLate)
+{
+  if (!function_pointers_.WaitForNextSampleClock) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxWaitForNextSampleClock.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxWaitForNextSampleClock(task, timeout, isLate);
+#else
+  return function_pointers_.WaitForNextSampleClock(task, timeout, isLate);
 #endif
 }
 
@@ -2579,6 +2815,30 @@ int32 NiDAQmxLibrary::WriteRaw(TaskHandle task, int32 numSamps, bool32 autoStart
   return DAQmxWriteRaw(task, numSamps, autoStart, timeout, writeArray, sampsPerChanWritten, reserved);
 #else
   return function_pointers_.WriteRaw(task, numSamps, autoStart, timeout, writeArray, sampsPerChanWritten, reserved);
+#endif
+}
+
+int32 NiDAQmxLibrary::WriteToTEDSFromArray(const char physicalChannel[], const uInt8 bitStream[], uInt32 arraySize, int32 basicTEDSOptions)
+{
+  if (!function_pointers_.WriteToTEDSFromArray) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxWriteToTEDSFromArray.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxWriteToTEDSFromArray(physicalChannel, bitStream, arraySize, basicTEDSOptions);
+#else
+  return function_pointers_.WriteToTEDSFromArray(physicalChannel, bitStream, arraySize, basicTEDSOptions);
+#endif
+}
+
+int32 NiDAQmxLibrary::WriteToTEDSFromFile(const char physicalChannel[], const char filePath[], int32 basicTEDSOptions)
+{
+  if (!function_pointers_.WriteToTEDSFromFile) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxWriteToTEDSFromFile.");
+  }
+#if defined(_MSC_VER)
+  return DAQmxWriteToTEDSFromFile(physicalChannel, filePath, basicTEDSOptions);
+#else
+  return function_pointers_.WriteToTEDSFromFile(physicalChannel, filePath, basicTEDSOptions);
 #endif
 }
 

--- a/generated/nidaqmx/nidaqmx_library_interface.h
+++ b/generated/nidaqmx/nidaqmx_library_interface.h
@@ -3,8 +3,8 @@
 //---------------------------------------------------------------------
 // Library wrapper for implementing interactions with NI-DAQMX
 //---------------------------------------------------------------------
-#ifndef NIDAQMX_LIBRARY_INTERFACE
-#define NIDAQMX_LIBRARY_INTERFACE
+#ifndef NIDAQMX_GRPC_LIBRARY_WRAPPER_H
+#define NIDAQMX_GRPC_LIBRARY_WRAPPER_H
 
 #include <grpcpp/grpcpp.h>
 #include <NIDAQmx.h>
@@ -234,4 +234,4 @@ class NiDAQmxLibraryInterface {
 };
 
 }  // namespace nidaqmx_grpc
-#endif /* NIDAQMX_LIBRARY_INTERFACE */
+#endif  // NIDAQMX_GRPC_LIBRARY_WRAPPER_H

--- a/generated/nidaqmx/nidaqmx_library_interface.h
+++ b/generated/nidaqmx/nidaqmx_library_interface.h
@@ -3,8 +3,8 @@
 //---------------------------------------------------------------------
 // Library wrapper for implementing interactions with NI-DAQMX
 //---------------------------------------------------------------------
-#ifndef NIDAQMX_GRPC_LIBRARY_WRAPPER_H
-#define NIDAQMX_GRPC_LIBRARY_WRAPPER_H
+#ifndef NIDAQMX_LIBRARY_INTERFACE
+#define NIDAQMX_LIBRARY_INTERFACE
 
 #include <grpcpp/grpcpp.h>
 #include <NIDAQmx.h>
@@ -15,8 +15,11 @@ class NiDAQmxLibraryInterface {
  public:
   virtual ~NiDAQmxLibraryInterface() {}
 
+  virtual int32 AddCDAQSyncConnection(const char portList[]) = 0;
   virtual int32 AddGlobalChansToTask(TaskHandle task, const char channelNames[]) = 0;
   virtual int32 AddNetworkDevice(const char ipAddress[], const char deviceName[], bool32 attemptReservation, float64 timeout, char deviceNameOut[], uInt32 deviceNameOutBufferSize) = 0;
+  virtual int32 AreConfiguredCDAQSyncPortsDisconnected(const char chassisDevicesPorts[], float64 timeout, bool32* disconnectedPortsExist) = 0;
+  virtual int32 AutoConfigureCDAQSyncConnections(const char chassisDevicesPorts[], float64 timeout) = 0;
   virtual int32 CalculateReversePolyCoeff(const float64 forwardCoeffs[], uInt32 numForwardCoeffsIn, float64 minValX, float64 maxValX, int32 numPointsToCompute, int32 reversePolyOrder, float64 reverseCoeffs[]) = 0;
   virtual int32 CfgAnlgEdgeRefTrig(TaskHandle task, const char triggerSource[], int32 triggerSlope, float64 triggerLevel, uInt32 pretriggerSamples) = 0;
   virtual int32 CfgAnlgEdgeStartTrig(TaskHandle task, const char triggerSource[], int32 triggerSlope, float64 triggerLevel) = 0;
@@ -41,8 +44,10 @@ class NiDAQmxLibraryInterface {
   virtual int32 CfgWatchdogAOExpirStates(TaskHandle task, const char channelNames[], const float64 expirStateArray[], int32 outputTypeArray[], uInt32 arraySize) = 0;
   virtual int32 CfgWatchdogCOExpirStates(TaskHandle task, const char channelNames[], int32 expirStateArray[], uInt32 arraySize) = 0;
   virtual int32 CfgWatchdogDOExpirStates(TaskHandle task, const char channelNames[], int32 expirStateArray[], uInt32 arraySize) = 0;
+  virtual int32 ClearTEDS(const char physicalChannel[]) = 0;
   virtual int32 ClearTask(TaskHandle task) = 0;
   virtual int32 ConfigureLogging(TaskHandle task, const char filePath[], int32 loggingMode, const char groupName[], int32 operation) = 0;
+  virtual int32 ConfigureTEDS(const char physicalChannel[], const char filePath[]) = 0;
   virtual int32 ConnectTerms(const char sourceTerminal[], const char destinationTerminal[], int32 signalModifiers) = 0;
   virtual int32 ControlWatchdogTask(TaskHandle task, int32 action) = 0;
   virtual int32 CreateAIAccel4WireDCVoltageChan(TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], int32 terminalConfig, float64 minVal, float64 maxVal, int32 units, float64 sensitivity, int32 sensitivityUnits, int32 voltageExcitSource, float64 voltageExcitVal, bool32 useExcitForScaling, const char customScaleName[]) = 0;
@@ -128,6 +133,10 @@ class NiDAQmxLibraryInterface {
   virtual int32 CreateWatchdogTimerTask(const char deviceName[], const char sessionName[], TaskHandle* task, float64 timeout, const char lines[], int32 expState) = 0;
   virtual int32 CreateWatchdogTimerTaskEx(const char deviceName[], const char sessionName[], TaskHandle* task, float64 timeout) = 0;
   virtual int32 DeleteNetworkDevice(const char deviceName[]) = 0;
+  virtual int32 DeleteSavedGlobalChan(const char channelName[]) = 0;
+  virtual int32 DeleteSavedScale(const char scaleName[]) = 0;
+  virtual int32 DeleteSavedTask(const char taskName[]) = 0;
+  virtual int32 DeviceSupportsCal(const char deviceName[], bool32* calSupported) = 0;
   virtual int32 DisableRefTrig(TaskHandle task) = 0;
   virtual int32 DisableStartTrig(TaskHandle task) = 0;
   virtual int32 DisconnectTerms(const char sourceTerminal[], const char destinationTerminal[]) = 0;
@@ -136,7 +145,9 @@ class NiDAQmxLibraryInterface {
   virtual int32 GetAIChanCalExpDate(TaskHandle task, const char channelName[], uInt32* year, uInt32* month, uInt32* day, uInt32* hour, uInt32* minute) = 0;
   virtual int32 GetArmStartTrigTimestampVal(TaskHandle task, CVIAbsoluteTime* data) = 0;
   virtual int32 GetArmStartTrigTrigWhen(TaskHandle task, CVIAbsoluteTime* data) = 0;
+  virtual int32 GetAutoConfiguredCDAQSyncConnections(char portList[], uInt32 portListSize) = 0;
   virtual int32 GetDigitalLogicFamilyPowerUpState(const char deviceName[], int32* logicFamily) = 0;
+  virtual int32 GetDisconnectedCDAQSyncPorts(char portList[], uInt32 portListSize) = 0;
   virtual int32 GetErrorString(int32 errorCode, char errorString[], uInt32 bufferSize) = 0;
   virtual int32 GetExtendedErrorInfo(char errorString[], uInt32 bufferSize) = 0;
   virtual int32 GetFirstSampClkWhen(TaskHandle task, CVIAbsoluteTime* data) = 0;
@@ -145,6 +156,7 @@ class NiDAQmxLibraryInterface {
   virtual int32 GetNthTaskDevice(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize) = 0;
   virtual int32 GetNthTaskReadChannel(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize) = 0;
   virtual int32 GetRefTrigTimestampVal(TaskHandle task, CVIAbsoluteTime* data) = 0;
+  virtual int32 GetSelfCalLastDateAndTime(const char deviceName[], uInt32* year, uInt32* month, uInt32* day, uInt32* hour, uInt32* minute) = 0;
   virtual int32 GetStartTrigTimestampVal(TaskHandle task, CVIAbsoluteTime* data) = 0;
   virtual int32 GetStartTrigTrigWhen(TaskHandle task, CVIAbsoluteTime* data) = 0;
   virtual int32 GetSyncPulseTimeWhen(TaskHandle task, CVIAbsoluteTime* data) = 0;
@@ -175,8 +187,13 @@ class NiDAQmxLibraryInterface {
   virtual int32 ReadDigitalU8(TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved) = 0;
   virtual int32 ReadRaw(TaskHandle task, int32 numSampsPerChan, float64 timeout, uInt8 readArray[], uInt32 arraySizeInBytes, int32* sampsRead, int32* numBytesPerSamp, bool32* reserved) = 0;
   virtual int32 RegisterDoneEvent(TaskHandle task, uInt32 options, DAQmxDoneEventCallbackPtr callbackFunction, void* callbackData) = 0;
+  virtual int32 RemoveCDAQSyncConnection(const char portList[]) = 0;
   virtual int32 ReserveNetworkDevice(const char deviceName[], bool32 overrideReservation) = 0;
   virtual int32 ResetDevice(const char deviceName[]) = 0;
+  virtual int32 SaveGlobalChan(TaskHandle task, const char channelName[], const char saveAs[], const char author[], uInt32 options) = 0;
+  virtual int32 SaveScale(const char scaleName[], const char saveAs[], const char author[], uInt32 options) = 0;
+  virtual int32 SaveTask(TaskHandle task, const char saveAs[], const char author[], uInt32 options) = 0;
+  virtual int32 SelfCal(const char deviceName[]) = 0;
   virtual int32 SelfTestDevice(const char deviceName[]) = 0;
   virtual int32 SetAIChanCalCalDate(TaskHandle task, const char channelName[], uInt32 year, uInt32 month, uInt32 day, uInt32 hour, uInt32 minute) = 0;
   virtual int32 SetAIChanCalExpDate(TaskHandle task, const char channelName[], uInt32 year, uInt32 month, uInt32 day, uInt32 hour, uInt32 minute) = 0;
@@ -191,6 +208,7 @@ class NiDAQmxLibraryInterface {
   virtual int32 TaskControl(TaskHandle task, int32 action) = 0;
   virtual int32 TristateOutputTerm(const char outputTerminal[]) = 0;
   virtual int32 UnreserveNetworkDevice(const char deviceName[]) = 0;
+  virtual int32 WaitForNextSampleClock(TaskHandle task, float64 timeout, bool32* isLate) = 0;
   virtual int32 WaitForValidTimestamp(TaskHandle task, int32 timestampEvent, float64 timeout, CVIAbsoluteTime* timestamp) = 0;
   virtual int32 WaitUntilTaskDone(TaskHandle task, float64 timeToWait) = 0;
   virtual int32 WriteAnalogF64(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const float64 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;
@@ -211,7 +229,9 @@ class NiDAQmxLibraryInterface {
   virtual int32 WriteDigitalU32(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt32 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;
   virtual int32 WriteDigitalU8(TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;
   virtual int32 WriteRaw(TaskHandle task, int32 numSamps, bool32 autoStart, float64 timeout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;
+  virtual int32 WriteToTEDSFromArray(const char physicalChannel[], const uInt8 bitStream[], uInt32 arraySize, int32 basicTEDSOptions) = 0;
+  virtual int32 WriteToTEDSFromFile(const char physicalChannel[], const char filePath[], int32 basicTEDSOptions) = 0;
 };
 
 }  // namespace nidaqmx_grpc
-#endif  // NIDAQMX_GRPC_LIBRARY_WRAPPER_H
+#endif /* NIDAQMX_LIBRARY_INTERFACE */

--- a/generated/nidaqmx/nidaqmx_mock_library.h
+++ b/generated/nidaqmx/nidaqmx_mock_library.h
@@ -17,8 +17,11 @@ namespace unit {
 
 class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
  public:
+  MOCK_METHOD(int32, AddCDAQSyncConnection, (const char portList[]), (override));
   MOCK_METHOD(int32, AddGlobalChansToTask, (TaskHandle task, const char channelNames[]), (override));
   MOCK_METHOD(int32, AddNetworkDevice, (const char ipAddress[], const char deviceName[], bool32 attemptReservation, float64 timeout, char deviceNameOut[], uInt32 deviceNameOutBufferSize), (override));
+  MOCK_METHOD(int32, AreConfiguredCDAQSyncPortsDisconnected, (const char chassisDevicesPorts[], float64 timeout, bool32* disconnectedPortsExist), (override));
+  MOCK_METHOD(int32, AutoConfigureCDAQSyncConnections, (const char chassisDevicesPorts[], float64 timeout), (override));
   MOCK_METHOD(int32, CalculateReversePolyCoeff, (const float64 forwardCoeffs[], uInt32 numForwardCoeffsIn, float64 minValX, float64 maxValX, int32 numPointsToCompute, int32 reversePolyOrder, float64 reverseCoeffs[]), (override));
   MOCK_METHOD(int32, CfgAnlgEdgeRefTrig, (TaskHandle task, const char triggerSource[], int32 triggerSlope, float64 triggerLevel, uInt32 pretriggerSamples), (override));
   MOCK_METHOD(int32, CfgAnlgEdgeStartTrig, (TaskHandle task, const char triggerSource[], int32 triggerSlope, float64 triggerLevel), (override));
@@ -43,8 +46,10 @@ class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   MOCK_METHOD(int32, CfgWatchdogAOExpirStates, (TaskHandle task, const char channelNames[], const float64 expirStateArray[], int32 outputTypeArray[], uInt32 arraySize), (override));
   MOCK_METHOD(int32, CfgWatchdogCOExpirStates, (TaskHandle task, const char channelNames[], int32 expirStateArray[], uInt32 arraySize), (override));
   MOCK_METHOD(int32, CfgWatchdogDOExpirStates, (TaskHandle task, const char channelNames[], int32 expirStateArray[], uInt32 arraySize), (override));
+  MOCK_METHOD(int32, ClearTEDS, (const char physicalChannel[]), (override));
   MOCK_METHOD(int32, ClearTask, (TaskHandle task), (override));
   MOCK_METHOD(int32, ConfigureLogging, (TaskHandle task, const char filePath[], int32 loggingMode, const char groupName[], int32 operation), (override));
+  MOCK_METHOD(int32, ConfigureTEDS, (const char physicalChannel[], const char filePath[]), (override));
   MOCK_METHOD(int32, ConnectTerms, (const char sourceTerminal[], const char destinationTerminal[], int32 signalModifiers), (override));
   MOCK_METHOD(int32, ControlWatchdogTask, (TaskHandle task, int32 action), (override));
   MOCK_METHOD(int32, CreateAIAccel4WireDCVoltageChan, (TaskHandle task, const char physicalChannel[], const char nameToAssignToChannel[], int32 terminalConfig, float64 minVal, float64 maxVal, int32 units, float64 sensitivity, int32 sensitivityUnits, int32 voltageExcitSource, float64 voltageExcitVal, bool32 useExcitForScaling, const char customScaleName[]), (override));
@@ -130,6 +135,10 @@ class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   MOCK_METHOD(int32, CreateWatchdogTimerTask, (const char deviceName[], const char sessionName[], TaskHandle* task, float64 timeout, const char lines[], int32 expState), (override));
   MOCK_METHOD(int32, CreateWatchdogTimerTaskEx, (const char deviceName[], const char sessionName[], TaskHandle* task, float64 timeout), (override));
   MOCK_METHOD(int32, DeleteNetworkDevice, (const char deviceName[]), (override));
+  MOCK_METHOD(int32, DeleteSavedGlobalChan, (const char channelName[]), (override));
+  MOCK_METHOD(int32, DeleteSavedScale, (const char scaleName[]), (override));
+  MOCK_METHOD(int32, DeleteSavedTask, (const char taskName[]), (override));
+  MOCK_METHOD(int32, DeviceSupportsCal, (const char deviceName[], bool32* calSupported), (override));
   MOCK_METHOD(int32, DisableRefTrig, (TaskHandle task), (override));
   MOCK_METHOD(int32, DisableStartTrig, (TaskHandle task), (override));
   MOCK_METHOD(int32, DisconnectTerms, (const char sourceTerminal[], const char destinationTerminal[]), (override));
@@ -138,7 +147,9 @@ class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   MOCK_METHOD(int32, GetAIChanCalExpDate, (TaskHandle task, const char channelName[], uInt32* year, uInt32* month, uInt32* day, uInt32* hour, uInt32* minute), (override));
   MOCK_METHOD(int32, GetArmStartTrigTimestampVal, (TaskHandle task, CVIAbsoluteTime* data), (override));
   MOCK_METHOD(int32, GetArmStartTrigTrigWhen, (TaskHandle task, CVIAbsoluteTime* data), (override));
+  MOCK_METHOD(int32, GetAutoConfiguredCDAQSyncConnections, (char portList[], uInt32 portListSize), (override));
   MOCK_METHOD(int32, GetDigitalLogicFamilyPowerUpState, (const char deviceName[], int32* logicFamily), (override));
+  MOCK_METHOD(int32, GetDisconnectedCDAQSyncPorts, (char portList[], uInt32 portListSize), (override));
   MOCK_METHOD(int32, GetErrorString, (int32 errorCode, char errorString[], uInt32 bufferSize), (override));
   MOCK_METHOD(int32, GetExtendedErrorInfo, (char errorString[], uInt32 bufferSize), (override));
   MOCK_METHOD(int32, GetFirstSampClkWhen, (TaskHandle task, CVIAbsoluteTime* data), (override));
@@ -147,6 +158,7 @@ class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   MOCK_METHOD(int32, GetNthTaskDevice, (TaskHandle task, uInt32 index, char buffer[], int32 bufferSize), (override));
   MOCK_METHOD(int32, GetNthTaskReadChannel, (TaskHandle task, uInt32 index, char buffer[], int32 bufferSize), (override));
   MOCK_METHOD(int32, GetRefTrigTimestampVal, (TaskHandle task, CVIAbsoluteTime* data), (override));
+  MOCK_METHOD(int32, GetSelfCalLastDateAndTime, (const char deviceName[], uInt32* year, uInt32* month, uInt32* day, uInt32* hour, uInt32* minute), (override));
   MOCK_METHOD(int32, GetStartTrigTimestampVal, (TaskHandle task, CVIAbsoluteTime* data), (override));
   MOCK_METHOD(int32, GetStartTrigTrigWhen, (TaskHandle task, CVIAbsoluteTime* data), (override));
   MOCK_METHOD(int32, GetSyncPulseTimeWhen, (TaskHandle task, CVIAbsoluteTime* data), (override));
@@ -177,8 +189,13 @@ class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   MOCK_METHOD(int32, ReadDigitalU8, (TaskHandle task, int32 numSampsPerChan, float64 timeout, int32 fillMode, uInt8 readArray[], uInt32 arraySizeInSamps, int32* sampsPerChanRead, bool32* reserved), (override));
   MOCK_METHOD(int32, ReadRaw, (TaskHandle task, int32 numSampsPerChan, float64 timeout, uInt8 readArray[], uInt32 arraySizeInBytes, int32* sampsRead, int32* numBytesPerSamp, bool32* reserved), (override));
   MOCK_METHOD(int32, RegisterDoneEvent, (TaskHandle task, uInt32 options, DAQmxDoneEventCallbackPtr callbackFunction, void* callbackData), (override));
+  MOCK_METHOD(int32, RemoveCDAQSyncConnection, (const char portList[]), (override));
   MOCK_METHOD(int32, ReserveNetworkDevice, (const char deviceName[], bool32 overrideReservation), (override));
   MOCK_METHOD(int32, ResetDevice, (const char deviceName[]), (override));
+  MOCK_METHOD(int32, SaveGlobalChan, (TaskHandle task, const char channelName[], const char saveAs[], const char author[], uInt32 options), (override));
+  MOCK_METHOD(int32, SaveScale, (const char scaleName[], const char saveAs[], const char author[], uInt32 options), (override));
+  MOCK_METHOD(int32, SaveTask, (TaskHandle task, const char saveAs[], const char author[], uInt32 options), (override));
+  MOCK_METHOD(int32, SelfCal, (const char deviceName[]), (override));
   MOCK_METHOD(int32, SelfTestDevice, (const char deviceName[]), (override));
   MOCK_METHOD(int32, SetAIChanCalCalDate, (TaskHandle task, const char channelName[], uInt32 year, uInt32 month, uInt32 day, uInt32 hour, uInt32 minute), (override));
   MOCK_METHOD(int32, SetAIChanCalExpDate, (TaskHandle task, const char channelName[], uInt32 year, uInt32 month, uInt32 day, uInt32 hour, uInt32 minute), (override));
@@ -193,6 +210,7 @@ class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   MOCK_METHOD(int32, TaskControl, (TaskHandle task, int32 action), (override));
   MOCK_METHOD(int32, TristateOutputTerm, (const char outputTerminal[]), (override));
   MOCK_METHOD(int32, UnreserveNetworkDevice, (const char deviceName[]), (override));
+  MOCK_METHOD(int32, WaitForNextSampleClock, (TaskHandle task, float64 timeout, bool32* isLate), (override));
   MOCK_METHOD(int32, WaitForValidTimestamp, (TaskHandle task, int32 timestampEvent, float64 timeout, CVIAbsoluteTime* timestamp), (override));
   MOCK_METHOD(int32, WaitUntilTaskDone, (TaskHandle task, float64 timeToWait), (override));
   MOCK_METHOD(int32, WriteAnalogF64, (TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const float64 writeArray[], int32* sampsPerChanWritten, bool32* reserved), (override));
@@ -213,6 +231,8 @@ class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   MOCK_METHOD(int32, WriteDigitalU32, (TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt32 writeArray[], int32* sampsPerChanWritten, bool32* reserved), (override));
   MOCK_METHOD(int32, WriteDigitalU8, (TaskHandle task, int32 numSampsPerChan, bool32 autoStart, float64 timeout, int32 dataLayout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved), (override));
   MOCK_METHOD(int32, WriteRaw, (TaskHandle task, int32 numSamps, bool32 autoStart, float64 timeout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved), (override));
+  MOCK_METHOD(int32, WriteToTEDSFromArray, (const char physicalChannel[], const uInt8 bitStream[], uInt32 arraySize, int32 basicTEDSOptions), (override));
+  MOCK_METHOD(int32, WriteToTEDSFromFile, (const char physicalChannel[], const char filePath[], int32 basicTEDSOptions), (override));
 };
 
 }  // namespace unit

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -26,6 +26,24 @@ namespace nidaqmx_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::AddCDAQSyncConnection(::grpc::ServerContext* context, const AddCDAQSyncConnectionRequest* request, AddCDAQSyncConnectionResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto port_list = request->port_list().c_str();
+      auto status = library_->AddCDAQSyncConnection(port_list);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiDAQmxService::AddGlobalChansToTask(::grpc::ServerContext* context, const AddGlobalChansToTaskRequest* request, AddGlobalChansToTaskResponse* response)
   {
     if (context->IsCancelled()) {
@@ -66,6 +84,48 @@ namespace nidaqmx_grpc {
       if (status == 0) {
         response->set_device_name_out(device_name_out);
       }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::AreConfiguredCDAQSyncPortsDisconnected(::grpc::ServerContext* context, const AreConfiguredCDAQSyncPortsDisconnectedRequest* request, AreConfiguredCDAQSyncPortsDisconnectedResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto chassis_devices_ports = request->chassis_devices_ports().c_str();
+      float64 timeout = request->timeout();
+      bool32 disconnected_ports_exist {};
+      auto status = library_->AreConfiguredCDAQSyncPortsDisconnected(chassis_devices_ports, timeout, &disconnected_ports_exist);
+      response->set_status(status);
+      if (status == 0) {
+        response->set_disconnected_ports_exist(disconnected_ports_exist);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::AutoConfigureCDAQSyncConnections(::grpc::ServerContext* context, const AutoConfigureCDAQSyncConnectionsRequest* request, AutoConfigureCDAQSyncConnectionsResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto chassis_devices_ports = request->chassis_devices_ports().c_str();
+      float64 timeout = request->timeout();
+      auto status = library_->AutoConfigureCDAQSyncConnections(chassis_devices_ports, timeout);
+      response->set_status(status);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
@@ -982,6 +1042,24 @@ namespace nidaqmx_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::ClearTEDS(::grpc::ServerContext* context, const ClearTEDSRequest* request, ClearTEDSResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto physical_channel = request->physical_channel().c_str();
+      auto status = library_->ClearTEDS(physical_channel);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiDAQmxService::ClearTask(::grpc::ServerContext* context, const ClearTaskRequest* request, ClearTaskResponse* response)
   {
     if (context->IsCancelled()) {
@@ -1045,6 +1123,25 @@ namespace nidaqmx_grpc {
       }
 
       auto status = library_->ConfigureLogging(task, file_path, logging_mode, group_name, operation);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::ConfigureTEDS(::grpc::ServerContext* context, const ConfigureTEDSRequest* request, ConfigureTEDSResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto physical_channel = request->physical_channel().c_str();
+      auto file_path = request->file_path().c_str();
+      auto status = library_->ConfigureTEDS(physical_channel, file_path);
       response->set_status(status);
       return ::grpc::Status::OK;
     }
@@ -6621,6 +6718,82 @@ namespace nidaqmx_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::DeleteSavedGlobalChan(::grpc::ServerContext* context, const DeleteSavedGlobalChanRequest* request, DeleteSavedGlobalChanResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto channel_name = request->channel_name().c_str();
+      auto status = library_->DeleteSavedGlobalChan(channel_name);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::DeleteSavedScale(::grpc::ServerContext* context, const DeleteSavedScaleRequest* request, DeleteSavedScaleResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto scale_name = request->scale_name().c_str();
+      auto status = library_->DeleteSavedScale(scale_name);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::DeleteSavedTask(::grpc::ServerContext* context, const DeleteSavedTaskRequest* request, DeleteSavedTaskResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto task_name = request->task_name().c_str();
+      auto status = library_->DeleteSavedTask(task_name);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::DeviceSupportsCal(::grpc::ServerContext* context, const DeviceSupportsCalRequest* request, DeviceSupportsCalResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto device_name = request->device_name().c_str();
+      bool32 cal_supported {};
+      auto status = library_->DeviceSupportsCal(device_name, &cal_supported);
+      response->set_status(status);
+      if (status == 0) {
+        response->set_cal_supported(cal_supported);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiDAQmxService::DisableRefTrig(::grpc::ServerContext* context, const DisableRefTrigRequest* request, DisableRefTrigResponse* response)
   {
     if (context->IsCancelled()) {
@@ -6824,6 +6997,31 @@ namespace nidaqmx_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::GetAutoConfiguredCDAQSyncConnections(::grpc::ServerContext* context, const GetAutoConfiguredCDAQSyncConnectionsRequest* request, GetAutoConfiguredCDAQSyncConnectionsResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      uInt32 port_list_size = request->port_list_size();
+      std::string port_list;
+      if (port_list_size > 0) {
+          port_list.resize(port_list_size-1);
+      }
+      auto status = library_->GetAutoConfiguredCDAQSyncConnections((char*)port_list.data(), port_list_size);
+      response->set_status(status);
+      if (status == 0) {
+        response->set_port_list(port_list);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiDAQmxService::GetDigitalLogicFamilyPowerUpState(::grpc::ServerContext* context, const GetDigitalLogicFamilyPowerUpStateRequest* request, GetDigitalLogicFamilyPowerUpStateResponse* response)
   {
     if (context->IsCancelled()) {
@@ -6836,6 +7034,31 @@ namespace nidaqmx_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_logic_family(logic_family);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::GetDisconnectedCDAQSyncPorts(::grpc::ServerContext* context, const GetDisconnectedCDAQSyncPortsRequest* request, GetDisconnectedCDAQSyncPortsResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      uInt32 port_list_size = request->port_list_size();
+      std::string port_list;
+      if (port_list_size > 0) {
+          port_list.resize(port_list_size-1);
+      }
+      auto status = library_->GetDisconnectedCDAQSyncPorts((char*)port_list.data(), port_list_size);
+      response->set_status(status);
+      if (status == 0) {
+        response->set_port_list(port_list);
       }
       return ::grpc::Status::OK;
     }
@@ -7040,6 +7263,36 @@ namespace nidaqmx_grpc {
       response->set_status(status);
       if (status == 0) {
         convert_to_grpc(data, response->mutable_data());
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::GetSelfCalLastDateAndTime(::grpc::ServerContext* context, const GetSelfCalLastDateAndTimeRequest* request, GetSelfCalLastDateAndTimeResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto device_name = request->device_name().c_str();
+      uInt32 year {};
+      uInt32 month {};
+      uInt32 day {};
+      uInt32 hour {};
+      uInt32 minute {};
+      auto status = library_->GetSelfCalLastDateAndTime(device_name, &year, &month, &day, &hour, &minute);
+      response->set_status(status);
+      if (status == 0) {
+        response->set_year(year);
+        response->set_month(month);
+        response->set_day(day);
+        response->set_hour(hour);
+        response->set_minute(minute);
       }
       return ::grpc::Status::OK;
     }
@@ -8104,6 +8357,24 @@ namespace nidaqmx_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::RemoveCDAQSyncConnection(::grpc::ServerContext* context, const RemoveCDAQSyncConnectionRequest* request, RemoveCDAQSyncConnectionResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto port_list = request->port_list().c_str();
+      auto status = library_->RemoveCDAQSyncConnection(port_list);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiDAQmxService::ReserveNetworkDevice(::grpc::ServerContext* context, const ReserveNetworkDeviceRequest* request, ReserveNetworkDeviceResponse* response)
   {
     if (context->IsCancelled()) {
@@ -8131,6 +8402,135 @@ namespace nidaqmx_grpc {
     try {
       auto device_name = request->device_name().c_str();
       auto status = library_->ResetDevice(device_name);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::SaveGlobalChan(::grpc::ServerContext* context, const SaveGlobalChanRequest* request, SaveGlobalChanResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto task_grpc_session = request->task();
+      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      auto channel_name = request->channel_name().c_str();
+      auto save_as = request->save_as().c_str();
+      auto author = request->author().c_str();
+      uInt32 options;
+      switch (request->options_enum_case()) {
+        case nidaqmx_grpc::SaveGlobalChanRequest::OptionsEnumCase::kOptions: {
+          options = static_cast<uInt32>(request->options());
+          break;
+        }
+        case nidaqmx_grpc::SaveGlobalChanRequest::OptionsEnumCase::kOptionsRaw: {
+          options = static_cast<uInt32>(request->options_raw());
+          break;
+        }
+        case nidaqmx_grpc::SaveGlobalChanRequest::OptionsEnumCase::OPTIONS_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for options was not specified or out of range");
+          break;
+        }
+      }
+
+      auto status = library_->SaveGlobalChan(task, channel_name, save_as, author, options);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::SaveScale(::grpc::ServerContext* context, const SaveScaleRequest* request, SaveScaleResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto scale_name = request->scale_name().c_str();
+      auto save_as = request->save_as().c_str();
+      auto author = request->author().c_str();
+      uInt32 options;
+      switch (request->options_enum_case()) {
+        case nidaqmx_grpc::SaveScaleRequest::OptionsEnumCase::kOptions: {
+          options = static_cast<uInt32>(request->options());
+          break;
+        }
+        case nidaqmx_grpc::SaveScaleRequest::OptionsEnumCase::kOptionsRaw: {
+          options = static_cast<uInt32>(request->options_raw());
+          break;
+        }
+        case nidaqmx_grpc::SaveScaleRequest::OptionsEnumCase::OPTIONS_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for options was not specified or out of range");
+          break;
+        }
+      }
+
+      auto status = library_->SaveScale(scale_name, save_as, author, options);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::SaveTask(::grpc::ServerContext* context, const SaveTaskRequest* request, SaveTaskResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto task_grpc_session = request->task();
+      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      auto save_as = request->save_as().c_str();
+      auto author = request->author().c_str();
+      uInt32 options;
+      switch (request->options_enum_case()) {
+        case nidaqmx_grpc::SaveTaskRequest::OptionsEnumCase::kOptions: {
+          options = static_cast<uInt32>(request->options());
+          break;
+        }
+        case nidaqmx_grpc::SaveTaskRequest::OptionsEnumCase::kOptionsRaw: {
+          options = static_cast<uInt32>(request->options_raw());
+          break;
+        }
+        case nidaqmx_grpc::SaveTaskRequest::OptionsEnumCase::OPTIONS_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for options was not specified or out of range");
+          break;
+        }
+      }
+
+      auto status = library_->SaveTask(task, save_as, author, options);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::SelfCal(::grpc::ServerContext* context, const SelfCalRequest* request, SelfCalResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto device_name = request->device_name().c_str();
+      auto status = library_->SelfCal(device_name);
       response->set_status(status);
       return ::grpc::Status::OK;
     }
@@ -8443,6 +8843,30 @@ namespace nidaqmx_grpc {
       auto device_name = request->device_name().c_str();
       auto status = library_->UnreserveNetworkDevice(device_name);
       response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::WaitForNextSampleClock(::grpc::ServerContext* context, const WaitForNextSampleClockRequest* request, WaitForNextSampleClockResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto task_grpc_session = request->task();
+      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      float64 timeout = request->timeout();
+      bool32 is_late {};
+      auto status = library_->WaitForNextSampleClock(task, timeout, &is_late);
+      response->set_status(status);
+      if (status == 0) {
+        response->set_is_late(is_late);
+      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
@@ -9240,6 +9664,77 @@ namespace nidaqmx_grpc {
       if (status == 0) {
         response->set_samps_per_chan_written(samps_per_chan_written);
       }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::WriteToTEDSFromArray(::grpc::ServerContext* context, const WriteToTEDSFromArrayRequest* request, WriteToTEDSFromArrayResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto physical_channel = request->physical_channel().c_str();
+      const uInt8* bit_stream = (const uInt8*)request->bit_stream().c_str();
+      uInt32 array_size = request->array_size();
+      int32 basic_teds_options;
+      switch (request->basic_teds_options_enum_case()) {
+        case nidaqmx_grpc::WriteToTEDSFromArrayRequest::BasicTedsOptionsEnumCase::kBasicTedsOptions: {
+          basic_teds_options = static_cast<int32>(request->basic_teds_options());
+          break;
+        }
+        case nidaqmx_grpc::WriteToTEDSFromArrayRequest::BasicTedsOptionsEnumCase::kBasicTedsOptionsRaw: {
+          basic_teds_options = static_cast<int32>(request->basic_teds_options_raw());
+          break;
+        }
+        case nidaqmx_grpc::WriteToTEDSFromArrayRequest::BasicTedsOptionsEnumCase::BASIC_TEDS_OPTIONS_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for basic_teds_options was not specified or out of range");
+          break;
+        }
+      }
+
+      auto status = library_->WriteToTEDSFromArray(physical_channel, bit_stream, array_size, basic_teds_options);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::WriteToTEDSFromFile(::grpc::ServerContext* context, const WriteToTEDSFromFileRequest* request, WriteToTEDSFromFileResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto physical_channel = request->physical_channel().c_str();
+      auto file_path = request->file_path().c_str();
+      int32 basic_teds_options;
+      switch (request->basic_teds_options_enum_case()) {
+        case nidaqmx_grpc::WriteToTEDSFromFileRequest::BasicTedsOptionsEnumCase::kBasicTedsOptions: {
+          basic_teds_options = static_cast<int32>(request->basic_teds_options());
+          break;
+        }
+        case nidaqmx_grpc::WriteToTEDSFromFileRequest::BasicTedsOptionsEnumCase::kBasicTedsOptionsRaw: {
+          basic_teds_options = static_cast<int32>(request->basic_teds_options_raw());
+          break;
+        }
+        case nidaqmx_grpc::WriteToTEDSFromFileRequest::BasicTedsOptionsEnumCase::BASIC_TEDS_OPTIONS_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for basic_teds_options was not specified or out of range");
+          break;
+        }
+      }
+
+      auto status = library_->WriteToTEDSFromFile(physical_channel, file_path, basic_teds_options);
+      response->set_status(status);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {

--- a/generated/nidaqmx/nidaqmx_service.h
+++ b/generated/nidaqmx/nidaqmx_service.h
@@ -28,8 +28,11 @@ public:
   NiDAQmxService(NiDAQmxLibraryInterface* library, ResourceRepositorySharedPtr session_repository);
   virtual ~NiDAQmxService();
   
+  ::grpc::Status AddCDAQSyncConnection(::grpc::ServerContext* context, const AddCDAQSyncConnectionRequest* request, AddCDAQSyncConnectionResponse* response) override;
   ::grpc::Status AddGlobalChansToTask(::grpc::ServerContext* context, const AddGlobalChansToTaskRequest* request, AddGlobalChansToTaskResponse* response) override;
   ::grpc::Status AddNetworkDevice(::grpc::ServerContext* context, const AddNetworkDeviceRequest* request, AddNetworkDeviceResponse* response) override;
+  ::grpc::Status AreConfiguredCDAQSyncPortsDisconnected(::grpc::ServerContext* context, const AreConfiguredCDAQSyncPortsDisconnectedRequest* request, AreConfiguredCDAQSyncPortsDisconnectedResponse* response) override;
+  ::grpc::Status AutoConfigureCDAQSyncConnections(::grpc::ServerContext* context, const AutoConfigureCDAQSyncConnectionsRequest* request, AutoConfigureCDAQSyncConnectionsResponse* response) override;
   ::grpc::Status CalculateReversePolyCoeff(::grpc::ServerContext* context, const CalculateReversePolyCoeffRequest* request, CalculateReversePolyCoeffResponse* response) override;
   ::grpc::Status CfgAnlgEdgeRefTrig(::grpc::ServerContext* context, const CfgAnlgEdgeRefTrigRequest* request, CfgAnlgEdgeRefTrigResponse* response) override;
   ::grpc::Status CfgAnlgEdgeStartTrig(::grpc::ServerContext* context, const CfgAnlgEdgeStartTrigRequest* request, CfgAnlgEdgeStartTrigResponse* response) override;
@@ -54,8 +57,10 @@ public:
   ::grpc::Status CfgWatchdogAOExpirStates(::grpc::ServerContext* context, const CfgWatchdogAOExpirStatesRequest* request, CfgWatchdogAOExpirStatesResponse* response) override;
   ::grpc::Status CfgWatchdogCOExpirStates(::grpc::ServerContext* context, const CfgWatchdogCOExpirStatesRequest* request, CfgWatchdogCOExpirStatesResponse* response) override;
   ::grpc::Status CfgWatchdogDOExpirStates(::grpc::ServerContext* context, const CfgWatchdogDOExpirStatesRequest* request, CfgWatchdogDOExpirStatesResponse* response) override;
+  ::grpc::Status ClearTEDS(::grpc::ServerContext* context, const ClearTEDSRequest* request, ClearTEDSResponse* response) override;
   ::grpc::Status ClearTask(::grpc::ServerContext* context, const ClearTaskRequest* request, ClearTaskResponse* response) override;
   ::grpc::Status ConfigureLogging(::grpc::ServerContext* context, const ConfigureLoggingRequest* request, ConfigureLoggingResponse* response) override;
+  ::grpc::Status ConfigureTEDS(::grpc::ServerContext* context, const ConfigureTEDSRequest* request, ConfigureTEDSResponse* response) override;
   ::grpc::Status ConnectTerms(::grpc::ServerContext* context, const ConnectTermsRequest* request, ConnectTermsResponse* response) override;
   ::grpc::Status ControlWatchdogTask(::grpc::ServerContext* context, const ControlWatchdogTaskRequest* request, ControlWatchdogTaskResponse* response) override;
   ::grpc::Status CreateAIAccel4WireDCVoltageChan(::grpc::ServerContext* context, const CreateAIAccel4WireDCVoltageChanRequest* request, CreateAIAccel4WireDCVoltageChanResponse* response) override;
@@ -141,6 +146,10 @@ public:
   ::grpc::Status CreateWatchdogTimerTask(::grpc::ServerContext* context, const CreateWatchdogTimerTaskRequest* request, CreateWatchdogTimerTaskResponse* response) override;
   ::grpc::Status CreateWatchdogTimerTaskEx(::grpc::ServerContext* context, const CreateWatchdogTimerTaskExRequest* request, CreateWatchdogTimerTaskExResponse* response) override;
   ::grpc::Status DeleteNetworkDevice(::grpc::ServerContext* context, const DeleteNetworkDeviceRequest* request, DeleteNetworkDeviceResponse* response) override;
+  ::grpc::Status DeleteSavedGlobalChan(::grpc::ServerContext* context, const DeleteSavedGlobalChanRequest* request, DeleteSavedGlobalChanResponse* response) override;
+  ::grpc::Status DeleteSavedScale(::grpc::ServerContext* context, const DeleteSavedScaleRequest* request, DeleteSavedScaleResponse* response) override;
+  ::grpc::Status DeleteSavedTask(::grpc::ServerContext* context, const DeleteSavedTaskRequest* request, DeleteSavedTaskResponse* response) override;
+  ::grpc::Status DeviceSupportsCal(::grpc::ServerContext* context, const DeviceSupportsCalRequest* request, DeviceSupportsCalResponse* response) override;
   ::grpc::Status DisableRefTrig(::grpc::ServerContext* context, const DisableRefTrigRequest* request, DisableRefTrigResponse* response) override;
   ::grpc::Status DisableStartTrig(::grpc::ServerContext* context, const DisableStartTrigRequest* request, DisableStartTrigResponse* response) override;
   ::grpc::Status DisconnectTerms(::grpc::ServerContext* context, const DisconnectTermsRequest* request, DisconnectTermsResponse* response) override;
@@ -149,7 +158,9 @@ public:
   ::grpc::Status GetAIChanCalExpDate(::grpc::ServerContext* context, const GetAIChanCalExpDateRequest* request, GetAIChanCalExpDateResponse* response) override;
   ::grpc::Status GetArmStartTrigTimestampVal(::grpc::ServerContext* context, const GetArmStartTrigTimestampValRequest* request, GetArmStartTrigTimestampValResponse* response) override;
   ::grpc::Status GetArmStartTrigTrigWhen(::grpc::ServerContext* context, const GetArmStartTrigTrigWhenRequest* request, GetArmStartTrigTrigWhenResponse* response) override;
+  ::grpc::Status GetAutoConfiguredCDAQSyncConnections(::grpc::ServerContext* context, const GetAutoConfiguredCDAQSyncConnectionsRequest* request, GetAutoConfiguredCDAQSyncConnectionsResponse* response) override;
   ::grpc::Status GetDigitalLogicFamilyPowerUpState(::grpc::ServerContext* context, const GetDigitalLogicFamilyPowerUpStateRequest* request, GetDigitalLogicFamilyPowerUpStateResponse* response) override;
+  ::grpc::Status GetDisconnectedCDAQSyncPorts(::grpc::ServerContext* context, const GetDisconnectedCDAQSyncPortsRequest* request, GetDisconnectedCDAQSyncPortsResponse* response) override;
   ::grpc::Status GetErrorString(::grpc::ServerContext* context, const GetErrorStringRequest* request, GetErrorStringResponse* response) override;
   ::grpc::Status GetExtendedErrorInfo(::grpc::ServerContext* context, const GetExtendedErrorInfoRequest* request, GetExtendedErrorInfoResponse* response) override;
   ::grpc::Status GetFirstSampClkWhen(::grpc::ServerContext* context, const GetFirstSampClkWhenRequest* request, GetFirstSampClkWhenResponse* response) override;
@@ -158,6 +169,7 @@ public:
   ::grpc::Status GetNthTaskDevice(::grpc::ServerContext* context, const GetNthTaskDeviceRequest* request, GetNthTaskDeviceResponse* response) override;
   ::grpc::Status GetNthTaskReadChannel(::grpc::ServerContext* context, const GetNthTaskReadChannelRequest* request, GetNthTaskReadChannelResponse* response) override;
   ::grpc::Status GetRefTrigTimestampVal(::grpc::ServerContext* context, const GetRefTrigTimestampValRequest* request, GetRefTrigTimestampValResponse* response) override;
+  ::grpc::Status GetSelfCalLastDateAndTime(::grpc::ServerContext* context, const GetSelfCalLastDateAndTimeRequest* request, GetSelfCalLastDateAndTimeResponse* response) override;
   ::grpc::Status GetStartTrigTimestampVal(::grpc::ServerContext* context, const GetStartTrigTimestampValRequest* request, GetStartTrigTimestampValResponse* response) override;
   ::grpc::Status GetStartTrigTrigWhen(::grpc::ServerContext* context, const GetStartTrigTrigWhenRequest* request, GetStartTrigTrigWhenResponse* response) override;
   ::grpc::Status GetSyncPulseTimeWhen(::grpc::ServerContext* context, const GetSyncPulseTimeWhenRequest* request, GetSyncPulseTimeWhenResponse* response) override;
@@ -188,8 +200,13 @@ public:
   ::grpc::Status ReadDigitalU8(::grpc::ServerContext* context, const ReadDigitalU8Request* request, ReadDigitalU8Response* response) override;
   ::grpc::Status ReadRaw(::grpc::ServerContext* context, const ReadRawRequest* request, ReadRawResponse* response) override;
   ::grpc::Status RegisterDoneEvent(::grpc::ServerContext* context, const RegisterDoneEventRequest* request, ::grpc::ServerWriter<RegisterDoneEventResponse>* writer) override;
+  ::grpc::Status RemoveCDAQSyncConnection(::grpc::ServerContext* context, const RemoveCDAQSyncConnectionRequest* request, RemoveCDAQSyncConnectionResponse* response) override;
   ::grpc::Status ReserveNetworkDevice(::grpc::ServerContext* context, const ReserveNetworkDeviceRequest* request, ReserveNetworkDeviceResponse* response) override;
   ::grpc::Status ResetDevice(::grpc::ServerContext* context, const ResetDeviceRequest* request, ResetDeviceResponse* response) override;
+  ::grpc::Status SaveGlobalChan(::grpc::ServerContext* context, const SaveGlobalChanRequest* request, SaveGlobalChanResponse* response) override;
+  ::grpc::Status SaveScale(::grpc::ServerContext* context, const SaveScaleRequest* request, SaveScaleResponse* response) override;
+  ::grpc::Status SaveTask(::grpc::ServerContext* context, const SaveTaskRequest* request, SaveTaskResponse* response) override;
+  ::grpc::Status SelfCal(::grpc::ServerContext* context, const SelfCalRequest* request, SelfCalResponse* response) override;
   ::grpc::Status SelfTestDevice(::grpc::ServerContext* context, const SelfTestDeviceRequest* request, SelfTestDeviceResponse* response) override;
   ::grpc::Status SetAIChanCalCalDate(::grpc::ServerContext* context, const SetAIChanCalCalDateRequest* request, SetAIChanCalCalDateResponse* response) override;
   ::grpc::Status SetAIChanCalExpDate(::grpc::ServerContext* context, const SetAIChanCalExpDateRequest* request, SetAIChanCalExpDateResponse* response) override;
@@ -204,6 +221,7 @@ public:
   ::grpc::Status TaskControl(::grpc::ServerContext* context, const TaskControlRequest* request, TaskControlResponse* response) override;
   ::grpc::Status TristateOutputTerm(::grpc::ServerContext* context, const TristateOutputTermRequest* request, TristateOutputTermResponse* response) override;
   ::grpc::Status UnreserveNetworkDevice(::grpc::ServerContext* context, const UnreserveNetworkDeviceRequest* request, UnreserveNetworkDeviceResponse* response) override;
+  ::grpc::Status WaitForNextSampleClock(::grpc::ServerContext* context, const WaitForNextSampleClockRequest* request, WaitForNextSampleClockResponse* response) override;
   ::grpc::Status WaitForValidTimestamp(::grpc::ServerContext* context, const WaitForValidTimestampRequest* request, WaitForValidTimestampResponse* response) override;
   ::grpc::Status WaitUntilTaskDone(::grpc::ServerContext* context, const WaitUntilTaskDoneRequest* request, WaitUntilTaskDoneResponse* response) override;
   ::grpc::Status WriteAnalogF64(::grpc::ServerContext* context, const WriteAnalogF64Request* request, WriteAnalogF64Response* response) override;
@@ -224,6 +242,8 @@ public:
   ::grpc::Status WriteDigitalU32(::grpc::ServerContext* context, const WriteDigitalU32Request* request, WriteDigitalU32Response* response) override;
   ::grpc::Status WriteDigitalU8(::grpc::ServerContext* context, const WriteDigitalU8Request* request, WriteDigitalU8Response* response) override;
   ::grpc::Status WriteRaw(::grpc::ServerContext* context, const WriteRawRequest* request, WriteRawResponse* response) override;
+  ::grpc::Status WriteToTEDSFromArray(::grpc::ServerContext* context, const WriteToTEDSFromArrayRequest* request, WriteToTEDSFromArrayResponse* response) override;
+  ::grpc::Status WriteToTEDSFromFile(::grpc::ServerContext* context, const WriteToTEDSFromFileRequest* request, WriteToTEDSFromFileResponse* response) override;
 private:
   NiDAQmxLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;

--- a/source/codegen/metadata/nidaqmx/enums.py
+++ b/source/codegen/metadata/nidaqmx/enums.py
@@ -2095,23 +2095,14 @@ enums = {
     'WriteBasicTEDSOptions': {
         'values': [
             {
-                'documentation': {
-                    'description': 'blah'
-                },
                 'name': 'WRITE_TO_EEPROM',
                 'value': 12538
             },
             {
-                'documentation': {
-                    'description': 'blah'
-                },
                 'name': 'WRITE_TO_PROM',
                 'value': 12539
             },
             {
-                'documentation': {
-                    'description': 'blah'
-                },
                 'name': 'DO_NOT_WRITE',
                 'value': 12540
             }

--- a/source/codegen/metadata/nidaqmx/enums.py
+++ b/source/codegen/metadata/nidaqmx/enums.py
@@ -1281,6 +1281,22 @@ enums = {
             }
         ]
     },
+    'SaveOptions': {
+        'values': [
+            {
+                'name': 'OVERWRITE',
+                'value': 1
+            },
+            {
+                'name': 'ALLOW_INTERACTIVE_EDITING',
+                'value': 2
+            },
+            {
+                'name': 'ALLOW_INTERACTIVE_DELETION',
+                'value': 4
+            }
+        ]
+    },
     'Signal': {
         'values': [
             {
@@ -2073,6 +2089,31 @@ enums = {
                 },
                 'name': 'LEAVING_WIN',
                 'value': 10208
+            }
+        ]
+    },
+    'WriteBasicTEDSOptions': {
+        'values': [
+            {
+                'documentation': {
+                    'description': 'blah'
+                },
+                'name': 'WRITE_TO_EEPROM',
+                'value': 12538
+            },
+            {
+                'documentation': {
+                    'description': 'blah'
+                },
+                'name': 'WRITE_TO_PROM',
+                'value': 12539
+            },
+            {
+                'documentation': {
+                    'description': 'blah'
+                },
+                'name': 'DO_NOT_WRITE',
+                'value': 12540
             }
         ]
     }

--- a/source/codegen/metadata/nidaqmx/functions.py
+++ b/source/codegen/metadata/nidaqmx/functions.py
@@ -1,4 +1,14 @@
 functions = {
+    'AddCDAQSyncConnection': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'portList',
+                'type': 'const char[]'
+            }
+        ],
+        'returns': 'int32'
+    },
     'AddGlobalChansToTask': {
         'parameters': [
             {
@@ -49,6 +59,41 @@ functions = {
                 'direction': 'in',
                 'name': 'deviceNameOutBufferSize',
                 'type': 'uInt32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'AreConfiguredCDAQSyncPortsDisconnected': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'chassisDevicesPorts',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'timeout',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'disconnectedPortsExist',
+                'type': 'bool32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'AutoConfigureCDAQSyncConnections': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'chassisDevicesPorts',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'timeout',
+                'type': 'float64'
             }
         ],
         'returns': 'int32'
@@ -766,6 +811,16 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'ClearTEDS': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'physicalChannel',
+                'type': 'const char[]'
+            }
+        ],
+        'returns': 'int32'
+    },
     'ClearTask': {
         'parameters': [
             {
@@ -804,6 +859,21 @@ functions = {
                 'enum': 'LoggingOperation',
                 'name': 'operation',
                 'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'ConfigureTEDS': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'physicalChannel',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'filePath',
+                'type': 'const char[]'
             }
         ],
         'returns': 'int32'
@@ -5537,6 +5607,51 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'DeleteSavedGlobalChan': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'channelName',
+                'type': 'const char[]'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'DeleteSavedScale': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'scaleName',
+                'type': 'const char[]'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'DeleteSavedTask': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'taskName',
+                'type': 'const char[]'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'DeviceSupportsCal': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'deviceName',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'out',
+                'name': 'calSupported',
+                'type': 'bool32'
+            }
+        ],
+        'returns': 'int32'
+    },
     'DisableRefTrig': {
         'parameters': [
             {
@@ -5703,6 +5818,25 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'GetAutoConfiguredCDAQSyncConnections': {
+        'parameters': [
+            {
+                'direction': 'out',
+                'name': 'portList',
+                'size': {
+                    'mechanism': 'passed-in',
+                    'value': 'portListSize'
+                },
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'portListSize',
+                'type': 'uInt32'
+            }
+        ],
+        'returns': 'int32'
+    },
     'GetDigitalLogicFamilyPowerUpState': {
         'parameters': [
             {
@@ -5714,6 +5848,25 @@ functions = {
                 'direction': 'out',
                 'name': 'logicFamily',
                 'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'GetDisconnectedCDAQSyncPorts': {
+        'parameters': [
+            {
+                'direction': 'out',
+                'name': 'portList',
+                'size': {
+                    'mechanism': 'passed-in',
+                    'value': 'portListSize'
+                },
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'portListSize',
+                'type': 'uInt32'
             }
         ],
         'returns': 'int32'
@@ -5889,6 +6042,41 @@ functions = {
                 'direction': 'out',
                 'name': 'data',
                 'type': 'CVIAbsoluteTime'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'GetSelfCalLastDateAndTime': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'deviceName',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'out',
+                'name': 'year',
+                'type': 'uInt32'
+            },
+            {
+                'direction': 'out',
+                'name': 'month',
+                'type': 'uInt32'
+            },
+            {
+                'direction': 'out',
+                'name': 'day',
+                'type': 'uInt32'
+            },
+            {
+                'direction': 'out',
+                'name': 'hour',
+                'type': 'uInt32'
+            },
+            {
+                'direction': 'out',
+                'name': 'minute',
+                'type': 'uInt32'
             }
         ],
         'returns': 'int32'
@@ -7111,6 +7299,16 @@ functions = {
         'returns': 'int32',
         'stream_response': True
     },
+    'RemoveCDAQSyncConnection': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'portList',
+                'type': 'const char[]'
+            }
+        ],
+        'returns': 'int32'
+    },
     'ReserveNetworkDevice': {
         'parameters': [
             {
@@ -7127,6 +7325,99 @@ functions = {
         'returns': 'int32'
     },
     'ResetDevice': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'deviceName',
+                'type': 'const char[]'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'SaveGlobalChan': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'task',
+                'type': 'TaskHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'channelName',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'saveAs',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'author',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'in',
+                'enum': 'SaveOptions',
+                'name': 'options',
+                'type': 'uInt32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'SaveScale': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'scaleName',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'saveAs',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'author',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'in',
+                'enum': 'SaveOptions',
+                'name': 'options',
+                'type': 'uInt32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'SaveTask': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'task',
+                'type': 'TaskHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'saveAs',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'author',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'in',
+                'enum': 'SaveOptions',
+                'name': 'options',
+                'type': 'uInt32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'SelfCal': {
         'parameters': [
             {
                 'direction': 'in',
@@ -7369,6 +7660,26 @@ functions = {
                 'direction': 'in',
                 'name': 'deviceName',
                 'type': 'const char[]'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'WaitForNextSampleClock': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'task',
+                'type': 'TaskHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'timeout',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'isLate',
+                'type': 'bool32'
             }
         ],
         'returns': 'int32'
@@ -8221,6 +8532,53 @@ functions = {
                 'name': 'reserved',
                 'pass_null': True,
                 'type': 'bool32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'WriteToTEDSFromArray': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'physicalChannel',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'bitStream',
+                'type': 'const uInt8[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'arraySize',
+                'type': 'uInt32'
+            },
+            {
+                'direction': 'in',
+                'enum': 'WriteBasicTEDSOptions',
+                'name': 'basicTEDSOptions',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'WriteToTEDSFromFile': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'physicalChannel',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'filePath',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'in',
+                'enum': 'WriteBasicTEDSOptions',
+                'name': 'basicTEDSOptions',
+                'type': 'int32'
             }
         ],
         'returns': 'int32'

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -560,6 +560,7 @@ class NiDAQmxDriverApiTests : public Test {
     ::grpc::ClientContext context;
     AddNetworkDeviceRequest request;
     request.set_ip_address(ip_address);
+    request.set_device_name_out_buffer_size(1024);
     return stub()->AddNetworkDevice(&context, request, &response);
   }
 

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -96,7 +96,7 @@ class NiDAQmxDriverApiTests : public Test {
     return stub()->CreateTask(&context, request, &response);
   }
 
-  ::grpc::Status clear_task(ClearTaskResponse& response)
+  ::grpc::Status clear_task(ClearTaskResponse& response = ThrowawayResponse<ClearTaskResponse>::response())
   {
     ::grpc::ClientContext context;
     ClearTaskRequest request;
@@ -525,6 +525,42 @@ class NiDAQmxDriverApiTests : public Test {
     request.mutable_when()->CopyFrom(time);
     request.set_timescale(Timescale2::TIMESCALE2_IO_DEVICE_TIME);
     return stub()->CfgTimeStartTrig(&context, request, &response);
+  }
+
+  ::grpc::Status save_task(SaveTaskResponse& response){
+    ::grpc::ClientContext context;
+    SaveTaskRequest request;
+    set_request_session_id(request);
+    request.set_author("grpc.tester@ni.com");
+    request.set_options_raw(SaveOptions::SAVE_OPTIONS_OVERWRITE | SaveOptions::SAVE_OPTIONS_ALLOW_INTERACTIVE_DELETION);
+    request.set_save_as("saved_task");
+    return stub()->SaveTask(&context, request, &response);
+  }
+
+  ::grpc::Status load_task(LoadTaskResponse& response){
+    ::grpc::ClientContext context;
+    LoadTaskRequest request;
+    request.set_session_name("saved_task");
+    auto status = stub()->LoadTask(&context, request, &response);
+    if (status.ok()) {
+      EXPECT_NE(driver_session_->id(), response.task().id());
+      driver_session_ = std::make_unique<nidevice_grpc::Session>(response.task());
+    }
+    return status;
+  }
+
+  ::grpc::Status self_cal(SelfCalResponse& response) {
+    ::grpc::ClientContext context;
+    SelfCalRequest request;
+    request.set_device_name(DEVICE_NAME);
+    return stub()->SelfCal(&context, request, &response);
+  }
+
+  ::grpc::Status get_self_cal_last_date_and_time(GetSelfCalLastDateAndTimeResponse& response) {
+    ::grpc::ClientContext context;
+    GetSelfCalLastDateAndTimeRequest request;
+    // request.set_device_name();
+    return stub()->GetSelfCalLastDateAndTime(&context, request, &response);
   }
 
   std::unique_ptr<NiDAQmx::Stub>& stub()
@@ -1015,6 +1051,46 @@ TEST_F(NiDAQmxDriverApiTests, AIVoltageChannel_CfgTimeStartTrig_ReturnsError) {
   auto status = cfg_time_start_trig(response);
 
   EXPECT_DAQ_ERROR(DAQmxErrorInvalidAttributeValue, status, response);
+}
+
+TEST_F(NiDAQmxDriverApiTests, LoadedVoltageTask_ReadAIData_ReturnsDataInExpectedRange) {
+  const auto AI_MIN = 0.0;
+  const auto AI_MAX = 1.0;
+  const auto NUM_SAMPS = 10;
+  create_ai_voltage_chan(AI_MIN, AI_MAX);
+  auto save_response = SaveTaskResponse{};
+  auto status = save_task(save_response);
+  EXPECT_SUCCESS(status, save_response);
+  clear_task();
+  auto load_response = LoadTaskResponse{};
+  status = load_task(load_response);
+  EXPECT_SUCCESS(status, load_response);
+
+  auto read_response = ReadAnalogF64Response{};
+  status = read_analog_f64(NUM_SAMPS, NUM_SAMPS, read_response);
+
+  EXPECT_SUCCESS(status, read_response);
+  EXPECT_DATA_IN_RANGE(read_response.read_array(), AI_MIN, AI_MAX);
+}
+
+
+TEST_F(NiDAQmxDriverApiTests, SelfCal_Succeeds) {
+  auto response = SelfCalResponse{};
+  auto status = self_cal(response);
+
+  EXPECT_SUCCESS(status, response);
+}
+
+TEST_F(NiDAQmxDriverApiTests, GetSelfCalLastDateAndTime) {
+  auto response = GetSelfCalLastDateAndTimeResponse{};
+  auto status = get_self_cal_last_date_and_time(response);
+
+  EXPECT_SUCCESS(status, response);
+  EXPECT_EQ(0, response.year());
+  EXPECT_EQ(0, response.month());
+  EXPECT_EQ(0, response.day());
+  EXPECT_EQ(0, response.hour());
+  EXPECT_EQ(0, response.minute());
 }
 }  // namespace system
 }  // namespace tests


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds [DAQmx Advanced functions](https://zone.ni.com/reference/en-XX/help/370471AM-01/TOC27.htm) to grpc-device.

Note: Calibration is limited to SelfCal.

### Why should this Pull Request be merged?

Adds support for advanced DAQmx features to grpc-device.

### What testing has been done?

Ran and passed all DAQ tests.
Some python test spot checks (including adding a real daq network device).