### PR TITLE
Fix some C++ warnings

### DIFF
--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -524,7 +524,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto sequence_name = request->sequence_name().c_str();
-      ViInt32 attribute_id_count = request->attribute_ids().size();
+      ViInt32 attribute_id_count = static_cast<ViInt32>(request->attribute_ids().size());
       auto attribute_ids = const_cast<ViInt32*>(reinterpret_cast<const ViInt32*>(request->attribute_ids().data()));
       ViBoolean set_as_active_sequence = request->set_as_active_sequence();
       auto status = library_->CreateAdvancedSequenceWithChannels(vi, channel_name, sequence_name, attribute_id_count, attribute_ids, set_as_active_sequence);
@@ -547,7 +547,7 @@ namespace nidcpower_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto sequence_name = request->sequence_name().c_str();
-      ViInt32 attribute_id_count = request->attribute_ids().size();
+      ViInt32 attribute_id_count = static_cast<ViInt32>(request->attribute_ids().size());
       auto attribute_ids = const_cast<ViInt32*>(reinterpret_cast<const ViInt32*>(request->attribute_ids().data()));
       ViBoolean set_as_active_sequence = request->set_as_active_sequence();
       auto status = library_->CreateAdvancedSequence(vi, sequence_name, attribute_id_count, attribute_ids, set_as_active_sequence);
@@ -2746,7 +2746,7 @@ namespace nidcpower_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 size = request->configuration().size();
+      ViInt32 size = static_cast<ViInt32>(request->configuration().size());
       auto configuration = const_cast<ViAddr*>(reinterpret_cast<const ViAddr*>(request->configuration().data()));
       auto status = library_->ImportAttributeConfigurationBuffer(vi, size, configuration);
       response->set_status(status);
@@ -3391,7 +3391,7 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       auto values = const_cast<ViReal64*>(request->values().data());
       auto source_delays = const_cast<ViReal64*>(request->source_delays().data());
-      ViUInt32 size = request->source_delays().size();
+      ViUInt32 size = static_cast<ViUInt32>(request->source_delays().size());
       auto status = library_->SetSequence(vi, channel_name, values, source_delays, size);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -113,7 +113,7 @@ namespace nidigitalpattern_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
-      ViInt32 num_offsets = request->offsets().size();
+      ViInt32 num_offsets = static_cast<ViInt32>(request->offsets().size());
       auto offsets = const_cast<ViReal64*>(request->offsets().data());
       auto status = library_->ApplyTDROffsets(vi, channel_list, num_offsets, offsets);
       response->set_status(status);
@@ -3461,7 +3461,7 @@ namespace nidigitalpattern_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto waveform_name = request->waveform_name().c_str();
-      ViInt32 waveform_size = request->waveform_data().size();
+      ViInt32 waveform_size = static_cast<ViInt32>(request->waveform_data().size());
       auto waveform_data = const_cast<ViUInt32*>(reinterpret_cast<const ViUInt32*>(request->waveform_data().data()));
       auto status = library_->WriteSourceWaveformBroadcastU32(vi, waveform_name, waveform_size, waveform_data);
       response->set_status(status);

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -1870,7 +1870,7 @@ namespace nidmm_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 size = request->configuration().size();
+      ViInt32 size = static_cast<ViInt32>(request->configuration().size());
       ViInt8* configuration = (ViInt8*)request->configuration().c_str();
       auto status = library_->ImportAttributeConfigurationBuffer(vi, size, configuration);
       response->set_status(status);

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -100,7 +100,7 @@ namespace nifake_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 count = request->delays().size();
+      ViInt32 count = static_cast<ViInt32>(request->delays().size());
       auto delays = const_cast<ViReal64*>(request->delays().data());
       auto status = library_->AcceptListOfDurationsInSeconds(vi, count, delays);
       response->set_status(status);
@@ -146,7 +146,7 @@ namespace nifake_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 array_len = request->u_int32_array().size();
+      ViInt32 array_len = static_cast<ViInt32>(request->u_int32_array().size());
       auto u_int32_array = const_cast<ViUInt32*>(reinterpret_cast<const ViUInt32*>(request->u_int32_array().data()));
       auto status = library_->AcceptViUInt32Array(vi, array_len, u_int32_array);
       response->set_status(status);
