### PR TITLE
Fix #359 - Handle cases when the ivi-dance-with-a-twist size gets smaller

### DIFF
--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -1398,6 +1398,7 @@ namespace nidigitalpattern_grpc {
         }
         response->set_status(status);
         if (status == 0) {
+          response->mutable_data()->Resize(actual_num_waveforms, 0);
           response->set_actual_num_waveforms(actual_num_waveforms);
           response->set_actual_samples_per_waveform(actual_samples_per_waveform);
         }
@@ -1479,6 +1480,7 @@ namespace nidigitalpattern_grpc {
           CopyBytesToEnums(actual_pin_states, response->mutable_actual_pin_states());
           response->set_actual_pin_states_raw(actual_pin_states);
           Copy(per_pin_pass_fail, response->mutable_per_pin_pass_fail());
+          response->mutable_per_pin_pass_fail()->Resize(actual_num_pin_data, 0);
           response->set_actual_num_pin_data(actual_num_pin_data);
         }
         return ::grpc::Status::OK;
@@ -1598,6 +1600,7 @@ namespace nidigitalpattern_grpc {
         }
         response->set_status(status);
         if (status == 0) {
+          response->mutable_frequencies()->Resize(actual_num_frequencies, 0);
           response->set_actual_num_frequencies(actual_num_frequencies);
         }
         return ::grpc::Status::OK;
@@ -1928,6 +1931,7 @@ namespace nidigitalpattern_grpc {
         }
         response->set_status(status);
         if (status == 0) {
+          response->mutable_failure_count()->Resize(actual_num_read, 0);
           response->set_actual_num_read(actual_num_read);
         }
         return ::grpc::Status::OK;
@@ -1990,6 +1994,7 @@ namespace nidigitalpattern_grpc {
         }
         response->set_status(status);
         if (status == 0) {
+          response->mutable_pin_indexes()->Resize(actual_num_pins, 0);
           response->set_actual_num_pins(actual_num_pins);
         }
         return ::grpc::Status::OK;
@@ -2155,6 +2160,9 @@ namespace nidigitalpattern_grpc {
         }
         response->set_status(status);
         if (status == 0) {
+          response->mutable_pin_indexes()->Resize(actual_num_values, 0);
+          response->mutable_site_numbers()->Resize(actual_num_values, 0);
+          response->mutable_channel_indexes()->Resize(actual_num_values, 0);
           response->set_actual_num_values(actual_num_values);
         }
         return ::grpc::Status::OK;
@@ -2193,6 +2201,7 @@ namespace nidigitalpattern_grpc {
         response->set_status(status);
         if (status == 0) {
           Copy(pass_fail, response->mutable_pass_fail());
+          response->mutable_pass_fail()->Resize(actual_num_sites, 0);
           response->set_actual_num_sites(actual_num_sites);
         }
         return ::grpc::Status::OK;
@@ -2247,6 +2256,7 @@ namespace nidigitalpattern_grpc {
         }
         response->set_status(status);
         if (status == 0) {
+          response->mutable_site_numbers()->Resize(actual_num_site_numbers, 0);
           response->set_actual_num_site_numbers(actual_num_site_numbers);
         }
         return ::grpc::Status::OK;
@@ -2950,6 +2960,7 @@ namespace nidigitalpattern_grpc {
         }
         response->set_status(status);
         if (status == 0) {
+          response->mutable_measurements()->Resize(actual_num_read, 0);
           response->set_actual_num_read(actual_num_read);
         }
         return ::grpc::Status::OK;
@@ -3419,6 +3430,7 @@ namespace nidigitalpattern_grpc {
         }
         response->set_status(status);
         if (status == 0) {
+          response->mutable_offsets()->Resize(actual_num_offsets, 0);
           response->set_actual_num_offsets(actual_num_offsets);
         }
         return ::grpc::Status::OK;

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -525,6 +525,7 @@ namespace nifake_grpc {
         }
         response->set_status(status);
         if (status == 0) {
+          response->mutable_array_out()->Resize(actual_size, 0);
           response->set_actual_size(actual_size);
         }
         return ::grpc::Status::OK;
@@ -1317,6 +1318,7 @@ namespace nifake_grpc {
         }
         response->set_status(status);
         if (status == 0) {
+          response->mutable_data()->Resize(buffer_size, 0);
           response->set_buffer_size(buffer_size);
         }
         return ::grpc::Status::OK;

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -2137,6 +2137,7 @@ namespace nifgen_grpc {
         }
         response->set_status(status);
         if (status == 0) {
+          response->mutable_coefficients_array()->Resize(number_of_coefficients_read, 0);
           response->set_number_of_coefficients_read(number_of_coefficients_read);
         }
         return ::grpc::Status::OK;

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -664,6 +664,10 @@ ${copy_to_response_with_transform(source_buffer=parameter_name, parameter_name=p
 %     elif common_helpers.is_struct(parameter) or parameter['type'] == 'ViBoolean[]':
         Copy(${parameter_name}, response->mutable_${parameter_name}());
 %     endif
+%     if common_helpers.is_ivi_dance_array_with_a_twist_param(parameter):
+## This code doesn't handle all parameter types, see what initialize_output_params() does for that.
+        response->mutable_${parameter_name}()->Resize(${common_helpers.camel_to_snake(parameter['size']['value_twist'])}, 0);
+%     endif
 %   elif parameter['type'] == 'ViSession':
         auto session_id = session_repository_->resolve_session_id(${parameter_name});
         response->mutable_${parameter_name}()->set_id(session_id);


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes a race condition where if we call an `ivi-dance-with-a-twist` function and the size of the required array gets smaller, we would not correctly shrink the array to the desired size.

### Why should this Pull Request be merged?

Only return valid data instead of data that may have some 0's at the end.

### What testing has been done?

Added a new unit test, ran all unit tests and some system tests.