### PR TITLE
Fix exception handling in betterproto examples (fixes #282)

### DIFF
--- a/examples/niscope/graph-measurement-betterproto.py
+++ b/examples/niscope/graph-measurement-betterproto.py
@@ -38,6 +38,7 @@ import matplotlib.pyplot as plt
 import time
 import sys
 from grpclib.client import Channel
+from grpclib.exceptions import GRPCError
 
 server_address = "localhost"
 server_port = "31763"
@@ -197,13 +198,13 @@ async def main():
         grpc_scope = await OpenGrpcScope(resource, server_address, server_port)
         await ConfigureGrpcScope(*grpc_scope)
         await MeasureGrpcScope(*grpc_scope)
+    except GRPCError as e:
+        if e.status.name == "UNIMPLEMENTED":
+            print("The operation is not implemented or is not supported/enabled in this service")
+        else:
+            print(f"GRPCError: {str(e)}")
     except Exception as e:
-        error_message = e.args[1]
-        if e.args[0] == 22:
-            error_message = f"Failed to connect to server on {server_address}:{server_port}"
-        elif e.status.name == "UNIMPLEMENTED":
-            error_message = "The operation is not implemented or is not supported/enabled in this service"
-        print(error_message)
+        print(str(e))
     finally:
         if grpc_scope:
             await CloseGrpcScope(*grpc_scope)

--- a/examples/niscope/plot-read-waveform-betterproto.py
+++ b/examples/niscope/plot-read-waveform-betterproto.py
@@ -35,8 +35,9 @@
 
 from nidevice import niscope_grpc
 import asyncio
-from grpclib.client import Channel
 import sys
+from grpclib.client import Channel
+from grpclib.exceptions import GRPCError
 
 server_address = "localhost"
 server_port = "31763"
@@ -133,13 +134,13 @@ async def PerformAcquire():
         values = read_result.waveform[0:10]
         print(values)
     
+    except GRPCError as e:
+        if e.status.name == "UNIMPLEMENTED":
+            print("The operation is not implemented or is not supported/enabled in this service")
+        else:
+            print(f"GRPCError: {str(e)}")
     except Exception as e:
-        error_message = e.args[1]
-        if e.args[0] == 22:
-            error_message = f"Failed to connect to server on {server_address}:{server_port}"
-        elif e.status.name == "UNIMPLEMENTED":
-            error_message = "The operation is not implemented or is not supported/enabled in this service"
-        print(error_message)
+        print(str(e))
     finally:
         if('vi' in vars() and vi.id != 0):
             await scope_service.close(vi = vi)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes #282.

Update to the same implementation we used for DAQmx after running into this issue.

### Why should this Pull Request be merged?

The previous implementation tried to catch specific OS exceptions in a way that doesn't work in all configurations and, in some cases, crashes during handling.

### What testing has been done?

Ran the included examples:
* No server running -> Reasonable error.
* Bogus IP address -> Reasonable error.
* Invalid driver configuration -> Reasonable error.
* Working server -> Produces data.