### PR TITLE
Add GetTaskAttributeUInt32 to analog-input example

### DIFF
--- a/examples/nidaqmx/analog-input-every-n-samples.py
+++ b/examples/nidaqmx/analog-input-every-n-samples.py
@@ -17,6 +17,7 @@
 #
 # Server machine's IP address, port number, and physical channel name can be passed as separate command line arguments.
 #   > python analog-input-every-n-samples.py <server_address> <port_number> <physical_channel_name>
+# To acquire data from multiple channels, pass in a list or range of channels (i.e., Dev1/ai0:3).
 # If they are not passed in as command line arguments, then by default the server address will be "localhost:31763", with "Dev1/ai0" as the physical channel name
 import asyncio
 import grpc
@@ -96,6 +97,13 @@ async def main():
 
             await raise_if_error_async(client.StartTask(nidaqmx_types.StartTaskRequest(task=task)))
 
+            response = await raise_if_error_async(
+                client.GetTaskAttributeUInt32(
+                    nidaqmx_types.GetTaskAttributeUInt32Request(
+                        task=task, attribute=nidaqmx_types.TASK_ATTRIBUTE_NUM_CHANS)))
+
+            number_of_channels = response.value
+
             async def read_data():
                 async for every_n_samples_response in every_n_samples_stream:
                     await raise_if_error(every_n_samples_response)
@@ -105,8 +113,11 @@ async def main():
                                 task=task,
                                 num_samps_per_chan=100,
                                 fill_mode=nidaqmx_types.GroupBy.GROUP_BY_GROUP_BY_CHANNEL,
-                                array_size_in_samps=100)))
+                                array_size_in_samps=number_of_channels * 100)))
 
+                    print(
+                        f"Acquired {len(read_response.read_array)} samples",
+                        f"({read_response.samps_per_chan_read} samples per channel)")
                     print("Read Data:", read_response.read_array[:10])
 
             async def wait_for_done():

--- a/examples/nidaqmx/analog-input.py
+++ b/examples/nidaqmx/analog-input.py
@@ -17,7 +17,8 @@
 #
 # Server machine's IP address, port number, and physical channel name can be passed as separate command line arguments.
 #   > python analog-input.py <server_address> <port_number> <physical_channel_name>
-# If they are not passed in as command line arguments, then by default the server address will be "localhost:31763", with "Dev1/ai0" as the physical channel name
+# To acquire data from multiple channels, pass in a list or range of channels (i.e., Dev1/ai0:3).
+# If they are not passed in as command line arguments, then by default the server address will be "localhost:31763", with "Dev1/ai0" as the physical channel name.
 import grpc
 import sys
 

--- a/examples/nidaqmx/analog-input.py
+++ b/examples/nidaqmx/analog-input.py
@@ -72,6 +72,8 @@ try:
 
     RaiseIfError(client.StartTask(nidaqmx_types.StartTaskRequest(task=task)))
 
+    # Get the number of channels. This may be greater than 1 if the physical_channel
+    # parameter is a list or range of channels.
     response = client.GetTaskAttributeUInt32(
         nidaqmx_types.GetTaskAttributeUInt32Request(
             task=task, attribute=nidaqmx_types.TASK_ATTRIBUTE_NUM_CHANS))

--- a/examples/nidaqmx/analog-input.py
+++ b/examples/nidaqmx/analog-input.py
@@ -61,8 +61,7 @@ try:
         terminal_config=nidaqmx_types.INPUT_TERM_CFG_WITH_DEFAULT_CFG_DEFAULT,
         min_val=-10.0,
         max_val=10.0,
-        units=nidaqmx_types.VOLTAGE_UNITS2_VOLTS
-    )))
+        units=nidaqmx_types.VOLTAGE_UNITS2_VOLTS)))
 
     RaiseIfError(client.CfgSampClkTiming(nidaqmx_types.CfgSampClkTimingRequest(
         task=task,
@@ -73,10 +72,16 @@ try:
 
     RaiseIfError(client.StartTask(nidaqmx_types.StartTaskRequest(task=task)))
 
+    response = client.GetTaskAttributeUInt32(
+        nidaqmx_types.GetTaskAttributeUInt32Request(
+            task=task, attribute=nidaqmx_types.TASK_ATTRIBUTE_NUM_CHANS))
+    RaiseIfError(response)
+    number_of_channels = response.value
+
     response = client.ReadAnalogF64(nidaqmx_types.ReadAnalogF64Request(
         task=task,
         num_samps_per_chan=1000,
-        array_size_in_samps=1000,
+        array_size_in_samps=number_of_channels * 1000,
         fill_mode=nidaqmx_types.GROUP_BY_GROUP_BY_CHANNEL,
         timeout=10.0))
     RaiseIfError(response)

--- a/examples/nidaqmx/analog-input.py
+++ b/examples/nidaqmx/analog-input.py
@@ -85,7 +85,9 @@ try:
         fill_mode=nidaqmx_types.GROUP_BY_GROUP_BY_CHANNEL,
         timeout=10.0))
     RaiseIfError(response)
-    print(f"Acquired {response.samps_per_chan_read} samples")
+    print(
+        f"Acquired {len(response.read_array)} samples",
+        f"({response.samps_per_chan_read} samples per channel)")
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:


### PR DESCRIPTION
### What does this Pull Request accomplish?

Read `TASK_ATTRIBUTE_NUM_CHANS` to calculate `array_size_in_samps` in the analog-input example. 

### Why should this Pull Request be merged?

We want to include attribute accessors in the examples as a way of documenting that API.

### What testing has been done?

Ran included example, double-checked the response value was correct (`1`).