@@ -239,7 +239,7 @@ namespace nifake_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 number_count = request->numbers().size();
+      ViInt32 number_count = static_cast<ViInt32>(request->numbers().size());
       auto numbers = const_cast<ViReal64*>(request->numbers().data());
       auto status = library_->DoubleAllTheNums(vi, number_count, numbers);
       response->set_status(status);
@@ -917,7 +917,7 @@ namespace nifake_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 size_in_bytes = request->configuration().size();
+      ViInt32 size_in_bytes = static_cast<ViInt32>(request->configuration().size());
       ViInt8* configuration = (ViInt8*)request->configuration().c_str();
       auto status = library_->ImportAttributeConfigurationBuffer(vi, size_in_bytes, configuration);
       response->set_status(status);
@@ -1003,7 +1003,7 @@ namespace nifake_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 output_array_size = request->output_array_size();
-      ViInt32 input_array_sizes = request->input_array_of_integers().size();
+      ViInt32 input_array_sizes = static_cast<ViInt32>(request->input_array_of_integers().size());
       auto input_array_of_floats = const_cast<ViReal64*>(request->input_array_of_floats().data());
       auto input_array_of_integers_request = request->input_array_of_integers();
       std::vector<ViInt16> input_array_of_integers;
@@ -1041,7 +1041,7 @@ namespace nifake_grpc {
       auto values2 = const_cast<ViReal64*>(request->values2().data());
       auto values3 = const_cast<ViReal64*>(request->values3().data());
       auto values4 = const_cast<ViReal64*>(request->values4().data());
-      ViInt32 size = request->values4().size();
+      ViInt32 size = static_cast<ViInt32>(request->values4().size());
       auto status = library_->MultipleArraysSameSize(vi, values1, values2, values3, values4, size);
       response->set_status(status);
       return ::grpc::Status::OK;
@@ -1121,7 +1121,7 @@ namespace nifake_grpc {
         }
       }
 
-      ViInt32 string_size = request->a_string().size();
+      ViInt32 string_size = static_cast<ViInt32>(request->a_string().size());
       auto a_string = request->a_string().c_str();
       auto status = library_->ParametersAreMultipleTypes(vi, a_boolean, an_int32, an_int64, an_int_enum, a_float, a_float_enum, string_size, a_string);
       response->set_status(status);
@@ -1336,7 +1336,7 @@ namespace nifake_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 number_of_elements = request->cs().size();
+      ViInt32 number_of_elements = static_cast<ViInt32>(request->cs().size());
       auto cs_request = request->cs();
       std::vector<CustomStruct> cs;
       Copy(cs_request, &cs);
@@ -1443,7 +1443,7 @@ namespace nifake_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 number_of_samples = request->waveform().size();
+      ViInt32 number_of_samples = static_cast<ViInt32>(request->waveform().size());
       auto waveform = const_cast<ViReal64*>(request->waveform().data());
       auto status = library_->WriteWaveform(vi, number_of_samples, waveform);
       response->set_status(status);
