### PR TITLE
Implement range checking for coerced scalar inputs

### DIFF
--- a/generated/nifake_non_ivi/nifake_non_ivi.proto
+++ b/generated/nifake_non_ivi/nifake_non_ivi.proto
@@ -36,6 +36,7 @@ service NiFakeNonIvi {
   rpc InputVarArgs(InputVarArgsRequest) returns (InputVarArgsResponse);
   rpc OutputVarArgs(OutputVarArgsRequest) returns (OutputVarArgsResponse);
   rpc ResetMarbleAttribute(ResetMarbleAttributeRequest) returns (ResetMarbleAttributeResponse);
+  rpc ScalarsWithNarrowIntegerTypes(ScalarsWithNarrowIntegerTypesRequest) returns (ScalarsWithNarrowIntegerTypesResponse);
   rpc SetMarbleAttributeDouble(SetMarbleAttributeDoubleRequest) returns (SetMarbleAttributeDoubleResponse);
   rpc SetMarbleAttributeInt32(SetMarbleAttributeInt32Request) returns (SetMarbleAttributeInt32Response);
   rpc SetColors(SetColorsRequest) returns (SetColorsResponse);
@@ -292,6 +293,16 @@ message ResetMarbleAttributeRequest {
 }
 
 message ResetMarbleAttributeResponse {
+  int32 status = 1;
+}
+
+message ScalarsWithNarrowIntegerTypesRequest {
+  uint32 u16 = 1;
+  int32 i16 = 2;
+  int32 i8 = 3;
+}
+
+message ScalarsWithNarrowIntegerTypesResponse {
   int32 status = 1;
 }
 

--- a/generated/nifake_non_ivi/nifake_non_ivi_client.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_client.cpp
@@ -346,6 +346,24 @@ reset_marble_attribute(const StubPtr& stub, const nidevice_grpc::Session& handle
   return response;
 }
 
+ScalarsWithNarrowIntegerTypesResponse
+scalars_with_narrow_integer_types(const StubPtr& stub, const pb::uint32& u16, const pb::int32& i16, const pb::int32& i8)
+{
+  ::grpc::ClientContext context;
+
+  auto request = ScalarsWithNarrowIntegerTypesRequest{};
+  request.set_u16(u16);
+  request.set_i16(i16);
+  request.set_i8(i8);
+
+  auto response = ScalarsWithNarrowIntegerTypesResponse{};
+
+  raise_if_error(
+      stub->ScalarsWithNarrowIntegerTypes(&context, request, &response));
+
+  return response;
+}
+
 SetMarbleAttributeDoubleResponse
 set_marble_attribute_double(const StubPtr& stub, const nidevice_grpc::Session& handle, const simple_variant<MarbleDoubleAttribute, pb::int32>& attribute, const double& value)
 {

--- a/generated/nifake_non_ivi/nifake_non_ivi_client.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_client.h
@@ -41,6 +41,7 @@ OutputTimestampResponse output_timestamp(const StubPtr& stub);
 InputVarArgsResponse input_var_args(const StubPtr& stub, const pb::string& input_name, const std::vector<StringAndEnum>& string_and_enums);
 OutputVarArgsResponse output_var_args(const StubPtr& stub, const pb::string& input_name, const std::vector<pb::string>& channel_names);
 ResetMarbleAttributeResponse reset_marble_attribute(const StubPtr& stub, const nidevice_grpc::Session& handle, const simple_variant<MarbleResetAttribute, pb::int32>& attribute);
+ScalarsWithNarrowIntegerTypesResponse scalars_with_narrow_integer_types(const StubPtr& stub, const pb::uint32& u16, const pb::int32& i16, const pb::int32& i8);
 SetMarbleAttributeDoubleResponse set_marble_attribute_double(const StubPtr& stub, const nidevice_grpc::Session& handle, const simple_variant<MarbleDoubleAttribute, pb::int32>& attribute, const double& value);
 SetMarbleAttributeInt32Response set_marble_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session& handle, const simple_variant<MarbleInt32Attribute, pb::int32>& attribute, const simple_variant<MarbleInt32AttributeValues, pb::int32>& value);
 SetColorsResponse set_colors(const StubPtr& stub, const std::vector<pb::int32>& colors, const pb::int32& size);

--- a/generated/nifake_non_ivi/nifake_non_ivi_library.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_library.cpp
@@ -40,6 +40,7 @@ NiFakeNonIviLibrary::NiFakeNonIviLibrary() : shared_library_(kLibraryName)
   function_pointers_.InputVarArgs = reinterpret_cast<InputVarArgsPtr>(shared_library_.get_function_pointer("niFakeNonIvi_InputVarArgs"));
   function_pointers_.OutputVarArgs = reinterpret_cast<OutputVarArgsPtr>(shared_library_.get_function_pointer("niFakeNonIvi_OutputVarArgs"));
   function_pointers_.ResetMarbleAttribute = reinterpret_cast<ResetMarbleAttributePtr>(shared_library_.get_function_pointer("niFakeNonIvi_ResetMarbleAttribute"));
+  function_pointers_.ScalarsWithNarrowIntegerTypes = reinterpret_cast<ScalarsWithNarrowIntegerTypesPtr>(shared_library_.get_function_pointer("niFakeNonIvi_ScalarsWithNarrowIntegerTypes"));
   function_pointers_.SetMarbleAttributeDouble = reinterpret_cast<SetMarbleAttributeDoublePtr>(shared_library_.get_function_pointer("niFakeNonIvi_SetMarbleAttributeDouble"));
   function_pointers_.SetMarbleAttributeInt32 = reinterpret_cast<SetMarbleAttributeInt32Ptr>(shared_library_.get_function_pointer("niFakeNonIvi_SetMarbleAttributeInt32"));
   function_pointers_.SetColors = reinterpret_cast<SetColorsPtr>(shared_library_.get_function_pointer("niFakeNonIvi_SetColors"));
@@ -285,6 +286,18 @@ int32 NiFakeNonIviLibrary::ResetMarbleAttribute(FakeHandle handle, int32 attribu
   return niFakeNonIvi_ResetMarbleAttribute(handle, attribute);
 #else
   return function_pointers_.ResetMarbleAttribute(handle, attribute);
+#endif
+}
+
+int32 NiFakeNonIviLibrary::ScalarsWithNarrowIntegerTypes(myUInt16 u16, myInt16 i16, myInt8 i8)
+{
+  if (!function_pointers_.ScalarsWithNarrowIntegerTypes) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFakeNonIvi_ScalarsWithNarrowIntegerTypes.");
+  }
+#if defined(_MSC_VER)
+  return niFakeNonIvi_ScalarsWithNarrowIntegerTypes(u16, i16, i8);
+#else
+  return function_pointers_.ScalarsWithNarrowIntegerTypes(u16, i16, i8);
 #endif
 }
 

