### PR TITLE
Add comment about simulated hardware

### DIFF
--- a/examples/nidaqmx/analog-input-betterproto.py
+++ b/examples/nidaqmx/analog-input-betterproto.py
@@ -20,6 +20,8 @@
 # when calling cfg_samp_clk_timing, we set active_edge_raw instead of active_edge to avoid a default raw value
 # being used.
 #
+# To run this example without hardware: create a simulated device in NI MAX on the server (Windows only).
+# 
 # Running from command line:
 #
 # Server machine's IP address, port number, and physical channel name can be passed as separate command line arguments.

--- a/examples/nidaqmx/analog-input.py
+++ b/examples/nidaqmx/analog-input.py
@@ -11,6 +11,8 @@
 # For instructions on how to use protoc to generate gRPC client interfaces, see our "Creating a gRPC Client" wiki page.
 # Link: https://github.com/ni/grpc-device/wiki/Creating-a-gRPC-Client
 #
+# To run this example without hardware: create a simulated device in NI MAX on the server (Windows only).
+#
 # Running from command line:
 #
 # Server machine's IP address, port number, and physical channel name can be passed as separate command line arguments.

--- a/examples/nidaqmx/analog-output.py
+++ b/examples/nidaqmx/analog-output.py
@@ -11,6 +11,8 @@
 # For instructions on how to use protoc to generate gRPC client interfaces, see our "Creating a gRPC Client" wiki page.
 # Link: https://github.com/ni/grpc-device/wiki/Creating-a-gRPC-Client
 #
+# To run this example without hardware: create a simulated device in NI MAX on the server (Windows only).
+#
 # Running from command line:
 #
 # Server machine's IP address, port number, and physical channel name can be passed as separate command line arguments.

--- a/examples/nidaqmx/counter-input.py
+++ b/examples/nidaqmx/counter-input.py
@@ -11,6 +11,8 @@
 # For instructions on how to use protoc to generate gRPC client interfaces, see our "Creating a gRPC Client" wiki page.
 # Link: https://github.com/ni/grpc-device/wiki/Creating-a-gRPC-Client
 #
+# To run this example without hardware: create a simulated device in NI MAX on the server (Windows only).
+#
 # Running from command line:
 #
 # Server machine's IP address, port number, and counter name can be passed as separate command line arguments.

--- a/examples/nidaqmx/counter-output.py
+++ b/examples/nidaqmx/counter-output.py
@@ -11,6 +11,8 @@
 # For instructions on how to use protoc to generate gRPC client interfaces, see our "Creating a gRPC Client" wiki page.
 # Link: https://github.com/ni/grpc-device/wiki/Creating-a-gRPC-Client
 #
+# To run this example without hardware: create a simulated device in NI MAX on the server (Windows only).
+#
 # Running from command line:
 #
 # Server machine's IP address, port number, and counter name can be passed as separate command line arguments.

--- a/examples/nidaqmx/digital-input-betterproto.py
+++ b/examples/nidaqmx/digital-input-betterproto.py
@@ -20,6 +20,8 @@
 # when calling read_digital_u32, we set fill_mode_raw instead of fill_mode to avoid a default raw value
 # being used.
 #
+# To run this example without hardware: create a simulated device in NI MAX on the server (Windows only).
+#
 # Running from command line:
 #
 # Server machine's IP address, port number, and lines name can be passed as separate command line arguments.

--- a/examples/nidaqmx/digital-input.py
+++ b/examples/nidaqmx/digital-input.py
@@ -11,6 +11,8 @@
 # For instructions on how to use protoc to generate gRPC client interfaces, see our "Creating a gRPC Client" wiki page.
 # Link: https://github.com/ni/grpc-device/wiki/Creating-a-gRPC-Client
 #
+# To run this example without hardware: create a simulated device in NI MAX on the server (Windows only).
+#
 # Running from command line:
 #
 # Server machine's IP address, port number, and lines name can be passed as separate command line arguments.

--- a/examples/nidaqmx/digital-output.py
+++ b/examples/nidaqmx/digital-output.py
@@ -11,6 +11,8 @@
 # For instructions on how to use protoc to generate gRPC client interfaces, see our "Creating a gRPC Client" wiki page.
 # Link: https://github.com/ni/grpc-device/wiki/Creating-a-gRPC-Client
 #
+# To run this example without hardware: create a simulated device in NI MAX on the server (Windows only).
+#
 # Running from command line:
 #
 # Server machine's IP address, port number, and lines name can be passed as separate command line arguments.


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add the following comment to nidaqmx examples:
```python
# To run this example without hardware: create a simulated device in NI MAX on the server (Windows only).
```

### Why should this Pull Request be merged?

MI supports per-session simulated devices through their C API. This allows them to be run without hardware with no special setup. DAQ does not have that feature and the comment explains the extra step.

### What testing has been done?

None
