### PR TITLE
Add hardcoded_value mechanism

### DIFF
--- a/generated/nidaqmx/nidaqmx.proto
+++ b/generated/nidaqmx/nidaqmx.proto
@@ -4070,7 +4070,6 @@ message ReadRawResponse {
 
 message RegisterDoneEventRequest {
   nidevice_grpc.Session task = 1;
-  uint32 options = 2;
 }
 
 message RegisterDoneEventResponse {
@@ -4084,7 +4083,6 @@ message RegisterEveryNSamplesEventRequest {
     int32 every_n_samples_event_type_raw = 3;
   }
   uint32 n_samples = 4;
-  uint32 options = 5;
 }
 
 message RegisterEveryNSamplesEventResponse {
@@ -4100,7 +4098,6 @@ message RegisterSignalEventRequest {
     Signal2 signal_id = 2;
     int32 signal_id_raw = 3;
   }
-  uint32 options = 4;
 }
 
 message RegisterSignalEventResponse {

--- a/generated/nidaqmx/nidaqmx_library.cpp
+++ b/generated/nidaqmx/nidaqmx_library.cpp
@@ -1949,27 +1949,27 @@ int32 NiDAQmxLibrary::GetRefTrigTimestampVal(TaskHandle task, CVIAbsoluteTime* d
 #endif
 }
 
-int32 NiDAQmxLibrary::GetScaleAttributeDouble(const char scaleName[], int32 attribute, float64* value)
+int32 NiDAQmxLibrary::GetScaleAttributeDouble(const char scaleName[], int32 attribute, float64* value, uInt32 size)
 {
   if (!function_pointers_.GetScaleAttributeDouble) {
     throw nidevice_grpc::LibraryLoadException("Could not find DAQmxGetScaleAttribute.");
   }
 #if defined(_MSC_VER)
-  return DAQmxGetScaleAttribute(scaleName, attribute, value);
+  return DAQmxGetScaleAttribute(scaleName, attribute, value, size);
 #else
-  return function_pointers_.GetScaleAttributeDouble(scaleName, attribute, value);
+  return function_pointers_.GetScaleAttributeDouble(scaleName, attribute, value, size);
 #endif
 }
 
-int32 NiDAQmxLibrary::GetScaleAttributeInt32(const char scaleName[], int32 attribute, int32* value)
+int32 NiDAQmxLibrary::GetScaleAttributeInt32(const char scaleName[], int32 attribute, int32* value, uInt32 size)
 {
   if (!function_pointers_.GetScaleAttributeInt32) {
     throw nidevice_grpc::LibraryLoadException("Could not find DAQmxGetScaleAttribute.");
   }
 #if defined(_MSC_VER)
-  return DAQmxGetScaleAttribute(scaleName, attribute, value);
+  return DAQmxGetScaleAttribute(scaleName, attribute, value, size);
 #else
-  return function_pointers_.GetScaleAttributeInt32(scaleName, attribute, value);
+  return function_pointers_.GetScaleAttributeInt32(scaleName, attribute, value, size);
 #endif
 }
 
@@ -2537,27 +2537,27 @@ int32 NiDAQmxLibrary::SetFirstSampClkWhen(TaskHandle task, CVIAbsoluteTime data)
 #endif
 }
 
-int32 NiDAQmxLibrary::SetScaleAttributeDouble(const char scaleName[], int32 attribute, float64 value)
+int32 NiDAQmxLibrary::SetScaleAttributeDouble(const char scaleName[], int32 attribute, float64 value, uInt32 size)
 {
   if (!function_pointers_.SetScaleAttributeDouble) {
     throw nidevice_grpc::LibraryLoadException("Could not find DAQmxSetScaleAttribute.");
   }
 #if defined(_MSC_VER)
-  return DAQmxSetScaleAttribute(scaleName, attribute, value);
+  return DAQmxSetScaleAttribute(scaleName, attribute, value, size);
 #else
-  return function_pointers_.SetScaleAttributeDouble(scaleName, attribute, value);
+  return function_pointers_.SetScaleAttributeDouble(scaleName, attribute, value, size);
 #endif
 }
 
-int32 NiDAQmxLibrary::SetScaleAttributeInt32(const char scaleName[], int32 attribute, int32 value)
+int32 NiDAQmxLibrary::SetScaleAttributeInt32(const char scaleName[], int32 attribute, int32 value, uInt32 size)
 {
   if (!function_pointers_.SetScaleAttributeInt32) {
     throw nidevice_grpc::LibraryLoadException("Could not find DAQmxSetScaleAttribute.");
   }
 #if defined(_MSC_VER)
-  return DAQmxSetScaleAttribute(scaleName, attribute, value);
+  return DAQmxSetScaleAttribute(scaleName, attribute, value, size);
 #else
-  return function_pointers_.SetScaleAttributeInt32(scaleName, attribute, value);
+  return function_pointers_.SetScaleAttributeInt32(scaleName, attribute, value, size);
 #endif
 }
 

--- a/generated/nidaqmx/nidaqmx_library.h
+++ b/generated/nidaqmx/nidaqmx_library.h
@@ -159,8 +159,8 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   int32 GetNthTaskDevice(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize);
   int32 GetNthTaskReadChannel(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize);
   int32 GetRefTrigTimestampVal(TaskHandle task, CVIAbsoluteTime* data);
-  int32 GetScaleAttributeDouble(const char scaleName[], int32 attribute, float64* value);
-  int32 GetScaleAttributeInt32(const char scaleName[], int32 attribute, int32* value);
+  int32 GetScaleAttributeDouble(const char scaleName[], int32 attribute, float64* value, uInt32 size);
+  int32 GetScaleAttributeInt32(const char scaleName[], int32 attribute, int32* value, uInt32 size);
   int32 GetSelfCalLastDateAndTime(const char deviceName[], uInt32* year, uInt32* month, uInt32* day, uInt32* hour, uInt32* minute);
   int32 GetStartTrigTimestampVal(TaskHandle task, CVIAbsoluteTime* data);
   int32 GetStartTrigTrigWhen(TaskHandle task, CVIAbsoluteTime* data);
@@ -208,8 +208,8 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   int32 SetArmStartTrigTrigWhen(TaskHandle task, CVIAbsoluteTime data);
   int32 SetDigitalLogicFamilyPowerUpState(const char deviceName[], int32 logicFamily);
   int32 SetFirstSampClkWhen(TaskHandle task, CVIAbsoluteTime data);
-  int32 SetScaleAttributeDouble(const char scaleName[], int32 attribute, float64 value);
-  int32 SetScaleAttributeInt32(const char scaleName[], int32 attribute, int32 value);
+  int32 SetScaleAttributeDouble(const char scaleName[], int32 attribute, float64 value, uInt32 size);
+  int32 SetScaleAttributeInt32(const char scaleName[], int32 attribute, int32 value, uInt32 size);
   int32 SetStartTrigTrigWhen(TaskHandle task, CVIAbsoluteTime data);
   int32 SetSyncPulseTimeWhen(TaskHandle task, CVIAbsoluteTime data);
   int32 StartNewFile(TaskHandle task, const char filePath[]);
@@ -384,8 +384,8 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   using GetNthTaskDevicePtr = int32 (*)(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize);
   using GetNthTaskReadChannelPtr = int32 (*)(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize);
   using GetRefTrigTimestampValPtr = int32 (*)(TaskHandle task, CVIAbsoluteTime* data);
-  using GetScaleAttributeDoublePtr = int32 (*)(const char scaleName[], int32 attribute, float64* value);
-  using GetScaleAttributeInt32Ptr = int32 (*)(const char scaleName[], int32 attribute, int32* value);
+  using GetScaleAttributeDoublePtr = int32 (*)(const char scaleName[], int32 attribute, float64* value, uInt32 size);
+  using GetScaleAttributeInt32Ptr = int32 (*)(const char scaleName[], int32 attribute, int32* value, uInt32 size);
   using GetSelfCalLastDateAndTimePtr = int32 (*)(const char deviceName[], uInt32* year, uInt32* month, uInt32* day, uInt32* hour, uInt32* minute);
   using GetStartTrigTimestampValPtr = int32 (*)(TaskHandle task, CVIAbsoluteTime* data);
   using GetStartTrigTrigWhenPtr = int32 (*)(TaskHandle task, CVIAbsoluteTime* data);
@@ -433,8 +433,8 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   using SetArmStartTrigTrigWhenPtr = int32 (*)(TaskHandle task, CVIAbsoluteTime data);
   using SetDigitalLogicFamilyPowerUpStatePtr = int32 (*)(const char deviceName[], int32 logicFamily);
   using SetFirstSampClkWhenPtr = int32 (*)(TaskHandle task, CVIAbsoluteTime data);
-  using SetScaleAttributeDoublePtr = int32 (*)(const char scaleName[], int32 attribute, float64 value);
-  using SetScaleAttributeInt32Ptr = int32 (*)(const char scaleName[], int32 attribute, int32 value);
+  using SetScaleAttributeDoublePtr = int32 (*)(const char scaleName[], int32 attribute, float64 value, uInt32 size);
+  using SetScaleAttributeInt32Ptr = int32 (*)(const char scaleName[], int32 attribute, int32 value, uInt32 size);
   using SetStartTrigTrigWhenPtr = int32 (*)(TaskHandle task, CVIAbsoluteTime data);
   using SetSyncPulseTimeWhenPtr = int32 (*)(TaskHandle task, CVIAbsoluteTime data);
   using StartNewFilePtr = int32 (*)(TaskHandle task, const char filePath[]);

--- a/generated/nidaqmx/nidaqmx_library_interface.h
+++ b/generated/nidaqmx/nidaqmx_library_interface.h
@@ -156,8 +156,8 @@ class NiDAQmxLibraryInterface {
   virtual int32 GetNthTaskDevice(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize) = 0;
   virtual int32 GetNthTaskReadChannel(TaskHandle task, uInt32 index, char buffer[], int32 bufferSize) = 0;
   virtual int32 GetRefTrigTimestampVal(TaskHandle task, CVIAbsoluteTime* data) = 0;
-  virtual int32 GetScaleAttributeDouble(const char scaleName[], int32 attribute, float64* value) = 0;
-  virtual int32 GetScaleAttributeInt32(const char scaleName[], int32 attribute, int32* value) = 0;
+  virtual int32 GetScaleAttributeDouble(const char scaleName[], int32 attribute, float64* value, uInt32 size) = 0;
+  virtual int32 GetScaleAttributeInt32(const char scaleName[], int32 attribute, int32* value, uInt32 size) = 0;
   virtual int32 GetSelfCalLastDateAndTime(const char deviceName[], uInt32* year, uInt32* month, uInt32* day, uInt32* hour, uInt32* minute) = 0;
   virtual int32 GetStartTrigTimestampVal(TaskHandle task, CVIAbsoluteTime* data) = 0;
   virtual int32 GetStartTrigTrigWhen(TaskHandle task, CVIAbsoluteTime* data) = 0;
@@ -204,8 +204,8 @@ class NiDAQmxLibraryInterface {
   virtual int32 SetArmStartTrigTrigWhen(TaskHandle task, CVIAbsoluteTime data) = 0;
   virtual int32 SetDigitalLogicFamilyPowerUpState(const char deviceName[], int32 logicFamily) = 0;
   virtual int32 SetFirstSampClkWhen(TaskHandle task, CVIAbsoluteTime data) = 0;
-  virtual int32 SetScaleAttributeDouble(const char scaleName[], int32 attribute, float64 value) = 0;
-  virtual int32 SetScaleAttributeInt32(const char scaleName[], int32 attribute, int32 value) = 0;
+  virtual int32 SetScaleAttributeDouble(const char scaleName[], int32 attribute, float64 value, uInt32 size) = 0;
+  virtual int32 SetScaleAttributeInt32(const char scaleName[], int32 attribute, int32 value, uInt32 size) = 0;
   virtual int32 SetStartTrigTrigWhen(TaskHandle task, CVIAbsoluteTime data) = 0;
   virtual int32 SetSyncPulseTimeWhen(TaskHandle task, CVIAbsoluteTime data) = 0;
   virtual int32 StartNewFile(TaskHandle task, const char filePath[]) = 0;

--- a/generated/nidaqmx/nidaqmx_mock_library.h
+++ b/generated/nidaqmx/nidaqmx_mock_library.h
@@ -158,8 +158,8 @@ class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   MOCK_METHOD(int32, GetNthTaskDevice, (TaskHandle task, uInt32 index, char buffer[], int32 bufferSize), (override));
   MOCK_METHOD(int32, GetNthTaskReadChannel, (TaskHandle task, uInt32 index, char buffer[], int32 bufferSize), (override));
   MOCK_METHOD(int32, GetRefTrigTimestampVal, (TaskHandle task, CVIAbsoluteTime* data), (override));
-  MOCK_METHOD(int32, GetScaleAttributeDouble, (const char scaleName[], int32 attribute, float64* value), (override));
-  MOCK_METHOD(int32, GetScaleAttributeInt32, (const char scaleName[], int32 attribute, int32* value), (override));
+  MOCK_METHOD(int32, GetScaleAttributeDouble, (const char scaleName[], int32 attribute, float64* value, uInt32 size), (override));
+  MOCK_METHOD(int32, GetScaleAttributeInt32, (const char scaleName[], int32 attribute, int32* value, uInt32 size), (override));
   MOCK_METHOD(int32, GetSelfCalLastDateAndTime, (const char deviceName[], uInt32* year, uInt32* month, uInt32* day, uInt32* hour, uInt32* minute), (override));
   MOCK_METHOD(int32, GetStartTrigTimestampVal, (TaskHandle task, CVIAbsoluteTime* data), (override));
   MOCK_METHOD(int32, GetStartTrigTrigWhen, (TaskHandle task, CVIAbsoluteTime* data), (override));
@@ -206,8 +206,8 @@ class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   MOCK_METHOD(int32, SetArmStartTrigTrigWhen, (TaskHandle task, CVIAbsoluteTime data), (override));
   MOCK_METHOD(int32, SetDigitalLogicFamilyPowerUpState, (const char deviceName[], int32 logicFamily), (override));
   MOCK_METHOD(int32, SetFirstSampClkWhen, (TaskHandle task, CVIAbsoluteTime data), (override));
-  MOCK_METHOD(int32, SetScaleAttributeDouble, (const char scaleName[], int32 attribute, float64 value), (override));
-  MOCK_METHOD(int32, SetScaleAttributeInt32, (const char scaleName[], int32 attribute, int32 value), (override));
+  MOCK_METHOD(int32, SetScaleAttributeDouble, (const char scaleName[], int32 attribute, float64 value, uInt32 size), (override));
+  MOCK_METHOD(int32, SetScaleAttributeInt32, (const char scaleName[], int32 attribute, int32 value, uInt32 size), (override));
   MOCK_METHOD(int32, SetStartTrigTrigWhen, (TaskHandle task, CVIAbsoluteTime data), (override));
   MOCK_METHOD(int32, SetSyncPulseTimeWhen, (TaskHandle task, CVIAbsoluteTime data), (override));
   MOCK_METHOD(int32, StartNewFile, (TaskHandle task, const char filePath[]), (override));

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -8434,7 +8434,7 @@ namespace nidaqmx_grpc {
 
         auto task_grpc_session = request->task();
         TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
-        uInt32 options = request->options();
+        auto options = 0U;
 
         auto status = library->RegisterDoneEvent(task, options, CallbackRouter::handle_callback, handler->token());
 
@@ -8509,7 +8509,7 @@ namespace nidaqmx_grpc {
         }
   
         uInt32 n_samples = request->n_samples();
-        uInt32 options = request->options();
+        auto options = 0U;
 
         auto status = library->RegisterEveryNSamplesEvent(task, every_n_samples_event_type, n_samples, options, CallbackRouter::handle_callback, handler->token());
 
@@ -8581,7 +8581,7 @@ namespace nidaqmx_grpc {
           }
         }
   
-        uInt32 options = request->options();
+        auto options = 0U;
 
         auto status = library->RegisterSignalEvent(task, signal_id, options, CallbackRouter::handle_callback, handler->token());
 

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -7284,8 +7284,9 @@ namespace nidaqmx_grpc {
     try {
       auto scale_name = request->scale_name().c_str();
       int32 attribute = request->attribute();
+      auto size = 0U;
       float64 value {};
-      auto status = library_->GetScaleAttributeDouble(scale_name, attribute, &value);
+      auto status = library_->GetScaleAttributeDouble(scale_name, attribute, &value, size);
       response->set_status(status);
       if (status == 0) {
         response->set_value(value);
@@ -7307,8 +7308,9 @@ namespace nidaqmx_grpc {
     try {
       auto scale_name = request->scale_name().c_str();
       int32 attribute = request->attribute();
+      auto size = 0U;
       int32 value {};
-      auto status = library_->GetScaleAttributeInt32(scale_name, attribute, &value);
+      auto status = library_->GetScaleAttributeInt32(scale_name, attribute, &value, size);
       response->set_status(status);
       if (status == 0) {
         response->set_value(value);
@@ -8988,7 +8990,8 @@ namespace nidaqmx_grpc {
       auto scale_name = request->scale_name().c_str();
       int32 attribute = request->attribute();
       float64 value = request->value();
-      auto status = library_->SetScaleAttributeDouble(scale_name, attribute, value);
+      auto size = 0U;
+      auto status = library_->SetScaleAttributeDouble(scale_name, attribute, value, size);
       response->set_status(status);
       return ::grpc::Status::OK;
     }
@@ -9023,7 +9026,8 @@ namespace nidaqmx_grpc {
         }
       }
 
-      auto status = library_->SetScaleAttributeInt32(scale_name, attribute, value);
+      auto size = 0U;
+      auto status = library_->SetScaleAttributeInt32(scale_name, attribute, value, size);
       response->set_status(status);
       return ::grpc::Status::OK;
     }

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -10,16 +10,12 @@ def is_input_parameter(parameter):
     return "in" in parameter["direction"]
 
 
-def is_pass_null_parameter(parameter):
-    return parameter.get('pass_null', False)
-
-
 def is_callback_token_parameter(parameter):
     return parameter.get('callback_token', False)
 
 
 def is_pointer_parameter(parameter):
-    return is_output_parameter(parameter) or is_pass_null_parameter(parameter) or is_callback_token_parameter(parameter)
+    return is_output_parameter(parameter) or parameter.get('pointer', False)
 
 
 # This means the parameter follows a specific varargs convention where

--- a/source/codegen/metadata/nidaqmx/functions.py
+++ b/source/codegen/metadata/nidaqmx/functions.py
@@ -6064,6 +6064,13 @@ functions = {
                 'direction': 'out',
                 'name': 'value',
                 'type': 'float64'
+            },
+            {
+                'direction': 'in',
+                'hardcoded_value': '0U',
+                'include_in_proto': False,
+                'name': 'size',
+                'type': 'uInt32'
             }
         ],
         'returns': 'int32'
@@ -6086,6 +6093,13 @@ functions = {
                 'direction': 'out',
                 'name': 'value',
                 'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'hardcoded_value': '0U',
+                'include_in_proto': False,
+                'name': 'size',
+                'type': 'uInt32'
             }
         ],
         'returns': 'int32'
@@ -7815,6 +7829,13 @@ functions = {
                 'direction': 'in',
                 'name': 'value',
                 'type': 'float64'
+            },
+            {
+                'direction': 'in',
+                'hardcoded_value': '0U',
+                'include_in_proto': False,
+                'name': 'size',
+                'type': 'uInt32'
             }
         ],
         'returns': 'int32'
@@ -7837,6 +7858,13 @@ functions = {
                 'direction': 'in',
                 'name': 'value',
                 'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'hardcoded_value': '0U',
+                'include_in_proto': False,
+                'name': 'size',
+                'type': 'uInt32'
             }
         ],
         'returns': 'int32'

--- a/source/codegen/metadata/nidaqmx/functions.py
+++ b/source/codegen/metadata/nidaqmx/functions.py
@@ -6246,9 +6246,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -6273,9 +6274,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -6326,9 +6328,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -6378,9 +6381,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -6431,9 +6435,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -6483,9 +6488,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -6529,9 +6535,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -6581,9 +6588,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -6608,9 +6616,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -6635,9 +6644,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -6681,9 +6691,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -6733,9 +6744,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -6794,9 +6806,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -6826,9 +6839,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -6887,9 +6901,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -6919,9 +6934,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -6980,9 +6996,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -7012,9 +7029,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -7069,9 +7087,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -7096,9 +7115,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -7149,9 +7169,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -7201,9 +7222,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -7253,9 +7275,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -7304,9 +7327,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -7321,6 +7345,8 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': '0U',
+                'include_in_proto': False,
                 'name': 'options',
                 'type': 'uInt32'
             },
@@ -7348,6 +7374,7 @@ functions = {
                 'direction': 'in',
                 'include_in_proto': False,
                 'name': 'callbackData',
+                'pointer': True,
                 'type': 'void'
             }
         ],
@@ -7374,6 +7401,8 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': '0U',
+                'include_in_proto': False,
                 'name': 'options',
                 'type': 'uInt32'
             },
