### PR TITLE
Add system tests for RFmxSpecAn

### DIFF
--- a/generated/nirfmxspecan/nirfmxspecan_service.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_service.cpp
@@ -11703,6 +11703,9 @@ namespace nirfmxspecan_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::ValueOutOfRangeException& ex) {
+      return ::grpc::Status(::grpc::OUT_OF_RANGE, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -11992,6 +11995,9 @@ namespace nirfmxspecan_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::ValueOutOfRangeException& ex) {
+      return ::grpc::Status(::grpc::OUT_OF_RANGE, ex.what());
     }
   }
 

--- a/source/codegen/metadata/nirfmxspecan/functions.py
+++ b/source/codegen/metadata/nirfmxspecan/functions.py
@@ -6049,6 +6049,7 @@ functions = {
                 'type': 'int32'
             },
             {
+                'coerced': True,
                 'direction': 'out',
                 'name': 'attrVal',
                 'type': 'int16'
@@ -6395,6 +6396,7 @@ functions = {
                 'type': 'int32'
             },
             {
+                'coerced': True,
                 'direction': 'out',
                 'name': 'attrVal',
                 'type': 'uInt16'
@@ -12273,6 +12275,7 @@ functions = {
                 'type': 'int32'
             },
             {
+                'coerced': True,
                 'direction': 'in',
                 'name': 'attrVal',
                 'type': 'int16'
@@ -12580,6 +12583,7 @@ functions = {
                 'type': 'int32'
             },
             {
+                'coerced': True,
                 'direction': 'in',
                 'name': 'attrVal',
                 'type': 'uInt16'

--- a/source/tests/system/nirfmxinstr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxinstr_driver_api_tests.cpp
@@ -29,6 +29,7 @@ class NiRFmxInstrDriverApiTests : public Test {
       : device_server_(DeviceServerInterface::Singleton()),
         stub_(NiRFmxInstr::NewStub(device_server_->InProcessChannel()))
   {
+    device_server_->ResetServer();
   }
 
   virtual ~NiRFmxInstrDriverApiTests() {}
@@ -75,7 +76,8 @@ TEST_F(NiRFmxInstrDriverApiTests, Init_Close_Succeeds)
 
   auto close_response = client::close(stub(), session, 0);
 
-  EXPECT_SUCCESS(session, close_response);
+  // Don't check_error because this can report stale errors from previous tests.
+  ni::tests::system::EXPECT_SUCCESS(close_response);
 }
 }  // namespace
 }  // namespace system

--- a/source/tests/system/nirfmxspecan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxspecan_driver_api_tests.cpp
@@ -1,3 +1,4 @@
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <thread>
@@ -23,6 +24,12 @@ template <typename TResponse>
 void EXPECT_SUCCESS(const TResponse& response)
 {
   EXPECT_EQ(krfmxSpecAnDriverApiSuccess, response.status());
+}
+
+template <typename TResponse>
+void EXPECT_RFMX_ERROR(pb::int32 expected_error, const TResponse& response)
+{
+  EXPECT_EQ(expected_error, response.status());
 }
 
 class NiRFmxSpecAnDriverApiTests : public ::testing::Test {
@@ -62,6 +69,14 @@ class NiRFmxSpecAnDriverApiTests : public ::testing::Test {
     check_error(session);
   }
 
+  template <typename TResponse>
+  void EXPECT_RFMX_ERROR(pb::int32 expected_error, const std::string& message_substring, const nidevice_grpc::Session& session, const TResponse& response)
+  {
+    ni::tests::system::EXPECT_RFMX_ERROR(expected_error, response);
+    const auto error = client::get_error(stub(), session);
+    EXPECT_THAT(error.error_description(), HasSubstr(message_substring));
+  }
+
  private:
   DeviceServerInterface* device_server_;
   std::unique_ptr<NiRFmxSpecAn::Stub> nirfmxspecan_stub_;
@@ -86,6 +101,45 @@ nidevice_grpc::Session init_session(const client::StubPtr& stub, const std::stri
   return init_session(stub, model, "FakeDevice");
 }
 
+template <typename TFloat, typename TComplex>
+TComplex complex(TFloat real, TFloat imaginary)
+{
+  auto c = TComplex{};
+  c.set_real(real);
+  c.set_imaginary(imaginary);
+  return c;
+}
+
+template <typename TFloat, typename TComplex>
+std::vector<TComplex> complex_array(
+    std::vector<TFloat> reals,
+    std::vector<TFloat> imaginaries)
+{
+  auto c = std::vector<TComplex>{};
+  c.reserve(reals.size());
+  std::transform(
+      reals.begin(),
+      reals.end(),
+      imaginaries.begin(),
+      std::back_inserter(c),
+      [](TFloat real, TFloat imaginary) { return complex<TFloat, TComplex>(real, imaginary); });
+  return c;
+}
+
+std::vector<nidevice_grpc::NIComplexNumberF32> complex_f32_array(
+    std::vector<float> reals,
+    std::vector<float> imaginaries)
+{
+  return complex_array<float, nidevice_grpc::NIComplexNumberF32>(reals, imaginaries);
+}
+
+std::vector<nidevice_grpc::NIComplexNumber> complex_number_array(
+    std::vector<double> reals,
+    std::vector<double> imaginaries)
+{
+  return complex_array<double, nidevice_grpc::NIComplexNumber>(reals, imaginaries);
+}
+
 TEST_F(NiRFmxSpecAnDriverApiTests, SpectrumBasicFromExample_DataLooksReasonable)
 {
   auto session = init_session(stub(), PXI_5663);
@@ -106,10 +160,153 @@ TEST_F(NiRFmxSpecAnDriverApiTests, SpectrumBasicFromExample_DataLooksReasonable)
   EXPECT_LT(read_response.spectrum(1004), read_response.spectrum(midpoint_x));
 }
 
+TEST_F(NiRFmxSpecAnDriverApiTests, AcpBasicFromExample_DataLooksReasonable)
+{
+  auto session = init_session(stub(), PXI_5663);
+  EXPECT_SUCCESS(session, client::set_attribute_string(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_SELECTED_PORTS, std::string("")));
+  EXPECT_SUCCESS(session, client::cfg_rf(stub(), session, "", 1e9, 0.0, 0.0));
+  EXPECT_SUCCESS(session, client::acp_cfg_averaging(stub(), session, "", false, 10, AcpAveragingType::ACP_AVERAGING_TYPE_RMS));
+  EXPECT_SUCCESS(session, client::acp_cfg_carrier_and_offsets(stub(), session, "", 1e6, 2, 1e6));
+
+  const auto read_response = client::acp_read(stub(), session, "", 10.0);
+  EXPECT_SUCCESS(session, read_response);
+
+  EXPECT_GT(read_response.carrier_absolute_power(), 0.0);
+  EXPECT_LT(read_response.offset_ch0_lower_relative_power(), 0.0);
+  EXPECT_LT(read_response.offset_ch0_upper_relative_power(), 0.0);
+  EXPECT_LT(read_response.offset_ch1_lower_relative_power(), 0.0);
+  EXPECT_LT(read_response.offset_ch1_upper_relative_power(), 0.0);
+}
+
+TEST_F(NiRFmxSpecAnDriverApiTests, FcntBasicFromExample_DataLooksReasonable)
+{
+  auto session = init_session(stub(), PXI_5663);
+  EXPECT_SUCCESS(session, client::cfg_rf(stub(), session, "", 1e9, 0.0, 0.0));
+  EXPECT_SUCCESS(session, client::f_cnt_cfg_measurement_interval(stub(), session, "", 1e-3));
+  EXPECT_SUCCESS(session, client::f_cnt_cfg_averaging(stub(), session, "", false, 10, FcntAveragingType::FCNT_AVERAGING_TYPE_MEAN));
+  EXPECT_SUCCESS(session, client::f_cnt_cfg_rbw_filter(stub(), session, "", 100e3, FcntRbwFilterType::FCNT_RBW_FILTER_TYPE_NONE, 0.1));
+
+  const auto read_response = client::f_cnt_read(stub(), session, "", 10.0);
+  EXPECT_SUCCESS(session, read_response);
+
+  EXPECT_GT(read_response.average_relative_frequency(), 0.0);
+  EXPECT_GT(read_response.average_absolute_frequency(), read_response.average_relative_frequency());
+  EXPECT_GT(read_response.mean_phase(), 0.0);
+}
+
+TEST_F(NiRFmxSpecAnDriverApiTests, HarmFromExample_NoError)
+{
+  constexpr auto NUMBER_OF_HARMONICS = 3;
+  auto session = init_session(stub(), PXI_5663);
+  EXPECT_SUCCESS(session, client::cfg_frequency_reference(stub(), session, "", FrequencyReferenceSource::FREQUENCY_REFERENCE_SOURCE_ONBOARD_CLOCK, 10e6));
+  EXPECT_SUCCESS(session, client::cfg_rf(stub(), session, "", 1e9, 0.0, 0.0));
+  EXPECT_SUCCESS(session, client::select_measurements(stub(), session, "", MeasurementTypes::MEASUREMENT_TYPES_HARMONICS, true));
+  EXPECT_SUCCESS(session, client::harm_cfg_fundamental_rbw(stub(), session, "", 100e3, HarmRbwFilterType::HARM_RBW_FILTER_TYPE_GAUSSIAN, 0.010));
+  EXPECT_SUCCESS(session, client::harm_cfg_fundamental_measurement_interval(stub(), session, "", 1e-3));
+  EXPECT_SUCCESS(session, client::harm_cfg_auto_harmonics(stub(), session, "", true));
+  EXPECT_SUCCESS(session, client::harm_cfg_number_of_harmonics(stub(), session, "", NUMBER_OF_HARMONICS));
+  EXPECT_SUCCESS(session, client::harm_cfg_averaging(stub(), session, "", false, 10, HarmAveragingType::HARM_AVERAGING_TYPE_RMS));
+  EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
+
+  const auto fetch_thd_response = client::harm_fetch_thd(stub(), session, "", 10.0);
+  EXPECT_SUCCESS(session, fetch_thd_response);
+  const auto fetch_measurement_response = client::harm_fetch_harmonic_measurement_array(stub(), session, "", 10.0);
+  EXPECT_SUCCESS(session, fetch_measurement_response);
+  for (auto i = 0; i < NUMBER_OF_HARMONICS; ++i) {
+    const auto harmonic_string_response = client::build_harmonic_string(stub(), "", i);
+    EXPECT_SUCCESS(session, harmonic_string_response);
+    const auto power_trace_response = client::harm_fetch_harmonic_power_trace(stub(), session, harmonic_string_response.selector_string_out(), 10.0);
+    EXPECT_SUCCESS(session, power_trace_response);
+  }
+}
+
+TEST_F(NiRFmxSpecAnDriverApiTests, AMPMFromExample_NoError)
+{
+  auto session = init_session(stub(), PXI_5663);
+  EXPECT_SUCCESS(session, client::cfg_frequency_reference(stub(), session, "", FrequencyReferenceSource::FREQUENCY_REFERENCE_SOURCE_ONBOARD_CLOCK, 10e6));
+  EXPECT_SUCCESS(
+      session,
+      client::cfg_digital_edge_trigger(stub(), session, "", DigitalEdgeTriggerSource::DIGITAL_EDGE_TRIGGER_SOURCE_PXI_TRIG0, DigitalEdgeTriggerEdge::DIGITAL_EDGE_TRIGGER_EDGE_RISING_EDGE, 0.0, true));
+  EXPECT_SUCCESS(session, client::cfg_rf(stub(), session, "", 1e9, 0.0, 0.0));
+  EXPECT_SUCCESS(session, client::select_measurements(stub(), session, "", MeasurementTypes::MEASUREMENT_TYPES_AMPM, true));
+  EXPECT_SUCCESS(session, client::dpd_cfg_dut_average_input_power(stub(), session, "", -20.0));
+  EXPECT_SUCCESS(
+      session,
+      client::ampm_cfg_reference_waveform(
+          stub(),
+          session,
+          "",
+          0.0,
+          0.1,
+          // Note: this is random data.
+          complex_f32_array({0.7f, 0.5f, 0.0f, -0.5f, -0.7f}, {-1.5f, -1.7f, -2.0f, -2.3f, -2.5f}),
+          false,
+          AmpmSignalType::AMPM_SIGNAL_TYPE_MODULATED));
+  EXPECT_SUCCESS(session, client::ampm_cfg_measurement_sample_rate(stub(), session, "", AmpmMeasurementSampleRateMode::AMPM_MEASUREMENT_SAMPLE_RATE_MODE_REFERENCE_WAVEFORM, 120e6));
+  EXPECT_SUCCESS(session, client::ampm_cfg_measurement_interval(stub(), session, "", 100e-6));
+  EXPECT_SUCCESS(session, client::ampm_cfg_threshold(stub(), session, "", true, -20.0, AmpmThresholdType::AMPM_THRESHOLD_TYPE_RELATIVE));
+  EXPECT_SUCCESS(session, client::ampm_cfg_reference_power_type(stub(), session, "", AmpmReferencePowerType::AMPM_REFERENCE_POWER_TYPE_INPUT));
+  EXPECT_SUCCESS(session, client::auto_level(stub(), session, "", 20e6, 100e-6));
+  EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
+
+  const auto dut_char_response = client::ampm_fetch_dut_characteristics(stub(), session, "", 10.0);
+  EXPECT_SUCCESS(session, dut_char_response);
+  const auto error_response = client::ampm_fetch_error(stub(), session, "", 10.0);
+  EXPECT_SUCCESS(session, error_response);
+  const auto curve_fit_response = client::ampm_fetch_curve_fit_residual(stub(), session, "", 10.0);
+  EXPECT_SUCCESS(session, curve_fit_response);
+  const auto am_to_am_response = client::ampm_fetch_am_to_am_trace(stub(), session, "", 10.0);
+  EXPECT_SUCCESS(session, am_to_am_response);
+}
+
+// Note: there aren't any complex attributes in attributes.py, but this at least exercises the code.
+TEST_F(NiRFmxSpecAnDriverApiTests, SetAttributeComplex_ExpectedError)
+{
+  const auto session = init_session(stub(), PXI_5663);
+
+  EXPECT_RFMX_ERROR(
+      -380231, "This attribute is read-only and cannot be written", session,
+      client::set_attribute_ni_complex_double_array(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_SEM_RESULTS_CARRIER_FREQUENCY, complex_number_array({1.2, 2.2}, {1e6, 1.01e6})));
+}
+
+// Note: there aren't any i8 attributes in attributes.py, but this at least exercises the code.
+TEST_F(NiRFmxSpecAnDriverApiTests, SetAttributeInt8_ExpectedError)
+{
+  const auto session = init_session(stub(), PXI_5663);
+
+  EXPECT_RFMX_ERROR(
+      -380251, "Incorrect data type specified", session,
+      client::set_attribute_i8(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, 1));
+  EXPECT_RFMX_ERROR(
+      -380251, "Incorrect data type specified", session,
+      client::set_attribute_u8(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, 1));
+  EXPECT_RFMX_ERROR(
+      -380251, "Incorrect data type specified", session,
+      client::set_attribute_i8_array(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, {1, 0, -1, 0}));
+  EXPECT_RFMX_ERROR(
+      -380251, "Incorrect data type specified", session,
+      client::set_attribute_u8_array(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, {1, 0, 1, 0}));
+}
+
+// Note: there aren't any i16 attributes in attributes.py, but this at least exercises the code.
+TEST_F(NiRFmxSpecAnDriverApiTests, SetAttributeInt16_ExpectedError)
+{
+  const auto session = init_session(stub(), PXI_5663);
+
+  EXPECT_RFMX_ERROR(
+      -380251, "Incorrect data type specified", session,
+      client::set_attribute_i16(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, -400));
+  EXPECT_RFMX_ERROR(
+      -380251, "Incorrect data type specified", session,
+      client::set_attribute_u16(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, 400));
+}
+
 TEST_F(NiRFmxSpecAnDriverApiTests, SetAndGetAttributeInt32_Succeeds)
 {
   auto session = init_session(stub(), PXI_5663);
-  EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, NiRFmxSpecAnInt32AttributeValues::NIRFMXSPECAN_INT32_NF_EXTERNAL_PREAMP_PRESENT_TRUE));
+  EXPECT_SUCCESS(
+      session,
+      client::set_attribute_i32(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, NiRFmxSpecAnInt32AttributeValues::NIRFMXSPECAN_INT32_NF_EXTERNAL_PREAMP_PRESENT_TRUE));
   // This is one way to get the driver in a state where we can get attributes
   EXPECT_SUCCESS(session, client::spectrum_read(stub(), session, "", 10.0));
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add system level tests based on examples and exercising datatypes that require conversion.

### Why should this Pull Request be merged?

Fills out acceptance table for initial SpecAn extraction feature.

### What testing has been done?

Ran and passed all RFmx Tests.

Stepped through debugger on attribute conversion tests to ensure that the values were correct when passed to the driver.