### PR TITLE
Make client artifacts toggle-aware

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -157,23 +157,6 @@ jobs:
         path: ni-grpc-device-tests-linux-glibc${{ matrix.config.glibc_version }}-x64.tar.gz
         retention-days: 5
 
-    - name: Stage Linux Client Files
-      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
-      run: |
-        mkdir -p ${{ runner.temp }}/staging/proto
-        cp generated/**/*.proto source/protobuf/*.proto ${{ runner.temp }}/staging/proto
-        cp -r examples/ ${{ runner.temp }}/staging/
-        cp LICENSE ThirdPartyNotices.txt ${{ runner.temp }}/staging/
-        tar -cvzf ni-grpc-device-client.tar.gz -C ${{ runner.temp }}/staging/ --exclude *nifake* examples/ proto/ LICENSE ThirdPartyNotices.txt
-
-    - name: Upload Linux Client Files Artifact
-      uses: actions/upload-artifact@v2
-      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
-      with:
-        name: ni-grpc-device-client-Linux
-        path: ni-grpc-device-client.tar.gz
-        retention-days: 5
-
     - name: Upload Windows Server Information Artifact
       uses: actions/upload-artifact@v2
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}
@@ -208,24 +191,6 @@ jobs:
           build/Release/UnitTestsRunner.exe
           LICENSE
           ThirdPartyNotices.txt
-        retention-days: 5
-
-    - name: Stage Windows Client Files
-      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}
-      shell: powershell
-      run: |
-        mkdir "${{ runner.temp }}/staging/proto"
-        Copy-Item "source/protobuf/*.proto", "generated/**/*.proto" -Exclude "*nifake*" -Destination "${{ runner.temp }}/staging/proto/"
-        Copy-Item "examples/" -Recurse -Destination "${{ runner.temp }}/staging/"
-        Copy-Item "LICENSE","ThirdPartyNotices.txt" -Destination "${{ runner.temp }}/staging/"
-
-    - name: Upload Windows Client Files Artifact
-      uses: actions/upload-artifact@v2
-      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}
-      with:
-        name: ni-grpc-device-client
-        path: |
-          ${{ runner.temp }}/staging
         retention-days: 5
 
   trigger_main_ci:

--- a/.github/workflows/create_client_artifacts.yml
+++ b/.github/workflows/create_client_artifacts.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
       - 'releases/**'
-  pull_request:
-    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/create_client_artifacts.yml
+++ b/.github/workflows/create_client_artifacts.yml
@@ -1,0 +1,67 @@
+name: Create Client Artifacts
+
+on:
+  push:
+    branches:
+      - main
+      - 'releases/**'
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+        - {
+            name: "Windows Build", artifact: "Windows.tar.xz",
+            os: windows-latest,
+          }
+        - {
+            name: "Ubuntu Build", artifact: "Linux.tar.xz",
+            os: ubuntu-18.04,
+          }
+
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+
+    - name: Setup python3
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install build dependencies
+      run: python -m pip install -r python_build_modules.txt
+
+    - name: Stage Client Files
+      run: |
+        python source/codegen/stage_client_files.py -o ${{ runner.temp }}/staging/
+
+    - name: Tar Linux Client Files
+      if: ${{ (runner.os == 'Linux') }}
+      run: |
+        tar -cvzf ni-grpc-device-client.tar.gz -C ${{ runner.temp }}/staging/ .
+
+    - name: Upload Linux Client Files Artifact
+      uses: actions/upload-artifact@v2
+      if: ${{ runner.os == 'Linux' }}
+      with:
+        name: ni-grpc-device-client-Linux
+        path: ni-grpc-device-client.tar.gz
+        retention-days: 5
+
+    - name: Upload Windows Client Files Artifact
+      uses: actions/upload-artifact@v2
+      if: ${{ runner.os == 'Windows' }}
+      with:
+        name: ni-grpc-device-client
+        path: |
+          ${{ runner.temp }}/staging
+        retention-days: 5
+
+

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -776,3 +776,8 @@ def get_additional_headers(config: dict, including_from_file: str) -> List[str]:
 
 def get_enum_value_prefix(enum_name: str, enum: dict) -> str:
     return enum.get("enum-value-prefix", pascal_to_snake(enum_name).upper())
+
+
+def get_driver_readiness(config: dict) -> str:
+    return config.get('code_readiness', 'Release')
+    

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -324,7 +324,7 @@ def get_toggle_member_name(fully_qualified_toggle_name: str) -> str:
 
 
 def get_driver_service_readiness(config: dict) -> str:
-    readiness = config.get('code_readiness', 'Release')
+    readiness = common_helpers.get_driver_readiness(config)
     return to_cpp_readiness(readiness)
 
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Moves artifact staging to a python script, which can use driver metadata to check toggle state and only include proto/example files for release-ready drivers.

### Why should this Pull Request be merged?

Allows us to release with drivers that are (cleanly) toggled off.

### What testing has been done?

Several test builds on my private repo and locally.