### PR TITLE
remove InitializeExternalAlignment from RFSA

### DIFF
--- a/generated/nirfsa/nirfsa.proto
+++ b/generated/nirfsa/nirfsa.proto
@@ -94,7 +94,6 @@ service NiRFSA {
   rpc GetUserData(GetUserDataRequest) returns (GetUserDataResponse);
   rpc Init(InitRequest) returns (InitResponse);
   rpc InitWithOptions(InitWithOptionsRequest) returns (InitWithOptionsResponse);
-  rpc InitializeExternalAlignment(InitializeExternalAlignmentRequest) returns (InitializeExternalAlignmentResponse);
   rpc Initiate(InitiateRequest) returns (InitiateResponse);
   rpc InvalidateAllAttributes(InvalidateAllAttributesRequest) returns (InvalidateAllAttributesResponse);
   rpc IsSelfCalValid(IsSelfCalValidRequest) returns (IsSelfCalValidResponse);
@@ -1620,16 +1619,6 @@ message InitWithOptionsRequest {
 }
 
 message InitWithOptionsResponse {
-  int32 status = 1;
-  nidevice_grpc.Session vi = 2;
-}
-
-message InitializeExternalAlignmentRequest {
-  string resource_name = 1;
-  string option_string = 2;
-}
-
-message InitializeExternalAlignmentResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
 }

--- a/generated/nirfsa/nirfsa_client.cpp
+++ b/generated/nirfsa/nirfsa_client.cpp
@@ -1495,23 +1495,6 @@ init_with_options(const StubPtr& stub, const pb::string& resource_name, const bo
   return response;
 }
 
