### PR TITLE
Add feature toggle to allow undefined attributes with attribute_raw

### DIFF
--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -7156,10 +7156,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetBufferAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::BufferUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetBufferAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::BufferUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetBufferAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7167,8 +7170,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::BufferUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       uInt32 value {};
       auto status = library_->GetBufferAttributeUInt32(task, attribute, &value);
@@ -7196,10 +7197,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetCalInfoAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::CalibrationInfoBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetCalInfoAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::CalibrationInfoBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetCalInfoAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7207,8 +7211,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::CalibrationInfoBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       bool32 value {};
@@ -7237,10 +7239,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetCalInfoAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::CalibrationInfoDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetCalInfoAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::CalibrationInfoDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetCalInfoAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7248,8 +7253,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::CalibrationInfoDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       float64 value {};
@@ -7278,10 +7281,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetCalInfoAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::CalibrationInfoStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetCalInfoAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::CalibrationInfoStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetCalInfoAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7289,8 +7295,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::CalibrationInfoStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -7335,10 +7339,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetCalInfoAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::CalibrationInfoUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetCalInfoAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::CalibrationInfoUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetCalInfoAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7346,8 +7353,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::CalibrationInfoUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       uInt32 value {};
@@ -7378,10 +7383,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetChanAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ChannelBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetChanAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ChannelBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetChanAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7389,8 +7397,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ChannelBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       bool32 value {};
@@ -7421,10 +7427,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetChanAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ChannelDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetChanAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ChannelDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetChanAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7432,8 +7441,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ChannelDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       float64 value {};
@@ -7464,10 +7471,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetChanAttributeDoubleArrayRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ChannelDoubleArrayAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetChanAttributeDoubleArrayRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ChannelDoubleArrayAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetChanAttributeDoubleArrayRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7475,8 +7485,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ChannelDoubleArrayAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -7520,10 +7528,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetChanAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ChannelInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetChanAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ChannelInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetChanAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7531,8 +7542,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ChannelInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       int32 value {};
@@ -7569,10 +7578,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetChanAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ChannelStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetChanAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ChannelStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetChanAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7580,8 +7592,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ChannelStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -7628,10 +7638,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetChanAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ChannelUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetChanAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ChannelUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetChanAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7639,8 +7652,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ChannelUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       uInt32 value {};
@@ -7669,10 +7680,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetDeviceAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::DeviceBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetDeviceAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::DeviceBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetDeviceAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7680,8 +7694,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::DeviceBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       bool32 value {};
@@ -7710,10 +7722,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetDeviceAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::DeviceDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetDeviceAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::DeviceDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetDeviceAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7721,8 +7736,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::DeviceDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       float64 value {};
@@ -7751,10 +7764,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetDeviceAttributeDoubleArrayRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::DeviceDoubleArrayAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetDeviceAttributeDoubleArrayRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::DeviceDoubleArrayAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetDeviceAttributeDoubleArrayRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7762,8 +7778,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::DeviceDoubleArrayAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -7805,10 +7819,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetDeviceAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::DeviceInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetDeviceAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::DeviceInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetDeviceAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7816,8 +7833,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::DeviceInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       int32 value {};
@@ -7852,10 +7867,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetDeviceAttributeInt32ArrayRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::DeviceInt32ArrayAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetDeviceAttributeInt32ArrayRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::DeviceInt32ArrayAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetDeviceAttributeInt32ArrayRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7863,8 +7881,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::DeviceInt32ArrayAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -7920,10 +7936,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetDeviceAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::DeviceStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetDeviceAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::DeviceStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetDeviceAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7931,8 +7950,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::DeviceStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -7977,10 +7994,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetDeviceAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::DeviceUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetDeviceAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::DeviceUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetDeviceAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -7988,8 +8008,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::DeviceUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       uInt32 value {};
@@ -8018,10 +8036,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetDeviceAttributeUInt32ArrayRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::DeviceUInt32ArrayAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetDeviceAttributeUInt32ArrayRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::DeviceUInt32ArrayAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetDeviceAttributeUInt32ArrayRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -8029,8 +8050,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::DeviceUInt32ArrayAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -8262,10 +8281,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetExportedSignalAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ExportSignalBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetExportedSignalAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ExportSignalBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetExportedSignalAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -8273,8 +8295,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ExportSignalBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       bool32 value {};
@@ -8304,10 +8324,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetExportedSignalAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ExportSignalDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetExportedSignalAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ExportSignalDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetExportedSignalAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -8315,8 +8338,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ExportSignalDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       float64 value {};
@@ -8346,10 +8367,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetExportedSignalAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ExportSignalInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetExportedSignalAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ExportSignalInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetExportedSignalAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -8357,8 +8381,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ExportSignalInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       int32 value {};
@@ -8394,10 +8416,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetExportedSignalAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ExportSignalStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetExportedSignalAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ExportSignalStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetExportedSignalAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -8405,8 +8430,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ExportSignalStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -8452,10 +8475,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetExportedSignalAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ExportSignalUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetExportedSignalAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ExportSignalUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetExportedSignalAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -8463,8 +8489,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ExportSignalUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       uInt32 value {};
@@ -8700,10 +8724,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetPersistedChanAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::PersistedChannelBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPersistedChanAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::PersistedChannelBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPersistedChanAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -8711,8 +8738,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::PersistedChannelBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       bool32 value {};
@@ -8741,10 +8766,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetPersistedChanAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::PersistedChannelStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPersistedChanAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::PersistedChannelStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPersistedChanAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -8752,8 +8780,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::PersistedChannelStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -8798,10 +8824,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetPersistedScaleAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::PersistedScaleBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPersistedScaleAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::PersistedScaleBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPersistedScaleAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -8809,8 +8838,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::PersistedScaleBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       bool32 value {};
@@ -8839,10 +8866,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetPersistedScaleAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::PersistedScaleStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPersistedScaleAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::PersistedScaleStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPersistedScaleAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -8850,8 +8880,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::PersistedScaleStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -8896,10 +8924,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetPersistedTaskAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::PersistedTaskBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPersistedTaskAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::PersistedTaskBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPersistedTaskAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -8907,8 +8938,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::PersistedTaskBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       bool32 value {};
@@ -8937,10 +8966,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetPersistedTaskAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::PersistedTaskStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPersistedTaskAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::PersistedTaskStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPersistedTaskAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -8948,8 +8980,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::PersistedTaskStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -8994,10 +9024,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetPhysicalChanAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::PhysicalChannelBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9005,8 +9038,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       bool32 value {};
@@ -9035,10 +9066,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetPhysicalChanAttributeBytesRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::PhysicalChannelBytesAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeBytesRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelBytesAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeBytesRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9046,8 +9080,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelBytesAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -9089,10 +9121,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetPhysicalChanAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::PhysicalChannelDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9100,8 +9135,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       float64 value {};
@@ -9130,10 +9163,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetPhysicalChanAttributeDoubleArrayRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::PhysicalChannelDoubleArrayAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeDoubleArrayRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelDoubleArrayAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeDoubleArrayRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9141,8 +9177,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelDoubleArrayAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -9184,10 +9218,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetPhysicalChanAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::PhysicalChannelInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9195,8 +9232,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       int32 value {};
@@ -9231,10 +9266,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetPhysicalChanAttributeInt32ArrayRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::PhysicalChannelInt32ArrayAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeInt32ArrayRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelInt32ArrayAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeInt32ArrayRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9242,8 +9280,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelInt32ArrayAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -9299,10 +9335,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetPhysicalChanAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::PhysicalChannelStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9310,8 +9349,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -9356,10 +9393,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetPhysicalChanAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::PhysicalChannelUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9367,8 +9407,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       uInt32 value {};
@@ -9397,10 +9435,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetPhysicalChanAttributeUInt32ArrayRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::PhysicalChannelUInt32ArrayAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeUInt32ArrayRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelUInt32ArrayAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetPhysicalChanAttributeUInt32ArrayRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9408,8 +9449,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::PhysicalChannelUInt32ArrayAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -9452,10 +9491,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetReadAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ReadBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetReadAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ReadBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetReadAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9463,8 +9505,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ReadBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       bool32 value {};
@@ -9494,10 +9534,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetReadAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ReadDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetReadAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ReadDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetReadAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9505,8 +9548,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ReadDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       float64 value {};
@@ -9536,10 +9577,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetReadAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ReadInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetReadAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ReadInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetReadAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9547,8 +9591,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ReadInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       int32 value {};
@@ -9584,10 +9626,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetReadAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ReadStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetReadAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ReadStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetReadAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9595,8 +9640,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ReadStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -9642,10 +9685,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetReadAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ReadUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetReadAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ReadUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetReadAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9653,8 +9699,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ReadUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       uInt32 value {};
@@ -9684,10 +9728,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetReadAttributeUInt64Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ReadUInt64Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetReadAttributeUInt64Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ReadUInt64Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetReadAttributeUInt64Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9695,8 +9742,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ReadUInt64Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       uInt64 value {};
@@ -9726,10 +9771,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetRealTimeAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::RealTimeBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetRealTimeAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::RealTimeBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetRealTimeAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9737,8 +9785,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::RealTimeBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       bool32 value {};
@@ -9768,10 +9814,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetRealTimeAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::RealTimeInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetRealTimeAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::RealTimeInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetRealTimeAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9779,8 +9828,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::RealTimeInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       int32 value {};
@@ -9816,10 +9863,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetRealTimeAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::RealTimeUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetRealTimeAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::RealTimeUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetRealTimeAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9827,8 +9877,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::RealTimeUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       uInt32 value {};
@@ -9880,10 +9928,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetScaleAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ScaleDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetScaleAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ScaleDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetScaleAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9891,8 +9942,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ScaleDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       float64 value {};
@@ -9921,10 +9970,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetScaleAttributeDoubleArrayRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ScaleDoubleArrayAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetScaleAttributeDoubleArrayRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ScaleDoubleArrayAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetScaleAttributeDoubleArrayRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9932,8 +9984,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ScaleDoubleArrayAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -9975,10 +10025,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetScaleAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ScaleInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetScaleAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ScaleInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetScaleAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -9986,8 +10039,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ScaleInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       int32 value {};
@@ -10022,10 +10073,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetScaleAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ScaleStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetScaleAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ScaleStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetScaleAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10033,8 +10087,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ScaleStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -10177,10 +10229,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetSystemInfoAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::SystemStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetSystemInfoAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::SystemStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetSystemInfoAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10188,8 +10243,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::SystemStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -10233,10 +10286,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetSystemInfoAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::SystemUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetSystemInfoAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::SystemUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetSystemInfoAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10244,8 +10300,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::SystemUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       uInt32 value {};
@@ -10275,10 +10329,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTaskAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TaskBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTaskAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TaskBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTaskAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10286,8 +10343,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TaskBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       bool32 value {};
@@ -10317,10 +10372,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTaskAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TaskStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTaskAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TaskStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTaskAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10328,8 +10386,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TaskStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -10375,10 +10431,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTaskAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TaskUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTaskAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TaskUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTaskAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10386,8 +10445,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TaskUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       uInt32 value {};
@@ -10417,10 +10474,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10428,8 +10488,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       bool32 value {};
@@ -10459,10 +10517,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10470,8 +10531,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       float64 value {};
@@ -10502,10 +10561,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeExBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeExBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeExBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10513,8 +10575,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       bool32 value {};
@@ -10545,10 +10605,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeExDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeExDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeExDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10556,8 +10619,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       float64 value {};
@@ -10588,10 +10649,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeExInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeExInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeExInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10599,8 +10663,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       int32 value {};
@@ -10637,10 +10699,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeExStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeExStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeExStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10648,8 +10713,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -10696,10 +10759,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeExTimestampRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingTimestampAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeExTimestampRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingTimestampAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeExTimestampRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10707,8 +10773,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingTimestampAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       CVIAbsoluteTime value {};
@@ -10739,10 +10803,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeExUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeExUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeExUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10750,8 +10817,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       uInt32 value {};
@@ -10781,10 +10846,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10792,8 +10860,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       int32 value {};
@@ -10829,10 +10895,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10840,8 +10909,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -10887,10 +10954,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeTimestampRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingTimestampAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeTimestampRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingTimestampAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeTimestampRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10898,8 +10968,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingTimestampAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       CVIAbsoluteTime value {};
@@ -10929,10 +10997,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTimingAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10940,8 +11011,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       uInt32 value {};
@@ -10971,10 +11040,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTrigAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TriggerBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTrigAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TriggerBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTrigAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -10982,8 +11054,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TriggerBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       bool32 value {};
@@ -11013,10 +11083,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTrigAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TriggerDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTrigAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TriggerDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTrigAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -11024,8 +11097,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TriggerDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       float64 value {};
@@ -11055,10 +11126,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTrigAttributeDoubleArrayRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TriggerDoubleArrayAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTrigAttributeDoubleArrayRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TriggerDoubleArrayAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTrigAttributeDoubleArrayRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -11066,8 +11140,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TriggerDoubleArrayAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -11110,10 +11182,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTrigAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TriggerInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTrigAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TriggerInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTrigAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -11121,8 +11196,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TriggerInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       int32 value {};
@@ -11158,10 +11231,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTrigAttributeInt32ArrayRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TriggerInt32ArrayAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTrigAttributeInt32ArrayRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TriggerInt32ArrayAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTrigAttributeInt32ArrayRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -11169,8 +11245,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TriggerInt32ArrayAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -11227,10 +11301,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTrigAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TriggerStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTrigAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TriggerStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTrigAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -11238,8 +11315,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TriggerStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -11285,10 +11360,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTrigAttributeTimestampRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TriggerTimestampAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTrigAttributeTimestampRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TriggerTimestampAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTrigAttributeTimestampRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -11296,8 +11374,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TriggerTimestampAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       CVIAbsoluteTime value {};
@@ -11327,10 +11403,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTrigAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TriggerUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTrigAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TriggerUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetTrigAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -11338,8 +11417,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TriggerUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       uInt32 value {};
@@ -11370,10 +11447,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetWatchdogAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WatchdogBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWatchdogAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WatchdogBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWatchdogAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -11381,8 +11461,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WatchdogBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       bool32 value {};
@@ -11413,10 +11491,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetWatchdogAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WatchdogDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWatchdogAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WatchdogDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWatchdogAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -11424,8 +11505,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WatchdogDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       float64 value {};
@@ -11456,10 +11535,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetWatchdogAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WatchdogInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWatchdogAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WatchdogInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWatchdogAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -11467,8 +11549,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WatchdogInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       int32 value {};
@@ -11505,10 +11585,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetWatchdogAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WatchdogStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWatchdogAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WatchdogStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWatchdogAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -11516,8 +11599,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WatchdogStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -11563,10 +11644,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetWriteAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WriteBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWriteAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WriteBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWriteAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -11574,8 +11658,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WriteBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       bool32 value {};
@@ -11605,10 +11687,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetWriteAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WriteDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWriteAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WriteDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWriteAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -11616,8 +11701,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WriteDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       float64 value {};
@@ -11647,10 +11730,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetWriteAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WriteInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWriteAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WriteInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWriteAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -11658,8 +11744,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WriteInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       int32 value {};
@@ -11695,10 +11779,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetWriteAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WriteStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWriteAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WriteStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWriteAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -11706,8 +11793,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WriteStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
 
       while (true) {
@@ -11753,10 +11838,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetWriteAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WriteUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWriteAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WriteUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::GetWriteAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -11764,8 +11852,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WriteUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto size = 0U;
       uInt32 value {};
@@ -13020,10 +13106,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::ResetBufferAttributeRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::BufferResetAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetBufferAttributeRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::BufferResetAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetBufferAttributeRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13031,8 +13120,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::BufferResetAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto status = library_->ResetBufferAttribute(task, attribute);
       response->set_status(status);
@@ -13058,10 +13145,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::ResetChanAttributeRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ChannelResetAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetChanAttributeRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ChannelResetAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetChanAttributeRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13069,8 +13159,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ChannelResetAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto status = library_->ResetChanAttribute(task, channel, attribute);
       response->set_status(status);
@@ -13113,10 +13201,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::ResetExportedSignalAttributeRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ExportSignalResetAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetExportedSignalAttributeRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ExportSignalResetAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetExportedSignalAttributeRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13124,8 +13215,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ExportSignalResetAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto status = library_->ResetExportedSignalAttribute(task, attribute);
       response->set_status(status);
@@ -13150,10 +13239,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::ResetReadAttributeRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ReadResetAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetReadAttributeRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ReadResetAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetReadAttributeRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13161,8 +13253,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ReadResetAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto status = library_->ResetReadAttribute(task, attribute);
       response->set_status(status);
@@ -13187,10 +13277,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::ResetRealTimeAttributeRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::RealTimeResetAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetRealTimeAttributeRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::RealTimeResetAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetRealTimeAttributeRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13198,8 +13291,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::RealTimeResetAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto status = library_->ResetRealTimeAttribute(task, attribute);
       response->set_status(status);
@@ -13224,10 +13315,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::ResetTimingAttributeRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingResetAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetTimingAttributeRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingResetAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetTimingAttributeRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13235,8 +13329,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingResetAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto status = library_->ResetTimingAttribute(task, attribute);
       response->set_status(status);
@@ -13262,10 +13354,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::ResetTimingAttributeExRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingResetAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetTimingAttributeExRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingResetAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetTimingAttributeExRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13273,8 +13368,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingResetAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto status = library_->ResetTimingAttributeEx(task, device_names, attribute);
       response->set_status(status);
@@ -13299,10 +13392,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::ResetTrigAttributeRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TriggerResetAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetTrigAttributeRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TriggerResetAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetTrigAttributeRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13310,8 +13406,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TriggerResetAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto status = library_->ResetTrigAttribute(task, attribute);
       response->set_status(status);
@@ -13337,10 +13431,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::ResetWatchdogAttributeRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WatchdogResetAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetWatchdogAttributeRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WatchdogResetAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetWatchdogAttributeRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13348,8 +13445,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WatchdogResetAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto status = library_->ResetWatchdogAttribute(task, lines, attribute);
       response->set_status(status);
@@ -13374,10 +13469,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::ResetWriteAttributeRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WriteResetAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetWriteAttributeRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WriteResetAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::ResetWriteAttributeRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13385,8 +13483,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WriteResetAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto status = library_->ResetWriteAttribute(task, attribute);
       response->set_status(status);
@@ -13672,10 +13768,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetBufferAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::BufferUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetBufferAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::BufferUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetBufferAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13683,8 +13782,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::BufferUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       uInt32 value = request->value();
       auto status = library_->SetBufferAttributeUInt32(task, attribute, value);
@@ -13709,10 +13806,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetCalInfoAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::CalibrationInfoBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetCalInfoAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::CalibrationInfoBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetCalInfoAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13720,8 +13820,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::CalibrationInfoBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       bool32 value = request->value();
       auto size = 0U;
@@ -13747,10 +13845,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetCalInfoAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::CalibrationInfoDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetCalInfoAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::CalibrationInfoDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetCalInfoAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13758,8 +13859,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::CalibrationInfoDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       float64 value = request->value();
       auto size = 0U;
@@ -13785,10 +13884,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetCalInfoAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::CalibrationInfoStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetCalInfoAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::CalibrationInfoStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetCalInfoAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13796,8 +13898,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::CalibrationInfoStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto value = request->value().c_str();
       auto size = 0U;
@@ -13823,10 +13923,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetCalInfoAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::CalibrationInfoUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetCalInfoAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::CalibrationInfoUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetCalInfoAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13834,8 +13937,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::CalibrationInfoUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       uInt32 value = request->value();
       auto size = 0U;
@@ -13863,10 +13964,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetChanAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ChannelBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetChanAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ChannelBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetChanAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13874,8 +13978,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ChannelBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       bool32 value = request->value();
       auto size = 0U;
@@ -13903,10 +14005,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetChanAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ChannelDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetChanAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ChannelDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetChanAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13914,8 +14019,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ChannelDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       float64 value = request->value();
       auto size = 0U;
@@ -13943,10 +14046,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetChanAttributeDoubleArrayRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ChannelDoubleArrayAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetChanAttributeDoubleArrayRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ChannelDoubleArrayAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetChanAttributeDoubleArrayRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13954,8 +14060,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ChannelDoubleArrayAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto value = const_cast<const float64*>(request->value().data());
       uInt32 size = static_cast<uInt32>(request->value().size());
@@ -13983,10 +14087,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetChanAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ChannelInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetChanAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ChannelInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetChanAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -13994,8 +14101,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ChannelInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       int32 value;
       switch (request->value_enum_case()) {
@@ -14038,10 +14143,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetChanAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ChannelStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetChanAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ChannelStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetChanAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14049,8 +14157,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ChannelStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto value = request->value().c_str();
       auto size = 0U;
@@ -14078,10 +14184,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetChanAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ChannelUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetChanAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ChannelUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetChanAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14089,8 +14198,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ChannelUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       uInt32 value = request->value();
       auto size = 0U;
@@ -14227,10 +14334,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetExportedSignalAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ExportSignalBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetExportedSignalAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ExportSignalBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetExportedSignalAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14238,8 +14348,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ExportSignalBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       bool32 value = request->value();
       auto size = 0U;
@@ -14266,10 +14374,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetExportedSignalAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ExportSignalDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetExportedSignalAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ExportSignalDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetExportedSignalAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14277,8 +14388,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ExportSignalDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       float64 value = request->value();
       auto size = 0U;
@@ -14305,10 +14414,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetExportedSignalAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ExportSignalInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetExportedSignalAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ExportSignalInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetExportedSignalAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14316,8 +14428,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ExportSignalInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       int32 value;
       switch (request->value_enum_case()) {
@@ -14359,10 +14469,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetExportedSignalAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ExportSignalStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetExportedSignalAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ExportSignalStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetExportedSignalAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14370,8 +14483,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ExportSignalStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto value = request->value().c_str();
       auto size = 0U;
@@ -14398,10 +14509,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetExportedSignalAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ExportSignalUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetExportedSignalAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ExportSignalUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetExportedSignalAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14409,8 +14523,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ExportSignalUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       uInt32 value = request->value();
       auto size = 0U;
@@ -14457,10 +14569,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetReadAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ReadBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetReadAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ReadBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetReadAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14468,8 +14583,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ReadBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       bool32 value = request->value();
       auto size = 0U;
@@ -14496,10 +14609,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetReadAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ReadDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetReadAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ReadDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetReadAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14507,8 +14623,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ReadDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       float64 value = request->value();
       auto size = 0U;
@@ -14535,10 +14649,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetReadAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ReadInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetReadAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ReadInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetReadAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14546,8 +14663,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ReadInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       int32 value;
       switch (request->value_enum_case()) {
@@ -14589,10 +14704,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetReadAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ReadStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetReadAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ReadStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetReadAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14600,8 +14718,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ReadStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto value = request->value().c_str();
       auto size = 0U;
@@ -14628,10 +14744,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetReadAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ReadUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetReadAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ReadUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetReadAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14639,8 +14758,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ReadUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       uInt32 value = request->value();
       auto size = 0U;
@@ -14667,10 +14784,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetReadAttributeUInt64Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ReadUInt64Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetReadAttributeUInt64Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ReadUInt64Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetReadAttributeUInt64Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14678,8 +14798,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ReadUInt64Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       uInt64 value = request->value();
       auto size = 0U;
@@ -14706,10 +14824,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetRealTimeAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::RealTimeBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetRealTimeAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::RealTimeBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetRealTimeAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14717,8 +14838,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::RealTimeBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       bool32 value = request->value();
       auto size = 0U;
@@ -14745,10 +14864,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetRealTimeAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::RealTimeInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetRealTimeAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::RealTimeInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetRealTimeAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14756,8 +14878,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::RealTimeInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       int32 value;
       switch (request->value_enum_case()) {
@@ -14799,10 +14919,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetRealTimeAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::RealTimeUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetRealTimeAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::RealTimeUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetRealTimeAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14810,8 +14933,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::RealTimeUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       uInt32 value = request->value();
       auto size = 0U;
@@ -14837,10 +14958,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetScaleAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ScaleDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetScaleAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ScaleDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetScaleAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14848,8 +14972,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ScaleDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       float64 value = request->value();
       auto size = 0U;
@@ -14875,10 +14997,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetScaleAttributeDoubleArrayRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ScaleDoubleArrayAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetScaleAttributeDoubleArrayRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ScaleDoubleArrayAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetScaleAttributeDoubleArrayRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14886,8 +15011,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ScaleDoubleArrayAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto value = const_cast<const float64*>(request->value().data());
       uInt32 size = static_cast<uInt32>(request->value().size());
@@ -14913,10 +15036,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetScaleAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ScaleInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetScaleAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ScaleInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetScaleAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14924,8 +15050,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ScaleInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       int32 value;
       switch (request->value_enum_case()) {
@@ -14966,10 +15090,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetScaleAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::ScaleStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetScaleAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::ScaleStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetScaleAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -14977,8 +15104,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::ScaleStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto value = request->value().c_str();
       auto size = 0U;
@@ -15045,10 +15170,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15056,8 +15184,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       bool32 value = request->value();
       auto size = 0U;
@@ -15084,10 +15210,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15095,8 +15224,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       float64 value = request->value();
       auto size = 0U;
@@ -15124,10 +15251,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeExBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeExBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeExBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15135,8 +15265,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       bool32 value = request->value();
       auto size = 0U;
@@ -15164,10 +15292,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeExDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeExDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeExDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15175,8 +15306,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       float64 value = request->value();
       auto size = 0U;
@@ -15204,10 +15333,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeExInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeExInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeExInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15215,8 +15347,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       int32 value;
       switch (request->value_enum_case()) {
@@ -15259,10 +15389,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeExStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeExStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeExStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15270,8 +15403,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto value = request->value().c_str();
       auto size = 0U;
@@ -15299,10 +15430,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeExTimestampRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingTimestampAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeExTimestampRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingTimestampAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeExTimestampRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15310,8 +15444,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingTimestampAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       CVIAbsoluteTime value = convert_from_grpc<CVIAbsoluteTime>(request->value());
       auto size = 0U;
@@ -15339,10 +15471,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeExUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeExUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeExUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15350,8 +15485,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       uInt32 value = request->value();
       auto size = 0U;
@@ -15378,10 +15511,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15389,8 +15525,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       int32 value;
       switch (request->value_enum_case()) {
@@ -15432,10 +15566,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15443,8 +15580,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto value = request->value().c_str();
       auto size = 0U;
@@ -15471,10 +15606,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeTimestampRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingTimestampAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeTimestampRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingTimestampAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeTimestampRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15482,8 +15620,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingTimestampAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       CVIAbsoluteTime value = convert_from_grpc<CVIAbsoluteTime>(request->value());
       auto size = 0U;
@@ -15510,10 +15646,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TimingUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TimingUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTimingAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15521,8 +15660,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TimingUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       uInt32 value = request->value();
       auto size = 0U;
@@ -15549,10 +15686,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTrigAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TriggerBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTrigAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TriggerBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTrigAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15560,8 +15700,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TriggerBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       bool32 value = request->value();
       auto size = 0U;
@@ -15588,10 +15726,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTrigAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TriggerDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTrigAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TriggerDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTrigAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15599,8 +15740,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TriggerDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       float64 value = request->value();
       auto size = 0U;
@@ -15627,10 +15766,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTrigAttributeDoubleArrayRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TriggerDoubleArrayAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTrigAttributeDoubleArrayRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TriggerDoubleArrayAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTrigAttributeDoubleArrayRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15638,8 +15780,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TriggerDoubleArrayAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto value = const_cast<const float64*>(request->value().data());
       uInt32 size = static_cast<uInt32>(request->value().size());
@@ -15666,10 +15806,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTrigAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TriggerInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTrigAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TriggerInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTrigAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15677,8 +15820,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TriggerInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       int32 value;
       switch (request->value_enum_case()) {
@@ -15720,10 +15861,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTrigAttributeInt32ArrayRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TriggerInt32ArrayAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTrigAttributeInt32ArrayRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TriggerInt32ArrayAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTrigAttributeInt32ArrayRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15731,8 +15875,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TriggerInt32ArrayAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto value = reinterpret_cast<const int32*>(request->value().data());
       uInt32 size = request->size();
@@ -15759,10 +15901,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTrigAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TriggerStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTrigAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TriggerStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTrigAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15770,8 +15915,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TriggerStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto value = request->value().c_str();
       auto size = 0U;
@@ -15798,10 +15941,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTrigAttributeTimestampRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TriggerTimestampAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTrigAttributeTimestampRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TriggerTimestampAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTrigAttributeTimestampRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15809,8 +15955,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TriggerTimestampAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       CVIAbsoluteTime value = convert_from_grpc<CVIAbsoluteTime>(request->value());
       auto size = 0U;
@@ -15837,10 +15981,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTrigAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::TriggerUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTrigAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::TriggerUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetTrigAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15848,8 +15995,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::TriggerUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       uInt32 value = request->value();
       auto size = 0U;
@@ -15877,10 +16022,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetWatchdogAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WatchdogBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWatchdogAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WatchdogBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWatchdogAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15888,8 +16036,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WatchdogBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       bool32 value = request->value();
       auto size = 0U;
@@ -15917,10 +16063,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetWatchdogAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WatchdogDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWatchdogAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WatchdogDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWatchdogAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15928,8 +16077,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WatchdogDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       float64 value = request->value();
       auto size = 0U;
@@ -15957,10 +16104,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetWatchdogAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WatchdogInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWatchdogAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WatchdogInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWatchdogAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -15968,8 +16118,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WatchdogInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       int32 value;
       switch (request->value_enum_case()) {
@@ -16012,10 +16160,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetWatchdogAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WatchdogStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWatchdogAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WatchdogStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWatchdogAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -16023,8 +16174,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WatchdogStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto value = request->value().c_str();
       auto size = 0U;
@@ -16051,10 +16200,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetWriteAttributeBoolRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WriteBoolAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWriteAttributeBoolRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WriteBoolAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWriteAttributeBoolRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -16062,8 +16214,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WriteBoolAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       bool32 value = request->value();
       auto size = 0U;
@@ -16090,10 +16240,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetWriteAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WriteDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWriteAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WriteDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWriteAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -16101,8 +16254,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WriteDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       float64 value = request->value();
       auto size = 0U;
@@ -16129,10 +16280,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetWriteAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WriteInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWriteAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WriteInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWriteAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -16140,8 +16294,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WriteInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       int32 value;
       switch (request->value_enum_case()) {
@@ -16183,10 +16335,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetWriteAttributeStringRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WriteStringAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWriteAttributeStringRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WriteStringAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWriteAttributeStringRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -16194,8 +16349,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WriteStringAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto value = request->value().c_str();
       auto size = 0U;
@@ -16222,10 +16375,13 @@ namespace nidaqmx_grpc {
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetWriteAttributeUInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nidaqmx_grpc::WriteUInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWriteAttributeUInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nidaqmx_grpc::WriteUInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nidaqmx_grpc::SetWriteAttributeUInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -16233,8 +16389,6 @@ namespace nidaqmx_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nidaqmx_grpc::WriteUInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       uInt32 value = request->value();
       auto size = 0U;

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -63,10 +63,13 @@ namespace nifake_non_ivi_grpc {
       switch (request->attribute_enum_case()) {
         case nifake_non_ivi_grpc::GetMarbleAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nifake_non_ivi_grpc::MarbleDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nifake_non_ivi_grpc::GetMarbleAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nifake_non_ivi_grpc::MarbleDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nifake_non_ivi_grpc::GetMarbleAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -74,8 +77,6 @@ namespace nifake_non_ivi_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nifake_non_ivi_grpc::MarbleDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       double value {};
       auto status = library_->GetMarbleAttributeDouble(handle, attribute, &value);
@@ -104,10 +105,13 @@ namespace nifake_non_ivi_grpc {
       switch (request->attribute_enum_case()) {
         case nifake_non_ivi_grpc::GetMarbleAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nifake_non_ivi_grpc::MarbleInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nifake_non_ivi_grpc::GetMarbleAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nifake_non_ivi_grpc::MarbleInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nifake_non_ivi_grpc::GetMarbleAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -115,8 +119,6 @@ namespace nifake_non_ivi_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nifake_non_ivi_grpc::MarbleInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       int32 value {};
       auto status = library_->GetMarbleAttributeInt32(handle, attribute, &value);
@@ -151,10 +153,13 @@ namespace nifake_non_ivi_grpc {
       switch (request->attribute_enum_case()) {
         case nifake_non_ivi_grpc::GetMarbleAttributeInt32ArrayRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nifake_non_ivi_grpc::MarbleInt32ArrayAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nifake_non_ivi_grpc::GetMarbleAttributeInt32ArrayRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nifake_non_ivi_grpc::MarbleInt32ArrayAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nifake_non_ivi_grpc::GetMarbleAttributeInt32ArrayRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -162,8 +167,6 @@ namespace nifake_non_ivi_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nifake_non_ivi_grpc::MarbleInt32ArrayAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       response->mutable_value_raw()->Resize(10, 0);
       int32* value = reinterpret_cast<int32*>(response->mutable_value_raw()->mutable_data());
@@ -637,10 +640,13 @@ namespace nifake_non_ivi_grpc {
       switch (request->attribute_enum_case()) {
         case nifake_non_ivi_grpc::ResetMarbleAttributeRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nifake_non_ivi_grpc::MarbleResetAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nifake_non_ivi_grpc::ResetMarbleAttributeRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nifake_non_ivi_grpc::MarbleResetAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nifake_non_ivi_grpc::ResetMarbleAttributeRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -648,8 +654,6 @@ namespace nifake_non_ivi_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nifake_non_ivi_grpc::MarbleResetAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       auto status = library_->ResetMarbleAttribute(handle, attribute);
       response->set_status(status);
@@ -674,10 +678,13 @@ namespace nifake_non_ivi_grpc {
       switch (request->attribute_enum_case()) {
         case nifake_non_ivi_grpc::SetMarbleAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nifake_non_ivi_grpc::MarbleDoubleAttributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nifake_non_ivi_grpc::SetMarbleAttributeDoubleRequest::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nifake_non_ivi_grpc::MarbleDoubleAttributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nifake_non_ivi_grpc::SetMarbleAttributeDoubleRequest::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -685,8 +692,6 @@ namespace nifake_non_ivi_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nifake_non_ivi_grpc::MarbleDoubleAttributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       double value = request->value();
       auto status = library_->SetMarbleAttributeDouble(handle, attribute, value);
@@ -712,10 +717,13 @@ namespace nifake_non_ivi_grpc {
       switch (request->attribute_enum_case()) {
         case nifake_non_ivi_grpc::SetMarbleAttributeInt32Request::AttributeEnumCase::kAttribute: {
           attribute = static_cast<int32>(request->attribute());
+          attribute = nifake_non_ivi_grpc::MarbleInt32Attributes_IsValid(attribute) ? attribute : 0;
           break;
         }
         case nifake_non_ivi_grpc::SetMarbleAttributeInt32Request::AttributeEnumCase::kAttributeRaw: {
           attribute = static_cast<int32>(request->attribute_raw());
+          auto attribute_is_valid = nifake_non_ivi_grpc::MarbleInt32Attributes_IsValid(attribute) || feature_toggles_.is_allow_undefined_attributes_enabled;
+          attribute = attribute_is_valid ? attribute : 0;
           break;
         }
         case nifake_non_ivi_grpc::SetMarbleAttributeInt32Request::AttributeEnumCase::ATTRIBUTE_ENUM_NOT_SET: {
@@ -723,8 +731,6 @@ namespace nifake_non_ivi_grpc {
           break;
         }
       }
-      auto attribute_is_valid = nifake_non_ivi_grpc::MarbleInt32Attributes_IsValid(attribute);
-      attribute = attribute_is_valid ? attribute : 0;
 
       int32 value;
       switch (request->value_enum_case()) {
@@ -786,7 +792,9 @@ namespace nifake_non_ivi_grpc {
   NiFakeNonIviService::NiFakeNonIviFeatureToggles::NiFakeNonIviFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("nifake_non_ivi", CodeReadiness::kNextRelease))
+        feature_toggles.is_feature_enabled("nifake_non_ivi", CodeReadiness::kNextRelease)),
+      is_allow_undefined_attributes_enabled(
+        feature_toggles.is_feature_enabled("nifake_non_ivi.allow_undefined_attributes", CodeReadiness::kPrototype))
   {
   }
 } // namespace nifake_non_ivi_grpc

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.h
@@ -65,6 +65,7 @@ private:
     NiFakeNonIviFeatureToggles(const nidevice_grpc::FeatureToggles& feature_toggles);
 
     bool is_enabled;
+    bool is_allow_undefined_attributes_enabled;
   };
 
   NiFakeNonIviFeatureToggles feature_toggles_;

--- a/source/codegen/metadata/nifake_non_ivi/config.py
+++ b/source/codegen/metadata/nifake_non_ivi/config.py
@@ -43,6 +43,9 @@ config = {
         'CallbackPtr': 'void'
     },
     'code_readiness': 'NextRelease',
+    'feature_toggles': {
+        'nifake_non_ivi.allow_undefined_attributes': 'Prototype' 
+    },
     'split_attributes_by_type': True,
     'supports_raw_attributes': True,
     'library_info': {

--- a/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
+++ b/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
@@ -955,6 +955,30 @@ TEST_F(NiFakeNonIviServiceTests, SetMarbleAttributeRawWithInvalidAttribute_Passe
   EXPECT_EQ(kDriverSuccess, response.status());
 }
 
+struct NiFakeNonIviServiceAllowUndefinedAttributesTests : public NiFakeNonIviServiceTests {
+  NiFakeNonIviServiceAllowUndefinedAttributesTests()
+      : NiFakeNonIviServiceTests(
+            nidevice_grpc::FeatureToggles({{"nifake_non_ivi.allow_undefined_attributes", true}}))
+  {
+  }
+};
+
+TEST_F(NiFakeNonIviServiceAllowUndefinedAttributesTests, ServiceWithAllowUndefinedAttributes_SetMarbleAttributeRawWithInvalidAttribute_PassesZeroAttributeToLibrary)
+{
+  const auto RAW_ATTRIBUTE = 9999;
+  const auto DOUBLE_VALUE = 1.234;
+  EXPECT_CALL(library_, SetMarbleAttributeDouble(_, RAW_ATTRIBUTE, DOUBLE_VALUE))
+      .WillOnce(Return(kDriverSuccess));
+  ::grpc::ServerContext context;
+  SetMarbleAttributeDoubleRequest request;
+  request.set_attribute_raw(RAW_ATTRIBUTE);
+  request.set_value(DOUBLE_VALUE);
+  SetMarbleAttributeDoubleResponse response;
+  service_.SetMarbleAttributeDouble(&context, &request, &response);
+
+  EXPECT_EQ(kDriverSuccess, response.status());
+}
+
 TEST_F(NiFakeNonIviServiceTests, SetColors_PassesColorsArrayToLibrary)
 {
   const auto COLORS = std::vector<BeautifulColor>{

--- a/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
+++ b/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
@@ -963,7 +963,7 @@ struct NiFakeNonIviServiceAllowUndefinedAttributesTests : public NiFakeNonIviSer
   }
 };
 
-TEST_F(NiFakeNonIviServiceAllowUndefinedAttributesTests, ServiceWithAllowUndefinedAttributes_SetMarbleAttributeRawWithInvalidAttribute_PassesZeroAttributeToLibrary)
+TEST_F(NiFakeNonIviServiceAllowUndefinedAttributesTests, ServiceWithAllowUndefinedAttributes_SetMarbleAttributeRawWithInvalidAttribute_PassesRawAttributeToLibrary)
 {
   const auto RAW_ATTRIBUTE = 9999;
   const auto DOUBLE_VALUE = 1.234;


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add a feature toggle to the DAQ service to allow accessing undefined attributes with `attribute_raw`.

### Why should this Pull Request be merged?

Accessing undefined attributes can potentially crash the server if it's a real attribute with the wrong datatype. But we'd like to leave open the option of accessing hidden/missing attributes if a customer needs it. Adding a toggle for access through `attribute_raw` make the server "safe-by-default" but gives us a fallback option.

### What testing has been done?

Ran and passed all DAQ tests.
Ran new fake non-ivi test covering this case.
Manual testing with DAQ server with toggle enabled.
* Note: this is tricky to test with out `DeviceServerInterface::Singleton` implementation because we only init the server once per process. I think it would work to migrate the singleton to a test fixture without a huge performance penalty. But I don't think we want to test with multiple active services. So we would have to migrate all tests to use fixtures for that.