### PR TITLE
Fixup fixed size strings in RFSA/G

### DIFF
--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -108,6 +108,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_device_name_out(device_name_out);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_device_name_out()));
         }
         return ::grpc::Status::OK;
       }
@@ -7172,6 +7173,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_port_list(port_list);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_port_list()));
         }
         return ::grpc::Status::OK;
       }
@@ -7356,6 +7358,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -7653,6 +7656,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -8011,6 +8015,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -8258,6 +8263,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_port_list(port_list);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_port_list()));
         }
         return ::grpc::Status::OK;
       }
@@ -8297,6 +8303,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_error_string(error_string);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_string()));
         }
         return ::grpc::Status::OK;
       }
@@ -8491,6 +8498,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -8572,6 +8580,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_error_string(error_string);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_string()));
         }
         return ::grpc::Status::OK;
       }
@@ -8659,6 +8668,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_buffer(buffer);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_buffer()));
         }
         return ::grpc::Status::OK;
       }
@@ -8700,6 +8710,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_buffer(buffer);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_buffer()));
         }
         return ::grpc::Status::OK;
       }
@@ -8741,6 +8752,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_buffer(buffer);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_buffer()));
         }
         return ::grpc::Status::OK;
       }
@@ -8841,6 +8853,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -8941,6 +8954,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -9041,6 +9055,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -9410,6 +9425,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -9701,6 +9717,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -10148,6 +10165,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -10304,6 +10322,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -10447,6 +10466,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -10774,6 +10794,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -11014,6 +11035,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -11463,6 +11485,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -11747,6 +11770,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -11941,6 +11965,7 @@ namespace nidaqmx_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -2144,6 +2144,7 @@ namespace nidcpower_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_error_message(error_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
       return ::grpc::Status::OK;
     }
@@ -2437,6 +2438,7 @@ namespace nidcpower_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_attribute_value(attribute_value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_attribute_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -2478,6 +2480,7 @@ namespace nidcpower_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_channel_name(channel_name);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_channel_name()));
         }
         return ::grpc::Status::OK;
       }
@@ -2519,6 +2522,7 @@ namespace nidcpower_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_channel_name(channel_name);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_channel_name()));
         }
         return ::grpc::Status::OK;
       }
@@ -2561,6 +2565,7 @@ namespace nidcpower_grpc {
         if (status == 0) {
           response->set_code(code);
           response->set_description(description);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_description()));
         }
         return ::grpc::Status::OK;
       }
@@ -2678,6 +2683,7 @@ namespace nidcpower_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_coercion_record(coercion_record);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_coercion_record()));
         }
         return ::grpc::Status::OK;
       }
@@ -2718,6 +2724,7 @@ namespace nidcpower_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_interchange_warning(interchange_warning);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_interchange_warning()));
         }
         return ::grpc::Status::OK;
       }
@@ -3168,7 +3175,9 @@ namespace nidcpower_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_instrument_driver_revision(instrument_driver_revision);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_instrument_driver_revision()));
         response->set_firmware_revision(firmware_revision);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_firmware_revision()));
       }
       return ::grpc::Status::OK;
     }
@@ -3194,6 +3203,7 @@ namespace nidcpower_grpc {
       if (status == 0) {
         response->set_self_test_result(self_test_result);
         response->set_self_test_message(self_test_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_self_test_message()));
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -1318,6 +1318,7 @@ namespace nidigitalpattern_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_error_message(error_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
       return ::grpc::Status::OK;
     }
@@ -1769,6 +1770,7 @@ namespace nidigitalpattern_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -1810,6 +1812,7 @@ namespace nidigitalpattern_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_name(name);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_name()));
         }
         return ::grpc::Status::OK;
       }
@@ -1851,6 +1854,7 @@ namespace nidigitalpattern_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_names(names);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_names()));
         }
         return ::grpc::Status::OK;
       }
@@ -1893,6 +1897,7 @@ namespace nidigitalpattern_grpc {
         if (status == 0) {
           response->set_error_code(error_code);
           response->set_error_description(error_description);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_description()));
         }
         return ::grpc::Status::OK;
       }
@@ -2036,6 +2041,7 @@ namespace nidigitalpattern_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_name(name);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_name()));
         }
         return ::grpc::Status::OK;
       }
@@ -2077,6 +2083,7 @@ namespace nidigitalpattern_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_pin_list(pin_list);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_pin_list()));
         }
         return ::grpc::Status::OK;
       }
@@ -2118,6 +2125,7 @@ namespace nidigitalpattern_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_name(name);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_name()));
         }
         return ::grpc::Status::OK;
       }
@@ -2390,6 +2398,7 @@ namespace nidigitalpattern_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_name(name);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_name()));
         }
         return ::grpc::Status::OK;
       }
@@ -3186,6 +3195,7 @@ namespace nidigitalpattern_grpc {
       if (status == 0) {
         response->set_test_result(test_result);
         response->set_test_message(test_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_test_message()));
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -1497,6 +1497,7 @@ namespace nidmm_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_attribute_value(attribute_value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_attribute_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -1608,6 +1609,7 @@ namespace nidmm_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_channel_string(channel_string);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_channel_string()));
         }
         return ::grpc::Status::OK;
       }
@@ -1674,6 +1676,7 @@ namespace nidmm_grpc {
         if (status == 0) {
           response->set_error_code(error_code);
           response->set_description(description);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_description()));
         }
         return ::grpc::Status::OK;
       }
@@ -1715,6 +1718,7 @@ namespace nidmm_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_error_message(error_message);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
         }
         return ::grpc::Status::OK;
       }
@@ -1840,6 +1844,7 @@ namespace nidmm_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_coercion_record(coercion_record);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_coercion_record()));
         }
         return ::grpc::Status::OK;
       }
@@ -1880,6 +1885,7 @@ namespace nidmm_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_interchange_warning(interchange_warning);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_interchange_warning()));
         }
         return ::grpc::Status::OK;
       }
@@ -2376,7 +2382,9 @@ namespace nidmm_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_instrument_driver_revision(instrument_driver_revision);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_instrument_driver_revision()));
         response->set_firmware_revision(firmware_revision);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_firmware_revision()));
       }
       return ::grpc::Status::OK;
     }
