### PR TITLE
Add support for scalar custom types

### DIFF
--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <vector>
 #include "custom/nidaqmx_conversions.h"
+#include <server/converters.h>
 #include <server/callback_router.h>
 #include <server/server_reactor.h>
 #include "nidaqmx_library.h"

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -17692,8 +17692,3 @@ namespace nidaqmx_grpc {
   }
 } // namespace nidaqmx_grpc
 
-namespace nidevice_grpc {
-namespace converters {
-} // converters
-} // nidevice_grpc
-

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -12,12 +12,14 @@
 #include <atomic>
 #include <vector>
 #include "custom/nidaqmx_conversions.h"
-#include <server/converters.h>
 #include <server/callback_router.h>
 #include <server/server_reactor.h>
 #include "nidaqmx_library.h"
 
 namespace nidaqmx_grpc {
+
+  using nidevice_grpc::converters::convert_from_grpc;
+  using nidevice_grpc::converters::convert_to_grpc;
 
   const auto kErrorReadBufferTooSmall = -200229;
   const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;
@@ -17688,4 +17690,9 @@ namespace nidaqmx_grpc {
   {
   }
 } // namespace nidaqmx_grpc
+
+namespace nidevice_grpc {
+namespace converters {
+} // converters
+} // nidevice_grpc
 

--- a/generated/nidaqmx/nidaqmx_service.h
+++ b/generated/nidaqmx/nidaqmx_service.h
@@ -13,6 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
+#include <server/converters.h>
 #include <server/feature_toggles.h>
 #include <server/session_resource_repository.h>
 #include <server/shared_library.h>
@@ -435,5 +436,10 @@ private:
 };
 
 } // namespace nidaqmx_grpc
+
+namespace nidevice_grpc {
+namespace converters {
+} // namespace converters
+} // namespace nidevice_grpc
 
 #endif  // NIDAQMX_GRPC_SERVICE_H

--- a/generated/nidaqmx/nidaqmx_service.h
+++ b/generated/nidaqmx/nidaqmx_service.h
@@ -437,9 +437,4 @@ private:
 
 } // namespace nidaqmx_grpc
 