@@ -1550,7 +1550,7 @@ namespace nifake_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 number_of_elements = request->an_array().size();
+      ViInt32 number_of_elements = static_cast<ViInt32>(request->an_array().size());
       auto an_array_request = request->an_array();
       std::vector<ViInt16> an_array;
       std::transform(

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -95,12 +95,12 @@ private:
   void Copy(const std::vector<CustomStruct>& input, google::protobuf::RepeatedPtrField<nifake_grpc::FakeCustomStruct>* output);
   CustomStruct ConvertMessage(const nifake_grpc::FakeCustomStruct& input);
   void Copy(const google::protobuf::RepeatedPtrField<nifake_grpc::FakeCustomStruct>& input, std::vector<CustomStruct>* output);
-  std::map<std::int32_t, float> floatenum_input_map_ { {1, 3.5f},{2, 4.5f},{3, 5.5f},{4, 6.5f},{5, 7.5f}, };
-  std::map<float, std::int32_t> floatenum_output_map_ { {3.5f, 1},{4.5f, 2},{5.5f, 3},{6.5f, 4},{7.5f, 5}, };
+  std::map<std::int32_t, double> floatenum_input_map_ { {1, 3.5f},{2, 4.5f},{3, 5.5f},{4, 6.5f},{5, 7.5f}, };
+  std::map<double, std::int32_t> floatenum_output_map_ { {3.5f, 1},{4.5f, 2},{5.5f, 3},{6.5f, 4},{7.5f, 5}, };
   std::map<std::int32_t, std::string> mobileosnames_input_map_ { {1, "Android"},{2, "iOS"},{3, "None"}, };
   std::map<std::string, std::int32_t> mobileosnames_output_map_ { {"Android", 1},{"iOS", 2},{"None", 3}, };
-  std::map<std::int32_t, float> nifakereal64attributevaluesmapped_input_map_ { {1, 3.5f},{2, 4.5f},{3, 5.5f},{4, 6.5f},{5, 7.5f}, };
-  std::map<float, std::int32_t> nifakereal64attributevaluesmapped_output_map_ { {3.5f, 1},{4.5f, 2},{5.5f, 3},{6.5f, 4},{7.5f, 5}, };
+  std::map<std::int32_t, double> nifakereal64attributevaluesmapped_input_map_ { {1, 3.5f},{2, 4.5f},{3, 5.5f},{4, 6.5f},{5, 7.5f}, };
+  std::map<double, std::int32_t> nifakereal64attributevaluesmapped_output_map_ { {3.5f, 1},{4.5f, 2},{5.5f, 3},{6.5f, 4},{7.5f, 5}, };
 };
 
 } // namespace nifake_grpc

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -660,7 +660,7 @@ namespace nifgen_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
-      ViInt32 number_of_coefficients = request->coefficients_array().size();
+      ViInt32 number_of_coefficients = static_cast<ViInt32>(request->coefficients_array().size());
       auto coefficients_array = const_cast<ViReal64*>(request->coefficients_array().data());
       auto status = library_->ConfigureCustomFIRFilterCoefficients(vi, channel_name, number_of_coefficients, coefficients_array);
       response->set_status(status);
@@ -1106,7 +1106,7 @@ namespace nifgen_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 sequence_length = request->loop_counts_array().size();
+      ViInt32 sequence_length = static_cast<ViInt32>(request->loop_counts_array().size());
       auto waveform_handles_array = const_cast<ViInt32*>(reinterpret_cast<const ViInt32*>(request->waveform_handles_array().data()));
       auto loop_counts_array = const_cast<ViInt32*>(reinterpret_cast<const ViInt32*>(request->loop_counts_array().data()));
       ViInt32 sequence_handle {};
@@ -1148,7 +1148,7 @@ namespace nifgen_grpc {
         }
       }
 
-      ViInt32 frequency_list_length = request->duration_array().size();
+      ViInt32 frequency_list_length = static_cast<ViInt32>(request->duration_array().size());
       auto frequency_array = const_cast<ViReal64*>(request->frequency_array().data());
       auto duration_array = const_cast<ViReal64*>(request->duration_array().data());
       ViInt32 frequency_list_handle {};
@@ -1175,7 +1175,7 @@ namespace nifgen_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
-      ViInt32 number_of_samples = request->waveform_data_array().size();
+      ViInt32 number_of_samples = static_cast<ViInt32>(request->waveform_data_array().size());
       auto waveform_data_array_request = request->waveform_data_array();
       std::vector<NIComplexNumber_struct> waveform_data_array;
       Copy(waveform_data_array_request, &waveform_data_array);
@@ -1203,7 +1203,7 @@ namespace nifgen_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
-      ViInt32 waveform_size = request->waveform_data_array().size();
+      ViInt32 waveform_size = static_cast<ViInt32>(request->waveform_data_array().size());
       auto waveform_data_array = const_cast<ViReal64*>(request->waveform_data_array().data());
       ViInt32 waveform_handle {};
       auto status = library_->CreateWaveformF64(vi, channel_name, waveform_size, waveform_data_array, &waveform_handle);