@@ -2421,6 +2429,7 @@ namespace nidmm_grpc {
       if (status == 0) {
         response->set_self_test_result(self_test_result);
         response->set_self_test_message(self_test_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_self_test_message()));
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -414,6 +414,7 @@ namespace nifake_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_a_string(a_string);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_a_string()));
       }
       return ::grpc::Status::OK;
     }
@@ -453,6 +454,7 @@ namespace nifake_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_a_string(a_string);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_a_string()));
         }
         return ::grpc::Status::OK;
       }
@@ -902,6 +904,7 @@ namespace nifake_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_attribute_value(attribute_value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_attribute_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -1517,6 +1520,7 @@ namespace nifake_grpc {
       if (status == 0) {
         response->set_a_number(a_number);
         response->set_a_string(a_string);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_a_string()));
       }
       return ::grpc::Status::OK;
     }
@@ -1623,6 +1627,7 @@ namespace nifake_grpc {
           }
           response->set_a_float_enum_raw(a_float_enum);
           response->set_a_string(a_string);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_a_string()));
         }
         return ::grpc::Status::OK;
       }

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -1598,6 +1598,7 @@ namespace nifgen_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_error_message(error_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
       return ::grpc::Status::OK;
     }
@@ -1622,6 +1623,7 @@ namespace nifgen_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_error_message(error_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
       return ::grpc::Status::OK;
     }
@@ -1647,6 +1649,7 @@ namespace nifgen_grpc {
       if (status == 0) {
         response->set_error_code(error_code);
         response->set_error_message(error_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
       return ::grpc::Status::OK;
     }
@@ -1908,6 +1911,7 @@ namespace nifgen_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_attribute_value(attribute_value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_attribute_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -1949,6 +1953,7 @@ namespace nifgen_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_channel_string(channel_string);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_channel_string()));
         }
         return ::grpc::Status::OK;
       }
@@ -1991,6 +1996,7 @@ namespace nifgen_grpc {
         if (status == 0) {
           response->set_error_code(error_code);
           response->set_error_description(error_description);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_description()));
         }
         return ::grpc::Status::OK;
       }
@@ -2171,6 +2177,7 @@ namespace nifgen_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_coercion_record(coercion_record);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_coercion_record()));
         }
         return ::grpc::Status::OK;
       }
@@ -2211,6 +2218,7 @@ namespace nifgen_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_interchange_warning(interchange_warning);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_interchange_warning()));
         }
         return ::grpc::Status::OK;
       }
@@ -2768,7 +2776,9 @@ namespace nifgen_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_instrument_driver_revision(instrument_driver_revision);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_instrument_driver_revision()));
         response->set_firmware_revision(firmware_revision);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_firmware_revision()));
       }
       return ::grpc::Status::OK;
     }
@@ -2865,6 +2875,7 @@ namespace nifgen_grpc {
       if (status == 0) {
         response->set_self_test_result(self_test_result);
         response->set_self_test_message(self_test_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_self_test_message()));
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nirfsa/nirfsa_library.cpp
+++ b/generated/nirfsa/nirfsa_library.cpp
@@ -729,7 +729,7 @@ ViStatus NiRFSALibrary::EnableSessionAccess(ViSession vi, ViBoolean enable)
 #endif
 }
 
