### PR TITLE
Add support for ViAttr[]

### DIFF
--- a/generated/nifake/nifake.proto
+++ b/generated/nifake/nifake.proto
@@ -23,6 +23,7 @@ service NiFake {
   rpc BoolArrayOutputFunction(BoolArrayOutputFunctionRequest) returns (BoolArrayOutputFunctionResponse);
   rpc BoolArrayInputFunction(BoolArrayInputFunctionRequest) returns (BoolArrayInputFunctionResponse);
   rpc CommandWithReservedParam(CommandWithReservedParamRequest) returns (CommandWithReservedParamResponse);
+  rpc CreateConfigurationList(CreateConfigurationListRequest) returns (CreateConfigurationListResponse);
   rpc DoubleAllTheNums(DoubleAllTheNumsRequest) returns (DoubleAllTheNumsResponse);
   rpc EnumArrayOutputFunction(EnumArrayOutputFunctionRequest) returns (EnumArrayOutputFunctionResponse);
   rpc EnumInputFunctionWithDefaults(EnumInputFunctionWithDefaultsRequest) returns (EnumInputFunctionWithDefaultsResponse);
@@ -211,6 +212,14 @@ message CommandWithReservedParamRequest {
 }
 
 message CommandWithReservedParamResponse {
+  int32 status = 1;
+}
+
+message CreateConfigurationListRequest {
+  repeated NiFakeAttributes list_attribute_ids = 1;
+}
+
+message CreateConfigurationListResponse {
   int32 status = 1;
 }
 

--- a/generated/nifake/nifake_client.cpp
+++ b/generated/nifake/nifake_client.cpp
@@ -135,6 +135,22 @@ command_with_reserved_param(const StubPtr& stub, const nidevice_grpc::Session& v
   return response;
 }
 
+CreateConfigurationListResponse
+create_configuration_list(const StubPtr& stub, const std::vector<NiFakeAttributes>& list_attribute_ids)
+{
+  ::grpc::ClientContext context;
+
+  auto request = CreateConfigurationListRequest{};
+  copy_array(list_attribute_ids, request.mutable_list_attribute_ids());
+
+  auto response = CreateConfigurationListResponse{};
+
+  raise_if_error(
+      stub->CreateConfigurationList(&context, request, &response));
+
+  return response;
+}
+
 DoubleAllTheNumsResponse
 double_all_the_nums(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::vector<double>& numbers)
 {

--- a/generated/nifake/nifake_client.h
+++ b/generated/nifake/nifake_client.h
@@ -29,6 +29,7 @@ AcceptViUInt32ArrayResponse accept_vi_uint32_array(const StubPtr& stub, const ni
 BoolArrayOutputFunctionResponse bool_array_output_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& number_of_elements);
 BoolArrayInputFunctionResponse bool_array_input_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& number_of_elements, const std::vector<bool>& an_array);
 CommandWithReservedParamResponse command_with_reserved_param(const StubPtr& stub, const nidevice_grpc::Session& vi);
+CreateConfigurationListResponse create_configuration_list(const StubPtr& stub, const std::vector<NiFakeAttributes>& list_attribute_ids);
 DoubleAllTheNumsResponse double_all_the_nums(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::vector<double>& numbers);
 EnumArrayOutputFunctionResponse enum_array_output_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& number_of_elements);
 EnumInputFunctionWithDefaultsResponse enum_input_function_with_defaults(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<Turtle, pb::int32>& a_turtle);

--- a/generated/nifake/nifake_library.cpp
+++ b/generated/nifake/nifake_library.cpp
@@ -28,6 +28,7 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.BoolArrayOutputFunction = reinterpret_cast<BoolArrayOutputFunctionPtr>(shared_library_.get_function_pointer("niFake_BoolArrayOutputFunction"));
   function_pointers_.BoolArrayInputFunction = reinterpret_cast<BoolArrayInputFunctionPtr>(shared_library_.get_function_pointer("niFake_BoolArrayInputFunction"));
   function_pointers_.CommandWithReservedParam = reinterpret_cast<CommandWithReservedParamPtr>(shared_library_.get_function_pointer("niFake_CommandWithReservedParam"));
+  function_pointers_.CreateConfigurationList = reinterpret_cast<CreateConfigurationListPtr>(shared_library_.get_function_pointer("niFake_CreateConfigurationList"));
   function_pointers_.DoubleAllTheNums = reinterpret_cast<DoubleAllTheNumsPtr>(shared_library_.get_function_pointer("niFake_DoubleAllTheNums"));
   function_pointers_.EnumArrayOutputFunction = reinterpret_cast<EnumArrayOutputFunctionPtr>(shared_library_.get_function_pointer("niFake_EnumArrayOutputFunction"));
   function_pointers_.EnumInputFunctionWithDefaults = reinterpret_cast<EnumInputFunctionWithDefaultsPtr>(shared_library_.get_function_pointer("niFake_EnumInputFunctionWithDefaults"));
