### PR TITLE
Add bitfield enum array output for IsSelfCalValid

### DIFF
--- a/generated/nifake/nifake.proto
+++ b/generated/nifake/nifake.proto
@@ -32,6 +32,7 @@ service NiFake {
   rpc GetABoolean(GetABooleanRequest) returns (GetABooleanResponse);
   rpc GetANumber(GetANumberRequest) returns (GetANumberResponse);
   rpc GetAStringOfFixedMaximumSize(GetAStringOfFixedMaximumSizeRequest) returns (GetAStringOfFixedMaximumSizeResponse);
+  rpc GetBitfieldAsEnumArray(GetBitfieldAsEnumArrayRequest) returns (GetBitfieldAsEnumArrayResponse);
   rpc GetAnIviDanceString(GetAnIviDanceStringRequest) returns (GetAnIviDanceStringResponse);
   rpc GetAnIviDanceWithATwistArray(GetAnIviDanceWithATwistArrayRequest) returns (GetAnIviDanceWithATwistArrayResponse);
   rpc GetAnIviDanceWithATwistArrayOfCustomType(GetAnIviDanceWithATwistArrayOfCustomTypeRequest) returns (GetAnIviDanceWithATwistArrayOfCustomTypeResponse);
@@ -97,6 +98,14 @@ enum NiFakeAttributes {
   NIFAKE_ATTRIBUTE_READ_WRITE_INTEGER_WITH_CONVERTER = 1000008;
   NIFAKE_ATTRIBUTE_READ_WRITE_DOUBLE_WITH_REPEATED_CAPABILITY = 1000009;
   NIFAKE_ATTRIBUTE_READ_WRITE_STRING_REPEATED_CAPABILITY = 1000010;
+}
+
+enum Bitfield {
+  BITFIELD_UNSPECIFIED = 0;
+  BITFIELD_FLAG_A = 1;
+  BITFIELD_FLAG_B = 2;
+  BITFIELD_FLAG_C = 4;
+  BITFIELD_FLAG_D = 8;
 }
 
 enum Color {
@@ -307,6 +316,15 @@ message GetAStringOfFixedMaximumSizeRequest {
 message GetAStringOfFixedMaximumSizeResponse {
   int32 status = 1;
   string a_string = 2;
+}
+
+message GetBitfieldAsEnumArrayRequest {
+}
+
+message GetBitfieldAsEnumArrayResponse {
+  int32 status = 1;
+  repeated Bitfield flags_array = 2;
+  int64 flags_raw = 3;
 }
 
 message GetAnIviDanceStringRequest {

--- a/generated/nifake/nifake_client.cpp
+++ b/generated/nifake/nifake_client.cpp
@@ -290,6 +290,21 @@ get_a_string_of_fixed_maximum_size(const StubPtr& stub, const nidevice_grpc::Ses
   return response;
 }
 
+GetBitfieldAsEnumArrayResponse
+get_bitfield_as_enum_array(const StubPtr& stub)
+{
+  ::grpc::ClientContext context;
+
+  auto request = GetBitfieldAsEnumArrayRequest{};
+
+  auto response = GetBitfieldAsEnumArrayResponse{};
+
+  raise_if_error(
+      stub->GetBitfieldAsEnumArray(&context, request, &response));
+
+  return response;
+}
+
 GetAnIviDanceStringResponse
 get_an_ivi_dance_string(const StubPtr& stub, const nidevice_grpc::Session& vi)
 {

--- a/generated/nifake/nifake_client.h
+++ b/generated/nifake/nifake_client.h
@@ -38,6 +38,7 @@ FetchWaveformResponse fetch_waveform(const StubPtr& stub, const nidevice_grpc::S
 GetABooleanResponse get_a_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetANumberResponse get_a_number(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetAStringOfFixedMaximumSizeResponse get_a_string_of_fixed_maximum_size(const StubPtr& stub, const nidevice_grpc::Session& vi);
+GetBitfieldAsEnumArrayResponse get_bitfield_as_enum_array(const StubPtr& stub);
 GetAnIviDanceStringResponse get_an_ivi_dance_string(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetAnIviDanceWithATwistArrayResponse get_an_ivi_dance_with_a_twist_array(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& a_string);
 GetAnIviDanceWithATwistArrayOfCustomTypeResponse get_an_ivi_dance_with_a_twist_array_of_custom_type(const StubPtr& stub, const nidevice_grpc::Session& vi);

--- a/generated/nifake/nifake_library.cpp
+++ b/generated/nifake/nifake_library.cpp
@@ -37,6 +37,7 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.GetABoolean = reinterpret_cast<GetABooleanPtr>(shared_library_.get_function_pointer("niFake_GetABoolean"));
   function_pointers_.GetANumber = reinterpret_cast<GetANumberPtr>(shared_library_.get_function_pointer("niFake_GetANumber"));
   function_pointers_.GetAStringOfFixedMaximumSize = reinterpret_cast<GetAStringOfFixedMaximumSizePtr>(shared_library_.get_function_pointer("niFake_GetAStringOfFixedMaximumSize"));
+  function_pointers_.GetBitfieldAsEnumArray = reinterpret_cast<GetBitfieldAsEnumArrayPtr>(shared_library_.get_function_pointer("niFake_GetBitfieldAsEnumArray"));
   function_pointers_.GetAnIviDanceString = reinterpret_cast<GetAnIviDanceStringPtr>(shared_library_.get_function_pointer("niFake_GetAnIviDanceString"));
   function_pointers_.GetAnIviDanceWithATwistArray = reinterpret_cast<GetAnIviDanceWithATwistArrayPtr>(shared_library_.get_function_pointer("niFake_GetAnIviDanceWithATwistArray"));
   function_pointers_.GetAnIviDanceWithATwistArrayOfCustomType = reinterpret_cast<GetAnIviDanceWithATwistArrayOfCustomTypePtr>(shared_library_.get_function_pointer("niFake_GetAnIviDanceWithATwistArrayOfCustomType"));
@@ -298,6 +299,18 @@ ViStatus NiFakeLibrary::GetAStringOfFixedMaximumSize(ViSession vi, ViChar aStrin
   return niFake_GetAStringOfFixedMaximumSize(vi, aString);
 #else
   return function_pointers_.GetAStringOfFixedMaximumSize(vi, aString);
+#endif
+}
+
+ViStatus NiFakeLibrary::GetBitfieldAsEnumArray(ViInt64* flags)
+{
+  if (!function_pointers_.GetBitfieldAsEnumArray) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_GetBitfieldAsEnumArray.");
+  }
+#if defined(_MSC_VER)
+  return niFake_GetBitfieldAsEnumArray(flags);
+#else
+  return function_pointers_.GetBitfieldAsEnumArray(flags);
 #endif
 }
 

--- a/generated/nifake/nifake_library.h
+++ b/generated/nifake/nifake_library.h
@@ -34,6 +34,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus GetABoolean(ViSession vi, ViBoolean* aBoolean);
   ViStatus GetANumber(ViSession vi, ViInt16* aNumber);
   ViStatus GetAStringOfFixedMaximumSize(ViSession vi, ViChar aString[256]);
+  ViStatus GetBitfieldAsEnumArray(ViInt64* flags);
   ViStatus GetAnIviDanceString(ViSession vi, ViInt32 bufferSize, ViChar aString[]);
   ViStatus GetAnIviDanceWithATwistArray(ViSession vi, ViConstString aString, ViInt32 bufferSize, ViInt32 arrayOut[], ViInt32* actualSize);
   ViStatus GetAnIviDanceWithATwistArrayOfCustomType(ViSession vi, ViInt32 bufferSize, CustomStruct arrayOut[], ViInt32* actualSize);
@@ -111,6 +112,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using GetABooleanPtr = decltype(&niFake_GetABoolean);
   using GetANumberPtr = decltype(&niFake_GetANumber);
   using GetAStringOfFixedMaximumSizePtr = decltype(&niFake_GetAStringOfFixedMaximumSize);
+  using GetBitfieldAsEnumArrayPtr = decltype(&niFake_GetBitfieldAsEnumArray);
   using GetAnIviDanceStringPtr = decltype(&niFake_GetAnIviDanceString);
   using GetAnIviDanceWithATwistArrayPtr = decltype(&niFake_GetAnIviDanceWithATwistArray);
   using GetAnIviDanceWithATwistArrayOfCustomTypePtr = decltype(&niFake_GetAnIviDanceWithATwistArrayOfCustomType);
@@ -188,6 +190,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     GetABooleanPtr GetABoolean;
     GetANumberPtr GetANumber;
     GetAStringOfFixedMaximumSizePtr GetAStringOfFixedMaximumSize;
+    GetBitfieldAsEnumArrayPtr GetBitfieldAsEnumArray;
     GetAnIviDanceStringPtr GetAnIviDanceString;
     GetAnIviDanceWithATwistArrayPtr GetAnIviDanceWithATwistArray;
     GetAnIviDanceWithATwistArrayOfCustomTypePtr GetAnIviDanceWithATwistArrayOfCustomType;

--- a/generated/nifake/nifake_library_interface.h
+++ b/generated/nifake/nifake_library_interface.h
@@ -31,6 +31,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus GetABoolean(ViSession vi, ViBoolean* aBoolean) = 0;
   virtual ViStatus GetANumber(ViSession vi, ViInt16* aNumber) = 0;
   virtual ViStatus GetAStringOfFixedMaximumSize(ViSession vi, ViChar aString[256]) = 0;
+  virtual ViStatus GetBitfieldAsEnumArray(ViInt64* flags) = 0;
   virtual ViStatus GetAnIviDanceString(ViSession vi, ViInt32 bufferSize, ViChar aString[]) = 0;
   virtual ViStatus GetAnIviDanceWithATwistArray(ViSession vi, ViConstString aString, ViInt32 bufferSize, ViInt32 arrayOut[], ViInt32* actualSize) = 0;
   virtual ViStatus GetAnIviDanceWithATwistArrayOfCustomType(ViSession vi, ViInt32 bufferSize, CustomStruct arrayOut[], ViInt32* actualSize) = 0;

--- a/generated/nifake/nifake_mock_library.h
+++ b/generated/nifake/nifake_mock_library.h
@@ -33,6 +33,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, GetABoolean, (ViSession vi, ViBoolean* aBoolean), (override));
   MOCK_METHOD(ViStatus, GetANumber, (ViSession vi, ViInt16* aNumber), (override));
   MOCK_METHOD(ViStatus, GetAStringOfFixedMaximumSize, (ViSession vi, ViChar aString[256]), (override));
+  MOCK_METHOD(ViStatus, GetBitfieldAsEnumArray, (ViInt64* flags), (override));
   MOCK_METHOD(ViStatus, GetAnIviDanceString, (ViSession vi, ViInt32 bufferSize, ViChar aString[]), (override));
   MOCK_METHOD(ViStatus, GetAnIviDanceWithATwistArray, (ViSession vi, ViConstString aString, ViInt32 bufferSize, ViInt32 arrayOut[], ViInt32* actualSize), (override));
   MOCK_METHOD(ViStatus, GetAnIviDanceWithATwistArrayOfCustomType, (ViSession vi, ViInt32 bufferSize, CustomStruct arrayOut[], ViInt32* actualSize), (override));

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -425,6 +425,35 @@ namespace nifake_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::GetBitfieldAsEnumArray(::grpc::ServerContext* context, const GetBitfieldAsEnumArrayRequest* request, GetBitfieldAsEnumArrayResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      ViInt64 flags {};
+      auto status = library_->GetBitfieldAsEnumArray(&flags);
+      response->set_status(status);
+      if (status == 0) {
+        if (flags & 0x1)
+          response->add_flags_array(Bitfield::BITFIELD_FLAG_A);
+        if (flags & 0x2)
+          response->add_flags_array(Bitfield::BITFIELD_FLAG_B);
+        if (flags & 0x4)
+          response->add_flags_array(Bitfield::BITFIELD_FLAG_C);
+        if (flags & 0x8)
+          response->add_flags_array(Bitfield::BITFIELD_FLAG_D);
+        response->set_flags_raw(flags);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetAnIviDanceString(::grpc::ServerContext* context, const GetAnIviDanceStringRequest* request, GetAnIviDanceStringResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -49,6 +49,7 @@ public:
   ::grpc::Status GetABoolean(::grpc::ServerContext* context, const GetABooleanRequest* request, GetABooleanResponse* response) override;
   ::grpc::Status GetANumber(::grpc::ServerContext* context, const GetANumberRequest* request, GetANumberResponse* response) override;
   ::grpc::Status GetAStringOfFixedMaximumSize(::grpc::ServerContext* context, const GetAStringOfFixedMaximumSizeRequest* request, GetAStringOfFixedMaximumSizeResponse* response) override;
+  ::grpc::Status GetBitfieldAsEnumArray(::grpc::ServerContext* context, const GetBitfieldAsEnumArrayRequest* request, GetBitfieldAsEnumArrayResponse* response) override;
   ::grpc::Status GetAnIviDanceString(::grpc::ServerContext* context, const GetAnIviDanceStringRequest* request, GetAnIviDanceStringResponse* response) override;
   ::grpc::Status GetAnIviDanceWithATwistArray(::grpc::ServerContext* context, const GetAnIviDanceWithATwistArrayRequest* request, GetAnIviDanceWithATwistArrayResponse* response) override;
   ::grpc::Status GetAnIviDanceWithATwistArrayOfCustomType(::grpc::ServerContext* context, const GetAnIviDanceWithATwistArrayOfCustomTypeRequest* request, GetAnIviDanceWithATwistArrayOfCustomTypeResponse* response) override;

--- a/generated/nirfsa/nirfsa.proto
+++ b/generated/nirfsa/nirfsa.proto
@@ -503,20 +503,20 @@ enum ResetWithOptionsStepsToOmit {
   RESET_WITH_OPTIONS_STEPS_TO_OMIT_DEEMBEDDING_TABLES = 2;
 }
 
-enum SelfCalibrateStepsToOmit {
+enum SelfCalibrateSteps {
   option allow_alias = true;
-  SELF_CALIBRATE_STEPS_TO_OMIT_UNSPECIFIED = 0;
-  SELF_CALIBRATE_STEPS_TO_OMIT_OMIT_NONE = 0;
-  SELF_CALIBRATE_STEPS_TO_OMIT_ALIGNMENT = 1;
-  SELF_CALIBRATE_STEPS_TO_OMIT_GAIN_REFERENCE = 2;
-  SELF_CALIBRATE_STEPS_TO_OMIT_IF_FLATNESS = 4;
-  SELF_CALIBRATE_STEPS_TO_OMIT_DIGITIZER_SELF_CAL = 8;
-  SELF_CALIBRATE_STEPS_TO_OMIT_LO_SELF_CAL = 16;
-  SELF_CALIBRATE_STEPS_TO_OMIT_AMPLITUDE_ACCURACY = 32;
-  SELF_CALIBRATE_STEPS_TO_OMIT_RESIDUAL_LO_POWER = 64;
-  SELF_CALIBRATE_STEPS_TO_OMIT_IMAGE_SUPPRESSION = 128;
-  SELF_CALIBRATE_STEPS_TO_OMIT_SYNTHESIZER_ALIGNMENT = 256;
-  SELF_CALIBRATE_STEPS_TO_OMIT_DC_OFFSET = 512;
+  SELF_CALIBRATE_STEPS_UNSPECIFIED = 0;
+  SELF_CALIBRATE_STEPS_NONE = 0;
+  SELF_CALIBRATE_STEPS_ALIGNMENT = 1;
+  SELF_CALIBRATE_STEPS_GAIN_REFERENCE = 2;
+  SELF_CALIBRATE_STEPS_IF_FLATNESS = 4;
+  SELF_CALIBRATE_STEPS_DIGITIZER_SELF_CAL = 8;
+  SELF_CALIBRATE_STEPS_LO_SELF_CAL = 16;
+  SELF_CALIBRATE_STEPS_AMPLITUDE_ACCURACY = 32;
+  SELF_CALIBRATE_STEPS_RESIDUAL_LO_POWER = 64;
+  SELF_CALIBRATE_STEPS_IMAGE_SUPPRESSION = 128;
+  SELF_CALIBRATE_STEPS_SYNTHESIZER_ALIGNMENT = 256;
+  SELF_CALIBRATE_STEPS_DC_OFFSET = 512;
 }
 
 enum Signal {
@@ -1817,7 +1817,8 @@ message IsSelfCalValidRequest {
 message IsSelfCalValidResponse {
   int32 status = 1;
   bool self_cal_valid = 2;
-  int64 valid_steps = 3;
+  repeated SelfCalibrateSteps valid_steps_array = 3;
+  int64 valid_steps_raw = 4;
 }
 
 message PerformThermalCorrectionRequest {
@@ -1934,7 +1935,7 @@ message SelfCalResponse {
 message SelfCalibrateRequest {
   nidevice_grpc.Session vi = 1;
   oneof steps_to_omit_enum {
-    SelfCalibrateStepsToOmit steps_to_omit = 2;
+    SelfCalibrateSteps steps_to_omit = 2;
     int64 steps_to_omit_raw = 3;
   }
 }
@@ -1946,7 +1947,7 @@ message SelfCalibrateResponse {
 message SelfCalibrateRangeRequest {
   nidevice_grpc.Session vi = 1;
   oneof steps_to_omit_enum {
-    SelfCalibrateStepsToOmit steps_to_omit = 2;
+    SelfCalibrateSteps steps_to_omit = 2;
     int64 steps_to_omit_raw = 3;
   }
   double min_frequency = 4;

--- a/generated/nirfsa/nirfsa_client.cpp
+++ b/generated/nirfsa/nirfsa_client.cpp
@@ -2004,13 +2004,13 @@ self_cal(const StubPtr& stub, const nidevice_grpc::Session& vi)
 }
 
 SelfCalibrateResponse
-self_calibrate(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<SelfCalibrateStepsToOmit, pb::int64>& steps_to_omit)
+self_calibrate(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<SelfCalibrateSteps, pb::int64>& steps_to_omit)
 {
   ::grpc::ClientContext context;
 
   auto request = SelfCalibrateRequest{};
   request.mutable_vi()->CopyFrom(vi);
-  const auto steps_to_omit_ptr = steps_to_omit.get_if<SelfCalibrateStepsToOmit>();
+  const auto steps_to_omit_ptr = steps_to_omit.get_if<SelfCalibrateSteps>();
   const auto steps_to_omit_raw_ptr = steps_to_omit.get_if<pb::int64>();
   if (steps_to_omit_ptr) {
     request.set_steps_to_omit(*steps_to_omit_ptr);
@@ -2028,13 +2028,13 @@ self_calibrate(const StubPtr& stub, const nidevice_grpc::Session& vi, const simp
 }
 
 SelfCalibrateRangeResponse
-self_calibrate_range(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<SelfCalibrateStepsToOmit, pb::int64>& steps_to_omit, const double& min_frequency, const double& max_frequency, const double& min_reference_level, const double& max_reference_level)
+self_calibrate_range(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<SelfCalibrateSteps, pb::int64>& steps_to_omit, const double& min_frequency, const double& max_frequency, const double& min_reference_level, const double& max_reference_level)
 {
   ::grpc::ClientContext context;
 
   auto request = SelfCalibrateRangeRequest{};
   request.mutable_vi()->CopyFrom(vi);
-  const auto steps_to_omit_ptr = steps_to_omit.get_if<SelfCalibrateStepsToOmit>();
+  const auto steps_to_omit_ptr = steps_to_omit.get_if<SelfCalibrateSteps>();
   const auto steps_to_omit_raw_ptr = steps_to_omit.get_if<pb::int64>();
   if (steps_to_omit_ptr) {
     request.set_steps_to_omit(*steps_to_omit_ptr);

--- a/generated/nirfsa/nirfsa_client.h
+++ b/generated/nirfsa/nirfsa_client.h
@@ -127,8 +127,8 @@ ResetWithDefaultsResponse reset_with_defaults(const StubPtr& stub, const nidevic
 ResetWithOptionsResponse reset_with_options(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<ResetWithOptionsStepsToOmit, pb::uint64>& steps_to_omit);
 RevisionQueryResponse revision_query(const StubPtr& stub, const nidevice_grpc::Session& vi);
 SelfCalResponse self_cal(const StubPtr& stub, const nidevice_grpc::Session& vi);
-SelfCalibrateResponse self_calibrate(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<SelfCalibrateStepsToOmit, pb::int64>& steps_to_omit);
-SelfCalibrateRangeResponse self_calibrate_range(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<SelfCalibrateStepsToOmit, pb::int64>& steps_to_omit, const double& min_frequency, const double& max_frequency, const double& min_reference_level, const double& max_reference_level);
+SelfCalibrateResponse self_calibrate(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<SelfCalibrateSteps, pb::int64>& steps_to_omit);
+SelfCalibrateRangeResponse self_calibrate_range(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<SelfCalibrateSteps, pb::int64>& steps_to_omit, const double& min_frequency, const double& max_frequency, const double& min_reference_level, const double& max_reference_level);
 SelfTestResponse self_test(const StubPtr& stub, const nidevice_grpc::Session& vi);
 SendSoftwareEdgeTriggerResponse send_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<Signal, pb::int32>& trigger, const pb::string& trigger_identifier);
 SetAttributeViBooleanResponse set_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiRFSAAttributes& attribute_id, const bool& value);

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -2709,7 +2709,27 @@ namespace nirfsa_grpc {
       response->set_status(status);
       if (status == 0) {
         response->set_self_cal_valid(self_cal_valid);
-        response->set_valid_steps(valid_steps);
+        if (valid_steps & 0x1)
+          response->add_valid_steps_array(SelfCalibrateSteps::SELF_CALIBRATE_STEPS_ALIGNMENT);
+        if (valid_steps & 0x2)
+          response->add_valid_steps_array(SelfCalibrateSteps::SELF_CALIBRATE_STEPS_GAIN_REFERENCE);
+        if (valid_steps & 0x4)
+          response->add_valid_steps_array(SelfCalibrateSteps::SELF_CALIBRATE_STEPS_IF_FLATNESS);
+        if (valid_steps & 0x8)
+          response->add_valid_steps_array(SelfCalibrateSteps::SELF_CALIBRATE_STEPS_DIGITIZER_SELF_CAL);
+        if (valid_steps & 0x10)
+          response->add_valid_steps_array(SelfCalibrateSteps::SELF_CALIBRATE_STEPS_LO_SELF_CAL);
+        if (valid_steps & 0x20)
+          response->add_valid_steps_array(SelfCalibrateSteps::SELF_CALIBRATE_STEPS_AMPLITUDE_ACCURACY);
+        if (valid_steps & 0x40)
+          response->add_valid_steps_array(SelfCalibrateSteps::SELF_CALIBRATE_STEPS_RESIDUAL_LO_POWER);
+        if (valid_steps & 0x80)
+          response->add_valid_steps_array(SelfCalibrateSteps::SELF_CALIBRATE_STEPS_IMAGE_SUPPRESSION);
+        if (valid_steps & 0x100)
+          response->add_valid_steps_array(SelfCalibrateSteps::SELF_CALIBRATE_STEPS_SYNTHESIZER_ALIGNMENT);
+        if (valid_steps & 0x200)
+          response->add_valid_steps_array(SelfCalibrateSteps::SELF_CALIBRATE_STEPS_DC_OFFSET);
+        response->set_valid_steps_raw(valid_steps);
       }
       return ::grpc::Status::OK;
     }

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -38,7 +38,11 @@ def is_array(dataType: str):
 
 
 def is_enum(parameter: dict):
-    return "enum" in parameter or "mapped-enum" in parameter
+    return (
+        "enum" in parameter 
+        or "mapped-enum" in parameter 
+        or "bitfield_as_enum_array" in parameter
+    )
 
 
 def is_custom_struct(parameter: dict) -> bool:
@@ -363,6 +367,8 @@ def get_function_enums(functions):
                 function_enums.add(parameter['enum'])
             if 'mapped-enum' in parameter:
                 function_enums.add(parameter['mapped-enum'])
+            if 'bitfield_as_enum_array' in parameter:
+                function_enums.add(parameter['bitfield_as_enum_array'])
     return sorted(function_enums)
 
 
@@ -766,3 +772,7 @@ def get_additional_headers(config: dict, including_from_file: str) -> List[str]:
         for header, required_by in additional_header_requirements.items()
         if including_from_file in required_by
     )
+
+
+def get_enum_value_prefix(enum_name: str, enum: dict) -> str:
+    return enum.get("enum-value-prefix", pascal_to_snake(enum_name).upper())

--- a/source/codegen/metadata/nifake/enums.py
+++ b/source/codegen/metadata/nifake/enums.py
@@ -21,6 +21,26 @@ enums = {
             }
         ]
     },
+    'Bitfield': {
+        'values': [
+            {
+                'name': 'FLAG_A',
+                'value': 1,
+            },
+            {
+                'name': 'FLAG_B',
+                'value': 2,
+            },
+            {
+                'name': 'FLAG_C',
+                'value': 4,
+            },
+            {
+                'name': 'FLAG_D',
+                'value': 8,
+            },
+        ]
+    },
     'Color': {
         'values': [
             {

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -541,6 +541,17 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'GetBitfieldAsEnumArray': {
+        'parameters': [
+            {
+                'bitfield_as_enum_array': 'Bitfield',
+                'direction': 'out',
+                'name': 'flags',
+                'type': 'ViInt64',
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'GetAnIviDanceString': {
         'codegen_method': 'public',
         'documentation': {

--- a/source/codegen/metadata/nirfsa/enums.py
+++ b/source/codegen/metadata/nirfsa/enums.py
@@ -1621,10 +1621,10 @@ enums = {
             }
         ]
     },
-    'SelfCalibrateStepsToOmit': {
+    'SelfCalibrateSteps': {
         'values': [
             {
-                'name': 'OMIT_NONE',
+                'name': 'NONE',
                 'value': 0
             },
             {

--- a/source/codegen/metadata/nirfsa/functions.py
+++ b/source/codegen/metadata/nirfsa/functions.py
@@ -2337,6 +2337,7 @@ functions = {
                 'type': 'ViBoolean'
             },
             {
+                'bitfield_as_enum_array': 'SelfCalibrateSteps',
                 'direction': 'out',
                 'name': 'validSteps',
                 'type': 'ViInt64'
@@ -2606,7 +2607,7 @@ functions = {
             },
             {
                 'direction': 'in',
-                'enum': 'SelfCalibrateStepsToOmit',
+                'enum': 'SelfCalibrateSteps',
                 'name': 'stepsToOmit',
                 'type': 'ViInt64'
             }
@@ -2622,7 +2623,7 @@ functions = {
             },
             {
                 'direction': 'in',
-                'enum': 'SelfCalibrateStepsToOmit',
+                'enum': 'SelfCalibrateSteps',
                 'name': 'stepsToOmit',
                 'type': 'ViInt64'
             },

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -58,6 +58,7 @@ PARAM_SCHEMA = Schema(
         Optional('type'): str,
         Optional('grpc_type'): str,
         Optional('documentation'): DOCUMENTATION_SCHEMA,
+        Optional('bitfield_as_enum_array'): str,
         Optional('enum'): str,
         Optional('size'): SIZE_SCHEMA,
         Optional('default_value'): Or(str, bool, int, float, None),

--- a/source/codegen/proto_helpers.py
+++ b/source/codegen/proto_helpers.py
@@ -24,7 +24,7 @@ def get_enum_definitions(enums_to_define, enums):
   for enum_name in (e for e in enums if e in enums_to_define):
     enum = enums[enum_name]
     allow_alias = should_allow_alias(enum)
-    enum_value_prefix = enum.get("enum-value-prefix", common_helpers.pascal_to_snake(enum_name).upper())
+    enum_value_prefix = common_helpers.get_enum_value_prefix(enum_name, enum)
     if enum.get("generate-mappings", False):
       values = [{"name": f"{enum_value_prefix}_{value['name']}", "value": index + 1} for index, value in enumerate(enum["values"])]
     else:
@@ -105,6 +105,13 @@ def get_enum_parameters(parameter, parameter_name, parameter_type, is_array, use
       "type": mapped_type,
       "grpc_field_number": grpc_mapped_field_number
     })
+  if 'bitfield_as_enum_array' in parameter:
+    enum_parameters.append({
+      "name": f"{parameter_name}_array",
+      "type": f"repeated {parameter['bitfield_as_enum_array']}",
+      "grpc_field_number": generate_parameter_field_number(parameter, used_indexes, "_array")
+    })
+
   grpc_raw_field_number = generate_parameter_field_number(parameter, used_indexes, "_raw")
   enum_parameters.append({
     "name": f"{parameter_name}_raw",

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -348,3 +348,16 @@ def get_enums_to_map(functions: dict, enums: dict) -> List[str]:
         for e in function_enums 
         if should_generate_mappings(e)
     ]
+
+
+def get_bitfield_value_to_name_mapping(parameter: dict, enums: dict) -> Dict[int, str]:
+    enum_name = parameter["bitfield_as_enum_array"]
+    enum = enums[enum_name]
+    enum_value_prefix = common_helpers.get_enum_value_prefix(enum_name, enum)
+    enum_qualified_name_prefix = f"{enum_name}::{enum_value_prefix}"
+
+    return {
+        v["value"]: f"{enum_qualified_name_prefix}_{v['name']}"
+        for v in enum["values"]
+        if v["value"] != 0 # zero values can't be flags!
+    }

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -611,6 +611,7 @@ ${initialize_standard_input_param(function_name, parameter)}
 <%
   has_mapped_enum = 'mapped-enum' in parameter
   has_unmapped_enum = 'enum' in parameter
+  is_bitfield_as_enum_array = 'bitfield_as_enum_array' in parameter
   if has_mapped_enum:
     mapped_enum_name = parameter["mapped-enum"]
     map_name = mapped_enum_name.lower() + "_output_map_"
@@ -654,6 +655,12 @@ ${copy_to_response_with_transform(source_buffer=raw_response_field, parameter_na
 %       else:
         response->set_${parameter_name}(static_cast<${namespace_prefix}${parameter["enum"]}>(${parameter_name}));
 %       endif
+%     endif
+%     if is_bitfield_as_enum_array:
+%       for flag_value, flag_enum_name in service_helpers.get_bitfield_value_to_name_mapping(parameter, enums).items():
+        if (${parameter_name} & ${hex(flag_value)})
+          response->add_${parameter_name}_array(${flag_enum_name});
+%       endfor
 %     endif
 %     if not uses_raw_output_as_read_buffer: # Set data to raw, unless we *got* the data from raw.
         response->set_${parameter_name}_raw(${parameter_name});

--- a/source/tests/system/nirfsa_driver_api_tests.cpp
+++ b/source/tests/system/nirfsa_driver_api_tests.cpp
@@ -560,9 +560,19 @@ TEST_F(NiRFSADriverApiTests, TwoSessions_SetupTclkSyncPulseSenderSynchronization
 TEST_F(NiRFSADriverApiTests, SelfCalibrateWithStepsToOmit_Succeeds)
 {
   auto session = init_session(stub(), PXI_5663E);
-  const auto response = client::self_calibrate(stub(), session, SelfCalibrateStepsToOmit::SELF_CALIBRATE_STEPS_TO_OMIT_ALIGNMENT);
+  const auto response = client::self_calibrate(stub(), session, SelfCalibrateSteps::SELF_CALIBRATE_STEPS_ALIGNMENT);
 
   EXPECT_SUCCESS(session, response);
+}
+
+TEST_F(NiRFSADriverApiTests, IsSelfCalValid)
+{
+  auto session = init_session(stub(), PXI_5663E);
+  const auto response = client::is_self_cal_valid(stub(), session);
+
+  EXPECT_SUCCESS(session, response);
+  EXPECT_THAT(response.valid_steps_array(), ElementsAre(SELF_CALIBRATE_STEPS_DIGITIZER_SELF_CAL));
+  EXPECT_EQ(NIRFSA_VAL_SELF_CAL_DIGITIZER_SELF_CAL, response.valid_steps_raw());
 }
 
 TEST_F(NiRFSADriverApiTests, SelfTest_Succeeds)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add `bitfield_as_enum_array` parameter configuration option.
* Allows representing a bitfield as an array of enum values (for each matched bit).
* Currently only supported for outputs (using normal enums + raw works pretty well for inputs and is what we are doing in other cases).

### Why should this Pull Request be merged?

Allows using enum values for `IsSelfCalValid`.

### What testing has been done?

Ran and passed included tests.

Some manual testing with json client.