-ViStatus NiRFSALibrary::ErrorMessage(ViSession vi, ViStatus statusCode, ViChar errorMessage[256])
+ViStatus NiRFSALibrary::ErrorMessage(ViSession vi, ViStatus statusCode, ViChar errorMessage[1024])
 {
   if (!function_pointers_.ErrorMessage) {
     throw nidevice_grpc::LibraryLoadException("Could not find niRFSA_error_message.");
@@ -741,7 +741,7 @@ ViStatus NiRFSALibrary::ErrorMessage(ViSession vi, ViStatus statusCode, ViChar e
 #endif
 }
 
-ViStatus NiRFSALibrary::ErrorQuery(ViSession vi, ViInt32* errorCode, ViChar errorMessage[256])
+ViStatus NiRFSALibrary::ErrorQuery(ViSession vi, ViInt32* errorCode, ViChar errorMessage[1024])
 {
   if (!function_pointers_.ErrorQuery) {
     throw nidevice_grpc::LibraryLoadException("Could not find niRFSA_error_query.");
@@ -933,7 +933,7 @@ ViStatus NiRFSALibrary::GetAttributeViString(ViSession vi, ViConstString channel
 #endif
 }
 
-ViStatus NiRFSALibrary::GetCalUserDefinedInfo(ViSession vi, ViChar info[256])
+ViStatus NiRFSALibrary::GetCalUserDefinedInfo(ViSession vi, ViChar info[2048])
 {
   if (!function_pointers_.GetCalUserDefinedInfo) {
     throw nidevice_grpc::LibraryLoadException("Could not find niRFSA_GetCalUserDefinedInfo.");
@@ -1445,7 +1445,7 @@ ViStatus NiRFSALibrary::SelfCalibrateRange(ViSession vi, ViInt64 stepsToOmit, Vi
 #endif
 }
 
-ViStatus NiRFSALibrary::SelfTest(ViSession vi, ViInt16* testResult, ViChar testMessage[256])
+ViStatus NiRFSALibrary::SelfTest(ViSession vi, ViInt16* testResult, ViChar testMessage[2048])
 {
   if (!function_pointers_.SelfTest) {
     throw nidevice_grpc::LibraryLoadException("Could not find niRFSA_self_test.");

--- a/generated/nirfsa/nirfsa_library.h
+++ b/generated/nirfsa/nirfsa_library.h
@@ -66,8 +66,8 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   ViStatus DisableRefTrigger(ViSession vi);
   ViStatus DisableStartTrigger(ViSession vi);
   ViStatus EnableSessionAccess(ViSession vi, ViBoolean enable);
-  ViStatus ErrorMessage(ViSession vi, ViStatus statusCode, ViChar errorMessage[256]);
-  ViStatus ErrorQuery(ViSession vi, ViInt32* errorCode, ViChar errorMessage[256]);
+  ViStatus ErrorMessage(ViSession vi, ViStatus statusCode, ViChar errorMessage[1024]);
+  ViStatus ErrorQuery(ViSession vi, ViInt32* errorCode, ViChar errorMessage[1024]);
   ViStatus ExportSignal(ViSession vi, ViInt32 signal, ViConstString signalIdentifier, ViConstString outputTerminal);
   ViStatus ExtCalStoreBaselineForSelfCalibration(ViSession vi, ViString password, ViInt64 selfCalibrationStep);
   ViStatus ExternalAlignmentAdjustPreselector(ViSession vi, ViInt32 numberOfCoefficients, ViReal64 coefficients[]);
@@ -83,7 +83,7 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   ViStatus GetAttributeViReal64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViReal64* value);
   ViStatus GetAttributeViSession(ViSession vi, ViConstString channelName, ViAttr attributeId, ViSession* value);
   ViStatus GetAttributeViString(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 bufSize, ViChar value[]);
-  ViStatus GetCalUserDefinedInfo(ViSession vi, ViChar info[256]);
+  ViStatus GetCalUserDefinedInfo(ViSession vi, ViChar info[2048]);
   ViStatus GetCalUserDefinedInfoMaxSize(ViSession vi, ViInt32* infoSize);
   ViStatus GetDeembeddingSparameters(ViSession vi, NIComplexNumber_struct sparameters[], ViInt32 sparametersArraySize, ViInt32* numberOfSparameters, ViInt32* numberOfPorts);
   ViStatus GetDeviceResponse(ViSession vi, ViConstString channelList, ViInt32 responseType, ViInt32 bufferSize, ViReal64 frequencies[], ViReal64 magnitudeResponse[], ViReal64 phaseResponse[], ViInt32* numberOfFrequencies);
@@ -126,7 +126,7 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   ViStatus SelfCal(ViSession vi);
   ViStatus SelfCalibrate(ViSession vi, ViInt64 stepsToOmit);
   ViStatus SelfCalibrateRange(ViSession vi, ViInt64 stepsToOmit, ViReal64 minFrequency, ViReal64 maxFrequency, ViReal64 minReferenceLevel, ViReal64 maxReferenceLevel);
-  ViStatus SelfTest(ViSession vi, ViInt16* testResult, ViChar testMessage[256]);
+  ViStatus SelfTest(ViSession vi, ViInt16* testResult, ViChar testMessage[2048]);
   ViStatus SendSoftwareEdgeTrigger(ViSession vi, ViInt32 trigger, ViConstString triggerIdentifier);
   ViStatus SetAttributeViBoolean(ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean value);
   ViStatus SetAttributeViInt32(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 value);

--- a/generated/nirfsa/nirfsa_library_interface.h
+++ b/generated/nirfsa/nirfsa_library_interface.h
@@ -64,8 +64,8 @@ class NiRFSALibraryInterface {
   virtual ViStatus DisableRefTrigger(ViSession vi) = 0;
   virtual ViStatus DisableStartTrigger(ViSession vi) = 0;
   virtual ViStatus EnableSessionAccess(ViSession vi, ViBoolean enable) = 0;
-  virtual ViStatus ErrorMessage(ViSession vi, ViStatus statusCode, ViChar errorMessage[256]) = 0;
-  virtual ViStatus ErrorQuery(ViSession vi, ViInt32* errorCode, ViChar errorMessage[256]) = 0;
+  virtual ViStatus ErrorMessage(ViSession vi, ViStatus statusCode, ViChar errorMessage[1024]) = 0;
+  virtual ViStatus ErrorQuery(ViSession vi, ViInt32* errorCode, ViChar errorMessage[1024]) = 0;
   virtual ViStatus ExportSignal(ViSession vi, ViInt32 signal, ViConstString signalIdentifier, ViConstString outputTerminal) = 0;
   virtual ViStatus ExtCalStoreBaselineForSelfCalibration(ViSession vi, ViString password, ViInt64 selfCalibrationStep) = 0;
   virtual ViStatus ExternalAlignmentAdjustPreselector(ViSession vi, ViInt32 numberOfCoefficients, ViReal64 coefficients[]) = 0;
@@ -81,7 +81,7 @@ class NiRFSALibraryInterface {
   virtual ViStatus GetAttributeViReal64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViReal64* value) = 0;
   virtual ViStatus GetAttributeViSession(ViSession vi, ViConstString channelName, ViAttr attributeId, ViSession* value) = 0;
   virtual ViStatus GetAttributeViString(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 bufSize, ViChar value[]) = 0;
-  virtual ViStatus GetCalUserDefinedInfo(ViSession vi, ViChar info[256]) = 0;
+  virtual ViStatus GetCalUserDefinedInfo(ViSession vi, ViChar info[2048]) = 0;
   virtual ViStatus GetCalUserDefinedInfoMaxSize(ViSession vi, ViInt32* infoSize) = 0;
   virtual ViStatus GetDeembeddingSparameters(ViSession vi, NIComplexNumber_struct sparameters[], ViInt32 sparametersArraySize, ViInt32* numberOfSparameters, ViInt32* numberOfPorts) = 0;
   virtual ViStatus GetDeviceResponse(ViSession vi, ViConstString channelList, ViInt32 responseType, ViInt32 bufferSize, ViReal64 frequencies[], ViReal64 magnitudeResponse[], ViReal64 phaseResponse[], ViInt32* numberOfFrequencies) = 0;
@@ -124,7 +124,7 @@ class NiRFSALibraryInterface {
   virtual ViStatus SelfCal(ViSession vi) = 0;
   virtual ViStatus SelfCalibrate(ViSession vi, ViInt64 stepsToOmit) = 0;
   virtual ViStatus SelfCalibrateRange(ViSession vi, ViInt64 stepsToOmit, ViReal64 minFrequency, ViReal64 maxFrequency, ViReal64 minReferenceLevel, ViReal64 maxReferenceLevel) = 0;
-  virtual ViStatus SelfTest(ViSession vi, ViInt16* testResult, ViChar testMessage[256]) = 0;
+  virtual ViStatus SelfTest(ViSession vi, ViInt16* testResult, ViChar testMessage[2048]) = 0;
   virtual ViStatus SendSoftwareEdgeTrigger(ViSession vi, ViInt32 trigger, ViConstString triggerIdentifier) = 0;
   virtual ViStatus SetAttributeViBoolean(ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean value) = 0;
   virtual ViStatus SetAttributeViInt32(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 value) = 0;

--- a/generated/nirfsa/nirfsa_mock_library.h
+++ b/generated/nirfsa/nirfsa_mock_library.h
@@ -65,8 +65,8 @@ class NiRFSAMockLibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   MOCK_METHOD(ViStatus, DisableRefTrigger, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, DisableStartTrigger, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, EnableSessionAccess, (ViSession vi, ViBoolean enable), (override));
-  MOCK_METHOD(ViStatus, ErrorMessage, (ViSession vi, ViStatus statusCode, ViChar errorMessage[256]), (override));
-  MOCK_METHOD(ViStatus, ErrorQuery, (ViSession vi, ViInt32* errorCode, ViChar errorMessage[256]), (override));
+  MOCK_METHOD(ViStatus, ErrorMessage, (ViSession vi, ViStatus statusCode, ViChar errorMessage[1024]), (override));
+  MOCK_METHOD(ViStatus, ErrorQuery, (ViSession vi, ViInt32* errorCode, ViChar errorMessage[1024]), (override));
   MOCK_METHOD(ViStatus, ExportSignal, (ViSession vi, ViInt32 signal, ViConstString signalIdentifier, ViConstString outputTerminal), (override));
   MOCK_METHOD(ViStatus, ExtCalStoreBaselineForSelfCalibration, (ViSession vi, ViString password, ViInt64 selfCalibrationStep), (override));
   MOCK_METHOD(ViStatus, ExternalAlignmentAdjustPreselector, (ViSession vi, ViInt32 numberOfCoefficients, ViReal64 coefficients[]), (override));
@@ -82,7 +82,7 @@ class NiRFSAMockLibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   MOCK_METHOD(ViStatus, GetAttributeViReal64, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViReal64* value), (override));
   MOCK_METHOD(ViStatus, GetAttributeViSession, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViSession* value), (override));
   MOCK_METHOD(ViStatus, GetAttributeViString, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 bufSize, ViChar value[]), (override));
-  MOCK_METHOD(ViStatus, GetCalUserDefinedInfo, (ViSession vi, ViChar info[256]), (override));
+  MOCK_METHOD(ViStatus, GetCalUserDefinedInfo, (ViSession vi, ViChar info[2048]), (override));
   MOCK_METHOD(ViStatus, GetCalUserDefinedInfoMaxSize, (ViSession vi, ViInt32* infoSize), (override));
   MOCK_METHOD(ViStatus, GetDeembeddingSparameters, (ViSession vi, NIComplexNumber_struct sparameters[], ViInt32 sparametersArraySize, ViInt32* numberOfSparameters, ViInt32* numberOfPorts), (override));
   MOCK_METHOD(ViStatus, GetDeviceResponse, (ViSession vi, ViConstString channelList, ViInt32 responseType, ViInt32 bufferSize, ViReal64 frequencies[], ViReal64 magnitudeResponse[], ViReal64 phaseResponse[], ViInt32* numberOfFrequencies), (override));
@@ -125,7 +125,7 @@ class NiRFSAMockLibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   MOCK_METHOD(ViStatus, SelfCal, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, SelfCalibrate, (ViSession vi, ViInt64 stepsToOmit), (override));
   MOCK_METHOD(ViStatus, SelfCalibrateRange, (ViSession vi, ViInt64 stepsToOmit, ViReal64 minFrequency, ViReal64 maxFrequency, ViReal64 minReferenceLevel, ViReal64 maxReferenceLevel), (override));
-  MOCK_METHOD(ViStatus, SelfTest, (ViSession vi, ViInt16* testResult, ViChar testMessage[256]), (override));
+  MOCK_METHOD(ViStatus, SelfTest, (ViSession vi, ViInt16* testResult, ViChar testMessage[2048]), (override));
   MOCK_METHOD(ViStatus, SendSoftwareEdgeTrigger, (ViSession vi, ViInt32 trigger, ViConstString triggerIdentifier), (override));
   MOCK_METHOD(ViStatus, SetAttributeViBoolean, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean value), (override));
   MOCK_METHOD(ViStatus, SetAttributeViInt32, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 value), (override));

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -1294,11 +1294,12 @@ namespace nirfsa_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViStatus status_code = request->status_code();
-      std::string error_message(256 - 1, '\0');
+      std::string error_message(1024 - 1, '\0');
       auto status = library_->ErrorMessage(vi, status_code, (ViChar*)error_message.data());
       response->set_status(status);
       if (status == 0) {
         response->set_error_message(error_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
       return ::grpc::Status::OK;
     }
@@ -1318,12 +1319,13 @@ namespace nirfsa_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 error_code {};
-      std::string error_message(256 - 1, '\0');
+      std::string error_message(1024 - 1, '\0');
       auto status = library_->ErrorQuery(vi, &error_code, (ViChar*)error_message.data());
       response->set_status(status);
       if (status == 0) {
         response->set_error_code(error_code);
         response->set_error_message(error_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
       return ::grpc::Status::OK;
     }
@@ -1766,6 +1768,7 @@ namespace nirfsa_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -1785,11 +1788,12 @@ namespace nirfsa_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      std::string info(256 - 1, '\0');
+      std::string info(2048 - 1, '\0');
       auto status = library_->GetCalUserDefinedInfo(vi, (ViChar*)info.data());
       response->set_status(status);
       if (status == 0) {
         response->set_info(info);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_info()));
       }
       return ::grpc::Status::OK;
     }
@@ -1961,6 +1965,7 @@ namespace nirfsa_grpc {
         if (status == 0) {
           response->set_error_code(error_code);
           response->set_error_description(error_description);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_description()));
         }
         return ::grpc::Status::OK;
       }
@@ -2488,6 +2493,7 @@ namespace nirfsa_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_terminal_name(terminal_name);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_terminal_name()));
       }
       return ::grpc::Status::OK;
     }
