### PR TITLE
Remove LockSession and UnlockSession from all driver services

### DIFF
--- a/generated/nidcpower/nidcpower.proto
+++ b/generated/nidcpower/nidcpower.proto
@@ -126,7 +126,6 @@ service NiDCPower {
   rpc ImportAttributeConfigurationFile(ImportAttributeConfigurationFileRequest) returns (ImportAttributeConfigurationFileResponse);
   rpc InitializeWithChannels(InitializeWithChannelsRequest) returns (InitializeWithChannelsResponse);
   rpc Initiate(InitiateRequest) returns (InitiateResponse);
-  rpc LockSession(LockSessionRequest) returns (LockSessionResponse);
   rpc Measure(MeasureRequest) returns (MeasureResponse);
   rpc MeasureMultiple(MeasureMultipleRequest) returns (MeasureMultipleResponse);
   rpc QueryInCompliance(QueryInComplianceRequest) returns (QueryInComplianceResponse);
@@ -149,7 +148,6 @@ service NiDCPower {
   rpc SetAttributeViSession(SetAttributeViSessionRequest) returns (SetAttributeViSessionResponse);
   rpc SetAttributeViString(SetAttributeViStringRequest) returns (SetAttributeViStringResponse);
   rpc SetSequence(SetSequenceRequest) returns (SetSequenceResponse);
-  rpc UnlockSession(UnlockSessionRequest) returns (UnlockSessionResponse);
   rpc WaitForEvent(WaitForEventRequest) returns (WaitForEventResponse);
 }
 
@@ -1612,15 +1610,6 @@ message InitiateResponse {
   int32 status = 1;
 }
 
-message LockSessionRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message LockSessionResponse {
-  int32 status = 1;
-  bool caller_has_lock = 2;
-}
-
 message MeasureRequest {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
@@ -1857,15 +1846,6 @@ message SetSequenceRequest {
 
 message SetSequenceResponse {
   int32 status = 1;
-}
-
-message UnlockSessionRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message UnlockSessionResponse {
-  int32 status = 1;
-  bool caller_has_lock = 2;
 }
 
 message WaitForEventRequest {

--- a/generated/nidcpower/nidcpower_client.cpp
+++ b/generated/nidcpower/nidcpower_client.cpp
@@ -2097,22 +2097,6 @@ initiate(const StubPtr& stub, const nidevice_grpc::Session& vi)
   return response;
 }
 
-LockSessionResponse
-lock_session(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = LockSessionRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = LockSessionResponse{};
-
-  raise_if_error(
-      stub->LockSession(&context, request, &response));
-
-  return response;
-}
-
 MeasureResponse
 measure(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const simple_variant<MeasurementTypes, pb::int32>& measurement_type)
 {
@@ -2530,22 +2514,6 @@ set_sequence(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::st
 
   raise_if_error(
       stub->SetSequence(&context, request, &response));
-
-  return response;
-}
-
-UnlockSessionResponse
-unlock_session(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = UnlockSessionRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = UnlockSessionResponse{};
-
-  raise_if_error(
-      stub->UnlockSession(&context, request, &response));
 
   return response;
 }

--- a/generated/nidcpower/nidcpower_client.h
+++ b/generated/nidcpower/nidcpower_client.h
@@ -132,7 +132,6 @@ ImportAttributeConfigurationBufferResponse import_attribute_configuration_buffer
 ImportAttributeConfigurationFileResponse import_attribute_configuration_file(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& file_path);
 InitializeWithChannelsResponse initialize_with_channels(const StubPtr& stub, const pb::string& resource_name, const pb::string& channels, const bool& reset, const pb::string& option_string);
 InitiateResponse initiate(const StubPtr& stub, const nidevice_grpc::Session& vi);
-LockSessionResponse lock_session(const StubPtr& stub, const nidevice_grpc::Session& vi);
 MeasureResponse measure(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const simple_variant<MeasurementTypes, pb::int32>& measurement_type);
 MeasureMultipleResponse measure_multiple(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name);
 QueryInComplianceResponse query_in_compliance(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name);
@@ -155,7 +154,6 @@ SetAttributeViReal64Response set_attribute_vi_real64(const StubPtr& stub, const 
 SetAttributeViSessionResponse set_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiDCPowerAttributes& attribute_id, const nidevice_grpc::Session& attribute_value);
 SetAttributeViStringResponse set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiDCPowerAttributes& attribute_id, const pb::string& attribute_value_raw);
 SetSequenceResponse set_sequence(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const std::vector<double>& values, const std::vector<double>& source_delays);
-UnlockSessionResponse unlock_session(const StubPtr& stub, const nidevice_grpc::Session& vi);
 WaitForEventResponse wait_for_event(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<ExportSignal, pb::int32>& event_id, const double& timeout);
 
 } // namespace nidcpower_grpc::experimental::client

--- a/generated/nidcpower/nidcpower_library.cpp
+++ b/generated/nidcpower/nidcpower_library.cpp
@@ -1495,11 +1495,7 @@ ViStatus NiDCPowerLibrary::LockSession(ViSession vi, ViBoolean* callerHasLock)
   if (!function_pointers_.LockSession) {
     throw nidevice_grpc::LibraryLoadException("Could not find niDCPower_LockSession.");
   }
-#if defined(_MSC_VER)
-  return niDCPower_LockSession(vi, callerHasLock);
-#else
   return function_pointers_.LockSession(vi, callerHasLock);
-#endif
 }
 
 ViStatus NiDCPowerLibrary::Measure(ViSession vi, ViConstString channelName, ViInt32 measurementType, ViReal64* measurement)
@@ -1779,11 +1775,7 @@ ViStatus NiDCPowerLibrary::UnlockSession(ViSession vi, ViBoolean* callerHasLock)
   if (!function_pointers_.UnlockSession) {
     throw nidevice_grpc::LibraryLoadException("Could not find niDCPower_UnlockSession.");
   }
-#if defined(_MSC_VER)
-  return niDCPower_UnlockSession(vi, callerHasLock);
-#else
   return function_pointers_.UnlockSession(vi, callerHasLock);
-#endif
 }
 
 ViStatus NiDCPowerLibrary::WaitForEvent(ViSession vi, ViInt32 eventId, ViReal64 timeout)

--- a/generated/nidcpower/nidcpower_library.h
+++ b/generated/nidcpower/nidcpower_library.h
@@ -266,7 +266,7 @@ class NiDCPowerLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
   using ImportAttributeConfigurationFilePtr = decltype(&niDCPower_ImportAttributeConfigurationFile);
   using InitializeWithChannelsPtr = decltype(&niDCPower_InitializeWithChannels);
   using InitiatePtr = decltype(&niDCPower_Initiate);
-  using LockSessionPtr = decltype(&niDCPower_LockSession);
+  using LockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using MeasurePtr = decltype(&niDCPower_Measure);
   using MeasureMultiplePtr = decltype(&niDCPower_MeasureMultiple);
   using ParseChannelCountPtr = ViStatus (*)(ViSession vi, ViConstString channelsString, ViUInt32* numberOfChannels);
@@ -290,7 +290,7 @@ class NiDCPowerLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
   using SetAttributeViSessionPtr = decltype(&niDCPower_SetAttributeViSession);
   using SetAttributeViStringPtr = decltype(&niDCPower_SetAttributeViString);
   using SetSequencePtr = decltype(&niDCPower_SetSequence);
