### PR TITLE
Add support for splitting attribute enums by type

### DIFF
--- a/generated/nidaqmx/nidaqmx.proto
+++ b/generated/nidaqmx/nidaqmx.proto
@@ -246,21 +246,30 @@ service NiDAQmx {
   rpc WriteToTEDSFromFile(WriteToTEDSFromFileRequest) returns (WriteToTEDSFromFileResponse);
 }
 
-enum ScaleAttributes {
-  SCALE_ATTRIBUTE_UNSPECIFIED = 0;
+enum ScaleAttributesString {
+  SCALE_STRING_ATTRIBUTE_UNSPECIFIED = 0;
   SCALE_ATTRIBUTE_DESCR = 4646;
+  SCALE_ATTRIBUTE_SCALED_UNITS = 6427;
+}
+enum ScaleAttributesDouble {
+  SCALE_DOUBLE_ATTRIBUTE_UNSPECIFIED = 0;
   SCALE_ATTRIBUTE_LIN_SLOPE = 4647;
   SCALE_ATTRIBUTE_LIN_Y_INTERCEPT = 4648;
   SCALE_ATTRIBUTE_MAP_SCALED_MAX = 4649;
   SCALE_ATTRIBUTE_MAP_SCALED_MIN = 4656;
   SCALE_ATTRIBUTE_MAP_PRE_SCALED_MAX = 4657;
   SCALE_ATTRIBUTE_MAP_PRE_SCALED_MIN = 4658;
+}
+enum ScaleAttributesDoubleArray {
+  SCALE_DOUBLE_ARRAY_ATTRIBUTE_UNSPECIFIED = 0;
   SCALE_ATTRIBUTE_POLY_FORWARD_COEFF = 4660;
   SCALE_ATTRIBUTE_POLY_REVERSE_COEFF = 4661;
   SCALE_ATTRIBUTE_TABLE_SCALED_VALS = 4662;
   SCALE_ATTRIBUTE_TABLE_PRE_SCALED_VALS = 4663;
+}
+enum ScaleAttributesInt32 {
+  SCALE_INT32_ATTRIBUTE_UNSPECIFIED = 0;
   SCALE_ATTRIBUTE_PRE_SCALED_UNITS = 6391;
-  SCALE_ATTRIBUTE_SCALED_UNITS = 6427;
   SCALE_ATTRIBUTE_TYPE = 6441;
 }
 
@@ -3642,7 +3651,7 @@ message GetRefTrigTimestampValResponse {
 
 message GetScaleAttributeDoubleRequest {
   string scale_name = 1;
-  ScaleAttributes attribute = 2;
+  ScaleAttributesDouble attribute = 2;
 }
 
 message GetScaleAttributeDoubleResponse {
@@ -3652,7 +3661,7 @@ message GetScaleAttributeDoubleResponse {
 
 message GetScaleAttributeDoubleArrayRequest {
   string scale_name = 1;
-  ScaleAttributes attribute = 2;
+  ScaleAttributesDoubleArray attribute = 2;
   uint32 size = 3;
 }
 
@@ -3663,7 +3672,7 @@ message GetScaleAttributeDoubleArrayResponse {
 
 message GetScaleAttributeInt32Request {
   string scale_name = 1;
-  ScaleAttributes attribute = 2;
+  ScaleAttributesInt32 attribute = 2;
 }
 
 message GetScaleAttributeInt32Response {
@@ -3673,7 +3682,7 @@ message GetScaleAttributeInt32Response {
 
 message GetScaleAttributeStringRequest {
   string scale_name = 1;
-  ScaleAttributes attribute = 2;
+  ScaleAttributesString attribute = 2;
   uint32 size = 3;
 }
 
@@ -4285,7 +4294,7 @@ message SetFirstSampClkWhenResponse {
 
 message SetScaleAttributeDoubleRequest {
   string scale_name = 1;
-  ScaleAttributes attribute = 2;
+  ScaleAttributesDouble attribute = 2;
   double value = 3;
 }
 
@@ -4295,7 +4304,7 @@ message SetScaleAttributeDoubleResponse {
 
 message SetScaleAttributeDoubleArrayRequest {
   string scale_name = 1;
-  ScaleAttributes attribute = 2;
+  ScaleAttributesDoubleArray attribute = 2;
   repeated double value = 3;
   uint32 size = 4;
 }
@@ -4306,7 +4315,7 @@ message SetScaleAttributeDoubleArrayResponse {
 
 message SetScaleAttributeInt32Request {
   string scale_name = 1;
-  ScaleAttributes attribute = 2;
+  ScaleAttributesInt32 attribute = 2;
   oneof value_enum {
     ScaleInt32AttributeValues value = 3;
     int32 value_raw = 4;
@@ -4319,7 +4328,7 @@ message SetScaleAttributeInt32Response {
 
 message SetScaleAttributeStringRequest {
   string scale_name = 1;
-  ScaleAttributes attribute = 2;
+  ScaleAttributesString attribute = 2;
   string value = 3;
 }
 

--- a/generated/nidaqmx/nidaqmx.proto
+++ b/generated/nidaqmx/nidaqmx.proto
@@ -246,12 +246,13 @@ service NiDAQmx {
   rpc WriteToTEDSFromFile(WriteToTEDSFromFileRequest) returns (WriteToTEDSFromFileResponse);
 }
 
-enum ScaleAttributesString {
+enum ScaleStringAttributes {
   SCALE_STRING_ATTRIBUTE_UNSPECIFIED = 0;
   SCALE_ATTRIBUTE_DESCR = 4646;
   SCALE_ATTRIBUTE_SCALED_UNITS = 6427;
 }
-enum ScaleAttributesDouble {
+
+enum ScaleDoubleAttributes {
   SCALE_DOUBLE_ATTRIBUTE_UNSPECIFIED = 0;
   SCALE_ATTRIBUTE_LIN_SLOPE = 4647;
   SCALE_ATTRIBUTE_LIN_Y_INTERCEPT = 4648;
@@ -260,14 +261,16 @@ enum ScaleAttributesDouble {
   SCALE_ATTRIBUTE_MAP_PRE_SCALED_MAX = 4657;
   SCALE_ATTRIBUTE_MAP_PRE_SCALED_MIN = 4658;
 }
-enum ScaleAttributesDoubleArray {
+
+enum ScaleDoubleArrayAttributes {
   SCALE_DOUBLE_ARRAY_ATTRIBUTE_UNSPECIFIED = 0;
   SCALE_ATTRIBUTE_POLY_FORWARD_COEFF = 4660;
   SCALE_ATTRIBUTE_POLY_REVERSE_COEFF = 4661;
   SCALE_ATTRIBUTE_TABLE_SCALED_VALS = 4662;
   SCALE_ATTRIBUTE_TABLE_PRE_SCALED_VALS = 4663;
 }
-enum ScaleAttributesInt32 {
+
+enum ScaleInt32Attributes {
   SCALE_INT32_ATTRIBUTE_UNSPECIFIED = 0;
   SCALE_ATTRIBUTE_PRE_SCALED_UNITS = 6391;
   SCALE_ATTRIBUTE_TYPE = 6441;
@@ -3651,7 +3654,7 @@ message GetRefTrigTimestampValResponse {
 
 message GetScaleAttributeDoubleRequest {
   string scale_name = 1;
-  ScaleAttributesDouble attribute = 2;
+  ScaleDoubleAttributes attribute = 2;
 }
 
 message GetScaleAttributeDoubleResponse {
@@ -3661,7 +3664,7 @@ message GetScaleAttributeDoubleResponse {
 
 message GetScaleAttributeDoubleArrayRequest {
   string scale_name = 1;
-  ScaleAttributesDoubleArray attribute = 2;
+  ScaleDoubleArrayAttributes attribute = 2;
   uint32 size = 3;
 }
 
@@ -3672,7 +3675,7 @@ message GetScaleAttributeDoubleArrayResponse {
 
 message GetScaleAttributeInt32Request {
   string scale_name = 1;
-  ScaleAttributesInt32 attribute = 2;
+  ScaleInt32Attributes attribute = 2;
 }
 
 message GetScaleAttributeInt32Response {
@@ -3682,7 +3685,7 @@ message GetScaleAttributeInt32Response {
 
 message GetScaleAttributeStringRequest {
   string scale_name = 1;
-  ScaleAttributesString attribute = 2;
+  ScaleStringAttributes attribute = 2;
   uint32 size = 3;
 }
 
@@ -4294,7 +4297,7 @@ message SetFirstSampClkWhenResponse {
 
 message SetScaleAttributeDoubleRequest {
   string scale_name = 1;
-  ScaleAttributesDouble attribute = 2;
+  ScaleDoubleAttributes attribute = 2;
   double value = 3;
 }
 
@@ -4304,7 +4307,7 @@ message SetScaleAttributeDoubleResponse {
 
 message SetScaleAttributeDoubleArrayRequest {
   string scale_name = 1;
-  ScaleAttributesDoubleArray attribute = 2;
+  ScaleDoubleArrayAttributes attribute = 2;
   repeated double value = 3;
   uint32 size = 4;
 }
@@ -4315,7 +4318,7 @@ message SetScaleAttributeDoubleArrayResponse {
 
 message SetScaleAttributeInt32Request {
   string scale_name = 1;
-  ScaleAttributesInt32 attribute = 2;
+  ScaleInt32Attributes attribute = 2;
   oneof value_enum {
     ScaleInt32AttributeValues value = 3;
     int32 value_raw = 4;
@@ -4328,7 +4331,7 @@ message SetScaleAttributeInt32Response {
 
 message SetScaleAttributeStringRequest {
   string scale_name = 1;
-  ScaleAttributesString attribute = 2;
+  ScaleStringAttributes attribute = 2;
   string value = 3;
 }
 

--- a/generated/nifake_non_ivi/nifake_non_ivi.proto
+++ b/generated/nifake_non_ivi/nifake_non_ivi.proto
@@ -36,9 +36,12 @@ service NiFakeNonIvi {
   rpc SetMarbleAttributeInt32(SetMarbleAttributeInt32Request) returns (SetMarbleAttributeInt32Response);
 }
 
-enum MarbleAttributes {
-  MARBLE_ATTRIBUTE_UNSPECIFIED = 0;
+enum MarbleAttributesInt32 {
+  MARBLE_INT32_ATTRIBUTE_UNSPECIFIED = 0;
   MARBLE_ATTRIBUTE_COLOR = 1234;
+}
+enum MarbleAttributesDouble {
+  MARBLE_DOUBLE_ATTRIBUTE_UNSPECIFIED = 0;
   MARBLE_ATTRIBUTE_WEIGHT = 4444;
 }
 
@@ -74,7 +77,7 @@ message CloseResponse {
 
 message GetMarbleAttributeDoubleRequest {
   nidevice_grpc.Session handle = 1;
-  MarbleAttributes attribute = 2;
+  MarbleAttributesDouble attribute = 2;
 }
 
 message GetMarbleAttributeDoubleResponse {
@@ -84,7 +87,7 @@ message GetMarbleAttributeDoubleResponse {
 
 message GetMarbleAttributeInt32Request {
   nidevice_grpc.Session handle = 1;
-  MarbleAttributes attribute = 2;
+  MarbleAttributesInt32 attribute = 2;
 }
 
 message GetMarbleAttributeInt32Response {
@@ -206,7 +209,7 @@ message InputVarArgsResponse {
 
 message SetMarbleAttributeDoubleRequest {
   nidevice_grpc.Session handle = 1;
-  MarbleAttributes attribute = 2;
+  MarbleAttributesDouble attribute = 2;
   double value = 3;
 }
 
@@ -216,7 +219,7 @@ message SetMarbleAttributeDoubleResponse {
 
 message SetMarbleAttributeInt32Request {
   nidevice_grpc.Session handle = 1;
-  MarbleAttributes attribute = 2;
+  MarbleAttributesInt32 attribute = 2;
   oneof value_enum {
     MarbleInt32AttributeValues value = 3;
     int32 value_raw = 4;

--- a/generated/nifake_non_ivi/nifake_non_ivi.proto
+++ b/generated/nifake_non_ivi/nifake_non_ivi.proto
@@ -36,11 +36,12 @@ service NiFakeNonIvi {
   rpc SetMarbleAttributeInt32(SetMarbleAttributeInt32Request) returns (SetMarbleAttributeInt32Response);
 }
 
-enum MarbleAttributesInt32 {
+enum MarbleInt32Attributes {
   MARBLE_INT32_ATTRIBUTE_UNSPECIFIED = 0;
   MARBLE_ATTRIBUTE_COLOR = 1234;
 }
-enum MarbleAttributesDouble {
+
+enum MarbleDoubleAttributes {
   MARBLE_DOUBLE_ATTRIBUTE_UNSPECIFIED = 0;
   MARBLE_ATTRIBUTE_WEIGHT = 4444;
 }
@@ -77,7 +78,7 @@ message CloseResponse {
 
 message GetMarbleAttributeDoubleRequest {
   nidevice_grpc.Session handle = 1;
-  MarbleAttributesDouble attribute = 2;
+  MarbleDoubleAttributes attribute = 2;
 }
 
 message GetMarbleAttributeDoubleResponse {
@@ -87,7 +88,7 @@ message GetMarbleAttributeDoubleResponse {
 
 message GetMarbleAttributeInt32Request {
   nidevice_grpc.Session handle = 1;
-  MarbleAttributesInt32 attribute = 2;
+  MarbleInt32Attributes attribute = 2;
 }
 
 message GetMarbleAttributeInt32Response {
@@ -209,7 +210,7 @@ message InputVarArgsResponse {
 
 message SetMarbleAttributeDoubleRequest {
   nidevice_grpc.Session handle = 1;
-  MarbleAttributesDouble attribute = 2;
+  MarbleDoubleAttributes attribute = 2;
   double value = 3;
 }
 
@@ -219,7 +220,7 @@ message SetMarbleAttributeDoubleResponse {
 
 message SetMarbleAttributeInt32Request {
   nidevice_grpc.Session handle = 1;
-  MarbleAttributesInt32 attribute = 2;
+  MarbleInt32Attributes attribute = 2;
   oneof value_enum {
     MarbleInt32AttributeValues value = 3;
     int32 value_raw = 4;

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -348,7 +348,7 @@ class AttributeGroup:
 
 
 def get_attribute_enum_name(group_name, data_type):
-    return f'{group_name}Attributes{data_type}'
+    return f'{group_name}{data_type}Attributes'
 
 
 def get_attribute_groups(data):

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -25,7 +25,7 @@ def is_repeated_varargs_parameter(parameter):
 
 
 def is_array(dataType):
-    return dataType.endswith("[]")
+    return dataType.endswith("[]") or dataType.endswith("*")
 
 
 def is_enum(parameter):
@@ -141,13 +141,13 @@ def pascal_to_camel(pascal_string):
 
 
 def ensure_pascal_case(pascal_or_camel_string):
-  '''Ensures that a camel/pascal case string is pascal case
-  NOTE: does not distinguish leading all-caps acronyms.'''
-  match = re.fullmatch(r'^([a-z])(.*)$', pascal_or_camel_string)
-  if match:
-    return match[1].upper() + match[2]
+    '''Ensures that a camel/pascal case string is pascal case
+    NOTE: does not distinguish leading all-caps acronyms.'''
+    match = re.fullmatch(r'^([a-z])(.*)$', pascal_or_camel_string)
+    if match:
+        return match[1].upper() + match[2]
   
-  return pascal_or_camel_string
+    return pascal_or_camel_string
 
 def pascal_to_snake(pascal_string):
     '''Returns a snake_string for a given PascalString.'''
@@ -163,20 +163,20 @@ def filter_proto_rpc_functions(functions):
 
 
 def get_attribute_enums_by_type(attributes):
-  '''Returns a dictionary of different attribute data types that use enum alongwith set of enums used'''
-  attribute_enums_by_type = defaultdict(set)
-  # For Compatibility: Pre-adding the following types to the map causes them to use value_raw
-  # params even if they have no enum values. This is part of the shipping API for MI drivers.
-  for enum_type in ['ViInt32', 'ViInt64', 'ViReal64', 'ViString']:
-    attribute_enums_by_type[enum_type] = set()
+    '''Returns a dictionary of different attribute data types that use enum alongwith set of enums used'''
+    attribute_enums_by_type = defaultdict(set)
+    # For Compatibility: Pre-adding the following types to the map causes them to use value_raw
+    # params even if they have no enum values. This is part of the shipping API for MI drivers.
+    for enum_type in ['ViInt32', 'ViInt64', 'ViReal64', 'ViString']:
+        attribute_enums_by_type[enum_type] = set()
 
-  for attribute_name in attributes:
-    attribute = attributes[attribute_name]
-    if 'enum' in attribute:
-      attribute_type = attribute['type']
-      enum_name = attribute['enum']
-      attribute_enums_by_type[attribute_type].add(enum_name)
-  return attribute_enums_by_type
+    for attribute_name in attributes:
+        attribute = attributes[attribute_name]
+        if 'enum' in attribute:
+            attribute_type = attribute['type']
+            enum_name = attribute['enum']
+            attribute_enums_by_type[attribute_type].add(enum_name)
+    return attribute_enums_by_type
 
 
 def get_function_enums(functions):
@@ -328,23 +328,147 @@ def filter_parameters_for_grpc_fields(parameters):
   return [p for p in parameters if p.get('include_in_proto', True)]
 
 
-def get_attribute_groups(data):
-  attributes = data['attributes']
-  config = data["config"]
+class AttributeGroup:
+    def __init__(self, name, attributes, config):
+        self.name = name
+        self.attributes = attributes
+        self._config = config
 
-  # If the attributes are already in string categories: those are the groups. Return as-is.
-  first_key = next(iter(attributes), None)
-  if isinstance(first_key, str):
-    return attributes
-  
-  # If there's just one level of attributes: use the service_class_prefix as the group.
-  service_class_prefix = config['service_class_prefix']
-  return {service_class_prefix: attributes}
+
+    def get_attributes_split_by_type(self):
+        if not get_split_attributes_by_type(self._config):
+            return {'': self.attributes}
+
+        categorized_attributes = defaultdict(dict)
+        for id, data in self.attributes.items():
+            data_type = get_grpc_type_name_for_identifier(
+                data['type'], self._config)
+            categorized_attributes[data_type][id] = data
+        return categorized_attributes
+
+
+def get_attribute_enum_name(group_name, data_type):
+    return f'{group_name}Attributes{data_type}'
+
+
+def get_attribute_groups(data):
+    attributes = data['attributes']
+    config = data['config']
+
+    # If the attributes are already in string categories: those are the groups. Return as-is.
+    first_key = next(iter(attributes), None)
+    if isinstance(first_key, str):
+        return [AttributeGroup(name, attributes, config) for name, attributes in attributes.items()]
+
+    # If there's just one level of attributes: use the service_class_prefix as the group.
+    service_class_prefix = config['service_class_prefix']
+    return [AttributeGroup(service_class_prefix, attributes, config)]
 
 
 def strip_prefix(s: str, prefix: str) -> str:
-  return s[len(prefix) :] if s.startswith(prefix) else s
+    return s[len(prefix):] if s.startswith(prefix) else s
 
 
 def strip_suffix(s: str, suffix: str) -> str:
     return s[: -len(suffix)] if s.endswith(suffix) else s
+
+
+def get_grpc_type_name_for_identifier(data_type, config):
+    """
+    Used to create an identifier string based on the grpc_type
+    i.e., double -> Double. repeated double -> DoubleArray.
+    """
+    grpc_type = get_grpc_type(data_type, config)
+    grpc_type = re.sub(r'^(repeated )(\w+)$', r'\2Array', grpc_type)
+    return ensure_pascal_case(grpc_type)
+
+
+def get_grpc_type_from_ivi(type, is_array, driver_name_pascal):
+    add_repeated = is_array
+    if 'ViSession' in type:
+        type = 'nidevice_grpc.Session'
+    if 'ViBoolean' in type:
+        type = 'bool'
+    if 'ViReal64' in type:
+        type = 'double'
+    if 'ViInt32' in type:
+        type = 'sint32'
+    if 'ViConstString' in type:
+        type = 'string'
+    if 'ViString' in type:
+        type = 'string'
+    if 'ViRsrc' in type:
+        type = 'string'
+    if 'ViChar' in type:
+        if is_array:
+            add_repeated = False
+            type = 'string'
+        else:
+            type = 'uint32'
+    if 'ViReal32' in type:
+        type = 'float'
+    if 'ViAttr' in type:
+        type = driver_name_pascal + "Attributes"
+    if 'ViInt8' in type:
+        if is_array:
+            type = "bytes"
+            add_repeated = False
+        else:
+            type = 'uint32'
+    if 'void*' in type:
+        type = 'fixed64'
+    if 'ViInt16' in type:
+        type = 'sint32'
+    if 'ViInt64' in type:
+        type = 'int64'
+    if 'ViUInt16' in type:
+        type = 'uint32'
+    if 'ViUInt32' in type:
+        type = 'uint32'
+    if 'ViUInt64' in type:
+        type = 'uint64'
+    if 'ViUInt8' in type:
+        if is_array:
+            type = "bytes"
+            add_repeated = False
+        else:
+            type = 'uint32'
+    if 'ViStatus' in type:
+        type = 'sint32'
+    if 'ViAddr' in type:
+        type = 'fixed64'
+    if 'int' == type:
+        type = 'sint32'
+    if "[]" in type:
+        type = type.replace("[]", "")
+
+    return "repeated " + type if add_repeated else type
+
+
+def get_grpc_type(data_type, config):
+    service_class_prefix = config['service_class_prefix']
+    if 'type_to_grpc_type' in config:
+        type_map = config['type_to_grpc_type']
+        stripped_type = strip_prefix(data_type, 'const ')
+        if stripped_type in type_map:
+            return type_map[stripped_type]
+
+        repeated = is_array(data_type)
+
+        stripped_type = strip_suffix(stripped_type, '*')
+        stripped_type = strip_suffix(stripped_type, '[]')
+
+        # Note: if we never resolve or strip anything, this will fallback
+        # to the original datatype.
+        resolved_type = type_map.get(stripped_type, stripped_type)
+
+        return f'repeated {resolved_type}' if repeated else resolved_type
+
+    return get_grpc_type_from_ivi(
+        data_type,
+        is_array(data_type),
+        service_class_prefix)
+
+
+def get_split_attributes_by_type(config):
+    return config.get('split_attributes_by_type', False)

--- a/source/codegen/generate_service.py
+++ b/source/codegen/generate_service.py
@@ -25,48 +25,10 @@ def generate_service_file(metadata, template_file_name, generated_file_suffix, g
   f.write(template.render(data=metadata))
   f.close()
 
-
-class AttributeValueExpander:
-  '''Wraps an _attribute_type_map of:
-  
-  group -> type -> attributes
-
-  and implements the metadata_mutations to add_attribute_values_enums and expand_attribute_function_value_param.
-  '''
-  def __init__(self, metadata):
-    self._metadata = metadata
-    self._attribute_type_map = {}
-
-    for group_name, attributes in common_helpers.get_attribute_groups(metadata).items():
-      attribute_enums_by_type = common_helpers.get_attribute_enums_by_type(attributes)
-      metadata_mutation.add_attribute_values_enums(metadata["enums"], attribute_enums_by_type, group_name)
-      self._attribute_type_map[group_name] = attribute_enums_by_type
-
-
-  def get_used_attribute_group_name(self, parameters):
-    # All attribute parameters must have a grpc_type of {group_name}Attributes.
-    # In MI, this is handled during metadata mutation of ViAttr types.
-    param_types = (param["grpc_type"] for param in parameters)
-    param_types = (common_helpers.strip_suffix(p, "Attributes") for p in param_types)
-    attribute_params = (p for p in param_types if p in self._attribute_type_map)
-    return next(attribute_params, None)
-
-
-  def expand_attribute_value_params(self, func):
-    parameters = func["parameters"]
-    attribute_group_name = self.get_used_attribute_group_name(parameters)
-    if attribute_group_name:
-      metadata_mutation.expand_attribute_function_value_param(
-        func,
-        self._metadata["enums"], 
-        self._attribute_type_map[attribute_group_name], 
-        attribute_group_name)
-
-
 def mutate_metadata(metadata):
   config = metadata["config"]
   
-  attribute_expander = AttributeValueExpander(metadata)
+  attribute_expander = metadata_mutation.AttributeValueExpander(metadata)
   for function_name in metadata["functions"]:
     function = metadata["functions"][function_name]
     parameters = function["parameters"]

--- a/source/codegen/generate_service.py
+++ b/source/codegen/generate_service.py
@@ -28,7 +28,7 @@ def generate_service_file(metadata, template_file_name, generated_file_suffix, g
 def mutate_metadata(metadata):
   config = metadata["config"]
   
-  attribute_expander = metadata_mutation.AttributeValueExpander(metadata)
+  attribute_expander = metadata_mutation.AttributeAccessorExpander(metadata)
   for function_name in metadata["functions"]:
     function = metadata["functions"][function_name]
     parameters = function["parameters"]
@@ -39,6 +39,7 @@ def mutate_metadata(metadata):
     metadata_mutation.mark_mapped_enum_params(parameters, metadata["enums"])
     metadata_mutation.populate_grpc_types(parameters, config)
     attribute_expander.expand_attribute_value_params(function)
+    attribute_expander.patch_attribute_enum_type(function)
 
 
 def generate_all(metadata_dir, gen_dir):

--- a/source/codegen/metadata/nidaqmx/config.py
+++ b/source/codegen/metadata/nidaqmx/config.py
@@ -32,7 +32,6 @@ config = {
     'additional_headers': ['custom/nidaqmx_conversions.h'],
     'type_to_grpc_type': {
         'TaskHandle': 'nidevice_grpc.Session',
-        'const char[]': 'string',
         'char[]': 'string',
         'float64': 'double',
         'bool32': 'bool',
@@ -48,6 +47,7 @@ config = {
         'DAQmxSignalEventCallbackPtr': 'void',
         'CVIAbsoluteTime': 'google.protobuf.Timestamp'
     },
+    'split_attributes_by_type': True,
     'driver_name': 'NI-DAQMX',
     'extra_errors_used': [
     ],

--- a/source/codegen/metadata/nifake_non_ivi/config.py
+++ b/source/codegen/metadata/nifake_non_ivi/config.py
@@ -35,13 +35,14 @@ config = {
     'additional_headers': ['custom/nidaqmx_conversions.h'],
     'type_to_grpc_type': {
         'FakeHandle': 'nidevice_grpc.Session',
-        'const char[]': 'string',
+        'char[]': 'string',
         'myInt16': 'int32',
         'myUInt16': 'uint32',
         'myInt8': 'int32',
         'myUInt8[]': 'bytes',
         'CallbackPtr': 'void'
     },
+    'split_attributes_by_type': True,
     'library_info': {
         'Linux': {
             '64bit': {

--- a/source/codegen/metadata_mutation.py
+++ b/source/codegen/metadata_mutation.py
@@ -147,7 +147,6 @@ class AttributeAccessorExpander:
         self._config = metadata['config']
         self._enums = metadata['enums']
         self._attribute_type_map = {}
-        self._spit_by_type = False
 
         for group in common_helpers.get_attribute_groups(metadata):
             attribute_enums_by_type = common_helpers.get_attribute_enums_by_type(

--- a/source/codegen/metadata_mutation.py
+++ b/source/codegen/metadata_mutation.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+from typing import Optional
 import common_helpers
 
 RESERVED_WORDS = [
@@ -79,101 +81,16 @@ def mark_mapped_enum_params(parameters, enums):
             param['mapped-enum'] = enum_name
 
 
-def get_grpc_type_from_ivi(type, is_array, driver_name_pascal):
-    add_repeated = is_array
-    if 'ViSession' in type:
-        type = 'nidevice_grpc.Session'
-    if 'ViBoolean' in type:
-        type = 'bool'
-    if 'ViReal64' in type:
-        type = 'double'
-    if 'ViInt32' in type:
-        type = 'sint32'
-    if 'ViConstString' in type:
-        type = 'string'
-    if 'ViString' in type:
-        type = 'string'
-    if 'ViRsrc' in type:
-        type = 'string'
-    if 'ViChar' in type:
-        if is_array:
-            add_repeated = False
-            type = 'string'
-        else:
-            type = 'uint32'
-    if 'ViReal32' in type:
-        type = 'float'
-    if 'ViAttr' in type:
-        type = driver_name_pascal + "Attributes"
-    if 'ViInt8' in type:
-        if is_array:
-            type = "bytes"
-            add_repeated = False
-        else:
-            type = 'uint32'
-    if 'void*' in type:
-        type = 'fixed64'
-    if 'ViInt16' in type:
-        type = 'sint32'
-    if 'ViInt64' in type:
-        type = 'int64'
-    if 'ViUInt16' in type:
-        type = 'uint32'
-    if 'ViUInt32' in type:
-        type = 'uint32'
-    if 'ViUInt64' in type:
-        type = 'uint64'
-    if 'ViUInt8' in type:
-        if is_array:
-            type = "bytes"
-            add_repeated = False
-        else:
-            type = 'uint32'
-    if 'ViStatus' in type:
-        type = 'sint32'
-    if 'ViAddr' in type:
-        type = 'fixed64'
-    if 'int' == type:
-        type = 'sint32'
-    if "[]" in type:
-        type = type.replace("[]", "")
-
-    return "repeated " + type if add_repeated else type
-
-
 def populate_grpc_types(parameters, config):
-    service_class_prefix = config["service_class_prefix"]
-    for parameter in parameters:
-        if 'callback_params' in parameter:
-            populate_grpc_types(parameter['callback_params'], config)
-        if 'grpc_type' in parameter:
-          continue
-        if 'type_to_grpc_type' in config:
-          type_map = config['type_to_grpc_type']
-          stripped_type = parameter['type']
-          if stripped_type in type_map:
-            parameter['grpc_type'] = type_map[stripped_type]
-            continue
-          if stripped_type.startswith('const '):
-            stripped_type = stripped_type[len('const '):]
-          if stripped_type in type_map:
-            parameter['grpc_type'] = type_map[stripped_type]
-            continue
-          is_array = False
-          if stripped_type.endswith('*'):
-            is_array = True
-            stripped_type = stripped_type[:-1]
-          elif stripped_type.endswith('[]'):
-            is_array = True
-            stripped_type = stripped_type[:-2]
-          if stripped_type in type_map:
-            parameter['grpc_type'] = 'repeated ' + type_map[stripped_type]
-            continue
-        is_array = common_helpers.is_array(parameter["type"])
-        parameter['grpc_type'] = get_grpc_type_from_ivi(
-            parameter['type'],
-            is_array,
-            service_class_prefix)
+  for parameter in parameters:
+    if 'callback_params' in parameter:
+        populate_grpc_types(
+            parameter['callback_params'], config)
+    if 'grpc_type' in parameter:
+        continue
+    parameter['grpc_type'] = common_helpers.get_grpc_type(
+        parameter['type'],
+        config)
 
 
 def get_short_enum_type_name(type):
@@ -215,41 +132,79 @@ def add_attribute_values_enums(enums, attribute_enums_by_type, group_name):
         add_enum(mapped_enum_name, mapped_values, enums, enum_value_prefix, is_mapped=True)
     
 
-class AttributeValueExpander:
-  '''Wraps an _attribute_type_map of:
-  
-  group -> type -> attributes
+AttributeReferencingParameter = namedtuple("AttributeReferencingParameter", ["attribute_group", "parameter"])
 
-  and implements the metadata_mutations to add_attribute_values_enums and expand_attribute_function_value_param.
-  '''
-  def __init__(self, metadata):
-    self._metadata = metadata
-    self._attribute_type_map = {}
+class AttributeAccessorExpander:
+    """
+    Wraps an _attribute_type_map of:
+    
+    group -> type -> attributes
 
-    for group_name, attributes in common_helpers.get_attribute_groups(metadata).items():
-      attribute_enums_by_type = common_helpers.get_attribute_enums_by_type(attributes)
-      add_attribute_values_enums(metadata["enums"], attribute_enums_by_type, group_name)
-      self._attribute_type_map[group_name] = attribute_enums_by_type
+    and implements the metadata_mutations to add_attribute_values_enums, expand_attribute_function_value_param,
+    and patch_attribute_enum_type.
+    """
+    def __init__(self, metadata):
+        self._config = metadata['config']
+        self._enums = metadata['enums']
+        self._attribute_type_map = {}
+        self._spit_by_type = False
+
+        for group in common_helpers.get_attribute_groups(metadata):
+            attribute_enums_by_type = common_helpers.get_attribute_enums_by_type(
+                group.attributes)
+            add_attribute_values_enums(
+                self._enums,
+                attribute_enums_by_type,
+                group.name)
+            self._attribute_type_map[group.name] = attribute_enums_by_type
 
 
-  def get_used_attribute_group_name(self, parameters):
-    # All attribute parameters must have a grpc_type of {group_name}Attributes.
-    # In MI, this is handled during metadata mutation of ViAttr types.
-    param_types = (param["grpc_type"] for param in parameters)
-    param_types = (common_helpers.strip_suffix(p, "Attributes") for p in param_types)
-    attribute_params = (p for p in param_types if p in self._attribute_type_map)
-    return next(attribute_params, None)
+    def get_attribute_reference_parameter(self, parameters) -> Optional[AttributeReferencingParameter]:
+        def try_resolve_attribute_reference(parameter) -> Optional[AttributeReferencingParameter]:
+            param_type = parameter['grpc_type']
+            # All attribute parameters must have a grpc_type of {group_name}Attributes.
+            # In MI, this is added during metadata mutation of ViAttr types.
+            potential_attribute_name = common_helpers.strip_suffix(param_type, 'Attributes')
+            if potential_attribute_name in self._attribute_type_map:
+                return AttributeReferencingParameter(potential_attribute_name, parameter)
+            return None
+
+        # Assumption: there are 0 or 1 parameters that reference an attribute per function.
+        attribute_resolve_results = (try_resolve_attribute_reference(p) for p in parameters)
+        valid_references = (ref for ref in attribute_resolve_results if ref)
+        return next(valid_references, None)
 
 
-  def expand_attribute_value_params(self, func):
-    parameters = func["parameters"]
-    attribute_group_name = self.get_used_attribute_group_name(parameters)
-    if attribute_group_name:
-      expand_attribute_function_value_param(
-        func,
-        self._metadata["enums"], 
-        self._attribute_type_map[attribute_group_name], 
-        attribute_group_name)
+    def patch_attribute_enum_type(self, func):
+        """
+        If a driver splits attribute enums by type, 
+        then the referencing functions need to be updated to match:
+        ScaleAttributes -> ScaleAttributesInt32, ScaleAttributesDouble, etc.
+        """
+        if not common_helpers.get_split_attributes_by_type(self._config):
+            return
+        parameters = func['parameters']
+        attribute_reference = self.get_attribute_reference_parameter(parameters)
+        if attribute_reference:
+            group = attribute_reference.attribute_group
+            attribute_param = attribute_reference.parameter
+            value_param = get_attribute_function_value_param(func)
+            type_name = common_helpers.get_grpc_type_name_for_identifier(
+                value_param['type'],
+                self._config)
+            attribute_param['grpc_type'] = common_helpers.get_attribute_enum_name(group, type_name)
+        
+
+    def expand_attribute_value_params(self, func):
+        parameters = func["parameters"]
+        attribute_reference = self.get_attribute_reference_parameter(parameters)
+        if attribute_reference:
+            expand_attribute_function_value_param(
+                func,
+                self._enums, 
+                self._attribute_type_map[attribute_reference.attribute_group], 
+                attribute_reference.attribute_group)
+
 
 def expand_attribute_function_value_param(function, enums, attribute_enums_by_type, service_class_prefix):
     """For SetAttribute and CheckAttribute APIs, update function metadata to mark value parameter as enum."""

--- a/source/codegen/templates/proto.mako
+++ b/source/codegen/templates/proto.mako
@@ -42,9 +42,9 @@ service ${service_class_prefix} {
 }
 
 % for group in common_helpers.get_attribute_groups(data):
-% for data_type, attributes in group.get_attributes_split_by_type().items():
+%   for data_type, attributes in group.get_attributes_split_by_type().items():
 ${mako_helper.define_attribute_enum(group.name, data_type, attributes)}\
-% endfor
+%   endfor
 % endfor
 ${mako_helper.define_function_enums(function_enums)}\
 ${mako_helper.insert_custom_template_if_found()}\

--- a/source/codegen/templates/proto.mako
+++ b/source/codegen/templates/proto.mako
@@ -46,7 +46,6 @@ service ${service_class_prefix} {
 ${mako_helper.define_attribute_enum(group.name, data_type, attributes)}\
 % endfor
 % endfor
-
 ${mako_helper.define_function_enums(function_enums)}\
 ${mako_helper.insert_custom_template_if_found()}\
 % for function in common_helpers.filter_proto_rpc_functions(functions):

--- a/source/codegen/templates/proto.mako
+++ b/source/codegen/templates/proto.mako
@@ -41,8 +41,10 @@ service ${service_class_prefix} {
 % endfor
 }
 
-% for group_name, attributes in common_helpers.get_attribute_groups(data).items():
-${mako_helper.define_attribute_enum(group_name, attributes)}\
+% for group in common_helpers.get_attribute_groups(data):
+% for data_type, attributes in group.get_attributes_split_by_type().items():
+${mako_helper.define_attribute_enum(group.name, data_type, attributes)}\
+% endfor
 % endfor
 
 ${mako_helper.define_function_enums(function_enums)}\

--- a/source/codegen/templates/proto_helpers.mako
+++ b/source/codegen/templates/proto_helpers.mako
@@ -22,6 +22,7 @@ enum ${common_helpers.get_attribute_enum_name(group_name, data_type)} {
   ${attribute_value_prefix}_${attribute_name} = ${attribute};
 % endfor
 }
+
 </%def>
 
 ## Define enums in the proto for each metadata enum referenced in a proto message.

--- a/source/codegen/templates/proto_helpers.mako
+++ b/source/codegen/templates/proto_helpers.mako
@@ -4,12 +4,17 @@
 %>
 
 ## Define a proto enum capturing attributes from the metadata.
-<%def name="define_attribute_enum(group_name, attributes)">\
+<%def name="define_attribute_enum(group_name, data_type, attributes)">\
 <%
   attribute_value_prefix = group_name.upper() + "_ATTRIBUTE"
+
+  # When attributes are split-by-datatype, the actual attributes don't need a type-name disabiguator because
+  # the original unsplit list didn't have duplicates. However, they each need a unique-ified UNSPECIFIED param.
+  unspecified_disambiguator = "_" + common_helpers.pascal_to_snake(data_type).upper() if data_type else ""
+  unspecified_attribute_value_prefix = group_name.upper() + unspecified_disambiguator + "_ATTRIBUTE"
 %>\
-enum ${group_name}Attributes {
-  ${attribute_value_prefix}_UNSPECIFIED = 0;
+enum ${common_helpers.get_attribute_enum_name(group_name, data_type)} {
+  ${unspecified_attribute_value_prefix}_UNSPECIFIED = 0;
 % for attribute in attributes:
 <%
    attribute_name = attributes[attribute]["name"]

--- a/source/codegen/templates/proto_helpers.mako
+++ b/source/codegen/templates/proto_helpers.mako
@@ -8,7 +8,7 @@
 <%
   attribute_value_prefix = group_name.upper() + "_ATTRIBUTE"
 
-  # When attributes are split-by-datatype, the actual attributes don't need a type-name disabiguator because
+  # When attributes are split-by-datatype, the actual attributes don't need a type-name disambiguator because
   # the original unsplit list didn't have duplicates. However, they each need a unique-ified UNSPECIFIED param.
   unspecified_disambiguator = "_" + common_helpers.pascal_to_snake(data_type).upper() if data_type else ""
   unspecified_attribute_value_prefix = group_name.upper() + unspecified_disambiguator + "_ATTRIBUTE"

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -690,7 +690,7 @@ class NiDAQmxDriverApiTests : public Test {
     return request;
   }
 
-  SetScaleAttributeDoubleArrayRequest create_set_scale_attribute_double_array_request(const std::string& scale_name, ScaleAttributesDoubleArray attribute, const std::vector<double>& value)
+  SetScaleAttributeDoubleArrayRequest create_set_scale_attribute_double_array_request(const std::string& scale_name, ScaleDoubleArrayAttributes attribute, const std::vector<double>& value)
   {
     SetScaleAttributeDoubleArrayRequest request;
     request.set_scale_name(scale_name);
@@ -957,7 +957,7 @@ TEST_F(NiDAQmxDriverApiTests, LinearScale_GetSlopeAttribute_ReturnsInitialSlopeV
 
   auto request = create_get_scale_attribute_request<GetScaleAttributeDoubleRequest>(
       SCALE_NAME,
-      ScaleAttributesDouble::SCALE_ATTRIBUTE_LIN_SLOPE);
+      ScaleDoubleAttributes::SCALE_ATTRIBUTE_LIN_SLOPE);
   GetScaleAttributeDoubleResponse response;
   auto status = get_scale_attribute_double(request, response);
 
@@ -972,13 +972,13 @@ TEST_F(NiDAQmxDriverApiTests, SetYInterceptAttribute_GetYInterceptAttribute_Retu
   auto scale_status = create_lin_scale(SCALE_NAME, 0.5);
   auto set_request = create_set_scale_attribute_request<SetScaleAttributeDoubleRequest>(
       SCALE_NAME,
-      ScaleAttributesDouble::SCALE_ATTRIBUTE_LIN_Y_INTERCEPT,
+      ScaleDoubleAttributes::SCALE_ATTRIBUTE_LIN_Y_INTERCEPT,
       Y_INTERCEPT);
   SetScaleAttributeDoubleResponse set_response;
   auto set_status = set_scale_attribute_double(set_request, set_response);
   auto request = create_get_scale_attribute_request<GetScaleAttributeDoubleRequest>(
       SCALE_NAME,
-      ScaleAttributesDouble::SCALE_ATTRIBUTE_LIN_Y_INTERCEPT);
+      ScaleDoubleAttributes::SCALE_ATTRIBUTE_LIN_Y_INTERCEPT);
   GetScaleAttributeDoubleResponse response;
   auto status = get_scale_attribute_double(request, response);
 
@@ -994,14 +994,14 @@ TEST_F(NiDAQmxDriverApiTests, SetPreScaledUnits_GetPreScaledUnits_ReturnsAttribu
   auto scale_status = create_lin_scale(SCALE_NAME, 0.5);
   auto set_request = create_set_scale_attribute_request<SetScaleAttributeInt32Request>(
       SCALE_NAME,
-      ScaleAttributesInt32::SCALE_ATTRIBUTE_PRE_SCALED_UNITS,
+      ScaleInt32Attributes::SCALE_ATTRIBUTE_PRE_SCALED_UNITS,
       ScaleInt32AttributeValues::SCALE_INT32_UNITS_PRE_SCALED_RPM);
   SetScaleAttributeInt32Response set_response;
   auto set_status = set_scale_attribute_i32(set_request, set_response);
 
   auto request = create_get_scale_attribute_request<GetScaleAttributeInt32Request>(
       SCALE_NAME,
-      ScaleAttributesInt32::SCALE_ATTRIBUTE_PRE_SCALED_UNITS);
+      ScaleInt32Attributes::SCALE_ATTRIBUTE_PRE_SCALED_UNITS);
   GetScaleAttributeInt32Response response;
   auto status = get_scale_attribute_i32(request, response);
 
@@ -1017,14 +1017,14 @@ TEST_F(NiDAQmxDriverApiTests, GetScaledUnitsAsDouble_Fails)
   auto scale_status = create_lin_scale(SCALE_NAME, 0.5);
   auto set_request = create_set_scale_attribute_request<SetScaleAttributeStringRequest>(
       SCALE_NAME,
-      ScaleAttributesString::SCALE_ATTRIBUTE_SCALED_UNITS,
+      ScaleStringAttributes::SCALE_ATTRIBUTE_SCALED_UNITS,
       UNITS);
   SetScaleAttributeStringResponse set_response;
   auto set_status = set_scale_attribute_string(set_request, set_response);
 
   auto request = create_get_scale_attribute_request<GetScaleAttributeDoubleRequest>(
       SCALE_NAME,
-      (ScaleAttributesDouble)ScaleAttributesString::SCALE_ATTRIBUTE_SCALED_UNITS);
+      (ScaleDoubleAttributes)ScaleStringAttributes::SCALE_ATTRIBUTE_SCALED_UNITS);
   GetScaleAttributeDoubleResponse response;
   auto status = get_scale_attribute_double(request, response);
 
@@ -1042,14 +1042,14 @@ TEST_F(NiDAQmxDriverApiTests, SetScaledUnits_GetScaledUnits_ReturnsAttribute)
   auto scale_status = create_lin_scale(SCALE_NAME, 0.5);
   auto set_request = create_set_scale_attribute_request<SetScaleAttributeStringRequest>(
       SCALE_NAME,
-      ScaleAttributesString::SCALE_ATTRIBUTE_SCALED_UNITS,
+      ScaleStringAttributes::SCALE_ATTRIBUTE_SCALED_UNITS,
       UNITS);
   SetScaleAttributeStringResponse set_response;
   auto set_status = set_scale_attribute_string(set_request, set_response);
 
   auto request = create_sized_get_scale_attribute_request<GetScaleAttributeStringRequest>(
       SCALE_NAME,
-      ScaleAttributesString::SCALE_ATTRIBUTE_SCALED_UNITS,
+      ScaleStringAttributes::SCALE_ATTRIBUTE_SCALED_UNITS,
       UNITS.length() + 1);
   GetScaleAttributeStringResponse response;
   auto status = get_scale_attribute_string(request, response);
@@ -1067,14 +1067,14 @@ TEST_F(NiDAQmxDriverApiTests, SetPolynomialForwardCoefficients_GetPolynomialForw
   auto scale_status = create_polynomial_scale(SCALE_NAME, INITIAL_COEFFICIENTS, INITIAL_COEFFICIENTS);
   auto set_request = create_set_scale_attribute_double_array_request(
       SCALE_NAME,
-      ScaleAttributesDoubleArray::SCALE_ATTRIBUTE_POLY_FORWARD_COEFF,
+      ScaleDoubleArrayAttributes::SCALE_ATTRIBUTE_POLY_FORWARD_COEFF,
       COEFFICIENTS);
   SetScaleAttributeDoubleArrayResponse set_response;
   auto set_status = set_scale_attribute_double_array(set_request, set_response);
 
   auto request = create_sized_get_scale_attribute_request<GetScaleAttributeDoubleArrayRequest>(
       SCALE_NAME,
-      ScaleAttributesDoubleArray::SCALE_ATTRIBUTE_POLY_FORWARD_COEFF,
+      ScaleDoubleArrayAttributes::SCALE_ATTRIBUTE_POLY_FORWARD_COEFF,
       COEFFICIENTS.size());
   GetScaleAttributeDoubleArrayResponse response;
   auto status = get_scale_attribute_double_array(request, response);

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -629,8 +629,8 @@ class NiDAQmxDriverApiTests : public Test {
     return stub()->ConfigureTEDS(&context, request, &response);
   }
 
-  template <typename TRequest>
-  TRequest create_get_scale_attribute_request(const std::string& scale_name, ScaleAttributes attribute)
+  template <typename TRequest, typename TAttributes>
+  TRequest create_get_scale_attribute_request(const std::string& scale_name, TAttributes attribute)
   {
     TRequest request;
     request.set_scale_name(scale_name);
@@ -638,8 +638,8 @@ class NiDAQmxDriverApiTests : public Test {
     return request;
   }
 
-  template <typename TRequest>
-  TRequest create_sized_get_scale_attribute_request(const std::string& scale_name, ScaleAttributes attribute, size_t size)
+  template <typename TRequest, typename TAttributes>
+  TRequest create_sized_get_scale_attribute_request(const std::string& scale_name, TAttributes attribute, size_t size)
   {
     auto request = create_get_scale_attribute_request<TRequest>(scale_name, attribute);
     request.set_size(static_cast<int32>(size));
@@ -670,8 +670,8 @@ class NiDAQmxDriverApiTests : public Test {
     return stub()->GetScaleAttributeInt32(&context, request, &response);
   }
 
-  template <typename TRequest, typename T>
-  TRequest create_set_scale_attribute_raw_request(const std::string& scale_name, ScaleAttributes attribute, T value)
+  template <typename TRequest, typename T, typename TAttributes>
+  TRequest create_set_scale_attribute_raw_request(const std::string& scale_name, TAttributes attribute, T value)
   {
     TRequest request;
     request.set_scale_name(scale_name);
@@ -680,8 +680,8 @@ class NiDAQmxDriverApiTests : public Test {
     return request;
   }
 
-  template <typename TRequest, typename T>
-  TRequest create_set_scale_attribute_request(const std::string& scale_name, ScaleAttributes attribute, T value)
+  template <typename TRequest, typename T, typename TAttributes>
+  TRequest create_set_scale_attribute_request(const std::string& scale_name, TAttributes attribute, T value)
   {
     TRequest request;
     request.set_scale_name(scale_name);
@@ -690,7 +690,7 @@ class NiDAQmxDriverApiTests : public Test {
     return request;
   }
 
-  SetScaleAttributeDoubleArrayRequest create_set_scale_attribute_double_array_request(const std::string& scale_name, ScaleAttributes attribute, const std::vector<double>& value)
+  SetScaleAttributeDoubleArrayRequest create_set_scale_attribute_double_array_request(const std::string& scale_name, ScaleAttributesDoubleArray attribute, const std::vector<double>& value)
   {
     SetScaleAttributeDoubleArrayRequest request;
     request.set_scale_name(scale_name);
@@ -957,7 +957,7 @@ TEST_F(NiDAQmxDriverApiTests, LinearScale_GetSlopeAttribute_ReturnsInitialSlopeV
 
   auto request = create_get_scale_attribute_request<GetScaleAttributeDoubleRequest>(
       SCALE_NAME,
-      ScaleAttributes::SCALE_ATTRIBUTE_LIN_SLOPE);
+      ScaleAttributesDouble::SCALE_ATTRIBUTE_LIN_SLOPE);
   GetScaleAttributeDoubleResponse response;
   auto status = get_scale_attribute_double(request, response);
 
@@ -972,14 +972,13 @@ TEST_F(NiDAQmxDriverApiTests, SetYInterceptAttribute_GetYInterceptAttribute_Retu
   auto scale_status = create_lin_scale(SCALE_NAME, 0.5);
   auto set_request = create_set_scale_attribute_request<SetScaleAttributeDoubleRequest>(
       SCALE_NAME,
-      ScaleAttributes::SCALE_ATTRIBUTE_LIN_Y_INTERCEPT,
+      ScaleAttributesDouble::SCALE_ATTRIBUTE_LIN_Y_INTERCEPT,
       Y_INTERCEPT);
   SetScaleAttributeDoubleResponse set_response;
   auto set_status = set_scale_attribute_double(set_request, set_response);
-
   auto request = create_get_scale_attribute_request<GetScaleAttributeDoubleRequest>(
       SCALE_NAME,
-      ScaleAttributes::SCALE_ATTRIBUTE_LIN_Y_INTERCEPT);
+      ScaleAttributesDouble::SCALE_ATTRIBUTE_LIN_Y_INTERCEPT);
   GetScaleAttributeDoubleResponse response;
   auto status = get_scale_attribute_double(request, response);
 
@@ -995,14 +994,14 @@ TEST_F(NiDAQmxDriverApiTests, SetPreScaledUnits_GetPreScaledUnits_ReturnsAttribu
   auto scale_status = create_lin_scale(SCALE_NAME, 0.5);
   auto set_request = create_set_scale_attribute_request<SetScaleAttributeInt32Request>(
       SCALE_NAME,
-      ScaleAttributes::SCALE_ATTRIBUTE_PRE_SCALED_UNITS,
+      ScaleAttributesInt32::SCALE_ATTRIBUTE_PRE_SCALED_UNITS,
       ScaleInt32AttributeValues::SCALE_INT32_UNITS_PRE_SCALED_RPM);
   SetScaleAttributeInt32Response set_response;
   auto set_status = set_scale_attribute_i32(set_request, set_response);
 
   auto request = create_get_scale_attribute_request<GetScaleAttributeInt32Request>(
       SCALE_NAME,
-      ScaleAttributes::SCALE_ATTRIBUTE_PRE_SCALED_UNITS);
+      ScaleAttributesInt32::SCALE_ATTRIBUTE_PRE_SCALED_UNITS);
   GetScaleAttributeInt32Response response;
   auto status = get_scale_attribute_i32(request, response);
 
@@ -1018,14 +1017,14 @@ TEST_F(NiDAQmxDriverApiTests, GetScaledUnitsAsDouble_Fails)
   auto scale_status = create_lin_scale(SCALE_NAME, 0.5);
   auto set_request = create_set_scale_attribute_request<SetScaleAttributeStringRequest>(
       SCALE_NAME,
-      ScaleAttributes::SCALE_ATTRIBUTE_SCALED_UNITS,
+      ScaleAttributesString::SCALE_ATTRIBUTE_SCALED_UNITS,
       UNITS);
   SetScaleAttributeStringResponse set_response;
   auto set_status = set_scale_attribute_string(set_request, set_response);
 
   auto request = create_get_scale_attribute_request<GetScaleAttributeDoubleRequest>(
       SCALE_NAME,
-      ScaleAttributes::SCALE_ATTRIBUTE_SCALED_UNITS);
+      (ScaleAttributesDouble)ScaleAttributesString::SCALE_ATTRIBUTE_SCALED_UNITS);
   GetScaleAttributeDoubleResponse response;
   auto status = get_scale_attribute_double(request, response);
 
@@ -1043,14 +1042,14 @@ TEST_F(NiDAQmxDriverApiTests, SetScaledUnits_GetScaledUnits_ReturnsAttribute)
   auto scale_status = create_lin_scale(SCALE_NAME, 0.5);
   auto set_request = create_set_scale_attribute_request<SetScaleAttributeStringRequest>(
       SCALE_NAME,
-      ScaleAttributes::SCALE_ATTRIBUTE_SCALED_UNITS,
+      ScaleAttributesString::SCALE_ATTRIBUTE_SCALED_UNITS,
       UNITS);
   SetScaleAttributeStringResponse set_response;
   auto set_status = set_scale_attribute_string(set_request, set_response);
 
   auto request = create_sized_get_scale_attribute_request<GetScaleAttributeStringRequest>(
       SCALE_NAME,
-      ScaleAttributes::SCALE_ATTRIBUTE_SCALED_UNITS,
+      ScaleAttributesString::SCALE_ATTRIBUTE_SCALED_UNITS,
       UNITS.length() + 1);
   GetScaleAttributeStringResponse response;
   auto status = get_scale_attribute_string(request, response);
@@ -1068,14 +1067,14 @@ TEST_F(NiDAQmxDriverApiTests, SetPolynomialForwardCoefficients_GetPolynomialForw
   auto scale_status = create_polynomial_scale(SCALE_NAME, INITIAL_COEFFICIENTS, INITIAL_COEFFICIENTS);
   auto set_request = create_set_scale_attribute_double_array_request(
       SCALE_NAME,
-      ScaleAttributes::SCALE_ATTRIBUTE_POLY_FORWARD_COEFF,
+      ScaleAttributesDoubleArray::SCALE_ATTRIBUTE_POLY_FORWARD_COEFF,
       COEFFICIENTS);
   SetScaleAttributeDoubleArrayResponse set_response;
   auto set_status = set_scale_attribute_double_array(set_request, set_response);
 
   auto request = create_sized_get_scale_attribute_request<GetScaleAttributeDoubleArrayRequest>(
       SCALE_NAME,
-      ScaleAttributes::SCALE_ATTRIBUTE_POLY_FORWARD_COEFF,
+      ScaleAttributesDoubleArray::SCALE_ATTRIBUTE_POLY_FORWARD_COEFF,
       COEFFICIENTS.size());
   GetScaleAttributeDoubleArrayResponse response;
   auto status = get_scale_attribute_double_array(request, response);

--- a/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
+++ b/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
@@ -654,7 +654,7 @@ TEST_F(NiFakeNonIviServiceTests, OutputTimestamp_KnownValue)
 
 TEST_F(NiFakeNonIviServiceTests, SetMarbleAttributeDouble_Succeeds)
 {
-  const auto ATTRIBUTE = MarbleAttributes::MARBLE_ATTRIBUTE_WEIGHT;
+  const auto ATTRIBUTE = MarbleAttributesDouble::MARBLE_ATTRIBUTE_WEIGHT;
   const auto VALUE = 1.2345;
   EXPECT_CALL(library_, SetMarbleAttributeDouble(_, ATTRIBUTE, VALUE))
       .WillOnce(Return(kDriverSuccess));
@@ -670,7 +670,7 @@ TEST_F(NiFakeNonIviServiceTests, SetMarbleAttributeDouble_Succeeds)
 
 TEST_F(NiFakeNonIviServiceTests, SetMarbleAttributeInt32_Succeeds)
 {
-  const auto ATTRIBUTE = MarbleAttributes::MARBLE_ATTRIBUTE_COLOR;
+  const auto ATTRIBUTE = MarbleAttributesInt32::MARBLE_ATTRIBUTE_COLOR;
   const auto VALUE = MarbleInt32AttributeValues::MARBLE_INT32_BEAUTIFUL_COLOR_GREEN;
   EXPECT_CALL(library_, SetMarbleAttributeInt32(_, ATTRIBUTE, VALUE))
       .WillOnce(Return(kDriverSuccess));
@@ -686,7 +686,7 @@ TEST_F(NiFakeNonIviServiceTests, SetMarbleAttributeInt32_Succeeds)
 
 TEST_F(NiFakeNonIviServiceTests, SetMarbleAttributeInt32Raw_Succeeds)
 {
-  const auto ATTRIBUTE = MarbleAttributes::MARBLE_ATTRIBUTE_COLOR;
+  const auto ATTRIBUTE = MarbleAttributesInt32::MARBLE_ATTRIBUTE_COLOR;
   const auto VALUE = 9999;
   EXPECT_CALL(library_, SetMarbleAttributeInt32(_, ATTRIBUTE, VALUE))
       .WillOnce(Return(kDriverSuccess));
@@ -702,7 +702,7 @@ TEST_F(NiFakeNonIviServiceTests, SetMarbleAttributeInt32Raw_Succeeds)
 
 TEST_F(NiFakeNonIviServiceTests, GetMarbleAttributeInt32_Succeeds)
 {
-  const auto ATTRIBUTE = MarbleAttributes::MARBLE_ATTRIBUTE_COLOR;
+  const auto ATTRIBUTE = MarbleAttributesInt32::MARBLE_ATTRIBUTE_COLOR;
   const auto VALUE = MarbleInt32AttributeValues::MARBLE_INT32_BEAUTIFUL_COLOR_AQUA;
   EXPECT_CALL(library_, GetMarbleAttributeInt32(_, ATTRIBUTE, _))
       .WillOnce(DoAll(SetArgPointee<2>(VALUE), Return(kDriverSuccess)));

--- a/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
+++ b/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
@@ -654,7 +654,7 @@ TEST_F(NiFakeNonIviServiceTests, OutputTimestamp_KnownValue)
 
 TEST_F(NiFakeNonIviServiceTests, SetMarbleAttributeDouble_Succeeds)
 {
-  const auto ATTRIBUTE = MarbleAttributesDouble::MARBLE_ATTRIBUTE_WEIGHT;
+  const auto ATTRIBUTE = MarbleDoubleAttributes::MARBLE_ATTRIBUTE_WEIGHT;
   const auto VALUE = 1.2345;
   EXPECT_CALL(library_, SetMarbleAttributeDouble(_, ATTRIBUTE, VALUE))
       .WillOnce(Return(kDriverSuccess));
@@ -670,7 +670,7 @@ TEST_F(NiFakeNonIviServiceTests, SetMarbleAttributeDouble_Succeeds)
 
 TEST_F(NiFakeNonIviServiceTests, SetMarbleAttributeInt32_Succeeds)
 {
-  const auto ATTRIBUTE = MarbleAttributesInt32::MARBLE_ATTRIBUTE_COLOR;
+  const auto ATTRIBUTE = MarbleInt32Attributes::MARBLE_ATTRIBUTE_COLOR;
   const auto VALUE = MarbleInt32AttributeValues::MARBLE_INT32_BEAUTIFUL_COLOR_GREEN;
   EXPECT_CALL(library_, SetMarbleAttributeInt32(_, ATTRIBUTE, VALUE))
       .WillOnce(Return(kDriverSuccess));
@@ -686,7 +686,7 @@ TEST_F(NiFakeNonIviServiceTests, SetMarbleAttributeInt32_Succeeds)
 
 TEST_F(NiFakeNonIviServiceTests, SetMarbleAttributeInt32Raw_Succeeds)
 {
-  const auto ATTRIBUTE = MarbleAttributesInt32::MARBLE_ATTRIBUTE_COLOR;
+  const auto ATTRIBUTE = MarbleInt32Attributes::MARBLE_ATTRIBUTE_COLOR;
   const auto VALUE = 9999;
   EXPECT_CALL(library_, SetMarbleAttributeInt32(_, ATTRIBUTE, VALUE))
       .WillOnce(Return(kDriverSuccess));
@@ -702,7 +702,7 @@ TEST_F(NiFakeNonIviServiceTests, SetMarbleAttributeInt32Raw_Succeeds)
 
 TEST_F(NiFakeNonIviServiceTests, GetMarbleAttributeInt32_Succeeds)
 {
-  const auto ATTRIBUTE = MarbleAttributesInt32::MARBLE_ATTRIBUTE_COLOR;
+  const auto ATTRIBUTE = MarbleInt32Attributes::MARBLE_ATTRIBUTE_COLOR;
   const auto VALUE = MarbleInt32AttributeValues::MARBLE_INT32_BEAUTIFUL_COLOR_AQUA;
   EXPECT_CALL(library_, GetMarbleAttributeInt32(_, ATTRIBUTE, _))
       .WillOnce(DoAll(SetArgPointee<2>(VALUE), Return(kDriverSuccess)));


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add support for splitting attribute enums by type.

### Why should this Pull Request be merged?

This makes it easier to determine which attributes are valid for typed attribute accessor methods.

### What testing has been done?

Ran and passed all DAQ tests.