### PR TITLE
Add support for attribute value enum output parameters

### DIFF
--- a/generated/nidaqmx/nidaqmx.proto
+++ b/generated/nidaqmx/nidaqmx.proto
@@ -3725,7 +3725,8 @@ message GetScaleAttributeInt32Request {
 
 message GetScaleAttributeInt32Response {
   int32 status = 1;
-  int32 value = 2;
+  ScaleInt32AttributeValues value = 2;
+  int32 value_raw = 3;
 }
 
 message GetScaleAttributeStringRequest {

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -7406,7 +7406,10 @@ namespace nidaqmx_grpc {
       auto status = library_->GetScaleAttributeInt32(scale_name, attribute, &value, size);
       response->set_status(status);
       if (status == 0) {
-        response->set_value(value);
+        bool value_is_valid = nidaqmx_grpc::ScaleInt32AttributeValues_IsValid(value);
+        auto value_as_valid_enum_value = value_is_valid ? value : 0;
+        response->set_value(static_cast<nidaqmx_grpc::ScaleInt32AttributeValues>(value_as_valid_enum_value));
+        response->set_value_raw(value);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nifake_non_ivi/nifake_non_ivi.proto
+++ b/generated/nifake_non_ivi/nifake_non_ivi.proto
@@ -41,6 +41,7 @@ service NiFakeNonIvi {
 enum MarbleInt32Attributes {
   MARBLE_INT32_ATTRIBUTE_UNSPECIFIED = 0;
   MARBLE_ATTRIBUTE_COLOR = 1234;
+  MARBLE_ATTRIBUTE_NUMBER_OF_FAILED_ATTEMPTS = 1551;
 }
 
 enum MarbleDoubleAttributes {
@@ -100,7 +101,8 @@ message GetMarbleAttributeInt32Request {
 
 message GetMarbleAttributeInt32Response {
   int32 status = 1;
-  int32 value = 2;
+  MarbleInt32AttributeValues value = 2;
+  int32 value_raw = 3;
 }
 
 message InitRequest {

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -85,7 +85,10 @@ namespace nifake_non_ivi_grpc {
       auto status = library_->GetMarbleAttributeInt32(handle, attribute, &value);
       response->set_status(status);
       if (status == 0) {
-        response->set_value(value);
+        bool value_is_valid = nifake_non_ivi_grpc::MarbleInt32AttributeValues_IsValid(value);
+        auto value_as_valid_enum_value = value_is_valid ? value : 0;
+        response->set_value(static_cast<nifake_non_ivi_grpc::MarbleInt32AttributeValues>(value_as_valid_enum_value));
+        response->set_value_raw(value);
       }
       return ::grpc::Status::OK;
     }

--- a/source/codegen/metadata/nifake_non_ivi/attributes.py
+++ b/source/codegen/metadata/nifake_non_ivi/attributes.py
@@ -7,6 +7,12 @@ attributes = {
             'resettable': False,
             'type': 'int32'
         },
+        1551: {
+            'access': 'read-write',
+            'name': 'NUMBER_OF_FAILED_ATTEMPTS',
+            'resettable': False,
+            'type': 'int32'
+        },
         4444: {
             'access': 'read-write',
             'name': 'WEIGHT',

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -544,6 +544,10 @@ ${initialize_standard_input_param(function_name, parameter)}
         if(${parameter_name} == (int)${parameter_name}) {
           response->set_${parameter_name}(static_cast<${namespace_prefix}${parameter["enum"]}>(static_cast<int>(${parameter_name})));
         }
+%       elif parameter.get("use_checked_enum_conversion", False):
+        bool ${parameter_name}_is_valid = ${namespace_prefix}${parameter["enum"]}_IsValid(${parameter_name});
+        auto ${parameter_name}_as_valid_enum_value = ${parameter_name}_is_valid ? ${parameter_name} : 0;
+        response->set_${parameter_name}(static_cast<${namespace_prefix}${parameter["enum"]}>(${parameter_name}_as_valid_enum_value));
 %       else:
         response->set_${parameter_name}(static_cast<${namespace_prefix}${parameter["enum"]}>(${parameter_name}));
 %       endif

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -393,6 +393,7 @@ class NiDAQmxDriverApiTests : public Test {
     set_request_session_id(request);
     return stub()->RegisterDoneEvent(&context, request);
   }
+
   auto register_every_n_samples_event(::grpc::ClientContext& context, uint32 n_samples)
   {
     RegisterEveryNSamplesEventRequest request;
@@ -1102,6 +1103,7 @@ TEST_F(NiDAQmxDriverApiTests, SetPreScaledUnits_GetPreScaledUnits_ReturnsAttribu
   EXPECT_SUCCESS(set_status, set_response);
   EXPECT_SUCCESS(status, response);
   EXPECT_EQ(ScaleInt32AttributeValues::SCALE_INT32_UNITS_PRE_SCALED_RPM, response.value());
+  EXPECT_EQ(ScaleInt32AttributeValues::SCALE_INT32_UNITS_PRE_SCALED_RPM, response.value_raw());
 }
 
 TEST_F(NiDAQmxDriverApiTests, GetScaledUnitsAsDouble_Fails)

--- a/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
+++ b/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
@@ -793,7 +793,7 @@ TEST_F(NiFakeNonIviServiceTests, SetMarbleAttributeInt32Raw_Succeeds)
   EXPECT_EQ(kDriverSuccess, response.status());
 }
 
-TEST_F(NiFakeNonIviServiceTests, GetMarbleAttributeInt32_Succeeds)
+TEST_F(NiFakeNonIviServiceTests, GetMarbleAttributeInt32Enum_ReturnsValueAndValueRaw)
 {
   const auto ATTRIBUTE = MarbleInt32Attributes::MARBLE_ATTRIBUTE_COLOR;
   const auto VALUE = MarbleInt32AttributeValues::MARBLE_INT32_BEAUTIFUL_COLOR_AQUA;
@@ -807,6 +807,24 @@ TEST_F(NiFakeNonIviServiceTests, GetMarbleAttributeInt32_Succeeds)
 
   EXPECT_EQ(kDriverSuccess, response.status());
   EXPECT_EQ(VALUE, response.value());
+  EXPECT_EQ(VALUE, response.value_raw());
+}
+
+TEST_F(NiFakeNonIviServiceTests, GetMarbleAttributeInt32NonEnum_ReturnsValueRawAndUnspecifiedValue)
+{
+  const auto ATTRIBUTE = MarbleInt32Attributes::MARBLE_ATTRIBUTE_NUMBER_OF_FAILED_ATTEMPTS;
+  const auto VALUE = 1000;
+  EXPECT_CALL(library_, GetMarbleAttributeInt32(_, ATTRIBUTE, _))
+      .WillOnce(DoAll(SetArgPointee<2>(VALUE), Return(kDriverSuccess)));
+  ::grpc::ServerContext context;
+  GetMarbleAttributeInt32Request request;
+  request.set_attribute(ATTRIBUTE);
+  GetMarbleAttributeInt32Response response;
+  service_.GetMarbleAttributeInt32(&context, &request, &response);
+
+  EXPECT_EQ(kDriverSuccess, response.status());
+  EXPECT_EQ(MarbleInt32AttributeValues::MARBLE_INT32_UNSPECIFIED, response.value());
+  EXPECT_EQ(VALUE, response.value_raw());
 }
 
 TEST_F(NiFakeNonIviServiceTests, ResetMarbleAttribute_Succeeds)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add support for enum output parameters for DAQ attributes.

Because attribute outputs are not guaranteed to be within the enum values. This requires a checked conversion using the protobuf generated IsValid methods.

### Why should this Pull Request be merged?

This makes it easier to determine if an output value is an enum and also to get correct auto-complete/etc for valid enum values.

### What testing has been done?

Ran and passed all DAQ tests.