### PR TITLE
Set Release readiness for RFSA/G services

### DIFF
--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -2999,7 +2999,7 @@ namespace nirfsa_grpc {
   NiRFSAFeatureToggles::NiRFSAFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("nirfsa", CodeReadiness::kNextRelease))
+        feature_toggles.is_feature_enabled("nirfsa", CodeReadiness::kRelease))
   {
   }
 } // namespace nirfsa_grpc

--- a/generated/nirfsg/nirfsg_service.cpp
+++ b/generated/nirfsg/nirfsg_service.cpp
@@ -3240,7 +3240,7 @@ namespace nirfsg_grpc {
   NiRFSGFeatureToggles::NiRFSGFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("nirfsg", CodeReadiness::kNextRelease))
+        feature_toggles.is_feature_enabled("nirfsg", CodeReadiness::kRelease))
   {
   }
 } // namespace nirfsg_grpc

--- a/source/codegen/metadata/nirfsa/config.py
+++ b/source/codegen/metadata/nirfsa/config.py
@@ -121,7 +121,7 @@ config = {
     'additional_headers': { 'custom/nirfsa_aliases.h': ['service.cpp', 'library_interface.h'] },
     'driver_name': 'NI-RFSA',
     'init_function': 'InitWithOptions',
-    'code_readiness': 'NextRelease',
+    'code_readiness': 'Release',
     'library_info': {
         'Linux': {
             '64bit': {

--- a/source/codegen/metadata/nirfsg/config.py
+++ b/source/codegen/metadata/nirfsg/config.py
@@ -14,7 +14,7 @@ config = {
         'task': 'generation'
     },
     'custom_types': [],
-    'code_readiness': 'NextRelease',
+    'code_readiness': 'Release',
     'driver_name': 'NI-RFSG',
     'extra_errors_used': [
     ],


### PR DESCRIPTION
### What does this Pull Request accomplish?

Set `Release` readiness for RFSA/G services so that they will be enabled by default.

### Why should this Pull Request be merged?

All acceptance criteria for RFSA/G have dev sign off.

### What testing has been done?

Manual testing of service with default configuration.