### PR TITLE
Fix name of python_build_requirements in client workflow

### DIFF
--- a/.github/workflows/create_client_artifacts.yml
+++ b/.github/workflows/create_client_artifacts.yml
@@ -34,7 +34,7 @@ jobs:
         python-version: '3.x'
 
     - name: Install build dependencies
-      run: python -m pip install -r python_build_modules.txt
+      run: python -m pip install -r python_build_requirements.txt
 
     - name: Stage Client Files
       run: |

--- a/.github/workflows/create_client_artifacts.yml
+++ b/.github/workflows/create_client_artifacts.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - 'releases/**'
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 jobs:
@@ -47,7 +49,7 @@ jobs:
 
     - name: Upload Linux Client Files Artifact
       uses: actions/upload-artifact@v2
-      if: ${{ runner.os == 'Linux' }}
+      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       with:
         name: ni-grpc-device-client-Linux
         path: ni-grpc-device-client.tar.gz
@@ -55,7 +57,7 @@ jobs:
 
     - name: Upload Windows Client Files Artifact
       uses: actions/upload-artifact@v2
-      if: ${{ runner.os == 'Windows' }}
+      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}
       with:
         name: ni-grpc-device-client
         path: |


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update the name of `python_build_modules` to `python_build_requirements` in client workflow yaml.

Enable client workflow builds on PRs.

### Why should this Pull Request be merged?

Fixes build.

Originally I left this off of PR builds to simplify the yml. Since I managed to break it the next day, that seems like the wrong choice.

### What testing has been done?

Build.