### PR TITLE
Fix size mechanism on RFSA GetDeembeddingSparameters

### DIFF
--- a/generated/nirfsa/nirfsa.proto
+++ b/generated/nirfsa/nirfsa.proto
@@ -1515,12 +1515,11 @@ message GetCalUserDefinedInfoMaxSizeResponse {
 
 message GetDeembeddingSparametersRequest {
   nidevice_grpc.Session vi = 1;
-  sint32 sparameters_array_size = 2;
 }
 
 message GetDeembeddingSparametersResponse {
   int32 status = 1;
-  NIComplexNumber sparameters = 2;
+  repeated NIComplexNumber sparameters = 2;
   sint32 number_of_sparameters = 3;
   sint32 number_of_ports = 4;
 }

--- a/generated/nirfsa/nirfsa_client.cpp
+++ b/generated/nirfsa/nirfsa_client.cpp
@@ -1337,13 +1337,12 @@ get_cal_user_defined_info_max_size(const StubPtr& stub, const nidevice_grpc::Ses
 }
 
 GetDeembeddingSparametersResponse
-get_deembedding_sparameters(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& sparameters_array_size)
+get_deembedding_sparameters(const StubPtr& stub, const nidevice_grpc::Session& vi)
 {
   ::grpc::ClientContext context;
 
   auto request = GetDeembeddingSparametersRequest{};
   request.mutable_vi()->CopyFrom(vi);
-  request.set_sparameters_array_size(sparameters_array_size);
 
   auto response = GetDeembeddingSparametersResponse{};
 

--- a/generated/nirfsa/nirfsa_client.h
+++ b/generated/nirfsa/nirfsa_client.h
@@ -89,7 +89,7 @@ GetAttributeViSessionResponse get_attribute_vi_session(const StubPtr& stub, cons
 GetAttributeViStringResponse get_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiRFSAAttributes& attribute_id);
 GetCalUserDefinedInfoResponse get_cal_user_defined_info(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetCalUserDefinedInfoMaxSizeResponse get_cal_user_defined_info_max_size(const StubPtr& stub, const nidevice_grpc::Session& vi);
-GetDeembeddingSparametersResponse get_deembedding_sparameters(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& sparameters_array_size);
+GetDeembeddingSparametersResponse get_deembedding_sparameters(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetDeviceResponseResponse get_device_response(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_list, const simple_variant<DeviceResponse, pb::int32>& response_type);
 GetErrorResponse get_error(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& error_description_buffer_size);
 GetExtCalLastDateAndTimeResponse get_ext_cal_last_date_and_time(const StubPtr& stub, const nidevice_grpc::Session& vi);

--- a/generated/nirfsa/nirfsa_library.cpp
+++ b/generated/nirfsa/nirfsa_library.cpp
@@ -957,7 +957,7 @@ ViStatus NiRFSALibrary::GetCalUserDefinedInfoMaxSize(ViSession vi, ViInt32* info
 #endif
 }
 
-ViStatus NiRFSALibrary::GetDeembeddingSparameters(ViSession vi, NIComplexNumber_struct* sparameters, ViInt32 sparametersArraySize, ViInt32* numberOfSparameters, ViInt32* numberOfPorts)
+ViStatus NiRFSALibrary::GetDeembeddingSparameters(ViSession vi, NIComplexNumber_struct sparameters[], ViInt32 sparametersArraySize, ViInt32* numberOfSparameters, ViInt32* numberOfPorts)
 {
   if (!function_pointers_.GetDeembeddingSparameters) {
     throw nidevice_grpc::LibraryLoadException("Could not find niRFSA_GetDeembeddingSparameters.");

--- a/generated/nirfsa/nirfsa_library.h
+++ b/generated/nirfsa/nirfsa_library.h
@@ -85,7 +85,7 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   ViStatus GetAttributeViString(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 bufSize, ViChar value[]);
   ViStatus GetCalUserDefinedInfo(ViSession vi, ViChar info[256]);
   ViStatus GetCalUserDefinedInfoMaxSize(ViSession vi, ViInt32* infoSize);
-  ViStatus GetDeembeddingSparameters(ViSession vi, NIComplexNumber_struct* sparameters, ViInt32 sparametersArraySize, ViInt32* numberOfSparameters, ViInt32* numberOfPorts);
+  ViStatus GetDeembeddingSparameters(ViSession vi, NIComplexNumber_struct sparameters[], ViInt32 sparametersArraySize, ViInt32* numberOfSparameters, ViInt32* numberOfPorts);
   ViStatus GetDeviceResponse(ViSession vi, ViConstString channelList, ViInt32 responseType, ViInt32 bufferSize, ViReal64 frequencies[], ViReal64 magnitudeResponse[], ViReal64 phaseResponse[], ViInt32* numberOfFrequencies);
   ViStatus GetError(ViSession vi, ViStatus* errorCode, ViInt32 errorDescriptionBufferSize, ViChar errorDescription[]);
   ViStatus GetExtCalLastDateAndTime(ViSession vi, ViInt32* year, ViInt32* month, ViInt32* day, ViInt32* hour, ViInt32* minute);

--- a/generated/nirfsa/nirfsa_library_interface.h
+++ b/generated/nirfsa/nirfsa_library_interface.h
@@ -83,7 +83,7 @@ class NiRFSALibraryInterface {
   virtual ViStatus GetAttributeViString(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 bufSize, ViChar value[]) = 0;
   virtual ViStatus GetCalUserDefinedInfo(ViSession vi, ViChar info[256]) = 0;
   virtual ViStatus GetCalUserDefinedInfoMaxSize(ViSession vi, ViInt32* infoSize) = 0;
-  virtual ViStatus GetDeembeddingSparameters(ViSession vi, NIComplexNumber_struct* sparameters, ViInt32 sparametersArraySize, ViInt32* numberOfSparameters, ViInt32* numberOfPorts) = 0;
+  virtual ViStatus GetDeembeddingSparameters(ViSession vi, NIComplexNumber_struct sparameters[], ViInt32 sparametersArraySize, ViInt32* numberOfSparameters, ViInt32* numberOfPorts) = 0;
   virtual ViStatus GetDeviceResponse(ViSession vi, ViConstString channelList, ViInt32 responseType, ViInt32 bufferSize, ViReal64 frequencies[], ViReal64 magnitudeResponse[], ViReal64 phaseResponse[], ViInt32* numberOfFrequencies) = 0;
   virtual ViStatus GetError(ViSession vi, ViStatus* errorCode, ViInt32 errorDescriptionBufferSize, ViChar errorDescription[]) = 0;
   virtual ViStatus GetExtCalLastDateAndTime(ViSession vi, ViInt32* year, ViInt32* month, ViInt32* day, ViInt32* hour, ViInt32* minute) = 0;

--- a/generated/nirfsa/nirfsa_mock_library.h
+++ b/generated/nirfsa/nirfsa_mock_library.h
@@ -84,7 +84,7 @@ class NiRFSAMockLibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   MOCK_METHOD(ViStatus, GetAttributeViString, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 bufSize, ViChar value[]), (override));
   MOCK_METHOD(ViStatus, GetCalUserDefinedInfo, (ViSession vi, ViChar info[256]), (override));
   MOCK_METHOD(ViStatus, GetCalUserDefinedInfoMaxSize, (ViSession vi, ViInt32* infoSize), (override));
-  MOCK_METHOD(ViStatus, GetDeembeddingSparameters, (ViSession vi, NIComplexNumber_struct* sparameters, ViInt32 sparametersArraySize, ViInt32* numberOfSparameters, ViInt32* numberOfPorts), (override));
+  MOCK_METHOD(ViStatus, GetDeembeddingSparameters, (ViSession vi, NIComplexNumber_struct sparameters[], ViInt32 sparametersArraySize, ViInt32* numberOfSparameters, ViInt32* numberOfPorts), (override));
   MOCK_METHOD(ViStatus, GetDeviceResponse, (ViSession vi, ViConstString channelList, ViInt32 responseType, ViInt32 bufferSize, ViReal64 frequencies[], ViReal64 magnitudeResponse[], ViReal64 phaseResponse[], ViInt32* numberOfFrequencies), (override));
   MOCK_METHOD(ViStatus, GetError, (ViSession vi, ViStatus* errorCode, ViInt32 errorDescriptionBufferSize, ViChar errorDescription[]), (override));
   MOCK_METHOD(ViStatus, GetExtCalLastDateAndTime, (ViSession vi, ViInt32* year, ViInt32* month, ViInt32* day, ViInt32* hour, ViInt32* minute), (override));

--- a/source/codegen/metadata/nirfsa/functions.py
+++ b/source/codegen/metadata/nirfsa/functions.py
@@ -1583,9 +1583,14 @@ functions = {
             },
             {
                 'direction': 'out',
-                'grpc_type': 'NIComplexNumber',
+                'grpc_type': 'repeated NIComplexNumber',
                 'name': 'sparameters',
-                'type': 'struct NIComplexNumber_struct'
+                'size': {
+                    'mechanism': 'ivi-dance-with-a-twist',
+                    'value': 'sparametersArraySize',
+                    'value_twist': 'numberOfSparameters'
+                },
+                'type': 'struct NIComplexNumber_struct[]'
             },
             {
                 'direction': 'in',


### PR DESCRIPTION
### What does this Pull Request accomplish?

Change `sparameters` output parameter from non-array to `ivi-dance-with-a-twist`.

### Why should this Pull Request be merged?

Fixes incorrect parameter binding.

### What testing has been done?

Manual testing/debugging through the API. I haven't been able to get a working test that returns multiple s-parameters, but the code/docs look OK.