@@ -1297,7 +1297,7 @@ namespace nifgen_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
-      ViInt32 waveform_size = request->waveform_data_array().size();
+      ViInt32 waveform_size = static_cast<ViInt32>(request->waveform_data_array().size());
       auto waveform_data_array_request = request->waveform_data_array();
       std::vector<ViInt16> waveform_data_array;
       std::transform(
@@ -1370,7 +1370,7 @@ namespace nifgen_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
-      ViInt32 waveform_size = request->waveform_data_array().size();
+      ViInt32 waveform_size = static_cast<ViInt32>(request->waveform_data_array().size());
       auto waveform_data_array = const_cast<ViReal64*>(request->waveform_data_array().data());
       auto status = library_->DefineUserStandardWaveform(vi, channel_name, waveform_size, waveform_data_array);
       response->set_status(status);
@@ -2307,7 +2307,7 @@ namespace nifgen_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 size_in_bytes = request->configuration().size();
+      ViInt32 size_in_bytes = static_cast<ViInt32>(request->configuration().size());
       auto configuration = const_cast<ViAddr*>(reinterpret_cast<const ViAddr*>(request->configuration().data()));
       auto status = library_->ImportAttributeConfigurationBuffer(vi, size_in_bytes, configuration);
       response->set_status(status);
@@ -3202,7 +3202,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 waveform_handle = request->waveform_handle();
-      ViInt32 size = request->data().size();
+      ViInt32 size = static_cast<ViInt32>(request->data().size());
       auto data_request = request->data();
       std::vector<ViInt16> data;
       std::transform(
@@ -3231,7 +3231,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 waveform_handle = request->waveform_handle();
-      ViInt32 size = request->data().size();
+      ViInt32 size = static_cast<ViInt32>(request->data().size());
       auto data_request = request->data();
       std::vector<NIComplexI16_struct> data;
       Copy(data_request, &data);
@@ -3256,7 +3256,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto waveform_name = request->waveform_name().c_str();
-      ViInt32 size = request->data().size();
+      ViInt32 size = static_cast<ViInt32>(request->data().size());
       auto data = const_cast<ViReal64*>(request->data().data());
       auto status = library_->WriteNamedWaveformF64(vi, channel_name, waveform_name, size, data);
       response->set_status(status);
@@ -3279,7 +3279,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto waveform_name = request->waveform_name().c_str();
-      ViInt32 size = request->data().size();
+      ViInt32 size = static_cast<ViInt32>(request->data().size());
       auto data_request = request->data();
       std::vector<ViInt16> data;
       std::transform(
@@ -3307,7 +3307,7 @@ namespace nifgen_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto endpoint_name = request->endpoint_name().c_str();
-      ViInt32 number_of_samples = request->endpoint_data().size();
+      ViInt32 number_of_samples = static_cast<ViInt32>(request->endpoint_data().size());
       auto endpoint_data_request = request->endpoint_data();
       std::vector<ViInt16> endpoint_data;
       std::transform(
@@ -3357,7 +3357,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 waveform_handle = request->waveform_handle();
-      ViInt32 size = request->data().size();
+      ViInt32 size = static_cast<ViInt32>(request->data().size());
       auto data = const_cast<ViReal64*>(request->data().data());
       auto status = library_->WriteWaveform(vi, channel_name, waveform_handle, size, data);
       response->set_status(status);
@@ -3379,7 +3379,7 @@ namespace nifgen_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
-      ViInt32 number_of_samples = request->data().size();
+      ViInt32 number_of_samples = static_cast<ViInt32>(request->data().size());
       auto data_request = request->data();
       std::vector<NIComplexNumber_struct> data;
       Copy(data_request, &data);
@@ -3405,7 +3405,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto waveform_name = request->waveform_name().c_str();
-      ViInt32 size = request->data().size();
+      ViInt32 size = static_cast<ViInt32>(request->data().size());
       auto data_request = request->data();
       std::vector<NIComplexNumber_struct> data;
       Copy(data_request, &data);
@@ -3430,7 +3430,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto waveform_name = request->waveform_name().c_str();
-      ViInt32 size = request->data().size();
+      ViInt32 size = static_cast<ViInt32>(request->data().size());
       auto data_request = request->data();
       std::vector<NIComplexI16_struct> data;
       Copy(data_request, &data);

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -718,7 +718,7 @@ namespace niscope_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
-      ViInt32 number_of_coefficients = request->coefficients().size();
+      ViInt32 number_of_coefficients = static_cast<ViInt32>(request->coefficients().size());
       auto coefficients = const_cast<ViReal64*>(request->coefficients().data());
       auto status = library_->ConfigureEqualizationFilterCoefficients(vi, channel_list, number_of_coefficients, coefficients);
       response->set_status(status);
@@ -1852,7 +1852,7 @@ namespace niscope_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 size_in_bytes = request->configuration().size();
+      ViInt32 size_in_bytes = static_cast<ViInt32>(request->configuration().size());
       ViInt8* configuration = (ViInt8*)request->configuration().c_str();
       auto status = library_->ImportAttributeConfigurationBuffer(vi, size_in_bytes, configuration);
       response->set_status(status);

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -31,7 +31,7 @@ namespace nitclk_grpc {
       return ::grpc::Status::CANCELLED;
     }
     try {
-      ViUInt32 session_count = request->sessions().size();
+      ViUInt32 session_count = static_cast<ViUInt32>(request->sessions().size());
       auto sessions_request = request->sessions();
       std::vector<ViSession> sessions;
       std::transform(
@@ -56,7 +56,7 @@ namespace nitclk_grpc {
       return ::grpc::Status::CANCELLED;
     }
     try {
-      ViUInt32 session_count = request->sessions().size();
+      ViUInt32 session_count = static_cast<ViUInt32>(request->sessions().size());
       auto sessions_request = request->sessions();
       std::vector<ViSession> sessions;
       std::transform(
@@ -165,7 +165,7 @@ namespace nitclk_grpc {
       return ::grpc::Status::CANCELLED;
     }
     try {
-      ViUInt32 session_count = request->sessions().size();
+      ViUInt32 session_count = static_cast<ViUInt32>(request->sessions().size());
       auto sessions_request = request->sessions();
       std::vector<ViSession> sessions;
       std::transform(
@@ -190,7 +190,7 @@ namespace nitclk_grpc {
       return ::grpc::Status::CANCELLED;
     }
     try {
-      ViUInt32 session_count = request->sessions().size();
+      ViUInt32 session_count = static_cast<ViUInt32>(request->sessions().size());
       auto sessions_request = request->sessions();
       std::vector<ViSession> sessions;
       std::transform(
@@ -286,7 +286,7 @@ namespace nitclk_grpc {
       return ::grpc::Status::CANCELLED;
     }
     try {
-      ViUInt32 session_count = request->sessions().size();
+      ViUInt32 session_count = static_cast<ViUInt32>(request->sessions().size());
       auto sessions_request = request->sessions();
       std::vector<ViSession> sessions;
       std::transform(
@@ -312,7 +312,7 @@ namespace nitclk_grpc {
       return ::grpc::Status::CANCELLED;
     }
     try {
-      ViUInt32 session_count = request->sessions().size();
+      ViUInt32 session_count = static_cast<ViUInt32>(request->sessions().size());
       auto sessions_request = request->sessions();
       std::vector<ViSession> sessions;
       std::transform(
@@ -338,7 +338,7 @@ namespace nitclk_grpc {
       return ::grpc::Status::CANCELLED;
     }
     try {
-      ViUInt32 session_count = request->sessions().size();
+      ViUInt32 session_count = static_cast<ViUInt32>(request->sessions().size());
       auto sessions_request = request->sessions();
       std::vector<ViSession> sessions;
       std::transform(
@@ -364,7 +364,7 @@ namespace nitclk_grpc {
       return ::grpc::Status::CANCELLED;
     }
     try {
-      ViUInt32 session_count = request->sessions().size();
+      ViUInt32 session_count = static_cast<ViUInt32>(request->sessions().size());
       auto sessions_request = request->sessions();
       std::vector<ViSession> sessions;
       std::transform(

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -178,7 +178,7 @@ def create_param(parameter, expand_varargs=True, any_not_include_in_proto=False)
 def python_to_c(enum):
     enum_value = enum["values"][0]["value"]
     if isinstance(enum_value, float):
-        return "float"
+        return "double"
     if isinstance(enum_value, int):
         return "std::int32_t"
     if isinstance(enum_value, str):

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -328,7 +328,7 @@ ${initialize_standard_input_param(function_name, parameter)}
   parameter_name = common_helpers.camel_to_snake(parameter['cppName'])
   field_name = common_helpers.camel_to_snake(parameter["determine_size_from"])
 %>\
-      ${parameter['type']} ${parameter_name} = request->${field_name}().size();\
+      ${parameter['type']} ${parameter_name} = static_cast<${parameter['type']}>(request->${field_name}().size());\
 </%def>
 
 

--- a/source/custom/nidaqmx_conversions.h
+++ b/source/custom/nidaqmx_conversions.h
@@ -31,7 +31,7 @@ void convert_to_grpc(const CVIAbsoluteTime& value, google::protobuf::Timestamp* 
   // This is losing some precision since doubles have 52 bits of precision.
   // But there are only 10^9 nanoseconds in a second which is ~31 bits of precision,
   // so it's still good enough for our purposes.
-  timestamp->set_nanos((static_cast<double>(value.cviTime.lsb) * NanosecondsPerSecond) / TwoToSixtyFour);
+  timestamp->set_nanos(static_cast<int32>((static_cast<double>(value.cviTime.lsb) * NanosecondsPerSecond) / TwoToSixtyFour));
 }
 
 template <>

--- a/source/custom/niscope_service.custom.cpp
+++ b/source/custom/niscope_service.custom.cpp
@@ -486,7 +486,7 @@ void CheckStatus(int status)
     CheckStatus(library_->GetScalingCoefficients(vi, channel_list, 0, nullptr, &number_of_coefficient_sets));
 
     std::vector<niScope_coefficientInfo> coefficient_info(number_of_coefficient_sets, niScope_coefficientInfo());
-    auto status = library_->GetScalingCoefficients(vi, channel_list, coefficient_info.size(), coefficient_info.data(), &number_of_coefficient_sets);
+    auto status = library_->GetScalingCoefficients(vi, channel_list, static_cast<ViInt32>(coefficient_info.size()), coefficient_info.data(), &number_of_coefficient_sets);
     response->set_status(status);
     if (status == 0) {
       response->set_number_of_coefficient_sets(number_of_coefficient_sets);

--- a/source/custom/niscope_service.custom.cpp
+++ b/source/custom/niscope_service.custom.cpp
@@ -453,7 +453,7 @@ void CheckStatus(int status)
     CheckStatus(library_->GetNormalizationCoefficients(vi, channel_list, 0, nullptr, &number_of_coefficient_sets));
 
     std::vector<niScope_coefficientInfo> coefficient_info(number_of_coefficient_sets, niScope_coefficientInfo());
-    auto status = library_->GetNormalizationCoefficients(vi, channel_list, coefficient_info.size(), coefficient_info.data(), &number_of_coefficient_sets);
+    auto status = library_->GetNormalizationCoefficients(vi, channel_list, static_cast<ViInt32>(coefficient_info.size()), coefficient_info.data(), &number_of_coefficient_sets);
     response->set_status(status);
     if (status == 0) {
       response->set_number_of_coefficient_sets(number_of_coefficient_sets);

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -1313,7 +1313,7 @@ TEST(NiFakeServiceTests, NiFakeService_ViUInt8ArrayInputFunction_CallsViUInt8Arr
   std::string input_array;
   input_array.push_back(0);
   input_array.push_back(127);
-  input_array.push_back(0xFF);
+  input_array.push_back(static_cast<char>(0xFF));
   request.set_an_array(input_array);
   nifake_grpc::ViUInt8ArrayInputFunctionResponse response;
   ::grpc::Status status = service.ViUInt8ArrayInputFunction(&context, &request, &response);


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fix some C++ warnings.

I was hoping to fix all warnings, but there's one caused by gRPC itself, and a few caused by delay loading some libraries we don't currently use in `ni_grpc_device_server` (`nidcpower.dll`, `niScope.dll`, and `niswitch.dll`). I'm assuming we will use those libraries at some point so I'm not removing them now.

Note that each commit in this PR fixes one category of warning, if that's easier to read.

### Why should this Pull Request be merged?

Fewer warnings makes it easier to see when new warnings are introduced.

### What testing has been done?

Ran unit tests.