### PR TITLE
Add note that disabled RFSA tests are fixed in dev

### DIFF
--- a/source/tests/system/nirfsa_driver_api_tests.cpp
+++ b/source/tests/system/nirfsa_driver_api_tests.cpp
@@ -437,6 +437,7 @@ TEST_F(NiRFSADriverApiTests, ReconfigureFetchOffset_UpdatesFetchOffsetSuccessful
 }
 
 // NOTE: disabled because this test requires a 58XX device. Simulating a 58XX hangs on shutdown.
+// FIXED in RFSA 21.5 (in development as of this comment).
 TEST_F(NiRFSADriverApiTests, DISABLED_ReconfigureDowncoverterMode_UpdatesDownconverterModeSuccessfully)
 {
   constexpr auto USER_DEFINED = NiRFSAInt32AttributeValues::NIRFSA_INT32_DOWNCONVERTER_FREQUENCY_OFFSET_MODE_USER_DEFINED;
@@ -607,6 +608,7 @@ TEST_F(NiRFSADriverApiTests, GetCalUserDefinedInfo_Succeeds)
 }
 
 // NOTE: disabled because this test requires a 58XX device. Simulating a 58XX hangs on shutdown.
+// FIXED in RFSA 21.5 (in development as of this comment).
 TEST_F(NiRFSADriverApiTests, DISABLED_GetDeembeddingCompensationGain_Succeeds)
 {
   auto session = init_session(stub(), "5830");


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add note to DISABLED RFSA tests that the issue with simulation is fixed in dev.

### Why should this Pull Request be merged?

This is a reminder to consider reenabling the tests once that's released.

### What testing has been done?

Tested the fix in an RFSA dev build.