### PR TITLE
Make server default max message size infinite

### DIFF
--- a/source/server/core_server.cpp
+++ b/source/server/core_server.cpp
@@ -42,6 +42,7 @@ struct ServerConfiguration {
   std::string server_cert;
   std::string server_key;
   std::string root_cert;
+  int max_message_size;
   nidevice_grpc::FeatureToggles feature_toggles;
 };
 
@@ -56,6 +57,7 @@ static ServerConfiguration GetConfiguration(const std::string& config_file_path)
     config.server_cert = server_config_parser.parse_server_cert();
     config.server_key = server_config_parser.parse_server_key();
     config.root_cert = server_config_parser.parse_root_cert();
+    config.max_message_size = server_config_parser.parse_max_message_size();
     config.feature_toggles = server_config_parser.parse_feature_toggles();
   }
   catch (const std::exception& ex) {
@@ -150,6 +152,9 @@ static void RunServer(const ServerConfiguration& config)
   if (nirfsa_service.is_enabled()) {
     builder.RegisterService(&nirfsa_service);
   }
+
+  builder.SetMaxSendMessageSize(config.max_message_size);
+  builder.SetMaxReceiveMessageSize(config.max_message_size);
 
   // Assemble the server.
   {

--- a/source/server/server_configuration_parser.cpp
+++ b/source/server/server_configuration_parser.cpp
@@ -21,6 +21,7 @@ static const char* kServerKeyJsonKey = "server_key";
 static const char* kRootCertJsonKey = "root_cert";
 static const char* kSecurityJsonKey = "security";
 static const char* kCertsFolderName = "certs";
+static const char* kMaxMessageSizeKey = "max_message_size";
 static const char* kFeatureTogglesKey = "feature_toggles";
 #if defined(_MSC_VER)
 static const char* kPathDelimitter = "\\";
@@ -131,6 +132,21 @@ std::string ServerConfigurationParser::parse_root_cert() const
   return file_name.empty() ? "" : read_keycert(certs_directory_ + kPathDelimitter + file_name);
 }
 
+int ServerConfigurationParser::parse_max_message_size() const
+{
+  auto max_size_section_it = config_file_.find(kMaxMessageSizeKey);
+  if (max_size_section_it != config_file_.end()) {
+    try {
+      return max_size_section_it->get<int>();
+    }
+    catch (const nlohmann::json::type_error& ex) {
+      throw InvalidMaxMessageSizeException(ex.what());
+    }
+  }
+
+  return UNLIMITED_MAX_MESSAGE_SIZE;
+}
+
 FeatureToggles ServerConfigurationParser::parse_feature_toggles() const
 {
   FeatureToggleConfigurationMap map;
@@ -223,6 +239,11 @@ ServerConfigurationParser::InvalidExePathException::InvalidExePathException()
 
 ServerConfigurationParser::InvalidFeatureToggleException::InvalidFeatureToggleException(const std::string& type_error_details)
     : std::runtime_error(kInvalidFeatureToggleMessage + type_error_details)
+{
+}
+
+ServerConfigurationParser::InvalidMaxMessageSizeException::InvalidMaxMessageSizeException(const std::string& type_error_details)
+    : std::runtime_error(kInvalidMaxMessageSizeMessage + type_error_details)
 {
 }
 }  // namespace nidevice_grpc

--- a/source/server/server_configuration_parser.h
+++ b/source/server/server_configuration_parser.h
@@ -16,8 +16,10 @@ static const char* kUnspecifiedPortMessage = "The server port must be specified 
 static const char* kValueTypeNotStringMessage = "The following key must be specified in the server's configuration file as a string enclosed with double quotes: ";
 static const char* kFileNotFoundMessage = "The following certificate file was not found: ";
 static const char* kInvalidExePathMessage = "The server was unable to resolve the current executable path.";
+static const char* kInvalidMaxMessageSizeMessage = "The max message size must be an integer.";
 static const char* kInvalidFeatureToggleMessage = "Feature Toggles must be specified as boolean fields in the form \"feature_toggles\": { \"feature1\": true, \"feature2\": false }. \n\n";
 static const char* kDefaultAddressPrefix = "[::]:";
+constexpr int UNLIMITED_MAX_MESSAGE_SIZE = -1;
 
 class ServerConfigurationParser {
  public:
@@ -32,6 +34,7 @@ class ServerConfigurationParser {
   std::string parse_server_cert() const;
   std::string parse_server_key() const;
   std::string parse_root_cert() const;
+  int parse_max_message_size() const;
   FeatureToggles parse_feature_toggles() const;
 
   struct ConfigFileNotFoundException : public std::runtime_error {
@@ -68,6 +71,10 @@ class ServerConfigurationParser {
 
   struct InvalidFeatureToggleException : std::runtime_error {
     InvalidFeatureToggleException(const std::string& type_error_details);
+  };
+
+  struct InvalidMaxMessageSizeException : std::runtime_error {
+    InvalidMaxMessageSizeException(const std::string& type_error_details);
   };
 
  private:


### PR DESCRIPTION
### What does this Pull Request accomplish?

Make the default max message size for the server infinite.

Add a `max_message_size` configuration option to use a different setting.

### Why should this Pull Request be merged?

The grpc default `max_message_size` is 4MB (enforced on receive). Some RF users use much larger waveforms and on many systems, that works fine.

### What testing has been done?

Manual testing with an above-default-limit waveform in RFSG: failed without change, passed with it, gives expected results with custom `max_message_size`.