-InitializeExternalAlignmentResponse
-initialize_external_alignment(const StubPtr& stub, const pb::string& resource_name, const pb::string& option_string)
-{
-  ::grpc::ClientContext context;
-
-  auto request = InitializeExternalAlignmentRequest{};
-  request.set_resource_name(resource_name);
-  request.set_option_string(option_string);
-
-  auto response = InitializeExternalAlignmentResponse{};
-
-  raise_if_error(
-      stub->InitializeExternalAlignment(&context, request, &response));
-
-  return response;
-}
-
 InitiateResponse
 initiate(const StubPtr& stub, const nidevice_grpc::Session& vi)
 {

--- a/generated/nirfsa/nirfsa_client.h
+++ b/generated/nirfsa/nirfsa_client.h
@@ -99,7 +99,6 @@ GetTerminalNameResponse get_terminal_name(const StubPtr& stub, const nidevice_gr
 GetUserDataResponse get_user_data(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& identifier);
 InitResponse init(const StubPtr& stub, const pb::string& resource_name, const bool& id_query, const bool& reset);
 InitWithOptionsResponse init_with_options(const StubPtr& stub, const pb::string& resource_name, const bool& id_query, const bool& reset, const pb::string& option_string);
-InitializeExternalAlignmentResponse initialize_external_alignment(const StubPtr& stub, const pb::string& resource_name, const pb::string& option_string);
 InitiateResponse initiate(const StubPtr& stub, const nidevice_grpc::Session& vi);
 InvalidateAllAttributesResponse invalidate_all_attributes(const StubPtr& stub, const nidevice_grpc::Session& vi);
 IsSelfCalValidResponse is_self_cal_valid(const StubPtr& stub, const nidevice_grpc::Session& vi);

--- a/generated/nirfsa/nirfsa_library.cpp
+++ b/generated/nirfsa/nirfsa_library.cpp
@@ -98,7 +98,6 @@ NiRFSALibrary::NiRFSALibrary() : shared_library_(kLibraryName)
   function_pointers_.GetUserData = reinterpret_cast<GetUserDataPtr>(shared_library_.get_function_pointer("niRFSA_GetUserData"));
   function_pointers_.Init = reinterpret_cast<InitPtr>(shared_library_.get_function_pointer("niRFSA_init"));
   function_pointers_.InitWithOptions = reinterpret_cast<InitWithOptionsPtr>(shared_library_.get_function_pointer("niRFSA_InitWithOptions"));
-  function_pointers_.InitializeExternalAlignment = reinterpret_cast<InitializeExternalAlignmentPtr>(shared_library_.get_function_pointer("niRFSA_InitializeExternalAlignment"));
   function_pointers_.Initiate = reinterpret_cast<InitiatePtr>(shared_library_.get_function_pointer("niRFSA_Initiate"));
   function_pointers_.InvalidateAllAttributes = reinterpret_cast<InvalidateAllAttributesPtr>(shared_library_.get_function_pointer("niRFSA_InvalidateAllAttributes"));
   function_pointers_.IsSelfCalValid = reinterpret_cast<IsSelfCalValidPtr>(shared_library_.get_function_pointer("niRFSA_IsSelfCalValid"));
@@ -1061,18 +1060,6 @@ ViStatus NiRFSALibrary::InitWithOptions(ViRsrc resourceName, ViBoolean idQuery, 
   return niRFSA_InitWithOptions(resourceName, idQuery, reset, optionString, vi);
 #else
   return function_pointers_.InitWithOptions(resourceName, idQuery, reset, optionString, vi);
-#endif
-}
-
-ViStatus NiRFSALibrary::InitializeExternalAlignment(ViRsrc resourceName, ViConstString optionString, ViSession* vi)
-{
-  if (!function_pointers_.InitializeExternalAlignment) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niRFSA_InitializeExternalAlignment.");
-  }
-#if defined(_MSC_VER)
-  return niRFSA_InitializeExternalAlignment(resourceName, optionString, vi);
-#else
-  return function_pointers_.InitializeExternalAlignment(resourceName, optionString, vi);
 #endif
 }
 

--- a/generated/nirfsa/nirfsa_library.h
+++ b/generated/nirfsa/nirfsa_library.h
@@ -95,7 +95,6 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   ViStatus GetUserData(ViSession vi, ViConstString identifier, ViInt32 bufferSize, ViInt8 data[], ViInt32* actualDataSize);
   ViStatus Init(ViRsrc resourceName, ViBoolean idQuery, ViBoolean reset, ViSession* vi);
   ViStatus InitWithOptions(ViRsrc resourceName, ViBoolean idQuery, ViBoolean reset, ViConstString optionString, ViSession* vi);
-  ViStatus InitializeExternalAlignment(ViRsrc resourceName, ViConstString optionString, ViSession* vi);
   ViStatus Initiate(ViSession vi);
   ViStatus InvalidateAllAttributes(ViSession vi);
   ViStatus IsSelfCalValid(ViSession vi, ViBoolean* selfCalValid, ViInt64* validSteps);
@@ -203,7 +202,6 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   using GetUserDataPtr = decltype(&niRFSA_GetUserData);
   using InitPtr = decltype(&niRFSA_init);
   using InitWithOptionsPtr = decltype(&niRFSA_InitWithOptions);
-  using InitializeExternalAlignmentPtr = decltype(&niRFSA_InitializeExternalAlignment);
   using InitiatePtr = decltype(&niRFSA_Initiate);
   using InvalidateAllAttributesPtr = decltype(&niRFSA_InvalidateAllAttributes);
   using IsSelfCalValidPtr = decltype(&niRFSA_IsSelfCalValid);
@@ -311,7 +309,6 @@ class NiRFSALibrary : public nirfsa_grpc::NiRFSALibraryInterface {
     GetUserDataPtr GetUserData;
     InitPtr Init;
     InitWithOptionsPtr InitWithOptions;
-    InitializeExternalAlignmentPtr InitializeExternalAlignment;
     InitiatePtr Initiate;
     InvalidateAllAttributesPtr InvalidateAllAttributes;
     IsSelfCalValidPtr IsSelfCalValid;

--- a/generated/nirfsa/nirfsa_library_interface.h
+++ b/generated/nirfsa/nirfsa_library_interface.h
@@ -93,7 +93,6 @@ class NiRFSALibraryInterface {
   virtual ViStatus GetUserData(ViSession vi, ViConstString identifier, ViInt32 bufferSize, ViInt8 data[], ViInt32* actualDataSize) = 0;
   virtual ViStatus Init(ViRsrc resourceName, ViBoolean idQuery, ViBoolean reset, ViSession* vi) = 0;
   virtual ViStatus InitWithOptions(ViRsrc resourceName, ViBoolean idQuery, ViBoolean reset, ViConstString optionString, ViSession* vi) = 0;
-  virtual ViStatus InitializeExternalAlignment(ViRsrc resourceName, ViConstString optionString, ViSession* vi) = 0;
   virtual ViStatus Initiate(ViSession vi) = 0;
   virtual ViStatus InvalidateAllAttributes(ViSession vi) = 0;
   virtual ViStatus IsSelfCalValid(ViSession vi, ViBoolean* selfCalValid, ViInt64* validSteps) = 0;

--- a/generated/nirfsa/nirfsa_mock_library.h
+++ b/generated/nirfsa/nirfsa_mock_library.h
@@ -94,7 +94,6 @@ class NiRFSAMockLibrary : public nirfsa_grpc::NiRFSALibraryInterface {
   MOCK_METHOD(ViStatus, GetUserData, (ViSession vi, ViConstString identifier, ViInt32 bufferSize, ViInt8 data[], ViInt32* actualDataSize), (override));
   MOCK_METHOD(ViStatus, Init, (ViRsrc resourceName, ViBoolean idQuery, ViBoolean reset, ViSession* vi), (override));
   MOCK_METHOD(ViStatus, InitWithOptions, (ViRsrc resourceName, ViBoolean idQuery, ViBoolean reset, ViConstString optionString, ViSession* vi), (override));
-  MOCK_METHOD(ViStatus, InitializeExternalAlignment, (ViRsrc resourceName, ViConstString optionString, ViSession* vi), (override));
   MOCK_METHOD(ViStatus, Initiate, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, InvalidateAllAttributes, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, IsSelfCalValid, (ViSession vi, ViBoolean* selfCalValid, ViInt64* validSteps), (override));

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -2304,30 +2304,6 @@ namespace nirfsa_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiRFSAService::InitializeExternalAlignment(::grpc::ServerContext* context, const InitializeExternalAlignmentRequest* request, InitializeExternalAlignmentResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      ViRsrc resource_name = (ViRsrc)request->resource_name().c_str();
-      auto option_string = request->option_string().c_str();
-      ViSession vi {};
-      auto status = library_->InitializeExternalAlignment(resource_name, option_string, &vi);
-      response->set_status(status);
-      if (status == 0) {
-        auto session_id = session_repository_->resolve_session_id(vi);
-        response->mutable_vi()->set_id(session_id);
-      }
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiRFSAService::Initiate(::grpc::ServerContext* context, const InitiateRequest* request, InitiateResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nirfsa/nirfsa_service.h
+++ b/generated/nirfsa/nirfsa_service.h
@@ -118,7 +118,6 @@ public:
   ::grpc::Status GetUserData(::grpc::ServerContext* context, const GetUserDataRequest* request, GetUserDataResponse* response) override;
   ::grpc::Status Init(::grpc::ServerContext* context, const InitRequest* request, InitResponse* response) override;
   ::grpc::Status InitWithOptions(::grpc::ServerContext* context, const InitWithOptionsRequest* request, InitWithOptionsResponse* response) override;
-  ::grpc::Status InitializeExternalAlignment(::grpc::ServerContext* context, const InitializeExternalAlignmentRequest* request, InitializeExternalAlignmentResponse* response) override;
   ::grpc::Status Initiate(::grpc::ServerContext* context, const InitiateRequest* request, InitiateResponse* response) override;
   ::grpc::Status InvalidateAllAttributes(::grpc::ServerContext* context, const InvalidateAllAttributesRequest* request, InvalidateAllAttributesResponse* response) override;
   ::grpc::Status IsSelfCalValid(::grpc::ServerContext* context, const IsSelfCalValidRequest* request, IsSelfCalValidResponse* response) override;

--- a/source/codegen/metadata/nirfsa/functions.py
+++ b/source/codegen/metadata/nirfsa/functions.py
@@ -1970,26 +1970,6 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
-    'InitializeExternalAlignment': {
-        'parameters': [
-            {
-                'direction': 'in',
-                'name': 'resourceName',
-                'type': 'ViRsrc'
-            },
-            {
-                'direction': 'in',
-                'name': 'optionString',
-                'type': 'ViConstString'
-            },
-            {
-                'direction': 'out',
-                'name': 'vi',
-                'type': 'ViSession'
-            }
-        ],
-        'returns': 'ViStatus'
-    },
     'Initiate': {
         'parameters': [
             {


### PR DESCRIPTION
### What does this Pull Request accomplish?

Removes an external calibration function from RFSA that we missed.

### Why should this Pull Request be merged?

We don't support external calibration in the gRPC API, and this is the only external calibration function left.

### What testing has been done?

Built RFSA system tests and searched to verify we don't call this from any examples.