@@ -7407,6 +7436,7 @@ functions = {
                 'direction': 'in',
                 'include_in_proto': False,
                 'name': 'callbackData',
+                'pointer': True,
                 'type': 'void'
             }
         ],
@@ -7428,6 +7458,8 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': '0U',
+                'include_in_proto': False,
                 'name': 'options',
                 'type': 'uInt32'
             },
@@ -7455,6 +7487,7 @@ functions = {
                 'direction': 'in',
                 'include_in_proto': False,
                 'name': 'callbackData',
+                'pointer': True,
                 'type': 'void'
             }
         ],
@@ -8010,9 +8043,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -8042,9 +8076,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -8091,9 +8126,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -8139,9 +8175,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -8188,9 +8225,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -8236,9 +8274,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -8289,9 +8328,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -8326,9 +8366,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -8379,9 +8420,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -8416,9 +8458,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -8469,9 +8512,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -8506,9 +8550,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -8554,9 +8599,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -8586,9 +8632,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -8635,9 +8682,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -8683,9 +8731,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -8731,9 +8780,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],
@@ -8773,9 +8823,10 @@ functions = {
             },
             {
                 'direction': 'in',
+                'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
                 'type': 'bool32'
             }
         ],

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -186,7 +186,8 @@ functions = {
                 'direction': 'in',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pass_null': True,
+                'pointer': True,
+                'hardcoded_value': "nullptr",
                 'type': 'ViBoolean'
             }
         ],

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -208,10 +208,10 @@ ${initialize_enum_input_param(function_name, parameter)}
 % elif 'callback_token' in parameter or 'callback_params' in parameter: ## pass
 % elif "determine_size_from" in parameter:
 ${initialize_len_input_param(parameter)}
