### PR TITLE
Fix size mechanism for RFSA GetError

### DIFF
--- a/generated/nirfsa/nirfsa.proto
+++ b/generated/nirfsa/nirfsa.proto
@@ -1543,7 +1543,6 @@ message GetDeviceResponseResponse {
 
 message GetErrorRequest {
   nidevice_grpc.Session vi = 1;
-  sint32 error_description_buffer_size = 2;
 }
 
 message GetErrorResponse {

--- a/generated/nirfsa/nirfsa_client.cpp
+++ b/generated/nirfsa/nirfsa_client.cpp
@@ -1378,13 +1378,12 @@ get_device_response(const StubPtr& stub, const nidevice_grpc::Session& vi, const
 }
 
 GetErrorResponse
-get_error(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& error_description_buffer_size)
+get_error(const StubPtr& stub, const nidevice_grpc::Session& vi)
 {
   ::grpc::ClientContext context;
 
   auto request = GetErrorRequest{};
   request.mutable_vi()->CopyFrom(vi);
-  request.set_error_description_buffer_size(error_description_buffer_size);
 
   auto response = GetErrorResponse{};
 

--- a/generated/nirfsa/nirfsa_client.h
+++ b/generated/nirfsa/nirfsa_client.h
@@ -91,7 +91,7 @@ GetCalUserDefinedInfoResponse get_cal_user_defined_info(const StubPtr& stub, con
 GetCalUserDefinedInfoMaxSizeResponse get_cal_user_defined_info_max_size(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetDeembeddingSparametersResponse get_deembedding_sparameters(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetDeviceResponseResponse get_device_response(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_list, const simple_variant<DeviceResponse, pb::int32>& response_type);
-GetErrorResponse get_error(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& error_description_buffer_size);
+GetErrorResponse get_error(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetExtCalLastDateAndTimeResponse get_ext_cal_last_date_and_time(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetExtCalLastTempResponse get_ext_cal_last_temp(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetExtCalRecommendedIntervalResponse get_ext_cal_recommended_interval(const StubPtr& stub, const nidevice_grpc::Session& vi);

--- a/source/codegen/metadata/nirfsa/functions.py
+++ b/source/codegen/metadata/nirfsa/functions.py
@@ -1692,7 +1692,7 @@ functions = {
                 'direction': 'out',
                 'name': 'errorDescription',
                 'size': {
-                    'mechanism': 'passed-in',
+                    'mechanism': 'ivi-dance',
                     'value': 'errorDescriptionBufferSize'
                 },
                 'type': 'ViChar[]'

--- a/source/tests/system/nirfsa_driver_api_tests.cpp
+++ b/source/tests/system/nirfsa_driver_api_tests.cpp
@@ -63,7 +63,7 @@ class NiRFSADriverApiTests : public Test {
 
   void check_error(const nidevice_grpc::Session& session)
   {
-    auto response = client::get_error(stub(), session, 2048);
+    auto response = client::get_error(stub(), session);
     EXPECT_EQ("", std::string(response.error_description().c_str()));
   }
 
@@ -81,9 +81,11 @@ class NiRFSADriverApiTests : public Test {
   }
 
   template <typename TResponse>
-  void EXPECT_RFSA_ERROR(pb::int32 expected_error, const nidevice_grpc::Session& session, const TResponse& response)
+  void EXPECT_RFSA_ERROR(pb::int32 expected_error, const std::string& message_substring, const nidevice_grpc::Session& session, const TResponse& response)
   {
     ni::tests::system::EXPECT_RFSA_ERROR(expected_error, response);
+    const auto error = client::get_error(stub(), session);
+    EXPECT_THAT(error.error_description(), HasSubstr(message_substring));
     clear_error(session);
   }
 
@@ -452,7 +454,7 @@ TEST_F(NiRFSADriverApiTests, CreateConfigurationListWithInvalidAttribute_Reports
       {NiRFSAAttributes::NIRFSA_ATTRIBUTE_EXTERNAL_GAIN, NiRFSAAttributes::NIRFSA_ATTRIBUTE_NOTCH_FILTER_ENABLED},
       true);
 
-  EXPECT_RFSA_ERROR(IVI_ERROR_ATTRIBUTE_NOT_SUPPORTED, session, response);
+  EXPECT_RFSA_ERROR(IVI_ERROR_ATTRIBUTE_NOT_SUPPORTED, "Attribute or property not supported.", session, response);
 }
 
 TEST_F(NiRFSADriverApiTests, GetScalingCoefficients_ReturnsCoefficients)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Set the size mechanism to `ivi-dance` on RFSA `GetError`.

### Why should this Pull Request be merged?

`GetError` supports the `ivi-dance` and this removes the need for passing in a buffer size.

### What testing has been done?

Ran and passed all RFSA tests.