### PR TITLE
Support mapped enums in generated test clients

### DIFF
--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -25,13 +25,6 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
-    # If 2 large cpp files are compiled in parallel, we can run out of memory.
-    # Increase swap space to protect against this.
-    - name: Set Swap Space
-      uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c
-      with:
-        swap-size-gb: 8
-
     - name: Checkout Repo
       uses: actions/checkout@v2
 
@@ -91,7 +84,7 @@ jobs:
       shell: cmake -P {0}
       run: |
         execute_process(
-          COMMAND cmake --build $ENV{GITHUB_WORKSPACE}/third_party/grpc/build -j 2
+          COMMAND cmake --build $ENV{GITHUB_WORKSPACE}/third_party/grpc/build
           RESULT_VARIABLE result
           OUTPUT_VARIABLE output
           ERROR_VARIABLE output
@@ -128,7 +121,7 @@ jobs:
       shell: cmake -P {0}
       run: |
         execute_process(
-          COMMAND cmake --build build --config $ENV{BUILD_TYPE} -j 2
+          COMMAND cmake --build build --config $ENV{BUILD_TYPE}
           RESULT_VARIABLE result
           OUTPUT_VARIABLE output
           ERROR_VARIABLE output

--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -25,6 +25,13 @@ jobs:
       with:
         access_token: ${{ github.token }}
 
+    # If 2 large cpp files are compiled in parallel, we can run out of memory.
+    # Increase swap space to protect against this.
+    - name: Set Swap Space
+      uses: pierotofy/set-swap-space@49819abfb41bd9b44fb781159c033dba90353a7c
+      with:
+        swap-size-gb: 8
+
     - name: Checkout Repo
       uses: actions/checkout@v2
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,7 @@ endif()
 # Link test executable against gtest
 add_executable(IntegrationTestsRunner
     "source/tests/utilities/run_all_tests.cpp"
+    "source/tests/integration/ni_fake_service_tests_endtoend.cpp"
     "source/tests/integration/ni_fake_non_ivi_service_tests_endtoend.cpp"
     "source/tests/integration/session_utilities_service_tests.cpp"
     "source/tests/integration/session_utilities_service_tests_endtoend.cpp"
@@ -266,8 +267,13 @@ add_executable(IntegrationTestsRunner
     "source/server/shared_library.cpp"
     ${session_proto_srcs}
     ${session_grpc_srcs}
+    "${proto_srcs_dir}/nifake.pb.cc"
+    "${proto_srcs_dir}/nifake.grpc.pb.cc"
     "${proto_srcs_dir}/nifake_non_ivi.pb.cc"
     "${proto_srcs_dir}/nifake_non_ivi.grpc.pb.cc"
+    "${service_output_dir}/nifake/nifake_client.cpp"
+    "${service_output_dir}/nifake/nifake_service.cpp"
+    "${service_output_dir}/nifake_non_ivi/nifake_non_ivi_client.cpp"
     "${service_output_dir}/nifake_non_ivi/nifake_non_ivi_service.cpp"
     "${custom_dir}/nifake_non_ivi_service.custom.cpp"
 )

--- a/generated/nifake/nifake_client.cpp
+++ b/generated/nifake/nifake_client.cpp
@@ -722,7 +722,7 @@ one_input_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
 }
 
 ParametersAreMultipleTypesResponse
-parameters_are_multiple_types(const StubPtr& stub, const nidevice_grpc::Session& vi, const bool& a_boolean, const pb::int32& an_int32, const pb::int64& an_int64, const simple_variant<Turtle, pb::int32>& an_int_enum, const double& a_float, const double& a_float_enum, const pb::string& a_string)
+parameters_are_multiple_types(const StubPtr& stub, const nidevice_grpc::Session& vi, const bool& a_boolean, const pb::int32& an_int32, const pb::int64& an_int64, const simple_variant<Turtle, pb::int32>& an_int_enum, const double& a_float, const simple_variant<FloatEnum, double>& a_float_enum, const pb::string& a_string)
 {
   ::grpc::ClientContext context;
 
@@ -740,7 +740,14 @@ parameters_are_multiple_types(const StubPtr& stub, const nidevice_grpc::Session&
     request.set_an_int_enum_raw(*an_int_enum_raw_ptr);
   }
   request.set_a_float(a_float);
-  request.set_a_float_enum(a_float_enum);
+  const auto a_float_enum_ptr = a_float_enum.get_if<FloatEnum>();
+  const auto a_float_enum_raw_ptr = a_float_enum.get_if<double>();
+  if (a_float_enum_ptr) {
+    request.set_a_float_enum_mapped(*a_float_enum_ptr);
+  }
+  else if (a_float_enum_raw_ptr) {
+    request.set_a_float_enum_raw(*a_float_enum_raw_ptr);
+  }
   request.set_a_string(a_string);
 
   auto response = ParametersAreMultipleTypesResponse{};
@@ -901,13 +908,20 @@ set_custom_type_array(const StubPtr& stub, const nidevice_grpc::Session& vi, con
 }
 
 StringValuedEnumInputFunctionWithDefaultsResponse
-string_valued_enum_input_function_with_defaults(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& a_mobile_os_name)
+string_valued_enum_input_function_with_defaults(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<MobileOSNames, std::string>& a_mobile_os_name)
 {
   ::grpc::ClientContext context;
 
   auto request = StringValuedEnumInputFunctionWithDefaultsRequest{};
   request.mutable_vi()->CopyFrom(vi);
-  request.set_a_mobile_os_name(a_mobile_os_name);
+  const auto a_mobile_os_name_ptr = a_mobile_os_name.get_if<MobileOSNames>();
+  const auto a_mobile_os_name_raw_ptr = a_mobile_os_name.get_if<std::string>();
+  if (a_mobile_os_name_ptr) {
+    request.set_a_mobile_os_name_mapped(*a_mobile_os_name_ptr);
+  }
+  else if (a_mobile_os_name_raw_ptr) {
+    request.set_a_mobile_os_name_raw(*a_mobile_os_name_raw_ptr);
+  }
 
   auto response = StringValuedEnumInputFunctionWithDefaultsResponse{};
 

--- a/generated/nifake/nifake_client.h
+++ b/generated/nifake/nifake_client.h
@@ -63,7 +63,7 @@ InitWithVarArgsResponse init_with_var_args(const StubPtr& stub, const pb::string
 MultipleArrayTypesResponse multiple_array_types(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& output_array_size, const std::vector<double>& input_array_of_floats, const std::vector<pb::int32>& input_array_of_integers);
 MultipleArraysSameSizeResponse multiple_arrays_same_size(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::vector<double>& values1, const std::vector<double>& values2, const std::vector<double>& values3, const std::vector<double>& values4);
 OneInputFunctionResponse one_input_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& a_number);
-ParametersAreMultipleTypesResponse parameters_are_multiple_types(const StubPtr& stub, const nidevice_grpc::Session& vi, const bool& a_boolean, const pb::int32& an_int32, const pb::int64& an_int64, const simple_variant<Turtle, pb::int32>& an_int_enum, const double& a_float, const double& a_float_enum, const pb::string& a_string);
+ParametersAreMultipleTypesResponse parameters_are_multiple_types(const StubPtr& stub, const nidevice_grpc::Session& vi, const bool& a_boolean, const pb::int32& an_int32, const pb::int64& an_int64, const simple_variant<Turtle, pb::int32>& an_int_enum, const double& a_float, const simple_variant<FloatEnum, double>& a_float_enum, const pb::string& a_string);
 PoorlyNamedSimpleFunctionResponse poorly_named_simple_function(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ReadResponse read(const StubPtr& stub, const nidevice_grpc::Session& vi, const double& maximum_time);
 ReadDataWithInOutIviTwistResponse read_data_with_in_out_ivi_twist(const StubPtr& stub);
@@ -73,7 +73,7 @@ ReturnDurationInSecondsResponse return_duration_in_seconds(const StubPtr& stub, 
 ReturnListOfDurationsInSecondsResponse return_list_of_durations_in_seconds(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& number_of_elements);
 ReturnMultipleTypesResponse return_multiple_types(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& array_size);
 SetCustomTypeArrayResponse set_custom_type_array(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::vector<FakeCustomStruct>& cs);
-StringValuedEnumInputFunctionWithDefaultsResponse string_valued_enum_input_function_with_defaults(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& a_mobile_os_name);
+StringValuedEnumInputFunctionWithDefaultsResponse string_valued_enum_input_function_with_defaults(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<MobileOSNames, std::string>& a_mobile_os_name);
 TwoInputFunctionResponse two_input_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const double& a_number, const pb::string& a_string);
 Use64BitNumberResponse use64_bit_number(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int64& input);
 WriteWaveformResponse write_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::vector<double>& waveform);

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -604,3 +604,18 @@ def get_split_attributes_by_type(config):
 
 def supports_raw_attributes(config: dict) -> bool:
     return config.get('supports_raw_attributes', False)
+
+
+def get_enum_value_cpp_type(enum: dict) -> str:
+    """Uses the python datatype of the first value in the enum to
+    infer the C++ type.
+    
+    Used for mapped enums."""
+    enum_value = enum["values"][0]["value"]
+    if isinstance(enum_value, float):
+        return "double"
+    if isinstance(enum_value, int):
+        return "std::int32_t"
+    if isinstance(enum_value, str):
+        return "std::string"
+    return "std::int32_t"

--- a/source/codegen/metadata_mutation.py
+++ b/source/codegen/metadata_mutation.py
@@ -249,12 +249,9 @@ def get_attribute_values_enum_name(group_name, type, is_mapped=False):
 def add_enum(enum_name, enum_values, enums, enum_value_prefix, is_mapped=False):
     if not enum_values:
         return
-    numeric_values = enum_values.values()
-    allow_alias = (0 in numeric_values) or (len(numeric_values) != len(set(numeric_values)))
     values = [{"name": name, "value": enum_values[name]} for name in enum_values]
     new_enum = {
         'enum-value-prefix': enum_value_prefix,
-        'allow-alias': allow_alias,
         'generate-mappings': is_mapped,
         'values': values
     }

--- a/source/codegen/proto_helpers.py
+++ b/source/codegen/proto_helpers.py
@@ -1,12 +1,11 @@
 import common_helpers
 
-def should_allow_alias(enums):
-  if enums.get("generate-mappings", False):
+def should_allow_alias(enum):
+  if enum.get("generate-mappings", False):
     return False
-  for value in enums["values"]:
-    if value["value"] == 0:
-      return True
-  return False
+  enum_values = [e["value"] for e in enum["values"]]
+  return (0 in enum_values) or (len(enum_values) != len(set(enum_values)))
+
 
 def generate_parameter_field_number(parameter, used_indexes, field_name_suffix=""):
   """Get unique field number for field corresponding to this parameter in proto file.
@@ -24,7 +23,7 @@ def get_enum_definitions(enums_to_define, enums):
   enum_definitions = {}
   for enum_name in (e for e in enums if e in enums_to_define):
     enum = enums[enum_name]
-    allow_alias = enum.get("allow-alias", should_allow_alias(enum))
+    allow_alias = should_allow_alias(enum)
     enum_value_prefix = enum.get("enum-value-prefix", common_helpers.pascal_to_snake(enum_name).upper())
     if enum.get("generate-mappings", False):
       values = [{"name": f"{enum_value_prefix}_{value['name']}", "value": index + 1} for index, value in enumerate(enum["values"])]

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -182,17 +182,6 @@ def create_param(parameter, expand_varargs=True, repeated_parameters=None):
         return f'{type} {name}'
 
 
-def python_to_c(enum):
-    enum_value = enum["values"][0]["value"]
-    if isinstance(enum_value, float):
-        return "double"
-    if isinstance(enum_value, int):
-        return "std::int32_t"
-    if isinstance(enum_value, str):
-        return "std::string"
-    return "std::int32_t"
-
-
 def format_value(value):
     if isinstance(value, str):
         value = f"\"{value}\""

--- a/source/codegen/templates/client.cpp.mako
+++ b/source/codegen/templates/client.cpp.mako
@@ -6,6 +6,7 @@ from client_helpers import ParamMechanism
 
 config = data['config']
 functions = data['functions']
+enums = data['enums']
 
 module_name = config["module_name"]
 service_class_prefix = config["service_class_prefix"]
@@ -43,24 +44,25 @@ namespace ${namespace} {
   response_type = service_helpers.get_response_type(stub_method_name)
   stub_param = f"const {stub_ptr_alias}& stub"
   is_streaming = common_helpers.has_streaming_response(f)
+  client_params = client_helpers.get_client_parameters(f, enums)
 %>\
 %   if is_streaming:
 ${client_helpers.streaming_response_type(response_type)}
-${client_method_name}(${client_helpers.create_streaming_params(f)})
+${client_method_name}(${client_helpers.create_streaming_params(client_params)})
 {
   auto request = ${request_type}{};
-${mako_helper.build_request(f)}\
+${mako_helper.build_request(client_params)}\
 
   return stub->${stub_method_name}(&context, request);
 }
 %   else:
 ${response_type}
-${client_method_name}(${client_helpers.create_unary_params(f)})
+${client_method_name}(${client_helpers.create_unary_params(client_params)})
 {
   ::grpc::ClientContext context;
 
   auto request = ${request_type}{};
-${mako_helper.build_request(f)}\
+${mako_helper.build_request(client_params)}\
 
   auto response = ${response_type}{};
 

--- a/source/codegen/templates/client.h.mako
+++ b/source/codegen/templates/client.h.mako
@@ -6,6 +6,7 @@ from client_helpers import ParamMechanism
 
 config = data['config']
 functions = data['functions']
+enums = data["enums"]
 
 service_class_prefix = config["service_class_prefix"]
 include_guard_name = service_helpers.get_include_guard_name(config, "_CLIENT_H")
@@ -48,11 +49,12 @@ using namespace nidevice_grpc::experimental::client;
   response_type = service_helpers.get_response_type(stub_method_name)
   stub_param = f"const {stub_ptr_alias}& stub"
   is_streaming = common_helpers.has_streaming_response(f)
+  client_params = client_helpers.get_client_parameters(f, enums)
 %>\
 %   if is_streaming:
-${client_helpers.streaming_response_type(response_type)} ${client_method_name}(${client_helpers.create_streaming_params(f)});
+${client_helpers.streaming_response_type(response_type)} ${client_method_name}(${client_helpers.create_streaming_params(client_params)});
 %   else:
-${response_type} ${client_method_name}(${client_helpers.create_unary_params(f)});
+${response_type} ${client_method_name}(${client_helpers.create_unary_params(client_params)});
 %   endif
 % endfor
 

--- a/source/codegen/templates/client_helpers.mako
+++ b/source/codegen/templates/client_helpers.mako
@@ -6,22 +6,24 @@ from client_helpers import ParamMechanism
 %>
 
 ## Copy data from the client method params to the request.
-<%def name="build_request(func)">\
-%   for param in client_helpers.get_client_parameters(func):
+<%def name="build_request(client_params)">\
+%   for param in client_params:
 <%
   field_name = common_helpers.camel_to_snake(param.name)
 %>\
 %     if param.mechanism == ParamMechanism.ARRAY:
   copy_array(${field_name}, request.mutable_${field_name}());
-%     elif param.mechanism == ParamMechanism.ENUM:
+%     elif param.mechanism in [ParamMechanism.ENUM, ParamMechanism.MAPPED_ENUM]:
 <%
   enum_type = client_helpers.get_enum_value_type(param)
   raw_type = client_helpers.get_enum_raw_type(param)
+  is_mapped = param.mechanism == ParamMechanism.MAPPED_ENUM
+  maybe_mapped_suffix = "_mapped" if is_mapped else ""
 %>\
   const auto ${field_name}_ptr = ${field_name}.get_if<${enum_type}>();
   const auto ${field_name}_raw_ptr = ${field_name}.get_if<${raw_type}>();
   if (${field_name}_ptr) {
-    request.set_${field_name}(*${field_name}_ptr);
+    request.set_${field_name}${maybe_mapped_suffix}(*${field_name}_ptr);
   }
   else if (${field_name}_raw_ptr) {
     request.set_${field_name}_raw(*${field_name}_raw_ptr);

--- a/source/codegen/templates/service.h.mako
+++ b/source/codegen/templates/service.h.mako
@@ -98,7 +98,7 @@ private:
 % endif
 % for enum in enums_to_map:
 <%
-  enum_value = service_helpers.python_to_c(enums[enum])
+  enum_value = common_helpers.get_enum_value_cpp_type(enums[enum])
 %>\
   std::map<std::int32_t, ${enum_value}> ${enum.lower()}_input_map_ { ${service_helpers.get_input_lookup_values(enums[enum])} };
   std::map<${enum_value}, std::int32_t> ${enum.lower()}_output_map_ { ${service_helpers.get_output_lookup_values(enums[enum])} };

--- a/source/tests/integration/ni_fake_service_tests_endtoend.cpp
+++ b/source/tests/integration/ni_fake_service_tests_endtoend.cpp
@@ -1,0 +1,95 @@
+#include <gtest/gtest.h>
+#include <nifake/nifake_client.h>
+#include <nifake/nifake_mock_library.h>
+#include <nifake/nifake_service.h>
+
+#include <atomic>
+#include <memory>
+#include <thread>
+
+namespace ni {
+namespace tests {
+namespace integration {
+
+namespace client = nifake_grpc::experimental::client;
+using namespace ::testing;
+using namespace nifake_grpc;
+const auto kDriverSuccess = 0U;
+
+// Test NiFakeService using a client stub.
+class NiFakeServiceTests_EndToEnd : public ::testing::Test {
+ public:
+  using FakeResourceRepository = nidevice_grpc::SessionResourceRepository<ViSession>;
+  nidevice_grpc::SessionRepository session_repository_;
+  std::shared_ptr<FakeResourceRepository> resource_repository_;
+  ni::tests::unit::NiFakeMockLibrary library_;
+  NiFakeService service_;
+  std::unique_ptr<::grpc::Server> server_;
+  std::unique_ptr<NiFake::Stub> stub_;
+  std::atomic<bool> shutdown_{false};
+
+  NiFakeServiceTests_EndToEnd()
+      : session_repository_(),
+        resource_repository_(std::make_shared<FakeResourceRepository>(&session_repository_)),
+        library_(),
+        service_(&library_, resource_repository_),
+        server_(start_server()),
+        stub_(NiFake::NewStub(server_->InProcessChannel(::grpc::ChannelArguments())))
+  {
+  }
+
+  virtual ~NiFakeServiceTests_EndToEnd()
+  {
+    shutdown();
+  }
+
+  void shutdown()
+  {
+    if (!shutdown_) {
+      shutdown_ = true;
+      server_->Shutdown();
+    }
+  }
+
+  std::unique_ptr<::grpc::Server> start_server()
+  {
+    ::grpc::ServerBuilder builder;
+    builder.RegisterService(&service_);
+    return builder.BuildAndStart();
+  }
+
+  std::unique_ptr<NiFake::Stub>& stub()
+  {
+    return stub_;
+  }
+};
+
+InitWithOptionsResponse init(const client::StubPtr& stub)
+{
+  return client::init_with_options(stub, "", false, false, "");
+}
+
+TEST_F(NiFakeServiceTests_EndToEnd, PassMappedEnumToGeneratedClient_PassesStringValueToLibraryAndSucceeds)
+{
+  auto init_response = init(stub());
+  const auto EXPECTED = NIFAKE_VAL_ANDROID;
+  EXPECT_CALL(library_, StringValuedEnumInputFunctionWithDefaults(_, Pointee(*EXPECTED)))
+      .WillOnce(Return(kDriverSuccess));
+  auto response = client::string_valued_enum_input_function_with_defaults(stub(), init_response.vi(), MobileOSNames::MOBILE_OS_NAMES_ANDROID);
+
+  EXPECT_EQ(kDriverSuccess, response.status());
+}
+
+TEST_F(NiFakeServiceTests_EndToEnd, PassMappedEnumRawValueToGeneratedClient_PassesStringValueToLibraryAndSucceeds)
+{
+  auto init_response = init(stub());
+  const auto RAW_VALUE = NIFAKE_VAL_IOS;
+  EXPECT_CALL(library_, StringValuedEnumInputFunctionWithDefaults(_, Pointee(*RAW_VALUE)))
+      .WillOnce(Return(kDriverSuccess));
+  auto response = client::string_valued_enum_input_function_with_defaults(stub(), init_response.vi(), std::string(RAW_VALUE));
+
+  EXPECT_EQ(kDriverSuccess, response.status());
+}
+}  // namespace integration
+}  // namespace tests
+}  // namespace ni


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fix the test client codegen to support mapped enums.
Add fake and fake-non-ivi clients to the IntegrationTestsRunner component to build these clients.

### Why should this Pull Request be merged?

Currently mapped enums are only used in the fake service. The clients for the fake services are generated but are not part of the build. The existing implementation does not work for mapped enums.

RFSA and RFSG have several mapped enums for string datatypes. Adding this codegen will allow us to build the test clients for those drivers when they are added to grpc-device.

### What testing has been done?

Ran and passed included tests.
* A new fake end-to-end tests component. The primary fake testing strategy calls directly into the service, so we need a different setup to test client wrappers.
Builds RFSA/RFSG as part of a larger change.