### PR TITLE
Update workflow to use ubuntu 18.04 runner

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -32,7 +32,7 @@ jobs:
           }
         - {
             name: "Ubuntu Build", artifact: "Linux.tar.xz",
-            os: ubuntu-16.04,
+            os: ubuntu-18.04,
             build_type: "Release", cc: "gcc-9", cxx: "g++-9",
             cmake_platform: "",
             cmake_number_of_jobs: "-j 2"
@@ -116,7 +116,7 @@ jobs:
     - name: Tar Linux Server Binaries
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       run: >-
-        tar -cvzf ni-grpc-device-server-linux-glibc2_23-x64.tar.gz
+        tar -cvzf ni-grpc-device-server-linux-glibc2_27-x64.tar.gz
         -C ${GITHUB_WORKSPACE}/build
         ni_grpc_device_server
         server_config.json
@@ -128,14 +128,14 @@ jobs:
       uses: actions/upload-artifact@v2
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       with:
-        name: ni-grpc-device-server-linux-glibc2_23-x64
-        path: ni-grpc-device-server-linux-glibc2_23-x64.tar.gz
+        name: ni-grpc-device-server-linux-glibc2_27-x64
+        path: ni-grpc-device-server-linux-glibc2_27-x64.tar.gz
         retention-days: 5
 
     - name: Tar Linux Test Binaries
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       run: >-
-        tar -cvzf ni-grpc-device-tests-linux-glibc2_23-x64.tar.gz
+        tar -cvzf ni-grpc-device-tests-linux-glibc2_27-x64.tar.gz
         -C ${GITHUB_WORKSPACE}/build
         certs/
         IntegrationTestsRunner
@@ -151,8 +151,8 @@ jobs:
       uses: actions/upload-artifact@v2
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       with:
-        name: ni-grpc-device-tests-linux-glibc2_23-x64
-        path: ni-grpc-device-tests-linux-glibc2_23-x64.tar.gz
+        name: ni-grpc-device-tests-linux-glibc2_27-x64
+        path: ni-grpc-device-tests-linux-glibc2_27-x64.tar.gz
         retention-days: 5
 
     - name: Stage Linux Client Files

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -35,7 +35,8 @@ jobs:
             os: ubuntu-18.04,
             build_type: "Release", cc: "gcc-9", cxx: "g++-9",
             cmake_platform: "",
-            cmake_number_of_jobs: "-j 2"
+            cmake_number_of_jobs: "-j 2",
+            glibc_version: "2_27"
           }
 
     steps:
@@ -116,7 +117,7 @@ jobs:
     - name: Tar Linux Server Binaries
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       run: >-
-        tar -cvzf ni-grpc-device-server-linux-glibc2_27-x64.tar.gz
+        tar -cvzf ni-grpc-device-server-linux-glibc${{ matrix.config.glibc_version }}-x64.tar.gz
         -C ${GITHUB_WORKSPACE}/build
         ni_grpc_device_server
         server_config.json
@@ -128,14 +129,14 @@ jobs:
       uses: actions/upload-artifact@v2
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       with:
-        name: ni-grpc-device-server-linux-glibc2_27-x64
-        path: ni-grpc-device-server-linux-glibc2_27-x64.tar.gz
+        name: ni-grpc-device-server-linux-glibc${{ matrix.config.glibc_version }}-x64
+        path: ni-grpc-device-server-linux-glibc${{ matrix.config.glibc_version }}-x64.tar.gz
         retention-days: 5
 
     - name: Tar Linux Test Binaries
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       run: >-
-        tar -cvzf ni-grpc-device-tests-linux-glibc2_27-x64.tar.gz
+        tar -cvzf ni-grpc-device-tests-linux-glibc${{ matrix.config.glibc_version }}-x64.tar.gz
         -C ${GITHUB_WORKSPACE}/build
         certs/
         IntegrationTestsRunner
@@ -151,8 +152,8 @@ jobs:
       uses: actions/upload-artifact@v2
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       with:
-        name: ni-grpc-device-tests-linux-glibc2_27-x64
-        path: ni-grpc-device-tests-linux-glibc2_27-x64.tar.gz
+        name: ni-grpc-device-tests-linux-glibc${{ matrix.config.glibc_version }}-x64
+        path: ni-grpc-device-tests-linux-glibc${{ matrix.config.glibc_version }}-x64.tar.gz
         retention-days: 5
 
     - name: Stage Linux Client Files


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update workflow to use ubuntu 18.04 runner.
Change artifact names to reflect the system glibc for 18.04 (2.27)

### Why should this Pull Request be merged?

GH is dropping support for ubuntu 16.04 runners.
We don't know of current clients that depend on older glibc. If we have requests, we can either have them build from source or set up a containerized workflow to do that build.

### What testing has been done?

Standard pre-submit build.