@@ -2944,7 +2950,9 @@ namespace nirfsa_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_driver_rev(driver_rev);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_driver_rev()));
         response->set_instr_rev(instr_rev);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_instr_rev()));
       }
       return ::grpc::Status::OK;
     }
@@ -3057,12 +3065,13 @@ namespace nirfsa_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt16 test_result {};
-      std::string test_message(256 - 1, '\0');
+      std::string test_message(2048 - 1, '\0');
       auto status = library_->SelfTest(vi, &test_result, (ViChar*)test_message.data());
       response->set_status(status);
       if (status == 0) {
         response->set_test_result(test_result);
         response->set_test_message(test_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_test_message()));
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nirfsg/nirfsg_library.cpp
+++ b/generated/nirfsg/nirfsg_library.cpp
@@ -747,7 +747,7 @@ ViStatus NiRFSGLibrary::DisableStartTrigger(ViSession vi)
 #endif
 }
 
-ViStatus NiRFSGLibrary::ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[256])
+ViStatus NiRFSGLibrary::ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[1024])
 {
   if (!function_pointers_.ErrorMessage) {
     throw nidevice_grpc::LibraryLoadException("Could not find niRFSG_error_message.");
@@ -759,7 +759,7 @@ ViStatus NiRFSGLibrary::ErrorMessage(ViSession vi, ViStatus errorCode, ViChar er
 #endif
 }
 
-ViStatus NiRFSGLibrary::ErrorQuery(ViSession vi, ViInt32* errorCode, ViChar errorMessage[256])
+ViStatus NiRFSGLibrary::ErrorQuery(ViSession vi, ViInt32* errorCode, ViChar errorMessage[1024])
 {
   if (!function_pointers_.ErrorQuery) {
     throw nidevice_grpc::LibraryLoadException("Could not find niRFSG_error_query.");
@@ -1235,7 +1235,7 @@ ViStatus NiRFSGLibrary::SelfCalibrateRange(ViSession vi, ViInt64 stepsToOmit, Vi
 #endif
 }
 
-ViStatus NiRFSGLibrary::SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256])
+ViStatus NiRFSGLibrary::SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[2048])
 {
   if (!function_pointers_.SelfTest) {
     throw nidevice_grpc::LibraryLoadException("Could not find niRFSG_self_test.");

--- a/generated/nirfsg/nirfsg_library.h
+++ b/generated/nirfsg/nirfsg_library.h
@@ -68,8 +68,8 @@ class NiRFSGLibrary : public nirfsg_grpc::NiRFSGLibraryInterface {
   ViStatus DisableConfigurationListStepTrigger(ViSession vi);
   ViStatus DisableScriptTrigger(ViSession vi, ViConstString triggerID);
   ViStatus DisableStartTrigger(ViSession vi);
-  ViStatus ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]);
-  ViStatus ErrorQuery(ViSession vi, ViInt32* errorCode, ViChar errorMessage[256]);
+  ViStatus ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[1024]);
+  ViStatus ErrorQuery(ViSession vi, ViInt32* errorCode, ViChar errorMessage[1024]);
   ViStatus ExportSignal(ViSession vi, ViInt32 signal, ViConstString signalIdentifier, ViConstString outputTerminal);
   ViStatus GetAttributeViBoolean(ViSession vi, ViConstString channelName, ViAttr attribute, ViBoolean* value);
   ViStatus GetAttributeViInt32(ViSession vi, ViConstString channelName, ViAttr attribute, ViInt32* value);
@@ -109,7 +109,7 @@ class NiRFSGLibrary : public nirfsg_grpc::NiRFSGLibraryInterface {
   ViStatus SelectArbWaveform(ViSession vi, ViConstString name);
   ViStatus SelfCal(ViSession vi);
   ViStatus SelfCalibrateRange(ViSession vi, ViInt64 stepsToOmit, ViReal64 minFrequency, ViReal64 maxFrequency, ViReal64 minPowerLevel, ViReal64 maxPowerLevel);
-  ViStatus SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]);
+  ViStatus SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[2048]);
   ViStatus SendSoftwareEdgeTrigger(ViSession vi, ViInt32 trigger, ViConstString triggerIdentifier);
   ViStatus SetArbWaveformNextWritePosition(ViSession vi, ViConstString waveformName, ViInt32 relativeTo, ViInt32 offset);
   ViStatus SetAttributeViBoolean(ViSession vi, ViConstString channelName, ViAttr attribute, ViBoolean value);

