### PR TITLE
Exclude ChangeExtCalPassword from RFSA

### DIFF
--- a/generated/nirfsa/nirfsa.proto
+++ b/generated/nirfsa/nirfsa.proto
@@ -18,7 +18,6 @@ import "session.proto";
 
 service NiRFSA {
   rpc Abort(AbortRequest) returns (AbortResponse);
-  rpc ChangeExtCalPassword(ChangeExtCalPasswordRequest) returns (ChangeExtCalPasswordResponse);
   rpc CheckAcquisitionStatus(CheckAcquisitionStatusRequest) returns (CheckAcquisitionStatusResponse);
   rpc ClearError(ClearErrorRequest) returns (ClearErrorResponse);
   rpc ClearSelfCalibrateRange(ClearSelfCalibrateRangeRequest) returns (ClearSelfCalibrateRangeResponse);
@@ -767,16 +766,6 @@ message AbortRequest {
 }
 
 message AbortResponse {
-  int32 status = 1;
-}
-
-message ChangeExtCalPasswordRequest {
-  nidevice_grpc.Session vi = 1;
-  string old_password = 2;
-  string new_password = 3;
-}
-
-message ChangeExtCalPasswordResponse {
   int32 status = 1;
 }
 

--- a/generated/nirfsa/nirfsa_client.cpp
+++ b/generated/nirfsa/nirfsa_client.cpp
@@ -33,24 +33,6 @@ abort(const StubPtr& stub, const nidevice_grpc::Session& vi)
   return response;
 }
 
-ChangeExtCalPasswordResponse
-change_ext_cal_password(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& old_password, const pb::string& new_password)
-{
-  ::grpc::ClientContext context;
-
-  auto request = ChangeExtCalPasswordRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-  request.set_old_password(old_password);
-  request.set_new_password(new_password);
-
-  auto response = ChangeExtCalPasswordResponse{};
-
-  raise_if_error(
-      stub->ChangeExtCalPassword(&context, request, &response));
-
-  return response;
-}
-
 CheckAcquisitionStatusResponse
 check_acquisition_status(const StubPtr& stub, const nidevice_grpc::Session& vi)
 {

--- a/generated/nirfsa/nirfsa_client.h
+++ b/generated/nirfsa/nirfsa_client.h
@@ -23,7 +23,6 @@ using namespace nidevice_grpc::experimental::client;
 
 
 AbortResponse abort(const StubPtr& stub, const nidevice_grpc::Session& vi);
-ChangeExtCalPasswordResponse change_ext_cal_password(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& old_password, const pb::string& new_password);
 CheckAcquisitionStatusResponse check_acquisition_status(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ClearErrorResponse clear_error(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ClearSelfCalibrateRangeResponse clear_self_calibrate_range(const StubPtr& stub, const nidevice_grpc::Session& vi);

--- a/generated/nirfsa/nirfsa_library.cpp
+++ b/generated/nirfsa/nirfsa_library.cpp
@@ -22,7 +22,6 @@ NiRFSALibrary::NiRFSALibrary() : shared_library_(kLibraryName)
     return;
   }
   function_pointers_.Abort = reinterpret_cast<AbortPtr>(shared_library_.get_function_pointer("niRFSA_Abort"));
-  function_pointers_.ChangeExtCalPassword = reinterpret_cast<ChangeExtCalPasswordPtr>(shared_library_.get_function_pointer("niRFSA_ChangeExtCalPassword"));
   function_pointers_.CheckAcquisitionStatus = reinterpret_cast<CheckAcquisitionStatusPtr>(shared_library_.get_function_pointer("niRFSA_CheckAcquisitionStatus"));
   function_pointers_.ClearError = reinterpret_cast<ClearErrorPtr>(shared_library_.get_function_pointer("niRFSA_ClearError"));
   function_pointers_.ClearSelfCalibrateRange = reinterpret_cast<ClearSelfCalibrateRangePtr>(shared_library_.get_function_pointer("niRFSA_ClearSelfCalibrateRange"));
@@ -150,18 +149,6 @@ ViStatus NiRFSALibrary::Abort(ViSession vi)
   return niRFSA_Abort(vi);
 #else
   return function_pointers_.Abort(vi);
-#endif
-}
-
-ViStatus NiRFSALibrary::ChangeExtCalPassword(ViSession vi, ViConstString oldPassword, ViConstString newPassword)
-{
-  if (!function_pointers_.ChangeExtCalPassword) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niRFSA_ChangeExtCalPassword.");
-  }
-#if defined(_MSC_VER)
-  return niRFSA_ChangeExtCalPassword(vi, oldPassword, newPassword);
-#else
-  return function_pointers_.ChangeExtCalPassword(vi, oldPassword, newPassword);
 #endif
 }
 

--- a/generated/nirfsa/nirfsa_library.h
+++ b/generated/nirfsa/nirfsa_library.h
@@ -19,7 +19,6 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
 
   ::grpc::Status check_function_exists(std::string functionName);
   ViStatus Abort(ViSession vi);
-  ViStatus ChangeExtCalPassword(ViSession vi, ViConstString oldPassword, ViConstString newPassword);
   ViStatus CheckAcquisitionStatus(ViSession vi, ViBoolean* isDone);
   ViStatus ClearError(ViSession vi);
   ViStatus ClearSelfCalibrateRange(ViSession vi);