-namespace nidevice_grpc {
-namespace converters {
-} // namespace converters
-} // namespace nidevice_grpc
-
 #endif  // NIDAQMX_GRPC_SERVICE_H

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -11,9 +11,11 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-#include <server/converters.h>
 
 namespace nidcpower_grpc {
+
+  using nidevice_grpc::converters::convert_from_grpc;
+  using nidevice_grpc::converters::convert_to_grpc;
 
   const auto kErrorReadBufferTooSmall = -200229;
   const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;
@@ -28,13 +30,6 @@ namespace nidcpower_grpc {
 
   NiDCPowerService::~NiDCPowerService()
   {
-  }
-
-  void NiDCPowerService::Copy(const std::vector<ViBoolean>& input, google::protobuf::RepeatedField<bool>* output) 
-  {
-    for (auto item : input) {
-      output->Add(item != VI_FALSE);
-    }
   }
 
   //---------------------------------------------------------------------
@@ -2272,7 +2267,7 @@ namespace nidcpower_grpc {
       auto status = library_->FetchMultiple(vi, channel_name, timeout, count, voltage_measurements, current_measurements, in_compliance.data(), &actual_count);
       response->set_status(status);
       if (status == 0) {
-        Copy(in_compliance, response->mutable_in_compliance());
+        convert_to_grpc(in_compliance, response->mutable_in_compliance());
         response->set_actual_count(actual_count);
       }
       return ::grpc::Status::OK;

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include <server/converters.h>
 
 namespace nidcpower_grpc {
 

--- a/generated/nidcpower/nidcpower_service.h
+++ b/generated/nidcpower/nidcpower_service.h
@@ -13,6 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
+#include <server/converters.h>
 #include <server/feature_toggles.h>
 #include <server/session_resource_repository.h>
 #include <server/shared_library.h>

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -11,9 +11,11 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-#include <server/converters.h>
 
 namespace nidigitalpattern_grpc {
+
+  using nidevice_grpc::converters::convert_from_grpc;
+  using nidevice_grpc::converters::convert_to_grpc;
 
   const auto kErrorReadBufferTooSmall = -200229;
   const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;
@@ -28,13 +30,6 @@ namespace nidigitalpattern_grpc {
 
   NiDigitalService::~NiDigitalService()
   {
-  }
-
-  void NiDigitalService::Copy(const std::vector<ViBoolean>& input, google::protobuf::RepeatedField<bool>* output) 
-  {
-    for (auto item : input) {
-      output->Add(item != VI_FALSE);
-    }
   }
 
   template <typename TEnum>
@@ -1480,7 +1475,7 @@ namespace nidigitalpattern_grpc {
           response->set_expected_pin_states_raw(expected_pin_states);
           CopyBytesToEnums(actual_pin_states, response->mutable_actual_pin_states());
           response->set_actual_pin_states_raw(actual_pin_states);
-          Copy(per_pin_pass_fail, response->mutable_per_pin_pass_fail());
+          convert_to_grpc(per_pin_pass_fail, response->mutable_per_pin_pass_fail());
           response->mutable_per_pin_pass_fail()->Resize(actual_num_pin_data, 0);
           response->set_actual_num_pin_data(actual_num_pin_data);
         }
@@ -2201,7 +2196,7 @@ namespace nidigitalpattern_grpc {
         }
         response->set_status(status);
         if (status == 0) {
-          Copy(pass_fail, response->mutable_pass_fail());
+          convert_to_grpc(pass_fail, response->mutable_pass_fail());
           response->mutable_pass_fail()->Resize(actual_num_sites, 0);
           response->set_actual_num_sites(actual_num_sites);
         }

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -1474,8 +1474,10 @@ namespace nidigitalpattern_grpc {
         if (status == 0) {
           CopyBytesToEnums(expected_pin_states, response->mutable_expected_pin_states());
           response->set_expected_pin_states_raw(expected_pin_states);
+          response->mutable_expected_pin_states()->Resize(actual_num_pin_data, 0);
           CopyBytesToEnums(actual_pin_states, response->mutable_actual_pin_states());
           response->set_actual_pin_states_raw(actual_pin_states);
+          response->mutable_actual_pin_states()->Resize(actual_num_pin_data, 0);
           convert_to_grpc(per_pin_pass_fail, response->mutable_per_pin_pass_fail());
           response->mutable_per_pin_pass_fail()->Resize(actual_num_pin_data, 0);
           response->set_actual_num_pin_data(actual_num_pin_data);
@@ -3065,6 +3067,7 @@ namespace nidigitalpattern_grpc {
         if (status == 0) {
           CopyBytesToEnums(data, response->mutable_data());
           response->set_data_raw(data);
+          response->mutable_data()->Resize(actual_num_read, 0);
           response->set_actual_num_read(actual_num_read);
         }
         return ::grpc::Status::OK;

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include <server/converters.h>
 
 namespace nidigitalpattern_grpc {
 

--- a/generated/nidigitalpattern/nidigitalpattern_service.h
+++ b/generated/nidigitalpattern/nidigitalpattern_service.h
@@ -13,6 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
+#include <server/converters.h>
 #include <server/feature_toggles.h>
 #include <server/session_resource_repository.h>
 #include <server/shared_library.h>

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include <server/converters.h>
 
 namespace nidmm_grpc {
 

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -11,9 +11,11 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-#include <server/converters.h>
 
 namespace nidmm_grpc {
+
+  using nidevice_grpc::converters::convert_from_grpc;
+  using nidevice_grpc::converters::convert_to_grpc;
 
   const auto kErrorReadBufferTooSmall = -200229;
   const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;

--- a/generated/nidmm/nidmm_service.h
+++ b/generated/nidmm/nidmm_service.h
@@ -13,6 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
+#include <server/converters.h>
 #include <server/feature_toggles.h>
 #include <server/session_resource_repository.h>
 #include <server/shared_library.h>

--- a/generated/nifake/nifake.proto
+++ b/generated/nifake/nifake.proto
@@ -49,6 +49,7 @@ service NiFake {
   rpc GetAttributeViString(GetAttributeViStringRequest) returns (GetAttributeViStringResponse);
   rpc GetCalDateAndTime(GetCalDateAndTimeRequest) returns (GetCalDateAndTimeResponse);
   rpc GetCalInterval(GetCalIntervalRequest) returns (GetCalIntervalResponse);
+  rpc GetCustomType(GetCustomTypeRequest) returns (GetCustomTypeResponse);
   rpc GetCustomTypeArray(GetCustomTypeArrayRequest) returns (GetCustomTypeArrayResponse);
   rpc GetEnumValue(GetEnumValueRequest) returns (GetEnumValueResponse);
   rpc GetViUInt8(GetViUInt8Request) returns (GetViUInt8Response);
@@ -70,6 +71,7 @@ service NiFake {
   rpc ReturnDurationInSeconds(ReturnDurationInSecondsRequest) returns (ReturnDurationInSecondsResponse);
   rpc ReturnListOfDurationsInSeconds(ReturnListOfDurationsInSecondsRequest) returns (ReturnListOfDurationsInSecondsResponse);
   rpc ReturnMultipleTypes(ReturnMultipleTypesRequest) returns (ReturnMultipleTypesResponse);
+  rpc SetCustomType(SetCustomTypeRequest) returns (SetCustomTypeResponse);
   rpc SetCustomTypeArray(SetCustomTypeArrayRequest) returns (SetCustomTypeArrayResponse);
   rpc StringValuedEnumInputFunctionWithDefaults(StringValuedEnumInputFunctionWithDefaultsRequest) returns (StringValuedEnumInputFunctionWithDefaultsResponse);
   rpc TwoInputFunction(TwoInputFunctionRequest) returns (TwoInputFunctionResponse);
@@ -480,6 +482,15 @@ message GetCalIntervalResponse {
   sint32 months = 2;
 }
 
+message GetCustomTypeRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetCustomTypeResponse {
+  int32 status = 1;
+  FakeCustomStruct cs = 2;
+}
+
 message GetCustomTypeArrayRequest {
   nidevice_grpc.Session vi = 1;
   sint32 number_of_elements = 2;
@@ -713,6 +724,15 @@ message ReturnMultipleTypesResponse {
   double a_float_enum_raw = 9;
   repeated double an_array = 10;
   string a_string = 11;
+}
+
+message SetCustomTypeRequest {
+  nidevice_grpc.Session vi = 1;
+  FakeCustomStruct cs = 2;
+}
+
+message SetCustomTypeResponse {
+  int32 status = 1;
 }
 
 message SetCustomTypeArrayRequest {

--- a/generated/nifake/nifake_client.cpp
+++ b/generated/nifake/nifake_client.cpp
@@ -573,6 +573,22 @@ get_cal_interval(const StubPtr& stub, const nidevice_grpc::Session& vi)
   return response;
 }
 
+GetCustomTypeResponse
+get_custom_type(const StubPtr& stub, const nidevice_grpc::Session& vi)
+{
+  ::grpc::ClientContext context;
+
+  auto request = GetCustomTypeRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+
+  auto response = GetCustomTypeResponse{};
+
+  raise_if_error(
+      stub->GetCustomType(&context, request, &response));
+
+  return response;
+}
+
 GetCustomTypeArrayResponse
 get_custom_type_array(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& number_of_elements)
 {
@@ -947,6 +963,23 @@ return_multiple_types(const StubPtr& stub, const nidevice_grpc::Session& vi, con
 
   raise_if_error(
       stub->ReturnMultipleTypes(&context, request, &response));
+
+  return response;
+}
+
+SetCustomTypeResponse
+set_custom_type(const StubPtr& stub, const nidevice_grpc::Session& vi, const FakeCustomStruct& cs)
+{
+  ::grpc::ClientContext context;
+
+  auto request = SetCustomTypeRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+  request.mutable_cs()->CopyFrom(cs);
+
+  auto response = SetCustomTypeResponse{};
+
+  raise_if_error(
+      stub->SetCustomType(&context, request, &response));
 
   return response;
 }

--- a/generated/nifake/nifake_client.h
+++ b/generated/nifake/nifake_client.h
@@ -55,6 +55,7 @@ GetAttributeViSessionResponse get_attribute_vi_session(const StubPtr& stub, cons
 GetAttributeViStringResponse get_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttributes& attribute_id);
 GetCalDateAndTimeResponse get_cal_date_and_time(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& cal_type);
 GetCalIntervalResponse get_cal_interval(const StubPtr& stub, const nidevice_grpc::Session& vi);
+GetCustomTypeResponse get_custom_type(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetCustomTypeArrayResponse get_custom_type_array(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& number_of_elements);
 GetEnumValueResponse get_enum_value(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetViUInt8Response get_vi_uint8(const StubPtr& stub, const nidevice_grpc::Session& vi);
@@ -76,6 +77,7 @@ ReturnANumberAndAStringResponse return_a_number_and_a_string(const StubPtr& stub
 ReturnDurationInSecondsResponse return_duration_in_seconds(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ReturnListOfDurationsInSecondsResponse return_list_of_durations_in_seconds(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& number_of_elements);
 ReturnMultipleTypesResponse return_multiple_types(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& array_size);
+SetCustomTypeResponse set_custom_type(const StubPtr& stub, const nidevice_grpc::Session& vi, const FakeCustomStruct& cs);
 SetCustomTypeArrayResponse set_custom_type_array(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::vector<FakeCustomStruct>& cs);
 StringValuedEnumInputFunctionWithDefaultsResponse string_valued_enum_input_function_with_defaults(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<MobileOSNames, std::string>& a_mobile_os_name);
 TwoInputFunctionResponse two_input_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const double& a_number, const pb::string& a_string);

--- a/generated/nifake/nifake_library.cpp
+++ b/generated/nifake/nifake_library.cpp
@@ -54,6 +54,7 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.GetAttributeViString = reinterpret_cast<GetAttributeViStringPtr>(shared_library_.get_function_pointer("niFake_GetAttributeViString"));
   function_pointers_.GetCalDateAndTime = reinterpret_cast<GetCalDateAndTimePtr>(shared_library_.get_function_pointer("niFake_GetCalDateAndTime"));
   function_pointers_.GetCalInterval = reinterpret_cast<GetCalIntervalPtr>(shared_library_.get_function_pointer("niFake_GetCalInterval"));
+  function_pointers_.GetCustomType = reinterpret_cast<GetCustomTypePtr>(shared_library_.get_function_pointer("niFake_GetCustomType"));
   function_pointers_.GetCustomTypeArray = reinterpret_cast<GetCustomTypeArrayPtr>(shared_library_.get_function_pointer("niFake_GetCustomTypeArray"));
   function_pointers_.GetEnumValue = reinterpret_cast<GetEnumValuePtr>(shared_library_.get_function_pointer("niFake_GetEnumValue"));
   function_pointers_.GetError = reinterpret_cast<GetErrorPtr>(shared_library_.get_function_pointer("niFake_GetError"));
@@ -82,6 +83,7 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.SetAttributeViInt64 = reinterpret_cast<SetAttributeViInt64Ptr>(shared_library_.get_function_pointer("niFake_SetAttributeViInt64"));
   function_pointers_.SetAttributeViReal64 = reinterpret_cast<SetAttributeViReal64Ptr>(shared_library_.get_function_pointer("niFake_SetAttributeViReal64"));
   function_pointers_.SetAttributeViString = reinterpret_cast<SetAttributeViStringPtr>(shared_library_.get_function_pointer("niFake_SetAttributeViString"));
+  function_pointers_.SetCustomType = reinterpret_cast<SetCustomTypePtr>(shared_library_.get_function_pointer("niFake_SetCustomType"));
   function_pointers_.SetCustomTypeArray = reinterpret_cast<SetCustomTypeArrayPtr>(shared_library_.get_function_pointer("niFake_SetCustomTypeArray"));
   function_pointers_.StringValuedEnumInputFunctionWithDefaults = reinterpret_cast<StringValuedEnumInputFunctionWithDefaultsPtr>(shared_library_.get_function_pointer("niFake_StringValuedEnumInputFunctionWithDefaults"));
   function_pointers_.TwoInputFunction = reinterpret_cast<TwoInputFunctionPtr>(shared_library_.get_function_pointer("niFake_TwoInputFunction"));
@@ -503,6 +505,18 @@ ViStatus NiFakeLibrary::GetCalInterval(ViSession vi, ViInt32* months)
 #endif
 }
 
+ViStatus NiFakeLibrary::GetCustomType(ViSession vi, CustomStruct* cs)
+{
+  if (!function_pointers_.GetCustomType) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_GetCustomType.");
+  }
+#if defined(_MSC_VER)
+  return niFake_GetCustomType(vi, cs);
+#else
+  return function_pointers_.GetCustomType(vi, cs);
+#endif
+}
+
 ViStatus NiFakeLibrary::GetCustomTypeArray(ViSession vi, ViInt32 numberOfElements, CustomStruct cs[])
 {
   if (!function_pointers_.GetCustomTypeArray) {
@@ -809,6 +823,18 @@ ViStatus NiFakeLibrary::SetAttributeViString(ViSession vi, ViConstString channel
     throw nidevice_grpc::LibraryLoadException("Could not find niFake_SetAttributeViString.");
   }
   return function_pointers_.SetAttributeViString(vi, channelName, attributeId, attributeValue);
+}
+
+ViStatus NiFakeLibrary::SetCustomType(ViSession vi, CustomStruct cs)
+{
+  if (!function_pointers_.SetCustomType) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_SetCustomType.");
+  }
+#if defined(_MSC_VER)
+  return niFake_SetCustomType(vi, cs);
+#else
+  return function_pointers_.SetCustomType(vi, cs);
+#endif
 }
 
 ViStatus NiFakeLibrary::SetCustomTypeArray(ViSession vi, ViInt32 numberOfElements, CustomStruct cs[])

--- a/generated/nifake/nifake_library.h
+++ b/generated/nifake/nifake_library.h
@@ -51,6 +51,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus GetAttributeViString(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 bufferSize, ViChar attributeValue[]);
   ViStatus GetCalDateAndTime(ViSession vi, ViInt32 calType, ViInt32* month, ViInt32* day, ViInt32* year, ViInt32* hour, ViInt32* minute);
   ViStatus GetCalInterval(ViSession vi, ViInt32* months);
+  ViStatus GetCustomType(ViSession vi, CustomStruct* cs);
   ViStatus GetCustomTypeArray(ViSession vi, ViInt32 numberOfElements, CustomStruct cs[]);
   ViStatus GetEnumValue(ViSession vi, ViInt32* aQuantity, ViInt16* aTurtle);
   ViStatus GetError(ViSession vi, ViStatus* errorCode, ViInt32 bufferSize, ViChar description[]);
@@ -79,6 +80,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus SetAttributeViInt64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64 attributeValue);
   ViStatus SetAttributeViReal64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViReal64 attributeValue);
   ViStatus SetAttributeViString(ViSession vi, ViConstString channelName, ViAttr attributeId, ViConstString attributeValue);
+  ViStatus SetCustomType(ViSession vi, CustomStruct cs);
   ViStatus SetCustomTypeArray(ViSession vi, ViInt32 numberOfElements, CustomStruct cs[]);
   ViStatus StringValuedEnumInputFunctionWithDefaults(ViSession vi, ViConstString aMobileOSName);
   ViStatus TwoInputFunction(ViSession vi, ViReal64 aNumber, ViString aString);
@@ -126,6 +128,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using GetAttributeViStringPtr = decltype(&niFake_GetAttributeViString);
   using GetCalDateAndTimePtr = decltype(&niFake_GetCalDateAndTime);
   using GetCalIntervalPtr = decltype(&niFake_GetCalInterval);
+  using GetCustomTypePtr = decltype(&niFake_GetCustomType);
   using GetCustomTypeArrayPtr = decltype(&niFake_GetCustomTypeArray);
   using GetEnumValuePtr = decltype(&niFake_GetEnumValue);
   using GetErrorPtr = ViStatus (*)(ViSession vi, ViStatus* errorCode, ViInt32 bufferSize, ViChar description[]);
@@ -154,6 +157,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using SetAttributeViInt64Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64 attributeValue);
   using SetAttributeViReal64Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViReal64 attributeValue);
   using SetAttributeViStringPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViConstString attributeValue);
+  using SetCustomTypePtr = decltype(&niFake_SetCustomType);
   using SetCustomTypeArrayPtr = decltype(&niFake_SetCustomTypeArray);
   using StringValuedEnumInputFunctionWithDefaultsPtr = decltype(&niFake_StringValuedEnumInputFunctionWithDefaults);
   using TwoInputFunctionPtr = decltype(&niFake_TwoInputFunction);
@@ -201,6 +205,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     GetAttributeViStringPtr GetAttributeViString;
     GetCalDateAndTimePtr GetCalDateAndTime;
     GetCalIntervalPtr GetCalInterval;
+    GetCustomTypePtr GetCustomType;
     GetCustomTypeArrayPtr GetCustomTypeArray;
     GetEnumValuePtr GetEnumValue;
     GetErrorPtr GetError;
@@ -229,6 +234,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     SetAttributeViInt64Ptr SetAttributeViInt64;
     SetAttributeViReal64Ptr SetAttributeViReal64;
     SetAttributeViStringPtr SetAttributeViString;
+    SetCustomTypePtr SetCustomType;
     SetCustomTypeArrayPtr SetCustomTypeArray;
     StringValuedEnumInputFunctionWithDefaultsPtr StringValuedEnumInputFunctionWithDefaults;
     TwoInputFunctionPtr TwoInputFunction;

--- a/generated/nifake/nifake_library_interface.h
+++ b/generated/nifake/nifake_library_interface.h
@@ -48,6 +48,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus GetAttributeViString(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 bufferSize, ViChar attributeValue[]) = 0;
   virtual ViStatus GetCalDateAndTime(ViSession vi, ViInt32 calType, ViInt32* month, ViInt32* day, ViInt32* year, ViInt32* hour, ViInt32* minute) = 0;
   virtual ViStatus GetCalInterval(ViSession vi, ViInt32* months) = 0;
+  virtual ViStatus GetCustomType(ViSession vi, CustomStruct* cs) = 0;
   virtual ViStatus GetCustomTypeArray(ViSession vi, ViInt32 numberOfElements, CustomStruct cs[]) = 0;
   virtual ViStatus GetEnumValue(ViSession vi, ViInt32* aQuantity, ViInt16* aTurtle) = 0;
   virtual ViStatus GetError(ViSession vi, ViStatus* errorCode, ViInt32 bufferSize, ViChar description[]) = 0;
@@ -76,6 +77,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus SetAttributeViInt64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64 attributeValue) = 0;
   virtual ViStatus SetAttributeViReal64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViReal64 attributeValue) = 0;
   virtual ViStatus SetAttributeViString(ViSession vi, ViConstString channelName, ViAttr attributeId, ViConstString attributeValue) = 0;
+  virtual ViStatus SetCustomType(ViSession vi, CustomStruct cs) = 0;
   virtual ViStatus SetCustomTypeArray(ViSession vi, ViInt32 numberOfElements, CustomStruct cs[]) = 0;
   virtual ViStatus StringValuedEnumInputFunctionWithDefaults(ViSession vi, ViConstString aMobileOSName) = 0;
   virtual ViStatus TwoInputFunction(ViSession vi, ViReal64 aNumber, ViString aString) = 0;

--- a/generated/nifake/nifake_mock_library.h
+++ b/generated/nifake/nifake_mock_library.h
@@ -50,6 +50,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, GetAttributeViString, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 bufferSize, ViChar attributeValue[]), (override));
   MOCK_METHOD(ViStatus, GetCalDateAndTime, (ViSession vi, ViInt32 calType, ViInt32* month, ViInt32* day, ViInt32* year, ViInt32* hour, ViInt32* minute), (override));
   MOCK_METHOD(ViStatus, GetCalInterval, (ViSession vi, ViInt32* months), (override));
+  MOCK_METHOD(ViStatus, GetCustomType, (ViSession vi, CustomStruct* cs), (override));
   MOCK_METHOD(ViStatus, GetCustomTypeArray, (ViSession vi, ViInt32 numberOfElements, CustomStruct cs[]), (override));
   MOCK_METHOD(ViStatus, GetEnumValue, (ViSession vi, ViInt32* aQuantity, ViInt16* aTurtle), (override));
   MOCK_METHOD(ViStatus, GetError, (ViSession vi, ViStatus* errorCode, ViInt32 bufferSize, ViChar description[]), (override));
@@ -78,6 +79,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, SetAttributeViInt64, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64 attributeValue), (override));
   MOCK_METHOD(ViStatus, SetAttributeViReal64, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViReal64 attributeValue), (override));
   MOCK_METHOD(ViStatus, SetAttributeViString, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViConstString attributeValue), (override));
+  MOCK_METHOD(ViStatus, SetCustomType, (ViSession vi, CustomStruct cs), (override));
   MOCK_METHOD(ViStatus, SetCustomTypeArray, (ViSession vi, ViInt32 numberOfElements, CustomStruct cs[]), (override));
   MOCK_METHOD(ViStatus, StringValuedEnumInputFunctionWithDefaults, (ViSession vi, ViConstString aMobileOSName), (override));
   MOCK_METHOD(ViStatus, TwoInputFunction, (ViSession vi, ViReal64 aNumber, ViString aString), (override));

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include <server/converters.h>
 
 namespace nifake_grpc {
 

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -11,9 +11,11 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-#include <server/converters.h>
 
 namespace nifake_grpc {
+
+  using nidevice_grpc::converters::convert_from_grpc;
+  using nidevice_grpc::converters::convert_to_grpc;
 
   const auto kErrorReadBufferTooSmall = -200229;
   const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;
@@ -30,13 +32,6 @@ namespace nifake_grpc {
   {
   }
 
-  void NiFakeService::Copy(const std::vector<ViBoolean>& input, google::protobuf::RepeatedField<bool>* output) 
-  {
-    for (auto item : input) {
-      output->Add(item != VI_FALSE);
-    }
-  }
-
   template <typename TEnum>
   void NiFakeService::CopyBytesToEnums(const std::string& input, google::protobuf::RepeatedField<TEnum>* output)
   {
@@ -44,38 +39,6 @@ namespace nifake_grpc {
     {
       output->Add(item);
     }
-  }
-
-  void NiFakeService::Copy(const CustomStruct& input, nifake_grpc::FakeCustomStruct* output) 
-  {
-    output->set_struct_int(input.structInt);
-    output->set_struct_double(input.structDouble);
-  }
-
-  void NiFakeService::Copy(const std::vector<CustomStruct>& input, google::protobuf::RepeatedPtrField<nifake_grpc::FakeCustomStruct>* output) 
-  {
-    for (auto item : input) {
-      auto message = new nifake_grpc::FakeCustomStruct();
-      Copy(item, message);
-      output->AddAllocated(message);
-    }
-  }
-
-   CustomStruct NiFakeService::ConvertMessage(const nifake_grpc::FakeCustomStruct& input) 
-  {
-    CustomStruct* output = new CustomStruct();  
-    output->structInt = input.struct_int();
-    output->structDouble = input.struct_double();
-    return *output;
-  }
-
-  void NiFakeService::Copy(const google::protobuf::RepeatedPtrField<nifake_grpc::FakeCustomStruct>& input, std::vector<CustomStruct>* output)
-  {
-    std::transform(
-        input.begin(),
-        input.end(),
-        std::back_inserter(*output),
-        [&](nifake_grpc::FakeCustomStruct x) { return ConvertMessage(x); });
   }
 
   //---------------------------------------------------------------------
@@ -179,7 +142,7 @@ namespace nifake_grpc {
       auto status = library_->BoolArrayOutputFunction(vi, number_of_elements, an_array.data());
       response->set_status(status);
       if (status == 0) {
-        Copy(an_array, response->mutable_an_array());
+        convert_to_grpc(an_array, response->mutable_an_array());
       }
       return ::grpc::Status::OK;
     }
@@ -563,7 +526,7 @@ namespace nifake_grpc {
         }
         response->set_status(status);
         if (status == 0) {
-          Copy(array_out, response->mutable_array_out());
+          convert_to_grpc(array_out, response->mutable_array_out());
           {
             auto shrunk_size = actual_size;
             auto current_size = response->mutable_array_out()->size();
@@ -645,7 +608,7 @@ namespace nifake_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_array_out(array_out);
-          nidevice_grpc::trim_trailing_nulls(*(response->mutable_array_out()));
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_array_out()));
           response->set_actual_size(actual_size);
         }
         return ::grpc::Status::OK;
@@ -684,7 +647,7 @@ namespace nifake_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_string_out(string_out);
-          nidevice_grpc::trim_trailing_nulls(*(response->mutable_string_out()));
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_string_out()));
           response->set_actual_size(actual_size);
         }
         return ::grpc::Status::OK;
@@ -1017,7 +980,7 @@ namespace nifake_grpc {
       auto status = library_->GetCustomTypeArray(vi, number_of_elements, cs.data());
       response->set_status(status);
       if (status == 0) {
-        Copy(cs, response->mutable_cs());
+        convert_to_grpc(cs, response->mutable_cs());
       }
       return ::grpc::Status::OK;
     }
@@ -1656,9 +1619,7 @@ namespace nifake_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 number_of_elements = static_cast<ViInt32>(request->cs().size());
-      auto cs_request = request->cs();
-      std::vector<CustomStruct> cs;
-      Copy(cs_request, &cs);
+      auto cs = convert_from_grpc<CustomStruct>(request->cs());
       auto status = library_->SetCustomTypeArray(vi, number_of_elements, cs.data());
       response->set_status(status);
       return ::grpc::Status::OK;
@@ -1898,4 +1859,25 @@ namespace nifake_grpc {
   {
   }
 } // namespace nifake_grpc
+
+namespace nidevice_grpc {
+namespace converters {
+template <>
+void convert_to_grpc(const CustomStruct& input, nifake_grpc::FakeCustomStruct* output) 
+{
+  output->set_struct_int(input.structInt);
+  output->set_struct_double(input.structDouble);
+}
+
+template <>
+CustomStruct convert_from_grpc(const nifake_grpc::FakeCustomStruct& input) 
+{
+  CustomStruct* output = new CustomStruct();  
+  output->structInt = input.struct_int();
+  output->structDouble = input.struct_double();
+  return *output;
+}
+
+} // converters
+} // nidevice_grpc
 

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -1916,10 +1916,10 @@ void convert_to_grpc(const CustomStruct& input, nifake_grpc::FakeCustomStruct* o
 template <>
 CustomStruct convert_from_grpc(const nifake_grpc::FakeCustomStruct& input) 
 {
-  CustomStruct* output = new CustomStruct();  
-  output->structInt = input.struct_int();
-  output->structDouble = input.struct_double();
-  return *output;
+  auto output = CustomStruct();  
+  output.structInt = input.struct_int();
+  output.structDouble = input.struct_double();
+  return output;
 }
 
 } // converters

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -968,6 +968,29 @@ namespace nifake_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::GetCustomType(::grpc::ServerContext* context, const GetCustomTypeRequest* request, GetCustomTypeResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      CustomStruct cs {};
+      auto status = library_->GetCustomType(vi, &cs);
+      response->set_status(status);
+      if (status == 0) {
+        convert_to_grpc(cs, response->mutable_cs());
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetCustomTypeArray(::grpc::ServerContext* context, const GetCustomTypeArrayRequest* request, GetCustomTypeArrayResponse* response)
   {
     if (context->IsCancelled()) {
@@ -1603,6 +1626,26 @@ namespace nifake_grpc {
         }
         return ::grpc::Status::OK;
       }
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::SetCustomType(::grpc::ServerContext* context, const SetCustomTypeRequest* request, SetCustomTypeResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      auto cs = convert_from_grpc<CustomStruct>(request->cs());
+      auto status = library_->SetCustomType(vi, cs);
+      response->set_status(status);
+      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -13,6 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
+#include <server/converters.h>
 #include <server/feature_toggles.h>
 #include <server/session_resource_repository.h>
 #include <server/shared_library.h>
@@ -104,10 +105,6 @@ private:
   void Copy(const std::vector<ViBoolean>& input, google::protobuf::RepeatedField<bool>* output);
   template <typename TEnum>
   void CopyBytesToEnums(const std::string& input, google::protobuf::RepeatedField<TEnum>* output);
-  void Copy(const CustomStruct& input, nifake_grpc::FakeCustomStruct* output);
-  void Copy(const std::vector<CustomStruct>& input, google::protobuf::RepeatedPtrField<nifake_grpc::FakeCustomStruct>* output);
-  CustomStruct ConvertMessage(const nifake_grpc::FakeCustomStruct& input);
-  void Copy(const google::protobuf::RepeatedPtrField<nifake_grpc::FakeCustomStruct>& input, std::vector<CustomStruct>* output);
   std::map<std::int32_t, double> floatenum_input_map_ { {1, 3.5f},{2, 4.5f},{3, 5.5f},{4, 6.5f},{5, 7.5f}, };
   std::map<double, std::int32_t> floatenum_output_map_ { {3.5f, 1},{4.5f, 2},{5.5f, 3},{6.5f, 4},{7.5f, 5}, };
   std::map<std::int32_t, std::string> mobileosnames_input_map_ { {1, "Android"},{2, "iOS"},{3, "None"}, };
@@ -127,5 +124,14 @@ private:
 };
 
 } // namespace nifake_grpc
+
+namespace nidevice_grpc {
+namespace converters {
+template <>
+void convert_to_grpc(const CustomStruct& input, nifake_grpc::FakeCustomStruct* output);
+template <>
+CustomStruct convert_from_grpc(const nifake_grpc::FakeCustomStruct& input);
+} // namespace converters
+} // namespace nidevice_grpc
 
 #endif  // NIFAKE_GRPC_SERVICE_H

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -66,6 +66,7 @@ public:
   ::grpc::Status GetAttributeViString(::grpc::ServerContext* context, const GetAttributeViStringRequest* request, GetAttributeViStringResponse* response) override;
   ::grpc::Status GetCalDateAndTime(::grpc::ServerContext* context, const GetCalDateAndTimeRequest* request, GetCalDateAndTimeResponse* response) override;
   ::grpc::Status GetCalInterval(::grpc::ServerContext* context, const GetCalIntervalRequest* request, GetCalIntervalResponse* response) override;
+  ::grpc::Status GetCustomType(::grpc::ServerContext* context, const GetCustomTypeRequest* request, GetCustomTypeResponse* response) override;
   ::grpc::Status GetCustomTypeArray(::grpc::ServerContext* context, const GetCustomTypeArrayRequest* request, GetCustomTypeArrayResponse* response) override;
   ::grpc::Status GetEnumValue(::grpc::ServerContext* context, const GetEnumValueRequest* request, GetEnumValueResponse* response) override;
   ::grpc::Status GetViUInt8(::grpc::ServerContext* context, const GetViUInt8Request* request, GetViUInt8Response* response) override;
@@ -87,6 +88,7 @@ public:
   ::grpc::Status ReturnDurationInSeconds(::grpc::ServerContext* context, const ReturnDurationInSecondsRequest* request, ReturnDurationInSecondsResponse* response) override;
   ::grpc::Status ReturnListOfDurationsInSeconds(::grpc::ServerContext* context, const ReturnListOfDurationsInSecondsRequest* request, ReturnListOfDurationsInSecondsResponse* response) override;
   ::grpc::Status ReturnMultipleTypes(::grpc::ServerContext* context, const ReturnMultipleTypesRequest* request, ReturnMultipleTypesResponse* response) override;
+  ::grpc::Status SetCustomType(::grpc::ServerContext* context, const SetCustomTypeRequest* request, SetCustomTypeResponse* response) override;
   ::grpc::Status SetCustomTypeArray(::grpc::ServerContext* context, const SetCustomTypeArrayRequest* request, SetCustomTypeArrayResponse* response) override;
   ::grpc::Status StringValuedEnumInputFunctionWithDefaults(::grpc::ServerContext* context, const StringValuedEnumInputFunctionWithDefaultsRequest* request, StringValuedEnumInputFunctionWithDefaultsResponse* response) override;
   ::grpc::Status TwoInputFunction(::grpc::ServerContext* context, const TwoInputFunctionRequest* request, TwoInputFunctionResponse* response) override;

--- a/generated/nifake_extension/nifake_extension_service.cpp
+++ b/generated/nifake_extension/nifake_extension_service.cpp
@@ -11,9 +11,11 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-#include <server/converters.h>
 
 namespace nifake_extension_grpc {
+
+  using nidevice_grpc::converters::convert_from_grpc;
+  using nidevice_grpc::converters::convert_to_grpc;
 
   NiFakeExtensionService::NiFakeExtensionService(
       NiFakeExtensionLibraryInterface* library,

--- a/generated/nifake_extension/nifake_extension_service.cpp
+++ b/generated/nifake_extension/nifake_extension_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include <server/converters.h>
 
 namespace nifake_extension_grpc {
 

--- a/generated/nifake_extension/nifake_extension_service.h
+++ b/generated/nifake_extension/nifake_extension_service.h
@@ -13,6 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
+#include <server/converters.h>
 #include <server/feature_toggles.h>
 #include <server/session_resource_repository.h>
 #include <server/shared_library.h>

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -803,8 +803,3 @@ namespace nifake_non_ivi_grpc {
   }
 } // namespace nifake_non_ivi_grpc
 
-namespace nidevice_grpc {
-namespace converters {
-} // converters
-} // nidevice_grpc
-

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -12,11 +12,13 @@
 #include <atomic>
 #include <vector>
 #include "custom/nidaqmx_conversions.h"
-#include <server/converters.h>
 #include <server/callback_router.h>
 #include <server/server_reactor.h>
 
 namespace nifake_non_ivi_grpc {
+
+  using nidevice_grpc::converters::convert_from_grpc;
+  using nidevice_grpc::converters::convert_to_grpc;
 
   NiFakeNonIviService::NiFakeNonIviService(
       NiFakeNonIviLibraryInterface* library,
@@ -799,4 +801,9 @@ namespace nifake_non_ivi_grpc {
   {
   }
 } // namespace nifake_non_ivi_grpc
+
+namespace nidevice_grpc {
+namespace converters {
+} // converters
+} // nidevice_grpc
 

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <vector>
 #include "custom/nidaqmx_conversions.h"
+#include <server/converters.h>
 #include <server/callback_router.h>
 #include <server/server_reactor.h>
 

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.h
@@ -13,6 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
+#include <server/converters.h>
 #include <server/feature_toggles.h>
 #include <server/session_resource_repository.h>
 #include <server/shared_library.h>
@@ -72,5 +73,10 @@ private:
 };
 
 } // namespace nifake_non_ivi_grpc
+
+namespace nidevice_grpc {
+namespace converters {
+} // namespace converters
+} // namespace nidevice_grpc
 
 #endif  // NIFAKE_NON_IVI_GRPC_SERVICE_H

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.h
@@ -74,9 +74,4 @@ private:
 
 } // namespace nifake_non_ivi_grpc
 
-namespace nidevice_grpc {
-namespace converters {
-} // namespace converters
-} // namespace nidevice_grpc
-
 #endif  // NIFAKE_NON_IVI_GRPC_SERVICE_H

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include <server/converters.h>
 
 namespace nifgen_grpc {
 

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -3477,19 +3477,19 @@ namespace converters {
 template <>
 NIComplexNumber_struct convert_from_grpc(const nifgen_grpc::NIComplexNumber& input) 
 {
-  NIComplexNumber_struct* output = new NIComplexNumber_struct();  
-  output->real = input.real();
-  output->imaginary = input.imaginary();
-  return *output;
+  auto output = NIComplexNumber_struct();  
+  output.real = input.real();
+  output.imaginary = input.imaginary();
+  return output;
 }
 
 template <>
 NIComplexI16_struct convert_from_grpc(const nifgen_grpc::NIComplexInt32& input) 
 {
-  NIComplexI16_struct* output = new NIComplexI16_struct();  
-  output->real = input.real();
-  output->imaginary = input.imaginary();
-  return *output;
+  auto output = NIComplexI16_struct();  
+  output.real = input.real();
+  output.imaginary = input.imaginary();
+  return output;
 }
 
 } // converters

--- a/generated/nifgen/nifgen_service.h
+++ b/generated/nifgen/nifgen_service.h
@@ -13,6 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
+#include <server/converters.h>
 #include <server/feature_toggles.h>
 #include <server/session_resource_repository.h>
 #include <server/shared_library.h>
@@ -170,10 +171,6 @@ public:
 private:
   NiFgenLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  NIComplexNumber_struct ConvertMessage(const nifgen_grpc::NIComplexNumber& input);
-  void Copy(const google::protobuf::RepeatedPtrField<nifgen_grpc::NIComplexNumber>& input, std::vector<NIComplexNumber_struct>* output);
-  NIComplexI16_struct ConvertMessage(const nifgen_grpc::NIComplexInt32& input);
-  void Copy(const google::protobuf::RepeatedPtrField<nifgen_grpc::NIComplexInt32>& input, std::vector<NIComplexI16_struct>* output);
 
   struct NiFgenFeatureToggles
   {
@@ -187,5 +184,14 @@ private:
 };
 
 } // namespace nifgen_grpc
+
+namespace nidevice_grpc {
+namespace converters {
+template <>
+NIComplexNumber_struct convert_from_grpc(const nifgen_grpc::NIComplexNumber& input);
+template <>
+NIComplexI16_struct convert_from_grpc(const nifgen_grpc::NIComplexInt32& input);
+} // namespace converters
+} // namespace nidevice_grpc
 
 #endif  // NIFGEN_GRPC_SERVICE_H

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include <server/converters.h>
 
 namespace nirfsa_grpc {
 

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -11,9 +11,11 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-#include <server/converters.h>
 
 namespace nirfsa_grpc {
+
+  using nidevice_grpc::converters::convert_from_grpc;
+  using nidevice_grpc::converters::convert_to_grpc;
 
   const auto kErrorReadBufferTooSmall = -200229;
   const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;
@@ -1928,7 +1930,7 @@ namespace nirfsa_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_name(name);
-          nidevice_grpc::trim_trailing_nulls(*(response->mutable_name()));
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_name()));
           response->set_buffer_size(buffer_size);
         }
         return ::grpc::Status::OK;

--- a/generated/nirfsa/nirfsa_service.h
+++ b/generated/nirfsa/nirfsa_service.h
@@ -13,6 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
+#include <server/converters.h>
 #include <server/feature_toggles.h>
 #include <server/session_resource_repository.h>
 #include <server/shared_library.h>

--- a/generated/nirfsg/nirfsg_service.cpp
+++ b/generated/nirfsg/nirfsg_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include <server/converters.h>
 
 namespace nirfsg_grpc {
 

--- a/generated/nirfsg/nirfsg_service.cpp
+++ b/generated/nirfsg/nirfsg_service.cpp
@@ -3320,28 +3320,28 @@ void convert_to_grpc(const NIComplexNumber_struct& input, nirfsg_grpc::NIComplex
 template <>
 NIComplexNumber_struct convert_from_grpc(const nirfsg_grpc::NIComplexNumber& input) 
 {
-  NIComplexNumber_struct* output = new NIComplexNumber_struct();  
-  output->real = input.real();
-  output->imaginary = input.imaginary();
-  return *output;
+  auto output = NIComplexNumber_struct();  
+  output.real = input.real();
+  output.imaginary = input.imaginary();
+  return output;
 }
 
 template <>
 NIComplexNumberF32_struct convert_from_grpc(const nirfsg_grpc::NIComplexNumberF32& input) 
 {
-  NIComplexNumberF32_struct* output = new NIComplexNumberF32_struct();  
-  output->real = input.real();
-  output->imaginary = input.imaginary();
-  return *output;
+  auto output = NIComplexNumberF32_struct();  
+  output.real = input.real();
+  output.imaginary = input.imaginary();
+  return output;
 }
 
 template <>
 NIComplexI16_struct convert_from_grpc(const nirfsg_grpc::NIComplexI16& input) 
 {
-  NIComplexI16_struct* output = new NIComplexI16_struct();  
-  output->real = input.real();
-  output->imaginary = input.imaginary();
-  return *output;
+  auto output = NIComplexI16_struct();  
+  output.real = input.real();
+  output.imaginary = input.imaginary();
+  return output;
 }
 
 } // converters

--- a/generated/nirfsg/nirfsg_service.cpp
+++ b/generated/nirfsg/nirfsg_service.cpp
@@ -11,9 +11,11 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-#include <server/converters.h>
 
 namespace nirfsg_grpc {
+
+  using nidevice_grpc::converters::convert_from_grpc;
+  using nidevice_grpc::converters::convert_to_grpc;
 
   const auto kErrorReadBufferTooSmall = -200229;
   const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;
@@ -28,72 +30,6 @@ namespace nirfsg_grpc {
 
   NiRFSGService::~NiRFSGService()
   {
-  }
-
-  void NiRFSGService::Copy(const NIComplexNumber_struct& input, nirfsg_grpc::NIComplexNumber* output) 
-  {
-    output->set_real(input.real);
-    output->set_imaginary(input.imaginary);
-  }
-
-  void NiRFSGService::Copy(const std::vector<NIComplexNumber_struct>& input, google::protobuf::RepeatedPtrField<nirfsg_grpc::NIComplexNumber>* output) 
-  {
-    for (auto item : input) {
-      auto message = new nirfsg_grpc::NIComplexNumber();
-      Copy(item, message);
-      output->AddAllocated(message);
-    }
-  }
-
-   NIComplexNumber_struct NiRFSGService::ConvertMessage(const nirfsg_grpc::NIComplexNumber& input) 
-  {
-    NIComplexNumber_struct* output = new NIComplexNumber_struct();  
-    output->real = input.real();
-    output->imaginary = input.imaginary();
-    return *output;
-  }
-
-  void NiRFSGService::Copy(const google::protobuf::RepeatedPtrField<nirfsg_grpc::NIComplexNumber>& input, std::vector<NIComplexNumber_struct>* output)
-  {
-    std::transform(
-        input.begin(),
-        input.end(),
-        std::back_inserter(*output),
-        [&](nirfsg_grpc::NIComplexNumber x) { return ConvertMessage(x); });
-  }
-
-   NIComplexNumberF32_struct NiRFSGService::ConvertMessage(const nirfsg_grpc::NIComplexNumberF32& input) 
-  {
-    NIComplexNumberF32_struct* output = new NIComplexNumberF32_struct();  
-    output->real = input.real();
-    output->imaginary = input.imaginary();
-    return *output;
-  }
-
-  void NiRFSGService::Copy(const google::protobuf::RepeatedPtrField<nirfsg_grpc::NIComplexNumberF32>& input, std::vector<NIComplexNumberF32_struct>* output)
-  {
-    std::transform(
-        input.begin(),
-        input.end(),
-        std::back_inserter(*output),
-        [&](nirfsg_grpc::NIComplexNumberF32 x) { return ConvertMessage(x); });
-  }
-
-   NIComplexI16_struct NiRFSGService::ConvertMessage(const nirfsg_grpc::NIComplexI16& input) 
-  {
-    NIComplexI16_struct* output = new NIComplexI16_struct();  
-    output->real = input.real();
-    output->imaginary = input.imaginary();
-    return *output;
-  }
-
-  void NiRFSGService::Copy(const google::protobuf::RepeatedPtrField<nirfsg_grpc::NIComplexI16>& input, std::vector<NIComplexI16_struct>* output)
-  {
-    std::transform(
-        input.begin(),
-        input.end(),
-        std::back_inserter(*output),
-        [&](nirfsg_grpc::NIComplexI16 x) { return ConvertMessage(x); });
   }
 
   //---------------------------------------------------------------------
@@ -1256,9 +1192,7 @@ namespace nirfsg_grpc {
       auto table_name = request->table_name().c_str();
       auto frequencies = const_cast<ViReal64*>(request->frequencies().data());
       ViInt32 frequencies_size = static_cast<ViInt32>(request->frequencies().size());
-      auto sparameter_table_request = request->sparameter_table();
-      std::vector<NIComplexNumber_struct> sparameter_table;
-      Copy(sparameter_table_request, &sparameter_table);
+      auto sparameter_table = convert_from_grpc<NIComplexNumber_struct>(request->sparameter_table());
       ViInt32 sparameter_table_size = static_cast<ViInt32>(request->sparameter_table().size());
       ViInt32 number_of_ports = request->number_of_ports();
       ViInt32 sparameter_orientation;
@@ -1879,7 +1813,7 @@ namespace nirfsg_grpc {
         }
         response->set_status(status);
         if (status == 0) {
-          Copy(sparameters, response->mutable_sparameters());
+          convert_to_grpc(sparameters, response->mutable_sparameters());
           {
             auto shrunk_size = number_of_sparameters;
             auto current_size = response->mutable_sparameters()->size();
@@ -3229,9 +3163,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 number_of_samples = static_cast<ViInt32>(request->wfm_data().size());
-      auto wfm_data_request = request->wfm_data();
-      std::vector<NIComplexNumberF32_struct> wfm_data;
-      Copy(wfm_data_request, &wfm_data);
+      auto wfm_data = convert_from_grpc<NIComplexNumberF32_struct>(request->wfm_data());
       ViBoolean more_data_pending = request->more_data_pending();
       auto status = library_->WriteArbWaveformComplexF32(vi, waveform_name, number_of_samples, wfm_data.data(), more_data_pending);
       response->set_status(status);
@@ -3254,9 +3186,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 number_of_samples = static_cast<ViInt32>(request->wfm_data().size());
-      auto wfm_data_request = request->wfm_data();
-      std::vector<NIComplexNumber_struct> wfm_data;
-      Copy(wfm_data_request, &wfm_data);
+      auto wfm_data = convert_from_grpc<NIComplexNumber_struct>(request->wfm_data());
       ViBoolean more_data_pending = request->more_data_pending();
       auto status = library_->WriteArbWaveformComplexF64(vi, waveform_name, number_of_samples, wfm_data.data(), more_data_pending);
       response->set_status(status);
@@ -3279,9 +3209,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 number_of_samples = static_cast<ViInt32>(request->wfm_data().size());
-      auto wfm_data_request = request->wfm_data();
-      std::vector<NIComplexI16_struct> wfm_data;
-      Copy(wfm_data_request, &wfm_data);
+      auto wfm_data = convert_from_grpc<NIComplexI16_struct>(request->wfm_data());
       auto status = library_->WriteArbWaveformComplexI16(vi, waveform_name, number_of_samples, wfm_data.data());
       response->set_status(status);
       return ::grpc::Status::OK;
@@ -3378,4 +3306,43 @@ namespace nirfsg_grpc {
   {
   }
 } // namespace nirfsg_grpc
+
+namespace nidevice_grpc {
+namespace converters {
+template <>
+void convert_to_grpc(const NIComplexNumber_struct& input, nirfsg_grpc::NIComplexNumber* output) 
+{
+  output->set_real(input.real);
+  output->set_imaginary(input.imaginary);
+}
+
+template <>
+NIComplexNumber_struct convert_from_grpc(const nirfsg_grpc::NIComplexNumber& input) 
+{
+  NIComplexNumber_struct* output = new NIComplexNumber_struct();  
+  output->real = input.real();
+  output->imaginary = input.imaginary();
+  return *output;
+}
+
+template <>
+NIComplexNumberF32_struct convert_from_grpc(const nirfsg_grpc::NIComplexNumberF32& input) 
+{
+  NIComplexNumberF32_struct* output = new NIComplexNumberF32_struct();  
+  output->real = input.real();
+  output->imaginary = input.imaginary();
+  return *output;
+}
+
+template <>
+NIComplexI16_struct convert_from_grpc(const nirfsg_grpc::NIComplexI16& input) 
+{
+  NIComplexI16_struct* output = new NIComplexI16_struct();  
+  output->real = input.real();
+  output->imaginary = input.imaginary();
+  return *output;
+}
+
+} // converters
+} // nidevice_grpc
 

--- a/generated/nirfsg/nirfsg_service.h
+++ b/generated/nirfsg/nirfsg_service.h
@@ -13,6 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
+#include <server/converters.h>
 #include <server/feature_toggles.h>
 #include <server/session_resource_repository.h>
 #include <server/shared_library.h>
@@ -150,14 +151,6 @@ public:
 private:
   NiRFSGLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  void Copy(const NIComplexNumber_struct& input, nirfsg_grpc::NIComplexNumber* output);
-  void Copy(const std::vector<NIComplexNumber_struct>& input, google::protobuf::RepeatedPtrField<nirfsg_grpc::NIComplexNumber>* output);
-  NIComplexNumber_struct ConvertMessage(const nirfsg_grpc::NIComplexNumber& input);
-  void Copy(const google::protobuf::RepeatedPtrField<nirfsg_grpc::NIComplexNumber>& input, std::vector<NIComplexNumber_struct>* output);
-  NIComplexNumberF32_struct ConvertMessage(const nirfsg_grpc::NIComplexNumberF32& input);
-  void Copy(const google::protobuf::RepeatedPtrField<nirfsg_grpc::NIComplexNumberF32>& input, std::vector<NIComplexNumberF32_struct>* output);
-  NIComplexI16_struct ConvertMessage(const nirfsg_grpc::NIComplexI16& input);
-  void Copy(const google::protobuf::RepeatedPtrField<nirfsg_grpc::NIComplexI16>& input, std::vector<NIComplexI16_struct>* output);
   std::map<std::int32_t, std::string> attrpxichassisclk10rangetable_input_map_ { {1, "None"},{2, "OnboardClock"},{3, "RefIn"}, };
   std::map<std::string, std::int32_t> attrpxichassisclk10rangetable_output_map_ { {"None", 1},{"OnboardClock", 2},{"RefIn", 3}, };
   std::map<std::int32_t, std::string> attrrefclocksourcerangetable_input_map_ { {1, "OnboardClock"},{2, "RefIn"},{3, "PXI_CLK"},{4, "ClkIn"},{5, "RefIn2"},{6, "PXI_ClkMaster"}, };
@@ -187,5 +180,18 @@ private:
 };
 
 } // namespace nirfsg_grpc
+
+namespace nidevice_grpc {
+namespace converters {
+template <>
+void convert_to_grpc(const NIComplexNumber_struct& input, nirfsg_grpc::NIComplexNumber* output);
+template <>
+NIComplexNumber_struct convert_from_grpc(const nirfsg_grpc::NIComplexNumber& input);
+template <>
+NIComplexNumberF32_struct convert_from_grpc(const nirfsg_grpc::NIComplexNumberF32& input);
+template <>
+NIComplexI16_struct convert_from_grpc(const nirfsg_grpc::NIComplexI16& input);
+} // namespace converters
+} // namespace nidevice_grpc
 
 #endif  // NIRFSG_GRPC_SERVICE_H

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -11,9 +11,11 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-#include <server/converters.h>
 
 namespace niscope_grpc {
+
+  using nidevice_grpc::converters::convert_from_grpc;
+  using nidevice_grpc::converters::convert_to_grpc;
 
   const auto kErrorReadBufferTooSmall = -200229;
   const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;
@@ -28,74 +30,6 @@ namespace niscope_grpc {
 
   NiScopeService::~NiScopeService()
   {
-  }
-
-  void NiScopeService::Copy(const niScope_wfmInfo& input, niscope_grpc::WaveformInfo* output) 
-  {
-    output->set_absolute_initial_x(input.absoluteInitialX);
-    output->set_relative_initial_x(input.relativeInitialX);
-    output->set_x_increment(input.xIncrement);
-    output->set_actual_samples(input.actualSamples);
-    output->set_offset(input.offset);
-    output->set_gain(input.gain);
-    output->set_reserved1(input.reserved1);
-    output->set_reserved2(input.reserved2);
-  }
-
-  void NiScopeService::Copy(const std::vector<niScope_wfmInfo>& input, google::protobuf::RepeatedPtrField<niscope_grpc::WaveformInfo>* output) 
-  {
-    for (auto item : input) {
-      auto message = new niscope_grpc::WaveformInfo();
-      Copy(item, message);
-      output->AddAllocated(message);
-    }
-  }
-
-  void NiScopeService::Copy(const niScope_coefficientInfo& input, niscope_grpc::CoefficientInfo* output) 
-  {
-    output->set_offset(input.offset);
-    output->set_gain(input.gain);
-    output->set_reserved1(input.reserved1);
-    output->set_reserved2(input.reserved2);
-  }
-
-  void NiScopeService::Copy(const std::vector<niScope_coefficientInfo>& input, google::protobuf::RepeatedPtrField<niscope_grpc::CoefficientInfo>* output) 
-  {
-    for (auto item : input) {
-      auto message = new niscope_grpc::CoefficientInfo();
-      Copy(item, message);
-      output->AddAllocated(message);
-    }
-  }
-
-  void NiScopeService::Copy(const NIComplexNumber_struct& input, niscope_grpc::NIComplexNumber* output) 
-  {
-    output->set_real(input.real);
-    output->set_imaginary(input.imaginary);
-  }
-
-  void NiScopeService::Copy(const std::vector<NIComplexNumber_struct>& input, google::protobuf::RepeatedPtrField<niscope_grpc::NIComplexNumber>* output) 
-  {
-    for (auto item : input) {
-      auto message = new niscope_grpc::NIComplexNumber();
-      Copy(item, message);
-      output->AddAllocated(message);
-    }
-  }
-
-  void NiScopeService::Copy(const NIComplexI16_struct& input, niscope_grpc::NIComplexInt32* output) 
-  {
-    output->set_real(input.real);
-    output->set_imaginary(input.imaginary);
-  }
-
-  void NiScopeService::Copy(const std::vector<NIComplexI16_struct>& input, google::protobuf::RepeatedPtrField<niscope_grpc::NIComplexInt32>* output) 
-  {
-    for (auto item : input) {
-      auto message = new niscope_grpc::NIComplexInt32();
-      Copy(item, message);
-      output->AddAllocated(message);
-    }
   }
 
   //---------------------------------------------------------------------
@@ -2453,4 +2387,45 @@ namespace niscope_grpc {
   {
   }
 } // namespace niscope_grpc
+
+namespace nidevice_grpc {
+namespace converters {
+template <>
+void convert_to_grpc(const niScope_wfmInfo& input, niscope_grpc::WaveformInfo* output) 
+{
+  output->set_absolute_initial_x(input.absoluteInitialX);
+  output->set_relative_initial_x(input.relativeInitialX);
+  output->set_x_increment(input.xIncrement);
+  output->set_actual_samples(input.actualSamples);
+  output->set_offset(input.offset);
+  output->set_gain(input.gain);
+  output->set_reserved1(input.reserved1);
+  output->set_reserved2(input.reserved2);
+}
+
+template <>
+void convert_to_grpc(const niScope_coefficientInfo& input, niscope_grpc::CoefficientInfo* output) 
+{
+  output->set_offset(input.offset);
+  output->set_gain(input.gain);
+  output->set_reserved1(input.reserved1);
+  output->set_reserved2(input.reserved2);
+}
+
+template <>
+void convert_to_grpc(const NIComplexNumber_struct& input, niscope_grpc::NIComplexNumber* output) 
+{
+  output->set_real(input.real);
+  output->set_imaginary(input.imaginary);
+}
+
+template <>
+void convert_to_grpc(const NIComplexI16_struct& input, niscope_grpc::NIComplexInt32* output) 
+{
+  output->set_real(input.real);
+  output->set_imaginary(input.imaginary);
+}
+
+} // converters
+} // nidevice_grpc
 

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include <server/converters.h>
 
 namespace niscope_grpc {
 

--- a/generated/niscope/niscope_service.h
+++ b/generated/niscope/niscope_service.h
@@ -13,6 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
+#include <server/converters.h>
 #include <server/feature_toggles.h>
 #include <server/session_resource_repository.h>
 #include <server/shared_library.h>
@@ -127,14 +128,6 @@ public:
 private:
   NiScopeLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  void Copy(const niScope_wfmInfo& input, niscope_grpc::WaveformInfo* output);
-  void Copy(const std::vector<niScope_wfmInfo>& input, google::protobuf::RepeatedPtrField<niscope_grpc::WaveformInfo>* output);
-  void Copy(const niScope_coefficientInfo& input, niscope_grpc::CoefficientInfo* output);
-  void Copy(const std::vector<niScope_coefficientInfo>& input, google::protobuf::RepeatedPtrField<niscope_grpc::CoefficientInfo>* output);
-  void Copy(const NIComplexNumber_struct& input, niscope_grpc::NIComplexNumber* output);
-  void Copy(const std::vector<NIComplexNumber_struct>& input, google::protobuf::RepeatedPtrField<niscope_grpc::NIComplexNumber>* output);
-  void Copy(const NIComplexI16_struct& input, niscope_grpc::NIComplexInt32* output);
-  void Copy(const std::vector<NIComplexI16_struct>& input, google::protobuf::RepeatedPtrField<niscope_grpc::NIComplexInt32>* output);
 
   struct NiScopeFeatureToggles
   {
@@ -148,5 +141,18 @@ private:
 };
 
 } // namespace niscope_grpc
+
+namespace nidevice_grpc {
+namespace converters {
+template <>
+void convert_to_grpc(const niScope_wfmInfo& input, niscope_grpc::WaveformInfo* output);
+template <>
+void convert_to_grpc(const niScope_coefficientInfo& input, niscope_grpc::CoefficientInfo* output);
+template <>
+void convert_to_grpc(const NIComplexNumber_struct& input, niscope_grpc::NIComplexNumber* output);
+template <>
+void convert_to_grpc(const NIComplexI16_struct& input, niscope_grpc::NIComplexInt32* output);
+} // namespace converters
+} // namespace nidevice_grpc
 
 #endif  // NISCOPE_GRPC_SERVICE_H

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -11,9 +11,11 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-#include <server/converters.h>
 
 namespace niswitch_grpc {
+
+  using nidevice_grpc::converters::convert_from_grpc;
+  using nidevice_grpc::converters::convert_to_grpc;
 
   const auto kErrorReadBufferTooSmall = -200229;
   const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include <server/converters.h>
 
 namespace niswitch_grpc {
 

--- a/generated/niswitch/niswitch_service.h
+++ b/generated/niswitch/niswitch_service.h
@@ -13,6 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
+#include <server/converters.h>
 #include <server/feature_toggles.h>
 #include <server/session_resource_repository.h>
 #include <server/shared_library.h>

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -11,9 +11,11 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-#include <server/converters.h>
 
 namespace nisync_grpc {
+
+  using nidevice_grpc::converters::convert_from_grpc;
+  using nidevice_grpc::converters::convert_to_grpc;
 
   const auto kErrorReadBufferTooSmall = -200229;
   const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include <server/converters.h>
 
 namespace nisync_grpc {
 

--- a/generated/nisync/nisync_service.h
+++ b/generated/nisync/nisync_service.h
@@ -13,6 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
+#include <server/converters.h>
 #include <server/feature_toggles.h>
 #include <server/session_resource_repository.h>
 #include <server/shared_library.h>

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -11,9 +11,11 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-#include <server/converters.h>
 
 namespace nitclk_grpc {
+
+  using nidevice_grpc::converters::convert_from_grpc;
+  using nidevice_grpc::converters::convert_to_grpc;
 
   const auto kErrorReadBufferTooSmall = -200229;
   const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include <server/converters.h>
 
 namespace nitclk_grpc {
 

--- a/generated/nitclk/nitclk_service.h
+++ b/generated/nitclk/nitclk_service.h
@@ -13,6 +13,7 @@
 #include <grpcpp/health_check_service_interface.h>
 #include <grpcpp/ext/proto_server_reflection_plugin.h>
 #include <map>
+#include <server/converters.h>
 #include <server/feature_toggles.h>
 #include <server/session_resource_repository.h>
 #include <server/shared_library.h>

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -48,13 +48,16 @@ def any_function_uses_timestamp(functions):
     return False
 
 
+def get_custom_types(config: dict) -> dict:
+    return config.get("custom_types", {})
+
+
 def get_input_and_output_custom_types(functions):
     '''Returns a set of custom types used by input and output parameters separately.'''
     input_custom_types = set()
     output_custom_types = set()
     for function in functions:
-        struct_array_params = [p for p in functions[function]
-                               ["parameters"] if is_struct(p) and is_array(p["type"])]
+        struct_array_params = [p for p in functions[function]["parameters"] if is_struct(p)]
         for parameter in struct_array_params:
             if is_input_parameter(parameter):
                 input_custom_types.add(
@@ -663,5 +666,11 @@ def get_enum_value_cpp_type(enum: dict) -> str:
     return "std::int32_t"
 
 
-def get_custom_types(config: dict) -> dict:
-    return config.get("custom_types", {})
+def is_regular_string_arg(parameter: dict) -> bool:
+    """Excludes: byte arrays"""
+    return is_string_arg(parameter) and not parameter["grpc_type"] == "bytes"
+
+
+def is_regular_byte_array_arg(parameter: dict)-> bool:
+    """Excludes: strings and byte arrays that are mapped to enums"""
+    return parameter["grpc_type"] == "bytes" and not is_enum(parameter)

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -661,3 +661,7 @@ def get_enum_value_cpp_type(enum: dict) -> str:
     if isinstance(enum_value, str):
         return "std::string"
     return "std::int32_t"
+
+
+def get_custom_types(config: dict) -> dict:
+    return config.get("custom_types", {})

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -57,8 +57,8 @@ def get_input_and_output_custom_types(functions):
     input_custom_types = set()
     output_custom_types = set()
     for function in functions:
-        struct_array_params = [p for p in functions[function]["parameters"] if is_struct(p)]
-        for parameter in struct_array_params:
+        struct_params = [p for p in functions[function]["parameters"] if is_struct(p)]
+        for parameter in struct_params:
             if is_input_parameter(parameter):
                 input_custom_types.add(
                     get_underlying_type_name(parameter["type"]))

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -1221,7 +1221,6 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetCustomType': {
-        'codegen_method': 'no',
         'documentation': {
             'description': 'This function returns a custom type.'
         },
@@ -2511,7 +2510,6 @@ functions = {
         'returns': 'ViStatus'
     },
     'SetCustomType': {
-        'codegen_method': 'no',
         'documentation': {
             'description': 'This function takes a custom type.'
         },

--- a/source/codegen/metadata/nirfsa/functions.py
+++ b/source/codegen/metadata/nirfsa/functions.py
@@ -1471,11 +1471,6 @@ functions = {
             {
                 'direction': 'out',
                 'name': 'numberOfGainReferenceCalConstants',
-                'size': {
-                    'mechanism': 'ivi-dance-with-a-twist',
-                    'value': 'bufferSize',
-                    'value_twist': 'gainReferenceCalConstants'
-                },
                 'type': 'ViInt32'
             }
         ],

--- a/source/codegen/templates/service.cpp.mako
+++ b/source/codegen/templates/service.cpp.mako
@@ -154,7 +154,7 @@ ${mako_helper.define_simple_method_body(function_name=function_name, function_da
   }
 } // namespace ${config["namespace_component"]}_grpc
 
-% if any(custom_types):
+% if any(input_custom_types) or any(output_custom_types):
 namespace nidevice_grpc {
 namespace converters {
 %   for custom_type in custom_types:

--- a/source/codegen/templates/service.cpp.mako
+++ b/source/codegen/templates/service.cpp.mako
@@ -172,11 +172,11 @@ void convert_to_grpc(const ${custom_type["name"]}& input, ${namespace_prefix}${c
 template <>
 ${custom_type["name"]} convert_from_grpc(const ${namespace_prefix}${custom_type["grpc_name"]}& input) 
 {
-  ${custom_type["name"]}* output = new ${custom_type["name"]}();  
+  auto output = ${custom_type["name"]}();  
 %       for field in custom_type["fields"]: 
-  output->${common_helpers.pascal_to_camel(common_helpers.snake_to_pascal(field["grpc_name"]))} = input.${common_helpers.camel_to_snake(field["name"])}();
+  output.${common_helpers.pascal_to_camel(common_helpers.snake_to_pascal(field["grpc_name"]))} = input.${common_helpers.camel_to_snake(field["name"])}();
 %       endfor
-  return *output;
+  return output;
 }
 
 %     endif

--- a/source/codegen/templates/service.h.mako
+++ b/source/codegen/templates/service.h.mako
@@ -108,7 +108,7 @@ private:
 
 } // namespace ${config["namespace_component"]}_grpc
 
-% if any(custom_types):
+% if any(input_custom_types) or any(output_custom_types):
 namespace nidevice_grpc {
 namespace converters {
 %   for custom_type in custom_types:

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -469,10 +469,8 @@ ${initialize_standard_input_param(function_name, parameter)}
         ${parameter_name}_request.end(),
         std::back_inserter(${parameter_name}),
         [](auto x) { return (${c_type_underlying_type})x; }); \
- % elif common_helpers.is_struct(parameter) and common_helpers.is_array(c_type):
-      auto ${parameter_name}_request = ${request_snippet};
-      std::vector<${c_type_underlying_type}> ${parameter_name};
-      Copy(${parameter_name}_request, &${parameter_name});\
+ % elif common_helpers.is_struct(parameter):
+      auto ${parameter_name} = convert_from_grpc<${c_type_underlying_type}>(${request_snippet});\
 % elif c_type in ['ViChar', 'ViInt8', 'ViInt16']:
       ${c_type} ${parameter_name} = (${c_type})${request_snippet};\
 % elif grpc_type == 'nidevice_grpc.Session':
@@ -663,7 +661,7 @@ ${copy_to_response_with_transform(source_buffer=parameter_name, parameter_name=p
 %     if common_helpers.is_string_arg(parameter):
         response->set_${parameter_name}(${parameter_name});
 %     elif common_helpers.is_struct(parameter) or parameter['type'] == 'ViBoolean[]':
-        Copy(${parameter_name}, response->mutable_${parameter_name}());
+        convert_to_grpc(${parameter_name}, response->mutable_${parameter_name}());
 %     endif
 %     if common_helpers.is_ivi_dance_array_with_a_twist_param(parameter):
 <%
@@ -672,7 +670,7 @@ ${copy_to_response_with_transform(source_buffer=parameter_name, parameter_name=p
 %       if parameter['grpc_type'] == 'bytes':
         response->mutable_${parameter_name}()->resize(${size});
 %       elif common_helpers.is_string_arg(parameter):
-        nidevice_grpc::trim_trailing_nulls(*(response->mutable_${parameter_name}()));
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_${parameter_name}()));
 %       elif common_helpers.is_struct(parameter):
 ##        RepeatedPtrField doesn't support Resize(), so use DeleteSubrange()
 ##        to delete any extra elements.

--- a/source/custom/nidaqmx_conversions.h
+++ b/source/custom/nidaqmx_conversions.h
@@ -1,20 +1,14 @@
+#ifndef NIDEVICE_GRPC_DEVICE_NIDAQMX_CONVERSIONS_H
+#define NIDEVICE_GRPC_DEVICE_NIDAQMX_CONVERSIONS_H
+
 // Needed for the definition of CVIAbsoluteTime
 #include <google/protobuf/util/time_util.h>
+#include <server/converters.h>
 
 #include "NIDAQmx.h"
 
-template <typename CType, typename GrpcType>
-void convert_to_grpc(const CType& value, GrpcType* value_out)
-{
-  *value_out = static_cast<GrpcType>(value);
-}
-
-template <typename CType, typename GrpcType>
-CType convert_from_grpc(const GrpcType& value)
-{
-  return static_cast<CType>(value);
-}
-
+namespace nidevice_grpc {
+namespace converters {
 const int64 SecondsFromCVI1904EpochTo1970Epoch = 2082844800LL;
 const double TwoToSixtyFour = (double)(1 << 31) * (double)(1 << 31) * (double)(1 << 2);
 const double NanosecondsPerSecond = 1000000000.0;
@@ -43,3 +37,7 @@ CVIAbsoluteTime convert_from_grpc(const google::protobuf::Timestamp& value)
   cviTime.cviTime.lsb = static_cast<uInt64>((static_cast<double>(value.nanos()) / NanosecondsPerSecond) * TwoToSixtyFour);
   return cviTime;
 }
+}  // namespace converters
+}  // namespace nidevice_grpc
+
+#endif  // NIDEVICE_GRPC_DEVICE_NIDAQMX_CONVERSIONS_H

--- a/source/custom/niscope_service.custom.cpp
+++ b/source/custom/niscope_service.custom.cpp
@@ -1,8 +1,12 @@
 #include <niscope/niscope_service.h>
+#include <server/converters.h>
 
 #include <stdexcept>
 
 namespace niscope_grpc {
+using nidevice_grpc::converters::convert_from_grpc;
+using nidevice_grpc::converters::convert_to_grpc;
+
 const auto kErrorReadBufferTooSmall = -200229;
 
 struct DriverErrorException : std::runtime_error {
@@ -43,7 +47,7 @@ void CheckStatus(int status)
     auto status = library_->Fetch(vi, channel_list, timeout, num_samples, waveform, waveform_info.data());
     response->set_status(status);
     if (status == 0) {
-      Copy(waveform_info, response->mutable_wfm_info());
+      convert_to_grpc(waveform_info, response->mutable_wfm_info());
     }
     return ::grpc::Status::OK;
   }
@@ -82,7 +86,7 @@ void CheckStatus(int status)
     auto status = library_->FetchBinary8(vi, channel_list, timeout, num_samples, waveform, waveform_info.data());
     response->set_status(status);
     if (status == 0) {
-      Copy(waveform_info, response->mutable_wfm_info());
+      convert_to_grpc(waveform_info, response->mutable_wfm_info());
     }
     return ::grpc::Status::OK;
   }
@@ -120,7 +124,7 @@ void CheckStatus(int status)
     auto status = library_->FetchBinary16(vi, channel_list, timeout, num_samples, waveform.data(), waveform_info.data());
     response->set_status(status);
     if (status == 0) {
-      Copy(waveform_info, response->mutable_wfm_info());
+      convert_to_grpc(waveform_info, response->mutable_wfm_info());
       response->mutable_waveform()->Add(waveform.begin(), waveform.end());
     }
     return ::grpc::Status::OK;
@@ -160,7 +164,7 @@ void CheckStatus(int status)
     response->set_status(status);
     if (status == 0) {
       response->mutable_waveform()->Add(waveform.begin(), waveform.end());
-      Copy(waveform_info, response->mutable_wfm_info());
+      convert_to_grpc(waveform_info, response->mutable_wfm_info());
     }
     return ::grpc::Status::OK;
   }
@@ -210,7 +214,7 @@ void CheckStatus(int status)
     auto status = library_->FetchArrayMeasurement(vi, channel_list, timeout, array_meas_function, measurement_waveform_size, meas_wfm, waveform_info.data());
     response->set_status(status);
     if (status == 0) {
-      Copy(waveform_info, response->mutable_wfm_info());
+      convert_to_grpc(waveform_info, response->mutable_wfm_info());
     }
     return ::grpc::Status::OK;
   }
@@ -304,7 +308,7 @@ void CheckStatus(int status)
     auto status = library_->Read(vi, channel_list, timeout, num_samples, waveform, waveform_info.data());
     response->set_status(status);
     if (status == 0) {
-      Copy(waveform_info, response->mutable_wfm_info());
+      convert_to_grpc(waveform_info, response->mutable_wfm_info());
     }
     return ::grpc::Status::OK;
   }
@@ -342,8 +346,8 @@ void CheckStatus(int status)
     auto status = library_->FetchComplex(vi, channel_list, timeout, num_samples, waveform.data(), waveform_info.data());
     response->set_status(status);
     if (status == 0) {
-      Copy(waveform, response->mutable_wfm());
-      Copy(waveform_info, response->mutable_wfm_info());
+      convert_to_grpc(waveform, response->mutable_wfm());
+      convert_to_grpc(waveform_info, response->mutable_wfm_info());
     }
     return ::grpc::Status::OK;
   }
@@ -381,8 +385,8 @@ void CheckStatus(int status)
     auto status = library_->FetchComplexBinary16(vi, channel_list, timeout, num_samples, waveform.data(), waveform_info.data());
     response->set_status(status);
     if (status == 0) {
-      Copy(waveform, response->mutable_wfm());
-      Copy(waveform_info, response->mutable_wfm_info());
+      convert_to_grpc(waveform, response->mutable_wfm());
+      convert_to_grpc(waveform_info, response->mutable_wfm_info());
     }
     return ::grpc::Status::OK;
   }
@@ -463,7 +467,7 @@ void CheckStatus(int status)
       response->set_status(status);
       if (status == 0) {
         response->set_number_of_coefficient_sets(number_of_coefficient_sets);
-        Copy(coefficient_info, response->mutable_coefficient_info());
+        convert_to_grpc(coefficient_info, response->mutable_coefficient_info());
       }
       return ::grpc::Status::OK;
     }
@@ -503,7 +507,7 @@ void CheckStatus(int status)
       response->set_status(status);
       if (status == 0) {
         response->set_number_of_coefficient_sets(number_of_coefficient_sets);
-        Copy(coefficient_info, response->mutable_coefficient_info());
+        convert_to_grpc(coefficient_info, response->mutable_coefficient_info());
       }
       return ::grpc::Status::OK;
     }

--- a/source/server/converters.h
+++ b/source/server/converters.h
@@ -1,5 +1,5 @@
-#ifndef CONVERTERS
-#define CONVERTERS
+#ifndef NIDEVICE_GRPC_DEVICE_CONVERTERS_H
+#define NIDEVICE_GRPC_DEVICE_CONVERTERS_H
 
 #include <google/protobuf/repeated_field.h>
 
@@ -67,4 +67,4 @@ inline void convert_to_grpc(const std::vector<BoolType>& input, google::protobuf
 }  // namespace converters
 }  // namespace nidevice_grpc
 
-#endif /* CONVERTERS */
+#endif /* NIDEVICE_GRPC_DEVICE_CONVERTERS_H */

--- a/source/server/converters.h
+++ b/source/server/converters.h
@@ -1,9 +1,14 @@
-#ifndef NIDEVICE_GRPC_DEVICE_CONVERTERS_H
-#define NIDEVICE_GRPC_DEVICE_CONVERTERS_H
+#ifndef CONVERTERS
+#define CONVERTERS
+
+#include <google/protobuf/repeated_field.h>
+
 #include <algorithm>
 #include <string>
+#include <vector>
 
 namespace nidevice_grpc {
+namespace converters {
 inline void trim_trailing_nulls(std::string& s)
 {
   // Erase from the first non-null character (going backwards) to the end.
@@ -15,6 +20,51 @@ inline void trim_trailing_nulls(std::string& s)
           .base(),
       s.end());
 }
+
+template <typename CType, typename GrpcType>
+void convert_to_grpc(const CType& value, GrpcType* value_out)
+{
+  *value_out = static_cast<GrpcType>(value);
+}
+
+template <typename CType, typename GrpcType>
+CType convert_from_grpc(const GrpcType& value)
+{
+  return static_cast<CType>(value);
+}
+
+template <typename CType, typename GrpcType>
+inline std::vector<CType> convert_from_grpc(const google::protobuf::RepeatedPtrField<GrpcType>& input)
+{
+  auto output = std::vector<CType>();
+  output.reserve(input.size());
+  std::transform(
+      input.begin(),
+      input.end(),
+      std::back_inserter(output),
+      [&](GrpcType x) { return convert_from_grpc<CType>(x); });
+  return output;
+}
+
+template <typename GrpcType, typename CType>
+inline void convert_to_grpc(const std::vector<CType>& input, google::protobuf::RepeatedPtrField<GrpcType>* output)
+{
+  for (auto item : input) {
+    auto message = new GrpcType();
+    convert_to_grpc(item, message);
+    output->AddAllocated(message);
+  }
+}
+
+template <typename BoolType>
+inline void convert_to_grpc(const std::vector<BoolType>& input, google::protobuf::RepeatedField<bool>* output)
+{
+  for (auto item : input) {
+    output->Add(item != BoolType(0));
+  }
+}
+
+}  // namespace converters
 }  // namespace nidevice_grpc
 
-#endif /* NIDEVICE_GRPC_DEVICE_CONVERTERS_H */
+#endif /* CONVERTERS */

--- a/source/tests/unit/converters_tests.cpp
+++ b/source/tests/unit/converters_tests.cpp
@@ -2,7 +2,7 @@
 #include <gtest/gtest.h>
 #include <server/converters.h>
 
-using namespace nidevice_grpc;
+using namespace nidevice_grpc::converters;
 using namespace ::testing;
 
 namespace ni {


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add the ability to read and write scalar custom types (previously only repeated custom types were supported).

Move towards a standardized `convert_to_grpc`/`convert_from_grpc` specialization syntax. This allows supporting scalars/arrays without adding yet another mako condition block.

### Why should this Pull Request be merged?

Scalar custom types are used by RFSA.

### What testing has been done?

Ran and passed new tests for `Get`/`SetCustomData`.
Ran and passed scope/DAQ/Digital system tests.