### PR TITLE
Add -j 2 to parallelize workflow builds

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -81,7 +81,7 @@ jobs:
       shell: cmake -P {0}
       run: |
         execute_process(
-          COMMAND cmake --build build --config $ENV{BUILD_TYPE}
+          COMMAND cmake --build build --config $ENV{BUILD_TYPE} -j 2
           RESULT_VARIABLE result
           OUTPUT_VARIABLE output
           ERROR_VARIABLE output

--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -121,7 +121,7 @@ jobs:
       shell: cmake -P {0}
       run: |
         execute_process(
-          COMMAND cmake --build build --config $ENV{BUILD_TYPE}
+          COMMAND cmake --build build --config $ENV{BUILD_TYPE} -j 2
           RESULT_VARIABLE result
           OUTPUT_VARIABLE output
           ERROR_VARIABLE output

--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -84,7 +84,7 @@ jobs:
       shell: cmake -P {0}
       run: |
         execute_process(
-          COMMAND cmake --build $ENV{GITHUB_WORKSPACE}/third_party/grpc/build
+          COMMAND cmake --build $ENV{GITHUB_WORKSPACE}/third_party/grpc/build -j 2
           RESULT_VARIABLE result
           OUTPUT_VARIABLE output
           ERROR_VARIABLE output


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add `-j 2 ` to workflow builds to use both cores on the GH agents.
See [cmake build documentation](https://cmake.org/cmake/help/latest/manual/cmake.1.html#build-a-project).

### Why should this Pull Request be merged?

Get faster results from workflow builds.

### What testing has been done?

Workflow builds run significantly faster on Linux, which is currently or slowest build. Windows is about-the-same or slightly faster.