-% elif common_helpers.is_pass_null_parameter(parameter):
-${initialize_pass_null_param(parameter)}
 % elif common_helpers.is_repeated_varargs_parameter(parameter):
 ${initialize_repeated_varargs_param(parameter)}
+% elif 'hardcoded_value' in parameter:
+${initialize_hardcoded_parameter(parameter)}
 % else:
 ${initialize_standard_input_param(function_name, parameter)}
 % endif
@@ -331,10 +331,12 @@ ${initialize_standard_input_param(function_name, parameter)}
       ${parameter['type']} ${parameter_name} = request->${field_name}().size();\
 </%def>
 
-## Initialize a 'pass_null' param.
-<%def name="initialize_pass_null_param(parameter)">\
-      auto ${common_helpers.camel_to_snake(parameter['cppName'])} = nullptr;\
+
+## Initialize a 'hardcoded' param.
+<%def name="initialize_hardcoded_parameter(parameter)">\
+      auto ${common_helpers.camel_to_snake(parameter['cppName'])} = ${parameter['hardcoded_value']};\
 </%def>
+
 
 ## Initialize an input parameter for an API call.
 <%def name="initialize_standard_input_param(function_name, parameter)">\

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -922,22 +922,19 @@ TEST_F(NiDAQmxDriverApiTests, SetPreScaledUnits_GetPreScaledUnits_ReturnsAttribu
   EXPECT_EQ(ScaleInt32AttributeValues::SCALE_INT32_UNITS_PRE_SCALED_RPM, response.value());
 }
 
