### PR TITLE
Support for byte arrays in ivi-twist resize

### DIFF
--- a/generated/nifake/nifake.proto
+++ b/generated/nifake/nifake.proto
@@ -34,6 +34,8 @@ service NiFake {
   rpc GetAStringOfFixedMaximumSize(GetAStringOfFixedMaximumSizeRequest) returns (GetAStringOfFixedMaximumSizeResponse);
   rpc GetAnIviDanceString(GetAnIviDanceStringRequest) returns (GetAnIviDanceStringResponse);
   rpc GetAnIviDanceWithATwistArray(GetAnIviDanceWithATwistArrayRequest) returns (GetAnIviDanceWithATwistArrayResponse);
+  rpc GetAnIviDanceWithATwistByteArray(GetAnIviDanceWithATwistByteArrayRequest) returns (GetAnIviDanceWithATwistByteArrayResponse);
+  rpc GetAnIviDanceWithATwistString(GetAnIviDanceWithATwistStringRequest) returns (GetAnIviDanceWithATwistStringResponse);
   rpc GetArraySizeForCustomCode(GetArraySizeForCustomCodeRequest) returns (GetArraySizeForCustomCodeResponse);
   rpc GetArrayUsingIviDance(GetArrayUsingIviDanceRequest) returns (GetArrayUsingIviDanceResponse);
   rpc GetArrayViUInt8WithEnum(GetArrayViUInt8WithEnumRequest) returns (GetArrayViUInt8WithEnumResponse);
@@ -319,6 +321,24 @@ message GetAnIviDanceWithATwistArrayRequest {
 message GetAnIviDanceWithATwistArrayResponse {
   int32 status = 1;
   repeated sint32 array_out = 2;
+  sint32 actual_size = 3;
+}
+
+message GetAnIviDanceWithATwistByteArrayRequest {
+}
+
+message GetAnIviDanceWithATwistByteArrayResponse {
+  int32 status = 1;
+  bytes array_out = 2;
+  sint32 actual_size = 3;
+}
+
+message GetAnIviDanceWithATwistStringRequest {
+}
+
+message GetAnIviDanceWithATwistStringResponse {
+  int32 status = 1;
+  string array_out = 2;
   sint32 actual_size = 3;
 }
 

--- a/generated/nifake/nifake_client.cpp
+++ b/generated/nifake/nifake_client.cpp
@@ -323,6 +323,36 @@ get_an_ivi_dance_with_a_twist_array(const StubPtr& stub, const nidevice_grpc::Se
   return response;
 }
 
+GetAnIviDanceWithATwistByteArrayResponse
+get_an_ivi_dance_with_a_twist_byte_array(const StubPtr& stub)
+{
+  ::grpc::ClientContext context;
+
+  auto request = GetAnIviDanceWithATwistByteArrayRequest{};
+
+  auto response = GetAnIviDanceWithATwistByteArrayResponse{};
+
+  raise_if_error(
+      stub->GetAnIviDanceWithATwistByteArray(&context, request, &response));
+
+  return response;
+}
+
+GetAnIviDanceWithATwistStringResponse
+get_an_ivi_dance_with_a_twist_string(const StubPtr& stub)
+{
+  ::grpc::ClientContext context;
+
+  auto request = GetAnIviDanceWithATwistStringRequest{};
+
+  auto response = GetAnIviDanceWithATwistStringResponse{};
+
+  raise_if_error(
+      stub->GetAnIviDanceWithATwistString(&context, request, &response));
+
+  return response;
+}
+
 GetArraySizeForCustomCodeResponse
 get_array_size_for_custom_code(const StubPtr& stub, const nidevice_grpc::Session& vi)
 {

--- a/generated/nifake/nifake_client.h
+++ b/generated/nifake/nifake_client.h
@@ -40,6 +40,8 @@ GetANumberResponse get_a_number(const StubPtr& stub, const nidevice_grpc::Sessio
 GetAStringOfFixedMaximumSizeResponse get_a_string_of_fixed_maximum_size(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetAnIviDanceStringResponse get_an_ivi_dance_string(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetAnIviDanceWithATwistArrayResponse get_an_ivi_dance_with_a_twist_array(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& a_string);
+GetAnIviDanceWithATwistByteArrayResponse get_an_ivi_dance_with_a_twist_byte_array(const StubPtr& stub);
+GetAnIviDanceWithATwistStringResponse get_an_ivi_dance_with_a_twist_string(const StubPtr& stub);
 GetArraySizeForCustomCodeResponse get_array_size_for_custom_code(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetArrayUsingIviDanceResponse get_array_using_ivi_dance(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetArrayViUInt8WithEnumResponse get_array_vi_uint8_with_enum(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& array_len);

--- a/generated/nifake/nifake_library.cpp
+++ b/generated/nifake/nifake_library.cpp
@@ -39,6 +39,8 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.GetAStringOfFixedMaximumSize = reinterpret_cast<GetAStringOfFixedMaximumSizePtr>(shared_library_.get_function_pointer("niFake_GetAStringOfFixedMaximumSize"));
   function_pointers_.GetAnIviDanceString = reinterpret_cast<GetAnIviDanceStringPtr>(shared_library_.get_function_pointer("niFake_GetAnIviDanceString"));
   function_pointers_.GetAnIviDanceWithATwistArray = reinterpret_cast<GetAnIviDanceWithATwistArrayPtr>(shared_library_.get_function_pointer("niFake_GetAnIviDanceWithATwistArray"));
+  function_pointers_.GetAnIviDanceWithATwistByteArray = reinterpret_cast<GetAnIviDanceWithATwistByteArrayPtr>(shared_library_.get_function_pointer("niFake_GetAnIviDanceWithATwistByteArray"));
+  function_pointers_.GetAnIviDanceWithATwistString = reinterpret_cast<GetAnIviDanceWithATwistStringPtr>(shared_library_.get_function_pointer("niFake_GetAnIviDanceWithATwistString"));
   function_pointers_.GetArraySizeForCustomCode = reinterpret_cast<GetArraySizeForCustomCodePtr>(shared_library_.get_function_pointer("niFake_GetArraySizeForCustomCode"));
   function_pointers_.GetArrayUsingIviDance = reinterpret_cast<GetArrayUsingIviDancePtr>(shared_library_.get_function_pointer("niFake_GetArrayUsingIviDance"));
   function_pointers_.GetArrayViUInt8WithEnum = reinterpret_cast<GetArrayViUInt8WithEnumPtr>(shared_library_.get_function_pointer("niFake_GetArrayViUInt8WithEnum"));
@@ -316,6 +318,30 @@ ViStatus NiFakeLibrary::GetAnIviDanceWithATwistArray(ViSession vi, ViConstString
   return niFake_GetAnIviDanceWithATwistArray(vi, aString, bufferSize, arrayOut, actualSize);
 #else
   return function_pointers_.GetAnIviDanceWithATwistArray(vi, aString, bufferSize, arrayOut, actualSize);
+#endif
+}
+
+ViStatus NiFakeLibrary::GetAnIviDanceWithATwistByteArray(ViInt32 bufferSize, ViInt8 arrayOut[], ViInt32* actualSize)
+{
+  if (!function_pointers_.GetAnIviDanceWithATwistByteArray) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_GetAnIviDanceWithATwistByteArray.");
+  }
+#if defined(_MSC_VER)
+  return niFake_GetAnIviDanceWithATwistByteArray(bufferSize, arrayOut, actualSize);
+#else
+  return function_pointers_.GetAnIviDanceWithATwistByteArray(bufferSize, arrayOut, actualSize);
+#endif
+}
+
+ViStatus NiFakeLibrary::GetAnIviDanceWithATwistString(ViInt32 bufferSize, ViChar arrayOut[], ViInt32* actualSize)
+{
+  if (!function_pointers_.GetAnIviDanceWithATwistString) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_GetAnIviDanceWithATwistString.");
+  }
+#if defined(_MSC_VER)
+  return niFake_GetAnIviDanceWithATwistString(bufferSize, arrayOut, actualSize);
+#else
+  return function_pointers_.GetAnIviDanceWithATwistString(bufferSize, arrayOut, actualSize);
 #endif
 }
 

--- a/generated/nifake/nifake_library.h
+++ b/generated/nifake/nifake_library.h
@@ -36,6 +36,8 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus GetAStringOfFixedMaximumSize(ViSession vi, ViChar aString[256]);
   ViStatus GetAnIviDanceString(ViSession vi, ViInt32 bufferSize, ViChar aString[]);
   ViStatus GetAnIviDanceWithATwistArray(ViSession vi, ViConstString aString, ViInt32 bufferSize, ViInt32 arrayOut[], ViInt32* actualSize);
+  ViStatus GetAnIviDanceWithATwistByteArray(ViInt32 bufferSize, ViInt8 arrayOut[], ViInt32* actualSize);
+  ViStatus GetAnIviDanceWithATwistString(ViInt32 bufferSize, ViChar arrayOut[], ViInt32* actualSize);
   ViStatus GetArraySizeForCustomCode(ViSession vi, ViInt32* sizeOut);
   ViStatus GetArrayUsingIviDance(ViSession vi, ViInt32 arraySize, ViReal64 arrayOut[]);
   ViStatus GetArrayViUInt8WithEnum(ViSession vi, ViInt32 arrayLen, ViUInt8 uInt8EnumArray[]);
@@ -107,6 +109,8 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using GetAStringOfFixedMaximumSizePtr = decltype(&niFake_GetAStringOfFixedMaximumSize);
   using GetAnIviDanceStringPtr = decltype(&niFake_GetAnIviDanceString);
   using GetAnIviDanceWithATwistArrayPtr = decltype(&niFake_GetAnIviDanceWithATwistArray);
+  using GetAnIviDanceWithATwistByteArrayPtr = decltype(&niFake_GetAnIviDanceWithATwistByteArray);
+  using GetAnIviDanceWithATwistStringPtr = decltype(&niFake_GetAnIviDanceWithATwistString);
   using GetArraySizeForCustomCodePtr = decltype(&niFake_GetArraySizeForCustomCode);
   using GetArrayUsingIviDancePtr = decltype(&niFake_GetArrayUsingIviDance);
   using GetArrayViUInt8WithEnumPtr = decltype(&niFake_GetArrayViUInt8WithEnum);
@@ -178,6 +182,8 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     GetAStringOfFixedMaximumSizePtr GetAStringOfFixedMaximumSize;
     GetAnIviDanceStringPtr GetAnIviDanceString;
     GetAnIviDanceWithATwistArrayPtr GetAnIviDanceWithATwistArray;
+    GetAnIviDanceWithATwistByteArrayPtr GetAnIviDanceWithATwistByteArray;
+    GetAnIviDanceWithATwistStringPtr GetAnIviDanceWithATwistString;
     GetArraySizeForCustomCodePtr GetArraySizeForCustomCode;
     GetArrayUsingIviDancePtr GetArrayUsingIviDance;
     GetArrayViUInt8WithEnumPtr GetArrayViUInt8WithEnum;

--- a/generated/nifake/nifake_library_interface.h
+++ b/generated/nifake/nifake_library_interface.h
@@ -33,6 +33,8 @@ class NiFakeLibraryInterface {
   virtual ViStatus GetAStringOfFixedMaximumSize(ViSession vi, ViChar aString[256]) = 0;
   virtual ViStatus GetAnIviDanceString(ViSession vi, ViInt32 bufferSize, ViChar aString[]) = 0;
   virtual ViStatus GetAnIviDanceWithATwistArray(ViSession vi, ViConstString aString, ViInt32 bufferSize, ViInt32 arrayOut[], ViInt32* actualSize) = 0;
+  virtual ViStatus GetAnIviDanceWithATwistByteArray(ViInt32 bufferSize, ViInt8 arrayOut[], ViInt32* actualSize) = 0;
+  virtual ViStatus GetAnIviDanceWithATwistString(ViInt32 bufferSize, ViChar arrayOut[], ViInt32* actualSize) = 0;
   virtual ViStatus GetArraySizeForCustomCode(ViSession vi, ViInt32* sizeOut) = 0;
   virtual ViStatus GetArrayUsingIviDance(ViSession vi, ViInt32 arraySize, ViReal64 arrayOut[]) = 0;
   virtual ViStatus GetArrayViUInt8WithEnum(ViSession vi, ViInt32 arrayLen, ViUInt8 uInt8EnumArray[]) = 0;

--- a/generated/nifake/nifake_mock_library.h
+++ b/generated/nifake/nifake_mock_library.h
@@ -35,6 +35,8 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, GetAStringOfFixedMaximumSize, (ViSession vi, ViChar aString[256]), (override));
   MOCK_METHOD(ViStatus, GetAnIviDanceString, (ViSession vi, ViInt32 bufferSize, ViChar aString[]), (override));
   MOCK_METHOD(ViStatus, GetAnIviDanceWithATwistArray, (ViSession vi, ViConstString aString, ViInt32 bufferSize, ViInt32 arrayOut[], ViInt32* actualSize), (override));
+  MOCK_METHOD(ViStatus, GetAnIviDanceWithATwistByteArray, (ViInt32 bufferSize, ViInt8 arrayOut[], ViInt32* actualSize), (override));
+  MOCK_METHOD(ViStatus, GetAnIviDanceWithATwistString, (ViInt32 bufferSize, ViChar arrayOut[], ViInt32* actualSize), (override));
   MOCK_METHOD(ViStatus, GetArraySizeForCustomCode, (ViSession vi, ViInt32* sizeOut), (override));
   MOCK_METHOD(ViStatus, GetArrayUsingIviDance, (ViSession vi, ViInt32 arraySize, ViReal64 arrayOut[]), (override));
   MOCK_METHOD(ViStatus, GetArrayViUInt8WithEnum, (ViSession vi, ViInt32 arrayLen, ViUInt8 uInt8EnumArray[]), (override));

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -538,6 +538,81 @@ namespace nifake_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::GetAnIviDanceWithATwistByteArray(::grpc::ServerContext* context, const GetAnIviDanceWithATwistByteArrayRequest* request, GetAnIviDanceWithATwistByteArrayResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      ViInt32 actual_size {};
+      while (true) {
+        auto status = library_->GetAnIviDanceWithATwistByteArray(0, nullptr, &actual_size);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        std::string array_out(actual_size, '\0');
+        auto buffer_size = actual_size;
+        status = library_->GetAnIviDanceWithATwistByteArray(buffer_size, (ViInt8*)array_out.data(), &actual_size);
+        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
+          // buffer is now too small, try again
+          continue;
+        }
+        response->set_status(status);
+        if (status == 0) {
+          response->set_array_out(array_out);
+          response->mutable_array_out()->resize(actual_size);
+          response->set_actual_size(actual_size);
+        }
+        return ::grpc::Status::OK;
+      }
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::GetAnIviDanceWithATwistString(::grpc::ServerContext* context, const GetAnIviDanceWithATwistStringRequest* request, GetAnIviDanceWithATwistStringResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      ViInt32 actual_size {};
+      while (true) {
+        auto status = library_->GetAnIviDanceWithATwistString(0, nullptr, &actual_size);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        std::string array_out;
+        if (actual_size > 0) {
+            array_out.resize(actual_size-1);
+        }
+        auto buffer_size = actual_size;
+        status = library_->GetAnIviDanceWithATwistString(buffer_size, (ViChar*)array_out.data(), &actual_size);
+        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
+          // buffer is now too small, try again
+          continue;
+        }
+        response->set_status(status);
+        if (status == 0) {
+          response->set_array_out(array_out);
+          response->mutable_array_out()->resize(actual_size-1);
+          response->set_actual_size(actual_size);
+        }
+        return ::grpc::Status::OK;
+      }
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetArraySizeForCustomCode(::grpc::ServerContext* context, const GetArraySizeForCustomCodeRequest* request, GetArraySizeForCustomCodeResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -50,6 +50,8 @@ public:
   ::grpc::Status GetAStringOfFixedMaximumSize(::grpc::ServerContext* context, const GetAStringOfFixedMaximumSizeRequest* request, GetAStringOfFixedMaximumSizeResponse* response) override;
   ::grpc::Status GetAnIviDanceString(::grpc::ServerContext* context, const GetAnIviDanceStringRequest* request, GetAnIviDanceStringResponse* response) override;
   ::grpc::Status GetAnIviDanceWithATwistArray(::grpc::ServerContext* context, const GetAnIviDanceWithATwistArrayRequest* request, GetAnIviDanceWithATwistArrayResponse* response) override;
+  ::grpc::Status GetAnIviDanceWithATwistByteArray(::grpc::ServerContext* context, const GetAnIviDanceWithATwistByteArrayRequest* request, GetAnIviDanceWithATwistByteArrayResponse* response) override;
+  ::grpc::Status GetAnIviDanceWithATwistString(::grpc::ServerContext* context, const GetAnIviDanceWithATwistStringRequest* request, GetAnIviDanceWithATwistStringResponse* response) override;
   ::grpc::Status GetArraySizeForCustomCode(::grpc::ServerContext* context, const GetArraySizeForCustomCodeRequest* request, GetArraySizeForCustomCodeResponse* response) override;
   ::grpc::Status GetArrayUsingIviDance(::grpc::ServerContext* context, const GetArrayUsingIviDanceRequest* request, GetArrayUsingIviDanceResponse* response) override;
   ::grpc::Status GetArrayViUInt8WithEnum(::grpc::ServerContext* context, const GetArrayViUInt8WithEnumRequest* request, GetArrayViUInt8WithEnumResponse* response) override;

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -613,6 +613,56 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'GetAnIviDanceWithATwistByteArray': {
+        'parameters': [
+            {
+                'name': 'bufferSize',
+                'direction': 'in',
+                'type': 'ViInt32'
+            },
+            {
+                'name': 'arrayOut',
+                'direction': 'out',
+                'size': {
+                    'mechanism': 'ivi-dance-with-a-twist',
+                    'value': 'bufferSize',
+                    'value_twist': 'actualSize'
+                },
+                'type': 'ViInt8[]'
+            },
+            {
+                'name': 'actualSize',
+                'direction': 'out',
+                'type': 'ViInt32'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+        'GetAnIviDanceWithATwistString': {
+        'parameters': [
+            {
+                'name': 'bufferSize',
+                'direction': 'in',
+                'type': 'ViInt32'
+            },
+            {
+                'name': 'arrayOut',
+                'direction': 'out',
+                'size': {
+                    'mechanism': 'ivi-dance-with-a-twist',
+                    'value': 'bufferSize',
+                    'value_twist': 'actualSize'
+                },
+                'type': 'ViChar[]'
+            },
+            {
+                'name': 'actualSize',
+                'direction': 'out',
+                'type': 'ViInt32'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'GetArrayForCustomCodeCustomType': {
         'codegen_method': 'no',
         'documentation': {

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -665,8 +665,17 @@ ${copy_to_response_with_transform(source_buffer=parameter_name, parameter_name=p
         Copy(${parameter_name}, response->mutable_${parameter_name}());
 %     endif
 %     if common_helpers.is_ivi_dance_array_with_a_twist_param(parameter):
-## This code doesn't handle all parameter types, see what initialize_output_params() does for that.
-        response->mutable_${parameter_name}()->Resize(${common_helpers.camel_to_snake(parameter['size']['value_twist'])}, 0);
+<%
+  actual_size_param_name = common_helpers.camel_to_snake(parameter['size']['value_twist'])
+%>\
+%       if parameter['grpc_type'] == 'bytes':
+        response->mutable_${parameter_name}()->resize(${actual_size_param_name});
+%       elif common_helpers.is_string_arg(parameter):
+        response->mutable_${parameter_name}()->resize(${actual_size_param_name}-1);
+%       else:
+## This code doesn't handle all parameter types (i.e., enums), see what initialize_output_params() does for that.
+        response->mutable_${parameter_name}()->Resize(${actual_size_param_name}, 0);
+%       endif
 %     endif
 %   elif parameter['type'] == 'ViSession':
         auto session_id = session_repository_->resolve_session_id(${parameter_name});

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -1796,7 +1796,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistByteArrayWithSmall
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
   std::uint32_t session_id = create_session(library, service, kTestViSession);
-  const auto DATA = std::vector{'a', 'b'};
+  const auto DATA = std::vector<char>{'a', 'b'};
   const auto NEW_SIZE = static_cast<ViInt32>(DATA.size());
   const auto OLD_SIZE = NEW_SIZE + 1;
   // ivi-dance-with-a-twist call


### PR DESCRIPTION
### What does this Pull Request accomplish?

Handle byte arrays and strings in `ivi-dance-with-a-twist` resize-to-smaller code.
Use the `std::string` `resize` method instead of `Resize` that is used for other grpc repeated/array fields.

### Why should this Pull Request be merged?

RFSA has `ivi-dance-with-a-twist` methods for strings and byte arrays that won't build without this change.

### What testing has been done?

Builds with fake implementation.
Ran and passed included test.