--- a/generated/nirfsg/nirfsg_library_interface.h
+++ b/generated/nirfsg/nirfsg_library_interface.h
@@ -65,8 +65,8 @@ class NiRFSGLibraryInterface {
   virtual ViStatus DisableConfigurationListStepTrigger(ViSession vi) = 0;
   virtual ViStatus DisableScriptTrigger(ViSession vi, ViConstString triggerID) = 0;
   virtual ViStatus DisableStartTrigger(ViSession vi) = 0;
-  virtual ViStatus ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]) = 0;
-  virtual ViStatus ErrorQuery(ViSession vi, ViInt32* errorCode, ViChar errorMessage[256]) = 0;
+  virtual ViStatus ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[1024]) = 0;
+  virtual ViStatus ErrorQuery(ViSession vi, ViInt32* errorCode, ViChar errorMessage[1024]) = 0;
   virtual ViStatus ExportSignal(ViSession vi, ViInt32 signal, ViConstString signalIdentifier, ViConstString outputTerminal) = 0;
   virtual ViStatus GetAttributeViBoolean(ViSession vi, ViConstString channelName, ViAttr attribute, ViBoolean* value) = 0;
   virtual ViStatus GetAttributeViInt32(ViSession vi, ViConstString channelName, ViAttr attribute, ViInt32* value) = 0;
@@ -106,7 +106,7 @@ class NiRFSGLibraryInterface {
   virtual ViStatus SelectArbWaveform(ViSession vi, ViConstString name) = 0;
   virtual ViStatus SelfCal(ViSession vi) = 0;
   virtual ViStatus SelfCalibrateRange(ViSession vi, ViInt64 stepsToOmit, ViReal64 minFrequency, ViReal64 maxFrequency, ViReal64 minPowerLevel, ViReal64 maxPowerLevel) = 0;
-  virtual ViStatus SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]) = 0;
+  virtual ViStatus SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[2048]) = 0;
   virtual ViStatus SendSoftwareEdgeTrigger(ViSession vi, ViInt32 trigger, ViConstString triggerIdentifier) = 0;
   virtual ViStatus SetArbWaveformNextWritePosition(ViSession vi, ViConstString waveformName, ViInt32 relativeTo, ViInt32 offset) = 0;
   virtual ViStatus SetAttributeViBoolean(ViSession vi, ViConstString channelName, ViAttr attribute, ViBoolean value) = 0;

