### PR TITLE
sync: pps test cleans up

### DIFF
--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -1136,6 +1136,13 @@ TEST_F(NiSyncDriver6683Test, SetTimeReferencePPS_ReturnsSuccess)
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
+
+  // Switch back to free-running to free up the PFI line.
+  viStatus = VI_SUCCESS;
+  grpcStatus = call_SetTimeReferenceFreeRunning(&viStatus);
+
+  EXPECT_TRUE(grpcStatus.ok());
+  EXPECT_EQ(VI_SUCCESS, viStatus);
 }
 
 TEST_F(NiSyncDriver6683Test, SetTimeReferencePPSWithInvalidTerminal_ReturnsError)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Ensures that `SetTimeReferencePPS_ReturnsSuccess` leaves the device in a usable state by setting the time reference back to Free Running. This frees up the PFI line that was used.

### Why should this Pull Request be merged?

This allows tests to be run in any order. Previously the sync system tests only worked in the order that they were written and unintentionally assumed that `SetTimeReference1588_ReturnsSuccess` would run before other tests later in the file.

### What testing has been done?

It builds.
