### PR TITLE
avoid signed/unsigned comparison warning in ivi-dance

### DIFF
--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -2173,8 +2173,6 @@ namespace nidcpower_grpc {
         response->mutable_configuration()->Resize(size, 0);
         ViAddr* configuration = reinterpret_cast<ViAddr*>(response->mutable_configuration()->mutable_data());
         status = library_->ExportAttributeConfigurationBuffer(vi, size, configuration);
-        // We cast status into size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(size)) {
           // buffer is now too small, try again
           continue;
@@ -2431,8 +2429,6 @@ namespace nidcpower_grpc {
             attribute_value.resize(buffer_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -2474,8 +2470,6 @@ namespace nidcpower_grpc {
             channel_name.resize(buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_name.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -2517,8 +2511,6 @@ namespace nidcpower_grpc {
             channel_name.resize(buffer_size-1);
         }
         status = library_->GetChannelNameFromString(vi, index, buffer_size, (ViChar*)channel_name.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -2560,8 +2552,6 @@ namespace nidcpower_grpc {
             description.resize(buffer_size-1);
         }
         status = library_->GetError(vi, &code, buffer_size, (ViChar*)description.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -2680,8 +2670,6 @@ namespace nidcpower_grpc {
             coercion_record.resize(buffer_size-1);
         }
         status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -2722,8 +2710,6 @@ namespace nidcpower_grpc {
             interchange_warning.resize(buffer_size-1);
         }
         status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -2173,7 +2173,9 @@ namespace nidcpower_grpc {
         response->mutable_configuration()->Resize(size, 0);
         ViAddr* configuration = reinterpret_cast<ViAddr*>(response->mutable_configuration()->mutable_data());
         status = library_->ExportAttributeConfigurationBuffer(vi, size, configuration);
-        if (status == kErrorReadBufferTooSmall || status > size) {
+        // We cast status into size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -2429,7 +2431,9 @@ namespace nidcpower_grpc {
             attribute_value.resize(buffer_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -2470,7 +2474,9 @@ namespace nidcpower_grpc {
             channel_name.resize(buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_name.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -2511,7 +2517,9 @@ namespace nidcpower_grpc {
             channel_name.resize(buffer_size-1);
         }
         status = library_->GetChannelNameFromString(vi, index, buffer_size, (ViChar*)channel_name.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -2552,7 +2560,9 @@ namespace nidcpower_grpc {
             description.resize(buffer_size-1);
         }
         status = library_->GetError(vi, &code, buffer_size, (ViChar*)description.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -2670,7 +2680,9 @@ namespace nidcpower_grpc {
             coercion_record.resize(buffer_size-1);
         }
         status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -2710,7 +2722,9 @@ namespace nidcpower_grpc {
             interchange_warning.resize(buffer_size-1);
         }
         status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -1753,7 +1753,9 @@ namespace nidigitalpattern_grpc {
             value.resize(buffer_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute, buffer_size, (ViChar*)value.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1794,7 +1796,9 @@ namespace nidigitalpattern_grpc {
             name.resize(name_buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, name_buffer_size, (ViChar*)name.data());
-        if (status == kErrorReadBufferTooSmall || status > name_buffer_size) {
+        // We cast status into name_buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(name_buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1835,7 +1839,9 @@ namespace nidigitalpattern_grpc {
             names.resize(name_buffer_size-1);
         }
         status = library_->GetChannelNameFromString(vi, indices, name_buffer_size, (ViChar*)names.data());
-        if (status == kErrorReadBufferTooSmall || status > name_buffer_size) {
+        // We cast status into name_buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(name_buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1876,7 +1882,9 @@ namespace nidigitalpattern_grpc {
             error_description.resize(error_description_buffer_size-1);
         }
         status = library_->GetError(vi, &error_code, error_description_buffer_size, (ViChar*)error_description.data());
-        if (status == kErrorReadBufferTooSmall || status > error_description_buffer_size) {
+        // We cast status into error_description_buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(error_description_buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -2016,7 +2024,9 @@ namespace nidigitalpattern_grpc {
             name.resize(name_buffer_size-1);
         }
         status = library_->GetPatternName(vi, pattern_index, name_buffer_size, (ViChar*)name.data());
-        if (status == kErrorReadBufferTooSmall || status > name_buffer_size) {
+        // We cast status into name_buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(name_buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -2057,7 +2067,9 @@ namespace nidigitalpattern_grpc {
             pin_list.resize(pin_list_buffer_size-1);
         }
         status = library_->GetPatternPinList(vi, start_label, pin_list_buffer_size, (ViChar*)pin_list.data());
-        if (status == kErrorReadBufferTooSmall || status > pin_list_buffer_size) {
+        // We cast status into pin_list_buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(pin_list_buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -2098,7 +2110,9 @@ namespace nidigitalpattern_grpc {
             name.resize(name_buffer_size-1);
         }
         status = library_->GetPinName(vi, pin_index, name_buffer_size, (ViChar*)name.data());
-        if (status == kErrorReadBufferTooSmall || status > name_buffer_size) {
+        // We cast status into name_buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(name_buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -2362,7 +2376,9 @@ namespace nidigitalpattern_grpc {
             name.resize(name_buffer_size-1);
         }
         status = library_->GetTimeSetName(vi, time_set_index, name_buffer_size, (ViChar*)name.data());
-        if (status == kErrorReadBufferTooSmall || status > name_buffer_size) {
+        // We cast status into name_buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(name_buffer_size)) {
           // buffer is now too small, try again
           continue;
         }

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -1753,8 +1753,6 @@ namespace nidigitalpattern_grpc {
             value.resize(buffer_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute, buffer_size, (ViChar*)value.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -1796,8 +1794,6 @@ namespace nidigitalpattern_grpc {
             name.resize(name_buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, name_buffer_size, (ViChar*)name.data());
-        // We cast status into name_buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(name_buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -1839,8 +1835,6 @@ namespace nidigitalpattern_grpc {
             names.resize(name_buffer_size-1);
         }
         status = library_->GetChannelNameFromString(vi, indices, name_buffer_size, (ViChar*)names.data());
-        // We cast status into name_buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(name_buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -1882,8 +1876,6 @@ namespace nidigitalpattern_grpc {
             error_description.resize(error_description_buffer_size-1);
         }
         status = library_->GetError(vi, &error_code, error_description_buffer_size, (ViChar*)error_description.data());
-        // We cast status into error_description_buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(error_description_buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -2024,8 +2016,6 @@ namespace nidigitalpattern_grpc {
             name.resize(name_buffer_size-1);
         }
         status = library_->GetPatternName(vi, pattern_index, name_buffer_size, (ViChar*)name.data());
-        // We cast status into name_buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(name_buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -2067,8 +2057,6 @@ namespace nidigitalpattern_grpc {
             pin_list.resize(pin_list_buffer_size-1);
         }
         status = library_->GetPatternPinList(vi, start_label, pin_list_buffer_size, (ViChar*)pin_list.data());
-        // We cast status into pin_list_buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(pin_list_buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -2110,8 +2098,6 @@ namespace nidigitalpattern_grpc {
             name.resize(name_buffer_size-1);
         }
         status = library_->GetPinName(vi, pin_index, name_buffer_size, (ViChar*)name.data());
-        // We cast status into name_buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(name_buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -2376,8 +2362,6 @@ namespace nidigitalpattern_grpc {
             name.resize(name_buffer_size-1);
         }
         status = library_->GetTimeSetName(vi, time_set_index, name_buffer_size, (ViChar*)name.data());
-        // We cast status into name_buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(name_buffer_size)) {
           // buffer is now too small, try again
           continue;

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -1167,7 +1167,9 @@ namespace nidmm_grpc {
       
         std::string configuration(size, '\0');
         status = library_->ExportAttributeConfigurationBuffer(vi, size, (ViInt8*)configuration.data());
-        if (status == kErrorReadBufferTooSmall || status > size) {
+        // We cast status into size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1482,7 +1484,9 @@ namespace nidmm_grpc {
             attribute_value.resize(buffer_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1593,7 +1597,9 @@ namespace nidmm_grpc {
             channel_string.resize(buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_string.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1658,7 +1664,9 @@ namespace nidmm_grpc {
             description.resize(buffer_size-1);
         }
         status = library_->GetError(vi, &error_code, buffer_size, (ViChar*)description.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1700,7 +1708,9 @@ namespace nidmm_grpc {
             error_message.resize(buffer_size-1);
         }
         status = library_->GetErrorMessage(vi, error_code, buffer_size, (ViChar*)error_message.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1825,7 +1835,9 @@ namespace nidmm_grpc {
             coercion_record.resize(buffer_size-1);
         }
         status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1865,7 +1877,9 @@ namespace nidmm_grpc {
             interchange_warning.resize(buffer_size-1);
         }
         status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -1167,8 +1167,6 @@ namespace nidmm_grpc {
       
         std::string configuration(size, '\0');
         status = library_->ExportAttributeConfigurationBuffer(vi, size, (ViInt8*)configuration.data());
-        // We cast status into size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(size)) {
           // buffer is now too small, try again
           continue;
@@ -1484,8 +1482,6 @@ namespace nidmm_grpc {
             attribute_value.resize(buffer_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -1597,8 +1593,6 @@ namespace nidmm_grpc {
             channel_string.resize(buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_string.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -1664,8 +1658,6 @@ namespace nidmm_grpc {
             description.resize(buffer_size-1);
         }
         status = library_->GetError(vi, &error_code, buffer_size, (ViChar*)description.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -1708,8 +1700,6 @@ namespace nidmm_grpc {
             error_message.resize(buffer_size-1);
         }
         status = library_->GetErrorMessage(vi, error_code, buffer_size, (ViChar*)error_message.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -1835,8 +1825,6 @@ namespace nidmm_grpc {
             coercion_record.resize(buffer_size-1);
         }
         status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -1877,8 +1865,6 @@ namespace nidmm_grpc {
             interchange_warning.resize(buffer_size-1);
         }
         status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -323,8 +323,6 @@ namespace nifake_grpc {
       
         std::string configuration(size_in_bytes, '\0');
         status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, (ViInt8*)configuration.data());
-        // We cast status into size_in_bytes above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(size_in_bytes)) {
           // buffer is now too small, try again
           continue;
@@ -460,8 +458,6 @@ namespace nifake_grpc {
             a_string.resize(buffer_size-1);
         }
         status = library_->GetAnIviDanceString(vi, buffer_size, (ViChar*)a_string.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -560,8 +556,6 @@ namespace nifake_grpc {
         response->mutable_array_out()->Resize(array_size, 0);
         ViReal64* array_out = response->mutable_array_out()->mutable_data();
         status = library_->GetArrayUsingIviDance(vi, array_size, array_out);
-        // We cast status into array_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(array_size)) {
           // buffer is now too small, try again
           continue;
@@ -753,8 +747,6 @@ namespace nifake_grpc {
             attribute_value.resize(buffer_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -1395,8 +1387,6 @@ namespace nifake_grpc {
             a_string.resize(string_size-1);
         }
         status = library_->ReturnMultipleTypes(vi, &a_boolean, &an_int32, &an_int64, &an_int_enum, &a_float, &a_float_enum, array_size, an_array, string_size, (ViChar*)a_string.data());
-        // We cast status into string_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(string_size)) {
           // buffer is now too small, try again
           continue;

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -323,7 +323,9 @@ namespace nifake_grpc {
       
         std::string configuration(size_in_bytes, '\0');
         status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, (ViInt8*)configuration.data());
-        if (status == kErrorReadBufferTooSmall || status > size_in_bytes) {
+        // We cast status into size_in_bytes above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(size_in_bytes)) {
           // buffer is now too small, try again
           continue;
         }
@@ -458,7 +460,9 @@ namespace nifake_grpc {
             a_string.resize(buffer_size-1);
         }
         status = library_->GetAnIviDanceString(vi, buffer_size, (ViChar*)a_string.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -556,7 +560,9 @@ namespace nifake_grpc {
         response->mutable_array_out()->Resize(array_size, 0);
         ViReal64* array_out = response->mutable_array_out()->mutable_data();
         status = library_->GetArrayUsingIviDance(vi, array_size, array_out);
-        if (status == kErrorReadBufferTooSmall || status > array_size) {
+        // We cast status into array_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(array_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -747,7 +753,9 @@ namespace nifake_grpc {
             attribute_value.resize(buffer_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute_id, buffer_size, (ViChar*)attribute_value.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1387,7 +1395,9 @@ namespace nifake_grpc {
             a_string.resize(string_size-1);
         }
         status = library_->ReturnMultipleTypes(vi, &a_boolean, &an_int32, &an_int64, &an_int_enum, &a_float, &a_float_enum, array_size, an_array, string_size, (ViChar*)a_string.data());
-        if (status == kErrorReadBufferTooSmall || status > string_size) {
+        // We cast status into string_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(string_size)) {
           // buffer is now too small, try again
           continue;
         }

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -1699,8 +1699,6 @@ namespace nifgen_grpc {
         response->mutable_configuration()->Resize(size_in_bytes, 0);
         ViAddr* configuration = reinterpret_cast<ViAddr*>(response->mutable_configuration()->mutable_data());
         status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, configuration);
-        // We cast status into size_in_bytes above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(size_in_bytes)) {
           // buffer is now too small, try again
           continue;
@@ -1925,8 +1923,6 @@ namespace nifgen_grpc {
             attribute_value.resize(array_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute_id, array_size, (ViChar*)attribute_value.data());
-        // We cast status into array_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(array_size)) {
           // buffer is now too small, try again
           continue;
@@ -1968,8 +1964,6 @@ namespace nifgen_grpc {
             channel_string.resize(buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_string.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -2011,8 +2005,6 @@ namespace nifgen_grpc {
             error_description.resize(error_description_buffer_size-1);
         }
         status = library_->GetError(vi, &error_code, error_description_buffer_size, (ViChar*)error_description.data());
-        // We cast status into error_description_buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(error_description_buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -2192,8 +2184,6 @@ namespace nifgen_grpc {
             coercion_record.resize(buffer_size-1);
         }
         status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -2234,8 +2224,6 @@ namespace nifgen_grpc {
             interchange_warning.resize(buffer_size-1);
         }
         status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -1699,7 +1699,9 @@ namespace nifgen_grpc {
         response->mutable_configuration()->Resize(size_in_bytes, 0);
         ViAddr* configuration = reinterpret_cast<ViAddr*>(response->mutable_configuration()->mutable_data());
         status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, configuration);
-        if (status == kErrorReadBufferTooSmall || status > size_in_bytes) {
+        // We cast status into size_in_bytes above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(size_in_bytes)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1923,7 +1925,9 @@ namespace nifgen_grpc {
             attribute_value.resize(array_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute_id, array_size, (ViChar*)attribute_value.data());
-        if (status == kErrorReadBufferTooSmall || status > array_size) {
+        // We cast status into array_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(array_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1964,7 +1968,9 @@ namespace nifgen_grpc {
             channel_string.resize(buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_string.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -2005,7 +2011,9 @@ namespace nifgen_grpc {
             error_description.resize(error_description_buffer_size-1);
         }
         status = library_->GetError(vi, &error_code, error_description_buffer_size, (ViChar*)error_description.data());
-        if (status == kErrorReadBufferTooSmall || status > error_description_buffer_size) {
+        // We cast status into error_description_buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(error_description_buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -2184,7 +2192,9 @@ namespace nifgen_grpc {
             coercion_record.resize(buffer_size-1);
         }
         status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -2224,7 +2234,9 @@ namespace nifgen_grpc {
             interchange_warning.resize(buffer_size-1);
         }
         status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -1394,8 +1394,6 @@ namespace niscope_grpc {
       
         std::string configuration(size_in_bytes, '\0');
         status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, (ViInt8*)configuration.data());
-        // We cast status into size_in_bytes above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(size_in_bytes)) {
           // buffer is now too small, try again
           continue;
@@ -1621,8 +1619,6 @@ namespace niscope_grpc {
             value.resize(buf_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_list, attribute_id, buf_size, (ViChar*)value.data());
-        // We cast status into buf_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buf_size)) {
           // buffer is now too small, try again
           continue;
@@ -1664,8 +1660,6 @@ namespace niscope_grpc {
             channel_string.resize(buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_string.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -1707,8 +1701,6 @@ namespace niscope_grpc {
             name.resize(buffer_size-1);
         }
         status = library_->GetChannelNameFromString(vi, index, buffer_size, (ViChar*)name.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -1775,8 +1767,6 @@ namespace niscope_grpc {
             description.resize(buffer_size-1);
         }
         status = library_->GetError(vi, &error_code, buffer_size, (ViChar*)description.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -1819,8 +1809,6 @@ namespace niscope_grpc {
             error_message.resize(buffer_size-1);
         }
         status = library_->GetErrorMessage(vi, error_code, buffer_size, (ViChar*)error_message.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -1394,7 +1394,9 @@ namespace niscope_grpc {
       
         std::string configuration(size_in_bytes, '\0');
         status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, (ViInt8*)configuration.data());
-        if (status == kErrorReadBufferTooSmall || status > size_in_bytes) {
+        // We cast status into size_in_bytes above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(size_in_bytes)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1619,7 +1621,9 @@ namespace niscope_grpc {
             value.resize(buf_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_list, attribute_id, buf_size, (ViChar*)value.data());
-        if (status == kErrorReadBufferTooSmall || status > buf_size) {
+        // We cast status into buf_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buf_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1660,7 +1664,9 @@ namespace niscope_grpc {
             channel_string.resize(buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_string.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1701,7 +1707,9 @@ namespace niscope_grpc {
             name.resize(buffer_size-1);
         }
         status = library_->GetChannelNameFromString(vi, index, buffer_size, (ViChar*)name.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1767,7 +1775,9 @@ namespace niscope_grpc {
             description.resize(buffer_size-1);
         }
         status = library_->GetError(vi, &error_code, buffer_size, (ViChar*)description.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1809,7 +1819,9 @@ namespace niscope_grpc {
             error_message.resize(buffer_size-1);
         }
         status = library_->GetErrorMessage(vi, error_code, buffer_size, (ViChar*)error_message.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -631,7 +631,9 @@ namespace niswitch_grpc {
             attribute_value.resize(array_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute_id, array_size, (ViChar*)attribute_value.data());
-        if (status == kErrorReadBufferTooSmall || status > array_size) {
+        // We cast status into array_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(array_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -698,7 +700,9 @@ namespace niswitch_grpc {
             channel_name_buffer.resize(buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_name_buffer.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -739,7 +743,9 @@ namespace niswitch_grpc {
             description.resize(buffer_size-1);
         }
         status = library_->GetError(vi, &code, buffer_size, (ViChar*)description.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -780,7 +786,9 @@ namespace niswitch_grpc {
             coercion_record.resize(buffer_size-1);
         }
         status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -820,7 +828,9 @@ namespace niswitch_grpc {
             interchange_warning.resize(buffer_size-1);
         }
         status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -862,7 +872,9 @@ namespace niswitch_grpc {
             path.resize(buffer_size-1);
         }
         status = library_->GetPath(vi, channel1, channel2, buffer_size, (ViChar*)path.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -927,7 +939,9 @@ namespace niswitch_grpc {
             relay_name_buffer.resize(relay_name_buffer_size-1);
         }
         status = library_->GetRelayName(vi, index, relay_name_buffer_size, (ViChar*)relay_name_buffer.data());
-        if (status == kErrorReadBufferTooSmall || status > relay_name_buffer_size) {
+        // We cast status into relay_name_buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(relay_name_buffer_size)) {
           // buffer is now too small, try again
           continue;
         }

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -631,8 +631,6 @@ namespace niswitch_grpc {
             attribute_value.resize(array_size-1);
         }
         status = library_->GetAttributeViString(vi, channel_name, attribute_id, array_size, (ViChar*)attribute_value.data());
-        // We cast status into array_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(array_size)) {
           // buffer is now too small, try again
           continue;
@@ -700,8 +698,6 @@ namespace niswitch_grpc {
             channel_name_buffer.resize(buffer_size-1);
         }
         status = library_->GetChannelName(vi, index, buffer_size, (ViChar*)channel_name_buffer.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -743,8 +739,6 @@ namespace niswitch_grpc {
             description.resize(buffer_size-1);
         }
         status = library_->GetError(vi, &code, buffer_size, (ViChar*)description.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -786,8 +780,6 @@ namespace niswitch_grpc {
             coercion_record.resize(buffer_size-1);
         }
         status = library_->GetNextCoercionRecord(vi, buffer_size, (ViChar*)coercion_record.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -828,8 +820,6 @@ namespace niswitch_grpc {
             interchange_warning.resize(buffer_size-1);
         }
         status = library_->GetNextInterchangeWarning(vi, buffer_size, (ViChar*)interchange_warning.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -872,8 +862,6 @@ namespace niswitch_grpc {
             path.resize(buffer_size-1);
         }
         status = library_->GetPath(vi, channel1, channel2, buffer_size, (ViChar*)path.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -939,8 +927,6 @@ namespace niswitch_grpc {
             relay_name_buffer.resize(relay_name_buffer_size-1);
         }
         status = library_->GetRelayName(vi, index, relay_name_buffer_size, (ViChar*)relay_name_buffer.data());
-        // We cast status into relay_name_buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(relay_name_buffer_size)) {
           // buffer is now too small, try again
           continue;

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -1077,8 +1077,6 @@ namespace nisync_grpc {
             time_reference_names.resize(buffer_size-1);
         }
         status = library_->GetTimeReferenceNames(vi, buffer_size, (ViChar*)time_reference_names.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
@@ -1196,8 +1194,6 @@ namespace nisync_grpc {
             value.resize(buffer_size-1);
         }
         status = library_->GetAttributeViString(vi, active_item, attribute, buffer_size, (ViChar*)value.data());
-        // We cast status into buffer_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -1077,7 +1077,9 @@ namespace nisync_grpc {
             time_reference_names.resize(buffer_size-1);
         }
         status = library_->GetTimeReferenceNames(vi, buffer_size, (ViChar*)time_reference_names.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1194,7 +1196,9 @@ namespace nisync_grpc {
             value.resize(buffer_size-1);
         }
         status = library_->GetAttributeViString(vi, active_item, attribute, buffer_size, (ViChar*)value.data());
-        if (status == kErrorReadBufferTooSmall || status > buffer_size) {
+        // We cast status into buffer_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(buffer_size)) {
           // buffer is now too small, try again
           continue;
         }

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -149,8 +149,6 @@ namespace nitclk_grpc {
             error_string.resize(error_string_size-1);
         }
         status = library_->GetExtendedErrorInfo((ViChar*)error_string.data(), error_string_size);
-        // We cast status into error_string_size above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(error_string_size)) {
           // buffer is now too small, try again
           continue;

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -149,7 +149,9 @@ namespace nitclk_grpc {
             error_string.resize(error_string_size-1);
         }
         status = library_->GetExtendedErrorInfo((ViChar*)error_string.data(), error_string_size);
-        if (status == kErrorReadBufferTooSmall || status > error_string_size) {
+        // We cast status into error_string_size above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(error_string_size)) {
           // buffer is now too small, try again
           continue;
         }

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -57,7 +57,9 @@ ${initialize_input_params(function_name, non_ivi_params)}\
 ${initialize_output_params(output_parameters)}\
 </%block>\
         status = library_->${function_name}(${service_helpers.create_args(parameters)});
-        if (status == kErrorReadBufferTooSmall || status > ${common_helpers.camel_to_snake(size_param['cppName'])}) {
+        // We cast status into ${common_helpers.camel_to_snake(size_param['cppName'])} above, so it's safe to cast
+        // back to status's type here. (we do this to avoid a compiler warning)
+        if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(${common_helpers.camel_to_snake(size_param['cppName'])})) {
           // buffer is now too small, try again
           continue;
         }

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -57,8 +57,8 @@ ${initialize_input_params(function_name, non_ivi_params)}\
 ${initialize_output_params(output_parameters)}\
 </%block>\
         status = library_->${function_name}(${service_helpers.create_args(parameters)});
-        // We cast status into ${common_helpers.camel_to_snake(size_param['cppName'])} above, so it's safe to cast
-        // back to status's type here. (we do this to avoid a compiler warning)
+        ## We cast status into ${common_helpers.camel_to_snake(size_param['cppName'])} above, so it's safe to cast
+        ## back to status's type here. (we do this to avoid a compiler warning)
         if (status == kErrorReadBufferTooSmall || status > static_cast<decltype(status)>(${common_helpers.camel_to_snake(size_param['cppName'])})) {
           // buffer is now too small, try again
           continue;


### PR DESCRIPTION
### What does this Pull Request accomplish?

A signed/unsigned comparison warning was introduced in #309. This fixes the warning by explicitly casting, and explains in a comment why it is safe to do so.

### Why should this Pull Request be merged?

We should try to keep compiler warnings at a minimum.

### What testing has been done?

Still builds and unit tests pass.