--- a/generated/nirfsg/nirfsg_mock_library.h
+++ b/generated/nirfsg/nirfsg_mock_library.h
@@ -67,8 +67,8 @@ class NiRFSGMockLibrary : public nirfsg_grpc::NiRFSGLibraryInterface {
   MOCK_METHOD(ViStatus, DisableConfigurationListStepTrigger, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, DisableScriptTrigger, (ViSession vi, ViConstString triggerID), (override));
   MOCK_METHOD(ViStatus, DisableStartTrigger, (ViSession vi), (override));
-  MOCK_METHOD(ViStatus, ErrorMessage, (ViSession vi, ViStatus errorCode, ViChar errorMessage[256]), (override));
-  MOCK_METHOD(ViStatus, ErrorQuery, (ViSession vi, ViInt32* errorCode, ViChar errorMessage[256]), (override));
+  MOCK_METHOD(ViStatus, ErrorMessage, (ViSession vi, ViStatus errorCode, ViChar errorMessage[1024]), (override));
+  MOCK_METHOD(ViStatus, ErrorQuery, (ViSession vi, ViInt32* errorCode, ViChar errorMessage[1024]), (override));
   MOCK_METHOD(ViStatus, ExportSignal, (ViSession vi, ViInt32 signal, ViConstString signalIdentifier, ViConstString outputTerminal), (override));
   MOCK_METHOD(ViStatus, GetAttributeViBoolean, (ViSession vi, ViConstString channelName, ViAttr attribute, ViBoolean* value), (override));
   MOCK_METHOD(ViStatus, GetAttributeViInt32, (ViSession vi, ViConstString channelName, ViAttr attribute, ViInt32* value), (override));
@@ -108,7 +108,7 @@ class NiRFSGMockLibrary : public nirfsg_grpc::NiRFSGLibraryInterface {
   MOCK_METHOD(ViStatus, SelectArbWaveform, (ViSession vi, ViConstString name), (override));
   MOCK_METHOD(ViStatus, SelfCal, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, SelfCalibrateRange, (ViSession vi, ViInt64 stepsToOmit, ViReal64 minFrequency, ViReal64 maxFrequency, ViReal64 minPowerLevel, ViReal64 maxPowerLevel), (override));
-  MOCK_METHOD(ViStatus, SelfTest, (ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]), (override));
+  MOCK_METHOD(ViStatus, SelfTest, (ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[2048]), (override));
   MOCK_METHOD(ViStatus, SendSoftwareEdgeTrigger, (ViSession vi, ViInt32 trigger, ViConstString triggerIdentifier), (override));
   MOCK_METHOD(ViStatus, SetArbWaveformNextWritePosition, (ViSession vi, ViConstString waveformName, ViInt32 relativeTo, ViInt32 offset), (override));
   MOCK_METHOD(ViStatus, SetAttributeViBoolean, (ViSession vi, ViConstString channelName, ViAttr attribute, ViBoolean value), (override));

--- a/generated/nirfsg/nirfsg_service.cpp
+++ b/generated/nirfsg/nirfsg_service.cpp
@@ -1465,11 +1465,12 @@ namespace nirfsg_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViStatus error_code = request->error_code();
-      std::string error_message(256 - 1, '\0');
+      std::string error_message(1024 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       response->set_status(status);
       if (status == 0) {
         response->set_error_message(error_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
       return ::grpc::Status::OK;
     }
@@ -1489,12 +1490,13 @@ namespace nirfsg_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 error_code {};
-      std::string error_message(256 - 1, '\0');
+      std::string error_message(1024 - 1, '\0');
       auto status = library_->ErrorQuery(vi, &error_code, (ViChar*)error_message.data());
       response->set_status(status);
       if (status == 0) {
         response->set_error_code(error_code);
         response->set_error_message(error_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
       return ::grpc::Status::OK;
     }
@@ -1737,6 +1739,7 @@ namespace nirfsg_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -1778,6 +1781,7 @@ namespace nirfsg_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_name(name);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_name()));
         }
         return ::grpc::Status::OK;
       }
@@ -1866,6 +1870,7 @@ namespace nirfsg_grpc {
         if (status == 0) {
           response->set_error_code(error_code);
           response->set_error_description(error_description);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_description()));
         }
         return ::grpc::Status::OK;
       }
@@ -2087,6 +2092,7 @@ namespace nirfsg_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_terminal_name(terminal_name);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_terminal_name()));
         }
         return ::grpc::Status::OK;
       }
@@ -2594,7 +2600,9 @@ namespace nirfsg_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_instrument_driver_revision(instrument_driver_revision);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_instrument_driver_revision()));
         response->set_firmware_revision(firmware_revision);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_firmware_revision()));
       }
       return ::grpc::Status::OK;
     }
@@ -2713,12 +2721,13 @@ namespace nirfsg_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt16 self_test_result {};
-      std::string self_test_message(256 - 1, '\0');
+      std::string self_test_message(2048 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
       if (status == 0) {
         response->set_self_test_result(self_test_result);
         response->set_self_test_message(self_test_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_self_test_message()));
       }
       return ::grpc::Status::OK;
     }

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -1305,6 +1305,7 @@ namespace niscope_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_error_description(error_description);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_description()));
       }
       return ::grpc::Status::OK;
     }
@@ -1566,6 +1567,7 @@ namespace niscope_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -1607,6 +1609,7 @@ namespace niscope_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_channel_string(channel_string);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_channel_string()));
         }
         return ::grpc::Status::OK;
       }
@@ -1648,6 +1651,7 @@ namespace niscope_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_name(name);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_name()));
         }
         return ::grpc::Status::OK;
       }
@@ -1715,6 +1719,7 @@ namespace niscope_grpc {
         if (status == 0) {
           response->set_error_code(error_code);
           response->set_description(description);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_description()));
         }
         return ::grpc::Status::OK;
       }
@@ -1756,6 +1761,7 @@ namespace niscope_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_error_message(error_message);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
         }
         return ::grpc::Status::OK;
       }
@@ -2037,7 +2043,9 @@ namespace niscope_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_driver_revision(driver_revision);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_driver_revision()));
         response->set_firmware_revision(firmware_revision);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_firmware_revision()));
       }
       return ::grpc::Status::OK;
     }
