### PR TITLE
Rename PowerUpStates enum to PowerUpChannelType

### DIFF
--- a/generated/nidaqmx/nidaqmx.proto
+++ b/generated/nidaqmx/nidaqmx.proto
@@ -602,12 +602,12 @@ enum Polarity2 {
   POLARITY2_ACTIVE_LOW = 10096;
 }
 
-enum PowerUpStates {
+enum PowerUpChannelType {
   option allow_alias = true;
-  POWER_UP_STATES_UNSPECIFIED = 0;
-  POWER_UP_STATES_CHANNEL_VOLTAGE = 0;
-  POWER_UP_STATES_CHANNEL_CURRENT = 1;
-  POWER_UP_STATES_CHANNEL_HIGH_IMPEDANCE = 2;
+  POWER_UP_CHANNEL_TYPE_UNSPECIFIED = 0;
+  POWER_UP_CHANNEL_TYPE_CHANNEL_VOLTAGE = 0;
+  POWER_UP_CHANNEL_TYPE_CHANNEL_CURRENT = 1;
+  POWER_UP_CHANNEL_TYPE_CHANNEL_HIGH_IMPEDANCE = 2;
 }
 
 enum PressureUnits {
@@ -919,7 +919,7 @@ enum ScaleInt32AttributeValues {
 message AnalogPowerUpState {
   string channelNames = 1;
   double state = 2;
-  PowerUpStates channelType = 3;
+  PowerUpChannelType channelType = 3;
 }
 message AddCDAQSyncConnectionRequest {
   string port_list = 1;

--- a/source/codegen/metadata/nidaqmx/config.py
+++ b/source/codegen/metadata/nidaqmx/config.py
@@ -23,7 +23,7 @@ config = {
                 },
                 {
                     'type': 'int32',
-                    'enum': 'PowerUpStates',
+                    'enum': 'PowerUpChannelType',
                     'name': 'channelType',
                 }
             ]

--- a/source/codegen/metadata/nidaqmx/custom_proto.mako
+++ b/source/codegen/metadata/nidaqmx/custom_proto.mako
@@ -1,5 +1,5 @@
 message AnalogPowerUpState {
   string channelNames = 1;
   double state = 2;
-  PowerUpStates channelType = 3;
+  PowerUpChannelType channelType = 3;
 }

--- a/source/codegen/metadata/nidaqmx/enums.py
+++ b/source/codegen/metadata/nidaqmx/enums.py
@@ -1153,7 +1153,7 @@ enums = {
             }
         ]
     },
-    'PowerUpStates': {
+    'PowerUpChannelType': {
         'values': [
             {
                 'name': 'CHANNEL_VOLTAGE',

--- a/source/codegen/metadata/nidaqmx/functions.py
+++ b/source/codegen/metadata/nidaqmx/functions.py
@@ -7811,7 +7811,7 @@ functions = {
             },
             {
                 'direction': 'in',
-                'enum': 'PowerUpStates',
+                'enum': 'PowerUpChannelType',
                 'include_in_proto': False,
                 'name': 'channelType',
                 'repeating_var_arg': True,


### PR DESCRIPTION
### What does this Pull Request accomplish?

Rename the `PowerUpStates` enum to `PowerUpChannelType`.

### Why should this Pull Request be merged?

This is being used for the `channelType` param of `SetAnalogPowerUpStates`, which is not a `PowerUpState`.
There's actually another enum in DAQ called `PowerUpStates` that is used for digital power up states.
Most places in NI's code do not name this set of values, but I found one wrapper idl that called it `PowerUpChannelType`.

### What testing has been done?

Ran and passed all DAQ tests.