### PR TITLE
Fail workflow if files are dirtied during build

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -100,6 +100,13 @@ jobs:
           message(FATAL_ERROR "Build failed")
         endif()
 
+    # The generated source in git must match the output of workflow builds.
+    # If this step fails, something is changing during build. Either:
+    # 1. Fix non-deterministic codegen, OR
+    # 2. Build locally to ensure generated files are up-to-date.
+    - name: Check for files dirtied by codegen
+      run: git diff --exit-code
+
     - name: Run Tests
       shell: cmake -P {0}
       run: |

--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -134,6 +134,13 @@ jobs:
           message(FATAL_ERROR "Build failed")
         endif()
 
+    # The generated source in git must match the output of workflow builds.
+    # If this step fails, something is changing during build. Either:
+    # 1. Fix non-deterministic codegen, OR
+    # 2. Build locally to ensure generated files are up-to-date.
+    - name: Check for files dirtied by codegen
+      run: git diff --exit-code
+
     - name: Tar Server Build Files
       if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases') }}
       run: >-

--- a/source/codegen/generate_shared_service_files.py
+++ b/source/codegen/generate_shared_service_files.py
@@ -6,7 +6,7 @@ from template_helpers import instantiate_mako_template, write_if_changed, load_m
 def generate_register_all_services(metadata_dir: Path, output_dir: Path) -> None:
   driver_modules = [
     load_metadata(p)
-    for p in metadata_dir.iterdir()
+    for p in sorted(metadata_dir.iterdir())
     if p.is_dir() and not "fake" in p.name
   ]
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update `build_cmake.yml` and `build_nilrt.yml` to fail if files are changed during build/codegen.

### Why should this Pull Request be merged?

This ensures that our generated source code is up-to-date. This is important to (a) ensure that our review/tracking process for generated code is sound and (b) ensure that other workflow runs that operate on the generated source get the same inputs.

### What testing has been done?

Testing of workflow results with induced failures (and fixing those failures).