--- a/generated/nifake_non_ivi/nifake_non_ivi_library.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_library.h
@@ -37,6 +37,7 @@ class NiFakeNonIviLibrary : public nifake_non_ivi_grpc::NiFakeNonIviLibraryInter
   int32 InputVarArgs(const char inputName[], const char channelName[], int32 color, double powerUpState, const char channelName0[], int32 color0, double powerUpState0, const char channelName1[], int32 color1, double powerUpState1, const char channelName2[], int32 color2, double powerUpState2);
   int32 OutputVarArgs(const char inputName[], const char channelName[], int32* color, const char channelName0[], int32* color0, const char channelName1[], int32* color1, const char channelName2[], int32* color2);
   int32 ResetMarbleAttribute(FakeHandle handle, int32 attribute);
+  int32 ScalarsWithNarrowIntegerTypes(myUInt16 u16, myInt16 i16, myInt8 i8);
   int32 SetMarbleAttributeDouble(FakeHandle handle, int32 attribute, double value);
   int32 SetMarbleAttributeInt32(FakeHandle handle, int32 attribute, int32 value);
   int32 SetColors(int32 colors[3], int32 size);
@@ -65,6 +66,7 @@ class NiFakeNonIviLibrary : public nifake_non_ivi_grpc::NiFakeNonIviLibraryInter
   using InputVarArgsPtr = decltype(&niFakeNonIvi_InputVarArgs);
   using OutputVarArgsPtr = decltype(&niFakeNonIvi_OutputVarArgs);
   using ResetMarbleAttributePtr = decltype(&niFakeNonIvi_ResetMarbleAttribute);