@@ -128,7 +127,6 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
 
  private:
   using AbortPtr = decltype(&niRFSA_Abort);
-  using ChangeExtCalPasswordPtr = decltype(&niRFSA_ChangeExtCalPassword);
   using CheckAcquisitionStatusPtr = decltype(&niRFSA_CheckAcquisitionStatus);
   using ClearErrorPtr = decltype(&niRFSA_ClearError);
   using ClearSelfCalibrateRangePtr = decltype(&niRFSA_ClearSelfCalibrateRange);
@@ -237,7 +235,6 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
 
   typedef struct FunctionPointers {
     AbortPtr Abort;
-    ChangeExtCalPasswordPtr ChangeExtCalPassword;
     CheckAcquisitionStatusPtr CheckAcquisitionStatus;
     ClearErrorPtr ClearError;
     ClearSelfCalibrateRangePtr ClearSelfCalibrateRange;

--- a/generated/nirfsa/nirfsa_library_interface.h
+++ b/generated/nirfsa/nirfsa_library_interface.h
@@ -17,7 +17,6 @@ class NiRFSALibraryInterface {
   virtual ~NiRFSALibraryInterface() {}
 
   virtual ViStatus Abort(ViSession vi) = 0;
-  virtual ViStatus ChangeExtCalPassword(ViSession vi, ViConstString oldPassword, ViConstString newPassword) = 0;
   virtual ViStatus CheckAcquisitionStatus(ViSession vi, ViBoolean* isDone) = 0;
   virtual ViStatus ClearError(ViSession vi) = 0;
   virtual ViStatus ClearSelfCalibrateRange(ViSession vi) = 0;

--- a/generated/nirfsa/nirfsa_mock_library.h
+++ b/generated/nirfsa/nirfsa_mock_library.h
@@ -18,7 +18,6 @@ namespace unit {
 class NiRFSAMockLibrary : public nirfsa_grpc::NiRFSALibraryInterface {
  public:
   MOCK_METHOD(ViStatus, Abort, (ViSession vi), (override));
-  MOCK_METHOD(ViStatus, ChangeExtCalPassword, (ViSession vi, ViConstString oldPassword, ViConstString newPassword), (override));
   MOCK_METHOD(ViStatus, CheckAcquisitionStatus, (ViSession vi, ViBoolean* isDone), (override));
   MOCK_METHOD(ViStatus, ClearError, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, ClearSelfCalibrateRange, (ViSession vi), (override));

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -55,27 +55,6 @@ namespace nirfsa_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiRFSAService::ChangeExtCalPassword(::grpc::ServerContext* context, const ChangeExtCalPasswordRequest* request, ChangeExtCalPasswordResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      auto old_password = request->old_password().c_str();
-      auto new_password = request->new_password().c_str();
-      auto status = library_->ChangeExtCalPassword(vi, old_password, new_password);
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiRFSAService::CheckAcquisitionStatus(::grpc::ServerContext* context, const CheckAcquisitionStatusRequest* request, CheckAcquisitionStatusResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nirfsa/nirfsa_service.h
+++ b/generated/nirfsa/nirfsa_service.h
@@ -34,7 +34,6 @@ public:
   virtual ~NiRFSAService();
   
   ::grpc::Status Abort(::grpc::ServerContext* context, const AbortRequest* request, AbortResponse* response) override;
-  ::grpc::Status ChangeExtCalPassword(::grpc::ServerContext* context, const ChangeExtCalPasswordRequest* request, ChangeExtCalPasswordResponse* response) override;
   ::grpc::Status CheckAcquisitionStatus(::grpc::ServerContext* context, const CheckAcquisitionStatusRequest* request, CheckAcquisitionStatusResponse* response) override;
   ::grpc::Status ClearError(::grpc::ServerContext* context, const ClearErrorRequest* request, ClearErrorResponse* response) override;
   ::grpc::Status ClearSelfCalibrateRange(::grpc::ServerContext* context, const ClearSelfCalibrateRangeRequest* request, ClearSelfCalibrateRangeResponse* response) override;

--- a/source/codegen/metadata/nirfsa/functions.py
+++ b/source/codegen/metadata/nirfsa/functions.py
@@ -9,26 +9,6 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
-    'ChangeExtCalPassword': {
-        'parameters': [
-            {
-                'direction': 'in',
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'direction': 'in',
-                'name': 'oldPassword',
-                'type': 'ViConstString'
-            },
-            {
-                'direction': 'in',
-                'name': 'newPassword',
-                'type': 'ViConstString'
-            }
-        ],
-        'returns': 'ViStatus'
-    },
     'CheckAcquisitionStatus': {
         'parameters': [
             {


### PR DESCRIPTION
### What does this Pull Request accomplish?

Remove `ChangeExtCalPassword` from RFSA API.

### Why should this Pull Request be merged?

`ChangeExtCalPassword` is one of the ExtCal methods that *can* be used without an ExtCal session. So, we could include it. But it's better to avoid adding passwords to our API and changing passwords is more of an active ExtCal operation even though it's not performing calibration per se.

### What testing has been done?

Builds.