### PR TITLE
Fix callback example to wait for initial_metadata

### DIFF
--- a/examples/nidaqmx/analog-input-every-n-samples.py
+++ b/examples/nidaqmx/analog-input-every-n-samples.py
@@ -88,7 +88,12 @@ async def main():
                     n_samples=100,
                     every_n_samples_event_type=nidaqmx_types.EVERY_N_SAMPLES_EVENT_TYPE_ACQUIRED_INTO_BUFFER))
 
+            # Wait for initial_metadata to ensure that the callback is registered before starting the task.
+            await every_n_samples_stream.initial_metadata()
+
             done_event_stream = client.RegisterDoneEvent(nidaqmx_types.RegisterDoneEventRequest(task=task))
+            
+            await done_event_stream.initial_metadata()
 
             await raise_if_error_async(client.StartTask(nidaqmx_types.StartTaskRequest(task=task)))
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fix the every-n-samples callback example to wait for `initial_metadata`.

### Why should this Pull Request be merged?

If the register does not happen before the call to start task, then registering the event will fail. Waiting for `initial_metadata` ensures that the driver call has been made.

### What testing has been done?

Changed the callback codegen to sleep for a second before calling register. This consistently fails with the original code and consistently passes with the new code.
Note that the existing C++ system tests already `WaitForInitialMetadata` (where the mechanism for doing so is more obvious).