-TEST_F(NiDAQmxDriverApiTests, SetScaledUnitsAsDouble_Fails)
+TEST_F(NiDAQmxDriverApiTests, GetScaledUnitsAsDouble_Fails)
 {
   const auto SCALE_NAME = std::string("TestScale");
   auto scale_status = create_lin_scale(SCALE_NAME, 0.5);
-  auto set_request = create_set_scale_attribute_request<SetScaleAttributeDoubleRequest>(
-    SCALE_NAME, 
-    ScaleAttributes::SCALE_ATTRIBUTE_SCALED_UNITS, 
-    ScaleInt32AttributeValues::SCALE_INT32_RPM);
-  SetScaleAttributeDoubleResponse set_response;
-  auto status = set_scale_attribute_double(set_request, set_response);
+  GetScaleAttributeDoubleResponse response;
+  auto status = get_scale_attribute_double(SCALE_NAME, ScaleAttributes::SCALE_ATTRIBUTE_SCALED_UNITS, response);
 
-  EXPECT_NE(DAQmxSuccess, set_response.status());
-  // Setting a scalar to a non-scalar field returns a positive value because that's the convention
+
+  EXPECT_NE(DAQmxSuccess, response.status());
+  // Getting a scalar from a non-scalar field returns a positive value because that's the convention
   // when you pass in zero for the size.
   // The key result here is: don't crash.
-  EXPECT_GT(0, set_response.status());
+  EXPECT_GT(0, response.status());
 }
 
 TEST_F(NiDAQmxDriverApiTests, AOVoltageChannel_WriteAOData_Succeeds)

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -922,6 +922,24 @@ TEST_F(NiDAQmxDriverApiTests, SetPreScaledUnits_GetPreScaledUnits_ReturnsAttribu
   EXPECT_EQ(ScaleInt32AttributeValues::SCALE_INT32_UNITS_PRE_SCALED_RPM, response.value());
 }
 
