### PR TITLE
Add automated spot tests for DAQmx Advanced API

### DIFF
--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -733,6 +733,16 @@ class NiDAQmxDriverApiTests : public Test {
     return stub()->WaitForNextSampleClock(&context, request, &response);
   }
 
+  ::grpc::Status connect_terms(const std::string& source, const std::string& destination, ConnectTermsResponse& response)
+  {
+    ::grpc::ClientContext context;
+    ConnectTermsRequest request;
+    request.set_source_terminal(source);
+    request.set_destination_terminal(destination);
+    request.set_signal_modifiers(InvertPolarity::INVERT_POLARITY_DO_NOT_INVERT_POLARITY);
+    return stub()->ConnectTerms(&context, request, &response);
+  }
+
   std::unique_ptr<NiDAQmx::Stub>& stub()
   {
     return nidaqmx_stub_;
@@ -1474,6 +1484,14 @@ TEST_F(NiDAQmxDriverApiTests, HardwareTimedTask_WaitForNextSampleClock_Succeeds)
   auto status = wait_for_next_sample_clock(response);
 
   EXPECT_SUCCESS(status, response);
+}
+
+TEST_F(NiDAQmxDriverApiTests, ConnectBogusTerms_FailsWithInvalidRoutingError)
+{
+  auto response = ConnectTermsResponse{};
+  auto status = connect_terms("ABC", "123", response);
+
+  EXPECT_DAQ_ERROR(DAQmxErrorInvalidTerm_Routing, status, response);
 }
 
 }  // namespace system

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -1557,7 +1557,7 @@ TEST_F(NiDAQmxDriverApiTests, DOWatchdogTask_StartTaskAndWatchdogTask_Succeeds)
       create_watchdog_response.task(),
       start_watchdog_response);
 
-  EXPECT_SUCCESS(start_watchdog_status, start_watchdown_response);
+  EXPECT_SUCCESS(start_watchdog_status, start_watchdog_response);
 }
 
 TEST_F(NiDAQmxDriverApiTests, AutoConfigureCDAQSyncConnections_ReturnsNotSupportedError)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add tests for every subsection of the advanced API.
Where the API is not easily testable with the simulated hardware setup: test for an API specific error code instead.

### Why should this Pull Request be merged?

Ensures that each API/concept has some code coverage testing.
Adds basic workflow testing for some advanced features.

### What testing has been done?

Ran and passed all DAQ tests.