### PR TITLE
Fix race condition in IVI dance (fixes #247)

### DIFF
--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -2160,20 +2160,26 @@ namespace nidcpower_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
 
-      auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 size = status;
+      
+        response->mutable_configuration()->Resize(size, 0);
+        ViAddr* configuration = reinterpret_cast<ViAddr*>(response->mutable_configuration()->mutable_data());
+        status = library_->ExportAttributeConfigurationBuffer(vi, size, configuration);
+        if (status > size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 size = status;
-
-      response->mutable_configuration()->Resize(size, 0);
-      ViAddr* configuration = reinterpret_cast<ViAddr*>(response->mutable_configuration()->mutable_data());
-      status = library_->ExportAttributeConfigurationBuffer(vi, size, configuration);
-      response->set_status(status);
-      if (status == 0) {
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -2408,23 +2414,29 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
 
-      auto status = library_->GetAttributeViString(vi, channel_name, attribute_id, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetAttributeViString(vi, channel_name, attribute_id, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string attribute_value;
+        if (buffer_size > 0) {
+            attribute_value.resize(buffer_size-1);
+        }
+        status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_attribute_value(attribute_value);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string attribute_value;
-      if (buffer_size > 0) {
-          attribute_value.resize(buffer_size-1);
-      }
-      status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_attribute_value(attribute_value);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -2443,23 +2455,29 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 index = request->index();
 
-      auto status = library_->GetChannelName(vi, index, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetChannelName(vi, index, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string channel_name;
+        if (buffer_size > 0) {
+            channel_name.resize(buffer_size-1);
+        }
+        status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_name.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_channel_name(channel_name);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string channel_name;
-      if (buffer_size > 0) {
-          channel_name.resize(buffer_size-1);
-      }
-      status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_name.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_channel_name(channel_name);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -2478,23 +2496,29 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto index = request->index().c_str();
 
-      auto status = library_->GetChannelNameFromString(vi, index, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetChannelNameFromString(vi, index, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string channel_name;
+        if (buffer_size > 0) {
+            channel_name.resize(buffer_size-1);
+        }
+        status = library_->GetChannelNameFromString(vi, index, buffer_size, (ViChar*)channel_name.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_channel_name(channel_name);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string channel_name;
-      if (buffer_size > 0) {
-          channel_name.resize(buffer_size-1);
-      }
-      status = library_->GetChannelNameFromString(vi, index, buffer_size, (ViChar*)channel_name.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_channel_name(channel_name);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -2512,25 +2536,31 @@ namespace nidcpower_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
 
-      auto status = library_->GetError(vi, nullptr, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetError(vi, nullptr, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        ViStatus code {};
+        std::string description;
+        if (buffer_size > 0) {
+            description.resize(buffer_size-1);
+        }
+        status = library_->GetError(vi, &code, buffer_size, (ViChar*)description.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
-        return ::grpc::Status::OK;
-      }
-      ViInt32 buffer_size = status;
-
-      ViStatus code {};
-      std::string description;
-      if (buffer_size > 0) {
-          description.resize(buffer_size-1);
-      }
-      status = library_->GetError(vi, &code, buffer_size, (ViChar*)description.data());
-      response->set_status(status);
-      if (status == 0) {
+        if (status == 0) {
         response->set_code(code);
         response->set_description(description);
+        }
+        return ::grpc::Status::OK;
       }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -2625,23 +2655,29 @@ namespace nidcpower_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
 
-      auto status = library_->GetNextCoercionRecord(vi, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetNextCoercionRecord(vi, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string coercion_record;
+        if (buffer_size > 0) {
+            coercion_record.resize(buffer_size-1);
+        }
+        status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_coercion_record(coercion_record);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string coercion_record;
-      if (buffer_size > 0) {
-          coercion_record.resize(buffer_size-1);
-      }
-      status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_coercion_record(coercion_record);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -2659,23 +2695,29 @@ namespace nidcpower_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
 
-      auto status = library_->GetNextInterchangeWarning(vi, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetNextInterchangeWarning(vi, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string interchange_warning;
+        if (buffer_size > 0) {
+            interchange_warning.resize(buffer_size-1);
+        }
+        status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_interchange_warning(interchange_warning);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string interchange_warning;
-      if (buffer_size > 0) {
-          interchange_warning.resize(buffer_size-1);
-      }
-      status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_interchange_warning(interchange_warning);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -11,9 +11,10 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-const auto kErrorReadBufferTooSmall = -200229;
 
 namespace nidcpower_grpc {
+
+  const auto kErrorReadBufferTooSmall = -200229;
 
   NiDCPowerService::NiDCPowerService(NiDCPowerLibraryInterface* library, ResourceRepositorySharedPtr session_repository)
       : library_(library), session_repository_(session_repository)

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+const auto kErrorReadBufferTooSmall = -200229;
 
 namespace nidcpower_grpc {
 
@@ -2171,7 +2172,7 @@ namespace nidcpower_grpc {
         response->mutable_configuration()->Resize(size, 0);
         ViAddr* configuration = reinterpret_cast<ViAddr*>(response->mutable_configuration()->mutable_data());
         status = library_->ExportAttributeConfigurationBuffer(vi, size, configuration);
-        if (status > size) {
+        if (status == kErrorReadBufferTooSmall || status > size) {
           // buffer is now too small, try again
           continue;
         }
@@ -2427,7 +2428,7 @@ namespace nidcpower_grpc {
             attribute_value.resize(buffer_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -2468,7 +2469,7 @@ namespace nidcpower_grpc {
             channel_name.resize(buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_name.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -2509,7 +2510,7 @@ namespace nidcpower_grpc {
             channel_name.resize(buffer_size-1);
         }
         status = library_->GetChannelNameFromString(vi, index, buffer_size, (ViChar*)channel_name.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -2550,7 +2551,7 @@ namespace nidcpower_grpc {
             description.resize(buffer_size-1);
         }
         status = library_->GetError(vi, &code, buffer_size, (ViChar*)description.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -2668,7 +2669,7 @@ namespace nidcpower_grpc {
             coercion_record.resize(buffer_size-1);
         }
         status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -2708,7 +2709,7 @@ namespace nidcpower_grpc {
             interchange_warning.resize(buffer_size-1);
         }
         status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -1752,7 +1752,7 @@ namespace nidigitalpattern_grpc {
             value.resize(buffer_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute, buffer_size, (ViChar*)value.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -1793,7 +1793,7 @@ namespace nidigitalpattern_grpc {
             name.resize(name_buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, name_buffer_size, (ViChar*)name.data());
-        if (status > name_buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > name_buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -1834,7 +1834,7 @@ namespace nidigitalpattern_grpc {
             names.resize(name_buffer_size-1);
         }
         status = library_->GetChannelNameFromString(vi, indices, name_buffer_size, (ViChar*)names.data());
-        if (status > name_buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > name_buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -1875,7 +1875,7 @@ namespace nidigitalpattern_grpc {
             error_description.resize(error_description_buffer_size-1);
         }
         status = library_->GetError(vi, &error_code, error_description_buffer_size, (ViChar*)error_description.data());
-        if (status > error_description_buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > error_description_buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -2015,7 +2015,7 @@ namespace nidigitalpattern_grpc {
             name.resize(name_buffer_size-1);
         }
         status = library_->GetPatternName(vi, pattern_index, name_buffer_size, (ViChar*)name.data());
-        if (status > name_buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > name_buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -2056,7 +2056,7 @@ namespace nidigitalpattern_grpc {
             pin_list.resize(pin_list_buffer_size-1);
         }
         status = library_->GetPatternPinList(vi, start_label, pin_list_buffer_size, (ViChar*)pin_list.data());
-        if (status > pin_list_buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > pin_list_buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -2097,7 +2097,7 @@ namespace nidigitalpattern_grpc {
             name.resize(name_buffer_size-1);
         }
         status = library_->GetPinName(vi, pin_index, name_buffer_size, (ViChar*)name.data());
-        if (status > name_buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > name_buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -2361,7 +2361,7 @@ namespace nidigitalpattern_grpc {
             name.resize(name_buffer_size-1);
         }
         status = library_->GetTimeSetName(vi, time_set_index, name_buffer_size, (ViChar*)name.data());
-        if (status > name_buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > name_buffer_size) {
           // buffer is now too small, try again
           continue;
         }

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -11,9 +11,10 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-const auto kErrorReadBufferTooSmall = -200229;
 
 namespace nidigitalpattern_grpc {
+
+  const auto kErrorReadBufferTooSmall = -200229;
 
   NiDigitalService::NiDigitalService(NiDigitalLibraryInterface* library, ResourceRepositorySharedPtr session_repository)
       : library_(library), session_repository_(session_repository)

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -1720,23 +1720,29 @@ namespace nidigitalpattern_grpc {
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute = request->attribute();
 
-      auto status = library_->GetAttributeViString(vi, channel_name, attribute, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetAttributeViString(vi, channel_name, attribute, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string value;
+        if (buffer_size > 0) {
+            value.resize(buffer_size-1);
+        }
+        status = library_->GetAttributeViString(vi, channel_name, attribute, buffer_size, (ViChar*)value.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_value(value);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string value;
-      if (buffer_size > 0) {
-          value.resize(buffer_size-1);
-      }
-      status = library_->GetAttributeViString(vi, channel_name, attribute, buffer_size, (ViChar*)value.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_value(value);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -1755,23 +1761,29 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 index = request->index();
 
-      auto status = library_->GetChannelName(vi, index, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetChannelName(vi, index, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 name_buffer_size = status;
+      
+        std::string name;
+        if (name_buffer_size > 0) {
+            name.resize(name_buffer_size-1);
+        }
+        status = library_->GetChannelName(vi, index, name_buffer_size, (ViChar*)name.data());
+        if (status > name_buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_name(name);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 name_buffer_size = status;
-
-      std::string name;
-      if (name_buffer_size > 0) {
-          name.resize(name_buffer_size-1);
-      }
-      status = library_->GetChannelName(vi, index, name_buffer_size, (ViChar*)name.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_name(name);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -1790,23 +1802,29 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto indices = request->indices().c_str();
 
-      auto status = library_->GetChannelNameFromString(vi, indices, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetChannelNameFromString(vi, indices, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 name_buffer_size = status;
+      
+        std::string names;
+        if (name_buffer_size > 0) {
+            names.resize(name_buffer_size-1);
+        }
+        status = library_->GetChannelNameFromString(vi, indices, name_buffer_size, (ViChar*)names.data());
+        if (status > name_buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_names(names);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 name_buffer_size = status;
-
-      std::string names;
-      if (name_buffer_size > 0) {
-          names.resize(name_buffer_size-1);
-      }
-      status = library_->GetChannelNameFromString(vi, indices, name_buffer_size, (ViChar*)names.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_names(names);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -1824,25 +1842,31 @@ namespace nidigitalpattern_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
 
-      auto status = library_->GetError(vi, nullptr, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetError(vi, nullptr, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 error_description_buffer_size = status;
+      
+        ViStatus error_code {};
+        std::string error_description;
+        if (error_description_buffer_size > 0) {
+            error_description.resize(error_description_buffer_size-1);
+        }
+        status = library_->GetError(vi, &error_code, error_description_buffer_size, (ViChar*)error_description.data());
+        if (status > error_description_buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
-        return ::grpc::Status::OK;
-      }
-      ViInt32 error_description_buffer_size = status;
-
-      ViStatus error_code {};
-      std::string error_description;
-      if (error_description_buffer_size > 0) {
-          error_description.resize(error_description_buffer_size-1);
-      }
-      status = library_->GetError(vi, &error_code, error_description_buffer_size, (ViChar*)error_description.data());
-      response->set_status(status);
-      if (status == 0) {
+        if (status == 0) {
         response->set_error_code(error_code);
         response->set_error_description(error_description);
+        }
+        return ::grpc::Status::OK;
       }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -1947,23 +1971,29 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 pattern_index = request->pattern_index();
 
-      auto status = library_->GetPatternName(vi, pattern_index, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetPatternName(vi, pattern_index, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 name_buffer_size = status;
+      
+        std::string name;
+        if (name_buffer_size > 0) {
+            name.resize(name_buffer_size-1);
+        }
+        status = library_->GetPatternName(vi, pattern_index, name_buffer_size, (ViChar*)name.data());
+        if (status > name_buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_name(name);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 name_buffer_size = status;
-
-      std::string name;
-      if (name_buffer_size > 0) {
-          name.resize(name_buffer_size-1);
-      }
-      status = library_->GetPatternName(vi, pattern_index, name_buffer_size, (ViChar*)name.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_name(name);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -1982,23 +2012,29 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto start_label = request->start_label().c_str();
 
-      auto status = library_->GetPatternPinList(vi, start_label, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetPatternPinList(vi, start_label, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 pin_list_buffer_size = status;
+      
+        std::string pin_list;
+        if (pin_list_buffer_size > 0) {
+            pin_list.resize(pin_list_buffer_size-1);
+        }
+        status = library_->GetPatternPinList(vi, start_label, pin_list_buffer_size, (ViChar*)pin_list.data());
+        if (status > pin_list_buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_pin_list(pin_list);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 pin_list_buffer_size = status;
-
-      std::string pin_list;
-      if (pin_list_buffer_size > 0) {
-          pin_list.resize(pin_list_buffer_size-1);
-      }
-      status = library_->GetPatternPinList(vi, start_label, pin_list_buffer_size, (ViChar*)pin_list.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_pin_list(pin_list);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -2017,23 +2053,29 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 pin_index = request->pin_index();
 
-      auto status = library_->GetPinName(vi, pin_index, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetPinName(vi, pin_index, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 name_buffer_size = status;
+      
+        std::string name;
+        if (name_buffer_size > 0) {
+            name.resize(name_buffer_size-1);
+        }
+        status = library_->GetPinName(vi, pin_index, name_buffer_size, (ViChar*)name.data());
+        if (status > name_buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_name(name);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 name_buffer_size = status;
-
-      std::string name;
-      if (name_buffer_size > 0) {
-          name.resize(name_buffer_size-1);
-      }
-      status = library_->GetPinName(vi, pin_index, name_buffer_size, (ViChar*)name.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_name(name);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -2257,23 +2299,29 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 time_set_index = request->time_set_index();
 
-      auto status = library_->GetTimeSetName(vi, time_set_index, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetTimeSetName(vi, time_set_index, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 name_buffer_size = status;
+      
+        std::string name;
+        if (name_buffer_size > 0) {
+            name.resize(name_buffer_size-1);
+        }
+        status = library_->GetTimeSetName(vi, time_set_index, name_buffer_size, (ViChar*)name.data());
+        if (status > name_buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_name(name);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 name_buffer_size = status;
-
-      std::string name;
-      if (name_buffer_size > 0) {
-          name.resize(name_buffer_size-1);
-      }
-      status = library_->GetTimeSetName(vi, time_set_index, name_buffer_size, (ViChar*)name.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_name(name);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+const auto kErrorReadBufferTooSmall = -200229;
 
 namespace nidmm_grpc {
 
@@ -1165,7 +1166,7 @@ namespace nidmm_grpc {
       
         std::string configuration(size, '\0');
         status = library_->ExportAttributeConfigurationBuffer(vi, size, (ViInt8*)configuration.data());
-        if (status > size) {
+        if (status == kErrorReadBufferTooSmall || status > size) {
           // buffer is now too small, try again
           continue;
         }
@@ -1480,7 +1481,7 @@ namespace nidmm_grpc {
             attribute_value.resize(buffer_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -1591,7 +1592,7 @@ namespace nidmm_grpc {
             channel_string.resize(buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_string.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -1656,7 +1657,7 @@ namespace nidmm_grpc {
             description.resize(buffer_size-1);
         }
         status = library_->GetError(vi, &error_code, buffer_size, (ViChar*)description.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -1698,7 +1699,7 @@ namespace nidmm_grpc {
             error_message.resize(buffer_size-1);
         }
         status = library_->GetErrorMessage(vi, error_code, buffer_size, (ViChar*)error_message.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -1823,7 +1824,7 @@ namespace nidmm_grpc {
             coercion_record.resize(buffer_size-1);
         }
         status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -1863,7 +1864,7 @@ namespace nidmm_grpc {
             interchange_warning.resize(buffer_size-1);
         }
         status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -1155,20 +1155,26 @@ namespace nidmm_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
 
-      auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 size = status;
+      
+        std::string configuration(size, '\0');
+        status = library_->ExportAttributeConfigurationBuffer(vi, size, (ViInt8*)configuration.data());
+        if (status > size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_configuration(configuration);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 size = status;
-
-      std::string configuration(size, '\0');
-      status = library_->ExportAttributeConfigurationBuffer(vi, size, (ViInt8*)configuration.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_configuration(configuration);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -1461,23 +1467,29 @@ namespace nidmm_grpc {
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
 
-      auto status = library_->GetAttributeViString(vi, channel_name, attribute_id, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetAttributeViString(vi, channel_name, attribute_id, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string attribute_value;
+        if (buffer_size > 0) {
+            attribute_value.resize(buffer_size-1);
+        }
+        status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_attribute_value(attribute_value);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string attribute_value;
-      if (buffer_size > 0) {
-          attribute_value.resize(buffer_size-1);
-      }
-      status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_attribute_value(attribute_value);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -1566,23 +1578,29 @@ namespace nidmm_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 index = request->index();
 
-      auto status = library_->GetChannelName(vi, index, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetChannelName(vi, index, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string channel_string;
+        if (buffer_size > 0) {
+            channel_string.resize(buffer_size-1);
+        }
+        status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_string.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_channel_string(channel_string);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string channel_string;
-      if (buffer_size > 0) {
-          channel_string.resize(buffer_size-1);
-      }
-      status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_string.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_channel_string(channel_string);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -1624,25 +1642,31 @@ namespace nidmm_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
 
-      auto status = library_->GetError(vi, nullptr, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetError(vi, nullptr, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        ViStatus error_code {};
+        std::string description;
+        if (buffer_size > 0) {
+            description.resize(buffer_size-1);
+        }
+        status = library_->GetError(vi, &error_code, buffer_size, (ViChar*)description.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
-        return ::grpc::Status::OK;
-      }
-      ViInt32 buffer_size = status;
-
-      ViStatus error_code {};
-      std::string description;
-      if (buffer_size > 0) {
-          description.resize(buffer_size-1);
-      }
-      status = library_->GetError(vi, &error_code, buffer_size, (ViChar*)description.data());
-      response->set_status(status);
-      if (status == 0) {
+        if (status == 0) {
         response->set_error_code(error_code);
         response->set_description(description);
+        }
+        return ::grpc::Status::OK;
       }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -1661,23 +1685,29 @@ namespace nidmm_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViStatus error_code = request->error_code();
 
-      auto status = library_->GetErrorMessage(vi, error_code, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetErrorMessage(vi, error_code, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string error_message;
+        if (buffer_size > 0) {
+            error_message.resize(buffer_size-1);
+        }
+        status = library_->GetErrorMessage(vi, error_code, buffer_size, (ViChar*)error_message.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_error_message(error_message);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string error_message;
-      if (buffer_size > 0) {
-          error_message.resize(buffer_size-1);
-      }
-      status = library_->GetErrorMessage(vi, error_code, buffer_size, (ViChar*)error_message.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_error_message(error_message);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -1780,23 +1810,29 @@ namespace nidmm_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
 
-      auto status = library_->GetNextCoercionRecord(vi, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetNextCoercionRecord(vi, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string coercion_record;
+        if (buffer_size > 0) {
+            coercion_record.resize(buffer_size-1);
+        }
+        status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_coercion_record(coercion_record);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string coercion_record;
-      if (buffer_size > 0) {
-          coercion_record.resize(buffer_size-1);
-      }
-      status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_coercion_record(coercion_record);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -1814,23 +1850,29 @@ namespace nidmm_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
 
-      auto status = library_->GetNextInterchangeWarning(vi, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetNextInterchangeWarning(vi, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string interchange_warning;
+        if (buffer_size > 0) {
+            interchange_warning.resize(buffer_size-1);
+        }
+        status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_interchange_warning(interchange_warning);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string interchange_warning;
-      if (buffer_size > 0) {
-          interchange_warning.resize(buffer_size-1);
-      }
-      status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_interchange_warning(interchange_warning);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -11,9 +11,10 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-const auto kErrorReadBufferTooSmall = -200229;
 
 namespace nidmm_grpc {
+
+  const auto kErrorReadBufferTooSmall = -200229;
 
   NiDmmService::NiDmmService(NiDmmLibraryInterface* library, ResourceRepositorySharedPtr session_repository)
       : library_(library), session_repository_(session_repository)

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -311,20 +311,26 @@ namespace nifake_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
 
-      auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 size_in_bytes = status;
+      
+        std::string configuration(size_in_bytes, '\0');
+        status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, (ViInt8*)configuration.data());
+        if (status > size_in_bytes) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_configuration(configuration);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 size_in_bytes = status;
-
-      std::string configuration(size_in_bytes, '\0');
-      status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, (ViInt8*)configuration.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_configuration(configuration);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -437,23 +443,29 @@ namespace nifake_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
 
-      auto status = library_->GetAnIviDanceString(vi, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetAnIviDanceString(vi, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string a_string;
+        if (buffer_size > 0) {
+            a_string.resize(buffer_size-1);
+        }
+        status = library_->GetAnIviDanceString(vi, buffer_size, (ViChar*)a_string.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_a_string(a_string);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string a_string;
-      if (buffer_size > 0) {
-          a_string.resize(buffer_size-1);
-      }
-      status = library_->GetAnIviDanceString(vi, buffer_size, (ViChar*)a_string.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_a_string(a_string);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -525,20 +537,26 @@ namespace nifake_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
 
-      auto status = library_->GetArrayUsingIviDance(vi, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetArrayUsingIviDance(vi, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 array_size = status;
+      
+        response->mutable_array_out()->Resize(array_size, 0);
+        ViReal64* array_out = response->mutable_array_out()->mutable_data();
+        status = library_->GetArrayUsingIviDance(vi, array_size, array_out);
+        if (status > array_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 array_size = status;
-
-      response->mutable_array_out()->Resize(array_size, 0);
-      ViReal64* array_out = response->mutable_array_out()->mutable_data();
-      status = library_->GetArrayUsingIviDance(vi, array_size, array_out);
-      response->set_status(status);
-      if (status == 0) {
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -708,23 +726,29 @@ namespace nifake_grpc {
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
 
-      auto status = library_->GetAttributeViString(vi, channel_name, attribute_id, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetAttributeViString(vi, channel_name, attribute_id, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string attribute_value;
+        if (buffer_size > 0) {
+            attribute_value.resize(buffer_size-1);
+        }
+        status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_attribute_value(attribute_value);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string attribute_value;
-      if (buffer_size > 0) {
-          attribute_value.resize(buffer_size-1);
-      }
-      status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_attribute_value(attribute_value);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -1284,28 +1308,33 @@ namespace nifake_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 array_size = request->array_size();
 
-      auto status = library_->ReturnMultipleTypes(vi, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 0, nullptr, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->ReturnMultipleTypes(vi, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 0, nullptr, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 string_size = status;
+      
+        ViBoolean a_boolean {};
+        ViInt32 an_int32 {};
+        ViInt64 an_int64 {};
+        ViInt16 an_int_enum {};
+        ViReal64 a_float {};
+        ViReal64 a_float_enum {};
+        response->mutable_an_array()->Resize(array_size, 0);
+        ViReal64* an_array = response->mutable_an_array()->mutable_data();
+        std::string a_string;
+        if (string_size > 0) {
+            a_string.resize(string_size-1);
+        }
+        status = library_->ReturnMultipleTypes(vi, &a_boolean, &an_int32, &an_int64, &an_int_enum, &a_float, &a_float_enum, array_size, an_array, string_size, (ViChar*)a_string.data());
+        if (status > string_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
-        return ::grpc::Status::OK;
-      }
-      ViInt32 string_size = status;
-
-      ViBoolean a_boolean {};
-      ViInt32 an_int32 {};
-      ViInt64 an_int64 {};
-      ViInt16 an_int_enum {};
-      ViReal64 a_float {};
-      ViReal64 a_float_enum {};
-      response->mutable_an_array()->Resize(array_size, 0);
-      ViReal64* an_array = response->mutable_an_array()->mutable_data();
-      std::string a_string;
-      if (string_size > 0) {
-          a_string.resize(string_size-1);
-      }
-      status = library_->ReturnMultipleTypes(vi, &a_boolean, &an_int32, &an_int64, &an_int_enum, &a_float, &a_float_enum, array_size, an_array, string_size, (ViChar*)a_string.data());
-      response->set_status(status);
-      if (status == 0) {
+        if (status == 0) {
         response->set_a_boolean(a_boolean);
         response->set_an_int32(an_int32);
         response->set_an_int64(an_int64);
@@ -1318,8 +1347,9 @@ namespace nifake_grpc {
         }
         response->set_a_float_enum_raw(a_float_enum);
         response->set_a_string(a_string);
+        }
+        return ::grpc::Status::OK;
       }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -11,9 +11,10 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-const auto kErrorReadBufferTooSmall = -200229;
 
 namespace nifake_grpc {
+
+  const auto kErrorReadBufferTooSmall = -200229;
 
   NiFakeService::NiFakeService(NiFakeLibraryInterface* library, ResourceRepositorySharedPtr session_repository)
       : library_(library), session_repository_(session_repository)

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -322,7 +322,7 @@ namespace nifake_grpc {
       
         std::string configuration(size_in_bytes, '\0');
         status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, (ViInt8*)configuration.data());
-        if (status > size_in_bytes) {
+        if (status == kErrorReadBufferTooSmall || status > size_in_bytes) {
           // buffer is now too small, try again
           continue;
         }
@@ -457,7 +457,7 @@ namespace nifake_grpc {
             a_string.resize(buffer_size-1);
         }
         status = library_->GetAnIviDanceString(vi, buffer_size, (ViChar*)a_string.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -555,7 +555,7 @@ namespace nifake_grpc {
         response->mutable_array_out()->Resize(array_size, 0);
         ViReal64* array_out = response->mutable_array_out()->mutable_data();
         status = library_->GetArrayUsingIviDance(vi, array_size, array_out);
-        if (status > array_size) {
+        if (status == kErrorReadBufferTooSmall || status > array_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -746,7 +746,7 @@ namespace nifake_grpc {
             attribute_value.resize(buffer_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -1336,7 +1336,7 @@ namespace nifake_grpc {
             a_string.resize(string_size-1);
         }
         status = library_->ReturnMultipleTypes(vi, &a_boolean, &an_int32, &an_int64, &an_int_enum, &a_float, &a_float_enum, array_size, an_array, string_size, (ViChar*)a_string.data());
-        if (status > string_size) {
+        if (status == kErrorReadBufferTooSmall || status > string_size) {
           // buffer is now too small, try again
           continue;
         }

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -11,9 +11,10 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-const auto kErrorReadBufferTooSmall = -200229;
 
 namespace nifgen_grpc {
+
+  const auto kErrorReadBufferTooSmall = -200229;
 
   NiFgenService::NiFgenService(NiFgenLibraryInterface* library, ResourceRepositorySharedPtr session_repository)
       : library_(library), session_repository_(session_repository)

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -1698,7 +1698,7 @@ namespace nifgen_grpc {
         response->mutable_configuration()->Resize(size_in_bytes, 0);
         ViAddr* configuration = reinterpret_cast<ViAddr*>(response->mutable_configuration()->mutable_data());
         status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, configuration);
-        if (status > size_in_bytes) {
+        if (status == kErrorReadBufferTooSmall || status > size_in_bytes) {
           // buffer is now too small, try again
           continue;
         }
@@ -1922,7 +1922,7 @@ namespace nifgen_grpc {
             attribute_value.resize(array_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute_id, array_size, (ViChar*)attribute_value.data());
-        if (status > array_size) {
+        if (status == kErrorReadBufferTooSmall || status > array_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -1963,7 +1963,7 @@ namespace nifgen_grpc {
             channel_string.resize(buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_string.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -2004,7 +2004,7 @@ namespace nifgen_grpc {
             error_description.resize(error_description_buffer_size-1);
         }
         status = library_->GetError(vi, &error_code, error_description_buffer_size, (ViChar*)error_description.data());
-        if (status > error_description_buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > error_description_buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -2183,7 +2183,7 @@ namespace nifgen_grpc {
             coercion_record.resize(buffer_size-1);
         }
         status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -2223,7 +2223,7 @@ namespace nifgen_grpc {
             interchange_warning.resize(buffer_size-1);
         }
         status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -11,9 +11,10 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-const auto kErrorReadBufferTooSmall = -200229;
 
 namespace niscope_grpc {
+
+  const auto kErrorReadBufferTooSmall = -200229;
 
   NiScopeService::NiScopeService(NiScopeLibraryInterface* library, ResourceRepositorySharedPtr session_repository)
       : library_(library), session_repository_(session_repository)

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+const auto kErrorReadBufferTooSmall = -200229;
 
 namespace niscope_grpc {
 
@@ -1392,7 +1393,7 @@ namespace niscope_grpc {
       
         std::string configuration(size_in_bytes, '\0');
         status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, (ViInt8*)configuration.data());
-        if (status > size_in_bytes) {
+        if (status == kErrorReadBufferTooSmall || status > size_in_bytes) {
           // buffer is now too small, try again
           continue;
         }
@@ -1617,7 +1618,7 @@ namespace niscope_grpc {
             value.resize(buf_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_list, attribute_id, buf_size, (ViChar*)value.data());
-        if (status > buf_size) {
+        if (status == kErrorReadBufferTooSmall || status > buf_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -1658,7 +1659,7 @@ namespace niscope_grpc {
             channel_string.resize(buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_string.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -1699,7 +1700,7 @@ namespace niscope_grpc {
             name.resize(buffer_size-1);
         }
         status = library_->GetChannelNameFromString(vi, index, buffer_size, (ViChar*)name.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -1765,7 +1766,7 @@ namespace niscope_grpc {
             description.resize(buffer_size-1);
         }
         status = library_->GetError(vi, &error_code, buffer_size, (ViChar*)description.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -1807,7 +1808,7 @@ namespace niscope_grpc {
             error_message.resize(buffer_size-1);
         }
         status = library_->GetErrorMessage(vi, error_code, buffer_size, (ViChar*)error_message.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -1382,20 +1382,26 @@ namespace niscope_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
 
-      auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 size_in_bytes = status;
+      
+        std::string configuration(size_in_bytes, '\0');
+        status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, (ViInt8*)configuration.data());
+        if (status > size_in_bytes) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_configuration(configuration);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 size_in_bytes = status;
-
-      std::string configuration(size_in_bytes, '\0');
-      status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, (ViInt8*)configuration.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_configuration(configuration);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -1598,23 +1604,29 @@ namespace niscope_grpc {
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
 
-      auto status = library_->GetAttributeViString(vi, channel_list, attribute_id, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetAttributeViString(vi, channel_list, attribute_id, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buf_size = status;
+      
+        std::string value;
+        if (buf_size > 0) {
+            value.resize(buf_size-1);
+        }
+        status = library_->GetAttributeViString(vi, channel_list, attribute_id, buf_size, (ViChar*)value.data());
+        if (status > buf_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_value(value);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buf_size = status;
-
-      std::string value;
-      if (buf_size > 0) {
-          value.resize(buf_size-1);
-      }
-      status = library_->GetAttributeViString(vi, channel_list, attribute_id, buf_size, (ViChar*)value.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_value(value);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -1633,23 +1645,29 @@ namespace niscope_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 index = request->index();
 
-      auto status = library_->GetChannelName(vi, index, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetChannelName(vi, index, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string channel_string;
+        if (buffer_size > 0) {
+            channel_string.resize(buffer_size-1);
+        }
+        status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_string.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_channel_string(channel_string);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string channel_string;
-      if (buffer_size > 0) {
-          channel_string.resize(buffer_size-1);
-      }
-      status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_string.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_channel_string(channel_string);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -1668,23 +1686,29 @@ namespace niscope_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto index = request->index().c_str();
 
-      auto status = library_->GetChannelNameFromString(vi, index, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetChannelNameFromString(vi, index, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string name;
+        if (buffer_size > 0) {
+            name.resize(buffer_size-1);
+        }
+        status = library_->GetChannelNameFromString(vi, index, buffer_size, (ViChar*)name.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_name(name);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string name;
-      if (buffer_size > 0) {
-          name.resize(buffer_size-1);
-      }
-      status = library_->GetChannelNameFromString(vi, index, buffer_size, (ViChar*)name.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_name(name);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -1727,25 +1751,31 @@ namespace niscope_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
 
-      auto status = library_->GetError(vi, nullptr, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetError(vi, nullptr, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        ViStatus error_code {};
+        std::string description;
+        if (buffer_size > 0) {
+            description.resize(buffer_size-1);
+        }
+        status = library_->GetError(vi, &error_code, buffer_size, (ViChar*)description.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
-        return ::grpc::Status::OK;
-      }
-      ViInt32 buffer_size = status;
-
-      ViStatus error_code {};
-      std::string description;
-      if (buffer_size > 0) {
-          description.resize(buffer_size-1);
-      }
-      status = library_->GetError(vi, &error_code, buffer_size, (ViChar*)description.data());
-      response->set_status(status);
-      if (status == 0) {
+        if (status == 0) {
         response->set_error_code(error_code);
         response->set_description(description);
+        }
+        return ::grpc::Status::OK;
       }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -1764,23 +1794,29 @@ namespace niscope_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViStatus error_code = request->error_code();
 
-      auto status = library_->GetErrorMessage(vi, error_code, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetErrorMessage(vi, error_code, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string error_message;
+        if (buffer_size > 0) {
+            error_message.resize(buffer_size-1);
+        }
+        status = library_->GetErrorMessage(vi, error_code, buffer_size, (ViChar*)error_message.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_error_message(error_message);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string error_message;
-      if (buffer_size > 0) {
-          error_message.resize(buffer_size-1);
-      }
-      status = library_->GetErrorMessage(vi, error_code, buffer_size, (ViChar*)error_message.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_error_message(error_message);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+const auto kErrorReadBufferTooSmall = -200229;
 
 namespace niswitch_grpc {
 
@@ -629,7 +630,7 @@ namespace niswitch_grpc {
             attribute_value.resize(array_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute_id, array_size, (ViChar*)attribute_value.data());
-        if (status > array_size) {
+        if (status == kErrorReadBufferTooSmall || status > array_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -696,7 +697,7 @@ namespace niswitch_grpc {
             channel_name_buffer.resize(buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_name_buffer.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -737,7 +738,7 @@ namespace niswitch_grpc {
             description.resize(buffer_size-1);
         }
         status = library_->GetError(vi, &code, buffer_size, (ViChar*)description.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -778,7 +779,7 @@ namespace niswitch_grpc {
             coercion_record.resize(buffer_size-1);
         }
         status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -818,7 +819,7 @@ namespace niswitch_grpc {
             interchange_warning.resize(buffer_size-1);
         }
         status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -860,7 +861,7 @@ namespace niswitch_grpc {
             path.resize(buffer_size-1);
         }
         status = library_->GetPath(vi, channel1, channel2, buffer_size, (ViChar*)path.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -925,7 +926,7 @@ namespace niswitch_grpc {
             relay_name_buffer.resize(relay_name_buffer_size-1);
         }
         status = library_->GetRelayName(vi, index, relay_name_buffer_size, (ViChar*)relay_name_buffer.data());
-        if (status > relay_name_buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > relay_name_buffer_size) {
           // buffer is now too small, try again
           continue;
         }

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -11,9 +11,10 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-const auto kErrorReadBufferTooSmall = -200229;
 
 namespace niswitch_grpc {
+
+  const auto kErrorReadBufferTooSmall = -200229;
 
   NiSwitchService::NiSwitchService(NiSwitchLibraryInterface* library, ResourceRepositorySharedPtr session_repository)
       : library_(library), session_repository_(session_repository)

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -616,23 +616,29 @@ namespace niswitch_grpc {
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
 
-      auto status = library_->GetAttributeViString(vi, channel_name, attribute_id, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetAttributeViString(vi, channel_name, attribute_id, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 array_size = status;
+      
+        std::string attribute_value;
+        if (array_size > 0) {
+            attribute_value.resize(array_size-1);
+        }
+        status = library_->GetAttributeViString(vi, channel_name, attribute_id, array_size, (ViChar*)attribute_value.data());
+        if (status > array_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_attribute_value(attribute_value);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 array_size = status;
-
-      std::string attribute_value;
-      if (array_size > 0) {
-          attribute_value.resize(array_size-1);
-      }
-      status = library_->GetAttributeViString(vi, channel_name, attribute_id, array_size, (ViChar*)attribute_value.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_attribute_value(attribute_value);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -677,23 +683,29 @@ namespace niswitch_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 index = request->index();
 
-      auto status = library_->GetChannelName(vi, index, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetChannelName(vi, index, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string channel_name_buffer;
+        if (buffer_size > 0) {
+            channel_name_buffer.resize(buffer_size-1);
+        }
+        status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_name_buffer.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_channel_name_buffer(channel_name_buffer);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string channel_name_buffer;
-      if (buffer_size > 0) {
-          channel_name_buffer.resize(buffer_size-1);
-      }
-      status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_name_buffer.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_channel_name_buffer(channel_name_buffer);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -711,25 +723,31 @@ namespace niswitch_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
 
-      auto status = library_->GetError(vi, nullptr, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetError(vi, nullptr, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        ViStatus code {};
+        std::string description;
+        if (buffer_size > 0) {
+            description.resize(buffer_size-1);
+        }
+        status = library_->GetError(vi, &code, buffer_size, (ViChar*)description.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
-        return ::grpc::Status::OK;
-      }
-      ViInt32 buffer_size = status;
-
-      ViStatus code {};
-      std::string description;
-      if (buffer_size > 0) {
-          description.resize(buffer_size-1);
-      }
-      status = library_->GetError(vi, &code, buffer_size, (ViChar*)description.data());
-      response->set_status(status);
-      if (status == 0) {
+        if (status == 0) {
         response->set_code(code);
         response->set_description(description);
+        }
+        return ::grpc::Status::OK;
       }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -747,23 +765,29 @@ namespace niswitch_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
 
-      auto status = library_->GetNextCoercionRecord(vi, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetNextCoercionRecord(vi, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string coercion_record;
+        if (buffer_size > 0) {
+            coercion_record.resize(buffer_size-1);
+        }
+        status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_coercion_record(coercion_record);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string coercion_record;
-      if (buffer_size > 0) {
-          coercion_record.resize(buffer_size-1);
-      }
-      status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_coercion_record(coercion_record);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -781,23 +805,29 @@ namespace niswitch_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
 
-      auto status = library_->GetNextInterchangeWarning(vi, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetNextInterchangeWarning(vi, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string interchange_warning;
+        if (buffer_size > 0) {
+            interchange_warning.resize(buffer_size-1);
+        }
+        status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_interchange_warning(interchange_warning);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string interchange_warning;
-      if (buffer_size > 0) {
-          interchange_warning.resize(buffer_size-1);
-      }
-      status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_interchange_warning(interchange_warning);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -817,23 +847,29 @@ namespace niswitch_grpc {
       auto channel1 = request->channel1().c_str();
       auto channel2 = request->channel2().c_str();
 
-      auto status = library_->GetPath(vi, channel1, channel2, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetPath(vi, channel1, channel2, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 buffer_size = status;
+      
+        std::string path;
+        if (buffer_size > 0) {
+            path.resize(buffer_size-1);
+        }
+        status = library_->GetPath(vi, channel1, channel2, buffer_size, (ViChar*)path.data());
+        if (status > buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_path(path);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 buffer_size = status;
-
-      std::string path;
-      if (buffer_size > 0) {
-          path.resize(buffer_size-1);
-      }
-      status = library_->GetPath(vi, channel1, channel2, buffer_size, (ViChar*)path.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_path(path);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -876,23 +912,29 @@ namespace niswitch_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 index = request->index();
 
-      auto status = library_->GetRelayName(vi, index, 0, nullptr);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetRelayName(vi, index, 0, nullptr);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViInt32 relay_name_buffer_size = status;
+      
+        std::string relay_name_buffer;
+        if (relay_name_buffer_size > 0) {
+            relay_name_buffer.resize(relay_name_buffer_size-1);
+        }
+        status = library_->GetRelayName(vi, index, relay_name_buffer_size, (ViChar*)relay_name_buffer.data());
+        if (status > relay_name_buffer_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_relay_name_buffer(relay_name_buffer);
+        }
         return ::grpc::Status::OK;
       }
-      ViInt32 relay_name_buffer_size = status;
-
-      std::string relay_name_buffer;
-      if (relay_name_buffer_size > 0) {
-          relay_name_buffer.resize(relay_name_buffer_size-1);
-      }
-      status = library_->GetRelayName(vi, index, relay_name_buffer_size, (ViChar*)relay_name_buffer.data());
-      response->set_status(status);
-      if (status == 0) {
-        response->set_relay_name_buffer(relay_name_buffer);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+const auto kErrorReadBufferTooSmall = -200229;
 
 namespace nisync_grpc {
 
@@ -1075,7 +1076,7 @@ namespace nisync_grpc {
             time_reference_names.resize(buffer_size-1);
         }
         status = library_->GetTimeReferenceNames(vi, buffer_size, (ViChar*)time_reference_names.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }
@@ -1192,7 +1193,7 @@ namespace nisync_grpc {
             value.resize(buffer_size-1);
         }
         status = library_->GetAttributeViString(vi, active_item, attribute, buffer_size, (ViChar*)value.data());
-        if (status > buffer_size) {
+        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
           // buffer is now too small, try again
           continue;
         }

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -11,9 +11,10 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-const auto kErrorReadBufferTooSmall = -200229;
 
 namespace nisync_grpc {
+
+  const auto kErrorReadBufferTooSmall = -200229;
 
   NiSyncService::NiSyncService(NiSyncLibraryInterface* library, ResourceRepositorySharedPtr session_repository)
       : library_(library), session_repository_(session_repository)

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+const auto kErrorReadBufferTooSmall = -200229;
 
 namespace nitclk_grpc {
 
@@ -147,7 +148,7 @@ namespace nitclk_grpc {
             error_string.resize(error_string_size-1);
         }
         status = library_->GetExtendedErrorInfo((ViChar*)error_string.data(), error_string_size);
-        if (status > error_string_size) {
+        if (status == kErrorReadBufferTooSmall || status > error_string_size) {
           // buffer is now too small, try again
           continue;
         }

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -134,23 +134,29 @@ namespace nitclk_grpc {
     }
     try {
 
-      auto status = library_->GetExtendedErrorInfo(nullptr, 0);
-      if (status < 0) {
+      while (true) {
+        auto status = library_->GetExtendedErrorInfo(nullptr, 0);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        ViUInt32 error_string_size = status;
+      
+        std::string error_string;
+        if (error_string_size > 0) {
+            error_string.resize(error_string_size-1);
+        }
+        status = library_->GetExtendedErrorInfo((ViChar*)error_string.data(), error_string_size);
+        if (status > error_string_size) {
+          // buffer is now too small, try again
+          continue;
+        }
         response->set_status(status);
+        if (status == 0) {
+        response->set_error_string(error_string);
+        }
         return ::grpc::Status::OK;
       }
-      ViUInt32 error_string_size = status;
-
-      std::string error_string;
-      if (error_string_size > 0) {
-          error_string.resize(error_string_size-1);
-      }
-      status = library_->GetExtendedErrorInfo((ViChar*)error_string.data(), error_string_size);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_error_string(error_string);
-      }
-      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -11,9 +11,10 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-const auto kErrorReadBufferTooSmall = -200229;
 
 namespace nitclk_grpc {
+
+  const auto kErrorReadBufferTooSmall = -200229;
 
   NiTClkService::NiTClkService(NiTClkLibraryInterface* library, ResourceRepositorySharedPtr session_repository)
       : library_(library), session_repository_(session_repository)

--- a/source/codegen/templates/service.cpp.mako
+++ b/source/codegen/templates/service.cpp.mako
@@ -15,11 +15,11 @@ has_async_functions = any(service_helpers.get_async_functions(functions))
 function_names = service_helpers.filter_proto_rpc_functions_to_generate(functions)
 # If there are any non-mockable functions, we need to call the library directly, which
 # means we need another include file
-any_non_mockable_functions = any([not common_helpers.can_mock_function(functions[name]['parameters']) for name in function_names])
+any_non_mockable_functions = any(not common_helpers.can_mock_function(functions[name]['parameters']) for name in function_names)
 # Define the constant for buffer too small if we have any of these functions.
 any_ivi_dance_functions = any(
-  [common_helpers.has_ivi_dance_with_a_twist_param(functions[name]['parameters']) or
-   common_helpers.has_ivi_dance_param(functions[name]['parameters']) for name in function_names])
+  common_helpers.has_ivi_dance_with_a_twist_param(functions[name]['parameters']) or
+  common_helpers.has_ivi_dance_param(functions[name]['parameters']) for name in function_names)
 %>\
 <%namespace name="mako_helper" file="/service_helpers.mako"/>\
 

--- a/source/codegen/templates/service.cpp.mako
+++ b/source/codegen/templates/service.cpp.mako
@@ -17,7 +17,9 @@ function_names = service_helpers.filter_proto_rpc_functions_to_generate(function
 # means we need another include file
 any_non_mockable_functions = any([not common_helpers.can_mock_function(functions[name]['parameters']) for name in function_names])
 # Define the constant for buffer too small if we have any of these functions.
-any_ivi_dance_with_a_twist_functions = any([common_helpers.has_ivi_dance_with_a_twist_param(functions[name]['parameters']) for name in function_names])
+any_ivi_dance_functions = any(
+  [common_helpers.has_ivi_dance_with_a_twist_param(functions[name]['parameters']) or
+   common_helpers.has_ivi_dance_param(functions[name]['parameters']) for name in function_names])
 %>\
 <%namespace name="mako_helper" file="/service_helpers.mako"/>\
 
@@ -45,7 +47,7 @@ any_ivi_dance_with_a_twist_functions = any([common_helpers.has_ivi_dance_with_a_
 % if any_non_mockable_functions:
 #include "${module_name}_library.h"
 % endif
-% if any_ivi_dance_with_a_twist_functions:
+% if any_ivi_dance_functions:
 const auto kErrorReadBufferTooSmall = -200229;
 % endif
 

--- a/source/codegen/templates/service.cpp.mako
+++ b/source/codegen/templates/service.cpp.mako
@@ -16,6 +16,8 @@ function_names = service_helpers.filter_proto_rpc_functions_to_generate(function
 # If there are any non-mockable functions, we need to call the library directly, which
 # means we need another include file
 any_non_mockable_functions = any([not common_helpers.can_mock_function(functions[name]['parameters']) for name in function_names])
+# Define the constant for buffer too small if we have any of these functions.
+any_ivi_dance_with_a_twist_functions = any([common_helpers.has_ivi_dance_with_a_twist_param(functions[name]['parameters']) for name in function_names])
 %>\
 <%namespace name="mako_helper" file="/service_helpers.mako"/>\
 
@@ -42,6 +44,9 @@ any_non_mockable_functions = any([not common_helpers.can_mock_function(functions
 % endif
 % if any_non_mockable_functions:
 #include "${module_name}_library.h"
+% endif
+% if any_ivi_dance_with_a_twist_functions:
+const auto kErrorReadBufferTooSmall = -200229;
 % endif
 
 namespace ${config["namespace_component"]}_grpc {

--- a/source/codegen/templates/service.cpp.mako
+++ b/source/codegen/templates/service.cpp.mako
@@ -47,12 +47,13 @@ any_ivi_dance_functions = any(
 % if any_non_mockable_functions:
 #include "${module_name}_library.h"
 % endif
-% if any_ivi_dance_functions:
-const auto kErrorReadBufferTooSmall = -200229;
-% endif
 
 namespace ${config["namespace_component"]}_grpc {
 
+% if any_ivi_dance_functions:
+  const auto kErrorReadBufferTooSmall = -200229;
+
+% endif
   ${service_class_prefix}Service::${service_class_prefix}Service(${service_class_prefix}LibraryInterface* library, ResourceRepositorySharedPtr session_repository)
       : library_(library), session_repository_(session_repository)
   {

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -53,7 +53,7 @@ ${initialize_input_params(function_name, non_ivi_params)}\
 ${initialize_output_params(output_parameters)}\
 </%block>\
         status = library_->${function_name}(${service_helpers.create_args(parameters)});
-        if (status > ${common_helpers.camel_to_snake(size_param['cppName'])}) {
+        if (status == kErrorReadBufferTooSmall || status > ${common_helpers.camel_to_snake(size_param['cppName'])}) {
           // buffer is now too small, try again
           continue;
         }

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -1238,7 +1238,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetArrayUsingIviDance_CallsGetArrayUsingI
   EXPECT_THAT(response.array_out(), ElementsAreArray(doubles, expected_size));
 }
 
-TEST(NiFakeServiceTests, NiFakeService_GetArrayUsingIviDanceWithChangingValues_CallsGetArrayUsingIviDance)
+TEST(NiFakeServiceTests, NiFakeService_GetArrayUsingIviDanceWithChangingSizes_CallsGetArrayUsingIviDance)
 {
   nidevice_grpc::SessionRepository session_repository;
   NiFakeMockLibrary library;
@@ -1254,10 +1254,11 @@ TEST(NiFakeServiceTests, NiFakeService_GetArrayUsingIviDanceWithChangingValues_C
       .WillOnce(Return(expected_new_size));
   // follow up call - return that the array now needs to be bigger, so the ivi-dance
   // call will be made again.
-  EXPECT_CALL(library, GetArrayUsingIviDance(kTestViSession, expected_old_size, _))
-      .WillOnce(Return(expected_new_size));
+  ::testing::Expectation first_real_call = EXPECT_CALL(library, GetArrayUsingIviDance(kTestViSession, expected_old_size, _))
+                                               .WillOnce(Return(expected_new_size));
   // follow up call with size returned from ivi-dance setup.
   EXPECT_CALL(library, GetArrayUsingIviDance(kTestViSession, expected_new_size, _))
+      .After(first_real_call)
       .WillOnce(DoAll(
           SetArrayArgument<2>(doubles, doubles + expected_new_size),
           Return(kDriverSuccess)));
@@ -1519,6 +1520,51 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArray_CallsGetAnIv
   EXPECT_EQ(kDriverSuccess, response.status());
   EXPECT_THAT(response.array_out(), ElementsAreArray(array_out, expected_size));
   EXPECT_EQ(response.actual_size(), expected_size);
+}
+
+TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArrayWithChangingSizes_CallsGetAnIviDanceWithATwistArray)
+{
+  nidevice_grpc::SessionRepository session_repository;
+  NiFakeMockLibrary library;
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  std::uint32_t session_id = create_session(library, service, kTestViSession);
+  const char* a_string = "abc";
+  ViInt32 array_out[] = {1, 2, 3};
+  ViInt32 expected_old_size = 2;
+  ViInt32 expected_new_size = 3;
+  // ivi-dance-with-a-twist call
+  EXPECT_CALL(library, GetAnIviDanceWithATwistArray(kTestViSession, Pointee(*a_string), 0, nullptr, _))
+      .WillOnce(DoAll(
+          SetArgPointee<4>(expected_old_size),
+          Return(kDriverSuccess)))
+      .WillOnce(DoAll(
+          SetArgPointee<4>(expected_new_size),
+          Return(kDriverSuccess)));
+  // follow up call - return that the array now needs to be bigger, so the ivi-dance
+  // call will be made again.
+  // Use the value of the error here to ensure that it doesn't change.
+  ::testing::Expectation first_real_call = EXPECT_CALL(library, GetAnIviDanceWithATwistArray(kTestViSession, Pointee(*a_string), expected_old_size, _, _))
+                                               .WillOnce(Return(-200229));
+  // follow up call with size returned from ivi-dance-with-a-twist setup.
+  EXPECT_CALL(library, GetAnIviDanceWithATwistArray(kTestViSession, Pointee(*a_string), expected_new_size, _, _))
+      .After(first_real_call)
+      .WillOnce(DoAll(
+          SetArrayArgument<3>(array_out, array_out + expected_new_size),
+          SetArgPointee<4>(expected_new_size),
+          Return(kDriverSuccess)));
+
+  ::grpc::ServerContext context;
+  nifake_grpc::GetAnIviDanceWithATwistArrayRequest request;
+  request.mutable_vi()->set_id(session_id);
+  request.set_a_string(a_string);
+  nifake_grpc::GetAnIviDanceWithATwistArrayResponse response;
+  ::grpc::Status status = service.GetAnIviDanceWithATwistArray(&context, &request, &response);
+
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(kDriverSuccess, response.status());
+  EXPECT_THAT(response.array_out(), ElementsAreArray(array_out, expected_new_size));
+  EXPECT_EQ(response.actual_size(), expected_new_size);
 }
 
 TEST(NiFakeServiceTests, NiFakeService_AcceptViInt16Array_CallsAcceptViInt16Array)

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -1250,14 +1250,16 @@ TEST(NiFakeServiceTests, NiFakeService_GetArrayUsingIviDanceWithChangingValues_C
   ViInt32 expected_new_size = 3;
   // ivi-dance call
   EXPECT_CALL(library, GetArrayUsingIviDance(kTestViSession, 0, nullptr))
-      .WillOnce(Return(expected_old_size));
-  // follow up call
-  EXPECT_CALL(library, GetArrayUsingIviDance(kTestViSession, 2, _))
-      .WillOnce(Return(expected_old_size));
+      .WillOnce(Return(expected_old_size))
+      .WillOnce(Return(expected_new_size));
+  // follow up call - return that the array now needs to be bigger, so the ivi-dance
+  // call will be made again.
+  EXPECT_CALL(library, GetArrayUsingIviDance(kTestViSession, expected_old_size, _))
+      .WillOnce(Return(expected_new_size));
   // follow up call with size returned from ivi-dance setup.
-  EXPECT_CALL(library, GetArrayUsingIviDance(kTestViSession, expected_size, _))
+  EXPECT_CALL(library, GetArrayUsingIviDance(kTestViSession, expected_new_size, _))
       .WillOnce(DoAll(
-          SetArrayArgument<2>(doubles, doubles + expected_size),
+          SetArrayArgument<2>(doubles, doubles + expected_new_size),
           Return(kDriverSuccess)));
 
   ::grpc::ServerContext context;
@@ -1268,7 +1270,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetArrayUsingIviDanceWithChangingValues_C
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kDriverSuccess, response.status());
-  EXPECT_THAT(response.array_out(), ElementsAreArray(doubles, expected_size));
+  EXPECT_THAT(response.array_out(), ElementsAreArray(doubles, expected_new_size));
 }
 
 TEST(NiFakeServiceTests, NiFakeService_GetAttributeViString_CallsGetAttributeViString)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes a race condition if the size of a buffer changes between the initial sizing call and the "real" call afterwards.

This code assumes that if you pass in too small a buffer to a vanilla `ivi-dance` method it either returns the necessary size, or returns `kErrorReadBufferTooSmall`. For `ivi-dance-with-a-twist` methods, passing in too small a buffer will return `kErrorReadBufferTooSmall`.

### Why should this Pull Request be merged?

Race conditions are bad - not fixing this could lead to spurious errors when calling ivi-dance APIs.

### What testing has been done?

Added new unit tests for ivi-dance and ivi-dance-with-a-twist methods.