@@ -2109,6 +2117,7 @@ namespace niscope_grpc {
       if (status == 0) {
         response->set_self_test_result(self_test_result);
         response->set_self_test_message(self_test_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_self_test_message()));
       }
       return ::grpc::Status::OK;
     }

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -505,6 +505,7 @@ namespace niswitch_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_error_message(error_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
       return ::grpc::Status::OK;
     }
@@ -530,6 +531,7 @@ namespace niswitch_grpc {
       if (status == 0) {
         response->set_error_code(error_code);
         response->set_error_message(error_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
       return ::grpc::Status::OK;
     }
@@ -646,6 +648,7 @@ namespace niswitch_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_attribute_value(attribute_value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_attribute_value()));
         }
         return ::grpc::Status::OK;
       }
@@ -713,6 +716,7 @@ namespace niswitch_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_channel_name_buffer(channel_name_buffer);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_channel_name_buffer()));
         }
         return ::grpc::Status::OK;
       }
@@ -755,6 +759,7 @@ namespace niswitch_grpc {
         if (status == 0) {
           response->set_code(code);
           response->set_description(description);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_description()));
         }
         return ::grpc::Status::OK;
       }
@@ -795,6 +800,7 @@ namespace niswitch_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_coercion_record(coercion_record);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_coercion_record()));
         }
         return ::grpc::Status::OK;
       }
@@ -835,6 +841,7 @@ namespace niswitch_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_interchange_warning(interchange_warning);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_interchange_warning()));
         }
         return ::grpc::Status::OK;
       }
@@ -877,6 +884,7 @@ namespace niswitch_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_path(path);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_path()));
         }
         return ::grpc::Status::OK;
       }
@@ -942,6 +950,7 @@ namespace niswitch_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_relay_name_buffer(relay_name_buffer);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_relay_name_buffer()));
         }
         return ::grpc::Status::OK;
       }
@@ -1267,7 +1276,9 @@ namespace niswitch_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_instrument_driver_revision(instrument_driver_revision);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_instrument_driver_revision()));
         response->set_firmware_revision(firmware_revision);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_firmware_revision()));
       }
       return ::grpc::Status::OK;
     }
@@ -1433,6 +1444,7 @@ namespace niswitch_grpc {
       if (status == 0) {
         response->set_self_test_result(self_test_result);
         response->set_self_test_message(self_test_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_self_test_message()));
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -101,6 +101,7 @@ namespace nisync_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_error_message(error_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
       return ::grpc::Status::OK;
     }
@@ -164,6 +165,7 @@ namespace nisync_grpc {
       if (status == 0) {
         response->set_self_test_result(self_test_result);
         response->set_self_test_message(self_test_message);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_self_test_message()));
       }
       return ::grpc::Status::OK;
     }
@@ -188,7 +190,9 @@ namespace nisync_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_driver_revision(driver_revision);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_driver_revision()));
         response->set_firmware_revision(firmware_revision);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_firmware_revision()));
       }
       return ::grpc::Status::OK;
     }
@@ -1092,6 +1096,7 @@ namespace nisync_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_time_reference_names(time_reference_names);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_time_reference_names()));
         }
         return ::grpc::Status::OK;
       }
@@ -1209,6 +1214,7 @@ namespace nisync_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_value(value);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
         return ::grpc::Status::OK;
       }

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -164,6 +164,7 @@ namespace nitclk_grpc {
         response->set_status(status);
         if (status == 0) {
           response->set_error_string(error_string);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_string()));
         }
         return ::grpc::Status::OK;
       }

--- a/source/codegen/metadata/nirfsa/functions.py
+++ b/source/codegen/metadata/nirfsa/functions.py
@@ -975,7 +975,7 @@ functions = {
                 'name': 'errorMessage',
                 'size': {
                     'mechanism': 'fixed',
-                    'value': 256
+                    'value': 1024
                 },
                 'type': 'ViChar[]'
             }
@@ -1000,7 +1000,7 @@ functions = {
                 'name': 'errorMessage',
                 'size': {
                     'mechanism': 'fixed',
-                    'value': 256
+                    'value': 1024
                 },
                 'type': 'ViChar[]'
             }
@@ -1552,7 +1552,7 @@ functions = {
                 'name': 'info',
                 'size': {
                     'mechanism': 'fixed',
-                    'value': 256
+                    'value': 2048
                 },
                 'type': 'ViChar[]'
             }
@@ -2667,7 +2667,7 @@ functions = {
                 'name': 'testMessage',
                 'size': {
                     'mechanism': 'fixed',
-                    'value': 256
+                    'value': 2048
                 },
                 'type': 'ViChar[]'
             }
@@ -2855,10 +2855,6 @@ functions = {
             {
                 'direction': 'in',
                 'name': 'info',
-                'size': {
-                    'mechanism': 'fixed',
-                    'value': 256
-                },
                 'type': 'ViConstString'
             }
         ],

--- a/source/codegen/metadata/nirfsg/functions.py
+++ b/source/codegen/metadata/nirfsg/functions.py
@@ -969,7 +969,7 @@ functions = {
                 'name': 'errorMessage',
                 'size': {
                     'mechanism': 'fixed',
-                    'value': 256
+                    'value': 1024
                 },
                 'type': 'ViChar[]'
             }
@@ -994,7 +994,7 @@ functions = {
                 'name': 'errorMessage',
                 'size': {
                     'mechanism': 'fixed',
-                    'value': 256
+                    'value': 1024
                 },
                 'type': 'ViChar[]'
             }
@@ -1969,7 +1969,7 @@ functions = {
                 'name': 'selfTestMessage',
                 'size': {
                     'mechanism': 'fixed',
-                    'value': 256
+                    'value': 2048
                 },
                 'type': 'ViChar[]'
             }

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -600,11 +600,11 @@ ${initialize_standard_input_param(function_name, parameter)}
 %>\
 ## Note that this currently only supports one repeated output parameter.
         for (int i = 0; i < ${parameter_name}Vector.size(); ++i) {
-%   if 'enum' in parameter:
+%     if 'enum' in parameter:
           response->add_${varargs_parameter_name}(static_cast<${parameter['enum']}>(${parameter_name}Vector[i]));
-%   else:
+%     else:
           response->add_${varargs_parameter_name}(${parameter_name}Vector[i]);
-%   endif
+%     endif
         }
 %   elif common_helpers.is_repeated_varargs_parameter(parameter): #pass
 %   elif common_helpers.is_enum(parameter) == True:
