### PR TITLE
Add support for in/out ivi-dance-with-a-twist

### DIFF
--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -1390,7 +1390,8 @@ namespace nidigitalpattern_grpc {
         }
         response->mutable_data()->Resize(actual_num_waveforms, 0);
         ViUInt32* data = reinterpret_cast<ViUInt32*>(response->mutable_data()->mutable_data());
-        status = library_->FetchCaptureWaveformU32(vi, site_list, waveform_name, samples_to_read, timeout, actual_num_waveforms, data, &actual_num_waveforms, &actual_samples_per_waveform);
+        auto data_buffer_size = actual_num_waveforms;
+        status = library_->FetchCaptureWaveformU32(vi, site_list, waveform_name, samples_to_read, timeout, data_buffer_size, data, &actual_num_waveforms, &actual_samples_per_waveform);
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again
           continue;
@@ -1465,7 +1466,8 @@ namespace nidigitalpattern_grpc {
         std::string expected_pin_states(actual_num_pin_data, '\0');
         std::string actual_pin_states(actual_num_pin_data, '\0');
         std::vector<ViBoolean> per_pin_pass_fail(actual_num_pin_data, ViBoolean());
-        status = library_->FetchHistoryRAMCyclePinData(vi, site, pin_list, sample_index, dut_cycle_index, actual_num_pin_data, (ViUInt8*)expected_pin_states.data(), (ViUInt8*)actual_pin_states.data(), per_pin_pass_fail.data(), &actual_num_pin_data);
+        auto pin_data_buffer_size = actual_num_pin_data;
+        status = library_->FetchHistoryRAMCyclePinData(vi, site, pin_list, sample_index, dut_cycle_index, pin_data_buffer_size, (ViUInt8*)expected_pin_states.data(), (ViUInt8*)actual_pin_states.data(), per_pin_pass_fail.data(), &actual_num_pin_data);
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again
           continue;
@@ -1588,7 +1590,8 @@ namespace nidigitalpattern_grpc {
         }
         response->mutable_frequencies()->Resize(actual_num_frequencies, 0);
         ViReal64* frequencies = response->mutable_frequencies()->mutable_data();
-        status = library_->FrequencyCounterMeasureFrequency(vi, channel_list, actual_num_frequencies, frequencies, &actual_num_frequencies);
+        auto frequencies_buffer_size = actual_num_frequencies;
+        status = library_->FrequencyCounterMeasureFrequency(vi, channel_list, frequencies_buffer_size, frequencies, &actual_num_frequencies);
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again
           continue;
@@ -1917,7 +1920,8 @@ namespace nidigitalpattern_grpc {
         }
         response->mutable_failure_count()->Resize(actual_num_read, 0);
         ViInt64* failure_count = response->mutable_failure_count()->mutable_data();
-        status = library_->GetFailCount(vi, channel_list, actual_num_read, failure_count, &actual_num_read);
+        auto buffer_size = actual_num_read;
+        status = library_->GetFailCount(vi, channel_list, buffer_size, failure_count, &actual_num_read);
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again
           continue;
@@ -1978,7 +1982,8 @@ namespace nidigitalpattern_grpc {
         }
         response->mutable_pin_indexes()->Resize(actual_num_pins, 0);
         ViInt32* pin_indexes = reinterpret_cast<ViInt32*>(response->mutable_pin_indexes()->mutable_data());
-        status = library_->GetPatternPinIndexes(vi, start_label, actual_num_pins, pin_indexes, &actual_num_pins);
+        auto pin_indexes_buffer_size = actual_num_pins;
+        status = library_->GetPatternPinIndexes(vi, start_label, pin_indexes_buffer_size, pin_indexes, &actual_num_pins);
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again
           continue;
@@ -2142,7 +2147,8 @@ namespace nidigitalpattern_grpc {
         ViInt32* site_numbers = reinterpret_cast<ViInt32*>(response->mutable_site_numbers()->mutable_data());
         response->mutable_channel_indexes()->Resize(actual_num_values, 0);
         ViInt32* channel_indexes = reinterpret_cast<ViInt32*>(response->mutable_channel_indexes()->mutable_data());
-        status = library_->GetPinResultsPinInformation(vi, channel_list, actual_num_values, pin_indexes, site_numbers, channel_indexes, &actual_num_values);
+        auto buffer_size = actual_num_values;
+        status = library_->GetPinResultsPinInformation(vi, channel_list, buffer_size, pin_indexes, site_numbers, channel_indexes, &actual_num_values);
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again
           continue;
@@ -2178,7 +2184,8 @@ namespace nidigitalpattern_grpc {
           return ::grpc::Status::OK;
         }
         std::vector<ViBoolean> pass_fail(actual_num_sites, ViBoolean());
-        status = library_->GetSitePassFail(vi, site_list, actual_num_sites, pass_fail.data(), &actual_num_sites);
+        auto pass_fail_buffer_size = actual_num_sites;
+        status = library_->GetSitePassFail(vi, site_list, pass_fail_buffer_size, pass_fail.data(), &actual_num_sites);
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again
           continue;
@@ -2232,7 +2239,8 @@ namespace nidigitalpattern_grpc {
         }
         response->mutable_site_numbers()->Resize(actual_num_site_numbers, 0);
         ViInt32* site_numbers = reinterpret_cast<ViInt32*>(response->mutable_site_numbers()->mutable_data());
-        status = library_->GetSiteResultsSiteNumbers(vi, site_list, site_result_type, actual_num_site_numbers, site_numbers, &actual_num_site_numbers);
+        auto site_numbers_buffer_size = actual_num_site_numbers;
+        status = library_->GetSiteResultsSiteNumbers(vi, site_list, site_result_type, site_numbers_buffer_size, site_numbers, &actual_num_site_numbers);
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again
           continue;
@@ -2934,7 +2942,8 @@ namespace nidigitalpattern_grpc {
         }
         response->mutable_measurements()->Resize(actual_num_read, 0);
         ViReal64* measurements = response->mutable_measurements()->mutable_data();
-        status = library_->PPMUMeasure(vi, channel_list, measurement_type, actual_num_read, measurements, &actual_num_read);
+        auto buffer_size = actual_num_read;
+        status = library_->PPMUMeasure(vi, channel_list, measurement_type, buffer_size, measurements, &actual_num_read);
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again
           continue;
@@ -3038,7 +3047,8 @@ namespace nidigitalpattern_grpc {
           return ::grpc::Status::OK;
         }
         std::string data(actual_num_read, '\0');
-        status = library_->ReadStatic(vi, channel_list, actual_num_read, (ViUInt8*)data.data(), &actual_num_read);
+        auto buffer_size = actual_num_read;
+        status = library_->ReadStatic(vi, channel_list, buffer_size, (ViUInt8*)data.data(), &actual_num_read);
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again
           continue;
@@ -3401,7 +3411,8 @@ namespace nidigitalpattern_grpc {
         }
         response->mutable_offsets()->Resize(actual_num_offsets, 0);
         ViReal64* offsets = response->mutable_offsets()->mutable_data();
-        status = library_->TDR(vi, channel_list, apply_offsets, actual_num_offsets, offsets, &actual_num_offsets);
+        auto offsets_buffer_size = actual_num_offsets;
+        status = library_->TDR(vi, channel_list, apply_offsets, offsets_buffer_size, offsets, &actual_num_offsets);
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again
           continue;

--- a/generated/nifake/nifake.proto
+++ b/generated/nifake/nifake.proto
@@ -59,6 +59,7 @@ service NiFake {
   rpc ParametersAreMultipleTypes(ParametersAreMultipleTypesRequest) returns (ParametersAreMultipleTypesResponse);
   rpc PoorlyNamedSimpleFunction(PoorlyNamedSimpleFunctionRequest) returns (PoorlyNamedSimpleFunctionResponse);
   rpc Read(ReadRequest) returns (ReadResponse);
+  rpc ReadDataWithInOutIviTwist(ReadDataWithInOutIviTwistRequest) returns (ReadDataWithInOutIviTwistResponse);
   rpc ReadFromChannel(ReadFromChannelRequest) returns (ReadFromChannelResponse);
   rpc ReturnANumberAndAString(ReturnANumberAndAStringRequest) returns (ReturnANumberAndAStringResponse);
   rpc ReturnDurationInSeconds(ReturnDurationInSecondsRequest) returns (ReturnDurationInSecondsResponse);
@@ -594,6 +595,15 @@ message ReadRequest {
 message ReadResponse {
   int32 status = 1;
   double reading = 2;
+}
+
+message ReadDataWithInOutIviTwistRequest {
+}
+
+message ReadDataWithInOutIviTwistResponse {
+  int32 status = 1;
+  repeated sint32 data = 2;
+  sint32 buffer_size = 3;
 }
 
 message ReadFromChannelRequest {

--- a/generated/nifake/nifake_client.cpp
+++ b/generated/nifake/nifake_client.cpp
@@ -768,6 +768,21 @@ read(const StubPtr& stub, const nidevice_grpc::Session& vi, const double& maximu
   return response;
 }
 
+ReadDataWithInOutIviTwistResponse
+read_data_with_in_out_ivi_twist(const StubPtr& stub)
+{
+  ::grpc::ClientContext context;
+
+  auto request = ReadDataWithInOutIviTwistRequest{};
+
+  auto response = ReadDataWithInOutIviTwistResponse{};
+
+  raise_if_error(
+      stub->ReadDataWithInOutIviTwist(&context, request, &response));
+
+  return response;
+}
+
 ReadFromChannelResponse
 read_from_channel(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const pb::int32& maximum_time)
 {

--- a/generated/nifake/nifake_client.h
+++ b/generated/nifake/nifake_client.h
@@ -65,6 +65,7 @@ OneInputFunctionResponse one_input_function(const StubPtr& stub, const nidevice_
 ParametersAreMultipleTypesResponse parameters_are_multiple_types(const StubPtr& stub, const nidevice_grpc::Session& vi, const bool& a_boolean, const pb::int32& an_int32, const pb::int64& an_int64, const simple_variant<Turtle, pb::int32>& an_int_enum, const double& a_float, const double& a_float_enum, const pb::string& a_string);
 PoorlyNamedSimpleFunctionResponse poorly_named_simple_function(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ReadResponse read(const StubPtr& stub, const nidevice_grpc::Session& vi, const double& maximum_time);
+ReadDataWithInOutIviTwistResponse read_data_with_in_out_ivi_twist(const StubPtr& stub);
 ReadFromChannelResponse read_from_channel(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const pb::int32& maximum_time);
 ReturnANumberAndAStringResponse return_a_number_and_a_string(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ReturnDurationInSecondsResponse return_duration_in_seconds(const StubPtr& stub, const nidevice_grpc::Session& vi);

--- a/generated/nifake/nifake_library.cpp
+++ b/generated/nifake/nifake_library.cpp
@@ -66,6 +66,7 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.ParametersAreMultipleTypes = reinterpret_cast<ParametersAreMultipleTypesPtr>(shared_library_.get_function_pointer("niFake_ParametersAreMultipleTypes"));
   function_pointers_.PoorlyNamedSimpleFunction = reinterpret_cast<PoorlyNamedSimpleFunctionPtr>(shared_library_.get_function_pointer("niFake_PoorlyNamedSimpleFunction"));
   function_pointers_.Read = reinterpret_cast<ReadPtr>(shared_library_.get_function_pointer("niFake_Read"));
+  function_pointers_.ReadDataWithInOutIviTwist = reinterpret_cast<ReadDataWithInOutIviTwistPtr>(shared_library_.get_function_pointer("niFake_ReadDataWithInOutIviTwist"));
   function_pointers_.ReadFromChannel = reinterpret_cast<ReadFromChannelPtr>(shared_library_.get_function_pointer("niFake_ReadFromChannel"));
   function_pointers_.ReturnANumberAndAString = reinterpret_cast<ReturnANumberAndAStringPtr>(shared_library_.get_function_pointer("niFake_ReturnANumberAndAString"));
   function_pointers_.ReturnDurationInSeconds = reinterpret_cast<ReturnDurationInSecondsPtr>(shared_library_.get_function_pointer("niFake_ReturnDurationInSeconds"));
@@ -630,6 +631,18 @@ ViStatus NiFakeLibrary::Read(ViSession vi, ViReal64 maximumTime, ViReal64* readi
   return niFake_Read(vi, maximumTime, reading);
 #else
   return function_pointers_.Read(vi, maximumTime, reading);
+#endif
+}
+
+ViStatus NiFakeLibrary::ReadDataWithInOutIviTwist(ViInt32 data[], ViInt32* bufferSize)
+{
+  if (!function_pointers_.ReadDataWithInOutIviTwist) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_ReadDataWithInOutIviTwist.");
+  }
+#if defined(_MSC_VER)
+  return niFake_ReadDataWithInOutIviTwist(data, bufferSize);
+#else
+  return function_pointers_.ReadDataWithInOutIviTwist(data, bufferSize);
 #endif
 }
 

--- a/generated/nifake/nifake_library.h
+++ b/generated/nifake/nifake_library.h
@@ -63,6 +63,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus ParametersAreMultipleTypes(ViSession vi, ViBoolean aBoolean, ViInt32 anInt32, ViInt64 anInt64, ViInt16 anIntEnum, ViReal64 aFloat, ViReal64 aFloatEnum, ViInt32 stringSize, ViConstString aString);
   ViStatus PoorlyNamedSimpleFunction(ViSession vi);
   ViStatus Read(ViSession vi, ViReal64 maximumTime, ViReal64* reading);
+  ViStatus ReadDataWithInOutIviTwist(ViInt32 data[], ViInt32* bufferSize);
   ViStatus ReadFromChannel(ViSession vi, ViConstString channelName, ViInt32 maximumTime, ViReal64* reading);
   ViStatus ReturnANumberAndAString(ViSession vi, ViInt16* aNumber, ViChar aString[256]);
   ViStatus ReturnDurationInSeconds(ViSession vi, ViReal64* timedelta);
@@ -132,6 +133,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using ParametersAreMultipleTypesPtr = decltype(&niFake_ParametersAreMultipleTypes);
   using PoorlyNamedSimpleFunctionPtr = decltype(&niFake_PoorlyNamedSimpleFunction);
   using ReadPtr = decltype(&niFake_Read);
+  using ReadDataWithInOutIviTwistPtr = decltype(&niFake_ReadDataWithInOutIviTwist);
   using ReadFromChannelPtr = decltype(&niFake_ReadFromChannel);
   using ReturnANumberAndAStringPtr = decltype(&niFake_ReturnANumberAndAString);
   using ReturnDurationInSecondsPtr = decltype(&niFake_ReturnDurationInSeconds);
@@ -201,6 +203,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     ParametersAreMultipleTypesPtr ParametersAreMultipleTypes;
     PoorlyNamedSimpleFunctionPtr PoorlyNamedSimpleFunction;
     ReadPtr Read;
+    ReadDataWithInOutIviTwistPtr ReadDataWithInOutIviTwist;
     ReadFromChannelPtr ReadFromChannel;
     ReturnANumberAndAStringPtr ReturnANumberAndAString;
     ReturnDurationInSecondsPtr ReturnDurationInSeconds;

--- a/generated/nifake/nifake_library_interface.h
+++ b/generated/nifake/nifake_library_interface.h
@@ -60,6 +60,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus ParametersAreMultipleTypes(ViSession vi, ViBoolean aBoolean, ViInt32 anInt32, ViInt64 anInt64, ViInt16 anIntEnum, ViReal64 aFloat, ViReal64 aFloatEnum, ViInt32 stringSize, ViConstString aString) = 0;
   virtual ViStatus PoorlyNamedSimpleFunction(ViSession vi) = 0;
   virtual ViStatus Read(ViSession vi, ViReal64 maximumTime, ViReal64* reading) = 0;
+  virtual ViStatus ReadDataWithInOutIviTwist(ViInt32 data[], ViInt32* bufferSize) = 0;
   virtual ViStatus ReadFromChannel(ViSession vi, ViConstString channelName, ViInt32 maximumTime, ViReal64* reading) = 0;
   virtual ViStatus ReturnANumberAndAString(ViSession vi, ViInt16* aNumber, ViChar aString[256]) = 0;
   virtual ViStatus ReturnDurationInSeconds(ViSession vi, ViReal64* timedelta) = 0;

--- a/generated/nifake/nifake_mock_library.h
+++ b/generated/nifake/nifake_mock_library.h
@@ -62,6 +62,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, ParametersAreMultipleTypes, (ViSession vi, ViBoolean aBoolean, ViInt32 anInt32, ViInt64 anInt64, ViInt16 anIntEnum, ViReal64 aFloat, ViReal64 aFloatEnum, ViInt32 stringSize, ViConstString aString), (override));
   MOCK_METHOD(ViStatus, PoorlyNamedSimpleFunction, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, Read, (ViSession vi, ViReal64 maximumTime, ViReal64* reading), (override));
+  MOCK_METHOD(ViStatus, ReadDataWithInOutIviTwist, (ViInt32 data[], ViInt32* bufferSize), (override));
   MOCK_METHOD(ViStatus, ReadFromChannel, (ViSession vi, ViConstString channelName, ViInt32 maximumTime, ViReal64* reading), (override));
   MOCK_METHOD(ViStatus, ReturnANumberAndAString, (ViSession vi, ViInt16* aNumber, ViChar aString[256]), (override));
   MOCK_METHOD(ViStatus, ReturnDurationInSeconds, (ViSession vi, ViReal64* timedelta), (override));

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -75,6 +75,7 @@ public:
   ::grpc::Status ParametersAreMultipleTypes(::grpc::ServerContext* context, const ParametersAreMultipleTypesRequest* request, ParametersAreMultipleTypesResponse* response) override;
   ::grpc::Status PoorlyNamedSimpleFunction(::grpc::ServerContext* context, const PoorlyNamedSimpleFunctionRequest* request, PoorlyNamedSimpleFunctionResponse* response) override;
   ::grpc::Status Read(::grpc::ServerContext* context, const ReadRequest* request, ReadResponse* response) override;
+  ::grpc::Status ReadDataWithInOutIviTwist(::grpc::ServerContext* context, const ReadDataWithInOutIviTwistRequest* request, ReadDataWithInOutIviTwistResponse* response) override;
   ::grpc::Status ReadFromChannel(::grpc::ServerContext* context, const ReadFromChannelRequest* request, ReadFromChannelResponse* response) override;
   ::grpc::Status ReturnANumberAndAString(::grpc::ServerContext* context, const ReturnANumberAndAStringRequest* request, ReturnANumberAndAStringResponse* response) override;
   ::grpc::Status ReturnDurationInSeconds(::grpc::ServerContext* context, const ReturnDurationInSecondsRequest* request, ReturnDurationInSecondsResponse* response) override;

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -2129,7 +2129,8 @@ namespace nifgen_grpc {
         }
         response->mutable_coefficients_array()->Resize(number_of_coefficients_read, 0);
         ViReal64* coefficients_array = response->mutable_coefficients_array()->mutable_data();
-        status = library_->GetFIRFilterCoefficients(vi, channel_name, number_of_coefficients_read, coefficients_array, &number_of_coefficients_read);
+        auto array_size = number_of_coefficients_read;
+        status = library_->GetFIRFilterCoefficients(vi, channel_name, array_size, coefficients_array, &number_of_coefficients_read);
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again
           continue;

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -1,5 +1,6 @@
 import re
 from collections import defaultdict, namedtuple
+from typing import List
 
 
 def is_output_parameter(parameter):
@@ -311,6 +312,10 @@ def get_size_expression(parameter):
         return camel_to_snake(parameter['size']['value'])
 
 
+def get_param_cpp_name(parameter: dict) -> str:
+    return camel_to_snake(parameter["name"])
+
+
 def is_ivi_dance_array_param(parameter):
     return get_size_mechanism(parameter) == 'ivi-dance'
 
@@ -365,14 +370,28 @@ def has_ivi_dance_with_a_twist_param(parameters):
     return any(is_ivi_dance_array_with_a_twist_param(p) for p in parameters)
 
 
+def get_param_with_name(parameters: List[dict], name: str) -> dict:
+    matched_params = (
+        p
+        for p in parameters
+        if p['name'] == name
+    )
+    return next(matched_params)
+
+
 def get_ivi_dance_with_a_twist_params(parameters):
     array_param = next(
-        (p for p in parameters if is_ivi_dance_array_with_a_twist_param(p)), None)
-    size_param = next(
-        p for p in parameters if p['name'] == array_param['size']['value']) if array_param else None
-    other_params = (p for p in parameters if p !=
-                    array_param and p != size_param)
-    return (size_param, array_param, other_params)
+        (p for p in parameters if is_ivi_dance_array_with_a_twist_param(p)))
+
+    size_param = get_param_with_name(parameters, array_param['size']['value'])
+    twist_param = get_param_with_name(parameters, array_param['size']['value_twist'])
+
+    other_params = (
+        p 
+        for p in parameters 
+        if p not in [array_param, size_param, twist_param]
+    )
+    return (size_param, twist_param, array_param, other_params)
 
 
 def is_init_method(function_data):

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -1886,6 +1886,26 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'ReadDataWithInOutIviTwist': {
+        'parameters': [
+            {
+                'direction': 'out',
+                'name': 'data',
+                'size': {
+                    'mechanism': 'ivi-dance-with-a-twist',
+                    'value': 'bufferSize',
+                    'value_twist': 'bufferSize'
+                },
+                'type': 'ViInt32[]'
+            },
+            {
+                'name': 'bufferSize',
+                'direction': 'out',
+                'type': 'ViInt32'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'ReadFromChannel': {
         'codegen_method': 'public',
         'documentation': {

--- a/source/codegen/metadata_mutation.py
+++ b/source/codegen/metadata_mutation.py
@@ -55,7 +55,10 @@ def mark_non_proto_params(parameters):
         mechanism = common_helpers.get_size_mechanism(param)
         if mechanism in {'len', 'ivi-dance', 'ivi-dance-with-a-twist'}:
             size_param = get_size_param(param, parameters)
-            size_param['include_in_proto'] = False
+            if size_param['direction'] == 'in':
+                # Output size_params can still be included in the proto
+                # as information.
+                size_param['include_in_proto'] = False
             if mechanism == 'len':
                 if 'determine_size_from' not in size_param:
                     size_param['determine_size_from'] = []

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -75,8 +75,6 @@ def create_args(parameters):
             result = f'{result}({type_without_brackets}*){parameter_name}.data(), '
         elif parameter['type'] in {"ViBoolean[]", "ViSession[]", "ViInt16[]"}:
             result = f'{result}{parameter_name}.data(), '
-        elif parameter.get('is_size_param', False) and is_twist_mechanism:
-            result = f'{result}{twist_value_name}, '
         elif 'callback_params' in parameter:
             result = f'{result}CallbackRouter::handle_callback, '
         elif 'callback_token' in parameter:
@@ -110,13 +108,14 @@ def create_args_for_ivi_dance_with_a_twist(parameters):
     for parameter in parameters:
         name = common_helpers.camel_to_snake(parameter['cppName'])
         is_array = common_helpers.is_array(parameter['type'])
-        if parameter.get('is_size_param', False):
-            result = f'{result}0, '
-        elif common_helpers.is_output_parameter(parameter):
+        if common_helpers.is_output_parameter(parameter):
             if is_array:
                 result = f'{result}nullptr, '
             else:
+                # Pass the twist output param by pointer.
                 result = result + f'&{name}' + ', '
+        elif parameter.get('is_size_param', False):
+            result = f'{result}0, '
         else:
             result = result + common_helpers.camel_to_snake(name) + ', '
     return result[:-2]

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -78,10 +78,13 @@ ${set_response_values(output_parameters)}\
 ## Generate the core method body for an ivi-dance-with_a_twist method. This should be what gets included within the try block in the service method.
 <%def name="define_ivi_dance_with_a_twist_method_body(function_name, function_data, parameters)">\
 <%
-  (size_param, array_param, non_ivi_params) = common_helpers.get_ivi_dance_with_a_twist_params(parameters)
+  (size_param, twist_param, array_param, non_ivi_params) = common_helpers.get_ivi_dance_with_a_twist_params(parameters)
   output_parameters = [p for p in parameters if common_helpers.is_output_parameter(p)]
   array_output_parameters = [p for p in output_parameters if common_helpers.is_array(p['type'])]
   scalar_output_parameters = [p for p in output_parameters if p not in array_output_parameters]
+  size_param_name = common_helpers.get_param_cpp_name(size_param)
+  twist_param_name = common_helpers.get_param_cpp_name(twist_param)
+  is_in_out_twist = size_param_name == twist_param_name
 %>\
 ${initialize_input_params(function_name, non_ivi_params)}\
 ${initialize_output_params(scalar_output_parameters)}\
@@ -94,6 +97,9 @@ ${initialize_output_params(scalar_output_parameters)}\
 <%block filter="common_helpers.indent(1)">\
 ${initialize_output_params(array_output_parameters)}\
 </%block>\
+% if not is_in_out_twist:
+        auto ${size_param_name} = ${twist_param_name};
+% endif
         status = library_->${function_name}(${service_helpers.create_args(parameters)});
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add support for `ivi-dance-with-a-twist` when `value` and `value_twist` are the same. In this case, a single in/out parameter is used instead of a separate input and output,

### Why should this Pull Request be merged?

RFSA uses this convention on several methods. [Example](https://zone.ni.com/reference/en-XX/help/372058U-01/rfsacref/cvinirfsa_getrelayoperationscount/).

### What testing has been done?

Ran and passed included test.
Builds with some RFSA entry points as part of a larger change.