### PR TITLE
Support legacy sessions in dcpower tests

### DIFF
--- a/source/tests/system/nidcpower_driver_api_tests.cpp
+++ b/source/tests/system/nidcpower_driver_api_tests.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
+#include "nidcpower/nidcpower_client.h"
 #include "nidcpower/nidcpower_service.h"
 
 namespace ni {
@@ -8,6 +9,7 @@ namespace tests {
 namespace system {
 
 namespace dcpower = nidcpower_grpc;
+namespace client = nidcpower_grpc::experimental::client;
 
 const int kdcpowerDriverApiSuccess = 0;
 
@@ -44,19 +46,31 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
 
   void initialize_driver_session()
   {
-    ::grpc::ClientContext context;
-    dcpower::InitializeWithIndependentChannelsRequest request;
-    request.set_resource_name("FakeDevice");
-    request.set_option_string("Simulate=1, DriverSetup=Model:4147; BoardType:PXIe");
-    request.set_session_name("");
-    request.set_reset(false);
-    dcpower::InitializeWithIndependentChannelsResponse response;
+    try {
+      auto independent_response = client::initialize_with_independent_channels(
+          GetStub(),
+          "FakeDevice",
+          false,
+          "Simulate=1, DriverSetup=Model:4147; BoardType:PXIe");
+      driver_session_ = std::make_unique<nidevice_grpc::Session>(independent_response.vi());
+    }
+    catch (std::runtime_error&) {
+      auto legacy_response = client::initialize_with_channels(
+          GetStub(),
+          "FakeDevice",
+          "0",
+          false,
+          "Simulate=1, DriverSetup=Model:4147; BoardType:PXIe");
 
-    ::grpc::Status status = GetStub()->InitializeWithIndependentChannels(&context, request, &response);
-    driver_session_ = std::make_unique<nidevice_grpc::Session>(response.vi());
+      driver_session_ = std::make_unique<nidevice_grpc::Session>(legacy_response.vi());
+      ASSERT_EQ(kdcpowerDriverApiSuccess, legacy_response.status());
+      is_legacy_session_ = true;
+    }
+  }
 
-    ASSERT_TRUE(status.ok());
-    ASSERT_EQ(kdcpowerDriverApiSuccess, response.status());
+  bool is_legacy_session()
+  {
+    return is_legacy_session_;
   }
 
   void initiate()
@@ -300,7 +314,14 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   DeviceServerInterface* device_server_;
   std::unique_ptr<::nidevice_grpc::Session> driver_session_;
   std::unique_ptr<dcpower::NiDCPower::Stub> nidcpower_stub_;
+  bool is_legacy_session_{false};
 };
+
+// Some tests don't work with the legacy InitializeWithChannels API
+// because of differences in how channels are configured OR because they
+// test features of the independent channel API.
+#define GTEST_SKIP_IF_LEGACY() \
+  if (is_legacy_session()) GTEST_SKIP() << "Test not supported with legacy session API.";
 
 TEST_F(NiDCPowerDriverApiTest, PerformSelfTest_CompletesSuccessfuly)
 {
@@ -350,6 +371,7 @@ TEST_F(NiDCPowerDriverApiTest, SetAttributeViInt32_GetAttributeViInt32ReturnsSam
 
 TEST_F(NiDCPowerDriverApiTest, SetAttributeViReal64_GetAttributeViReal64ReturnsSameValue)
 {
+  GTEST_SKIP_IF_LEGACY();
   const char* channel_name = "0";
   // Attribute 'NIDCPOWER_ATTRIBUTE_MEASURE_WHEN' must be set to 'MEASURE_WHEN_NIDCPOWER_VAL_AUTOMATICALLY_AFTER_SOURCE_COMPLETE'
   // before setting attribute 'NIDCPOWER_ATTRIBUTE_SOURCE_DELAY'.
@@ -376,6 +398,7 @@ TEST_F(NiDCPowerDriverApiTest, SetAttributeViReal64_GetAttributeViReal64ReturnsS
 
 TEST_F(NiDCPowerDriverApiTest, SetAttributeViBoolean_GetAttributeViBooleanReturnsSameValue)
 {
+  GTEST_SKIP_IF_LEGACY();
   const char* channel_name = "0";
   // Attribute 'NIDCPOWER_ATTRIBUTE_MEASURE_WHEN' must be set to 'MEASURE_WHEN_NIDCPOWER_VAL_AUTOMATICALLY_AFTER_SOURCE_COMPLETE'
   // before setting attribute 'NIDCPOWER_ATTRIBUTE_MEASURE_RECORD_LENGTH_IS_FINITE'.
@@ -402,6 +425,7 @@ TEST_F(NiDCPowerDriverApiTest, SetAttributeViBoolean_GetAttributeViBooleanReturn
 
 TEST_F(NiDCPowerDriverApiTest, SetAttributeViString_GetAttributeViStringReturnsSameValue)
 {
+  GTEST_SKIP_IF_LEGACY();
   const char* channel_name = "0";
   const dcpower::NiDCPowerAttributes attribute_to_set = dcpower::NiDCPowerAttributes::NIDCPOWER_ATTRIBUTE_EXPORTED_START_TRIGGER_OUTPUT_TERMINAL;
   const ViString expected_value = "/Dev1/PXI_Trig0";
@@ -486,6 +510,7 @@ TEST_F(NiDCPowerDriverApiTest, SetMeasureWhenAndInitiate_MeasureMultiple_Returns
 
 TEST_F(NiDCPowerDriverApiTest, SetMeasureWhenAndInitiate_FetchMultiple_FetchesSuccessfully)
 {
+  GTEST_SKIP_IF_LEGACY();
   const char* channel_name = "0";
   // Attribute 'NIDCPOWER_ATTRIBUTE_MEASURE_WHEN' must be set before calling FetchMultiple
   set_int32_attribute(
@@ -502,6 +527,7 @@ TEST_F(NiDCPowerDriverApiTest, SetMeasureWhenAndInitiate_FetchMultiple_FetchesSu
 
 TEST_F(NiDCPowerDriverApiTest, VoltageLevelConfiguredAndExportedToBuffer_ResetAndImportConfigurationFromBuffer_ConfigurationIsImportedSuccessfully)
 {
+  GTEST_SKIP_IF_LEGACY();
   const char* channel_name = "0";
   auto expected_output_function = dcpower::OutputFunction::OUTPUT_FUNCTION_NIDCPOWER_VAL_DC_VOLTAGE;
   auto expected_voltage_level = 3.0;

--- a/source/tests/system/nidcpower_driver_api_tests.cpp
+++ b/source/tests/system/nidcpower_driver_api_tests.cpp
@@ -46,24 +46,28 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
 
   void initialize_driver_session()
   {
+    const auto DEVICE = "FakeDevice";
+    const auto OPTIONS = "Simulate=1, DriverSetup=Model:4147; BoardType:PXIe";
     try {
       auto independent_response = client::initialize_with_independent_channels(
           GetStub(),
-          "FakeDevice",
+          DEVICE,
           false,
-          "Simulate=1, DriverSetup=Model:4147; BoardType:PXIe");
+          OPTIONS);
+
+      ASSERT_EQ(kdcpowerDriverApiSuccess, independent_response.status());
       driver_session_ = std::make_unique<nidevice_grpc::Session>(independent_response.vi());
     }
     catch (std::runtime_error&) {
       auto legacy_response = client::initialize_with_channels(
           GetStub(),
-          "FakeDevice",
+          DEVICE,
           "0",
           false,
-          "Simulate=1, DriverSetup=Model:4147; BoardType:PXIe");
+          OPTIONS);
 
-      driver_session_ = std::make_unique<nidevice_grpc::Session>(legacy_response.vi());
       ASSERT_EQ(kdcpowerDriverApiSuccess, legacy_response.status());
+      driver_session_ = std::make_unique<nidevice_grpc::Session>(legacy_response.vi());
       is_legacy_session_ = true;
     }
   }

--- a/source/tests/system/nidcpower_driver_api_tests.cpp
+++ b/source/tests/system/nidcpower_driver_api_tests.cpp
@@ -432,7 +432,7 @@ TEST_F(NiDCPowerDriverApiTest, SetAttributeViString_GetAttributeViStringReturnsS
   GTEST_SKIP_IF_LEGACY();
   const char* channel_name = "0";
   const dcpower::NiDCPowerAttributes attribute_to_set = dcpower::NiDCPowerAttributes::NIDCPOWER_ATTRIBUTE_EXPORTED_START_TRIGGER_OUTPUT_TERMINAL;
-  const ViString expected_value = "/Dev1/PXI_Trig0";
+  const char* expected_value = "/Dev1/PXI_Trig0";
   ::grpc::ClientContext context;
   dcpower::SetAttributeViStringRequest request;
   request.mutable_vi()->set_id(GetSessionId());

--- a/source/tests/system/nidcpower_session_tests.cpp
+++ b/source/tests/system/nidcpower_session_tests.cpp
@@ -95,6 +95,7 @@ TEST_F(NiDCPowerSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDr
   auto status = call_initialize_with_independent_channels(kTestRsrc, kOptionsString, kTestSession, &response);
 
   GTEST_SKIP_IF_UNSUPPORTED(status);
+  EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
   EXPECT_NE(0, response.vi().id());
 }
@@ -105,6 +106,7 @@ TEST_F(NiDCPowerSessionTest, InitializeSessionWithDeviceAndNoSessionName_Creates
   ::grpc::Status status = call_initialize_with_independent_channels(kTestRsrc, kOptionsString, "", &response);
 
   GTEST_SKIP_IF_UNSUPPORTED(status);
+  EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
   EXPECT_NE(0, response.vi().id());
 }
@@ -124,6 +126,7 @@ TEST_F(NiDCPowerSessionTest, InitializedSession_CloseSession_ClosesDriverSession
   dcpower::InitializeWithIndependentChannelsResponse initialize_response;
   auto status = call_initialize_with_independent_channels(kTestRsrc, kOptionsString, kTestSession, &initialize_response);
   GTEST_SKIP_IF_UNSUPPORTED(status);
+  EXPECT_TRUE(status.ok());
   nidevice_grpc::Session session = initialize_response.vi();
 
   ::grpc::ClientContext context;

--- a/source/tests/system/nidcpower_session_tests.cpp
+++ b/source/tests/system/nidcpower_session_tests.cpp
@@ -142,7 +142,7 @@ TEST_F(NiDCPowerSessionTest, InitializedSession_CloseSession_ClosesDriverSession
 TEST_F(NiDCPowerSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
 {
   nidevice_grpc::Session session;
-  session.set_id(NULL);
+  session.set_id(0UL);
 
   ::grpc::ClientContext context;
   dcpower::CloseRequest request;

--- a/source/tests/system/nidcpower_session_tests.cpp
+++ b/source/tests/system/nidcpower_session_tests.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "nidcpower/nidcpower_client.h"
 #include "nidcpower/nidcpower_service.h"
 
 namespace ni {
@@ -9,7 +8,6 @@ namespace tests {
 namespace system {
 
 namespace dcpower = nidcpower_grpc;
-namespace client = nidcpower_grpc::experimental::client;
 
 const int kInvalidRsrc = -1074118656;
 const int kInvalidDCPowerSession = -1074130544;
@@ -89,7 +87,7 @@ class NiDCPowerSessionTest : public ::testing::Test {
 // To support testing with older versions: skip tests for InitializeWithIndependentChannels if
 // it returns an unsupported status.
 #define GTEST_SKIP_IF_UNSUPPORTED(status) \
-  if (status.error_code() == ::grpc::NOT_FOUND) GTEST_SKIP() << "UNSUPPORTED";
+  if (status.error_code() == ::grpc::NOT_FOUND) GTEST_SKIP() << "Function not supported.";
 
 TEST_F(NiDCPowerSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDriverSession)
 {

--- a/source/tests/utilities/client_helpers.h
+++ b/source/tests/utilities/client_helpers.h
@@ -49,7 +49,7 @@ class simple_variant {
 inline void raise_if_error(const ::grpc::Status& status)
 {
   if (!status.ok()) {
-    throw new std::runtime_error(status.error_message());
+    throw std::runtime_error(status.error_message());
   }
 }
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update dcpower tests to be more tolerant of older versions that don't have `InitializeWithIndependentChannels`.

For tests that run with the old `InitializeWithChannels` API: fallback to that init method and continue.
For tests that don't work with `InitializeWithChannels` or are explicitly written for `InitializeWithIndependentChannels`: Skip the test.

### Why should this Pull Request be merged?

InitializeWithIndependentChannels is a new API that hasn't been released yet on Linux. This makes it harder to test release drivers on Linux.

### What testing has been done?

Ran and passed all dcpower tests on Windows.

Ran and passed all dcpower tests on CentOS with the following skips:
```
[  SKIPPED ] NiDCPowerDriverApiTest.SetAttributeViReal64_GetAttributeViReal64ReturnsSameValue
[  SKIPPED ] NiDCPowerDriverApiTest.SetAttributeViBoolean_GetAttributeViBooleanReturnsSameValue
[  SKIPPED ] NiDCPowerDriverApiTest.SetAttributeViString_GetAttributeViStringReturnsSameValue
[  SKIPPED ] NiDCPowerDriverApiTest.SetMeasureWhenAndInitiate_FetchMultiple_FetchesSuccessfully
[  SKIPPED ] NiDCPowerDriverApiTest.VoltageLevelConfiguredAndExportedToBuffer_ResetAndImportConfigurationFromBuffer_ConfigurationIsImportedSuccessfully
[  SKIPPED ] NiDCPowerSessionTest.InitializeSessionWithDeviceAndSessionName_CreatesDriverSession
[  SKIPPED ] NiDCPowerSessionTest.InitializeSessionWithDeviceAndNoSessionName_CreatesDriverSession
[  SKIPPED ] NiDCPowerSessionTest.InitializedSession_CloseSession_ClosesDriverSession
```