@@ -677,16 +677,19 @@ ${copy_to_response_with_transform(source_buffer=parameter_name, parameter_name=p
 %   else:
         response->set_${parameter_name}(${parameter_name});
 %   endif
+%   if common_helpers.is_regular_string_arg(parameter):
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_${parameter_name}()));
+%   endif
 ### Handle ivi-dance-with-a-twist resizing.
-%     if common_helpers.is_ivi_dance_array_with_a_twist_param(parameter):
+%   if common_helpers.is_ivi_dance_array_with_a_twist_param(parameter):
 <%
   size = common_helpers.get_size_expression(parameter)
 %>\
-%       if common_helpers.is_regular_byte_array_arg(parameter):
+%     if common_helpers.is_regular_byte_array_arg(parameter):
         response->mutable_${parameter_name}()->resize(${size});
-%       elif common_helpers.is_regular_string_arg(parameter):
-        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_${parameter_name}()));
-%       elif common_helpers.is_struct(parameter):
+%     elif common_helpers.is_regular_string_arg(parameter):
+### pass: handled above with trim_trailing_nulls for all string outputs.
+%     elif common_helpers.is_struct(parameter):
 ##        RepeatedPtrField doesn't support Resize(), so use DeleteSubrange()
 ##        to delete any extra elements.
         {
@@ -696,11 +699,11 @@ ${copy_to_response_with_transform(source_buffer=parameter_name, parameter_name=p
             response->mutable_${parameter_name}()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
           }
         }        
-%       else:
+%     else:
 ## This code doesn't handle all parameter types (i.e., enums), see what initialize_output_params() does for that.
         response->mutable_${parameter_name}()->Resize(${size}, 0);
-%       endif
 %     endif
+%   endif
 % endfor
 </%def>
 

--- a/source/tests/system/nifgen_driver_api_tests.cpp
+++ b/source/tests/system/nifgen_driver_api_tests.cpp
@@ -415,7 +415,7 @@ TEST_F(NiFgenDriverApiTest, PerformSelfTest_CompletesSuccessfuly)
   EXPECT_TRUE(status.ok());
   expect_api_success(response.status());
   EXPECT_EQ(0, response.self_test_result());
-  EXPECT_LT(0, response.self_test_message().size());
+  EXPECT_EQ("", response.self_test_message());
 }
 
 TEST_F(NiFgenDriverApiTest, PerformReset_CompletesSuccessfuly)

--- a/source/tests/system/nirfsa_driver_api_tests.cpp
+++ b/source/tests/system/nirfsa_driver_api_tests.cpp
@@ -565,6 +565,37 @@ TEST_F(NiRFSADriverApiTests, SelfCalibrateWithStepsToOmit_Succeeds)
   EXPECT_SUCCESS(session, response);
 }
 
+TEST_F(NiRFSADriverApiTests, SelfTest_Succeeds)
+{
+  auto session = init_session(stub(), PXI_5663E);
+  const auto response = client::self_test(stub(), session);
+
+  EXPECT_SUCCESS(session, response);
+  EXPECT_EQ("PASS", response.test_message());
+}
+
+TEST_F(NiRFSADriverApiTests, ErrorMessage_ReturnsErrorMessage)
+{
+  auto session = init_session(stub(), PXI_5663E);
+  const auto response = client::error_message(stub(), session, IVI_ERROR_ATTRIBUTE_NOT_SUPPORTED);
+
+  EXPECT_SUCCESS(session, response);
+  EXPECT_EQ(
+      "IVI: (Hex 0xBFFA0012) Attribute or property not supported.",
+      response.error_message());
+}
+
+TEST_F(NiRFSADriverApiTests, GetCalUserDefinedInfo_Succeeds)
+{
+  auto session = init_session(stub(), PXI_5663E);
+  const auto response = client::get_cal_user_defined_info(stub(), session);
+
+  EXPECT_SUCCESS(session, response);
+  EXPECT_EQ(
+      "Simulated Device",
+      response.info());
+}
+
 // NOTE: disabled because this test requires a 58XX device. Simulating a 58XX hangs on shutdown.
 TEST_F(NiRFSADriverApiTests, DISABLED_GetDeembeddingCompensationGain_Succeeds)
 {

--- a/source/tests/system/nirfsg_driver_api_tests.cpp
+++ b/source/tests/system/nirfsg_driver_api_tests.cpp
@@ -111,7 +111,7 @@ TEST_F(NiRFSGDriverApiTests, PerformSelfTest_Succeeds)
   auto response = client::self_test(stub(), session);
   EXPECT_SUCCESS(session, response);
   EXPECT_EQ(0, response.self_test_result());
-  EXPECT_STREQ("Passed", response.self_test_message().c_str());
+  EXPECT_EQ("Passed", response.self_test_message());
 }
 
 TEST_F(NiRFSGDriverApiTests, PerformReset_Succeeds)
@@ -500,6 +500,17 @@ TEST_F(NiRFSGDriverApiTests, TwoSessions_SetupTclkSyncPulseSenderSynchronization
   auto result = nitclk_client::setup_for_sync_pulse_sender_synchronize(tclk_stub, {first_session, second_session}, 0);
 
   EXPECT_SUCCESS(first_session, result);
+}
+
+TEST_F(NiRFSGDriverApiTests, ErrorMessage_ReturnsErrorMessage)
+{
+  auto session = init_session(stub(), PXI_5652);
+  const auto response = client::error_message(stub(), session, IVI_ERROR_ATTRIBUTE_NOT_SUPPORTED);
+
+  EXPECT_SUCCESS(session, response);
+  EXPECT_EQ(
+      "IVI: (Hex 0xBFFA0012) Attribute or property not supported.",
+      response.error_message());
 }
 }  // namespace system
 }  // namespace tests


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fix the size of fixed sized strings to match the required sized from documentation and internal implementations.

Update `set_response_values` to `trim_trailing_nulls` on all string outputs.

### Why should this Pull Request be merged?

Ensures that the buffer size is big enough for the maximum required string.

Gets rid of bogus trailing nulls that leak through to clients.

### What testing has been done?

Ran and passed all system tests.