@@ -183,6 +184,18 @@ ViStatus NiFakeLibrary::CommandWithReservedParam(ViSession vi, ViBoolean* reserv
   return niFake_CommandWithReservedParam(vi, reserved);
 #else
   return function_pointers_.CommandWithReservedParam(vi, reserved);
+#endif
+}
+
+ViStatus NiFakeLibrary::CreateConfigurationList(ViInt32 numberOfListAttributes, ViAttr listAttributeIds[])
+{
+  if (!function_pointers_.CreateConfigurationList) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_CreateConfigurationList.");
+  }
+#if defined(_MSC_VER)
+  return niFake_CreateConfigurationList(numberOfListAttributes, listAttributeIds);
+#else
+  return function_pointers_.CreateConfigurationList(numberOfListAttributes, listAttributeIds);
 #endif
 }
 

--- a/generated/nifake/nifake_library.h
+++ b/generated/nifake/nifake_library.h
@@ -25,6 +25,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus BoolArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]);
   ViStatus BoolArrayInputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]);
   ViStatus CommandWithReservedParam(ViSession vi, ViBoolean* reserved);
+  ViStatus CreateConfigurationList(ViInt32 numberOfListAttributes, ViAttr listAttributeIds[]);
   ViStatus DoubleAllTheNums(ViSession vi, ViInt32 numberCount, ViReal64 numbers[]);
   ViStatus EnumArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViInt16 anArray[]);
   ViStatus EnumInputFunctionWithDefaults(ViSession vi, ViInt16 aTurtle);
@@ -95,6 +96,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using BoolArrayOutputFunctionPtr = decltype(&niFake_BoolArrayOutputFunction);
   using BoolArrayInputFunctionPtr = decltype(&niFake_BoolArrayInputFunction);
   using CommandWithReservedParamPtr = decltype(&niFake_CommandWithReservedParam);
+  using CreateConfigurationListPtr = decltype(&niFake_CreateConfigurationList);
   using DoubleAllTheNumsPtr = decltype(&niFake_DoubleAllTheNums);
   using EnumArrayOutputFunctionPtr = decltype(&niFake_EnumArrayOutputFunction);
   using EnumInputFunctionWithDefaultsPtr = decltype(&niFake_EnumInputFunctionWithDefaults);
@@ -165,6 +167,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     BoolArrayOutputFunctionPtr BoolArrayOutputFunction;
     BoolArrayInputFunctionPtr BoolArrayInputFunction;
     CommandWithReservedParamPtr CommandWithReservedParam;
+    CreateConfigurationListPtr CreateConfigurationList;
     DoubleAllTheNumsPtr DoubleAllTheNums;
     EnumArrayOutputFunctionPtr EnumArrayOutputFunction;
     EnumInputFunctionWithDefaultsPtr EnumInputFunctionWithDefaults;

--- a/generated/nifake/nifake_library_interface.h
+++ b/generated/nifake/nifake_library_interface.h
@@ -22,6 +22,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus BoolArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]) = 0;
   virtual ViStatus BoolArrayInputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]) = 0;
   virtual ViStatus CommandWithReservedParam(ViSession vi, ViBoolean* reserved) = 0;
+  virtual ViStatus CreateConfigurationList(ViInt32 numberOfListAttributes, ViAttr listAttributeIds[]) = 0;
   virtual ViStatus DoubleAllTheNums(ViSession vi, ViInt32 numberCount, ViReal64 numbers[]) = 0;
   virtual ViStatus EnumArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViInt16 anArray[]) = 0;
   virtual ViStatus EnumInputFunctionWithDefaults(ViSession vi, ViInt16 aTurtle) = 0;

--- a/generated/nifake/nifake_mock_library.h
+++ b/generated/nifake/nifake_mock_library.h
@@ -24,6 +24,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, BoolArrayOutputFunction, (ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]), (override));
   MOCK_METHOD(ViStatus, BoolArrayInputFunction, (ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]), (override));
   MOCK_METHOD(ViStatus, CommandWithReservedParam, (ViSession vi, ViBoolean* reserved), (override));