+TEST_F(NiDAQmxDriverApiTests, SetScaledUnitsAsDouble_Fails)
+{
+  const auto SCALE_NAME = std::string("TestScale");
+  auto scale_status = create_lin_scale(SCALE_NAME, 0.5);
+  auto set_request = create_set_scale_attribute_request<SetScaleAttributeDoubleRequest>(
+    SCALE_NAME, 
+    ScaleAttributes::SCALE_ATTRIBUTE_SCALED_UNITS, 
+    ScaleInt32AttributeValues::SCALE_INT32_RPM);
+  SetScaleAttributeDoubleResponse set_response;
+  auto status = set_scale_attribute_double(set_request, set_response);
+
+  EXPECT_NE(DAQmxSuccess, set_response.status());
+  // Setting a scalar to a non-scalar field returns a positive value because that's the convention
+  // when you pass in zero for the size.
+  // The key result here is: don't crash.
+  EXPECT_GT(0, set_response.status());
+}
+
 TEST_F(NiDAQmxDriverApiTests, AOVoltageChannel_WriteAOData_Succeeds)
 {
   const double AO_MIN = 1.0;


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add `hardcoded_value` parameter attribute to use in 3 cases:
* Replace the `pass_null` convention on `reserved` params.
* Hardcode `options` to zero on callback methods to disable calling the callback on the registering thread.
* Pass in zero for the size param for scalar attributes.

### Why should this Pull Request be merged?

Standardizes on shared convention and fixes some corner case issues.

### What testing has been done?

Ran and passed all DAQ tests.