-  using UnlockSessionPtr = decltype(&niDCPower_UnlockSession);
+  using UnlockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using WaitForEventPtr = decltype(&niDCPower_WaitForEvent);
 
   typedef struct FunctionPointers {

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -2876,29 +2876,6 @@ namespace nidcpower_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiDCPowerService::LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViBoolean caller_has_lock {};
-      auto status = library_->LockSession(vi, &caller_has_lock);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_caller_has_lock(caller_has_lock);
-      }
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiDCPowerService::Measure(::grpc::ServerContext* context, const MeasureRequest* request, MeasureResponse* response)
   {
     if (context->IsCancelled()) {
@@ -3442,29 +3419,6 @@ namespace nidcpower_grpc {
       ViUInt32 size = static_cast<ViUInt32>(request->source_delays().size());
       auto status = library_->SetSequence(vi, channel_name, values, source_delays, size);
       response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiDCPowerService::UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViBoolean caller_has_lock {};
-      auto status = library_->UnlockSession(vi, &caller_has_lock);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_caller_has_lock(caller_has_lock);
-      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {

--- a/generated/nidcpower/nidcpower_service.h
+++ b/generated/nidcpower/nidcpower_service.h
@@ -143,7 +143,6 @@ public:
   ::grpc::Status ImportAttributeConfigurationFile(::grpc::ServerContext* context, const ImportAttributeConfigurationFileRequest* request, ImportAttributeConfigurationFileResponse* response) override;
   ::grpc::Status InitializeWithChannels(::grpc::ServerContext* context, const InitializeWithChannelsRequest* request, InitializeWithChannelsResponse* response) override;
   ::grpc::Status Initiate(::grpc::ServerContext* context, const InitiateRequest* request, InitiateResponse* response) override;
-  ::grpc::Status LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response) override;
   ::grpc::Status Measure(::grpc::ServerContext* context, const MeasureRequest* request, MeasureResponse* response) override;
   ::grpc::Status MeasureMultiple(::grpc::ServerContext* context, const MeasureMultipleRequest* request, MeasureMultipleResponse* response) override;
   ::grpc::Status QueryInCompliance(::grpc::ServerContext* context, const QueryInComplianceRequest* request, QueryInComplianceResponse* response) override;
@@ -166,7 +165,6 @@ public:
   ::grpc::Status SetAttributeViSession(::grpc::ServerContext* context, const SetAttributeViSessionRequest* request, SetAttributeViSessionResponse* response) override;
   ::grpc::Status SetAttributeViString(::grpc::ServerContext* context, const SetAttributeViStringRequest* request, SetAttributeViStringResponse* response) override;
   ::grpc::Status SetSequence(::grpc::ServerContext* context, const SetSequenceRequest* request, SetSequenceResponse* response) override;
-  ::grpc::Status UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response) override;
   ::grpc::Status WaitForEvent(::grpc::ServerContext* context, const WaitForEventRequest* request, WaitForEventResponse* response) override;
 
   bool is_enabled();

--- a/generated/nidigitalpattern/nidigitalpattern.proto
+++ b/generated/nidigitalpattern/nidigitalpattern.proto
@@ -108,7 +108,6 @@ service NiDigital {
   rpc LoadPinMap(LoadPinMapRequest) returns (LoadPinMapResponse);
   rpc LoadSpecifications(LoadSpecificationsRequest) returns (LoadSpecificationsResponse);
   rpc LoadTiming(LoadTimingRequest) returns (LoadTimingResponse);
-  rpc LockSession(LockSessionRequest) returns (LockSessionResponse);
   rpc MapPinToChannel(MapPinToChannelRequest) returns (MapPinToChannelResponse);
   rpc PPMUConfigureApertureTime(PPMUConfigureApertureTimeRequest) returns (PPMUConfigureApertureTimeResponse);
   rpc PPMUConfigureCurrentLevel(PPMUConfigureCurrentLevelRequest) returns (PPMUConfigureCurrentLevelResponse);
@@ -139,7 +138,6 @@ service NiDigital {
   rpc TDR(TDRRequest) returns (TDRResponse);
   rpc UnloadAllPatterns(UnloadAllPatternsRequest) returns (UnloadAllPatternsResponse);
   rpc UnloadSpecifications(UnloadSpecificationsRequest) returns (UnloadSpecificationsResponse);
-  rpc UnlockSession(UnlockSessionRequest) returns (UnlockSessionResponse);
   rpc WaitUntilDone(WaitUntilDoneRequest) returns (WaitUntilDoneResponse);
   rpc WriteSequencerFlag(WriteSequencerFlagRequest) returns (WriteSequencerFlagResponse);
   rpc WriteSequencerFlagSynchronized(WriteSequencerFlagSynchronizedRequest) returns (WriteSequencerFlagSynchronizedResponse);
@@ -1417,15 +1415,6 @@ message LoadTimingResponse {
   int32 status = 1;
 }
 
-message LockSessionRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message LockSessionResponse {
-  int32 status = 1;
-  bool caller_has_lock = 2;
-}
-
 message MapPinToChannelRequest {
   nidevice_grpc.Session vi = 1;
   string pin = 2;
@@ -1752,15 +1741,6 @@ message UnloadSpecificationsRequest {
 
 message UnloadSpecificationsResponse {
   int32 status = 1;
-}
-
-message UnlockSessionRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message UnlockSessionResponse {
-  int32 status = 1;
-  bool caller_has_lock = 2;
 }
 
 message WaitUntilDoneRequest {

--- a/generated/nidigitalpattern/nidigitalpattern_client.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_client.cpp
@@ -1782,22 +1782,6 @@ load_timing(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::str
   return response;
 }
 
-LockSessionResponse
-lock_session(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = LockSessionRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = LockSessionResponse{};
-
-  raise_if_error(
-      stub->LockSession(&context, request, &response));
-
-  return response;
-}
-
 MapPinToChannelResponse
 map_pin_to_channel(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& pin, const pb::int32& site, const pb::string& channel)
 {
@@ -2379,22 +2363,6 @@ unload_specifications(const StubPtr& stub, const nidevice_grpc::Session& vi, con
 
   raise_if_error(
       stub->UnloadSpecifications(&context, request, &response));
-
-  return response;
-}
-
-UnlockSessionResponse
-unlock_session(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = UnlockSessionRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = UnlockSessionResponse{};
-
-  raise_if_error(
-      stub->UnlockSession(&context, request, &response));
 
   return response;
 }

--- a/generated/nidigitalpattern/nidigitalpattern_client.h
+++ b/generated/nidigitalpattern/nidigitalpattern_client.h
@@ -114,7 +114,6 @@ LoadPatternResponse load_pattern(const StubPtr& stub, const nidevice_grpc::Sessi
 LoadPinMapResponse load_pin_map(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& file_path);
 LoadSpecificationsResponse load_specifications(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& file_path);
 LoadTimingResponse load_timing(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& file_path);
-LockSessionResponse lock_session(const StubPtr& stub, const nidevice_grpc::Session& vi);
 MapPinToChannelResponse map_pin_to_channel(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& pin, const pb::int32& site, const pb::string& channel);
 PPMUConfigureApertureTimeResponse ppmu_configure_aperture_time(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_list, const double& aperture_time, const simple_variant<PpmuApertureTimeUnits, pb::int32>& units);
 PPMUConfigureCurrentLevelResponse ppmu_configure_current_level(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_list, const double& current_level);
@@ -145,7 +144,6 @@ SetAttributeViStringResponse set_attribute_vi_string(const StubPtr& stub, const 
 TDRResponse tdr(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_list, const bool& apply_offsets);
 UnloadAllPatternsResponse unload_all_patterns(const StubPtr& stub, const nidevice_grpc::Session& vi, const bool& unload_keep_alive_pattern);
 UnloadSpecificationsResponse unload_specifications(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& file_path);
-UnlockSessionResponse unlock_session(const StubPtr& stub, const nidevice_grpc::Session& vi);
 WaitUntilDoneResponse wait_until_done(const StubPtr& stub, const nidevice_grpc::Session& vi, const double& timeout);
 WriteSequencerFlagResponse write_sequencer_flag(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& flag, const bool& value);
 WriteSequencerFlagSynchronizedResponse write_sequencer_flag_synchronized(const StubPtr& stub, const pb::uint32& session_count, const std::vector<nidevice_grpc::Session>& sessions, const pb::string& flag, const bool& value);

--- a/generated/nidigitalpattern/nidigitalpattern_library.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_library.cpp
@@ -1275,11 +1275,7 @@ ViStatus NiDigitalLibrary::LockSession(ViSession vi, ViBoolean* callerHasLock)
   if (!function_pointers_.LockSession) {
     throw nidevice_grpc::LibraryLoadException("Could not find niDigital_LockSession.");
   }
-#if defined(_MSC_VER)
-  return niDigital_LockSession(vi, callerHasLock);
-#else
   return function_pointers_.LockSession(vi, callerHasLock);
-#endif
 }
 
 ViStatus NiDigitalLibrary::MapPinToChannel(ViSession vi, ViConstString pin, ViInt32 site, ViConstString channel)
@@ -1647,11 +1643,7 @@ ViStatus NiDigitalLibrary::UnlockSession(ViSession vi, ViBoolean* callerHasLock)
   if (!function_pointers_.UnlockSession) {
     throw nidevice_grpc::LibraryLoadException("Could not find niDigital_UnlockSession.");
   }
-#if defined(_MSC_VER)
-  return niDigital_UnlockSession(vi, callerHasLock);
-#else
   return function_pointers_.UnlockSession(vi, callerHasLock);
-#endif
 }
 
 ViStatus NiDigitalLibrary::WaitUntilDone(ViSession vi, ViReal64 timeout)

--- a/generated/nidigitalpattern/nidigitalpattern_library.h
+++ b/generated/nidigitalpattern/nidigitalpattern_library.h
@@ -244,7 +244,7 @@ class NiDigitalLibrary : public nidigitalpattern_grpc::NiDigitalLibraryInterface
   using LoadPinMapPtr = decltype(&niDigital_LoadPinMap);
   using LoadSpecificationsPtr = decltype(&niDigital_LoadSpecifications);
   using LoadTimingPtr = decltype(&niDigital_LoadTiming);
-  using LockSessionPtr = decltype(&niDigital_LockSession);
+  using LockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using MapPinToChannelPtr = decltype(&niDigital_MapPinToChannel);
   using PPMUConfigureApertureTimePtr = decltype(&niDigital_PPMU_ConfigureApertureTime);
   using PPMUConfigureCurrentLevelPtr = decltype(&niDigital_PPMU_ConfigureCurrentLevel);
@@ -275,7 +275,7 @@ class NiDigitalLibrary : public nidigitalpattern_grpc::NiDigitalLibraryInterface
   using TDRPtr = decltype(&niDigital_TDR);
   using UnloadAllPatternsPtr = decltype(&niDigital_UnloadAllPatterns);
   using UnloadSpecificationsPtr = decltype(&niDigital_UnloadSpecifications);
-  using UnlockSessionPtr = decltype(&niDigital_UnlockSession);
+  using UnlockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using WaitUntilDonePtr = decltype(&niDigital_WaitUntilDone);
   using WriteSequencerFlagPtr = decltype(&niDigital_WriteSequencerFlag);
   using WriteSequencerFlagSynchronizedPtr = decltype(&niDigital_WriteSequencerFlagSynchronized);

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -2656,29 +2656,6 @@ namespace nidigitalpattern_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiDigitalService::LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViBoolean caller_has_lock {};
-      auto status = library_->LockSession(vi, &caller_has_lock);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_caller_has_lock(caller_has_lock);
-      }
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiDigitalService::MapPinToChannel(::grpc::ServerContext* context, const MapPinToChannelRequest* request, MapPinToChannelResponse* response)
   {
     if (context->IsCancelled()) {
@@ -3474,29 +3451,6 @@ namespace nidigitalpattern_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->UnloadSpecifications(vi, file_path);
       response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiDigitalService::UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViBoolean caller_has_lock {};
-      auto status = library_->UnlockSession(vi, &caller_has_lock);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_caller_has_lock(caller_has_lock);
-      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {

--- a/generated/nidigitalpattern/nidigitalpattern_service.h
+++ b/generated/nidigitalpattern/nidigitalpattern_service.h
@@ -125,7 +125,6 @@ public:
   ::grpc::Status LoadPinMap(::grpc::ServerContext* context, const LoadPinMapRequest* request, LoadPinMapResponse* response) override;
   ::grpc::Status LoadSpecifications(::grpc::ServerContext* context, const LoadSpecificationsRequest* request, LoadSpecificationsResponse* response) override;
   ::grpc::Status LoadTiming(::grpc::ServerContext* context, const LoadTimingRequest* request, LoadTimingResponse* response) override;
-  ::grpc::Status LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response) override;
   ::grpc::Status MapPinToChannel(::grpc::ServerContext* context, const MapPinToChannelRequest* request, MapPinToChannelResponse* response) override;
   ::grpc::Status PPMUConfigureApertureTime(::grpc::ServerContext* context, const PPMUConfigureApertureTimeRequest* request, PPMUConfigureApertureTimeResponse* response) override;
   ::grpc::Status PPMUConfigureCurrentLevel(::grpc::ServerContext* context, const PPMUConfigureCurrentLevelRequest* request, PPMUConfigureCurrentLevelResponse* response) override;
@@ -156,7 +155,6 @@ public:
   ::grpc::Status TDR(::grpc::ServerContext* context, const TDRRequest* request, TDRResponse* response) override;
   ::grpc::Status UnloadAllPatterns(::grpc::ServerContext* context, const UnloadAllPatternsRequest* request, UnloadAllPatternsResponse* response) override;
   ::grpc::Status UnloadSpecifications(::grpc::ServerContext* context, const UnloadSpecificationsRequest* request, UnloadSpecificationsResponse* response) override;
-  ::grpc::Status UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response) override;
   ::grpc::Status WaitUntilDone(::grpc::ServerContext* context, const WaitUntilDoneRequest* request, WaitUntilDoneResponse* response) override;
   ::grpc::Status WriteSequencerFlag(::grpc::ServerContext* context, const WriteSequencerFlagRequest* request, WriteSequencerFlagResponse* response) override;
   ::grpc::Status WriteSequencerFlagSynchronized(::grpc::ServerContext* context, const WriteSequencerFlagSynchronizedRequest* request, WriteSequencerFlagSynchronizedResponse* response) override;

--- a/generated/nidmm/nidmm.proto
+++ b/generated/nidmm/nidmm.proto
@@ -86,7 +86,6 @@ service NiDmm {
   rpc InvalidateAllAttributes(InvalidateAllAttributesRequest) returns (InvalidateAllAttributesResponse);
   rpc IsOverRange(IsOverRangeRequest) returns (IsOverRangeResponse);
   rpc IsUnderRange(IsUnderRangeRequest) returns (IsUnderRangeResponse);
-  rpc LockSession(LockSessionRequest) returns (LockSessionResponse);
   rpc PerformOpenCableComp(PerformOpenCableCompRequest) returns (PerformOpenCableCompResponse);
   rpc PerformShortCableComp(PerformShortCableCompRequest) returns (PerformShortCableCompResponse);
   rpc Read(ReadRequest) returns (ReadResponse);
@@ -105,7 +104,6 @@ service NiDmm {
   rpc SetAttributeViReal64(SetAttributeViReal64Request) returns (SetAttributeViReal64Response);
   rpc SetAttributeViSession(SetAttributeViSessionRequest) returns (SetAttributeViSessionResponse);
   rpc SetAttributeViString(SetAttributeViStringRequest) returns (SetAttributeViStringResponse);
-  rpc UnlockSession(UnlockSessionRequest) returns (UnlockSessionResponse);
 }
 
 enum NiDmmAttributes {
@@ -1312,15 +1310,6 @@ message IsUnderRangeResponse {
   bool is_under_range = 2;
 }
 
-message LockSessionRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message LockSessionResponse {
-  int32 status = 1;
-  bool caller_has_lock = 2;
-}
-
 message PerformOpenCableCompRequest {
   nidevice_grpc.Session vi = 1;
 }
@@ -1514,14 +1503,5 @@ message SetAttributeViStringRequest {
 
 message SetAttributeViStringResponse {
   int32 status = 1;
-}
-
-message UnlockSessionRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message UnlockSessionResponse {
-  int32 status = 1;
-  bool caller_has_lock = 2;
 }
 

--- a/generated/nidmm/nidmm_client.cpp
+++ b/generated/nidmm/nidmm_client.cpp
@@ -1413,22 +1413,6 @@ is_under_range(const StubPtr& stub, const nidevice_grpc::Session& vi, const doub
   return response;
 }
 
-LockSessionResponse
-lock_session(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = LockSessionRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = LockSessionResponse{};
-
-  raise_if_error(
-      stub->LockSession(&context, request, &response));
-
-  return response;
-}
-
 PerformOpenCableCompResponse
 perform_open_cable_comp(const StubPtr& stub, const nidevice_grpc::Session& vi)
 {
@@ -1768,22 +1752,6 @@ set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
 
   raise_if_error(
       stub->SetAttributeViString(&context, request, &response));
-
-  return response;
-}
-
-UnlockSessionResponse
-unlock_session(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = UnlockSessionRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = UnlockSessionResponse{};
-
-  raise_if_error(
-      stub->UnlockSession(&context, request, &response));
 
   return response;
 }

--- a/generated/nidmm/nidmm_client.h
+++ b/generated/nidmm/nidmm_client.h
@@ -92,7 +92,6 @@ InitiateResponse initiate(const StubPtr& stub, const nidevice_grpc::Session& vi)
 InvalidateAllAttributesResponse invalidate_all_attributes(const StubPtr& stub, const nidevice_grpc::Session& vi);
 IsOverRangeResponse is_over_range(const StubPtr& stub, const nidevice_grpc::Session& vi, const double& measurement_value);
 IsUnderRangeResponse is_under_range(const StubPtr& stub, const nidevice_grpc::Session& vi, const double& measurement_value);
-LockSessionResponse lock_session(const StubPtr& stub, const nidevice_grpc::Session& vi);
 PerformOpenCableCompResponse perform_open_cable_comp(const StubPtr& stub, const nidevice_grpc::Session& vi);
 PerformShortCableCompResponse perform_short_cable_comp(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ReadResponse read(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<TimeLimit, pb::int32>& maximum_time);
@@ -111,7 +110,6 @@ SetAttributeViInt32Response set_attribute_vi_int32(const StubPtr& stub, const ni
 SetAttributeViReal64Response set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiDmmAttributes& attribute_id, const simple_variant<NiDmmReal64AttributeValues, double>& attribute_value);
 SetAttributeViSessionResponse set_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiDmmAttributes& attribute_id, const nidevice_grpc::Session& attribute_value);
 SetAttributeViStringResponse set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiDmmAttributes& attribute_id, const pb::string& attribute_value_raw);
-UnlockSessionResponse unlock_session(const StubPtr& stub, const nidevice_grpc::Session& vi);
 
 } // namespace nidmm_grpc::experimental::client
 

--- a/generated/nidmm/nidmm_library.cpp
+++ b/generated/nidmm/nidmm_library.cpp
@@ -969,11 +969,7 @@ ViStatus NiDmmLibrary::LockSession(ViSession vi, ViBoolean* callerHasLock)
   if (!function_pointers_.LockSession) {
     throw nidevice_grpc::LibraryLoadException("Could not find niDMM_LockSession.");
   }
-#if defined(_MSC_VER)
-  return niDMM_LockSession(vi, callerHasLock);
-#else
   return function_pointers_.LockSession(vi, callerHasLock);
-#endif
 }
 
 ViStatus NiDmmLibrary::PerformOpenCableComp(ViSession vi, ViReal64* conductance, ViReal64* susceptance)
@@ -1197,11 +1193,7 @@ ViStatus NiDmmLibrary::UnlockSession(ViSession vi, ViBoolean* callerHasLock)
   if (!function_pointers_.UnlockSession) {
     throw nidevice_grpc::LibraryLoadException("Could not find niDMM_UnlockSession.");
   }
-#if defined(_MSC_VER)
-  return niDMM_UnlockSession(vi, callerHasLock);
-#else
   return function_pointers_.UnlockSession(vi, callerHasLock);
-#endif
 }
 
 }  // namespace nidmm_grpc

--- a/generated/nidmm/nidmm_library.h
+++ b/generated/nidmm/nidmm_library.h
@@ -180,7 +180,7 @@ class NiDmmLibrary : public nidmm_grpc::NiDmmLibraryInterface {
   using InvalidateAllAttributesPtr = decltype(&niDMM_InvalidateAllAttributes);
   using IsOverRangePtr = decltype(&niDMM_IsOverRange);
   using IsUnderRangePtr = decltype(&niDMM_IsUnderRange);
-  using LockSessionPtr = decltype(&niDMM_LockSession);
+  using LockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using PerformOpenCableCompPtr = decltype(&niDMM_PerformOpenCableComp);
   using PerformShortCableCompPtr = decltype(&niDMM_PerformShortCableComp);
   using ReadPtr = decltype(&niDMM_Read);
@@ -199,7 +199,7 @@ class NiDmmLibrary : public nidmm_grpc::NiDmmLibraryInterface {
   using SetAttributeViReal64Ptr = decltype(&niDMM_SetAttributeViReal64);
   using SetAttributeViSessionPtr = decltype(&niDMM_SetAttributeViSession);
   using SetAttributeViStringPtr = decltype(&niDMM_SetAttributeViString);
-  using UnlockSessionPtr = decltype(&niDMM_UnlockSession);
+  using UnlockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
 
   typedef struct FunctionPointers {
     Control4022Ptr Control4022;

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -2106,29 +2106,6 @@ namespace nidmm_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiDmmService::LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViBoolean caller_has_lock {};
-      auto status = library_->LockSession(vi, &caller_has_lock);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_caller_has_lock(caller_has_lock);
-      }
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiDmmService::PerformOpenCableComp(::grpc::ServerContext* context, const PerformOpenCableCompRequest* request, PerformOpenCableCompResponse* response)
   {
     if (context->IsCancelled()) {
@@ -2605,29 +2582,6 @@ namespace nidmm_grpc {
       ViString attribute_value = (ViString)request->attribute_value_raw().c_str();
       auto status = library_->SetAttributeViString(vi, channel_name, attribute_id, attribute_value);
       response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiDmmService::UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViBoolean caller_has_lock {};
-      auto status = library_->UnlockSession(vi, &caller_has_lock);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_caller_has_lock(caller_has_lock);
-      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {

--- a/generated/nidmm/nidmm_service.h
+++ b/generated/nidmm/nidmm_service.h
@@ -103,7 +103,6 @@ public:
   ::grpc::Status InvalidateAllAttributes(::grpc::ServerContext* context, const InvalidateAllAttributesRequest* request, InvalidateAllAttributesResponse* response) override;
   ::grpc::Status IsOverRange(::grpc::ServerContext* context, const IsOverRangeRequest* request, IsOverRangeResponse* response) override;
   ::grpc::Status IsUnderRange(::grpc::ServerContext* context, const IsUnderRangeRequest* request, IsUnderRangeResponse* response) override;
-  ::grpc::Status LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response) override;
   ::grpc::Status PerformOpenCableComp(::grpc::ServerContext* context, const PerformOpenCableCompRequest* request, PerformOpenCableCompResponse* response) override;
   ::grpc::Status PerformShortCableComp(::grpc::ServerContext* context, const PerformShortCableCompRequest* request, PerformShortCableCompResponse* response) override;
   ::grpc::Status Read(::grpc::ServerContext* context, const ReadRequest* request, ReadResponse* response) override;
@@ -122,7 +121,6 @@ public:
   ::grpc::Status SetAttributeViReal64(::grpc::ServerContext* context, const SetAttributeViReal64Request* request, SetAttributeViReal64Response* response) override;
   ::grpc::Status SetAttributeViSession(::grpc::ServerContext* context, const SetAttributeViSessionRequest* request, SetAttributeViSessionResponse* response) override;
   ::grpc::Status SetAttributeViString(::grpc::ServerContext* context, const SetAttributeViStringRequest* request, SetAttributeViStringResponse* response) override;
-  ::grpc::Status UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response) override;
 
   bool is_enabled();
 private:

--- a/generated/nifgen/nifgen.proto
+++ b/generated/nifgen/nifgen.proto
@@ -113,7 +113,6 @@ service NiFgen {
   rpc InitiateGeneration(InitiateGenerationRequest) returns (InitiateGenerationResponse);
   rpc InvalidateAllAttributes(InvalidateAllAttributesRequest) returns (InvalidateAllAttributesResponse);
   rpc IsDone(IsDoneRequest) returns (IsDoneResponse);
-  rpc LockSession(LockSessionRequest) returns (LockSessionResponse);
   rpc ManualEnableP2PStream(ManualEnableP2PStreamRequest) returns (ManualEnableP2PStreamResponse);
   rpc QueryArbSeqCapabilities(QueryArbSeqCapabilitiesRequest) returns (QueryArbSeqCapabilitiesResponse);
   rpc QueryArbWfmCapabilities(QueryArbWfmCapabilitiesRequest) returns (QueryArbWfmCapabilitiesResponse);
@@ -137,7 +136,6 @@ service NiFgen {
   rpc SetAttributeViString(SetAttributeViStringRequest) returns (SetAttributeViStringResponse);
   rpc SetNamedWaveformNextWritePosition(SetNamedWaveformNextWritePositionRequest) returns (SetNamedWaveformNextWritePositionResponse);
   rpc SetWaveformNextWritePosition(SetWaveformNextWritePositionRequest) returns (SetWaveformNextWritePositionResponse);
-  rpc UnlockSession(UnlockSessionRequest) returns (UnlockSessionResponse);
   rpc WaitUntilDone(WaitUntilDoneRequest) returns (WaitUntilDoneResponse);
   rpc WriteBinary16Waveform(WriteBinary16WaveformRequest) returns (WriteBinary16WaveformResponse);
   rpc WriteComplexBinary16Waveform(WriteComplexBinary16WaveformRequest) returns (WriteComplexBinary16WaveformResponse);
@@ -1719,15 +1717,6 @@ message IsDoneResponse {
   bool done = 2;
 }
 
-message LockSessionRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message LockSessionResponse {
-  int32 status = 1;
-  bool caller_has_lock = 2;
-}
-
 message ManualEnableP2PStreamRequest {
   nidevice_grpc.Session vi = 1;
   string endpoint_name = 2;
@@ -1984,15 +1973,6 @@ message SetWaveformNextWritePositionRequest {
 
 message SetWaveformNextWritePositionResponse {
   int32 status = 1;
-}
-
-message UnlockSessionRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message UnlockSessionResponse {
-  int32 status = 1;
-  bool caller_has_lock = 2;
 }
 
 message WaitUntilDoneRequest {

--- a/generated/nifgen/nifgen_client.cpp
+++ b/generated/nifgen/nifgen_client.cpp
@@ -1810,22 +1810,6 @@ is_done(const StubPtr& stub, const nidevice_grpc::Session& vi)
   return response;
 }
 
-LockSessionResponse
-lock_session(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = LockSessionRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = LockSessionResponse{};
-
-  raise_if_error(
-      stub->LockSession(&context, request, &response));
-
-  return response;
-}
-
 ManualEnableP2PStreamResponse
 manual_enable_p2p_stream(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& endpoint_name)
 {
@@ -2273,22 +2257,6 @@ set_waveform_next_write_position(const StubPtr& stub, const nidevice_grpc::Sessi
 
   raise_if_error(
       stub->SetWaveformNextWritePosition(&context, request, &response));
-
-  return response;
-}
-
-UnlockSessionResponse
-unlock_session(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = UnlockSessionRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = UnlockSessionResponse{};
-
-  raise_if_error(
-      stub->UnlockSession(&context, request, &response));
 
   return response;
 }

--- a/generated/nifgen/nifgen_client.h
+++ b/generated/nifgen/nifgen_client.h
@@ -119,7 +119,6 @@ InitializeWithChannelsResponse initialize_with_channels(const StubPtr& stub, con
 InitiateGenerationResponse initiate_generation(const StubPtr& stub, const nidevice_grpc::Session& vi);
 InvalidateAllAttributesResponse invalidate_all_attributes(const StubPtr& stub, const nidevice_grpc::Session& vi);
 IsDoneResponse is_done(const StubPtr& stub, const nidevice_grpc::Session& vi);
-LockSessionResponse lock_session(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ManualEnableP2PStreamResponse manual_enable_p2p_stream(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& endpoint_name);
 QueryArbSeqCapabilitiesResponse query_arb_seq_capabilities(const StubPtr& stub, const nidevice_grpc::Session& vi);
 QueryArbWfmCapabilitiesResponse query_arb_wfm_capabilities(const StubPtr& stub, const nidevice_grpc::Session& vi);
@@ -143,7 +142,6 @@ SetAttributeViSessionResponse set_attribute_vi_session(const StubPtr& stub, cons
 SetAttributeViStringResponse set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFgenAttributes& attribute_id, const pb::string& attribute_value_raw);
 SetNamedWaveformNextWritePositionResponse set_named_waveform_next_write_position(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const pb::string& waveform_name, const simple_variant<RelativeTo, pb::int32>& relative_to, const pb::int32& offset);
 SetWaveformNextWritePositionResponse set_waveform_next_write_position(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const pb::int32& waveform_handle, const simple_variant<RelativeTo, pb::int32>& relative_to, const pb::int32& offset);
-UnlockSessionResponse unlock_session(const StubPtr& stub, const nidevice_grpc::Session& vi);
 WaitUntilDoneResponse wait_until_done(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& max_time);
 WriteBinary16WaveformResponse write_binary16_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const pb::int32& waveform_handle, const std::vector<pb::int32>& data);
 WriteComplexBinary16WaveformResponse write_complex_binary16_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const pb::int32& waveform_handle, const std::vector<NIComplexInt32>& data);

--- a/generated/nifgen/nifgen_library.cpp
+++ b/generated/nifgen/nifgen_library.cpp
@@ -1336,11 +1336,7 @@ ViStatus NiFgenLibrary::LockSession(ViSession vi, ViBoolean* callerHasLock)
   if (!function_pointers_.LockSession) {
     throw nidevice_grpc::LibraryLoadException("Could not find niFgen_LockSession.");
   }
-#if defined(_MSC_VER)
-  return niFgen_LockSession(vi, callerHasLock);
-#else
   return function_pointers_.LockSession(vi, callerHasLock);
-#endif
 }
 
 ViStatus NiFgenLibrary::ManualEnableP2PStream(ViSession vi, ViConstString endpointName)
@@ -1624,11 +1620,7 @@ ViStatus NiFgenLibrary::UnlockSession(ViSession vi, ViBoolean* callerHasLock)
   if (!function_pointers_.UnlockSession) {
     throw nidevice_grpc::LibraryLoadException("Could not find niFgen_UnlockSession.");
   }
-#if defined(_MSC_VER)
-  return niFgen_UnlockSession(vi, callerHasLock);
-#else
   return function_pointers_.UnlockSession(vi, callerHasLock);
-#endif
 }
 
 ViStatus NiFgenLibrary::WaitUntilDone(ViSession vi, ViInt32 maxTime)

--- a/generated/nifgen/nifgen_library.h
+++ b/generated/nifgen/nifgen_library.h
@@ -250,7 +250,7 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   using InitiateGenerationPtr = decltype(&niFgen_InitiateGeneration);
   using InvalidateAllAttributesPtr = decltype(&niFgen_InvalidateAllAttributes);
   using IsDonePtr = decltype(&niFgen_IsDone);
-  using LockSessionPtr = decltype(&niFgen_LockSession);
+  using LockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using ManualEnableP2PStreamPtr = decltype(&niFgen_ManualEnableP2PStream);
   using QueryArbSeqCapabilitiesPtr = decltype(&niFgen_QueryArbSeqCapabilities);
   using QueryArbWfmCapabilitiesPtr = decltype(&niFgen_QueryArbWfmCapabilities);
@@ -274,7 +274,7 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   using SetAttributeViStringPtr = decltype(&niFgen_SetAttributeViString);
   using SetNamedWaveformNextWritePositionPtr = decltype(&niFgen_SetNamedWaveformNextWritePosition);
   using SetWaveformNextWritePositionPtr = decltype(&niFgen_SetWaveformNextWritePosition);
-  using UnlockSessionPtr = decltype(&niFgen_UnlockSession);
+  using UnlockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using WaitUntilDonePtr = decltype(&niFgen_WaitUntilDone);
   using WriteBinary16WaveformPtr = decltype(&niFgen_WriteBinary16Waveform);
   using WriteComplexBinary16WaveformPtr = decltype(&niFgen_WriteComplexBinary16Waveform);

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -2523,29 +2523,6 @@ namespace nifgen_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViBoolean caller_has_lock {};
-      auto status = library_->LockSession(vi, &caller_has_lock);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_caller_has_lock(caller_has_lock);
-      }
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiFgenService::ManualEnableP2PStream(::grpc::ServerContext* context, const ManualEnableP2PStreamRequest* request, ManualEnableP2PStreamResponse* response)
   {
     if (context->IsCancelled()) {
@@ -3164,29 +3141,6 @@ namespace nifgen_grpc {
       ViInt32 offset = request->offset();
       auto status = library_->SetWaveformNextWritePosition(vi, channel_name, waveform_handle, relative_to, offset);
       response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFgenService::UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViBoolean caller_has_lock {};
-      auto status = library_->UnlockSession(vi, &caller_has_lock);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_caller_has_lock(caller_has_lock);
-      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {

--- a/generated/nifgen/nifgen_service.h
+++ b/generated/nifgen/nifgen_service.h
@@ -130,7 +130,6 @@ public:
   ::grpc::Status InitiateGeneration(::grpc::ServerContext* context, const InitiateGenerationRequest* request, InitiateGenerationResponse* response) override;
   ::grpc::Status InvalidateAllAttributes(::grpc::ServerContext* context, const InvalidateAllAttributesRequest* request, InvalidateAllAttributesResponse* response) override;
   ::grpc::Status IsDone(::grpc::ServerContext* context, const IsDoneRequest* request, IsDoneResponse* response) override;
-  ::grpc::Status LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response) override;
   ::grpc::Status ManualEnableP2PStream(::grpc::ServerContext* context, const ManualEnableP2PStreamRequest* request, ManualEnableP2PStreamResponse* response) override;
   ::grpc::Status QueryArbSeqCapabilities(::grpc::ServerContext* context, const QueryArbSeqCapabilitiesRequest* request, QueryArbSeqCapabilitiesResponse* response) override;
   ::grpc::Status QueryArbWfmCapabilities(::grpc::ServerContext* context, const QueryArbWfmCapabilitiesRequest* request, QueryArbWfmCapabilitiesResponse* response) override;
@@ -154,7 +153,6 @@ public:
   ::grpc::Status SetAttributeViString(::grpc::ServerContext* context, const SetAttributeViStringRequest* request, SetAttributeViStringResponse* response) override;
   ::grpc::Status SetNamedWaveformNextWritePosition(::grpc::ServerContext* context, const SetNamedWaveformNextWritePositionRequest* request, SetNamedWaveformNextWritePositionResponse* response) override;
   ::grpc::Status SetWaveformNextWritePosition(::grpc::ServerContext* context, const SetWaveformNextWritePositionRequest* request, SetWaveformNextWritePositionResponse* response) override;
-  ::grpc::Status UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response) override;
   ::grpc::Status WaitUntilDone(::grpc::ServerContext* context, const WaitUntilDoneRequest* request, WaitUntilDoneResponse* response) override;
   ::grpc::Status WriteBinary16Waveform(::grpc::ServerContext* context, const WriteBinary16WaveformRequest* request, WriteBinary16WaveformResponse* response) override;
   ::grpc::Status WriteComplexBinary16Waveform(::grpc::ServerContext* context, const WriteComplexBinary16WaveformRequest* request, WriteComplexBinary16WaveformResponse* response) override;

--- a/generated/nirfsa/nirfsa.proto
+++ b/generated/nirfsa/nirfsa.proto
@@ -110,7 +110,6 @@ service NiRFSA {
   rpc Initiate(InitiateRequest) returns (InitiateResponse);
   rpc InvalidateAllAttributes(InvalidateAllAttributesRequest) returns (InvalidateAllAttributesResponse);
   rpc IsSelfCalValid(IsSelfCalValidRequest) returns (IsSelfCalValidResponse);
-  rpc LockSession(LockSessionRequest) returns (LockSessionResponse);
   rpc PerformThermalCorrection(PerformThermalCorrectionRequest) returns (PerformThermalCorrectionResponse);
   rpc ReadIQSingleRecordComplexF64(ReadIQSingleRecordComplexF64Request) returns (ReadIQSingleRecordComplexF64Response);
   rpc ReadPowerSpectrumF32(ReadPowerSpectrumF32Request) returns (ReadPowerSpectrumF32Response);
@@ -134,7 +133,6 @@ service NiRFSA {
   rpc SetAttributeViString(SetAttributeViStringRequest) returns (SetAttributeViStringResponse);
   rpc SetCalUserDefinedInfo(SetCalUserDefinedInfoRequest) returns (SetCalUserDefinedInfoResponse);
   rpc SetUserData(SetUserDataRequest) returns (SetUserDataResponse);
-  rpc UnlockSession(UnlockSessionRequest) returns (UnlockSessionResponse);
 }
 
 enum NiRFSAAttributes {
@@ -1808,15 +1806,6 @@ message IsSelfCalValidResponse {
   int64 valid_steps = 3;
 }
 
-message LockSessionRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message LockSessionResponse {
-  int32 status = 1;
-  bool caller_has_lock = 2;
-}
-
 message PerformThermalCorrectionRequest {
   nidevice_grpc.Session vi = 1;
 }
@@ -2060,14 +2049,5 @@ message SetUserDataRequest {
 message SetUserDataResponse {
   int32 status = 1;
   bytes data = 2;
-}
-
-message UnlockSessionRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message UnlockSessionResponse {
-  int32 status = 1;
-  bool caller_has_lock = 2;
 }
 

--- a/generated/nirfsa/nirfsa_client.cpp
+++ b/generated/nirfsa/nirfsa_client.cpp
@@ -1808,22 +1808,6 @@ is_self_cal_valid(const StubPtr& stub, const nidevice_grpc::Session& vi)
   return response;
 }
 
-LockSessionResponse
-lock_session(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = LockSessionRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = LockSessionResponse{};
-
-  raise_if_error(
-      stub->LockSession(&context, request, &response));
-
-  return response;
-}
-
 PerformThermalCorrectionResponse
 perform_thermal_correction(const StubPtr& stub, const nidevice_grpc::Session& vi)
 {
@@ -2250,22 +2234,6 @@ set_user_data(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::s
 
   raise_if_error(
       stub->SetUserData(&context, request, &response));
-
-  return response;
-}
-
-UnlockSessionResponse
-unlock_session(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = UnlockSessionRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = UnlockSessionResponse{};
-
-  raise_if_error(
-      stub->UnlockSession(&context, request, &response));
 
   return response;
 }

--- a/generated/nirfsa/nirfsa_client.h
+++ b/generated/nirfsa/nirfsa_client.h
@@ -116,7 +116,6 @@ InitializeExternalAlignmentResponse initialize_external_alignment(const StubPtr&
 InitiateResponse initiate(const StubPtr& stub, const nidevice_grpc::Session& vi);
 InvalidateAllAttributesResponse invalidate_all_attributes(const StubPtr& stub, const nidevice_grpc::Session& vi);
 IsSelfCalValidResponse is_self_cal_valid(const StubPtr& stub, const nidevice_grpc::Session& vi);
-LockSessionResponse lock_session(const StubPtr& stub, const nidevice_grpc::Session& vi);
 PerformThermalCorrectionResponse perform_thermal_correction(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ReadIQSingleRecordComplexF64Response read_iq_single_record_complex_f64(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_list, const double& timeout, const pb::int64& data_array_size);
 ReadPowerSpectrumF32Response read_power_spectrum_f32(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_list, const double& timeout, const pb::int32& data_array_size);
@@ -140,7 +139,6 @@ SetAttributeViSessionResponse set_attribute_vi_session(const StubPtr& stub, cons
 SetAttributeViStringResponse set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiRFSAAttributes& attribute_id, const simple_variant<NiRFSAStringAttributeValuesMapped, std::string>& value);
 SetCalUserDefinedInfoResponse set_cal_user_defined_info(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& info);
 SetUserDataResponse set_user_data(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& identifier, const pb::int32& buffer_size);
-UnlockSessionResponse unlock_session(const StubPtr& stub, const nidevice_grpc::Session& vi);
 
 } // namespace nirfsa_grpc::experimental::client
 

--- a/generated/nirfsa/nirfsa_library.cpp
+++ b/generated/nirfsa/nirfsa_library.cpp
@@ -1286,11 +1286,7 @@ ViStatus NiRFSALibrary::LockSession(ViSession vi, ViBoolean* callerHasLock)
   if (!function_pointers_.LockSession) {
     throw nidevice_grpc::LibraryLoadException("Could not find niRFSA_LockSession.");
   }
-#if defined(_MSC_VER)
-  return niRFSA_LockSession(vi, callerHasLock);
-#else
   return function_pointers_.LockSession(vi, callerHasLock);
-#endif
 }
 
 ViStatus NiRFSALibrary::PerformThermalCorrection(ViSession vi)
@@ -1574,11 +1570,7 @@ ViStatus NiRFSALibrary::UnlockSession(ViSession vi, ViBoolean* callerHasLock)
   if (!function_pointers_.UnlockSession) {
     throw nidevice_grpc::LibraryLoadException("Could not find niRFSA_UnlockSession.");
   }
-#if defined(_MSC_VER)
-  return niRFSA_UnlockSession(vi, callerHasLock);
-#else
   return function_pointers_.UnlockSession(vi, callerHasLock);
-#endif
 }
 
 }  // namespace nirfsa_grpc

--- a/generated/nirfsa/nirfsa_library.h
+++ b/generated/nirfsa/nirfsa_library.h
@@ -233,7 +233,7 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   using InitiatePtr = decltype(&niRFSA_Initiate);
   using InvalidateAllAttributesPtr = decltype(&niRFSA_InvalidateAllAttributes);
   using IsSelfCalValidPtr = decltype(&niRFSA_IsSelfCalValid);
-  using LockSessionPtr = decltype(&niRFSA_LockSession);
+  using LockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using PerformThermalCorrectionPtr = decltype(&niRFSA_PerformThermalCorrection);
   using ReadIQSingleRecordComplexF64Ptr = decltype(&niRFSA_ReadIQSingleRecordComplexF64);
   using ReadPowerSpectrumF32Ptr = decltype(&niRFSA_ReadPowerSpectrumF32);
@@ -257,7 +257,7 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   using SetAttributeViStringPtr = decltype(&niRFSA_SetAttributeViString);
   using SetCalUserDefinedInfoPtr = decltype(&niRFSA_SetCalUserDefinedInfo);
   using SetUserDataPtr = decltype(&niRFSA_SetUserData);
-  using UnlockSessionPtr = decltype(&niRFSA_UnlockSession);
+  using UnlockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
 
   typedef struct FunctionPointers {
     AbortPtr Abort;

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -2714,29 +2714,6 @@ namespace nirfsa_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiRFSAService::LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViBoolean caller_has_lock {};
-      auto status = library_->LockSession(vi, &caller_has_lock);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_caller_has_lock(caller_has_lock);
-      }
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiRFSAService::PerformThermalCorrection(::grpc::ServerContext* context, const PerformThermalCorrectionRequest* request, PerformThermalCorrectionResponse* response)
   {
     if (context->IsCancelled()) {
@@ -3289,29 +3266,6 @@ namespace nirfsa_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_data(data);
-      }
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiRFSAService::UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViBoolean caller_has_lock {};
-      auto status = library_->UnlockSession(vi, &caller_has_lock);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_caller_has_lock(caller_has_lock);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nirfsa/nirfsa_service.h
+++ b/generated/nirfsa/nirfsa_service.h
@@ -127,7 +127,6 @@ public:
   ::grpc::Status Initiate(::grpc::ServerContext* context, const InitiateRequest* request, InitiateResponse* response) override;
   ::grpc::Status InvalidateAllAttributes(::grpc::ServerContext* context, const InvalidateAllAttributesRequest* request, InvalidateAllAttributesResponse* response) override;
   ::grpc::Status IsSelfCalValid(::grpc::ServerContext* context, const IsSelfCalValidRequest* request, IsSelfCalValidResponse* response) override;
-  ::grpc::Status LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response) override;
   ::grpc::Status PerformThermalCorrection(::grpc::ServerContext* context, const PerformThermalCorrectionRequest* request, PerformThermalCorrectionResponse* response) override;
   ::grpc::Status ReadIQSingleRecordComplexF64(::grpc::ServerContext* context, const ReadIQSingleRecordComplexF64Request* request, ReadIQSingleRecordComplexF64Response* response) override;
   ::grpc::Status ReadPowerSpectrumF32(::grpc::ServerContext* context, const ReadPowerSpectrumF32Request* request, ReadPowerSpectrumF32Response* response) override;
@@ -151,7 +150,6 @@ public:
   ::grpc::Status SetAttributeViString(::grpc::ServerContext* context, const SetAttributeViStringRequest* request, SetAttributeViStringResponse* response) override;
   ::grpc::Status SetCalUserDefinedInfo(::grpc::ServerContext* context, const SetCalUserDefinedInfoRequest* request, SetCalUserDefinedInfoResponse* response) override;
   ::grpc::Status SetUserData(::grpc::ServerContext* context, const SetUserDataRequest* request, SetUserDataResponse* response) override;
-  ::grpc::Status UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response) override;
 
   bool is_enabled();
 private:

--- a/generated/nirfsg/nirfsg.proto
+++ b/generated/nirfsg/nirfsg.proto
@@ -92,7 +92,6 @@ service NiRFSG {
   rpc Initiate(InitiateRequest) returns (InitiateResponse);
   rpc InvalidateAllAttributes(InvalidateAllAttributesRequest) returns (InvalidateAllAttributesResponse);
   rpc LoadConfigurationsFromFile(LoadConfigurationsFromFileRequest) returns (LoadConfigurationsFromFileResponse);
-  rpc LockSession(LockSessionRequest) returns (LockSessionResponse);
   rpc PerformPowerSearch(PerformPowerSearchRequest) returns (PerformPowerSearchResponse);
   rpc PerformThermalCorrection(PerformThermalCorrectionRequest) returns (PerformThermalCorrectionResponse);
   rpc QueryArbWaveformCapabilities(QueryArbWaveformCapabilitiesRequest) returns (QueryArbWaveformCapabilitiesResponse);
@@ -120,7 +119,6 @@ service NiRFSG {
   rpc SetWaveformBurstStartLocations(SetWaveformBurstStartLocationsRequest) returns (SetWaveformBurstStartLocationsResponse);
   rpc SetWaveformBurstStopLocations(SetWaveformBurstStopLocationsRequest) returns (SetWaveformBurstStopLocationsResponse);
   rpc SetWaveformMarkerEventLocations(SetWaveformMarkerEventLocationsRequest) returns (SetWaveformMarkerEventLocationsResponse);
-  rpc UnlockSession(UnlockSessionRequest) returns (UnlockSessionResponse);
   rpc WaitUntilSettled(WaitUntilSettledRequest) returns (WaitUntilSettledResponse);
   rpc WriteArbWaveform(WriteArbWaveformRequest) returns (WriteArbWaveformResponse);
   rpc WriteArbWaveformComplexF32(WriteArbWaveformComplexF32Request) returns (WriteArbWaveformComplexF32Response);
@@ -1578,15 +1576,6 @@ message LoadConfigurationsFromFileResponse {
   int32 status = 1;
 }
 
-message LockSessionRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message LockSessionResponse {
-  int32 status = 1;
-  bool caller_has_lock = 2;
-}
-
 message PerformPowerSearchRequest {
   nidevice_grpc.Session vi = 1;
 }
@@ -1869,15 +1858,6 @@ message SetWaveformMarkerEventLocationsRequest {
 
 message SetWaveformMarkerEventLocationsResponse {
   int32 status = 1;
-}
-
-message UnlockSessionRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message UnlockSessionResponse {
-  int32 status = 1;
-  bool caller_has_lock = 2;
 }
 
 message WaitUntilSettledRequest {

--- a/generated/nirfsg/nirfsg_client.cpp
+++ b/generated/nirfsg/nirfsg_client.cpp
@@ -1537,22 +1537,6 @@ load_configurations_from_file(const StubPtr& stub, const nidevice_grpc::Session&
   return response;
 }
 
-LockSessionResponse
-lock_session(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = LockSessionRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = LockSessionResponse{};
-
-  raise_if_error(
-      stub->LockSession(&context, request, &response));
-
-  return response;
-}
-
 PerformPowerSearchResponse
 perform_power_search(const StubPtr& stub, const nidevice_grpc::Session& vi)
 {
@@ -2061,22 +2045,6 @@ set_waveform_marker_event_locations(const StubPtr& stub, const nidevice_grpc::Se
 
   raise_if_error(
       stub->SetWaveformMarkerEventLocations(&context, request, &response));
-
-  return response;
-}
-
-UnlockSessionResponse
-unlock_session(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = UnlockSessionRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = UnlockSessionResponse{};
-
-  raise_if_error(
-      stub->UnlockSession(&context, request, &response));
 
   return response;
 }

--- a/generated/nirfsg/nirfsg_client.h
+++ b/generated/nirfsg/nirfsg_client.h
@@ -98,7 +98,6 @@ InitWithOptionsResponse init_with_options(const StubPtr& stub, const pb::string&
 InitiateResponse initiate(const StubPtr& stub, const nidevice_grpc::Session& vi);
 InvalidateAllAttributesResponse invalidate_all_attributes(const StubPtr& stub, const nidevice_grpc::Session& vi);
 LoadConfigurationsFromFileResponse load_configurations_from_file(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const pb::string& file_path);
-LockSessionResponse lock_session(const StubPtr& stub, const nidevice_grpc::Session& vi);
 PerformPowerSearchResponse perform_power_search(const StubPtr& stub, const nidevice_grpc::Session& vi);
 PerformThermalCorrectionResponse perform_thermal_correction(const StubPtr& stub, const nidevice_grpc::Session& vi);
 QueryArbWaveformCapabilitiesResponse query_arb_waveform_capabilities(const StubPtr& stub, const nidevice_grpc::Session& vi);
@@ -126,7 +125,6 @@ SetUserDataResponse set_user_data(const StubPtr& stub, const nidevice_grpc::Sess
 SetWaveformBurstStartLocationsResponse set_waveform_burst_start_locations(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const std::vector<double>& locations);
 SetWaveformBurstStopLocationsResponse set_waveform_burst_stop_locations(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const std::vector<double>& locations);
 SetWaveformMarkerEventLocationsResponse set_waveform_marker_event_locations(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const std::vector<double>& locations);
-UnlockSessionResponse unlock_session(const StubPtr& stub, const nidevice_grpc::Session& vi);
 WaitUntilSettledResponse wait_until_settled(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& max_time_milliseconds);
 WriteArbWaveformResponse write_arb_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& waveform_name, const std::vector<double>& i_data, const std::vector<double>& q_data, const bool& more_data_pending);
 WriteArbWaveformComplexF32Response write_arb_waveform_complex_f32(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& waveform_name, const std::vector<NIComplexNumberF32>& wfm_data, const bool& more_data_pending);

--- a/generated/nirfsg/nirfsg_library.cpp
+++ b/generated/nirfsg/nirfsg_library.cpp
@@ -1064,11 +1064,7 @@ ViStatus NiRFSGLibrary::LockSession(ViSession vi, ViBoolean* callerHasLock)
   if (!function_pointers_.LockSession) {
     throw nidevice_grpc::LibraryLoadException("Could not find niRFSG_LockSession.");
   }
-#if defined(_MSC_VER)
-  return niRFSG_LockSession(vi, callerHasLock);
-#else
   return function_pointers_.LockSession(vi, callerHasLock);
-#endif
 }
 
 ViStatus NiRFSGLibrary::PerformPowerSearch(ViSession vi)
@@ -1400,11 +1396,7 @@ ViStatus NiRFSGLibrary::UnlockSession(ViSession vi, ViBoolean* callerHasLock)
   if (!function_pointers_.UnlockSession) {
     throw nidevice_grpc::LibraryLoadException("Could not find niRFSG_UnlockSession.");
   }
-#if defined(_MSC_VER)
-  return niRFSG_UnlockSession(vi, callerHasLock);
-#else
   return function_pointers_.UnlockSession(vi, callerHasLock);
-#endif
 }
 
 ViStatus NiRFSGLibrary::WaitUntilSettled(ViSession vi, ViInt32 maxTimeMilliseconds)

--- a/generated/nirfsg/nirfsg_library.h
+++ b/generated/nirfsg/nirfsg_library.h
@@ -209,7 +209,7 @@ class NiRFSGLibrary : public nirfsg_grpc::NiRFSGLibraryInterface {
   using InitiatePtr = decltype(&niRFSG_Initiate);
   using InvalidateAllAttributesPtr = decltype(&niRFSG_InvalidateAllAttributes);
   using LoadConfigurationsFromFilePtr = decltype(&niRFSG_LoadConfigurationsFromFile);
-  using LockSessionPtr = decltype(&niRFSG_LockSession);
+  using LockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using PerformPowerSearchPtr = decltype(&niRFSG_PerformPowerSearch);
   using PerformThermalCorrectionPtr = decltype(&niRFSG_PerformThermalCorrection);
   using QueryArbWaveformCapabilitiesPtr = decltype(&niRFSG_QueryArbWaveformCapabilities);
@@ -237,7 +237,7 @@ class NiRFSGLibrary : public nirfsg_grpc::NiRFSGLibraryInterface {
   using SetWaveformBurstStartLocationsPtr = decltype(&niRFSG_SetWaveformBurstStartLocations);
   using SetWaveformBurstStopLocationsPtr = decltype(&niRFSG_SetWaveformBurstStopLocations);
   using SetWaveformMarkerEventLocationsPtr = decltype(&niRFSG_SetWaveformMarkerEventLocations);
-  using UnlockSessionPtr = decltype(&niRFSG_UnlockSession);
+  using UnlockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using WaitUntilSettledPtr = decltype(&niRFSG_WaitUntilSettled);
   using WriteArbWaveformPtr = decltype(&niRFSG_WriteArbWaveform);
   using WriteArbWaveformComplexF32Ptr = decltype(&niRFSG_WriteArbWaveformComplexF32);

--- a/generated/nirfsg/nirfsg_service.cpp
+++ b/generated/nirfsg/nirfsg_service.cpp
@@ -2363,29 +2363,6 @@ namespace nirfsg_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiRFSGService::LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViBoolean caller_has_lock {};
-      auto status = library_->LockSession(vi, &caller_has_lock);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_caller_has_lock(caller_has_lock);
-      }
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiRFSGService::PerformPowerSearch(::grpc::ServerContext* context, const PerformPowerSearchRequest* request, PerformPowerSearchResponse* response)
   {
     if (context->IsCancelled()) {
@@ -3045,29 +3022,6 @@ namespace nirfsg_grpc {
       auto locations = const_cast<ViReal64*>(request->locations().data());
       auto status = library_->SetWaveformMarkerEventLocations(vi, channel_name, number_of_locations, locations);
       response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiRFSGService::UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViBoolean caller_has_lock {};
-      auto status = library_->UnlockSession(vi, &caller_has_lock);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_caller_has_lock(caller_has_lock);
-      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {

--- a/generated/nirfsg/nirfsg_service.h
+++ b/generated/nirfsg/nirfsg_service.h
@@ -109,7 +109,6 @@ public:
   ::grpc::Status Initiate(::grpc::ServerContext* context, const InitiateRequest* request, InitiateResponse* response) override;
   ::grpc::Status InvalidateAllAttributes(::grpc::ServerContext* context, const InvalidateAllAttributesRequest* request, InvalidateAllAttributesResponse* response) override;
   ::grpc::Status LoadConfigurationsFromFile(::grpc::ServerContext* context, const LoadConfigurationsFromFileRequest* request, LoadConfigurationsFromFileResponse* response) override;
-  ::grpc::Status LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response) override;
   ::grpc::Status PerformPowerSearch(::grpc::ServerContext* context, const PerformPowerSearchRequest* request, PerformPowerSearchResponse* response) override;
   ::grpc::Status PerformThermalCorrection(::grpc::ServerContext* context, const PerformThermalCorrectionRequest* request, PerformThermalCorrectionResponse* response) override;
   ::grpc::Status QueryArbWaveformCapabilities(::grpc::ServerContext* context, const QueryArbWaveformCapabilitiesRequest* request, QueryArbWaveformCapabilitiesResponse* response) override;
@@ -137,7 +136,6 @@ public:
   ::grpc::Status SetWaveformBurstStartLocations(::grpc::ServerContext* context, const SetWaveformBurstStartLocationsRequest* request, SetWaveformBurstStartLocationsResponse* response) override;
   ::grpc::Status SetWaveformBurstStopLocations(::grpc::ServerContext* context, const SetWaveformBurstStopLocationsRequest* request, SetWaveformBurstStopLocationsResponse* response) override;
   ::grpc::Status SetWaveformMarkerEventLocations(::grpc::ServerContext* context, const SetWaveformMarkerEventLocationsRequest* request, SetWaveformMarkerEventLocationsResponse* response) override;
-  ::grpc::Status UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response) override;
   ::grpc::Status WaitUntilSettled(::grpc::ServerContext* context, const WaitUntilSettledRequest* request, WaitUntilSettledResponse* response) override;
   ::grpc::Status WriteArbWaveform(::grpc::ServerContext* context, const WriteArbWaveformRequest* request, WriteArbWaveformResponse* response) override;
   ::grpc::Status WriteArbWaveformComplexF32(::grpc::ServerContext* context, const WriteArbWaveformComplexF32Request* request, WriteArbWaveformComplexF32Response* response) override;

--- a/generated/niscope/niscope.proto
+++ b/generated/niscope/niscope.proto
@@ -87,7 +87,6 @@ service NiScope {
   rpc Init(InitRequest) returns (InitResponse);
   rpc InitWithOptions(InitWithOptionsRequest) returns (InitWithOptionsResponse);
   rpc InitiateAcquisition(InitiateAcquisitionRequest) returns (InitiateAcquisitionResponse);
-  rpc LockSession(LockSessionRequest) returns (LockSessionResponse);
   rpc ProbeCompensationSignalStart(ProbeCompensationSignalStartRequest) returns (ProbeCompensationSignalStartResponse);
   rpc ProbeCompensationSignalStop(ProbeCompensationSignalStopRequest) returns (ProbeCompensationSignalStopResponse);
   rpc Read(ReadRequest) returns (ReadResponse);
@@ -105,7 +104,6 @@ service NiScope {
   rpc SetAttributeViReal64(SetAttributeViReal64Request) returns (SetAttributeViReal64Response);
   rpc SetAttributeViSession(SetAttributeViSessionRequest) returns (SetAttributeViSessionResponse);
   rpc SetAttributeViString(SetAttributeViStringRequest) returns (SetAttributeViStringResponse);
-  rpc UnlockSession(UnlockSessionRequest) returns (UnlockSessionResponse);
 }
 
 enum NiScopeAttributes {
@@ -1670,15 +1668,6 @@ message InitiateAcquisitionResponse {
   int32 status = 1;
 }
 
-message LockSessionRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message LockSessionResponse {
-  int32 status = 1;
-  bool caller_has_lock = 2;
-}
-
 message ProbeCompensationSignalStartRequest {
   nidevice_grpc.Session vi = 1;
 }
@@ -1862,14 +1851,5 @@ message SetAttributeViStringRequest {
 
 message SetAttributeViStringResponse {
   int32 status = 1;
-}
-
-message UnlockSessionRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message UnlockSessionResponse {
-  int32 status = 1;
-  bool caller_has_lock = 2;
 }
 

--- a/generated/niscope/niscope_client.cpp
+++ b/generated/niscope/niscope_client.cpp
@@ -1540,22 +1540,6 @@ initiate_acquisition(const StubPtr& stub, const nidevice_grpc::Session& vi)
   return response;
 }
 
-LockSessionResponse
-lock_session(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = LockSessionRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = LockSessionResponse{};
-
-  raise_if_error(
-      stub->LockSession(&context, request, &response));
-
-  return response;
-}
-
 ProbeCompensationSignalStartResponse
 probe_compensation_signal_start(const StubPtr& stub, const nidevice_grpc::Session& vi)
 {
@@ -1884,22 +1868,6 @@ set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
 
   raise_if_error(
       stub->SetAttributeViString(&context, request, &response));
-
-  return response;
-}
-
-UnlockSessionResponse
-unlock_session(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = UnlockSessionRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = UnlockSessionResponse{};
-
-  raise_if_error(
-      stub->UnlockSession(&context, request, &response));
 
   return response;
 }

--- a/generated/niscope/niscope_client.h
+++ b/generated/niscope/niscope_client.h
@@ -93,7 +93,6 @@ ImportAttributeConfigurationFileResponse import_attribute_configuration_file(con
 InitResponse init(const StubPtr& stub, const pb::string& resource_name, const bool& id_query, const bool& reset_device);
 InitWithOptionsResponse init_with_options(const StubPtr& stub, const pb::string& resource_name, const bool& id_query, const bool& reset_device, const pb::string& option_string);
 InitiateAcquisitionResponse initiate_acquisition(const StubPtr& stub, const nidevice_grpc::Session& vi);
-LockSessionResponse lock_session(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ProbeCompensationSignalStartResponse probe_compensation_signal_start(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ProbeCompensationSignalStopResponse probe_compensation_signal_stop(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ReadResponse read(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_list, const double& timeout, const pb::int32& num_samples);
@@ -111,7 +110,6 @@ SetAttributeViInt64Response set_attribute_vi_int64(const StubPtr& stub, const ni
 SetAttributeViReal64Response set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_list, const NiScopeAttributes& attribute_id, const simple_variant<NiScopeReal64AttributeValues, double>& value);
 SetAttributeViSessionResponse set_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_list, const NiScopeAttributes& attribute_id, const nidevice_grpc::Session& value);
 SetAttributeViStringResponse set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_list, const NiScopeAttributes& attribute_id, const pb::string& value_raw);
-UnlockSessionResponse unlock_session(const StubPtr& stub, const nidevice_grpc::Session& vi);
 
 } // namespace niscope_grpc::experimental::client
 

--- a/generated/niscope/niscope_library.cpp
+++ b/generated/niscope/niscope_library.cpp
@@ -981,11 +981,7 @@ ViStatus NiScopeLibrary::LockSession(ViSession vi, ViBoolean* callerHasLock)
   if (!function_pointers_.LockSession) {
     throw nidevice_grpc::LibraryLoadException("Could not find niScope_LockSession.");
   }
-#if defined(_MSC_VER)
-  return niScope_LockSession(vi, callerHasLock);
-#else
   return function_pointers_.LockSession(vi, callerHasLock);
-#endif
 }
 
 ViStatus NiScopeLibrary::ProbeCompensationSignalStart(ViSession vi)
@@ -1197,11 +1193,7 @@ ViStatus NiScopeLibrary::UnlockSession(ViSession vi, ViBoolean* callerHasLock)
   if (!function_pointers_.UnlockSession) {
     throw nidevice_grpc::LibraryLoadException("Could not find niScope_UnlockSession.");
   }
-#if defined(_MSC_VER)
-  return niScope_UnlockSession(vi, callerHasLock);
-#else
   return function_pointers_.UnlockSession(vi, callerHasLock);
-#endif
 }
 
 }  // namespace niscope_grpc

--- a/generated/niscope/niscope_library.h
+++ b/generated/niscope/niscope_library.h
@@ -181,7 +181,7 @@ class NiScopeLibrary : public niscope_grpc::NiScopeLibraryInterface {
   using InitPtr = decltype(&niScope_init);
   using InitWithOptionsPtr = decltype(&niScope_InitWithOptions);
   using InitiateAcquisitionPtr = decltype(&niScope_InitiateAcquisition);
-  using LockSessionPtr = decltype(&niScope_LockSession);
+  using LockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using ProbeCompensationSignalStartPtr = decltype(&niScope_ProbeCompensationSignalStart);
   using ProbeCompensationSignalStopPtr = decltype(&niScope_ProbeCompensationSignalStop);
   using ReadPtr = decltype(&niScope_Read);
@@ -199,7 +199,7 @@ class NiScopeLibrary : public niscope_grpc::NiScopeLibraryInterface {
   using SetAttributeViReal64Ptr = decltype(&niScope_SetAttributeViReal64);
   using SetAttributeViSessionPtr = decltype(&niScope_SetAttributeViSession);
   using SetAttributeViStringPtr = decltype(&niScope_SetAttributeViString);
-  using UnlockSessionPtr = decltype(&niScope_UnlockSession);
+  using UnlockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
 
   typedef struct FunctionPointers {
     AbortPtr Abort;

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -1947,29 +1947,6 @@ namespace niscope_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiScopeService::LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViBoolean caller_has_lock {};
-      auto status = library_->LockSession(vi, &caller_has_lock);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_caller_has_lock(caller_has_lock);
-      }
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::ProbeCompensationSignalStart(::grpc::ServerContext* context, const ProbeCompensationSignalStartRequest* request, ProbeCompensationSignalStartResponse* response)
   {
     if (context->IsCancelled()) {
@@ -2346,29 +2323,6 @@ namespace niscope_grpc {
       auto value = request->value_raw().c_str();
       auto status = library_->SetAttributeViString(vi, channel_list, attribute_id, value);
       response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiScopeService::UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViBoolean caller_has_lock {};
-      auto status = library_->UnlockSession(vi, &caller_has_lock);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_caller_has_lock(caller_has_lock);
-      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {

--- a/generated/niscope/niscope_service.h
+++ b/generated/niscope/niscope_service.h
@@ -104,7 +104,6 @@ public:
   ::grpc::Status Init(::grpc::ServerContext* context, const InitRequest* request, InitResponse* response) override;
   ::grpc::Status InitWithOptions(::grpc::ServerContext* context, const InitWithOptionsRequest* request, InitWithOptionsResponse* response) override;
   ::grpc::Status InitiateAcquisition(::grpc::ServerContext* context, const InitiateAcquisitionRequest* request, InitiateAcquisitionResponse* response) override;
-  ::grpc::Status LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response) override;
   ::grpc::Status ProbeCompensationSignalStart(::grpc::ServerContext* context, const ProbeCompensationSignalStartRequest* request, ProbeCompensationSignalStartResponse* response) override;
   ::grpc::Status ProbeCompensationSignalStop(::grpc::ServerContext* context, const ProbeCompensationSignalStopRequest* request, ProbeCompensationSignalStopResponse* response) override;
   ::grpc::Status Read(::grpc::ServerContext* context, const ReadRequest* request, ReadResponse* response) override;
@@ -122,7 +121,6 @@ public:
   ::grpc::Status SetAttributeViReal64(::grpc::ServerContext* context, const SetAttributeViReal64Request* request, SetAttributeViReal64Response* response) override;
   ::grpc::Status SetAttributeViSession(::grpc::ServerContext* context, const SetAttributeViSessionRequest* request, SetAttributeViSessionResponse* response) override;
   ::grpc::Status SetAttributeViString(::grpc::ServerContext* context, const SetAttributeViStringRequest* request, SetAttributeViStringResponse* response) override;
-  ::grpc::Status UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response) override;
 
   bool is_enabled();
 private:

--- a/generated/niswitch/niswitch.proto
+++ b/generated/niswitch/niswitch.proto
@@ -57,7 +57,6 @@ service NiSwitch {
   rpc InvalidateAllAttributes(InvalidateAllAttributesRequest) returns (InvalidateAllAttributesResponse);
   rpc IsDebounced(IsDebouncedRequest) returns (IsDebouncedResponse);
   rpc IsScanning(IsScanningRequest) returns (IsScanningResponse);
-  rpc LockSession(LockSessionRequest) returns (LockSessionResponse);
   rpc RelayControl(RelayControlRequest) returns (RelayControlResponse);
   rpc Reset(ResetRequest) returns (ResetResponse);
   rpc ResetInterchangeCheck(ResetInterchangeCheckRequest) returns (ResetInterchangeCheckResponse);
@@ -75,7 +74,6 @@ service NiSwitch {
   rpc SetAttributeViSession(SetAttributeViSessionRequest) returns (SetAttributeViSessionResponse);
   rpc SetContinuousScan(SetContinuousScanRequest) returns (SetContinuousScanResponse);
   rpc SetPath(SetPathRequest) returns (SetPathResponse);
-  rpc UnlockSession(UnlockSessionRequest) returns (UnlockSessionResponse);
   rpc WaitForDebounce(WaitForDebounceRequest) returns (WaitForDebounceResponse);
   rpc WaitForScanComplete(WaitForScanCompleteRequest) returns (WaitForScanCompleteResponse);
 }
@@ -775,15 +773,6 @@ message IsScanningResponse {
   bool is_scanning = 2;
 }
 
-message LockSessionRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message LockSessionResponse {
-  int32 status = 1;
-  bool caller_has_lock = 2;
-}
-
 message RelayControlRequest {
   nidevice_grpc.Session vi = 1;
   string relay_name = 2;
@@ -970,15 +959,6 @@ message SetPathRequest {
 
 message SetPathResponse {
   int32 status = 1;
-}
-
-message UnlockSessionRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message UnlockSessionResponse {
-  int32 status = 1;
-  bool caller_has_lock = 2;
 }
 
 message WaitForDebounceRequest {

--- a/generated/niswitch/niswitch_client.cpp
+++ b/generated/niswitch/niswitch_client.cpp
@@ -754,22 +754,6 @@ is_scanning(const StubPtr& stub, const nidevice_grpc::Session& vi)
   return response;
 }
 
-LockSessionResponse
-lock_session(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = LockSessionRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = LockSessionResponse{};
-
-  raise_if_error(
-      stub->LockSession(&context, request, &response));
-
-  return response;
-}
-
 RelayControlResponse
 relay_control(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& relay_name, const simple_variant<RelayAction, pb::int32>& relay_action)
 {
@@ -1114,22 +1098,6 @@ set_path(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string
 
   raise_if_error(
       stub->SetPath(&context, request, &response));
-
-  return response;
-}
-
-UnlockSessionResponse
-unlock_session(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = UnlockSessionRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = UnlockSessionResponse{};
-
-  raise_if_error(
-      stub->UnlockSession(&context, request, &response));
 
   return response;
 }

--- a/generated/niswitch/niswitch_client.h
+++ b/generated/niswitch/niswitch_client.h
@@ -63,7 +63,6 @@ InitiateScanResponse initiate_scan(const StubPtr& stub, const nidevice_grpc::Ses
 InvalidateAllAttributesResponse invalidate_all_attributes(const StubPtr& stub, const nidevice_grpc::Session& vi);
 IsDebouncedResponse is_debounced(const StubPtr& stub, const nidevice_grpc::Session& vi);
 IsScanningResponse is_scanning(const StubPtr& stub, const nidevice_grpc::Session& vi);
-LockSessionResponse lock_session(const StubPtr& stub, const nidevice_grpc::Session& vi);
 RelayControlResponse relay_control(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& relay_name, const simple_variant<RelayAction, pb::int32>& relay_action);
 ResetResponse reset(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ResetInterchangeCheckResponse reset_interchange_check(const StubPtr& stub, const nidevice_grpc::Session& vi);
@@ -81,7 +80,6 @@ SetAttributeViStringResponse set_attribute_vi_string(const StubPtr& stub, const 
 SetAttributeViSessionResponse set_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiSwitchAttributes& attribute_id, const nidevice_grpc::Session& attribute_value);
 SetContinuousScanResponse set_continuous_scan(const StubPtr& stub, const nidevice_grpc::Session& vi, const bool& continuous_scan);
 SetPathResponse set_path(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& path_list);
-UnlockSessionResponse unlock_session(const StubPtr& stub, const nidevice_grpc::Session& vi);
 WaitForDebounceResponse wait_for_debounce(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& maximum_time_ms);
 WaitForScanCompleteResponse wait_for_scan_complete(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& maximum_time_ms);
 

--- a/generated/niswitch/niswitch_library.cpp
+++ b/generated/niswitch/niswitch_library.cpp
@@ -593,11 +593,7 @@ ViStatus NiSwitchLibrary::LockSession(ViSession vi, ViBoolean* callerHasLock)
   if (!function_pointers_.LockSession) {
     throw nidevice_grpc::LibraryLoadException("Could not find niSwitch_LockSession.");
   }
-#if defined(_MSC_VER)
-  return niSwitch_LockSession(vi, callerHasLock);
-#else
   return function_pointers_.LockSession(vi, callerHasLock);
-#endif
 }
 
 ViStatus NiSwitchLibrary::RelayControl(ViSession vi, ViConstString relayName, ViInt32 relayAction)
@@ -809,11 +805,7 @@ ViStatus NiSwitchLibrary::UnlockSession(ViSession vi, ViBoolean* callerHasLock)
   if (!function_pointers_.UnlockSession) {
     throw nidevice_grpc::LibraryLoadException("Could not find niSwitch_UnlockSession.");
   }
-#if defined(_MSC_VER)
-  return niSwitch_UnlockSession(vi, callerHasLock);
-#else
   return function_pointers_.UnlockSession(vi, callerHasLock);
-#endif
 }
 
 ViStatus NiSwitchLibrary::WaitForDebounce(ViSession vi, ViInt32 maximumTimeMs)

--- a/generated/niswitch/niswitch_library.h
+++ b/generated/niswitch/niswitch_library.h
@@ -123,7 +123,7 @@ class NiSwitchLibrary : public niswitch_grpc::NiSwitchLibraryInterface {
   using InvalidateAllAttributesPtr = decltype(&niSwitch_InvalidateAllAttributes);
   using IsDebouncedPtr = decltype(&niSwitch_IsDebounced);
   using IsScanningPtr = decltype(&niSwitch_IsScanning);
-  using LockSessionPtr = decltype(&niSwitch_LockSession);
+  using LockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using RelayControlPtr = decltype(&niSwitch_RelayControl);
   using ResetPtr = decltype(&niSwitch_reset);
   using ResetInterchangeCheckPtr = decltype(&niSwitch_ResetInterchangeCheck);
@@ -141,7 +141,7 @@ class NiSwitchLibrary : public niswitch_grpc::NiSwitchLibraryInterface {
   using SetAttributeViSessionPtr = decltype(&niSwitch_SetAttributeViSession);
   using SetContinuousScanPtr = decltype(&niSwitch_SetContinuousScan);
   using SetPathPtr = decltype(&niSwitch_SetPath);
-  using UnlockSessionPtr = decltype(&niSwitch_UnlockSession);
+  using UnlockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using WaitForDebouncePtr = decltype(&niSwitch_WaitForDebounce);
   using WaitForScanCompletePtr = decltype(&niSwitch_WaitForScanComplete);
 

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -1160,29 +1160,6 @@ namespace niswitch_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiSwitchService::LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViBoolean caller_has_lock {};
-      auto status = library_->LockSession(vi, &caller_has_lock);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_caller_has_lock(caller_has_lock);
-      }
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::RelayControl(::grpc::ServerContext* context, const RelayControlRequest* request, RelayControlResponse* response)
   {
     if (context->IsCancelled()) {
@@ -1642,29 +1619,6 @@ namespace niswitch_grpc {
       auto path_list = request->path_list().c_str();
       auto status = library_->SetPath(vi, path_list);
       response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiSwitchService::UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViBoolean caller_has_lock {};
-      auto status = library_->UnlockSession(vi, &caller_has_lock);
-      response->set_status(status);
-      if (status == 0) {
-        response->set_caller_has_lock(caller_has_lock);
-      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {

--- a/generated/niswitch/niswitch_service.h
+++ b/generated/niswitch/niswitch_service.h
@@ -74,7 +74,6 @@ public:
   ::grpc::Status InvalidateAllAttributes(::grpc::ServerContext* context, const InvalidateAllAttributesRequest* request, InvalidateAllAttributesResponse* response) override;
   ::grpc::Status IsDebounced(::grpc::ServerContext* context, const IsDebouncedRequest* request, IsDebouncedResponse* response) override;
   ::grpc::Status IsScanning(::grpc::ServerContext* context, const IsScanningRequest* request, IsScanningResponse* response) override;
-  ::grpc::Status LockSession(::grpc::ServerContext* context, const LockSessionRequest* request, LockSessionResponse* response) override;
   ::grpc::Status RelayControl(::grpc::ServerContext* context, const RelayControlRequest* request, RelayControlResponse* response) override;
   ::grpc::Status Reset(::grpc::ServerContext* context, const ResetRequest* request, ResetResponse* response) override;
   ::grpc::Status ResetInterchangeCheck(::grpc::ServerContext* context, const ResetInterchangeCheckRequest* request, ResetInterchangeCheckResponse* response) override;
@@ -92,7 +91,6 @@ public:
   ::grpc::Status SetAttributeViSession(::grpc::ServerContext* context, const SetAttributeViSessionRequest* request, SetAttributeViSessionResponse* response) override;
   ::grpc::Status SetContinuousScan(::grpc::ServerContext* context, const SetContinuousScanRequest* request, SetContinuousScanResponse* response) override;
   ::grpc::Status SetPath(::grpc::ServerContext* context, const SetPathRequest* request, SetPathResponse* response) override;
-  ::grpc::Status UnlockSession(::grpc::ServerContext* context, const UnlockSessionRequest* request, UnlockSessionResponse* response) override;
   ::grpc::Status WaitForDebounce(::grpc::ServerContext* context, const WaitForDebounceRequest* request, WaitForDebounceResponse* response) override;
   ::grpc::Status WaitForScanComplete(::grpc::ServerContext* context, const WaitForScanCompleteRequest* request, WaitForScanCompleteResponse* response) override;
 

--- a/source/codegen/metadata/nidcpower/functions.py
+++ b/source/codegen/metadata/nidcpower/functions.py
@@ -2204,6 +2204,7 @@ functions = {
     'returns': 'ViStatus'
   },
   'LockSession': {
+    'codegen_method': 'private',
     'parameters': [
       {
         'name': 'vi',
@@ -2735,6 +2736,7 @@ functions = {
     'returns': 'ViStatus'
   },
   'UnlockSession': {
+    'codegen_method': 'private',
     'parameters': [
       {
         'name': 'vi',

--- a/source/codegen/metadata/nidigitalpattern/functions.py
+++ b/source/codegen/metadata/nidigitalpattern/functions.py
@@ -2382,6 +2382,7 @@ functions = {
         "returns": "ViStatus"
     },
     "LockSession": {
+        'codegen_method': 'private',
         "parameters": [
             {
                 "direction": "in",
@@ -3091,6 +3092,7 @@ functions = {
         "returns": "ViStatus"
     },
     "UnlockSession": {
+        'codegen_method': 'private',
         "parameters": [
             {
                 "direction": "in",

--- a/source/codegen/metadata/nidmm/functions.py
+++ b/source/codegen/metadata/nidmm/functions.py
@@ -1463,6 +1463,7 @@ functions = {
         "returns": "ViStatus"
     },
     'LockSession': {
+        'codegen_method': 'private',
         'parameters': [
             {
                 'direction': 'in',
@@ -1863,6 +1864,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'UnlockSession': {
+        'codegen_method': 'private',
         'parameters': [
             {
                 'direction': 'in',

--- a/source/codegen/metadata/nifgen/functions.py
+++ b/source/codegen/metadata/nifgen/functions.py
@@ -2168,6 +2168,7 @@ functions = {
         'returns':'ViStatus'
     },
     'LockSession':{
+        'codegen_method': 'private',
         'parameters':[
             {
                 'name':'vi',
@@ -2698,6 +2699,7 @@ functions = {
         'returns':'ViStatus'
     },
     'UnlockSession':{
+        'codegen_method': 'private',
         'parameters':[
             {
                 'name':'vi',

--- a/source/codegen/metadata/nirfsa/functions.py
+++ b/source/codegen/metadata/nirfsa/functions.py
@@ -2345,6 +2345,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'LockSession': {
+        'codegen_method': 'private',
         'parameters': [
             {
                 'direction': 'in',
@@ -2890,6 +2891,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'UnlockSession': {
+        'codegen_method': 'private',
         'parameters': [
             {
                 'direction': 'in',

--- a/source/codegen/metadata/nirfsg/functions.py
+++ b/source/codegen/metadata/nirfsg/functions.py
@@ -1684,6 +1684,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'LockSession': {
+        'codegen_method': 'private',
         'parameters': [
             {
                 'direction': 'in',
@@ -2288,6 +2289,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'UnlockSession': {
+        'codegen_method': 'private',
         'parameters': [
             {
                 'direction': 'in',

--- a/source/codegen/metadata/niscope/functions.py
+++ b/source/codegen/metadata/niscope/functions.py
@@ -2194,6 +2194,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'LockSession': {
+        'codegen_method': 'private',
         'parameters': [
             {
                 'direction': 'in',
@@ -2606,6 +2607,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'UnlockSession': {
+        'codegen_method': 'private',
         'parameters': [
             {
                 'direction': 'in',

--- a/source/codegen/metadata/niswitch/functions.py
+++ b/source/codegen/metadata/niswitch/functions.py
@@ -878,6 +878,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'LockSession': {
+        'codegen_method': 'private',
         'parameters': [
             {
                 'direction': 'in',
@@ -1242,6 +1243,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'UnlockSession': {
+        'codegen_method': 'private',
         'parameters': [
             {
                 'direction': 'in',


### PR DESCRIPTION
### What does this Pull Request accomplish?

Remove `LockSession` and `UnlockSession` from all driver services.

Mark as `private` so that we can still use those methods internally in codegen if needed (this was discussed as an option for ivi-dance race conditions).

### Why should this Pull Request be merged?

Fixes #394 

Session locks have a thread affinity. Our server implementation runs on a thread pool and has no way to ensure that lock/access/unlock occur on the same thread. These methods are fundamentally broken.

Clients should use the session-level `Reserve`/`Unreserve` methods from `session.proto`.

### What testing has been done?

Ensured methods were correctly removed and are not called from tests/examples/etc.