+  MOCK_METHOD(ViStatus, CreateConfigurationList, (ViInt32 numberOfListAttributes, ViAttr listAttributeIds[]), (override));
   MOCK_METHOD(ViStatus, DoubleAllTheNums, (ViSession vi, ViInt32 numberCount, ViReal64 numbers[]), (override));
   MOCK_METHOD(ViStatus, EnumArrayOutputFunction, (ViSession vi, ViInt32 numberOfElements, ViInt16 anArray[]), (override));
   MOCK_METHOD(ViStatus, EnumInputFunctionWithDefaults, (ViSession vi, ViInt16 aTurtle), (override));

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -237,6 +237,25 @@ namespace nifake_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::CreateConfigurationList(::grpc::ServerContext* context, const CreateConfigurationListRequest* request, CreateConfigurationListResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      ViInt32 number_of_list_attributes = static_cast<ViInt32>(request->list_attribute_ids().size());
+      auto list_attribute_ids = const_cast<ViAttr*>(reinterpret_cast<const ViAttr*>(request->list_attribute_ids().data()));
+      auto status = library_->CreateConfigurationList(number_of_list_attributes, list_attribute_ids);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::DoubleAllTheNums(::grpc::ServerContext* context, const DoubleAllTheNumsRequest* request, DoubleAllTheNumsResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -39,6 +39,7 @@ public:
   ::grpc::Status BoolArrayOutputFunction(::grpc::ServerContext* context, const BoolArrayOutputFunctionRequest* request, BoolArrayOutputFunctionResponse* response) override;
   ::grpc::Status BoolArrayInputFunction(::grpc::ServerContext* context, const BoolArrayInputFunctionRequest* request, BoolArrayInputFunctionResponse* response) override;
   ::grpc::Status CommandWithReservedParam(::grpc::ServerContext* context, const CommandWithReservedParamRequest* request, CommandWithReservedParamResponse* response) override;
+  ::grpc::Status CreateConfigurationList(::grpc::ServerContext* context, const CreateConfigurationListRequest* request, CreateConfigurationListResponse* response) override;
   ::grpc::Status DoubleAllTheNums(::grpc::ServerContext* context, const DoubleAllTheNumsRequest* request, DoubleAllTheNumsResponse* response) override;
   ::grpc::Status EnumArrayOutputFunction(::grpc::ServerContext* context, const EnumArrayOutputFunctionRequest* request, EnumArrayOutputFunctionResponse* response) override;
   ::grpc::Status EnumInputFunctionWithDefaults(::grpc::ServerContext* context, const EnumInputFunctionWithDefaultsRequest* request, EnumInputFunctionWithDefaultsResponse* response) override;

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -193,6 +193,25 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'CreateConfigurationList': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'numberOfListAttributes',
+                'type': 'ViInt32'
+            },
+            {
+                'direction': 'in',
+                'name': 'listAttributeIds',
+                'size': {
+                    'mechanism': 'len',
+                    'value': 'numberOfListAttributes'
+                },
+                'type': 'ViAttr[]'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'DoubleAllTheNums': {
         'documentation': {
             'description': 'Test for buffer with converter'

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -478,7 +478,7 @@ ${initialize_standard_input_param(function_name, parameter)}
 % elif grpc_type == 'nidevice_grpc.Session':
       auto ${parameter_name}_grpc_session = ${request_snippet};
       ${c_type} ${parameter_name} = session_repository_->access_session(${parameter_name}_grpc_session.id(), ${parameter_name}_grpc_session.name());\
-% elif c_type in ['ViAddr[]', 'ViInt32[]', 'ViUInt32[]', 'int32[]', 'uInt32[]']:
+% elif c_type in ['ViAddr[]', 'ViInt32[]', 'ViUInt32[]', 'int32[]', 'uInt32[]', "ViAttr[]"]:
       auto ${parameter_name} = const_cast<${c_type_pointer}>(reinterpret_cast<const ${c_type_pointer}>(${request_snippet}.data()));\
 %elif c_type in ['const int32[]', 'const uInt32[]']:
       auto ${parameter_name} = reinterpret_cast<${c_type_pointer}>(${request_snippet}.data());\

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -1996,6 +1996,22 @@ TEST(NiFakeServiceTests, FakeService_ReadDataWithInOutIviTwist_DoesTwistAndRetur
   EXPECT_THAT(response.data(), ElementsAreArray(DATA, BUFFER_SIZE));
 }
 
+TEST(NiFakeServiceTests, FakeService_CreateConfigurationList_PassesAttributeArray)
+{
+  const auto ATTRIBUTES = std::vector<NiFakeAttributes>{NiFakeAttributes::NIFAKE_ATTRIBUTE_READ_WRITE_BOOL, NiFakeAttributes::NIFAKE_ATTRIBUTE_READ_WRITE_COLOR};
+  FakeServiceHolder service_holder;
+  EXPECT_CALL(service_holder.library, CreateConfigurationList(_, _))
+      .With(Args<1, 0>(ElementsAreArray(ATTRIBUTES.data(), ATTRIBUTES.size())))
+      .WillOnce(Return(kDriverSuccess));
+
+  auto request = CreateConfigurationListRequest{};
+  request.mutable_list_attribute_ids()->CopyFrom({ATTRIBUTES.cbegin(), ATTRIBUTES.cend()});
+  auto response = CreateConfigurationListResponse{};
+  service_holder.service.CreateConfigurationList(&service_holder.context, &request, &response);
+
+  EXPECT_EQ(0, response.status());
+}
+
 }  // namespace unit
 }  // namespace tests
 }  // namespace ni


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add support for `ViAttr[]` inputs to grpc-device.

### Why should this Pull Request be merged?

This is required by the RFSA function  [nirfsa_CreateConfigurationList](https://zone.ni.com/reference/en-XX/help/372058U-01/rfsacref/cvinirfsa_createconfigurationlist/).

### What testing has been done?

Ran and passed included test.
Builds with RFSA metadata as part of larger change.