### PR TITLE
Create flat artifact for windows workflow

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -173,6 +173,16 @@ jobs:
         path: ni-grpc-device-client.tar.gz
         retention-days: 5
 
+    - name: Upload Windows Server Information Artifact
+      uses: actions/upload-artifact@v2
+      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}
+      with:
+        name: ni-grpc-device-server-windows-x64
+        path: |
+          LICENSE
+          ThirdPartyNotices.txt
+        retention-days: 5
+
     - name: Upload Windows Server Binaries Artifact
       uses: actions/upload-artifact@v2
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}
@@ -181,8 +191,6 @@ jobs:
         path: |
           build/Release/ni_grpc_device_server.exe
           build/Release/server_config.json
-          LICENSE
-          ThirdPartyNotices.txt
         retention-days: 5
 
     - name: Upload Windows Test Binaries Artifact


### PR DESCRIPTION
### What does this Pull Request accomplish?

Change the `Upload Windows Server Binaries Artifact` action to be 2 steps so that it produces a flat archive.

### Why should this Pull Request be merged?

The default implementation of the upload-archive action uses the "least common ancestor" directory as the root path. This causes the exe and server_config to be put in build/Release subfolders. Currently our release process requires unzipping/rezipping to fix this.

Using 2 separate steps is awkward but easier than writing a "staging" step to copy the files to a different directory.

### What testing has been done?

Built a test archive on my user repo:
![image](https://user-images.githubusercontent.com/56981669/134069711-8166534b-c60b-43b0-aab7-83ed0e7429d0.png)