+  using ScalarsWithNarrowIntegerTypesPtr = decltype(&niFakeNonIvi_ScalarsWithNarrowIntegerTypes);
   using SetMarbleAttributeDoublePtr = decltype(&niFakeNonIvi_SetMarbleAttributeDouble);
   using SetMarbleAttributeInt32Ptr = decltype(&niFakeNonIvi_SetMarbleAttributeInt32);
   using SetColorsPtr = decltype(&niFakeNonIvi_SetColors);
@@ -93,6 +95,7 @@ class NiFakeNonIviLibrary : public nifake_non_ivi_grpc::NiFakeNonIviLibraryInter
     InputVarArgsPtr InputVarArgs;
     OutputVarArgsPtr OutputVarArgs;
     ResetMarbleAttributePtr ResetMarbleAttribute;
+    ScalarsWithNarrowIntegerTypesPtr ScalarsWithNarrowIntegerTypes;
     SetMarbleAttributeDoublePtr SetMarbleAttributeDouble;
     SetMarbleAttributeInt32Ptr SetMarbleAttributeInt32;
     SetColorsPtr SetColors;

--- a/generated/nifake_non_ivi/nifake_non_ivi_library_interface.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_library_interface.h
@@ -34,6 +34,7 @@ class NiFakeNonIviLibraryInterface {
   virtual int32 InputVarArgs(const char inputName[], const char channelName[], int32 color, double powerUpState, const char channelName0[], int32 color0, double powerUpState0, const char channelName1[], int32 color1, double powerUpState1, const char channelName2[], int32 color2, double powerUpState2) = 0;
   virtual int32 OutputVarArgs(const char inputName[], const char channelName[], int32* color, const char channelName0[], int32* color0, const char channelName1[], int32* color1, const char channelName2[], int32* color2) = 0;
   virtual int32 ResetMarbleAttribute(FakeHandle handle, int32 attribute) = 0;
+  virtual int32 ScalarsWithNarrowIntegerTypes(myUInt16 u16, myInt16 i16, myInt8 i8) = 0;
   virtual int32 SetMarbleAttributeDouble(FakeHandle handle, int32 attribute, double value) = 0;
   virtual int32 SetMarbleAttributeInt32(FakeHandle handle, int32 attribute, int32 value) = 0;
   virtual int32 SetColors(int32 colors[3], int32 size) = 0;

--- a/generated/nifake_non_ivi/nifake_non_ivi_mock_library.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_mock_library.h
@@ -36,6 +36,7 @@ class NiFakeNonIviMockLibrary : public nifake_non_ivi_grpc::NiFakeNonIviLibraryI
   MOCK_METHOD(int32, InputVarArgs, (const char inputName[], const char channelName[], int32 color, double powerUpState, const char channelName0[], int32 color0, double powerUpState0, const char channelName1[], int32 color1, double powerUpState1, const char channelName2[], int32 color2, double powerUpState2), (override));
   MOCK_METHOD(int32, OutputVarArgs, (const char inputName[], const char channelName[], int32* color, const char channelName0[], int32* color0, const char channelName1[], int32* color1, const char channelName2[], int32* color2), (override));
   MOCK_METHOD(int32, ResetMarbleAttribute, (FakeHandle handle, int32 attribute), (override));
+  MOCK_METHOD(int32, ScalarsWithNarrowIntegerTypes, (myUInt16 u16, myInt16 i16, myInt8 i8), (override));
   MOCK_METHOD(int32, SetMarbleAttributeDouble, (FakeHandle handle, int32 attribute, double value), (override));
   MOCK_METHOD(int32, SetMarbleAttributeInt32, (FakeHandle handle, int32 attribute, int32 value), (override));
   MOCK_METHOD(int32, SetColors, (int32 colors[3], int32 size), (override));

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -702,6 +702,56 @@ namespace nifake_non_ivi_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiFakeNonIviService::ScalarsWithNarrowIntegerTypes(::grpc::ServerContext* context, const ScalarsWithNarrowIntegerTypesRequest* request, ScalarsWithNarrowIntegerTypesResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto u16_raw = request->u16();
+      if (u16_raw < std::numeric_limits<myUInt16>::min() || u16_raw > std::numeric_limits<myUInt16>::max()) {
+          std::string message("value ");
+          message.append(std::to_string(u16_raw));
+          message.append(" doesn't fit in datatype ");
+          message.append("myUInt16");
+          throw nidevice_grpc::ValueOutOfRangeException(message);
+      }
+    auto u16 = static_cast<myUInt16>(u16_raw);
+
+      auto i16_raw = request->i16();
+      if (i16_raw < std::numeric_limits<myInt16>::min() || i16_raw > std::numeric_limits<myInt16>::max()) {
+          std::string message("value ");
+          message.append(std::to_string(i16_raw));
+          message.append(" doesn't fit in datatype ");
+          message.append("myInt16");
+          throw nidevice_grpc::ValueOutOfRangeException(message);
+      }
+    auto i16 = static_cast<myInt16>(i16_raw);
+
+      auto i8_raw = request->i8();
+      if (i8_raw < std::numeric_limits<myInt8>::min() || i8_raw > std::numeric_limits<myInt8>::max()) {
+          std::string message("value ");
+          message.append(std::to_string(i8_raw));
+          message.append(" doesn't fit in datatype ");
+          message.append("myInt8");
+          throw nidevice_grpc::ValueOutOfRangeException(message);
+      }
+    auto i8 = static_cast<myInt8>(i8_raw);
+
+      auto status = library_->ScalarsWithNarrowIntegerTypes(u16, i16, i8);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::ValueOutOfRangeException& ex) {
+      return ::grpc::Status(::grpc::OUT_OF_RANGE, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiFakeNonIviService::SetMarbleAttributeDouble(::grpc::ServerContext* context, const SetMarbleAttributeDoubleRequest* request, SetMarbleAttributeDoubleResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -716,7 +716,7 @@ namespace nifake_non_ivi_grpc {
           message.append("myUInt16");
           throw nidevice_grpc::ValueOutOfRangeException(message);
       }
-    auto u16 = static_cast<myUInt16>(u16_raw);
+      auto u16 = static_cast<myUInt16>(u16_raw);
 
       auto i16_raw = request->i16();
       if (i16_raw < std::numeric_limits<myInt16>::min() || i16_raw > std::numeric_limits<myInt16>::max()) {
@@ -726,7 +726,7 @@ namespace nifake_non_ivi_grpc {
           message.append("myInt16");
           throw nidevice_grpc::ValueOutOfRangeException(message);
       }
-    auto i16 = static_cast<myInt16>(i16_raw);
+      auto i16 = static_cast<myInt16>(i16_raw);
 
       auto i8_raw = request->i8();
       if (i8_raw < std::numeric_limits<myInt8>::min() || i8_raw > std::numeric_limits<myInt8>::max()) {
@@ -736,7 +736,7 @@ namespace nifake_non_ivi_grpc {
           message.append("myInt8");
           throw nidevice_grpc::ValueOutOfRangeException(message);
       }
-    auto i8 = static_cast<myInt8>(i8_raw);
+      auto i8 = static_cast<myInt8>(i8_raw);
 
       auto status = library_->ScalarsWithNarrowIntegerTypes(u16, i16, i8);
       response->set_status(status);

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.h
@@ -61,6 +61,7 @@ public:
   ::grpc::Status InputVarArgs(::grpc::ServerContext* context, const InputVarArgsRequest* request, InputVarArgsResponse* response) override;
   ::grpc::Status OutputVarArgs(::grpc::ServerContext* context, const OutputVarArgsRequest* request, OutputVarArgsResponse* response) override;
   ::grpc::Status ResetMarbleAttribute(::grpc::ServerContext* context, const ResetMarbleAttributeRequest* request, ResetMarbleAttributeResponse* response) override;
+  ::grpc::Status ScalarsWithNarrowIntegerTypes(::grpc::ServerContext* context, const ScalarsWithNarrowIntegerTypesRequest* request, ScalarsWithNarrowIntegerTypesResponse* response) override;
   ::grpc::Status SetMarbleAttributeDouble(::grpc::ServerContext* context, const SetMarbleAttributeDoubleRequest* request, SetMarbleAttributeDoubleResponse* response) override;
   ::grpc::Status SetMarbleAttributeInt32(::grpc::ServerContext* context, const SetMarbleAttributeInt32Request* request, SetMarbleAttributeInt32Response* response) override;
   ::grpc::Status SetColors(::grpc::ServerContext* context, const SetColorsRequest* request, SetColorsResponse* response) override;

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -2215,7 +2215,16 @@ namespace nirfmxinstr_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
-      int8 attr_val = request->attr_val();
+      auto attr_val_raw = request->attr_val();
+      if (attr_val_raw < std::numeric_limits<int8>::min() || attr_val_raw > std::numeric_limits<int8>::max()) {
+          std::string message("value ");
+          message.append(std::to_string(attr_val_raw));
+          message.append(" doesn't fit in datatype ");
+          message.append("int8");
+          throw nidevice_grpc::ValueOutOfRangeException(message);
+      }
+    auto attr_val = static_cast<int8>(attr_val_raw);
+
       auto status = library_->SetAttributeI8(instrument, channel_name, attribute_id, attr_val);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -2223,7 +2223,7 @@ namespace nirfmxinstr_grpc {
           message.append("int8");
           throw nidevice_grpc::ValueOutOfRangeException(message);
       }
-    auto attr_val = static_cast<int8>(attr_val_raw);
+      auto attr_val = static_cast<int8>(attr_val_raw);
 
       auto status = library_->SetAttributeI8(instrument, channel_name, attribute_id, attr_val);
       response->set_status(status);

--- a/generated/nirfmxspecan/nirfmxspecan_service.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_service.cpp
@@ -11703,7 +11703,7 @@ namespace nirfmxspecan_grpc {
           message.append("int16");
           throw nidevice_grpc::ValueOutOfRangeException(message);
       }
-    auto attr_val = static_cast<int16>(attr_val_raw);
+      auto attr_val = static_cast<int16>(attr_val_raw);
 
       auto status = library_->SetAttributeI16(instrument, selector_string, attribute_id, attr_val);
       response->set_status(status);
@@ -11850,7 +11850,7 @@ namespace nirfmxspecan_grpc {
           message.append("int8");
           throw nidevice_grpc::ValueOutOfRangeException(message);
       }
-    auto attr_val = static_cast<int8>(attr_val_raw);
+      auto attr_val = static_cast<int8>(attr_val_raw);
 
       auto status = library_->SetAttributeI8(instrument, selector_string, attribute_id, attr_val);
       response->set_status(status);
@@ -12014,7 +12014,7 @@ namespace nirfmxspecan_grpc {
           message.append("uInt16");
           throw nidevice_grpc::ValueOutOfRangeException(message);
       }
-    auto attr_val = static_cast<uInt16>(attr_val_raw);
+      auto attr_val = static_cast<uInt16>(attr_val_raw);
 
       auto status = library_->SetAttributeU16(instrument, selector_string, attribute_id, attr_val);
       response->set_status(status);

--- a/generated/nirfmxspecan/nirfmxspecan_service.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_service.cpp
@@ -11695,7 +11695,16 @@ namespace nirfmxspecan_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
-      int16 attr_val = request->attr_val();
+      auto attr_val_raw = request->attr_val();
+      if (attr_val_raw < std::numeric_limits<int16>::min() || attr_val_raw > std::numeric_limits<int16>::max()) {
+          std::string message("value ");
+          message.append(std::to_string(attr_val_raw));
+          message.append(" doesn't fit in datatype ");
+          message.append("int16");
+          throw nidevice_grpc::ValueOutOfRangeException(message);
+      }
+    auto attr_val = static_cast<int16>(attr_val_raw);
+
       auto status = library_->SetAttributeI16(instrument, selector_string, attribute_id, attr_val);
       response->set_status(status);
       return ::grpc::Status::OK;
@@ -11833,7 +11842,16 @@ namespace nirfmxspecan_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
-      int8 attr_val = request->attr_val();
+      auto attr_val_raw = request->attr_val();
+      if (attr_val_raw < std::numeric_limits<int8>::min() || attr_val_raw > std::numeric_limits<int8>::max()) {
+          std::string message("value ");
+          message.append(std::to_string(attr_val_raw));
+          message.append(" doesn't fit in datatype ");
+          message.append("int8");
+          throw nidevice_grpc::ValueOutOfRangeException(message);
+      }
+    auto attr_val = static_cast<int8>(attr_val_raw);
+
       auto status = library_->SetAttributeI8(instrument, selector_string, attribute_id, attr_val);
       response->set_status(status);
       return ::grpc::Status::OK;
@@ -11988,7 +12006,16 @@ namespace nirfmxspecan_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
-      uInt16 attr_val = request->attr_val();
+      auto attr_val_raw = request->attr_val();
+      if (attr_val_raw < std::numeric_limits<uInt16>::min() || attr_val_raw > std::numeric_limits<uInt16>::max()) {
+          std::string message("value ");
+          message.append(std::to_string(attr_val_raw));
+          message.append(" doesn't fit in datatype ");
+          message.append("uInt16");
+          throw nidevice_grpc::ValueOutOfRangeException(message);
+      }
+    auto attr_val = static_cast<uInt16>(attr_val_raw);
+
       auto status = library_->SetAttributeU16(instrument, selector_string, attribute_id, attr_val);
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/source/codegen/metadata/nifake_non_ivi/functions.py
+++ b/source/codegen/metadata/nifake_non_ivi/functions.py
@@ -436,6 +436,29 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'ScalarsWithNarrowIntegerTypes': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'u16',
+                'type': 'myUInt16',
+                'coerced': True
+            },
+            {
+                'direction': 'in',
+                'name': 'i16',
+                'type': 'myInt16',
+                'coerced': True
+            },
+            {
+                'direction': 'in',
+                'name': 'i8',
+                'type': 'myInt8',
+                'coerced': True
+            }
+        ],
+        'returns': 'int32'
+    },
     'SetMarbleAttributeDouble': {
         'parameters': [
             {

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -23,6 +23,13 @@ def get_c_element_type(parameter):
     return stripped_type
 
 
+def is_scalar_input_that_needs_coercion(parameter: dict) -> bool:
+    return (
+        common_helpers.is_input_parameter(parameter) 
+        and parameter.get('coerced', False)
+        and not common_helpers.is_array(parameter['type'])
+    )
+
 def is_input_array_that_needs_coercion(parameter):
     return common_helpers.is_input_parameter(parameter) and get_c_element_type_for_array_that_needs_coercion(parameter) is not None
 

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -491,6 +491,16 @@ ${initialize_standard_input_param(function_name, parameter)}
       auto ${parameter_name} = reinterpret_cast<${c_type_pointer}>(${request_snippet}.data());\
 %elif grpc_type == 'bytes':
       auto ${parameter_name} = reinterpret_cast<const unsigned char*>(${request_snippet}.data());\
+%elif service_helpers.is_scalar_input_that_needs_coercion(parameter):
+      auto ${parameter_name}_raw = ${request_snippet};
+      if (${parameter_name}_raw < std::numeric_limits<${c_type}>::min() || ${parameter_name}_raw > std::numeric_limits<${c_type}>::max()) {
+          std::string message("value ");
+          message.append(std::to_string(${parameter_name}_raw));
+          message.append(" doesn't fit in datatype ");
+          message.append("${c_type}");
+          throw nidevice_grpc::ValueOutOfRangeException(message);
+      }
+      auto ${parameter_name} = static_cast<${c_type}>(${parameter_name}_raw);
 %elif service_helpers.is_input_array_that_needs_coercion(parameter):
       auto ${parameter_name}_raw = ${request_snippet};
       auto ${parameter_name} = std::vector<${c_element_type_that_needs_coercion}>();

--- a/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
+++ b/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
@@ -396,6 +396,66 @@ TEST_F(NiFakeNonIviServiceTests, InputArraysWithNarrowIntegerTypes_I8DataOutOfRa
   EXPECT_THAT(status.error_message(), HasSubstr(std::to_string(INT8_MIN - 1)));
 }
 
+TEST_F(NiFakeNonIviServiceTests, ScalarsWithNarrowIntegerTypes_I8DataOutOfRangeTooLow_ReturnsError)
+{
+  EXPECT_CALL(library_, InputArraysWithNarrowIntegerTypes(_, _, _))
+      .Times(0);
+  ::grpc::ServerContext context;
+  ScalarsWithNarrowIntegerTypesRequest request;
+  request.set_i8(INT8_MIN - 1);
+  ScalarsWithNarrowIntegerTypesResponse response;
+  auto status = service_.ScalarsWithNarrowIntegerTypes(&context, &request, &response);
+
+  EXPECT_EQ(grpc::StatusCode::OUT_OF_RANGE, status.error_code());
+  EXPECT_THAT(status.error_message(), HasSubstr(std::to_string(INT8_MIN - 1)));
+}
+
+TEST_F(NiFakeNonIviServiceTests, ScalarsWithNarrowIntegerTypes_I16DataOutOfRangeTooHigh_ReturnsError)
+{
+  EXPECT_CALL(library_, InputArraysWithNarrowIntegerTypes(_, _, _))
+      .Times(0);
+  ::grpc::ServerContext context;
+  ScalarsWithNarrowIntegerTypesRequest request;
+  request.set_i16(INT16_MAX + 1);
+  ScalarsWithNarrowIntegerTypesResponse response;
+  auto status = service_.ScalarsWithNarrowIntegerTypes(&context, &request, &response);
+
+  EXPECT_EQ(grpc::StatusCode::OUT_OF_RANGE, status.error_code());
+  EXPECT_THAT(status.error_message(), HasSubstr(std::to_string(INT16_MAX + 1)));
+}
+
+TEST_F(NiFakeNonIviServiceTests, ScalarsWithNarrowIntegerTypes_U16DataOutOfRangeTooHigh_ReturnsError)
+{
+  EXPECT_CALL(library_, InputArraysWithNarrowIntegerTypes(_, _, _))
+      .Times(0);
+  ::grpc::ServerContext context;
+  ScalarsWithNarrowIntegerTypesRequest request;
+  request.set_u16(UINT16_MAX + 1);
+  ScalarsWithNarrowIntegerTypesResponse response;
+  auto status = service_.ScalarsWithNarrowIntegerTypes(&context, &request, &response);
+
+  EXPECT_EQ(grpc::StatusCode::OUT_OF_RANGE, status.error_code());
+  EXPECT_THAT(status.error_message(), HasSubstr(std::to_string(UINT16_MAX + 1)));
+}
+
+TEST_F(NiFakeNonIviServiceTests, ScalarsWithNarrowIntegerTypes_AllFieldsInRange_PassesThroughData)
+{
+  constexpr myUInt16 u16_val = UINT16_MAX;
+  constexpr myInt16 i16_val = INT16_MAX;
+  constexpr myInt8 i8_val = INT8_MAX;
+  EXPECT_CALL(library_, ScalarsWithNarrowIntegerTypes(u16_val, i16_val, i8_val))
+      .WillOnce(Return(kDriverSuccess));
+  ::grpc::ServerContext context;
+  ScalarsWithNarrowIntegerTypesRequest request;
+  request.set_u16(u16_val);
+  request.set_i16(i16_val);
+  request.set_i8(i8_val);
+  ScalarsWithNarrowIntegerTypesResponse response;
+  auto status = service_.ScalarsWithNarrowIntegerTypes(&context, &request, &response);
+
+  EXPECT_EQ(kDriverSuccess, response.status());
+}
+
 TEST_F(NiFakeNonIviServiceTests, OutputArraysWithNarrowIntegerTypes_U16)
 {
   ::grpc::ServerContext context;


### PR DESCRIPTION
### What does this Pull Request accomplish?

Implement range checking for coerced scalar inputs using similar code to existing logic for coerced arrays.

### Why should this Pull Request be merged?

Fixes #446.

Ensures that valid values are passed into the driver for datatypes that are narrower than protobuf numerics.

### What testing has been done?

Ran and passed new unit tests and all RFmx tests.