### PR TITLE
Populate response on warning

### DIFF
--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -38,6 +38,12 @@ namespace nidaqmx_grpc {
   {
   }
 
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return status >= 0;
+  }
+
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
   ::grpc::Status NiDAQmxService::AddCDAQSyncConnection(::grpc::ServerContext* context, const AddCDAQSyncConnectionRequest* request, AddCDAQSyncConnectionResponse* response)
@@ -107,7 +113,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_device_name_out(device_name_out);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_device_name_out()));
         }
@@ -132,7 +138,7 @@ namespace nidaqmx_grpc {
       bool32 disconnected_ports_exist {};
       auto status = library_->AreConfiguredCDAQSyncPortsDisconnected(chassis_devices_ports, timeout, &disconnected_ports_exist);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_disconnected_ports_exist(disconnected_ports_exist);
       }
       return ::grpc::Status::OK;
@@ -179,7 +185,7 @@ namespace nidaqmx_grpc {
       float64* reverse_coeffs = response->mutable_reverse_coeffs()->mutable_data();
       auto status = library_->CalculateReversePolyCoeff(forward_coeffs, num_forward_coeffs_in, min_val_x, max_val_x, num_points_to_compute, reverse_poly_order, reverse_coeffs);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
       }
       return ::grpc::Status::OK;
     }
@@ -6692,7 +6698,7 @@ namespace nidaqmx_grpc {
       auto cleanup_lambda = [&] (TaskHandle id) { library_->ClearTask(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_task()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -6744,7 +6750,7 @@ namespace nidaqmx_grpc {
       auto cleanup_lambda = [&] (TaskHandle id) { library_->ClearTask(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_task()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -6776,7 +6782,7 @@ namespace nidaqmx_grpc {
       auto cleanup_lambda = [&] (TaskHandle id) { library_->ClearTask(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_task()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -6870,7 +6876,7 @@ namespace nidaqmx_grpc {
       bool32 cal_supported {};
       auto status = library_->DeviceSupportsCal(device_name, &cal_supported);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_cal_supported(cal_supported);
       }
       return ::grpc::Status::OK;
@@ -6991,7 +6997,7 @@ namespace nidaqmx_grpc {
       uInt32 minute {};
       auto status = library_->GetAIChanCalCalDate(task, channel_name, &year, &month, &day, &hour, &minute);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_year(year);
         response->set_month(month);
         response->set_day(day);
@@ -7023,7 +7029,7 @@ namespace nidaqmx_grpc {
       uInt32 minute {};
       auto status = library_->GetAIChanCalExpDate(task, channel_name, &year, &month, &day, &hour, &minute);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_year(year);
         response->set_month(month);
         response->set_day(day);
@@ -7076,7 +7082,7 @@ namespace nidaqmx_grpc {
       stateVector.resize(channels.size());
       auto status = ((NiDAQmxLibrary*)library_)->GetAnalogPowerUpStates(device_name, get_channelName_if(channels, 0), get_state_if(stateVector, 0), get_channelType_if(channels, 0), get_channelName_if(channels, 1), get_state_if(stateVector, 1), get_channelType_if(channels, 1), get_channelName_if(channels, 2), get_state_if(stateVector, 2), get_channelType_if(channels, 2), get_channelName_if(channels, 3), get_state_if(stateVector, 3), get_channelType_if(channels, 3), get_channelName_if(channels, 4), get_state_if(stateVector, 4), get_channelType_if(channels, 4), get_channelName_if(channels, 5), get_state_if(stateVector, 5), get_channelType_if(channels, 5), get_channelName_if(channels, 6), get_state_if(stateVector, 6), get_channelType_if(channels, 6), get_channelName_if(channels, 7), get_state_if(stateVector, 7), get_channelType_if(channels, 7), get_channelName_if(channels, 8), get_state_if(stateVector, 8), get_channelType_if(channels, 8), get_channelName_if(channels, 9), get_state_if(stateVector, 9), get_channelType_if(channels, 9), get_channelName_if(channels, 10), get_state_if(stateVector, 10), get_channelType_if(channels, 10), get_channelName_if(channels, 11), get_state_if(stateVector, 11), get_channelType_if(channels, 11), get_channelName_if(channels, 12), get_state_if(stateVector, 12), get_channelType_if(channels, 12), get_channelName_if(channels, 13), get_state_if(stateVector, 13), get_channelType_if(channels, 13), get_channelName_if(channels, 14), get_state_if(stateVector, 14), get_channelType_if(channels, 14), get_channelName_if(channels, 15), get_state_if(stateVector, 15), get_channelType_if(channels, 15), get_channelName_if(channels, 16), get_state_if(stateVector, 16), get_channelType_if(channels, 16), get_channelName_if(channels, 17), get_state_if(stateVector, 17), get_channelType_if(channels, 17), get_channelName_if(channels, 18), get_state_if(stateVector, 18), get_channelType_if(channels, 18), get_channelName_if(channels, 19), get_state_if(stateVector, 19), get_channelType_if(channels, 19), get_channelName_if(channels, 20), get_state_if(stateVector, 20), get_channelType_if(channels, 20), get_channelName_if(channels, 21), get_state_if(stateVector, 21), get_channelType_if(channels, 21), get_channelName_if(channels, 22), get_state_if(stateVector, 22), get_channelType_if(channels, 22), get_channelName_if(channels, 23), get_state_if(stateVector, 23), get_channelType_if(channels, 23), get_channelName_if(channels, 24), get_state_if(stateVector, 24), get_channelType_if(channels, 24), get_channelName_if(channels, 25), get_state_if(stateVector, 25), get_channelType_if(channels, 25), get_channelName_if(channels, 26), get_state_if(stateVector, 26), get_channelType_if(channels, 26), get_channelName_if(channels, 27), get_state_if(stateVector, 27), get_channelType_if(channels, 27), get_channelName_if(channels, 28), get_state_if(stateVector, 28), get_channelType_if(channels, 28), get_channelName_if(channels, 29), get_state_if(stateVector, 29), get_channelType_if(channels, 29), get_channelName_if(channels, 30), get_state_if(stateVector, 30), get_channelType_if(channels, 30), get_channelName_if(channels, 31), get_state_if(stateVector, 31), get_channelType_if(channels, 31), get_channelName_if(channels, 32), get_state_if(stateVector, 32), get_channelType_if(channels, 32), get_channelName_if(channels, 33), get_state_if(stateVector, 33), get_channelType_if(channels, 33), get_channelName_if(channels, 34), get_state_if(stateVector, 34), get_channelType_if(channels, 34), get_channelName_if(channels, 35), get_state_if(stateVector, 35), get_channelType_if(channels, 35), get_channelName_if(channels, 36), get_state_if(stateVector, 36), get_channelType_if(channels, 36), get_channelName_if(channels, 37), get_state_if(stateVector, 37), get_channelType_if(channels, 37), get_channelName_if(channels, 38), get_state_if(stateVector, 38), get_channelType_if(channels, 38), get_channelName_if(channels, 39), get_state_if(stateVector, 39), get_channelType_if(channels, 39), get_channelName_if(channels, 40), get_state_if(stateVector, 40), get_channelType_if(channels, 40), get_channelName_if(channels, 41), get_state_if(stateVector, 41), get_channelType_if(channels, 41), get_channelName_if(channels, 42), get_state_if(stateVector, 42), get_channelType_if(channels, 42), get_channelName_if(channels, 43), get_state_if(stateVector, 43), get_channelType_if(channels, 43), get_channelName_if(channels, 44), get_state_if(stateVector, 44), get_channelType_if(channels, 44), get_channelName_if(channels, 45), get_state_if(stateVector, 45), get_channelType_if(channels, 45), get_channelName_if(channels, 46), get_state_if(stateVector, 46), get_channelType_if(channels, 46), get_channelName_if(channels, 47), get_state_if(stateVector, 47), get_channelType_if(channels, 47), get_channelName_if(channels, 48), get_state_if(stateVector, 48), get_channelType_if(channels, 48), get_channelName_if(channels, 49), get_state_if(stateVector, 49), get_channelType_if(channels, 49), get_channelName_if(channels, 50), get_state_if(stateVector, 50), get_channelType_if(channels, 50), get_channelName_if(channels, 51), get_state_if(stateVector, 51), get_channelType_if(channels, 51), get_channelName_if(channels, 52), get_state_if(stateVector, 52), get_channelType_if(channels, 52), get_channelName_if(channels, 53), get_state_if(stateVector, 53), get_channelType_if(channels, 53), get_channelName_if(channels, 54), get_state_if(stateVector, 54), get_channelType_if(channels, 54), get_channelName_if(channels, 55), get_state_if(stateVector, 55), get_channelType_if(channels, 55), get_channelName_if(channels, 56), get_state_if(stateVector, 56), get_channelType_if(channels, 56), get_channelName_if(channels, 57), get_state_if(stateVector, 57), get_channelType_if(channels, 57), get_channelName_if(channels, 58), get_state_if(stateVector, 58), get_channelType_if(channels, 58), get_channelName_if(channels, 59), get_state_if(stateVector, 59), get_channelType_if(channels, 59), get_channelName_if(channels, 60), get_state_if(stateVector, 60), get_channelType_if(channels, 60), get_channelName_if(channels, 61), get_state_if(stateVector, 61), get_channelType_if(channels, 61), get_channelName_if(channels, 62), get_state_if(stateVector, 62), get_channelType_if(channels, 62), get_channelName_if(channels, 63), get_state_if(stateVector, 63), get_channelType_if(channels, 63), get_channelName_if(channels, 64), get_state_if(stateVector, 64), get_channelType_if(channels, 64), get_channelName_if(channels, 65), get_state_if(stateVector, 65), get_channelType_if(channels, 65), get_channelName_if(channels, 66), get_state_if(stateVector, 66), get_channelType_if(channels, 66), get_channelName_if(channels, 67), get_state_if(stateVector, 67), get_channelType_if(channels, 67), get_channelName_if(channels, 68), get_state_if(stateVector, 68), get_channelType_if(channels, 68), get_channelName_if(channels, 69), get_state_if(stateVector, 69), get_channelType_if(channels, 69), get_channelName_if(channels, 70), get_state_if(stateVector, 70), get_channelType_if(channels, 70), get_channelName_if(channels, 71), get_state_if(stateVector, 71), get_channelType_if(channels, 71), get_channelName_if(channels, 72), get_state_if(stateVector, 72), get_channelType_if(channels, 72), get_channelName_if(channels, 73), get_state_if(stateVector, 73), get_channelType_if(channels, 73), get_channelName_if(channels, 74), get_state_if(stateVector, 74), get_channelType_if(channels, 74), get_channelName_if(channels, 75), get_state_if(stateVector, 75), get_channelType_if(channels, 75), get_channelName_if(channels, 76), get_state_if(stateVector, 76), get_channelType_if(channels, 76), get_channelName_if(channels, 77), get_state_if(stateVector, 77), get_channelType_if(channels, 77), get_channelName_if(channels, 78), get_state_if(stateVector, 78), get_channelType_if(channels, 78), get_channelName_if(channels, 79), get_state_if(stateVector, 79), get_channelType_if(channels, 79), get_channelName_if(channels, 80), get_state_if(stateVector, 80), get_channelType_if(channels, 80), get_channelName_if(channels, 81), get_state_if(stateVector, 81), get_channelType_if(channels, 81), get_channelName_if(channels, 82), get_state_if(stateVector, 82), get_channelType_if(channels, 82), get_channelName_if(channels, 83), get_state_if(stateVector, 83), get_channelType_if(channels, 83), get_channelName_if(channels, 84), get_state_if(stateVector, 84), get_channelType_if(channels, 84), get_channelName_if(channels, 85), get_state_if(stateVector, 85), get_channelType_if(channels, 85), get_channelName_if(channels, 86), get_state_if(stateVector, 86), get_channelType_if(channels, 86), get_channelName_if(channels, 87), get_state_if(stateVector, 87), get_channelType_if(channels, 87), get_channelName_if(channels, 88), get_state_if(stateVector, 88), get_channelType_if(channels, 88), get_channelName_if(channels, 89), get_state_if(stateVector, 89), get_channelType_if(channels, 89), get_channelName_if(channels, 90), get_state_if(stateVector, 90), get_channelType_if(channels, 90), get_channelName_if(channels, 91), get_state_if(stateVector, 91), get_channelType_if(channels, 91), get_channelName_if(channels, 92), get_state_if(stateVector, 92), get_channelType_if(channels, 92), get_channelName_if(channels, 93), get_state_if(stateVector, 93), get_channelType_if(channels, 93), get_channelName_if(channels, 94), get_state_if(stateVector, 94), get_channelType_if(channels, 94), get_channelName_if(channels, 95), get_state_if(stateVector, 95), get_channelType_if(channels, 95), get_channelName_if(channels, 96), get_state_if(stateVector, 96), get_channelType_if(channels, 96));
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         for (int i = 0; i < stateVector.size(); ++i) {
           response->add_power_up_states(stateVector[i]);
         }
@@ -7104,7 +7110,7 @@ namespace nidaqmx_grpc {
       int32* channel_type_array = reinterpret_cast<int32*>(response->mutable_channel_type_array_raw()->mutable_data());
       auto status = library_->GetAnalogPowerUpStatesWithOutputType(channel_names, state_array, channel_type_array, &array_size_copy);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_state_array()->Resize(array_size_copy, 0);
         response->mutable_channel_type_array()->Clear();
         response->mutable_channel_type_array()->Reserve(array_size_copy);
@@ -7136,7 +7142,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime data {};
       auto status = library_->GetArmStartTrigTimestampVal(task, &data);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(data, response->mutable_data());
       }
       return ::grpc::Status::OK;
@@ -7159,7 +7165,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime data {};
       auto status = library_->GetArmStartTrigTrigWhen(task, &data);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(data, response->mutable_data());
       }
       return ::grpc::Status::OK;
@@ -7196,7 +7202,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_port_list(port_list);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_port_list()));
         }
@@ -7240,7 +7246,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetBufferAttributeUInt32(task, attribute, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -7282,7 +7288,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetCalInfoAttributeBool(device_name, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -7324,7 +7330,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetCalInfoAttributeDouble(device_name, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -7381,7 +7387,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -7425,7 +7431,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetCalInfoAttributeUInt32(device_name, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -7469,7 +7475,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetChanAttributeBool(task, channel, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -7513,7 +7519,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetChanAttributeDouble(task, channel, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -7570,7 +7576,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
         }
         return ::grpc::Status::OK;
       }
@@ -7614,7 +7620,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetChanAttributeInt32(task, channel, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto checked_convert_value = [](auto raw_value) {
           bool raw_value_is_valid = nidaqmx_grpc::ChannelInt32AttributeValues_IsValid(raw_value);
           auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -7679,7 +7685,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -7725,7 +7731,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetChanAttributeUInt32(task, channel, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -7767,7 +7773,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetDeviceAttributeBool(device_name, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -7809,7 +7815,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetDeviceAttributeDouble(device_name, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -7864,7 +7870,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
         }
         return ::grpc::Status::OK;
       }
@@ -7906,7 +7912,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetDeviceAttributeInt32(device_name, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto checked_convert_value = [](auto raw_value) {
           bool raw_value_is_valid = nidaqmx_grpc::DeviceInt32AttributeValues_IsValid(raw_value);
           auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -7967,7 +7973,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           auto checked_convert_value = [](auto raw_value) {
             bool raw_value_is_valid = nidaqmx_grpc::DeviceInt32AttributeValues_IsValid(raw_value);
             auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -8038,7 +8044,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -8082,7 +8088,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetDeviceAttributeUInt32(device_name, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -8137,7 +8143,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
         }
         return ::grpc::Status::OK;
       }
@@ -8159,7 +8165,7 @@ namespace nidaqmx_grpc {
       int32 logic_family {};
       auto status = library_->GetDigitalLogicFamilyPowerUpState(device_name, &logic_family);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_logic_family(logic_family);
       }
       return ::grpc::Status::OK;
@@ -8202,7 +8208,7 @@ namespace nidaqmx_grpc {
       stateVector.resize(channel_name.size());
       auto status = ((NiDAQmxLibrary*)library_)->GetDigitalPowerUpStates(device_name, get_channelName_if(channel_name, 0), get_state_if(stateVector, 0), get_channelName_if(channel_name, 1), get_state_if(stateVector, 1), get_channelName_if(channel_name, 2), get_state_if(stateVector, 2), get_channelName_if(channel_name, 3), get_state_if(stateVector, 3), get_channelName_if(channel_name, 4), get_state_if(stateVector, 4), get_channelName_if(channel_name, 5), get_state_if(stateVector, 5), get_channelName_if(channel_name, 6), get_state_if(stateVector, 6), get_channelName_if(channel_name, 7), get_state_if(stateVector, 7), get_channelName_if(channel_name, 8), get_state_if(stateVector, 8), get_channelName_if(channel_name, 9), get_state_if(stateVector, 9), get_channelName_if(channel_name, 10), get_state_if(stateVector, 10), get_channelName_if(channel_name, 11), get_state_if(stateVector, 11), get_channelName_if(channel_name, 12), get_state_if(stateVector, 12), get_channelName_if(channel_name, 13), get_state_if(stateVector, 13), get_channelName_if(channel_name, 14), get_state_if(stateVector, 14), get_channelName_if(channel_name, 15), get_state_if(stateVector, 15), get_channelName_if(channel_name, 16), get_state_if(stateVector, 16), get_channelName_if(channel_name, 17), get_state_if(stateVector, 17), get_channelName_if(channel_name, 18), get_state_if(stateVector, 18), get_channelName_if(channel_name, 19), get_state_if(stateVector, 19), get_channelName_if(channel_name, 20), get_state_if(stateVector, 20), get_channelName_if(channel_name, 21), get_state_if(stateVector, 21), get_channelName_if(channel_name, 22), get_state_if(stateVector, 22), get_channelName_if(channel_name, 23), get_state_if(stateVector, 23), get_channelName_if(channel_name, 24), get_state_if(stateVector, 24), get_channelName_if(channel_name, 25), get_state_if(stateVector, 25), get_channelName_if(channel_name, 26), get_state_if(stateVector, 26), get_channelName_if(channel_name, 27), get_state_if(stateVector, 27), get_channelName_if(channel_name, 28), get_state_if(stateVector, 28), get_channelName_if(channel_name, 29), get_state_if(stateVector, 29), get_channelName_if(channel_name, 30), get_state_if(stateVector, 30), get_channelName_if(channel_name, 31), get_state_if(stateVector, 31), get_channelName_if(channel_name, 32), get_state_if(stateVector, 32), get_channelName_if(channel_name, 33), get_state_if(stateVector, 33), get_channelName_if(channel_name, 34), get_state_if(stateVector, 34), get_channelName_if(channel_name, 35), get_state_if(stateVector, 35), get_channelName_if(channel_name, 36), get_state_if(stateVector, 36), get_channelName_if(channel_name, 37), get_state_if(stateVector, 37), get_channelName_if(channel_name, 38), get_state_if(stateVector, 38), get_channelName_if(channel_name, 39), get_state_if(stateVector, 39), get_channelName_if(channel_name, 40), get_state_if(stateVector, 40), get_channelName_if(channel_name, 41), get_state_if(stateVector, 41), get_channelName_if(channel_name, 42), get_state_if(stateVector, 42), get_channelName_if(channel_name, 43), get_state_if(stateVector, 43), get_channelName_if(channel_name, 44), get_state_if(stateVector, 44), get_channelName_if(channel_name, 45), get_state_if(stateVector, 45), get_channelName_if(channel_name, 46), get_state_if(stateVector, 46), get_channelName_if(channel_name, 47), get_state_if(stateVector, 47), get_channelName_if(channel_name, 48), get_state_if(stateVector, 48), get_channelName_if(channel_name, 49), get_state_if(stateVector, 49), get_channelName_if(channel_name, 50), get_state_if(stateVector, 50), get_channelName_if(channel_name, 51), get_state_if(stateVector, 51), get_channelName_if(channel_name, 52), get_state_if(stateVector, 52), get_channelName_if(channel_name, 53), get_state_if(stateVector, 53), get_channelName_if(channel_name, 54), get_state_if(stateVector, 54), get_channelName_if(channel_name, 55), get_state_if(stateVector, 55), get_channelName_if(channel_name, 56), get_state_if(stateVector, 56), get_channelName_if(channel_name, 57), get_state_if(stateVector, 57), get_channelName_if(channel_name, 58), get_state_if(stateVector, 58), get_channelName_if(channel_name, 59), get_state_if(stateVector, 59), get_channelName_if(channel_name, 60), get_state_if(stateVector, 60), get_channelName_if(channel_name, 61), get_state_if(stateVector, 61), get_channelName_if(channel_name, 62), get_state_if(stateVector, 62), get_channelName_if(channel_name, 63), get_state_if(stateVector, 63), get_channelName_if(channel_name, 64), get_state_if(stateVector, 64), get_channelName_if(channel_name, 65), get_state_if(stateVector, 65), get_channelName_if(channel_name, 66), get_state_if(stateVector, 66), get_channelName_if(channel_name, 67), get_state_if(stateVector, 67), get_channelName_if(channel_name, 68), get_state_if(stateVector, 68), get_channelName_if(channel_name, 69), get_state_if(stateVector, 69), get_channelName_if(channel_name, 70), get_state_if(stateVector, 70), get_channelName_if(channel_name, 71), get_state_if(stateVector, 71), get_channelName_if(channel_name, 72), get_state_if(stateVector, 72), get_channelName_if(channel_name, 73), get_state_if(stateVector, 73), get_channelName_if(channel_name, 74), get_state_if(stateVector, 74), get_channelName_if(channel_name, 75), get_state_if(stateVector, 75), get_channelName_if(channel_name, 76), get_state_if(stateVector, 76), get_channelName_if(channel_name, 77), get_state_if(stateVector, 77), get_channelName_if(channel_name, 78), get_state_if(stateVector, 78), get_channelName_if(channel_name, 79), get_state_if(stateVector, 79), get_channelName_if(channel_name, 80), get_state_if(stateVector, 80), get_channelName_if(channel_name, 81), get_state_if(stateVector, 81), get_channelName_if(channel_name, 82), get_state_if(stateVector, 82), get_channelName_if(channel_name, 83), get_state_if(stateVector, 83), get_channelName_if(channel_name, 84), get_state_if(stateVector, 84), get_channelName_if(channel_name, 85), get_state_if(stateVector, 85), get_channelName_if(channel_name, 86), get_state_if(stateVector, 86), get_channelName_if(channel_name, 87), get_state_if(stateVector, 87), get_channelName_if(channel_name, 88), get_state_if(stateVector, 88), get_channelName_if(channel_name, 89), get_state_if(stateVector, 89), get_channelName_if(channel_name, 90), get_state_if(stateVector, 90), get_channelName_if(channel_name, 91), get_state_if(stateVector, 91), get_channelName_if(channel_name, 92), get_state_if(stateVector, 92), get_channelName_if(channel_name, 93), get_state_if(stateVector, 93), get_channelName_if(channel_name, 94), get_state_if(stateVector, 94), get_channelName_if(channel_name, 95), get_state_if(stateVector, 95), get_channelName_if(channel_name, 96), get_state_if(stateVector, 96));
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         for (int i = 0; i < stateVector.size(); ++i) {
           response->add_power_up_states(static_cast<PowerUpStates>(stateVector[i]));
         }
@@ -8247,7 +8253,7 @@ namespace nidaqmx_grpc {
       stateVector.resize(channel_name.size());
       auto status = ((NiDAQmxLibrary*)library_)->GetDigitalPullUpPullDownStates(device_name, get_channelName_if(channel_name, 0), get_state_if(stateVector, 0), get_channelName_if(channel_name, 1), get_state_if(stateVector, 1), get_channelName_if(channel_name, 2), get_state_if(stateVector, 2), get_channelName_if(channel_name, 3), get_state_if(stateVector, 3), get_channelName_if(channel_name, 4), get_state_if(stateVector, 4), get_channelName_if(channel_name, 5), get_state_if(stateVector, 5), get_channelName_if(channel_name, 6), get_state_if(stateVector, 6), get_channelName_if(channel_name, 7), get_state_if(stateVector, 7), get_channelName_if(channel_name, 8), get_state_if(stateVector, 8), get_channelName_if(channel_name, 9), get_state_if(stateVector, 9), get_channelName_if(channel_name, 10), get_state_if(stateVector, 10), get_channelName_if(channel_name, 11), get_state_if(stateVector, 11), get_channelName_if(channel_name, 12), get_state_if(stateVector, 12), get_channelName_if(channel_name, 13), get_state_if(stateVector, 13), get_channelName_if(channel_name, 14), get_state_if(stateVector, 14), get_channelName_if(channel_name, 15), get_state_if(stateVector, 15), get_channelName_if(channel_name, 16), get_state_if(stateVector, 16), get_channelName_if(channel_name, 17), get_state_if(stateVector, 17), get_channelName_if(channel_name, 18), get_state_if(stateVector, 18), get_channelName_if(channel_name, 19), get_state_if(stateVector, 19), get_channelName_if(channel_name, 20), get_state_if(stateVector, 20), get_channelName_if(channel_name, 21), get_state_if(stateVector, 21), get_channelName_if(channel_name, 22), get_state_if(stateVector, 22), get_channelName_if(channel_name, 23), get_state_if(stateVector, 23), get_channelName_if(channel_name, 24), get_state_if(stateVector, 24), get_channelName_if(channel_name, 25), get_state_if(stateVector, 25), get_channelName_if(channel_name, 26), get_state_if(stateVector, 26), get_channelName_if(channel_name, 27), get_state_if(stateVector, 27), get_channelName_if(channel_name, 28), get_state_if(stateVector, 28), get_channelName_if(channel_name, 29), get_state_if(stateVector, 29), get_channelName_if(channel_name, 30), get_state_if(stateVector, 30), get_channelName_if(channel_name, 31), get_state_if(stateVector, 31), get_channelName_if(channel_name, 32), get_state_if(stateVector, 32), get_channelName_if(channel_name, 33), get_state_if(stateVector, 33), get_channelName_if(channel_name, 34), get_state_if(stateVector, 34), get_channelName_if(channel_name, 35), get_state_if(stateVector, 35), get_channelName_if(channel_name, 36), get_state_if(stateVector, 36), get_channelName_if(channel_name, 37), get_state_if(stateVector, 37), get_channelName_if(channel_name, 38), get_state_if(stateVector, 38), get_channelName_if(channel_name, 39), get_state_if(stateVector, 39), get_channelName_if(channel_name, 40), get_state_if(stateVector, 40), get_channelName_if(channel_name, 41), get_state_if(stateVector, 41), get_channelName_if(channel_name, 42), get_state_if(stateVector, 42), get_channelName_if(channel_name, 43), get_state_if(stateVector, 43), get_channelName_if(channel_name, 44), get_state_if(stateVector, 44), get_channelName_if(channel_name, 45), get_state_if(stateVector, 45), get_channelName_if(channel_name, 46), get_state_if(stateVector, 46), get_channelName_if(channel_name, 47), get_state_if(stateVector, 47), get_channelName_if(channel_name, 48), get_state_if(stateVector, 48), get_channelName_if(channel_name, 49), get_state_if(stateVector, 49), get_channelName_if(channel_name, 50), get_state_if(stateVector, 50), get_channelName_if(channel_name, 51), get_state_if(stateVector, 51), get_channelName_if(channel_name, 52), get_state_if(stateVector, 52), get_channelName_if(channel_name, 53), get_state_if(stateVector, 53), get_channelName_if(channel_name, 54), get_state_if(stateVector, 54), get_channelName_if(channel_name, 55), get_state_if(stateVector, 55), get_channelName_if(channel_name, 56), get_state_if(stateVector, 56), get_channelName_if(channel_name, 57), get_state_if(stateVector, 57), get_channelName_if(channel_name, 58), get_state_if(stateVector, 58), get_channelName_if(channel_name, 59), get_state_if(stateVector, 59), get_channelName_if(channel_name, 60), get_state_if(stateVector, 60), get_channelName_if(channel_name, 61), get_state_if(stateVector, 61), get_channelName_if(channel_name, 62), get_state_if(stateVector, 62), get_channelName_if(channel_name, 63), get_state_if(stateVector, 63), get_channelName_if(channel_name, 64), get_state_if(stateVector, 64), get_channelName_if(channel_name, 65), get_state_if(stateVector, 65), get_channelName_if(channel_name, 66), get_state_if(stateVector, 66), get_channelName_if(channel_name, 67), get_state_if(stateVector, 67), get_channelName_if(channel_name, 68), get_state_if(stateVector, 68), get_channelName_if(channel_name, 69), get_state_if(stateVector, 69), get_channelName_if(channel_name, 70), get_state_if(stateVector, 70), get_channelName_if(channel_name, 71), get_state_if(stateVector, 71), get_channelName_if(channel_name, 72), get_state_if(stateVector, 72), get_channelName_if(channel_name, 73), get_state_if(stateVector, 73), get_channelName_if(channel_name, 74), get_state_if(stateVector, 74), get_channelName_if(channel_name, 75), get_state_if(stateVector, 75), get_channelName_if(channel_name, 76), get_state_if(stateVector, 76), get_channelName_if(channel_name, 77), get_state_if(stateVector, 77), get_channelName_if(channel_name, 78), get_state_if(stateVector, 78), get_channelName_if(channel_name, 79), get_state_if(stateVector, 79), get_channelName_if(channel_name, 80), get_state_if(stateVector, 80), get_channelName_if(channel_name, 81), get_state_if(stateVector, 81), get_channelName_if(channel_name, 82), get_state_if(stateVector, 82), get_channelName_if(channel_name, 83), get_state_if(stateVector, 83), get_channelName_if(channel_name, 84), get_state_if(stateVector, 84), get_channelName_if(channel_name, 85), get_state_if(stateVector, 85), get_channelName_if(channel_name, 86), get_state_if(stateVector, 86), get_channelName_if(channel_name, 87), get_state_if(stateVector, 87), get_channelName_if(channel_name, 88), get_state_if(stateVector, 88), get_channelName_if(channel_name, 89), get_state_if(stateVector, 89), get_channelName_if(channel_name, 90), get_state_if(stateVector, 90), get_channelName_if(channel_name, 91), get_state_if(stateVector, 91), get_channelName_if(channel_name, 92), get_state_if(stateVector, 92), get_channelName_if(channel_name, 93), get_state_if(stateVector, 93), get_channelName_if(channel_name, 94), get_state_if(stateVector, 94), get_channelName_if(channel_name, 95), get_state_if(stateVector, 95), get_channelName_if(channel_name, 96), get_state_if(stateVector, 96));
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         for (int i = 0; i < stateVector.size(); ++i) {
           response->add_pull_up_pull_down_states(static_cast<ResistorState>(stateVector[i]));
         }
@@ -8286,7 +8292,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_port_list(port_list);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_port_list()));
         }
@@ -8326,7 +8332,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_error_string(error_string);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_string()));
         }
@@ -8371,7 +8377,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetExportedSignalAttributeBool(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -8414,7 +8420,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetExportedSignalAttributeDouble(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -8457,7 +8463,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetExportedSignalAttributeInt32(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto checked_convert_value = [](auto raw_value) {
           bool raw_value_is_valid = nidaqmx_grpc::ExportSignalInt32AttributeValues_IsValid(raw_value);
           auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -8521,7 +8527,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -8566,7 +8572,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetExportedSignalAttributeUInt32(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -8603,7 +8609,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_error_string(error_string);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_string()));
         }
@@ -8628,7 +8634,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime data {};
       auto status = library_->GetFirstSampClkWhen(task, &data);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(data, response->mutable_data());
       }
       return ::grpc::Status::OK;
@@ -8651,7 +8657,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime data {};
       auto status = library_->GetFirstSampTimestampVal(task, &data);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(data, response->mutable_data());
       }
       return ::grpc::Status::OK;
@@ -8691,7 +8697,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_buffer(buffer);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_buffer()));
         }
@@ -8733,7 +8739,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_buffer(buffer);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_buffer()));
         }
@@ -8775,7 +8781,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_buffer(buffer);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_buffer()));
         }
@@ -8819,7 +8825,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetPersistedChanAttributeBool(channel, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -8876,7 +8882,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -8920,7 +8926,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetPersistedScaleAttributeBool(scale_name, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -8977,7 +8983,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -9021,7 +9027,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetPersistedTaskAttributeBool(task_name, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -9078,7 +9084,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -9122,7 +9128,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetPhysicalChanAttributeBool(physical_channel, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -9176,7 +9182,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
         }
         return ::grpc::Status::OK;
@@ -9219,7 +9225,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetPhysicalChanAttributeDouble(physical_channel, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -9274,7 +9280,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
         }
         return ::grpc::Status::OK;
       }
@@ -9316,7 +9322,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetPhysicalChanAttributeInt32(physical_channel, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto checked_convert_value = [](auto raw_value) {
           bool raw_value_is_valid = nidaqmx_grpc::PhysicalChannelInt32AttributeValues_IsValid(raw_value);
           auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -9377,7 +9383,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           auto checked_convert_value = [](auto raw_value) {
             bool raw_value_is_valid = nidaqmx_grpc::PhysicalChannelInt32AttributeValues_IsValid(raw_value);
             auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -9448,7 +9454,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -9492,7 +9498,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetPhysicalChanAttributeUInt32(physical_channel, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -9547,7 +9553,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
         }
         return ::grpc::Status::OK;
       }
@@ -9590,7 +9596,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetReadAttributeBool(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -9633,7 +9639,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetReadAttributeDouble(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -9676,7 +9682,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetReadAttributeInt32(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto checked_convert_value = [](auto raw_value) {
           bool raw_value_is_valid = nidaqmx_grpc::ReadInt32AttributeValues_IsValid(raw_value);
           auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -9740,7 +9746,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -9785,7 +9791,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetReadAttributeUInt32(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -9828,7 +9834,7 @@ namespace nidaqmx_grpc {
       uInt64 value {};
       auto status = library_->GetReadAttributeUInt64(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -9871,7 +9877,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetRealTimeAttributeBool(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -9914,7 +9920,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetRealTimeAttributeInt32(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto checked_convert_value = [](auto raw_value) {
           bool raw_value_is_valid = nidaqmx_grpc::RealTimeInt32AttributeValues_IsValid(raw_value);
           auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -9963,7 +9969,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetRealTimeAttributeUInt32(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -9986,7 +9992,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime data {};
       auto status = library_->GetRefTrigTimestampVal(task, &data);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(data, response->mutable_data());
       }
       return ::grpc::Status::OK;
@@ -10028,7 +10034,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetScaleAttributeDouble(scale_name, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -10083,7 +10089,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
         }
         return ::grpc::Status::OK;
       }
@@ -10125,7 +10131,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetScaleAttributeInt32(scale_name, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto checked_convert_value = [](auto raw_value) {
           bool raw_value_is_valid = nidaqmx_grpc::ScaleInt32AttributeValues_IsValid(raw_value);
           auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -10188,7 +10194,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -10216,7 +10222,7 @@ namespace nidaqmx_grpc {
       uInt32 minute {};
       auto status = library_->GetSelfCalLastDateAndTime(device_name, &year, &month, &day, &hour, &minute);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_year(year);
         response->set_month(month);
         response->set_day(day);
@@ -10243,7 +10249,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime data {};
       auto status = library_->GetStartTrigTimestampVal(task, &data);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(data, response->mutable_data());
       }
       return ::grpc::Status::OK;
@@ -10266,7 +10272,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime data {};
       auto status = library_->GetStartTrigTrigWhen(task, &data);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(data, response->mutable_data());
       }
       return ::grpc::Status::OK;
@@ -10289,7 +10295,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime data {};
       auto status = library_->GetSyncPulseTimeWhen(task, &data);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(data, response->mutable_data());
       }
       return ::grpc::Status::OK;
@@ -10345,7 +10351,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -10388,7 +10394,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetSystemInfoAttributeUInt32(attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -10431,7 +10437,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetTaskAttributeBool(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -10489,7 +10495,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -10534,7 +10540,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetTaskAttributeUInt32(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -10577,7 +10583,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetTimingAttributeBool(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -10620,7 +10626,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetTimingAttributeDouble(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -10664,7 +10670,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetTimingAttributeExBool(task, device_names, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -10708,7 +10714,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetTimingAttributeExDouble(task, device_names, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -10752,7 +10758,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetTimingAttributeExInt32(task, device_names, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto checked_convert_value = [](auto raw_value) {
           bool raw_value_is_valid = nidaqmx_grpc::TimingInt32AttributeValues_IsValid(raw_value);
           auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -10817,7 +10823,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -10863,7 +10869,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime value {};
       auto status = library_->GetTimingAttributeExTimestamp(task, device_names, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(value, response->mutable_value());
       }
       return ::grpc::Status::OK;
@@ -10907,7 +10913,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetTimingAttributeExUInt32(task, device_names, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -10951,7 +10957,7 @@ namespace nidaqmx_grpc {
       uInt64 value {};
       auto status = library_->GetTimingAttributeExUInt64(task, device_names, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -10994,7 +11000,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetTimingAttributeInt32(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto checked_convert_value = [](auto raw_value) {
           bool raw_value_is_valid = nidaqmx_grpc::TimingInt32AttributeValues_IsValid(raw_value);
           auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -11058,7 +11064,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -11103,7 +11109,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime value {};
       auto status = library_->GetTimingAttributeTimestamp(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(value, response->mutable_value());
       }
       return ::grpc::Status::OK;
@@ -11146,7 +11152,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetTimingAttributeUInt32(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -11189,7 +11195,7 @@ namespace nidaqmx_grpc {
       uInt64 value {};
       auto status = library_->GetTimingAttributeUInt64(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -11232,7 +11238,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetTrigAttributeBool(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -11275,7 +11281,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetTrigAttributeDouble(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -11331,7 +11337,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
         }
         return ::grpc::Status::OK;
       }
@@ -11374,7 +11380,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetTrigAttributeInt32(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto checked_convert_value = [](auto raw_value) {
           bool raw_value_is_valid = nidaqmx_grpc::TriggerInt32AttributeValues_IsValid(raw_value);
           auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -11436,7 +11442,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           auto checked_convert_value = [](auto raw_value) {
             bool raw_value_is_valid = nidaqmx_grpc::TriggerInt32AttributeValues_IsValid(raw_value);
             auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -11508,7 +11514,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -11553,7 +11559,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime value {};
       auto status = library_->GetTrigAttributeTimestamp(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(value, response->mutable_value());
       }
       return ::grpc::Status::OK;
@@ -11596,7 +11602,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetTrigAttributeUInt32(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -11640,7 +11646,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetWatchdogAttributeBool(task, lines, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -11684,7 +11690,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetWatchdogAttributeDouble(task, lines, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -11728,7 +11734,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetWatchdogAttributeInt32(task, lines, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto checked_convert_value = [](auto raw_value) {
           bool raw_value_is_valid = nidaqmx_grpc::WatchdogInt32AttributeValues_IsValid(raw_value);
           auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -11793,7 +11799,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -11838,7 +11844,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetWriteAttributeBool(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -11881,7 +11887,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetWriteAttributeDouble(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -11924,7 +11930,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetWriteAttributeInt32(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto checked_convert_value = [](auto raw_value) {
           bool raw_value_is_valid = nidaqmx_grpc::WriteInt32AttributeValues_IsValid(raw_value);
           auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -11988,7 +11994,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -12033,7 +12039,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetWriteAttributeUInt32(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -12076,7 +12082,7 @@ namespace nidaqmx_grpc {
       uInt64 value {};
       auto status = library_->GetWriteAttributeUInt64(task, attribute, &value, size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -12099,7 +12105,7 @@ namespace nidaqmx_grpc {
       bool32 is_task_done {};
       auto status = library_->IsTaskDone(task, &is_task_done);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_is_task_done(is_task_done);
       }
       return ::grpc::Status::OK;
@@ -12129,7 +12135,7 @@ namespace nidaqmx_grpc {
       auto cleanup_lambda = [&] (TaskHandle id) { library_->ClearTask(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_task()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -12174,7 +12180,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadAnalogF64(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_read(samps_per_chan_read);
       }
       return ::grpc::Status::OK;
@@ -12199,7 +12205,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->ReadAnalogScalarF64(task, timeout, &value, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -12243,7 +12249,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadBinaryI16(task, num_samps_per_chan, timeout, fill_mode, read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_read_array()->Clear();
         response->mutable_read_array()->Reserve(array_size_in_samps);
         std::transform(
@@ -12297,7 +12303,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadBinaryI32(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_read(samps_per_chan_read);
       }
       return ::grpc::Status::OK;
@@ -12341,7 +12347,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadBinaryU16(task, num_samps_per_chan, timeout, fill_mode, read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_read_array()->Clear();
         response->mutable_read_array()->Reserve(array_size_in_samps);
         std::transform(
@@ -12395,7 +12401,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadBinaryU32(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_read(samps_per_chan_read);
       }
       return ::grpc::Status::OK;
@@ -12424,7 +12430,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadCounterF64(task, num_samps_per_chan, timeout, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_read(samps_per_chan_read);
       }
       return ::grpc::Status::OK;
@@ -12469,7 +12475,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadCounterF64Ex(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_read(samps_per_chan_read);
       }
       return ::grpc::Status::OK;
@@ -12494,7 +12500,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->ReadCounterScalarF64(task, timeout, &value, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -12519,7 +12525,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->ReadCounterScalarU32(task, timeout, &value, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -12548,7 +12554,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadCounterU32(task, num_samps_per_chan, timeout, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_read(samps_per_chan_read);
       }
       return ::grpc::Status::OK;
@@ -12593,7 +12599,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadCounterU32Ex(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_read(samps_per_chan_read);
       }
       return ::grpc::Status::OK;
@@ -12640,7 +12646,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadCtrFreq(task, num_samps_per_chan, timeout, interleaved, read_array_frequency, read_array_duty_cycle, array_size_in_samps, &samps_per_chan_read, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_read(samps_per_chan_read);
       }
       return ::grpc::Status::OK;
@@ -12666,7 +12672,7 @@ namespace nidaqmx_grpc {
       float64 duty_cycle {};
       auto status = library_->ReadCtrFreqScalar(task, timeout, &frequency, &duty_cycle, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_frequency(frequency);
         response->set_duty_cycle(duty_cycle);
       }
@@ -12714,7 +12720,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadCtrTicks(task, num_samps_per_chan, timeout, interleaved, read_array_high_ticks, read_array_low_ticks, array_size_in_samps, &samps_per_chan_read, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_read(samps_per_chan_read);
       }
       return ::grpc::Status::OK;
@@ -12740,7 +12746,7 @@ namespace nidaqmx_grpc {
       uInt32 low_ticks {};
       auto status = library_->ReadCtrTicksScalar(task, timeout, &high_ticks, &low_ticks, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_high_ticks(high_ticks);
         response->set_low_ticks(low_ticks);
       }
@@ -12788,7 +12794,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadCtrTime(task, num_samps_per_chan, timeout, interleaved, read_array_high_time, read_array_low_time, array_size_in_samps, &samps_per_chan_read, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_read(samps_per_chan_read);
       }
       return ::grpc::Status::OK;
@@ -12814,7 +12820,7 @@ namespace nidaqmx_grpc {
       float64 low_time {};
       auto status = library_->ReadCtrTimeScalar(task, timeout, &high_time, &low_time, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_high_time(high_time);
         response->set_low_time(low_time);
       }
@@ -12860,7 +12866,7 @@ namespace nidaqmx_grpc {
       int32 num_bytes_per_samp {};
       auto status = library_->ReadDigitalLines(task, num_samps_per_chan, timeout, fill_mode, (uInt8*)read_array.data(), array_size_in_bytes, &samps_per_chan_read, &num_bytes_per_samp, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_read_array(read_array);
         response->set_samps_per_chan_read(samps_per_chan_read);
         response->set_num_bytes_per_samp(num_bytes_per_samp);
@@ -12887,7 +12893,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->ReadDigitalScalarU32(task, timeout, &value, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -12931,7 +12937,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadDigitalU16(task, num_samps_per_chan, timeout, fill_mode, read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_read_array()->Clear();
         response->mutable_read_array()->Reserve(array_size_in_samps);
         std::transform(
@@ -12985,7 +12991,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadDigitalU32(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_read(samps_per_chan_read);
       }
       return ::grpc::Status::OK;
@@ -13029,7 +13035,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadDigitalU8(task, num_samps_per_chan, timeout, fill_mode, (uInt8*)read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_read_array(read_array);
         response->set_samps_per_chan_read(samps_per_chan_read);
       }
@@ -13059,7 +13065,7 @@ namespace nidaqmx_grpc {
       int32 num_bytes_per_samp {};
       auto status = library_->ReadRaw(task, num_samps_per_chan, timeout, (uInt8*)read_array.data(), array_size_in_bytes, &samps_read, &num_bytes_per_samp, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_read_array(read_array);
         response->set_samps_read(samps_read);
         response->set_num_bytes_per_samp(num_bytes_per_samp);
@@ -16924,7 +16930,7 @@ namespace nidaqmx_grpc {
       bool32 is_late {};
       auto status = library_->WaitForNextSampleClock(task, timeout, &is_late);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_is_late(is_late);
       }
       return ::grpc::Status::OK;
@@ -16964,7 +16970,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime timestamp {};
       auto status = library_->WaitForValidTimestamp(task, timestamp_event, timeout, &timestamp);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(timestamp, response->mutable_timestamp());
       }
       return ::grpc::Status::OK;
@@ -17028,7 +17034,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteAnalogF64(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_written(samps_per_chan_written);
       }
       return ::grpc::Status::OK;
@@ -17112,7 +17118,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteBinaryI16(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array.data(), &samps_per_chan_written, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_written(samps_per_chan_written);
       }
       return ::grpc::Status::OK;
@@ -17159,7 +17165,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteBinaryI32(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_written(samps_per_chan_written);
       }
       return ::grpc::Status::OK;
@@ -17220,7 +17226,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteBinaryU16(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array.data(), &samps_per_chan_written, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_written(samps_per_chan_written);
       }
       return ::grpc::Status::OK;
@@ -17267,7 +17273,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteBinaryU32(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_written(samps_per_chan_written);
       }
       return ::grpc::Status::OK;
@@ -17312,7 +17318,7 @@ namespace nidaqmx_grpc {
       int32 num_samps_per_chan_written {};
       auto status = library_->WriteCtrFreq(task, num_samps_per_chan, auto_start, timeout, data_layout, frequency, duty_cycle, &num_samps_per_chan_written, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_num_samps_per_chan_written(num_samps_per_chan_written);
       }
       return ::grpc::Status::OK;
@@ -17381,7 +17387,7 @@ namespace nidaqmx_grpc {
       int32 num_samps_per_chan_written {};
       auto status = library_->WriteCtrTicks(task, num_samps_per_chan, auto_start, timeout, data_layout, high_ticks, low_ticks, &num_samps_per_chan_written, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_num_samps_per_chan_written(num_samps_per_chan_written);
       }
       return ::grpc::Status::OK;
@@ -17450,7 +17456,7 @@ namespace nidaqmx_grpc {
       int32 num_samps_per_chan_written {};
       auto status = library_->WriteCtrTime(task, num_samps_per_chan, auto_start, timeout, data_layout, high_time, low_time, &num_samps_per_chan_written, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_num_samps_per_chan_written(num_samps_per_chan_written);
       }
       return ::grpc::Status::OK;
@@ -17518,7 +17524,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteDigitalLines(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_written(samps_per_chan_written);
       }
       return ::grpc::Status::OK;
@@ -17602,7 +17608,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteDigitalU16(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array.data(), &samps_per_chan_written, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_written(samps_per_chan_written);
       }
       return ::grpc::Status::OK;
@@ -17649,7 +17655,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteDigitalU32(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_written(samps_per_chan_written);
       }
       return ::grpc::Status::OK;
@@ -17693,7 +17699,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteDigitalU8(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_written(samps_per_chan_written);
       }
       return ::grpc::Status::OK;
@@ -17721,7 +17727,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteRaw(task, num_samps, auto_start, timeout, write_array, &samps_per_chan_written, reserved);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_samps_per_chan_written(samps_per_chan_written);
       }
       return ::grpc::Status::OK;

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -35,6 +35,12 @@ namespace nidcpower_grpc {
   {
   }
 
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return status >= 0;
+  }
+
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
   ::grpc::Status NiDCPowerService::AbortWithChannels(::grpc::ServerContext* context, const AbortWithChannelsRequest* request, AbortWithChannelsResponse* response)
@@ -699,7 +705,7 @@ namespace nidcpower_grpc {
       ViInt32 error_code {};
       auto status = library_->ErrorQuery(vi, &error_code, error_message);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_error_code(error_code);
       }
       return ::grpc::Status::OK;
@@ -769,7 +775,7 @@ namespace nidcpower_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -2144,7 +2150,7 @@ namespace nidcpower_grpc {
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_error_message(error_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
@@ -2182,7 +2188,7 @@ namespace nidcpower_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
         }
         return ::grpc::Status::OK;
       }
@@ -2270,7 +2276,7 @@ namespace nidcpower_grpc {
       ViInt32 actual_count {};
       auto status = library_->FetchMultiple(vi, channel_name, timeout, count, voltage_measurements, current_measurements, in_compliance.data(), &actual_count);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(in_compliance, response->mutable_in_compliance());
         response->set_actual_count(actual_count);
       }
@@ -2296,7 +2302,7 @@ namespace nidcpower_grpc {
       ViBoolean attribute_value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -2321,7 +2327,7 @@ namespace nidcpower_grpc {
       ViInt32 attribute_value {};
       auto status = library_->GetAttributeViInt32(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -2346,7 +2352,7 @@ namespace nidcpower_grpc {
       ViInt64 attribute_value {};
       auto status = library_->GetAttributeViInt64(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -2371,7 +2377,7 @@ namespace nidcpower_grpc {
       ViReal64 attribute_value {};
       auto status = library_->GetAttributeViReal64(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -2396,7 +2402,7 @@ namespace nidcpower_grpc {
       ViSession attribute_value {};
       auto status = library_->GetAttributeViSession(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto session_id = session_repository_->resolve_session_id(attribute_value);
         response->mutable_attribute_value()->set_id(session_id);
       }
@@ -2438,7 +2444,7 @@ namespace nidcpower_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_attribute_value(attribute_value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_attribute_value()));
         }
@@ -2480,7 +2486,7 @@ namespace nidcpower_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_channel_name(channel_name);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_channel_name()));
         }
@@ -2522,7 +2528,7 @@ namespace nidcpower_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_channel_name(channel_name);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_channel_name()));
         }
@@ -2564,7 +2570,7 @@ namespace nidcpower_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_code(code);
           response->set_description(description);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_description()));
@@ -2594,7 +2600,7 @@ namespace nidcpower_grpc {
       ViInt32 minute {};
       auto status = library_->GetExtCalLastDateAndTime(vi, &year, &month, &day, &hour, &minute);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_year(year);
         response->set_month(month);
         response->set_day(day);
@@ -2621,7 +2627,7 @@ namespace nidcpower_grpc {
       ViReal64 temperature {};
       auto status = library_->GetExtCalLastTemp(vi, &temperature);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_temperature(temperature);
       }
       return ::grpc::Status::OK;
@@ -2644,7 +2650,7 @@ namespace nidcpower_grpc {
       ViInt32 months {};
       auto status = library_->GetExtCalRecommendedInterval(vi, &months);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_months(months);
       }
       return ::grpc::Status::OK;
@@ -2683,7 +2689,7 @@ namespace nidcpower_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_coercion_record(coercion_record);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_coercion_record()));
         }
@@ -2724,7 +2730,7 @@ namespace nidcpower_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_interchange_warning(interchange_warning);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_interchange_warning()));
         }
@@ -2753,7 +2759,7 @@ namespace nidcpower_grpc {
       ViInt32 minute {};
       auto status = library_->GetSelfCalLastDateAndTime(vi, &year, &month, &day, &hour, &minute);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_year(year);
         response->set_month(month);
         response->set_day(day);
@@ -2780,7 +2786,7 @@ namespace nidcpower_grpc {
       ViReal64 temperature {};
       auto status = library_->GetSelfCalLastTemp(vi, &temperature);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_temperature(temperature);
       }
       return ::grpc::Status::OK;
@@ -2854,7 +2860,7 @@ namespace nidcpower_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -2913,7 +2919,7 @@ namespace nidcpower_grpc {
       ViReal64 measurement {};
       auto status = library_->Measure(vi, channel_name, measurement_type, &measurement);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_measurement(measurement);
       }
       return ::grpc::Status::OK;
@@ -2937,7 +2943,7 @@ namespace nidcpower_grpc {
       ViBoolean in_compliance {};
       auto status = library_->QueryInCompliance(vi, channel_name, &in_compliance);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_in_compliance(in_compliance);
       }
       return ::grpc::Status::OK;
@@ -2962,7 +2968,7 @@ namespace nidcpower_grpc {
       ViReal64 max_current_limit {};
       auto status = library_->QueryMaxCurrentLimit(vi, channel_name, voltage_level, &max_current_limit);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_max_current_limit(max_current_limit);
       }
       return ::grpc::Status::OK;
@@ -2987,7 +2993,7 @@ namespace nidcpower_grpc {
       ViReal64 max_voltage_level {};
       auto status = library_->QueryMaxVoltageLevel(vi, channel_name, current_limit, &max_voltage_level);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_max_voltage_level(max_voltage_level);
       }
       return ::grpc::Status::OK;
@@ -3012,7 +3018,7 @@ namespace nidcpower_grpc {
       ViReal64 min_current_limit {};
       auto status = library_->QueryMinCurrentLimit(vi, channel_name, voltage_level, &min_current_limit);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_min_current_limit(min_current_limit);
       }
       return ::grpc::Status::OK;
@@ -3052,7 +3058,7 @@ namespace nidcpower_grpc {
       ViBoolean in_state {};
       auto status = library_->QueryOutputState(vi, channel_name, output_state, &in_state);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_in_state(in_state);
       }
       return ::grpc::Status::OK;
@@ -3075,7 +3081,7 @@ namespace nidcpower_grpc {
       ViReal64 temperature {};
       auto status = library_->ReadCurrentTemperature(vi, &temperature);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_temperature(temperature);
       }
       return ::grpc::Status::OK;
@@ -3175,7 +3181,7 @@ namespace nidcpower_grpc {
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_instrument_driver_revision(instrument_driver_revision);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_instrument_driver_revision()));
         response->set_firmware_revision(firmware_revision);
@@ -3202,7 +3208,7 @@ namespace nidcpower_grpc {
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_self_test_result(self_test_result);
         response->set_self_test_message(self_test_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_self_test_message()));

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -35,6 +35,12 @@ namespace nidigitalpattern_grpc {
   {
   }
 
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return status >= 0;
+  }
+
   template <typename TEnum>
   void NiDigitalService::CopyBytesToEnums(const std::string& input, google::protobuf::RepeatedField<TEnum>* output)
   {
@@ -1318,7 +1324,7 @@ namespace nidigitalpattern_grpc {
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_error_message(error_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
@@ -1397,7 +1403,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_data()->Resize(actual_num_waveforms, 0);
           response->set_actual_num_waveforms(actual_num_waveforms);
           response->set_actual_samples_per_waveform(actual_samples_per_waveform);
@@ -1429,7 +1435,7 @@ namespace nidigitalpattern_grpc {
       ViInt32 num_dut_cycles {};
       auto status = library_->FetchHistoryRAMCycleInformation(vi, site, sample_index, &pattern_index, &time_set_index, &vector_number, &cycle_number, &num_dut_cycles);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_pattern_index(pattern_index);
         response->set_time_set_index(time_set_index);
         response->set_vector_number(vector_number);
@@ -1474,7 +1480,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           CopyBytesToEnums(expected_pin_states, response->mutable_expected_pin_states());
           response->set_expected_pin_states_raw(expected_pin_states);
           response->mutable_expected_pin_states()->Resize(actual_num_pin_data, 0);
@@ -1508,7 +1514,7 @@ namespace nidigitalpattern_grpc {
       ViInt64 scan_cycle_number {};
       auto status = library_->FetchHistoryRAMScanCycleNumber(vi, site, sample_index, &scan_cycle_number);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_scan_cycle_number(scan_cycle_number);
       }
       return ::grpc::Status::OK;
@@ -1601,7 +1607,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_frequencies()->Resize(actual_num_frequencies, 0);
           response->set_actual_num_frequencies(actual_num_frequencies);
         }
@@ -1628,7 +1634,7 @@ namespace nidigitalpattern_grpc {
       ViBoolean value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_name, attribute, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1653,7 +1659,7 @@ namespace nidigitalpattern_grpc {
       ViInt32 value {};
       auto status = library_->GetAttributeViInt32(vi, channel_name, attribute, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1678,7 +1684,7 @@ namespace nidigitalpattern_grpc {
       ViInt64 value {};
       auto status = library_->GetAttributeViInt64(vi, channel_name, attribute, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1703,7 +1709,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 value {};
       auto status = library_->GetAttributeViReal64(vi, channel_name, attribute, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1728,7 +1734,7 @@ namespace nidigitalpattern_grpc {
       ViSession value {};
       auto status = library_->GetAttributeViSession(vi, channel_list, attribute, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto session_id = session_repository_->resolve_session_id(value);
         response->mutable_value()->set_id(session_id);
       }
@@ -1770,7 +1776,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -1812,7 +1818,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_name(name);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_name()));
         }
@@ -1854,7 +1860,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_names(names);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_names()));
         }
@@ -1896,7 +1902,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_error_code(error_code);
           response->set_error_description(error_description);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_description()));
@@ -1936,7 +1942,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_failure_count()->Resize(actual_num_read, 0);
           response->set_actual_num_read(actual_num_read);
         }
@@ -1962,7 +1968,7 @@ namespace nidigitalpattern_grpc {
       ViInt64 sample_count {};
       auto status = library_->GetHistoryRAMSampleCount(vi, site, &sample_count);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_sample_count(sample_count);
       }
       return ::grpc::Status::OK;
@@ -1999,7 +2005,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_pin_indexes()->Resize(actual_num_pins, 0);
           response->set_actual_num_pins(actual_num_pins);
         }
@@ -2041,7 +2047,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_name(name);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_name()));
         }
@@ -2083,7 +2089,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_pin_list(pin_list);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_pin_list()));
         }
@@ -2125,7 +2131,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_name(name);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_name()));
         }
@@ -2168,7 +2174,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_pin_indexes()->Resize(actual_num_values, 0);
           response->mutable_site_numbers()->Resize(actual_num_values, 0);
           response->mutable_channel_indexes()->Resize(actual_num_values, 0);
@@ -2208,7 +2214,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           convert_to_grpc(pass_fail, response->mutable_pass_fail());
           response->mutable_pass_fail()->Resize(actual_num_sites, 0);
           response->set_actual_num_sites(actual_num_sites);
@@ -2264,7 +2270,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_site_numbers()->Resize(actual_num_site_numbers, 0);
           response->set_actual_num_site_numbers(actual_num_site_numbers);
         }
@@ -2291,7 +2297,7 @@ namespace nidigitalpattern_grpc {
       ViInt32 format {};
       auto status = library_->GetTimeSetDriveFormat(vi, pin, time_set_name, &format);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_format(static_cast<nidigitalpattern_grpc::DriveFormat>(format));
         response->set_format_raw(format);
       }
@@ -2333,7 +2339,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 time {};
       auto status = library_->GetTimeSetEdge(vi, pin, time_set_name, edge, &time);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_time(time);
       }
       return ::grpc::Status::OK;
@@ -2358,7 +2364,7 @@ namespace nidigitalpattern_grpc {
       ViInt32 edge_multiplier {};
       auto status = library_->GetTimeSetEdgeMultiplier(vi, pin, time_set_name, &edge_multiplier);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_edge_multiplier(edge_multiplier);
       }
       return ::grpc::Status::OK;
@@ -2398,7 +2404,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_name(name);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_name()));
         }
@@ -2424,7 +2430,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 period {};
       auto status = library_->GetTimeSetPeriod(vi, time_set_name, &period);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_period(period);
       }
       return ::grpc::Status::OK;
@@ -2456,7 +2462,7 @@ namespace nidigitalpattern_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -2489,7 +2495,7 @@ namespace nidigitalpattern_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -2531,7 +2537,7 @@ namespace nidigitalpattern_grpc {
       ViBoolean done {};
       auto status = library_->IsDone(vi, &done);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_done(done);
       }
       return ::grpc::Status::OK;
@@ -2555,7 +2561,7 @@ namespace nidigitalpattern_grpc {
       ViBoolean enable {};
       auto status = library_->IsSiteEnabled(vi, site, &enable);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_enable(enable);
       }
       return ::grpc::Status::OK;
@@ -2946,7 +2952,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_measurements()->Resize(actual_num_read, 0);
           response->set_actual_num_read(actual_num_read);
         }
@@ -2992,7 +2998,7 @@ namespace nidigitalpattern_grpc {
       ViBoolean value {};
       auto status = library_->ReadSequencerFlag(vi, flag, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -3016,7 +3022,7 @@ namespace nidigitalpattern_grpc {
       ViInt32 value {};
       auto status = library_->ReadSequencerRegister(vi, reg, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -3052,7 +3058,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           CopyBytesToEnums(data, response->mutable_data());
           response->set_data_raw(data);
           response->mutable_data()->Resize(actual_num_read, 0);
@@ -3194,7 +3200,7 @@ namespace nidigitalpattern_grpc {
       std::string test_message(2048 - 1, '\0');
       auto status = library_->SelfTest(vi, &test_result, (ViChar*)test_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_test_result(test_result);
         response->set_test_message(test_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_test_message()));
@@ -3418,7 +3424,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_offsets()->Resize(actual_num_offsets, 0);
           response->set_actual_num_offsets(actual_num_offsets);
         }

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -35,6 +35,12 @@ namespace nidmm_grpc {
   {
   }
 
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return status >= 0;
+  }
+
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
   ::grpc::Status NiDmmService::Control4022(::grpc::ServerContext* context, const Control4022Request* request, Control4022Response* response)
@@ -1182,7 +1188,7 @@ namespace nidmm_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_configuration(configuration);
         }
         return ::grpc::Status::OK;
@@ -1242,7 +1248,7 @@ namespace nidmm_grpc {
       ViReal64 reading {};
       auto status = library_->Fetch(vi, maximum_time, &reading);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_reading(reading);
       }
       return ::grpc::Status::OK;
@@ -1284,7 +1290,7 @@ namespace nidmm_grpc {
       ViInt32 actual_number_of_points {};
       auto status = library_->FetchMultiPoint(vi, maximum_time, array_size, reading_array, &actual_number_of_points);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_actual_number_of_points(actual_number_of_points);
       }
       return ::grpc::Status::OK;
@@ -1326,7 +1332,7 @@ namespace nidmm_grpc {
       ViInt32 actual_number_of_points {};
       auto status = library_->FetchWaveform(vi, maximum_time, array_size, waveform_array, &actual_number_of_points);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_actual_number_of_points(actual_number_of_points);
       }
       return ::grpc::Status::OK;
@@ -1350,7 +1356,7 @@ namespace nidmm_grpc {
       ViInt32 aperture_time_units {};
       auto status = library_->GetApertureTimeInfo(vi, &aperture_time, &aperture_time_units);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         if(aperture_time == (int)aperture_time) {
           response->set_aperture_time(static_cast<nidmm_grpc::ApertureTime>(static_cast<int>(aperture_time)));
         }
@@ -1380,7 +1386,7 @@ namespace nidmm_grpc {
       ViBoolean attribute_value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -1405,7 +1411,7 @@ namespace nidmm_grpc {
       ViInt32 attribute_value {};
       auto status = library_->GetAttributeViInt32(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -1430,7 +1436,7 @@ namespace nidmm_grpc {
       ViReal64 attribute_value {};
       auto status = library_->GetAttributeViReal64(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -1455,7 +1461,7 @@ namespace nidmm_grpc {
       ViSession attribute_value {};
       auto status = library_->GetAttributeViSession(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto session_id = session_repository_->resolve_session_id(attribute_value);
         response->mutable_attribute_value()->set_id(session_id);
       }
@@ -1497,7 +1503,7 @@ namespace nidmm_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_attribute_value(attribute_value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_attribute_value()));
         }
@@ -1522,7 +1528,7 @@ namespace nidmm_grpc {
       ViReal64 actual_range {};
       auto status = library_->GetAutoRangeValue(vi, &actual_range);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_actual_range(actual_range);
       }
       return ::grpc::Status::OK;
@@ -1565,7 +1571,7 @@ namespace nidmm_grpc {
       ViInt32 minute {};
       auto status = library_->GetCalDateAndTime(vi, cal_type, &month, &day, &year, &hour, &minute);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_month(month);
         response->set_day(day);
         response->set_year(year);
@@ -1609,7 +1615,7 @@ namespace nidmm_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_channel_string(channel_string);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_channel_string()));
         }
@@ -1635,7 +1641,7 @@ namespace nidmm_grpc {
       ViReal64 temperature {};
       auto status = library_->GetDevTemp(vi, options, &temperature);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_temperature(temperature);
       }
       return ::grpc::Status::OK;
@@ -1675,7 +1681,7 @@ namespace nidmm_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_error_code(error_code);
           response->set_description(description);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_description()));
@@ -1718,7 +1724,7 @@ namespace nidmm_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_error_message(error_message);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
         }
@@ -1743,7 +1749,7 @@ namespace nidmm_grpc {
       ViInt32 months {};
       auto status = library_->GetExtCalRecommendedInterval(vi, &months);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_months(months);
       }
       return ::grpc::Status::OK;
@@ -1782,7 +1788,7 @@ namespace nidmm_grpc {
       ViReal64 temperature {};
       auto status = library_->GetLastCalTemp(vi, cal_type, &temperature);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_temperature(temperature);
       }
       return ::grpc::Status::OK;
@@ -1805,7 +1811,7 @@ namespace nidmm_grpc {
       ViReal64 period {};
       auto status = library_->GetMeasurementPeriod(vi, &period);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_period(period);
       }
       return ::grpc::Status::OK;
@@ -1844,7 +1850,7 @@ namespace nidmm_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_coercion_record(coercion_record);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_coercion_record()));
         }
@@ -1885,7 +1891,7 @@ namespace nidmm_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_interchange_warning(interchange_warning);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_interchange_warning()));
         }
@@ -1910,7 +1916,7 @@ namespace nidmm_grpc {
       ViBoolean self_cal_supported {};
       auto status = library_->GetSelfCalSupported(vi, &self_cal_supported);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_self_cal_supported(self_cal_supported);
       }
       return ::grpc::Status::OK;
@@ -1983,7 +1989,7 @@ namespace nidmm_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -2016,7 +2022,7 @@ namespace nidmm_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -2078,7 +2084,7 @@ namespace nidmm_grpc {
       ViBoolean is_over_range {};
       auto status = library_->IsOverRange(vi, measurement_value, &is_over_range);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_is_over_range(is_over_range);
       }
       return ::grpc::Status::OK;
@@ -2102,7 +2108,7 @@ namespace nidmm_grpc {
       ViBoolean is_under_range {};
       auto status = library_->IsUnderRange(vi, measurement_value, &is_under_range);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_is_under_range(is_under_range);
       }
       return ::grpc::Status::OK;
@@ -2126,7 +2132,7 @@ namespace nidmm_grpc {
       ViReal64 susceptance {};
       auto status = library_->PerformOpenCableComp(vi, &conductance, &susceptance);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_conductance(conductance);
         response->set_susceptance(susceptance);
       }
@@ -2151,7 +2157,7 @@ namespace nidmm_grpc {
       ViReal64 reactance {};
       auto status = library_->PerformShortCableComp(vi, &resistance, &reactance);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_resistance(resistance);
         response->set_reactance(reactance);
       }
@@ -2191,7 +2197,7 @@ namespace nidmm_grpc {
       ViReal64 reading {};
       auto status = library_->Read(vi, maximum_time, &reading);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_reading(reading);
       }
       return ::grpc::Status::OK;
@@ -2233,7 +2239,7 @@ namespace nidmm_grpc {
       ViInt32 actual_number_of_points {};
       auto status = library_->ReadMultiPoint(vi, maximum_time, array_size, reading_array, &actual_number_of_points);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_actual_number_of_points(actual_number_of_points);
       }
       return ::grpc::Status::OK;
@@ -2257,7 +2263,7 @@ namespace nidmm_grpc {
       ViInt16 acquisition_status {};
       auto status = library_->ReadStatus(vi, &acquisition_backlog, &acquisition_status);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_acquisition_backlog(acquisition_backlog);
         response->set_acquisition_status(static_cast<nidmm_grpc::AcquisitionStatus>(acquisition_status));
         response->set_acquisition_status_raw(acquisition_status);
@@ -2301,7 +2307,7 @@ namespace nidmm_grpc {
       ViInt32 actual_number_of_points {};
       auto status = library_->ReadWaveform(vi, maximum_time, array_size, waveform_array, &actual_number_of_points);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_actual_number_of_points(actual_number_of_points);
       }
       return ::grpc::Status::OK;
@@ -2382,7 +2388,7 @@ namespace nidmm_grpc {
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_instrument_driver_revision(instrument_driver_revision);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_instrument_driver_revision()));
         response->set_firmware_revision(firmware_revision);
@@ -2428,7 +2434,7 @@ namespace nidmm_grpc {
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_self_test_result(self_test_result);
         response->set_self_test_message(self_test_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_self_test_message()));

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -35,6 +35,12 @@ namespace nifake_grpc {
   {
   }
 
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return status >= 0;
+  }
+
   template <typename TEnum>
   void NiFakeService::CopyBytesToEnums(const std::string& input, google::protobuf::RepeatedField<TEnum>* output)
   {
@@ -144,7 +150,7 @@ namespace nifake_grpc {
       std::vector<ViBoolean> an_array(number_of_elements, ViBoolean());
       auto status = library_->BoolArrayOutputFunction(vi, number_of_elements, an_array.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(an_array, response->mutable_an_array());
       }
       return ::grpc::Status::OK;
@@ -318,7 +324,7 @@ namespace nifake_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_configuration(configuration);
         }
         return ::grpc::Status::OK;
@@ -345,7 +351,7 @@ namespace nifake_grpc {
       ViInt32 actual_number_of_samples {};
       auto status = library_->FetchWaveform(vi, number_of_samples, waveform_data, &actual_number_of_samples);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_actual_number_of_samples(actual_number_of_samples);
       }
       return ::grpc::Status::OK;
@@ -368,7 +374,7 @@ namespace nifake_grpc {
       ViBoolean a_boolean {};
       auto status = library_->GetABoolean(vi, &a_boolean);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_a_boolean(a_boolean);
       }
       return ::grpc::Status::OK;
@@ -391,7 +397,7 @@ namespace nifake_grpc {
       ViInt16 a_number {};
       auto status = library_->GetANumber(vi, &a_number);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_a_number(a_number);
       }
       return ::grpc::Status::OK;
@@ -414,7 +420,7 @@ namespace nifake_grpc {
       std::string a_string(256 - 1, '\0');
       auto status = library_->GetAStringOfFixedMaximumSize(vi, (ViChar*)a_string.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_a_string(a_string);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_a_string()));
       }
@@ -436,7 +442,7 @@ namespace nifake_grpc {
       ViInt64 flags {};
       auto status = library_->GetBitfieldAsEnumArray(&flags);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         if (flags & 0x1)
           response->add_flags_array(Bitfield::BITFIELD_FLAG_A);
         if (flags & 0x2)
@@ -483,7 +489,7 @@ namespace nifake_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_a_string(a_string);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_a_string()));
         }
@@ -522,7 +528,7 @@ namespace nifake_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_array_out()->Resize(actual_size, 0);
           response->set_actual_size(actual_size);
         }
@@ -559,7 +565,7 @@ namespace nifake_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           convert_to_grpc(array_out, response->mutable_array_out());
           {
             auto shrunk_size = actual_size;
@@ -604,7 +610,7 @@ namespace nifake_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_array_out()->Resize(actual_size, 0);
           response->set_actual_size(actual_size);
         }
@@ -639,7 +645,7 @@ namespace nifake_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_array_out(array_out);
           response->mutable_array_out()->resize(actual_size);
           response->set_actual_size(actual_size);
@@ -678,7 +684,7 @@ namespace nifake_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_array_out(array_out);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_array_out()));
           response->set_actual_size(actual_size);
@@ -717,7 +723,7 @@ namespace nifake_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_string_out(string_out);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_string_out()));
           response->set_actual_size(actual_size);
@@ -743,7 +749,7 @@ namespace nifake_grpc {
       ViInt32 size_out {};
       auto status = library_->GetArraySizeForCustomCode(vi, &size_out);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_size_out(size_out);
       }
       return ::grpc::Status::OK;
@@ -780,7 +786,7 @@ namespace nifake_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
         }
         return ::grpc::Status::OK;
       }
@@ -804,7 +810,7 @@ namespace nifake_grpc {
       std::string u_int8_enum_array(array_len, '\0');
       auto status = library_->GetArrayViUInt8WithEnum(vi, array_len, (ViUInt8*)u_int8_enum_array.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         CopyBytesToEnums(u_int8_enum_array, response->mutable_u_int8_enum_array());
         response->set_u_int8_enum_array_raw(u_int8_enum_array);
       }
@@ -830,7 +836,7 @@ namespace nifake_grpc {
       ViBoolean attribute_value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -855,7 +861,7 @@ namespace nifake_grpc {
       ViInt32 attribute_value {};
       auto status = library_->GetAttributeViInt32(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -880,7 +886,7 @@ namespace nifake_grpc {
       ViInt64 attribute_value {};
       auto status = library_->GetAttributeViInt64(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -905,7 +911,7 @@ namespace nifake_grpc {
       ViReal64 attribute_value {};
       auto status = library_->GetAttributeViReal64(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -929,7 +935,7 @@ namespace nifake_grpc {
       ViSession session_out {};
       auto status = library_->GetAttributeViSession(vi, attribute_id, &session_out);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto session_id = session_repository_->resolve_session_id(session_out);
         response->mutable_session_out()->set_id(session_id);
       }
@@ -971,7 +977,7 @@ namespace nifake_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_attribute_value(attribute_value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_attribute_value()));
         }
@@ -1001,7 +1007,7 @@ namespace nifake_grpc {
       ViInt32 minute {};
       auto status = library_->GetCalDateAndTime(vi, cal_type, &month, &day, &year, &hour, &minute);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_month(month);
         response->set_day(day);
         response->set_year(year);
@@ -1028,7 +1034,7 @@ namespace nifake_grpc {
       ViInt32 months {};
       auto status = library_->GetCalInterval(vi, &months);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_months(months);
       }
       return ::grpc::Status::OK;
@@ -1051,7 +1057,7 @@ namespace nifake_grpc {
       CustomStruct cs {};
       auto status = library_->GetCustomType(vi, &cs);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(cs, response->mutable_cs());
       }
       return ::grpc::Status::OK;
@@ -1075,7 +1081,7 @@ namespace nifake_grpc {
       std::vector<CustomStruct> cs(number_of_elements, CustomStruct());
       auto status = library_->GetCustomTypeArray(vi, number_of_elements, cs.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(cs, response->mutable_cs());
       }
       return ::grpc::Status::OK;
@@ -1099,7 +1105,7 @@ namespace nifake_grpc {
       ViInt16 a_turtle {};
       auto status = library_->GetEnumValue(vi, &a_quantity, &a_turtle);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_a_quantity(a_quantity);
         response->set_a_turtle(static_cast<nifake_grpc::Turtle>(a_turtle));
         response->set_a_turtle_raw(a_turtle);
@@ -1124,7 +1130,7 @@ namespace nifake_grpc {
       ViUInt8 a_uint8_number {};
       auto status = library_->GetViUInt8(vi, &a_uint8_number);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_a_uint8_number(a_uint8_number);
       }
       return ::grpc::Status::OK;
@@ -1149,7 +1155,7 @@ namespace nifake_grpc {
       ViInt32* int32_array = reinterpret_cast<ViInt32*>(response->mutable_int32_array()->mutable_data());
       auto status = library_->GetViInt32Array(vi, array_len, int32_array);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
       }
       return ::grpc::Status::OK;
     }
@@ -1173,7 +1179,7 @@ namespace nifake_grpc {
       ViUInt32* u_int32_array = reinterpret_cast<ViUInt32*>(response->mutable_u_int32_array()->mutable_data());
       auto status = library_->GetViUInt32Array(vi, array_len, u_int32_array);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
       }
       return ::grpc::Status::OK;
     }
@@ -1226,7 +1232,7 @@ namespace nifake_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -1257,7 +1263,7 @@ namespace nifake_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->CloseExtCal(id, 0); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -1307,7 +1313,7 @@ namespace nifake_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -1354,7 +1360,7 @@ namespace nifake_grpc {
       ViReal64* output_array_of_fixed_length = response->mutable_output_array_of_fixed_length()->mutable_data();
       auto status = library_->MultipleArrayTypes(vi, output_array_size, output_array, output_array_of_fixed_length, input_array_sizes, input_array_of_floats, input_array_of_integers.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
       }
       return ::grpc::Status::OK;
     }
@@ -1558,7 +1564,7 @@ namespace nifake_grpc {
       ViReal64 reading {};
       auto status = library_->Read(vi, maximum_time, &reading);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_reading(reading);
       }
       return ::grpc::Status::OK;
@@ -1591,7 +1597,7 @@ namespace nifake_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_data()->Resize(buffer_size, 0);
           response->set_buffer_size(buffer_size);
         }
@@ -1618,7 +1624,7 @@ namespace nifake_grpc {
       ViReal64 reading {};
       auto status = library_->ReadFromChannel(vi, channel_name, maximum_time, &reading);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_reading(reading);
       }
       return ::grpc::Status::OK;
@@ -1642,7 +1648,7 @@ namespace nifake_grpc {
       std::string a_string(256 - 1, '\0');
       auto status = library_->ReturnANumberAndAString(vi, &a_number, (ViChar*)a_string.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_a_number(a_number);
         response->set_a_string(a_string);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_a_string()));
@@ -1667,7 +1673,7 @@ namespace nifake_grpc {
       ViReal64 timedelta {};
       auto status = library_->ReturnDurationInSeconds(vi, &timedelta);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_timedelta(timedelta);
       }
       return ::grpc::Status::OK;
@@ -1692,7 +1698,7 @@ namespace nifake_grpc {
       ViReal64* timedeltas = response->mutable_timedeltas()->mutable_data();
       auto status = library_->ReturnListOfDurationsInSeconds(vi, number_of_elements, timedeltas);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
       }
       return ::grpc::Status::OK;
     }
@@ -1739,7 +1745,7 @@ namespace nifake_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_a_boolean(a_boolean);
           response->set_an_int32(an_int32);
           response->set_an_int64(an_int64);
@@ -1877,7 +1883,7 @@ namespace nifake_grpc {
       ViInt64 output {};
       auto status = library_->Use64BitNumber(vi, input, &output);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_output(output);
       }
       return ::grpc::Status::OK;
@@ -1984,7 +1990,7 @@ namespace nifake_grpc {
       std::string an_array(number_of_elements, '\0');
       auto status = library_->ViUInt8ArrayOutputFunction(vi, number_of_elements, (ViUInt8*)an_array.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_an_array(an_array);
       }
       return ::grpc::Status::OK;

--- a/generated/nifake_extension/nifake_extension_service.cpp
+++ b/generated/nifake_extension/nifake_extension_service.cpp
@@ -32,6 +32,12 @@ namespace nifake_extension_grpc {
   {
   }
 
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return status >= 0;
+  }
+
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeExtensionService::AddCoolFunctionality(::grpc::ServerContext* context, const AddCoolFunctionalityRequest* request, AddCoolFunctionalityResponse* response)

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -34,6 +34,12 @@ namespace nifake_non_ivi_grpc {
   {
   }
 
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return status >= 0;
+  }
+
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
   ::grpc::Status NiFakeNonIviService::Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response)
@@ -86,7 +92,7 @@ namespace nifake_non_ivi_grpc {
       double value {};
       auto status = library_->GetMarbleAttributeDouble(handle, attribute, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -128,7 +134,7 @@ namespace nifake_non_ivi_grpc {
       int32 value {};
       auto status = library_->GetMarbleAttributeInt32(handle, attribute, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto checked_convert_value = [](auto raw_value) {
           bool raw_value_is_valid = nifake_non_ivi_grpc::MarbleInt32AttributeValues_IsValid(raw_value);
           auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -177,7 +183,7 @@ namespace nifake_non_ivi_grpc {
       int32* value = reinterpret_cast<int32*>(response->mutable_value_raw()->mutable_data());
       auto status = library_->GetMarbleAttributeInt32Array(handle, attribute, value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto checked_convert_value = [](auto raw_value) {
           bool raw_value_is_valid = nifake_non_ivi_grpc::MarbleInt32AttributeValues_IsValid(raw_value);
           auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -220,7 +226,7 @@ namespace nifake_non_ivi_grpc {
       auto cleanup_lambda = [&] (FakeHandle id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_handle()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -250,7 +256,7 @@ namespace nifake_non_ivi_grpc {
       auto cleanup_lambda = [&] (FakeHandle id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_handle()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -348,7 +354,7 @@ namespace nifake_non_ivi_grpc {
       int32* data = reinterpret_cast<int32*>(response->mutable_data()->mutable_data());
       auto status = library_->IotaWithCustomSize(size_one, size_two, data);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
       }
       return ::grpc::Status::OK;
     }
@@ -373,7 +379,7 @@ namespace nifake_non_ivi_grpc {
       std::vector<myInt8> i8_data(number_of_i8_samples);
       auto status = library_->OutputArraysWithNarrowIntegerTypes(number_of_u16_samples, u16_data.data(), number_of_i16_samples, i16_data.data(), number_of_i8_samples, i8_data.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_u16_data()->Clear();
         response->mutable_u16_data()->Reserve(number_of_u16_samples);
         std::transform(
@@ -439,7 +445,7 @@ namespace nifake_non_ivi_grpc {
       std::string u8_data(number_of_u8_samples, '\0');
       auto status = library_->OutputArrayOfBytes(number_of_u8_samples, (myUInt8*)u8_data.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_u8_data(u8_data);
       }
       return ::grpc::Status::OK;
@@ -463,7 +469,7 @@ namespace nifake_non_ivi_grpc {
       std::vector<myUInt16> u16_data(array_size_copy);
       auto status = library_->OutputArraysWithPassedInByPtrMechanism(i32_data, u16_data.data(), &array_size_copy);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_i32_data()->Resize(array_size_copy, 0);
         response->mutable_u16_data()->Clear();
         response->mutable_u16_data()->Reserve(array_size_copy);
@@ -565,7 +571,7 @@ namespace nifake_non_ivi_grpc {
       CVIAbsoluteTime when {};
       auto status = library_->OutputTimestamp(&when);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(when, response->mutable_when());
       }
       return ::grpc::Status::OK;
@@ -652,7 +658,7 @@ namespace nifake_non_ivi_grpc {
       colorVector.resize(channel_names.size());
       auto status = library_->OutputVarArgs(input_name, get_channelName_if(channel_names, 0), get_color_if(colorVector, 0), get_channelName_if(channel_names, 1), get_color_if(colorVector, 1), get_channelName_if(channel_names, 2), get_color_if(colorVector, 2), get_channelName_if(channel_names, 3), get_color_if(colorVector, 3));
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         for (int i = 0; i < colorVector.size(); ++i) {
           response->add_colors(static_cast<BeautifulColor>(colorVector[i]));
         }
@@ -884,7 +890,7 @@ namespace nifake_non_ivi_grpc {
       std::vector<StructWithCoercion_struct> structs(number_of_structs, StructWithCoercion_struct());
       auto status = library_->GetStructsWithCoercion(number_of_structs, structs.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(structs, response->mutable_structs());
       }
       return ::grpc::Status::OK;

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -35,6 +35,12 @@ namespace nifgen_grpc {
   {
   }
 
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return status >= 0;
+  }
+
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
   ::grpc::Status NiFgenService::AbortGeneration(::grpc::ServerContext* context, const AbortGenerationRequest* request, AbortGenerationResponse* response)
@@ -111,7 +117,7 @@ namespace nifgen_grpc {
       ViInt32 waveform_handle {};
       auto status = library_->AllocateWaveform(vi, channel_name, waveform_size, &waveform_handle);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_waveform_handle(waveform_handle);
       }
       return ::grpc::Status::OK;
@@ -1101,7 +1107,7 @@ namespace nifgen_grpc {
       ViInt32 sequence_handle {};
       auto status = library_->CreateArbSequence(vi, sequence_length, waveform_handles_array, loop_counts_array, &sequence_handle);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_sequence_handle(sequence_handle);
       }
       return ::grpc::Status::OK;
@@ -1154,7 +1160,7 @@ namespace nifgen_grpc {
       ViInt32 frequency_list_handle {};
       auto status = library_->CreateFreqList(vi, waveform, frequency_list_length, frequency_array, duration_array, &frequency_list_handle);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_frequency_list_handle(frequency_list_handle);
       }
       return ::grpc::Status::OK;
@@ -1180,7 +1186,7 @@ namespace nifgen_grpc {
       ViInt32 waveform_handle {};
       auto status = library_->CreateWaveformComplexF64(vi, channel_name, number_of_samples, waveform_data_array.data(), &waveform_handle);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_waveform_handle(waveform_handle);
       }
       return ::grpc::Status::OK;
@@ -1206,7 +1212,7 @@ namespace nifgen_grpc {
       ViInt32 waveform_handle {};
       auto status = library_->CreateWaveformF64(vi, channel_name, waveform_size, waveform_data_array, &waveform_handle);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_waveform_handle(waveform_handle);
       }
       return ::grpc::Status::OK;
@@ -1247,7 +1253,7 @@ namespace nifgen_grpc {
       ViInt32 waveform_handle {};
       auto status = library_->CreateWaveformFromFileF64(vi, channel_name, file_name, byte_order, &waveform_handle);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_waveform_handle(waveform_handle);
       }
       return ::grpc::Status::OK;
@@ -1274,7 +1280,7 @@ namespace nifgen_grpc {
       ViInt32 waveform_handle {};
       auto status = library_->CreateWaveformFromFileHWS(vi, channel_name, file_name, use_rate_from_waveform, use_gain_and_offset_from_waveform, &waveform_handle);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_waveform_handle(waveform_handle);
       }
       return ::grpc::Status::OK;
@@ -1306,7 +1312,7 @@ namespace nifgen_grpc {
       ViInt32 waveform_handle {};
       auto status = library_->CreateWaveformI16(vi, channel_name, waveform_size, waveform_data_array.data(), &waveform_handle);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_waveform_handle(waveform_handle);
       }
       return ::grpc::Status::OK;
@@ -1347,7 +1353,7 @@ namespace nifgen_grpc {
       ViInt32 waveform_handle {};
       auto status = library_->CreateWaveformFromFileI16(vi, channel_name, file_name, byte_order, &waveform_handle);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_waveform_handle(waveform_handle);
       }
       return ::grpc::Status::OK;
@@ -1614,7 +1620,7 @@ namespace nifgen_grpc {
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorHandler(vi, error_code, (ViChar*)error_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_error_message(error_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
@@ -1639,7 +1645,7 @@ namespace nifgen_grpc {
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_error_message(error_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
@@ -1664,7 +1670,7 @@ namespace nifgen_grpc {
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorQuery(vi, &error_code, (ViChar*)error_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_error_code(error_code);
         response->set_error_message(error_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
@@ -1703,7 +1709,7 @@ namespace nifgen_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
         }
         return ::grpc::Status::OK;
       }
@@ -1785,7 +1791,7 @@ namespace nifgen_grpc {
       ViBoolean attribute_value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -1810,7 +1816,7 @@ namespace nifgen_grpc {
       ViInt32 attribute_value {};
       auto status = library_->GetAttributeViInt32(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -1835,7 +1841,7 @@ namespace nifgen_grpc {
       ViInt64 attribute_value {};
       auto status = library_->GetAttributeViInt64(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -1860,7 +1866,7 @@ namespace nifgen_grpc {
       ViReal64 attribute_value {};
       auto status = library_->GetAttributeViReal64(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -1885,7 +1891,7 @@ namespace nifgen_grpc {
       ViSession attribute_value {};
       auto status = library_->GetAttributeViSession(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto session_id = session_repository_->resolve_session_id(attribute_value);
         response->mutable_attribute_value()->set_id(session_id);
       }
@@ -1927,7 +1933,7 @@ namespace nifgen_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_attribute_value(attribute_value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_attribute_value()));
         }
@@ -1969,7 +1975,7 @@ namespace nifgen_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_channel_string(channel_string);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_channel_string()));
         }
@@ -2011,7 +2017,7 @@ namespace nifgen_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_error_code(error_code);
           response->set_error_description(error_description);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_description()));
@@ -2041,7 +2047,7 @@ namespace nifgen_grpc {
       ViInt32 minute {};
       auto status = library_->GetExtCalLastDateAndTime(vi, &year, &month, &day, &hour, &minute);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_year(year);
         response->set_month(month);
         response->set_day(day);
@@ -2068,7 +2074,7 @@ namespace nifgen_grpc {
       ViReal64 temperature {};
       auto status = library_->GetExtCalLastTemp(vi, &temperature);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_temperature(temperature);
       }
       return ::grpc::Status::OK;
@@ -2091,7 +2097,7 @@ namespace nifgen_grpc {
       ViInt32 months {};
       auto status = library_->GetExtCalRecommendedInterval(vi, &months);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_months(months);
       }
       return ::grpc::Status::OK;
@@ -2128,7 +2134,7 @@ namespace nifgen_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_coefficients_array()->Resize(number_of_coefficients_read, 0);
           response->set_number_of_coefficients_read(number_of_coefficients_read);
         }
@@ -2153,7 +2159,7 @@ namespace nifgen_grpc {
       ViInt32 state {};
       auto status = library_->GetHardwareState(vi, &state);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_state(static_cast<nifgen_grpc::HardwareState>(state));
         response->set_state_raw(state);
       }
@@ -2193,7 +2199,7 @@ namespace nifgen_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_coercion_record(coercion_record);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_coercion_record()));
         }
@@ -2234,7 +2240,7 @@ namespace nifgen_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_interchange_warning(interchange_warning);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_interchange_warning()));
         }
@@ -2263,7 +2269,7 @@ namespace nifgen_grpc {
       ViInt32 minute {};
       auto status = library_->GetSelfCalLastDateAndTime(vi, &year, &month, &day, &hour, &minute);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_year(year);
         response->set_month(month);
         response->set_day(day);
@@ -2290,7 +2296,7 @@ namespace nifgen_grpc {
       ViReal64 temperature {};
       auto status = library_->GetSelfCalLastTemp(vi, &temperature);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_temperature(temperature);
       }
       return ::grpc::Status::OK;
@@ -2313,7 +2319,7 @@ namespace nifgen_grpc {
       ViBoolean self_cal_supported {};
       auto status = library_->GetSelfCalSupported(vi, &self_cal_supported);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_self_cal_supported(self_cal_supported);
       }
       return ::grpc::Status::OK;
@@ -2337,7 +2343,7 @@ namespace nifgen_grpc {
       ViUInt32 reader_handle {};
       auto status = library_->GetStreamEndpointHandle(vi, stream_endpoint, &reader_handle);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_reader_handle(reader_handle);
       }
       return ::grpc::Status::OK;
@@ -2410,7 +2416,7 @@ namespace nifgen_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -2443,7 +2449,7 @@ namespace nifgen_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -2476,7 +2482,7 @@ namespace nifgen_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -2537,7 +2543,7 @@ namespace nifgen_grpc {
       ViBoolean done {};
       auto status = library_->IsDone(vi, &done);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_done(done);
       }
       return ::grpc::Status::OK;
@@ -2583,7 +2589,7 @@ namespace nifgen_grpc {
       ViInt32 maximum_loop_count {};
       auto status = library_->QueryArbSeqCapabilities(vi, &maximum_number_of_sequences, &minimum_sequence_length, &maximum_sequence_length, &maximum_loop_count);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_maximum_number_of_sequences(maximum_number_of_sequences);
         response->set_minimum_sequence_length(minimum_sequence_length);
         response->set_maximum_sequence_length(maximum_sequence_length);
@@ -2612,7 +2618,7 @@ namespace nifgen_grpc {
       ViInt32 maximum_waveform_size {};
       auto status = library_->QueryArbWfmCapabilities(vi, &maximum_number_of_waveforms, &waveform_quantum, &minimum_waveform_size, &maximum_waveform_size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_maximum_number_of_waveforms(maximum_number_of_waveforms);
         response->set_waveform_quantum(waveform_quantum);
         response->set_minimum_waveform_size(minimum_waveform_size);
@@ -2643,7 +2649,7 @@ namespace nifgen_grpc {
       ViReal64 frequency_list_duration_quantum {};
       auto status = library_->QueryFreqListCapabilities(vi, &maximum_number_of_freq_lists, &minimum_frequency_list_length, &maximum_frequency_list_length, &minimum_frequency_list_duration, &maximum_frequency_list_duration, &frequency_list_duration_quantum);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_maximum_number_of_freq_lists(maximum_number_of_freq_lists);
         response->set_minimum_frequency_list_length(minimum_frequency_list_length);
         response->set_maximum_frequency_list_length(maximum_frequency_list_length);
@@ -2671,7 +2677,7 @@ namespace nifgen_grpc {
       ViReal64 temperature {};
       auto status = library_->ReadCurrentTemperature(vi, &temperature);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_temperature(temperature);
       }
       return ::grpc::Status::OK;
@@ -2792,7 +2798,7 @@ namespace nifgen_grpc {
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_instrument_driver_revision(instrument_driver_revision);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_instrument_driver_revision()));
         response->set_firmware_revision(firmware_revision);
@@ -2890,7 +2896,7 @@ namespace nifgen_grpc {
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_self_test_result(self_test_result);
         response->set_self_test_message(self_test_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_self_test_message()));

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -35,6 +35,12 @@ namespace nirfmxinstr_grpc {
   {
   }
 
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return status >= 0;
+  }
+
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
   ::grpc::Status NiRFmxInstrService::BuildCalibrationPlaneString(::grpc::ServerContext* context, const BuildCalibrationPlaneStringRequest* request, BuildCalibrationPlaneStringResponse* response)
@@ -63,7 +69,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_selector_string(selector_string);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string()));
         }
@@ -104,7 +110,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_selector_string_out(selector_string_out);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string_out()));
         }
@@ -145,7 +151,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_selector_string_out(selector_string_out);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string_out()));
         }
@@ -186,7 +192,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_selector_string_out(selector_string_out);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string_out()));
         }
@@ -229,7 +235,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_selector_string_out(selector_string_out);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string_out()));
         }
@@ -467,7 +473,7 @@ namespace nirfmxinstr_grpc {
       int32 acquisition_done {};
       auto status = library_->CheckAcquisitionStatus(instrument, &acquisition_done);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_acquisition_done(acquisition_done);
       }
       return ::grpc::Status::OK;
@@ -492,7 +498,7 @@ namespace nirfmxinstr_grpc {
       int32 personality {};
       auto status = library_->CheckIfListExists(instrument, list_name, &list_exists, &personality);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_list_exists(list_exists);
         response->set_personality(personality);
       }
@@ -518,7 +524,7 @@ namespace nirfmxinstr_grpc {
       int32 personality {};
       auto status = library_->CheckIfSignalConfigurationExists(instrument, signal_name, &signal_configuration_exists, &personality);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_signal_configuration_exists(signal_configuration_exists);
         response->set_personality(personality);
       }
@@ -667,7 +673,7 @@ namespace nirfmxinstr_grpc {
       float32 attr_val {};
       auto status = library_->GetAttributeF32(instrument, channel_name, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attr_val(attr_val);
       }
       return ::grpc::Status::OK;
@@ -705,7 +711,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_attr_val()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
         }
@@ -732,7 +738,7 @@ namespace nirfmxinstr_grpc {
       float64 attr_val {};
       auto status = library_->GetAttributeF64(instrument, channel_name, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attr_val(attr_val);
       }
       return ::grpc::Status::OK;
@@ -770,7 +776,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_attr_val()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
         }
@@ -797,7 +803,7 @@ namespace nirfmxinstr_grpc {
       int16 attr_val {};
       auto status = library_->GetAttributeI16(instrument, channel_name, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attr_val(attr_val);
       }
       return ::grpc::Status::OK;
@@ -822,7 +828,7 @@ namespace nirfmxinstr_grpc {
       int32 attr_val {};
       auto status = library_->GetAttributeI32(instrument, channel_name, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto checked_convert_attr_val = [](auto raw_value) {
           bool raw_value_is_valid = nirfmxinstr_grpc::NiRFmxInstrInt32AttributeValues_IsValid(raw_value);
           auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -866,7 +872,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           auto checked_convert_attr_val = [](auto raw_value) {
             bool raw_value_is_valid = nirfmxinstr_grpc::NiRFmxInstrInt32AttributeValues_IsValid(raw_value);
             auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -907,7 +913,7 @@ namespace nirfmxinstr_grpc {
       int64 attr_val {};
       auto status = library_->GetAttributeI64(instrument, channel_name, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attr_val(attr_val);
       }
       return ::grpc::Status::OK;
@@ -945,7 +951,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_attr_val()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
         }
@@ -972,7 +978,7 @@ namespace nirfmxinstr_grpc {
       int8 attr_val {};
       auto status = library_->GetAttributeI8(instrument, channel_name, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attr_val(attr_val);
       }
       return ::grpc::Status::OK;
@@ -1009,7 +1015,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_attr_val()->Clear();
           response->mutable_attr_val()->Reserve(actual_array_size);
           std::transform(
@@ -1057,7 +1063,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           convert_to_grpc(attr_val, response->mutable_attr_val());
           {
             auto shrunk_size = actual_array_size;
@@ -1103,7 +1109,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           convert_to_grpc(attr_val, response->mutable_attr_val());
           {
             auto shrunk_size = actual_array_size;
@@ -1153,7 +1159,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_attr_val(attr_val);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_attr_val()));
         }
@@ -1180,7 +1186,7 @@ namespace nirfmxinstr_grpc {
       uInt16 attr_val {};
       auto status = library_->GetAttributeU16(instrument, channel_name, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attr_val(attr_val);
       }
       return ::grpc::Status::OK;
@@ -1205,7 +1211,7 @@ namespace nirfmxinstr_grpc {
       uInt32 attr_val {};
       auto status = library_->GetAttributeU32(instrument, channel_name, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attr_val(attr_val);
       }
       return ::grpc::Status::OK;
@@ -1243,7 +1249,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_attr_val()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
         }
@@ -1283,7 +1289,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_attr_val()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
         }
@@ -1310,7 +1316,7 @@ namespace nirfmxinstr_grpc {
       uInt8 attr_val {};
       auto status = library_->GetAttributeU8(instrument, channel_name, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attr_val(attr_val);
       }
       return ::grpc::Status::OK;
@@ -1347,7 +1353,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_attr_val(attr_val);
           response->mutable_attr_val()->resize(actual_array_size);
           response->set_actual_array_size(actual_array_size);
@@ -1390,7 +1396,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_available_ports(available_ports);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_available_ports()));
         }
@@ -1432,7 +1438,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_error_code(error_code);
           response->set_error_description(error_description);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_description()));
@@ -1475,7 +1481,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_error_description(error_description);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_description()));
         }
@@ -1501,7 +1507,7 @@ namespace nirfmxinstr_grpc {
       float64 external_attenuation {};
       auto status = library_->GetExternalAttenuationTableActualValue(instrument, selector_string, &external_attenuation);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_external_attenuation(external_attenuation);
       }
       return ::grpc::Status::OK;
@@ -1524,7 +1530,7 @@ namespace nirfmxinstr_grpc {
       uInt32 ni_rfsa_session {};
       auto status = library_->GetNIRFSASession(instrument, &ni_rfsa_session);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_ni_rfsa_session(ni_rfsa_session);
       }
       return ::grpc::Status::OK;
@@ -1560,7 +1566,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_nirfsa_sessions()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
         }
@@ -1587,7 +1593,7 @@ namespace nirfmxinstr_grpc {
       CVIAbsoluteTime timestamp {};
       auto status = library_->GetSelfCalibrateLastDateAndTime(instrument, selector_string, self_calibrate_step, &timestamp);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(timestamp, response->mutable_timestamp());
       }
       return ::grpc::Status::OK;
@@ -1612,7 +1618,7 @@ namespace nirfmxinstr_grpc {
       float64 temperature {};
       auto status = library_->GetSelfCalibrateLastTemperature(instrument, selector_string, self_calibrate_step, &temperature);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_temperature(temperature);
       }
       return ::grpc::Status::OK;
@@ -1644,7 +1650,7 @@ namespace nirfmxinstr_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXINSTR_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -1674,7 +1680,7 @@ namespace nirfmxinstr_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXINSTR_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -1705,7 +1711,7 @@ namespace nirfmxinstr_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXINSTR_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -1730,7 +1736,7 @@ namespace nirfmxinstr_grpc {
       int32 valid_steps {};
       auto status = library_->IsSelfCalibrateValid(instrument, selector_string, &self_calibrate_valid, &valid_steps);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_self_calibrate_valid(self_calibrate_valid);
         response->set_valid_steps(valid_steps);
       }
@@ -2506,7 +2512,7 @@ namespace nirfmxinstr_grpc {
       CVIAbsoluteTime timestamp {};
       auto status = library_->TimestampFromValues(seconds_since1970, fractional_seconds, &timestamp);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(timestamp, response->mutable_timestamp());
       }
       return ::grpc::Status::OK;
@@ -2529,7 +2535,7 @@ namespace nirfmxinstr_grpc {
       float64 fractional_seconds {};
       auto status = library_->ValuesFromTimestamp(timestamp, &seconds_since1970, &fractional_seconds);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_seconds_since1970(seconds_since1970);
         response->set_fractional_seconds(fractional_seconds);
       }

--- a/generated/nirfmxspecan/nirfmxspecan_service.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_service.cpp
@@ -35,6 +35,12 @@ namespace nirfmxspecan_grpc {
   {
   }
 
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return status >= 0;
+  }
+
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
   ::grpc::Status NiRFmxSpecAnService::ACPCfgAveraging(::grpc::ServerContext* context, const ACPCfgAveragingRequest* request, ACPCfgAveragingResponse* response)
@@ -798,7 +804,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_absolute_powers_trace()->Resize(actual_array_size, 0);
@@ -830,7 +836,7 @@ namespace nirfmxspecan_grpc {
       float64 integration_bandwidth {};
       auto status = library_->ACPFetchCarrierMeasurement(instrument, selector_string, timeout, &absolute_power, &total_relative_power, &carrier_offset, &integration_bandwidth);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_absolute_power(absolute_power);
         response->set_total_relative_power(total_relative_power);
         response->set_carrier_offset(carrier_offset);
@@ -858,7 +864,7 @@ namespace nirfmxspecan_grpc {
       float64 frequency_resolution {};
       auto status = library_->ACPFetchFrequencyResolution(instrument, selector_string, timeout, &frequency_resolution);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_frequency_resolution(frequency_resolution);
       }
       return ::grpc::Status::OK;
@@ -886,7 +892,7 @@ namespace nirfmxspecan_grpc {
       float64 upper_absolute_power {};
       auto status = library_->ACPFetchOffsetMeasurement(instrument, selector_string, timeout, &lower_relative_power, &upper_relative_power, &lower_absolute_power, &upper_absolute_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_lower_relative_power(lower_relative_power);
         response->set_upper_relative_power(upper_relative_power);
         response->set_lower_absolute_power(lower_absolute_power);
@@ -933,7 +939,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_lower_relative_power()->Resize(actual_array_size, 0);
           response->mutable_upper_relative_power()->Resize(actual_array_size, 0);
           response->mutable_lower_absolute_power()->Resize(actual_array_size, 0);
@@ -979,7 +985,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_relative_powers_trace()->Resize(actual_array_size, 0);
@@ -1023,7 +1029,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -1052,7 +1058,7 @@ namespace nirfmxspecan_grpc {
       float64 total_carrier_power {};
       auto status = library_->ACPFetchTotalCarrierPower(instrument, selector_string, timeout, &total_carrier_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_total_carrier_power(total_carrier_power);
       }
       return ::grpc::Status::OK;
@@ -1081,7 +1087,7 @@ namespace nirfmxspecan_grpc {
       float64 offset_ch1_upper_relative_power {};
       auto status = library_->ACPRead(instrument, selector_string, timeout, &carrier_absolute_power, &offset_ch0_lower_relative_power, &offset_ch0_upper_relative_power, &offset_ch1_lower_relative_power, &offset_ch1_upper_relative_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_carrier_absolute_power(carrier_absolute_power);
         response->set_offset_ch0_lower_relative_power(offset_ch0_lower_relative_power);
         response->set_offset_ch0_upper_relative_power(offset_ch0_upper_relative_power);
@@ -1109,7 +1115,7 @@ namespace nirfmxspecan_grpc {
       int32 noise_calibration_data_valid {};
       auto status = library_->ACPValidateNoiseCalibrationData(instrument, selector_string, &noise_calibration_data_valid);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_noise_calibration_data_valid(noise_calibration_data_valid);
       }
       return ::grpc::Status::OK;
@@ -1553,7 +1559,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_reference_powers()->Resize(actual_array_size, 0);
           response->mutable_measured_am_to_am()->Resize(actual_array_size, 0);
           response->mutable_curve_fit_am_to_am()->Resize(actual_array_size, 0);
@@ -1599,7 +1605,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_reference_powers()->Resize(actual_array_size, 0);
           response->mutable_measured_am_to_pm()->Resize(actual_array_size, 0);
           response->mutable_curve_fit_am_to_pm()->Resize(actual_array_size, 0);
@@ -1643,7 +1649,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_input_compression_point()->Resize(actual_array_size, 0);
           response->mutable_output_compression_point()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
@@ -1686,7 +1692,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_am_to_am_coefficients()->Resize(actual_array_size, 0);
           response->mutable_am_to_pm_coefficients()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
@@ -1715,7 +1721,7 @@ namespace nirfmxspecan_grpc {
       float64 am_to_pm_residual {};
       auto status = library_->AMPMFetchCurveFitResidual(instrument, selector_string, timeout, &am_to_am_residual, &am_to_pm_residual);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_am_to_am_residual(am_to_am_residual);
         response->set_am_to_pm_residual(am_to_pm_residual);
       }
@@ -1743,7 +1749,7 @@ namespace nirfmxspecan_grpc {
       float64 mean_rmsevm {};
       auto status = library_->AMPMFetchDUTCharacteristics(instrument, selector_string, timeout, &mean_linear_gain, &oned_b_compression_point, &mean_rmsevm);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_mean_linear_gain(mean_linear_gain);
         response->set_oned_b_compression_point(oned_b_compression_point);
         response->set_mean_rmsevm(mean_rmsevm);
@@ -1772,7 +1778,7 @@ namespace nirfmxspecan_grpc {
       float64 mean_phase_error {};
       auto status = library_->AMPMFetchError(instrument, selector_string, timeout, &gain_error_range, &phase_error_range, &mean_phase_error);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_gain_error_range(gain_error_range);
         response->set_phase_error_range(phase_error_range);
         response->set_mean_phase_error(mean_phase_error);
@@ -1813,7 +1819,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           convert_to_grpc(processed_mean_acquired_waveform, response->mutable_processed_mean_acquired_waveform());
@@ -1866,7 +1872,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_i()->Resize(actual_array_size, 0);
@@ -1910,7 +1916,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           convert_to_grpc(processed_reference_waveform, response->mutable_processed_reference_waveform());
@@ -1963,7 +1969,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_i()->Resize(actual_array_size, 0);
@@ -2008,7 +2014,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_relative_phase()->Resize(actual_array_size, 0);
@@ -2052,7 +2058,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_relative_power()->Resize(actual_array_size, 0);
@@ -2195,7 +2201,7 @@ namespace nirfmxspecan_grpc {
       float64 reference_level {};
       auto status = library_->AutoLevel(instrument, selector_string, bandwidth, measurement_interval, &reference_level);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_reference_level(reference_level);
       }
       return ::grpc::Status::OK;
@@ -2234,7 +2240,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_selector_string_out(selector_string_out);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string_out()));
         }
@@ -2275,7 +2281,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_selector_string_out(selector_string_out);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string_out()));
         }
@@ -2338,7 +2344,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_selector_string(selector_string);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string()));
         }
@@ -2379,7 +2385,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_selector_string(selector_string);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string()));
         }
@@ -2420,7 +2426,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_selector_string_out(selector_string_out);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string_out()));
         }
@@ -2461,7 +2467,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_selector_string_out(selector_string_out);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string_out()));
         }
@@ -2504,7 +2510,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_selector_string(selector_string);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string()));
         }
@@ -2545,7 +2551,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_selector_string_out(selector_string_out);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string_out()));
         }
@@ -2586,7 +2592,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_selector_string_out(selector_string_out);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string_out()));
         }
@@ -2627,7 +2633,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_selector_string(selector_string);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string()));
         }
@@ -2668,7 +2674,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_selector_string_out(selector_string_out);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_selector_string_out()));
         }
@@ -2818,7 +2824,7 @@ namespace nirfmxspecan_grpc {
       float64 one_ten_thousandth_percent_power {};
       auto status = library_->CCDFFetchBasicPowerProbabilities(instrument, selector_string, timeout, &ten_percent_power, &one_percent_power, &one_tenth_percent_power, &one_hundredth_percent_power, &one_thousandth_percent_power, &one_ten_thousandth_percent_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_ten_percent_power(ten_percent_power);
         response->set_one_percent_power(one_percent_power);
         response->set_one_tenth_percent_power(one_tenth_percent_power);
@@ -2863,7 +2869,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_gaussian_probabilities()->Resize(actual_array_size, 0);
@@ -2895,7 +2901,7 @@ namespace nirfmxspecan_grpc {
       int32 measured_samples_count {};
       auto status = library_->CCDFFetchPower(instrument, selector_string, timeout, &mean_power, &mean_power_percentile, &peak_power, &measured_samples_count);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_mean_power(mean_power);
         response->set_mean_power_percentile(mean_power_percentile);
         response->set_peak_power(peak_power);
@@ -2938,7 +2944,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_probabilities()->Resize(actual_array_size, 0);
@@ -2970,7 +2976,7 @@ namespace nirfmxspecan_grpc {
       int32 measured_samples_count {};
       auto status = library_->CCDFRead(instrument, selector_string, timeout, &mean_power, &mean_power_percentile, &peak_power, &measured_samples_count);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_mean_power(mean_power);
         response->set_mean_power_percentile(mean_power_percentile);
         response->set_peak_power(peak_power);
@@ -3241,7 +3247,7 @@ namespace nirfmxspecan_grpc {
       float64 relative_power {};
       auto status = library_->CHPFetchCarrierMeasurement(instrument, selector_string, timeout, &absolute_power, &psd, &relative_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_absolute_power(absolute_power);
         response->set_psd(psd);
         response->set_relative_power(relative_power);
@@ -3283,7 +3289,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -3312,7 +3318,7 @@ namespace nirfmxspecan_grpc {
       float64 total_carrier_power {};
       auto status = library_->CHPFetchTotalCarrierPower(instrument, selector_string, timeout, &total_carrier_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_total_carrier_power(total_carrier_power);
       }
       return ::grpc::Status::OK;
@@ -3338,7 +3344,7 @@ namespace nirfmxspecan_grpc {
       float64 psd {};
       auto status = library_->CHPRead(instrument, selector_string, timeout, &absolute_power, &psd);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_absolute_power(absolute_power);
         response->set_psd(psd);
       }
@@ -3363,7 +3369,7 @@ namespace nirfmxspecan_grpc {
       int32 noise_calibration_data_valid {};
       auto status = library_->CHPValidateNoiseCalibrationData(instrument, selector_string, &noise_calibration_data_valid);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_noise_calibration_data_valid(noise_calibration_data_valid);
       }
       return ::grpc::Status::OK;
@@ -3695,7 +3701,7 @@ namespace nirfmxspecan_grpc {
       int32 is_done {};
       auto status = library_->CheckMeasurementStatus(instrument, selector_string, &is_done);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_is_done(is_done);
       }
       return ::grpc::Status::OK;
@@ -3861,7 +3867,7 @@ namespace nirfmxspecan_grpc {
       int32 created_step_index {};
       auto status = library_->CreateListStep(instrument, selector_string, &created_step_index);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_created_step_index(created_step_index);
       }
       return ::grpc::Status::OK;
@@ -3927,7 +3933,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0_out(x0_out);
           response->set_dx_out(dx_out);
           convert_to_grpc(waveform_out, response->mutable_waveform_out());
@@ -4001,7 +4007,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0_out(x0_out);
           response->set_dx_out(dx_out);
           response->mutable_waveform_out_i()->Resize(actual_array_size, 0);
@@ -4052,7 +4058,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0_out(x0_out);
           response->set_dx_out(dx_out);
           convert_to_grpc(waveform_out, response->mutable_waveform_out());
@@ -4123,7 +4129,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0_out(x0_out);
           response->set_dx_out(dx_out);
           response->mutable_waveform_out_i()->Resize(actual_array_size, 0);
@@ -4949,7 +4955,7 @@ namespace nirfmxspecan_grpc {
       float64 pre_cfrpapr {};
       auto status = library_->DPDFetchApplyDPDPreCFRPAPR(instrument, selector_string, timeout, &pre_cfrpapr);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_pre_cfrpapr(pre_cfrpapr);
       }
       return ::grpc::Status::OK;
@@ -4974,7 +4980,7 @@ namespace nirfmxspecan_grpc {
       float64 average_gain {};
       auto status = library_->DPDFetchAverageGain(instrument, selector_string, timeout, &average_gain);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_average_gain(average_gain);
       }
       return ::grpc::Status::OK;
@@ -5011,7 +5017,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           convert_to_grpc(dpd_polynomial, response->mutable_dpd_polynomial());
           {
             auto shrunk_size = actual_array_size;
@@ -5060,7 +5066,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_i()->Resize(actual_array_size, 0);
           response->mutable_q()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
@@ -5102,7 +5108,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_input_powers()->Resize(actual_array_size, 0);
           convert_to_grpc(complex_gains, response->mutable_complex_gains());
           {
@@ -5154,7 +5160,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_input_powers()->Resize(actual_array_size, 0);
           response->mutable_i()->Resize(actual_array_size, 0);
           response->mutable_q()->Resize(actual_array_size, 0);
@@ -5183,7 +5189,7 @@ namespace nirfmxspecan_grpc {
       float64 nmse {};
       auto status = library_->DPDFetchNMSE(instrument, selector_string, timeout, &nmse);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_nmse(nmse);
       }
       return ::grpc::Status::OK;
@@ -5222,7 +5228,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           convert_to_grpc(processed_mean_acquired_waveform, response->mutable_processed_mean_acquired_waveform());
@@ -5275,7 +5281,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_i()->Resize(actual_array_size, 0);
@@ -5319,7 +5325,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           convert_to_grpc(processed_reference_waveform, response->mutable_processed_reference_waveform());
@@ -5372,7 +5378,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_i()->Resize(actual_array_size, 0);
@@ -5597,7 +5603,7 @@ namespace nirfmxspecan_grpc {
       float64 allan_deviation {};
       auto status = library_->FCntFetchAllanDeviation(instrument, selector_string, timeout, &allan_deviation);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_allan_deviation(allan_deviation);
       }
       return ::grpc::Status::OK;
@@ -5637,7 +5643,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_frequency_trace()->Resize(actual_array_size, 0);
@@ -5668,7 +5674,7 @@ namespace nirfmxspecan_grpc {
       float64 mean_phase {};
       auto status = library_->FCntFetchMeasurement(instrument, selector_string, timeout, &average_relative_frequency, &average_absolute_frequency, &mean_phase);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_average_relative_frequency(average_relative_frequency);
         response->set_average_absolute_frequency(average_absolute_frequency);
         response->set_mean_phase(mean_phase);
@@ -5710,7 +5716,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_phase_trace()->Resize(actual_array_size, 0);
@@ -5754,7 +5760,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_power_trace()->Resize(actual_array_size, 0);
@@ -5785,7 +5791,7 @@ namespace nirfmxspecan_grpc {
       float64 mean_phase {};
       auto status = library_->FCntRead(instrument, selector_string, timeout, &average_relative_frequency, &average_absolute_frequency, &mean_phase);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_average_relative_frequency(average_relative_frequency);
         response->set_average_absolute_frequency(average_absolute_frequency);
         response->set_mean_phase(mean_phase);
@@ -5827,7 +5833,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_result_names(result_names);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_result_names()));
           response->set_actual_result_names_size(actual_result_names_size);
@@ -5856,7 +5862,7 @@ namespace nirfmxspecan_grpc {
       float32 attr_val {};
       auto status = library_->GetAttributeF32(instrument, selector_string, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attr_val(attr_val);
       }
       return ::grpc::Status::OK;
@@ -5894,7 +5900,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_attr_val()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
         }
@@ -5921,7 +5927,7 @@ namespace nirfmxspecan_grpc {
       float64 attr_val {};
       auto status = library_->GetAttributeF64(instrument, selector_string, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attr_val(attr_val);
       }
       return ::grpc::Status::OK;
@@ -5959,7 +5965,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_attr_val()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
         }
@@ -5986,7 +5992,7 @@ namespace nirfmxspecan_grpc {
       int16 attr_val {};
       auto status = library_->GetAttributeI16(instrument, selector_string, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attr_val(attr_val);
       }
       return ::grpc::Status::OK;
@@ -6011,7 +6017,7 @@ namespace nirfmxspecan_grpc {
       int32 attr_val {};
       auto status = library_->GetAttributeI32(instrument, selector_string, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto checked_convert_attr_val = [](auto raw_value) {
           bool raw_value_is_valid = nirfmxspecan_grpc::NiRFmxSpecAnInt32AttributeValues_IsValid(raw_value);
           auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -6055,7 +6061,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           auto checked_convert_attr_val = [](auto raw_value) {
             bool raw_value_is_valid = nirfmxspecan_grpc::NiRFmxSpecAnInt32AttributeValues_IsValid(raw_value);
             auto valid_enum_value = raw_value_is_valid ? raw_value : 0;
@@ -6096,7 +6102,7 @@ namespace nirfmxspecan_grpc {
       int64 attr_val {};
       auto status = library_->GetAttributeI64(instrument, selector_string, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attr_val(attr_val);
       }
       return ::grpc::Status::OK;
@@ -6134,7 +6140,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_attr_val()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
         }
@@ -6161,7 +6167,7 @@ namespace nirfmxspecan_grpc {
       int8 attr_val {};
       auto status = library_->GetAttributeI8(instrument, selector_string, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attr_val(attr_val);
       }
       return ::grpc::Status::OK;
@@ -6198,7 +6204,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_attr_val()->Clear();
           response->mutable_attr_val()->Reserve(actual_array_size);
           std::transform(
@@ -6246,7 +6252,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           convert_to_grpc(attr_val, response->mutable_attr_val());
           {
             auto shrunk_size = actual_array_size;
@@ -6292,7 +6298,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           convert_to_grpc(attr_val, response->mutable_attr_val());
           {
             auto shrunk_size = actual_array_size;
@@ -6342,7 +6348,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_attr_val(attr_val);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_attr_val()));
         }
@@ -6369,7 +6375,7 @@ namespace nirfmxspecan_grpc {
       uInt16 attr_val {};
       auto status = library_->GetAttributeU16(instrument, selector_string, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attr_val(attr_val);
       }
       return ::grpc::Status::OK;
@@ -6394,7 +6400,7 @@ namespace nirfmxspecan_grpc {
       uInt32 attr_val {};
       auto status = library_->GetAttributeU32(instrument, selector_string, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attr_val(attr_val);
       }
       return ::grpc::Status::OK;
@@ -6432,7 +6438,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_attr_val()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
         }
@@ -6472,7 +6478,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_attr_val()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
         }
@@ -6499,7 +6505,7 @@ namespace nirfmxspecan_grpc {
       uInt8 attr_val {};
       auto status = library_->GetAttributeU8(instrument, selector_string, attribute_id, &attr_val);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attr_val(attr_val);
       }
       return ::grpc::Status::OK;
@@ -6536,7 +6542,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_attr_val(attr_val);
           response->mutable_attr_val()->resize(actual_array_size);
           response->set_actual_array_size(actual_array_size);
@@ -6579,7 +6585,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_error_code(error_code);
           response->set_error_description(error_description);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_description()));
@@ -6622,7 +6628,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_error_description(error_description);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_description()));
         }
@@ -6853,7 +6859,7 @@ namespace nirfmxspecan_grpc {
       float64 frequency {};
       auto status = library_->HarmFetchHarmonicMeasurement(instrument, selector_string, timeout, &average_relative_power, &average_absolute_power, &rbw, &frequency);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_average_relative_power(average_relative_power);
         response->set_average_absolute_power(average_absolute_power);
         response->set_rbw(rbw);
@@ -6900,7 +6906,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_average_relative_power()->Resize(actual_array_size, 0);
           response->mutable_average_absolute_power()->Resize(actual_array_size, 0);
           response->mutable_rbw()->Resize(actual_array_size, 0);
@@ -6945,7 +6951,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_power()->Resize(actual_array_size, 0);
@@ -6976,7 +6982,7 @@ namespace nirfmxspecan_grpc {
       float64 fundamental_frequency {};
       auto status = library_->HarmFetchTHD(instrument, selector_string, timeout, &total_harmonic_distortion, &average_fundamental_power, &fundamental_frequency);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_total_harmonic_distortion(total_harmonic_distortion);
         response->set_average_fundamental_power(average_fundamental_power);
         response->set_fundamental_frequency(fundamental_frequency);
@@ -7004,7 +7010,7 @@ namespace nirfmxspecan_grpc {
       float64 average_fundamental_power {};
       auto status = library_->HarmRead(instrument, selector_string, timeout, &total_harmonic_distortion, &average_fundamental_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_total_harmonic_distortion(total_harmonic_distortion);
         response->set_average_fundamental_power(average_fundamental_power);
       }
@@ -7391,7 +7397,7 @@ namespace nirfmxspecan_grpc {
       float64 upper_tone_power {};
       auto status = library_->IMFetchFundamentalMeasurement(instrument, selector_string, timeout, &lower_tone_power, &upper_tone_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_lower_tone_power(lower_tone_power);
         response->set_upper_tone_power(upper_tone_power);
       }
@@ -7420,7 +7426,7 @@ namespace nirfmxspecan_grpc {
       float64 upper_output_intercept_power {};
       auto status = library_->IMFetchInterceptPower(instrument, selector_string, timeout, &intermod_order, &worst_case_output_intercept_power, &lower_output_intercept_power, &upper_output_intercept_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_intermod_order(intermod_order);
         response->set_worst_case_output_intercept_power(worst_case_output_intercept_power);
         response->set_lower_output_intercept_power(lower_output_intercept_power);
@@ -7467,7 +7473,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_intermod_order()->Resize(actual_array_size, 0);
           response->mutable_worst_case_output_intercept_power()->Resize(actual_array_size, 0);
           response->mutable_lower_output_intercept_power()->Resize(actual_array_size, 0);
@@ -7499,7 +7505,7 @@ namespace nirfmxspecan_grpc {
       float64 upper_intermod_power {};
       auto status = library_->IMFetchIntermodMeasurement(instrument, selector_string, timeout, &intermod_order, &lower_intermod_power, &upper_intermod_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_intermod_order(intermod_order);
         response->set_lower_intermod_power(lower_intermod_power);
         response->set_upper_intermod_power(upper_intermod_power);
@@ -7543,7 +7549,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_intermod_order()->Resize(actual_array_size, 0);
           response->mutable_lower_intermod_power()->Resize(actual_array_size, 0);
           response->mutable_upper_intermod_power()->Resize(actual_array_size, 0);
@@ -7588,7 +7594,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -7679,7 +7685,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_t0(t0);
           response->set_dt(dt);
           convert_to_grpc(data, response->mutable_data());
@@ -7734,7 +7740,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_t0(t0);
           response->set_dt(dt);
           response->mutable_i()->Resize(actual_array_size, 0);
@@ -7763,7 +7769,7 @@ namespace nirfmxspecan_grpc {
       int32 records_done {};
       auto status = library_->IQGetRecordsDone(instrument, selector_string, &records_done);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_records_done(records_done);
       }
       return ::grpc::Status::OK;
@@ -7795,7 +7801,7 @@ namespace nirfmxspecan_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXSPECAN_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -7825,7 +7831,7 @@ namespace nirfmxspecan_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXSPECAN_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -8050,7 +8056,7 @@ namespace nirfmxspecan_grpc {
       float64 marker_y_location {};
       auto status = library_->MarkerFetchXY(instrument, selector_string, &marker_x_location, &marker_y_location);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_marker_x_location(marker_x_location);
         response->set_marker_y_location(marker_y_location);
       }
@@ -8091,7 +8097,7 @@ namespace nirfmxspecan_grpc {
       int32 next_peak_found {};
       auto status = library_->MarkerNextPeak(instrument, selector_string, next_peak, &next_peak_found);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_next_peak_found(next_peak_found);
       }
       return ::grpc::Status::OK;
@@ -8115,7 +8121,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_peaks {};
       auto status = library_->MarkerPeakSearch(instrument, selector_string, &number_of_peaks);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_number_of_peaks(number_of_peaks);
       }
       return ::grpc::Status::OK;
@@ -8689,7 +8695,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_analyzer_noise_figure()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
         }
@@ -8729,7 +8735,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_cold_source_power()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
         }
@@ -8773,7 +8779,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_dut_noise_figure()->Resize(actual_array_size, 0);
           response->mutable_dut_noise_temperature()->Resize(actual_array_size, 0);
           response->mutable_dut_gain()->Resize(actual_array_size, 0);
@@ -8817,7 +8823,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_hot_power()->Resize(actual_array_size, 0);
           response->mutable_cold_power()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
@@ -8860,7 +8866,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_measurement_y_factor()->Resize(actual_array_size, 0);
           response->mutable_calibration_y_factor()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
@@ -8903,7 +8909,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_attr_val(attr_val);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_attr_val()));
         }
@@ -8931,7 +8937,7 @@ namespace nirfmxspecan_grpc {
       float64 reference_level {};
       auto status = library_->NFRecommendReferenceLevel(instrument, selector_string, dut_max_gain, dut_max_noise_figure, &reference_level);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_reference_level(reference_level);
       }
       return ::grpc::Status::OK;
@@ -8976,7 +8982,7 @@ namespace nirfmxspecan_grpc {
       int32 calibration_data_valid {};
       auto status = library_->NFValidateCalibrationData(instrument, selector_string, &calibration_data_valid);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_calibration_data_valid(calibration_data_valid);
       }
       return ::grpc::Status::OK;
@@ -9218,7 +9224,7 @@ namespace nirfmxspecan_grpc {
       float64 stop_frequency {};
       auto status = library_->OBWFetchMeasurement(instrument, selector_string, timeout, &occupied_bandwidth, &average_power, &frequency_resolution, &start_frequency, &stop_frequency);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_occupied_bandwidth(occupied_bandwidth);
         response->set_average_power(average_power);
         response->set_frequency_resolution(frequency_resolution);
@@ -9262,7 +9268,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -9295,7 +9301,7 @@ namespace nirfmxspecan_grpc {
       float64 stop_frequency {};
       auto status = library_->OBWRead(instrument, selector_string, timeout, &occupied_bandwidth, &average_power, &frequency_resolution, &start_frequency, &stop_frequency);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_occupied_bandwidth(occupied_bandwidth);
         response->set_average_power(average_power);
         response->set_frequency_resolution(frequency_resolution);
@@ -9643,7 +9649,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_amplitude()->Resize(actual_array_size, 0);
@@ -9675,7 +9681,7 @@ namespace nirfmxspecan_grpc {
       float64 mean_absolute_amplitude {};
       auto status = library_->PAVTFetchPhaseAndAmplitude(instrument, selector_string, timeout, &mean_relative_phase, &mean_relative_amplitude, &mean_absolute_phase, &mean_absolute_amplitude);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_mean_relative_phase(mean_relative_phase);
         response->set_mean_relative_amplitude(mean_relative_amplitude);
         response->set_mean_absolute_phase(mean_absolute_phase);
@@ -9722,7 +9728,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_mean_relative_phase()->Resize(actual_array_size, 0);
           response->mutable_mean_relative_amplitude()->Resize(actual_array_size, 0);
           response->mutable_mean_absolute_phase()->Resize(actual_array_size, 0);
@@ -9768,7 +9774,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_phase()->Resize(actual_array_size, 0);
@@ -10104,7 +10110,7 @@ namespace nirfmxspecan_grpc {
       float64 carrier_power {};
       auto status = library_->PhaseNoiseFetchCarrierMeasurement(instrument, selector_string, timeout, &carrier_frequency, &carrier_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_carrier_frequency(carrier_frequency);
         response->set_carrier_power(carrier_power);
       }
@@ -10151,7 +10157,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_integrated_phase_noise()->Resize(actual_array_size, 0);
           response->mutable_residual_pm_in_radian()->Resize(actual_array_size, 0);
           response->mutable_residual_pm_in_degree()->Resize(actual_array_size, 0);
@@ -10197,7 +10203,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_frequency()->Resize(actual_array_size, 0);
           response->mutable_measured_phase_noise()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
@@ -10240,7 +10246,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_frequency()->Resize(actual_array_size, 0);
           response->mutable_smoothed_phase_noise()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
@@ -10281,7 +10287,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_spot_phase_noise()->Resize(actual_array_size, 0);
           response->set_actual_array_size(actual_array_size);
         }
@@ -11186,7 +11192,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_absolute_mask()->Resize(actual_array_size, 0);
@@ -11218,7 +11224,7 @@ namespace nirfmxspecan_grpc {
       float64 total_relative_power {};
       auto status = library_->SEMFetchCarrierMeasurement(instrument, selector_string, timeout, &absolute_power, &peak_absolute_power, &peak_frequency, &total_relative_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_absolute_power(absolute_power);
         response->set_peak_absolute_power(peak_absolute_power);
         response->set_peak_frequency(peak_frequency);
@@ -11246,7 +11252,7 @@ namespace nirfmxspecan_grpc {
       int32 composite_measurement_status {};
       auto status = library_->SEMFetchCompositeMeasurementStatus(instrument, selector_string, timeout, &composite_measurement_status);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_composite_measurement_status(static_cast<nirfmxspecan_grpc::SemCompositeMeasurementStatus>(composite_measurement_status));
         response->set_composite_measurement_status_raw(composite_measurement_status);
       }
@@ -11272,7 +11278,7 @@ namespace nirfmxspecan_grpc {
       float64 frequency_resolution {};
       auto status = library_->SEMFetchFrequencyResolution(instrument, selector_string, timeout, &frequency_resolution);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_frequency_resolution(frequency_resolution);
       }
       return ::grpc::Status::OK;
@@ -11301,7 +11307,7 @@ namespace nirfmxspecan_grpc {
       float64 margin_relative_power {};
       auto status = library_->SEMFetchLowerOffsetMargin(instrument, selector_string, timeout, &measurement_status, &margin, &margin_frequency, &margin_absolute_power, &margin_relative_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_measurement_status(static_cast<nirfmxspecan_grpc::SemLowerOffsetMeasurementStatus>(measurement_status));
         response->set_measurement_status_raw(measurement_status);
         response->set_margin(margin);
@@ -11352,7 +11358,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_measurement_status()->Clear();
           response->mutable_measurement_status()->Reserve(actual_array_size);
           std::transform(
@@ -11396,7 +11402,7 @@ namespace nirfmxspecan_grpc {
       float64 peak_relative_power {};
       auto status = library_->SEMFetchLowerOffsetPower(instrument, selector_string, timeout, &total_absolute_power, &total_relative_power, &peak_absolute_power, &peak_frequency, &peak_relative_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_total_absolute_power(total_absolute_power);
         response->set_total_relative_power(total_relative_power);
         response->set_peak_absolute_power(peak_absolute_power);
@@ -11446,7 +11452,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_total_absolute_power()->Resize(actual_array_size, 0);
           response->mutable_total_relative_power()->Resize(actual_array_size, 0);
           response->mutable_peak_absolute_power()->Resize(actual_array_size, 0);
@@ -11492,7 +11498,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_relative_mask()->Resize(actual_array_size, 0);
@@ -11536,7 +11542,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -11565,7 +11571,7 @@ namespace nirfmxspecan_grpc {
       float64 total_carrier_power {};
       auto status = library_->SEMFetchTotalCarrierPower(instrument, selector_string, timeout, &total_carrier_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_total_carrier_power(total_carrier_power);
       }
       return ::grpc::Status::OK;
@@ -11594,7 +11600,7 @@ namespace nirfmxspecan_grpc {
       float64 margin_relative_power {};
       auto status = library_->SEMFetchUpperOffsetMargin(instrument, selector_string, timeout, &measurement_status, &margin, &margin_frequency, &margin_absolute_power, &margin_relative_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_measurement_status(static_cast<nirfmxspecan_grpc::SemUpperOffsetMeasurementStatus>(measurement_status));
         response->set_measurement_status_raw(measurement_status);
         response->set_margin(margin);
@@ -11645,7 +11651,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_measurement_status()->Clear();
           response->mutable_measurement_status()->Reserve(actual_array_size);
           std::transform(
@@ -11689,7 +11695,7 @@ namespace nirfmxspecan_grpc {
       float64 peak_relative_power {};
       auto status = library_->SEMFetchUpperOffsetPower(instrument, selector_string, timeout, &total_absolute_power, &total_relative_power, &peak_absolute_power, &peak_frequency, &peak_relative_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_total_absolute_power(total_absolute_power);
         response->set_total_relative_power(total_relative_power);
         response->set_peak_absolute_power(peak_absolute_power);
@@ -11739,7 +11745,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_total_absolute_power()->Resize(actual_array_size, 0);
           response->mutable_total_relative_power()->Resize(actual_array_size, 0);
           response->mutable_peak_absolute_power()->Resize(actual_array_size, 0);
@@ -12671,7 +12677,7 @@ namespace nirfmxspecan_grpc {
       float64 frequency_resolution {};
       auto status = library_->SpectrumFetchMeasurement(instrument, selector_string, timeout, &peak_amplitude, &peak_frequency, &frequency_resolution);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_peak_amplitude(peak_amplitude);
         response->set_peak_frequency(peak_frequency);
         response->set_frequency_resolution(frequency_resolution);
@@ -12713,7 +12719,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_power()->Resize(actual_array_size, 0);
@@ -12757,7 +12763,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -12801,7 +12807,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -12829,7 +12835,7 @@ namespace nirfmxspecan_grpc {
       int32 noise_calibration_data_valid {};
       auto status = library_->SpectrumValidateNoiseCalibrationData(instrument, selector_string, &noise_calibration_data_valid);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_noise_calibration_data_valid(noise_calibration_data_valid);
       }
       return ::grpc::Status::OK;
@@ -13556,7 +13562,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_spur_frequency()->Resize(actual_array_size, 0);
           response->mutable_spur_amplitude()->Resize(actual_array_size, 0);
           response->mutable_spur_margin()->Resize(actual_array_size, 0);
@@ -13587,7 +13593,7 @@ namespace nirfmxspecan_grpc {
       int32 measurement_status {};
       auto status = library_->SpurFetchMeasurementStatus(instrument, selector_string, timeout, &measurement_status);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_measurement_status(static_cast<nirfmxspecan_grpc::SpurMeasurementStatus>(measurement_status));
         response->set_measurement_status_raw(measurement_status);
       }
@@ -13628,7 +13634,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_absolute_limit()->Resize(actual_array_size, 0);
@@ -13672,7 +13678,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_range_spectrum()->Resize(actual_array_size, 0);
@@ -13702,7 +13708,7 @@ namespace nirfmxspecan_grpc {
       int32 detected_spurs {};
       auto status = library_->SpurFetchRangeStatus(instrument, selector_string, timeout, &range_status, &detected_spurs);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_range_status(static_cast<nirfmxspecan_grpc::SpurRangeStatus>(range_status));
         response->set_range_status_raw(range_status);
         response->set_detected_spurs(detected_spurs);
@@ -13744,7 +13750,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_range_status()->Clear();
           response->mutable_range_status()->Reserve(actual_array_size);
           std::transform(
@@ -13784,7 +13790,7 @@ namespace nirfmxspecan_grpc {
       float64 spur_absolute_limit {};
       auto status = library_->SpurFetchSpurMeasurement(instrument, selector_string, timeout, &spur_frequency, &spur_amplitude, &spur_margin, &spur_absolute_limit);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_spur_frequency(spur_frequency);
         response->set_spur_amplitude(spur_amplitude);
         response->set_spur_margin(spur_margin);
@@ -13831,7 +13837,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_spur_frequency()->Resize(actual_array_size, 0);
           response->mutable_spur_amplitude()->Resize(actual_array_size, 0);
           response->mutable_spur_absolute_limit()->Resize(actual_array_size, 0);
@@ -14022,7 +14028,7 @@ namespace nirfmxspecan_grpc {
       float64 minimum_power {};
       auto status = library_->TXPFetchMeasurement(instrument, selector_string, timeout, &average_mean_power, &peak_to_average_ratio, &maximum_power, &minimum_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_average_mean_power(average_mean_power);
         response->set_peak_to_average_ratio(peak_to_average_ratio);
         response->set_maximum_power(maximum_power);
@@ -14065,7 +14071,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_x0(x0);
           response->set_dx(dx);
           response->mutable_power()->Resize(actual_array_size, 0);
@@ -14097,7 +14103,7 @@ namespace nirfmxspecan_grpc {
       float64 minimum_power {};
       auto status = library_->TXPRead(instrument, selector_string, timeout, &average_mean_power, &peak_to_average_ratio, &maximum_power, &minimum_power);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_average_mean_power(average_mean_power);
         response->set_peak_to_average_ratio(peak_to_average_ratio);
         response->set_maximum_power(maximum_power);

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -36,6 +36,12 @@ namespace nirfsa_grpc {
   {
   }
 
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return status >= 0;
+  }
+
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
   ::grpc::Status NiRFSAService::Abort(::grpc::ServerContext* context, const AbortRequest* request, AbortResponse* response)
@@ -68,7 +74,7 @@ namespace nirfsa_grpc {
       ViBoolean is_done {};
       auto status = library_->CheckAcquisitionStatus(vi, &is_done);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_is_done(is_done);
       }
       return ::grpc::Status::OK;
@@ -1075,7 +1081,7 @@ namespace nirfsa_grpc {
       std::string error_message(1024 - 1, '\0');
       auto status = library_->ErrorMessage(vi, status_code, (ViChar*)error_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_error_message(error_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
@@ -1100,7 +1106,7 @@ namespace nirfsa_grpc {
       std::string error_message(1024 - 1, '\0');
       auto status = library_->ErrorQuery(vi, &error_code, (ViChar*)error_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_error_code(error_code);
         response->set_error_message(error_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
@@ -1187,7 +1193,7 @@ namespace nirfsa_grpc {
       std::vector<niRFSA_wfmInfo_struct> wfm_info(number_of_records, niRFSA_wfmInfo_struct());
       auto status = library_->FetchIQMultiRecordComplexF32(vi, channel_list, starting_record, number_of_records, number_of_samples, timeout, data.data(), wfm_info.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(data, response->mutable_data());
         convert_to_grpc(wfm_info, response->mutable_wfm_info());
       }
@@ -1217,7 +1223,7 @@ namespace nirfsa_grpc {
       std::vector<niRFSA_wfmInfo_struct> wfm_info(number_of_records, niRFSA_wfmInfo_struct());
       auto status = library_->FetchIQMultiRecordComplexF64(vi, channel_list, starting_record, number_of_records, number_of_samples, timeout, data.data(), wfm_info.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(data, response->mutable_data());
         convert_to_grpc(wfm_info, response->mutable_wfm_info());
       }
@@ -1247,7 +1253,7 @@ namespace nirfsa_grpc {
       std::vector<niRFSA_wfmInfo_struct> wfm_info(number_of_records, niRFSA_wfmInfo_struct());
       auto status = library_->FetchIQMultiRecordComplexI16(vi, channel_list, starting_record, number_of_records, number_of_samples, timeout, data.data(), wfm_info.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(data, response->mutable_data());
         convert_to_grpc(wfm_info, response->mutable_wfm_info());
       }
@@ -1276,7 +1282,7 @@ namespace nirfsa_grpc {
       niRFSA_wfmInfo_struct wfm_info {};
       auto status = library_->FetchIQSingleRecordComplexF32(vi, channel_list, record_number, number_of_samples, timeout, data.data(), &wfm_info);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(data, response->mutable_data());
         convert_to_grpc(wfm_info, response->mutable_wfm_info());
       }
@@ -1305,7 +1311,7 @@ namespace nirfsa_grpc {
       niRFSA_wfmInfo_struct wfm_info {};
       auto status = library_->FetchIQSingleRecordComplexF64(vi, channel_list, record_number, number_of_samples, timeout, data.data(), &wfm_info);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(data, response->mutable_data());
         convert_to_grpc(wfm_info, response->mutable_wfm_info());
       }
@@ -1334,7 +1340,7 @@ namespace nirfsa_grpc {
       niRFSA_wfmInfo_struct wfm_info {};
       auto status = library_->FetchIQSingleRecordComplexI16(vi, channel_list, record_number, number_of_samples, timeout, data.data(), &wfm_info);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(data, response->mutable_data());
         convert_to_grpc(wfm_info, response->mutable_wfm_info());
       }
@@ -1360,7 +1366,7 @@ namespace nirfsa_grpc {
       ViBoolean value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_name, attribute_id, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1385,7 +1391,7 @@ namespace nirfsa_grpc {
       ViInt32 value {};
       auto status = library_->GetAttributeViInt32(vi, channel_name, attribute_id, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1410,7 +1416,7 @@ namespace nirfsa_grpc {
       ViInt64 value {};
       auto status = library_->GetAttributeViInt64(vi, channel_name, attribute_id, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1435,7 +1441,7 @@ namespace nirfsa_grpc {
       ViReal64 value {};
       auto status = library_->GetAttributeViReal64(vi, channel_name, attribute_id, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1460,7 +1466,7 @@ namespace nirfsa_grpc {
       ViSession value {};
       auto status = library_->GetAttributeViSession(vi, channel_name, attribute_id, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto session_id = session_repository_->resolve_session_id(value);
         response->mutable_value()->set_id(session_id);
       }
@@ -1502,7 +1508,7 @@ namespace nirfsa_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -1527,7 +1533,7 @@ namespace nirfsa_grpc {
       std::string info(2048 - 1, '\0');
       auto status = library_->GetCalUserDefinedInfo(vi, (ViChar*)info.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_info(info);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_info()));
       }
@@ -1551,7 +1557,7 @@ namespace nirfsa_grpc {
       ViInt32 info_size {};
       auto status = library_->GetCalUserDefinedInfoMaxSize(vi, &info_size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_info_size(info_size);
       }
       return ::grpc::Status::OK;
@@ -1587,7 +1593,7 @@ namespace nirfsa_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           convert_to_grpc(sparameters, response->mutable_sparameters());
           {
             auto shrunk_size = number_of_sparameters;
@@ -1654,7 +1660,7 @@ namespace nirfsa_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_frequencies()->Resize(number_of_frequencies, 0);
           response->mutable_magnitude_response()->Resize(number_of_frequencies, 0);
           response->mutable_phase_response()->Resize(number_of_frequencies, 0);
@@ -1698,7 +1704,7 @@ namespace nirfsa_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_error_code(error_code);
           response->set_error_description(error_description);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_description()));
@@ -1728,7 +1734,7 @@ namespace nirfsa_grpc {
       ViInt32 minute {};
       auto status = library_->GetExtCalLastDateAndTime(vi, &year, &month, &day, &hour, &minute);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_year(year);
         response->set_month(month);
         response->set_day(day);
@@ -1755,7 +1761,7 @@ namespace nirfsa_grpc {
       ViReal64 temperature {};
       auto status = library_->GetExtCalLastTemp(vi, &temperature);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_temperature(temperature);
       }
       return ::grpc::Status::OK;
@@ -1778,7 +1784,7 @@ namespace nirfsa_grpc {
       ViInt32 months {};
       auto status = library_->GetExtCalRecommendedInterval(vi, &months);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_months(months);
       }
       return ::grpc::Status::OK;
@@ -1803,7 +1809,7 @@ namespace nirfsa_grpc {
       ViInt64 backlog {};
       auto status = library_->GetFetchBacklog(vi, channel_list, record_number, &backlog);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_backlog(backlog);
       }
       return ::grpc::Status::OK;
@@ -1844,7 +1850,7 @@ namespace nirfsa_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_frequencies()->Resize(number_of_frequencies, 0);
           response->mutable_magnitude_response()->Resize(number_of_frequencies, 0);
           response->mutable_phase_response()->Resize(number_of_frequencies, 0);
@@ -1884,7 +1890,7 @@ namespace nirfsa_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           convert_to_grpc(coefficient_info, response->mutable_coefficient_info());
           {
             auto shrunk_size = number_of_coefficient_sets;
@@ -1917,7 +1923,7 @@ namespace nirfsa_grpc {
       ViInt32 number_of_spectral_lines {};
       auto status = library_->GetNumberOfSpectralLines(vi, channel_list, &number_of_spectral_lines);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_number_of_spectral_lines(number_of_spectral_lines);
       }
       return ::grpc::Status::OK;
@@ -1956,7 +1962,7 @@ namespace nirfsa_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_name(name);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_name()));
           response->set_buffer_size(buffer_size);
@@ -1995,7 +2001,7 @@ namespace nirfsa_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_operations_count()->Resize(buffer_size, 0);
           response->set_buffer_size(buffer_size);
         }
@@ -2033,7 +2039,7 @@ namespace nirfsa_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           convert_to_grpc(coefficient_info, response->mutable_coefficient_info());
           {
             auto shrunk_size = number_of_coefficient_sets;
@@ -2070,7 +2076,7 @@ namespace nirfsa_grpc {
       ViInt32 minute {};
       auto status = library_->GetSelfCalLastDateAndTime(vi, self_calibration_step, &year, &month, &day, &hour, &minute);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_year(year);
         response->set_month(month);
         response->set_day(day);
@@ -2098,7 +2104,7 @@ namespace nirfsa_grpc {
       ViReal64 temp {};
       auto status = library_->GetSelfCalLastTemp(vi, self_calibration_step, &temp);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_temp(temp);
       }
       return ::grpc::Status::OK;
@@ -2121,7 +2127,7 @@ namespace nirfsa_grpc {
       SmtSpectrumInfo_struct spectrum_info {};
       auto status = library_->GetSpectralInfoForSMT(vi, &spectrum_info);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(spectrum_info, response->mutable_spectrum_info());
       }
       return ::grpc::Status::OK;
@@ -2145,7 +2151,7 @@ namespace nirfsa_grpc {
       ViUInt32 writer_handle {};
       auto status = library_->GetStreamEndpointHandle(vi, stream_endpoint, &writer_handle);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_writer_handle(writer_handle);
       }
       return ::grpc::Status::OK;
@@ -2189,7 +2195,7 @@ namespace nirfsa_grpc {
       }
       auto status = library_->GetTerminalName(vi, signal, signal_identifier, buffer_size, (ViChar*)terminal_name.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_terminal_name(terminal_name);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_terminal_name()));
       }
@@ -2226,7 +2232,7 @@ namespace nirfsa_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_data(data);
           response->mutable_data()->resize(actual_data_size);
           response->set_actual_data_size(actual_data_size);
@@ -2261,7 +2267,7 @@ namespace nirfsa_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -2294,7 +2300,7 @@ namespace nirfsa_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -2356,7 +2362,7 @@ namespace nirfsa_grpc {
       ViInt64 valid_steps {};
       auto status = library_->IsSelfCalValid(vi, &self_cal_valid, &valid_steps);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_self_cal_valid(self_cal_valid);
         if (valid_steps & 0x1)
           response->add_valid_steps_array(SelfCalibrateSteps::SELF_CALIBRATE_STEPS_ALIGNMENT);
@@ -2423,7 +2429,7 @@ namespace nirfsa_grpc {
       niRFSA_wfmInfo_struct wfm_info {};
       auto status = library_->ReadIQSingleRecordComplexF64(vi, channel_list, timeout, data.data(), data_array_size, &wfm_info);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(data, response->mutable_data());
         convert_to_grpc(wfm_info, response->mutable_wfm_info());
       }
@@ -2452,7 +2458,7 @@ namespace nirfsa_grpc {
       niRFSA_spectrumInfo_struct spectrum_info {};
       auto status = library_->ReadPowerSpectrumF32(vi, channel_list, timeout, power_spectrum_data, data_array_size, &spectrum_info);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(spectrum_info, response->mutable_spectrum_info());
       }
       return ::grpc::Status::OK;
@@ -2480,7 +2486,7 @@ namespace nirfsa_grpc {
       niRFSA_spectrumInfo_struct spectrum_info {};
       auto status = library_->ReadPowerSpectrumF64(vi, channel_list, timeout, power_spectrum_data, data_array_size, &spectrum_info);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         convert_to_grpc(spectrum_info, response->mutable_spectrum_info());
       }
       return ::grpc::Status::OK;
@@ -2617,7 +2623,7 @@ namespace nirfsa_grpc {
       std::string instr_rev(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)driver_rev.data(), (ViChar*)instr_rev.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_driver_rev(driver_rev);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_driver_rev()));
         response->set_instr_rev(instr_rev);
@@ -2737,7 +2743,7 @@ namespace nirfsa_grpc {
       std::string test_message(2048 - 1, '\0');
       auto status = library_->SelfTest(vi, &test_result, (ViChar*)test_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_test_result(test_result);
         response->set_test_message(test_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_test_message()));
@@ -2987,7 +2993,7 @@ namespace nirfsa_grpc {
       std::string data(buffer_size, '\0');
       auto status = library_->SetUserData(vi, identifier, buffer_size, (ViInt8*)data.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_data(data);
       }
       return ::grpc::Status::OK;

--- a/generated/nirfsg/nirfsg_service.cpp
+++ b/generated/nirfsg/nirfsg_service.cpp
@@ -35,6 +35,12 @@ namespace nirfsg_grpc {
   {
   }
 
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return status >= 0;
+  }
+
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
   ::grpc::Status NiRFSGService::Abort(::grpc::ServerContext* context, const AbortRequest* request, AbortResponse* response)
@@ -270,7 +276,7 @@ namespace nirfsg_grpc {
       ViBoolean is_done {};
       auto status = library_->CheckGenerationStatus(vi, &is_done);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_is_done(is_done);
       }
       return ::grpc::Status::OK;
@@ -294,7 +300,7 @@ namespace nirfsg_grpc {
       ViBoolean list_exists {};
       auto status = library_->CheckIfConfigurationListExists(vi, list_name, &list_exists);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_list_exists(list_exists);
       }
       return ::grpc::Status::OK;
@@ -318,7 +324,7 @@ namespace nirfsg_grpc {
       ViBoolean script_exists {};
       auto status = library_->CheckIfScriptExists(vi, script_name, &script_exists);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_script_exists(script_exists);
       }
       return ::grpc::Status::OK;
@@ -342,7 +348,7 @@ namespace nirfsg_grpc {
       ViBoolean waveform_exists {};
       auto status = library_->CheckIfWaveformExists(vi, waveform_name, &waveform_exists);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_waveform_exists(waveform_exists);
       }
       return ::grpc::Status::OK;
@@ -1470,7 +1476,7 @@ namespace nirfsg_grpc {
       std::string error_message(1024 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_error_message(error_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
@@ -1495,7 +1501,7 @@ namespace nirfsg_grpc {
       std::string error_message(1024 - 1, '\0');
       auto status = library_->ErrorQuery(vi, &error_code, (ViChar*)error_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_error_code(error_code);
         response->set_error_message(error_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
@@ -1597,7 +1603,7 @@ namespace nirfsg_grpc {
       ViBoolean value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_name, attribute_id, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1622,7 +1628,7 @@ namespace nirfsg_grpc {
       ViInt32 value {};
       auto status = library_->GetAttributeViInt32(vi, channel_name, attribute_id, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1647,7 +1653,7 @@ namespace nirfsg_grpc {
       ViInt64 value {};
       auto status = library_->GetAttributeViInt64(vi, channel_name, attribute_id, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1672,7 +1678,7 @@ namespace nirfsg_grpc {
       ViReal64 value {};
       auto status = library_->GetAttributeViReal64(vi, channel_name, attribute_id, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1697,7 +1703,7 @@ namespace nirfsg_grpc {
       ViSession value {};
       auto status = library_->GetAttributeViSession(vi, channel_name, attribute_id, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto session_id = session_repository_->resolve_session_id(value);
         response->mutable_value()->set_id(session_id);
       }
@@ -1739,7 +1745,7 @@ namespace nirfsg_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -1781,7 +1787,7 @@ namespace nirfsg_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_name(name);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_name()));
         }
@@ -1819,7 +1825,7 @@ namespace nirfsg_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           convert_to_grpc(sparameters, response->mutable_sparameters());
           {
             auto shrunk_size = number_of_sparameters;
@@ -1869,7 +1875,7 @@ namespace nirfsg_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_error_code(error_code);
           response->set_error_description(error_description);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_description()));
@@ -1900,7 +1906,7 @@ namespace nirfsg_grpc {
       ViInt32 second {};
       auto status = library_->GetExternalCalibrationLastDateAndTime(vi, &year, &month, &day, &hour, &minute, &second);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_year(year);
         response->set_month(month);
         response->set_day(day);
@@ -1949,7 +1955,7 @@ namespace nirfsg_grpc {
       ViInt32 second {};
       auto status = library_->GetSelfCalibrationDateAndTime(vi, module, &year, &month, &day, &hour, &minute, &second);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_year(year);
         response->set_month(month);
         response->set_day(day);
@@ -1993,7 +1999,7 @@ namespace nirfsg_grpc {
       ViReal64 temperature {};
       auto status = library_->GetSelfCalibrationTemperature(vi, module, &temperature);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_temperature(temperature);
       }
       return ::grpc::Status::OK;
@@ -2068,7 +2074,7 @@ namespace nirfsg_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_terminal_name(terminal_name);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_terminal_name()));
         }
@@ -2106,7 +2112,7 @@ namespace nirfsg_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_data(data);
           response->mutable_data()->resize(actual_data_size);
           response->set_actual_data_size(actual_data_size);
@@ -2146,7 +2152,7 @@ namespace nirfsg_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_locations()->Resize(required_size, 0);
           response->set_required_size(required_size);
         }
@@ -2185,7 +2191,7 @@ namespace nirfsg_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_locations()->Resize(required_size, 0);
           response->set_required_size(required_size);
         }
@@ -2224,7 +2230,7 @@ namespace nirfsg_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->mutable_locations()->Resize(required_size, 0);
           response->set_required_size(required_size);
         }
@@ -2258,7 +2264,7 @@ namespace nirfsg_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_new_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -2291,7 +2297,7 @@ namespace nirfsg_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -2414,7 +2420,7 @@ namespace nirfsg_grpc {
       ViInt32 max_waveform_size {};
       auto status = library_->QueryArbWaveformCapabilities(vi, &max_number_waveforms, &waveform_quantum, &min_waveform_size, &max_waveform_size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_max_number_waveforms(max_number_waveforms);
         response->set_waveform_quantum(waveform_quantum);
         response->set_min_waveform_size(min_waveform_size);
@@ -2576,7 +2582,7 @@ namespace nirfsg_grpc {
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_instrument_driver_revision(instrument_driver_revision);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_instrument_driver_revision()));
         response->set_firmware_revision(firmware_revision);
@@ -2702,7 +2708,7 @@ namespace nirfsg_grpc {
       std::string self_test_message(2048 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_self_test_result(self_test_result);
         response->set_self_test_message(self_test_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_self_test_message()));

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -35,6 +35,12 @@ namespace niscope_grpc {
   {
   }
 
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return status >= 0;
+  }
+
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::Abort(::grpc::ServerContext* context, const AbortRequest* request, AbortResponse* response)
@@ -67,7 +73,7 @@ namespace niscope_grpc {
       ViInt32 acquisition_status {};
       auto status = library_->AcquisitionStatus(vi, &acquisition_status);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_acquisition_status(static_cast<niscope_grpc::AcquisitionStatus>(acquisition_status));
         response->set_acquisition_status_raw(acquisition_status);
       }
@@ -107,7 +113,7 @@ namespace niscope_grpc {
       ViInt32 meas_waveform_size {};
       auto status = library_->ActualMeasWfmSize(vi, array_meas_function, &meas_waveform_size);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_meas_waveform_size(meas_waveform_size);
       }
       return ::grpc::Status::OK;
@@ -131,7 +137,7 @@ namespace niscope_grpc {
       ViInt32 num_wfms {};
       auto status = library_->ActualNumWfms(vi, channel_list, &num_wfms);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_num_wfms(num_wfms);
       }
       return ::grpc::Status::OK;
@@ -154,7 +160,7 @@ namespace niscope_grpc {
       ViInt32 record_length {};
       auto status = library_->ActualRecordLength(vi, &record_length);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_record_length(record_length);
       }
       return ::grpc::Status::OK;
@@ -1305,7 +1311,7 @@ namespace niscope_grpc {
       std::string error_description(642 - 1, '\0');
       auto status = library_->ErrorHandler(vi, error_code, error_source, (ViChar*)error_description.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_error_description(error_description);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_description()));
       }
@@ -1342,7 +1348,7 @@ namespace niscope_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_configuration(configuration);
         }
         return ::grpc::Status::OK;
@@ -1425,7 +1431,7 @@ namespace niscope_grpc {
       ViBoolean value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_list, attribute_id, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1450,7 +1456,7 @@ namespace niscope_grpc {
       ViInt32 value {};
       auto status = library_->GetAttributeViInt32(vi, channel_list, attribute_id, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1475,7 +1481,7 @@ namespace niscope_grpc {
       ViInt64 value {};
       auto status = library_->GetAttributeViInt64(vi, channel_list, attribute_id, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1500,7 +1506,7 @@ namespace niscope_grpc {
       ViReal64 value {};
       auto status = library_->GetAttributeViReal64(vi, channel_list, attribute_id, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1525,7 +1531,7 @@ namespace niscope_grpc {
       ViSession value {};
       auto status = library_->GetAttributeViSession(vi, channel_list, attribute_id, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto session_id = session_repository_->resolve_session_id(value);
         response->mutable_value()->set_id(session_id);
       }
@@ -1567,7 +1573,7 @@ namespace niscope_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -1609,7 +1615,7 @@ namespace niscope_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_channel_string(channel_string);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_channel_string()));
         }
@@ -1651,7 +1657,7 @@ namespace niscope_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_name(name);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_name()));
         }
@@ -1679,7 +1685,7 @@ namespace niscope_grpc {
       ViReal64* coefficients = response->mutable_coefficients()->mutable_data();
       auto status = library_->GetEqualizationFilterCoefficients(vi, channel, number_of_coefficients, coefficients);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
       }
       return ::grpc::Status::OK;
     }
@@ -1718,7 +1724,7 @@ namespace niscope_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_error_code(error_code);
           response->set_description(description);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_description()));
@@ -1761,7 +1767,7 @@ namespace niscope_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_error_message(error_message);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
         }
@@ -1794,7 +1800,7 @@ namespace niscope_grpc {
       ViInt32 number_of_frequencies {};
       auto status = library_->GetFrequencyResponse(vi, channel, buffer_size, frequencies, amplitudes, phases, &number_of_frequencies);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_number_of_frequencies(number_of_frequencies);
       }
       return ::grpc::Status::OK;
@@ -1818,7 +1824,7 @@ namespace niscope_grpc {
       ViUInt32 writer_handle {};
       auto status = library_->GetStreamEndpointHandle(vi, stream_name, &writer_handle);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_writer_handle(writer_handle);
       }
       return ::grpc::Status::OK;
@@ -1891,7 +1897,7 @@ namespace niscope_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -1924,7 +1930,7 @@ namespace niscope_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -2043,7 +2049,7 @@ namespace niscope_grpc {
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_driver_revision(driver_revision);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_driver_revision()));
         response->set_firmware_revision(firmware_revision);
@@ -2069,7 +2075,7 @@ namespace niscope_grpc {
       ViInt32 sample_mode {};
       auto status = library_->SampleMode(vi, &sample_mode);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_sample_mode(sample_mode);
       }
       return ::grpc::Status::OK;
@@ -2092,7 +2098,7 @@ namespace niscope_grpc {
       ViReal64 sample_rate {};
       auto status = library_->SampleRate(vi, &sample_rate);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_sample_rate(sample_rate);
       }
       return ::grpc::Status::OK;
@@ -2116,7 +2122,7 @@ namespace niscope_grpc {
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_self_test_result(self_test_result);
         response->set_self_test_message(self_test_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_self_test_message()));

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -35,6 +35,12 @@ namespace niswitch_grpc {
   {
   }
 
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return status >= 0;
+  }
+
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
   ::grpc::Status NiSwitchService::AbortScan(::grpc::ServerContext* context, const AbortScanRequest* request, AbortScanResponse* response)
@@ -69,7 +75,7 @@ namespace niswitch_grpc {
       ViInt32 path_capability {};
       auto status = library_->CanConnect(vi, channel1, channel2, &path_capability);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_path_capability(static_cast<niswitch_grpc::PathCapability>(path_capability));
         response->set_path_capability_raw(path_capability);
       }
@@ -505,7 +511,7 @@ namespace niswitch_grpc {
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_error_message(error_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
@@ -530,7 +536,7 @@ namespace niswitch_grpc {
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorQuery(vi, &error_code, (ViChar*)error_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_error_code(error_code);
         response->set_error_message(error_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
@@ -557,7 +563,7 @@ namespace niswitch_grpc {
       ViBoolean attribute_value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -582,7 +588,7 @@ namespace niswitch_grpc {
       ViInt32 attribute_value {};
       auto status = library_->GetAttributeViInt32(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -607,7 +613,7 @@ namespace niswitch_grpc {
       ViReal64 attribute_value {};
       auto status = library_->GetAttributeViReal64(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_attribute_value(attribute_value);
       }
       return ::grpc::Status::OK;
@@ -648,7 +654,7 @@ namespace niswitch_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_attribute_value(attribute_value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_attribute_value()));
         }
@@ -675,7 +681,7 @@ namespace niswitch_grpc {
       ViSession attribute_value {};
       auto status = library_->GetAttributeViSession(vi, channel_name, attribute_id, &attribute_value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto session_id = session_repository_->resolve_session_id(attribute_value);
         response->mutable_attribute_value()->set_id(session_id);
       }
@@ -716,7 +722,7 @@ namespace niswitch_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_channel_name_buffer(channel_name_buffer);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_channel_name_buffer()));
         }
@@ -758,7 +764,7 @@ namespace niswitch_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_code(code);
           response->set_description(description);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_description()));
@@ -800,7 +806,7 @@ namespace niswitch_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_coercion_record(coercion_record);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_coercion_record()));
         }
@@ -841,7 +847,7 @@ namespace niswitch_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_interchange_warning(interchange_warning);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_interchange_warning()));
         }
@@ -884,7 +890,7 @@ namespace niswitch_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_path(path);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_path()));
         }
@@ -910,7 +916,7 @@ namespace niswitch_grpc {
       ViInt32 relay_count {};
       auto status = library_->GetRelayCount(vi, relay_name, &relay_count);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_relay_count(relay_count);
       }
       return ::grpc::Status::OK;
@@ -950,7 +956,7 @@ namespace niswitch_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_relay_name_buffer(relay_name_buffer);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_relay_name_buffer()));
         }
@@ -976,7 +982,7 @@ namespace niswitch_grpc {
       ViInt32 relay_position {};
       auto status = library_->GetRelayPosition(vi, relay_name, &relay_position);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_relay_position(static_cast<niswitch_grpc::RelayPosition>(relay_position));
         response->set_relay_position_raw(relay_position);
       }
@@ -1009,7 +1015,7 @@ namespace niswitch_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -1042,7 +1048,7 @@ namespace niswitch_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -1075,7 +1081,7 @@ namespace niswitch_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -1136,7 +1142,7 @@ namespace niswitch_grpc {
       ViBoolean is_debounced {};
       auto status = library_->IsDebounced(vi, &is_debounced);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_is_debounced(is_debounced);
       }
       return ::grpc::Status::OK;
@@ -1159,7 +1165,7 @@ namespace niswitch_grpc {
       ViBoolean is_scanning {};
       auto status = library_->IsScanning(vi, &is_scanning);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_is_scanning(is_scanning);
       }
       return ::grpc::Status::OK;
@@ -1276,7 +1282,7 @@ namespace niswitch_grpc {
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_instrument_driver_revision(instrument_driver_revision);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_instrument_driver_revision()));
         response->set_firmware_revision(firmware_revision);
@@ -1443,7 +1449,7 @@ namespace niswitch_grpc {
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_self_test_result(self_test_result);
         response->set_self_test_message(self_test_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_self_test_message()));

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -35,6 +35,12 @@ namespace nisync_grpc {
   {
   }
 
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return status >= 0;
+  }
+
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
   ::grpc::Status NiSyncService::Init(::grpc::ServerContext* context, const InitRequest* request, InitResponse* response)
@@ -57,7 +63,7 @@ namespace nisync_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -101,7 +107,7 @@ namespace nisync_grpc {
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_error_message(error_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
       }
@@ -164,7 +170,7 @@ namespace nisync_grpc {
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_self_test_result(self_test_result);
         response->set_self_test_message(self_test_message);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_self_test_message()));
@@ -190,7 +196,7 @@ namespace nisync_grpc {
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)driver_revision.data(), (ViChar*)firmware_revision.data());
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_driver_revision(driver_revision);
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_driver_revision()));
         response->set_firmware_revision(firmware_revision);
@@ -373,7 +379,7 @@ namespace nisync_grpc {
       ViReal64 error {};
       auto status = library_->MeasureFrequency(vi, src_terminal, duration, &actual_duration, &frequency, &error);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_actual_duration(actual_duration);
         response->set_frequency(frequency);
         response->set_error(error);
@@ -403,7 +409,7 @@ namespace nisync_grpc {
       ViReal64 frequency_error {};
       auto status = library_->MeasureFrequencyEx(vi, src_terminal, duration, decimation_count, &actual_duration, &frequency, &frequency_error);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_actual_duration(actual_duration);
         response->set_frequency(frequency);
         response->set_frequency_error(frequency_error);
@@ -529,7 +535,7 @@ namespace nisync_grpc {
       ViUInt16 time_fractional_nanoseconds {};
       auto status = library_->GetTime(vi, &time_seconds, &time_nanoseconds, &time_fractional_nanoseconds);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_time_seconds(time_seconds);
         response->set_time_nanoseconds(time_nanoseconds);
         response->set_time_fractional_nanoseconds(time_fractional_nanoseconds);
@@ -665,7 +671,7 @@ namespace nisync_grpc {
       ViInt32 detected_edge {};
       auto status = library_->ReadTriggerTimeStamp(vi, terminal, timeout, &time_seconds, &time_nanoseconds, &time_fractional_nanoseconds, &detected_edge);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_time_seconds(time_seconds);
         response->set_time_nanoseconds(time_nanoseconds);
         response->set_time_fractional_nanoseconds(time_fractional_nanoseconds);
@@ -925,7 +931,7 @@ namespace nisync_grpc {
       ViUInt16 gps_fractional_nanoseconds {};
       auto status = library_->ReadLastGPSTimestamp(vi, &timestamp_seconds, &timestamp_nanoseconds, &timestamp_fractional_nanoseconds, &gps_seconds, &gps_nanoseconds, &gps_fractional_nanoseconds);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_timestamp_seconds(timestamp_seconds);
         response->set_timestamp_nanoseconds(timestamp_nanoseconds);
         response->set_timestamp_fractional_nanoseconds(timestamp_fractional_nanoseconds);
@@ -959,7 +965,7 @@ namespace nisync_grpc {
       ViUInt16 irigb_fractional_nanoseconds {};
       auto status = library_->ReadLastIRIGTimestamp(vi, terminal, &timestamp_seconds, &timestamp_nanoseconds, &timestamp_fractional_nanoseconds, &irigb_seconds, &irigb_nanoseconds, &irigb_fractional_nanoseconds);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_timestamp_seconds(timestamp_seconds);
         response->set_timestamp_nanoseconds(timestamp_nanoseconds);
         response->set_timestamp_fractional_nanoseconds(timestamp_fractional_nanoseconds);
@@ -1028,7 +1034,7 @@ namespace nisync_grpc {
       ViReal64 up_velocity {};
       auto status = library_->GetVelocity(vi, &east_velocity, &north_velocity, &up_velocity);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_east_velocity(east_velocity);
         response->set_north_velocity(north_velocity);
         response->set_up_velocity(up_velocity);
@@ -1055,7 +1061,7 @@ namespace nisync_grpc {
       ViReal64 altitude {};
       auto status = library_->GetLocation(vi, &latitude, &longitude, &altitude);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_latitude(latitude);
         response->set_longitude(longitude);
         response->set_altitude(altitude);
@@ -1096,7 +1102,7 @@ namespace nisync_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_time_reference_names(time_reference_names);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_time_reference_names()));
         }
@@ -1123,7 +1129,7 @@ namespace nisync_grpc {
       ViInt32 value {};
       auto status = library_->GetAttributeViInt32(vi, active_item, attribute, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1148,7 +1154,7 @@ namespace nisync_grpc {
       ViReal64 value {};
       auto status = library_->GetAttributeViReal64(vi, active_item, attribute, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1173,7 +1179,7 @@ namespace nisync_grpc {
       ViBoolean value {};
       auto status = library_->GetAttributeViBoolean(vi, active_item, attribute, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -1214,7 +1220,7 @@ namespace nisync_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_value(value);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_value()));
         }
@@ -1331,7 +1337,7 @@ namespace nisync_grpc {
       ViInt32 minute {};
       auto status = library_->GetExtCalLastDateAndTime(vi, &year, &month, &day, &hour, &minute);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_year(year);
         response->set_month(month);
         response->set_day(day);
@@ -1358,7 +1364,7 @@ namespace nisync_grpc {
       ViReal64 temp {};
       auto status = library_->GetExtCalLastTemp(vi, &temp);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_temp(temp);
       }
       return ::grpc::Status::OK;
@@ -1381,7 +1387,7 @@ namespace nisync_grpc {
       ViInt32 months {};
       auto status = library_->GetExtCalRecommendedInterval(vi, &months);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_months(months);
       }
       return ::grpc::Status::OK;
@@ -1425,7 +1431,7 @@ namespace nisync_grpc {
       ViReal64 temperature {};
       auto status = library_->ReadCurrentTemperature(vi, &temperature);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_temperature(temperature);
       }
       return ::grpc::Status::OK;
@@ -1448,7 +1454,7 @@ namespace nisync_grpc {
       ViReal64 voltage {};
       auto status = library_->CalGetOscillatorVoltage(vi, &voltage);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_voltage(voltage);
       }
       return ::grpc::Status::OK;
@@ -1471,7 +1477,7 @@ namespace nisync_grpc {
       ViReal64 voltage {};
       auto status = library_->CalGetClk10PhaseVoltage(vi, &voltage);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_voltage(voltage);
       }
       return ::grpc::Status::OK;
@@ -1494,7 +1500,7 @@ namespace nisync_grpc {
       ViReal64 voltage {};
       auto status = library_->CalGetDDSStartPulsePhaseVoltage(vi, &voltage);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_voltage(voltage);
       }
       return ::grpc::Status::OK;
@@ -1517,7 +1523,7 @@ namespace nisync_grpc {
       ViReal64 phase {};
       auto status = library_->CalGetDDSInitialPhase(vi, &phase);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_phase(phase);
       }
       return ::grpc::Status::OK;
@@ -1548,7 +1554,7 @@ namespace nisync_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
       return ::grpc::Status::OK;
@@ -1592,7 +1598,7 @@ namespace nisync_grpc {
       ViReal64 old_voltage {};
       auto status = library_->CalAdjustOscillatorVoltage(vi, measured_voltage, &old_voltage);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_old_voltage(old_voltage);
       }
       return ::grpc::Status::OK;
@@ -1616,7 +1622,7 @@ namespace nisync_grpc {
       ViReal64 old_voltage {};
       auto status = library_->CalAdjustClk10PhaseVoltage(vi, measured_voltage, &old_voltage);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_old_voltage(old_voltage);
       }
       return ::grpc::Status::OK;
@@ -1640,7 +1646,7 @@ namespace nisync_grpc {
       ViReal64 old_voltage {};
       auto status = library_->CalAdjustDDSStartPulsePhaseVoltage(vi, measured_voltage, &old_voltage);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_old_voltage(old_voltage);
       }
       return ::grpc::Status::OK;
@@ -1664,7 +1670,7 @@ namespace nisync_grpc {
       ViReal64 old_phase {};
       auto status = library_->CalAdjustDDSInitialPhase(vi, measured_phase, &old_phase);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_old_phase(old_phase);
       }
       return ::grpc::Status::OK;

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -35,6 +35,12 @@ namespace nitclk_grpc {
   {
   }
 
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return status >= 0;
+  }
+
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
   ::grpc::Status NiTClkService::ConfigureForHomogeneousTriggers(::grpc::ServerContext* context, const ConfigureForHomogeneousTriggersRequest* request, ConfigureForHomogeneousTriggersResponse* response)
@@ -101,7 +107,7 @@ namespace nitclk_grpc {
       ViReal64 value {};
       auto status = library_->GetAttributeViReal64(session, channel_name, attribute_id, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_value(value);
       }
       return ::grpc::Status::OK;
@@ -126,7 +132,7 @@ namespace nitclk_grpc {
       ViSession value {};
       auto status = library_->GetAttributeViSession(session, channel_name, attribute_id, &value);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         auto session_id = session_repository_->resolve_session_id(value);
         response->mutable_value()->set_id(session_id);
       }
@@ -164,7 +170,7 @@ namespace nitclk_grpc {
           continue;
         }
         response->set_status(status);
-        if (status == 0) {
+        if (status_ok(status)) {
           response->set_error_string(error_string);
           nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_string()));
         }
@@ -220,7 +226,7 @@ namespace nitclk_grpc {
       ViBoolean done {};
       auto status = library_->IsDone(session_count, sessions.data(), &done);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->set_done(done);
       }
       return ::grpc::Status::OK;

--- a/source/codegen/metadata/nidaqmx/config.py
+++ b/source/codegen/metadata/nidaqmx/config.py
@@ -132,6 +132,7 @@ config = {
     ],
     'init_function': 'CreateTask',
     'resource_handle_type': 'TaskHandle',
+    'status_ok': 'status >= 0',
     'library_info': {
         'Linux': {
             '64bit': {

--- a/source/codegen/metadata/nidcpower/config.py
+++ b/source/codegen/metadata/nidcpower/config.py
@@ -22,6 +22,7 @@ config = {
         'SelfTestError'
     ],
     'init_function': 'InitializeWithChannels',
+    'status_ok': 'status >= 0',
     'library_info': {
         'Linux': {
             '64bit': {

--- a/source/codegen/metadata/nidigitalpattern/config.py
+++ b/source/codegen/metadata/nidigitalpattern/config.py
@@ -24,6 +24,7 @@ config = {
         'SelfTestError'
     ],
     'init_function': 'InitWithOptions',
+    'status_ok': 'status >= 0',
     'library_info': {
         'Linux': {
             '64bit': {

--- a/source/codegen/metadata/nidmm/config.py
+++ b/source/codegen/metadata/nidmm/config.py
@@ -22,6 +22,7 @@ config = {
         'SelfTestError'
     ],
     'init_function': 'InitWithOptions',
+    'status_ok': 'status >= 0',
     'library_info': {
         'Linux': {
             '64bit': {

--- a/source/codegen/metadata/nifake/config.py
+++ b/source/codegen/metadata/nifake/config.py
@@ -57,6 +57,7 @@ config = {
         'SelfTestError'
     ],
     'init_function': 'InitWithOptions',
+    'status_ok': 'status >= 0',
     'library_info': {
         'Linux': {
             '64bit': {

--- a/source/codegen/metadata/nifake_extension/config.py
+++ b/source/codegen/metadata/nifake_extension/config.py
@@ -11,6 +11,7 @@ config = {
     'close_function': None,
     'driver_name': 'NI-FAKE-EXTENSION',
     'custom_types': [],
+    'status_ok': 'status >= 0',
     'library_info': {
         'Linux': {
             '64bit': {

--- a/source/codegen/metadata/nifake_non_ivi/config.py
+++ b/source/codegen/metadata/nifake_non_ivi/config.py
@@ -11,6 +11,7 @@ config = {
     'close_function': 'Close',
     'driver_name': 'NI-FAKE-NON-IVI',
     'resource_handle_type': 'FakeHandle',
+    'status_ok': 'status >= 0',
     'custom_types': [
         {
             'name': 'StringAndEnum',

--- a/source/codegen/metadata/nifgen/config.py
+++ b/source/codegen/metadata/nifgen/config.py
@@ -21,6 +21,7 @@ config = {
         'SelfTestError'
     ],
     'init_function': 'InitializeWithChannels',
+    'status_ok': 'status >= 0',
     'library_info': {
         'Linux': {
             '64bit': {

--- a/source/codegen/metadata/nirfmxinstr/config.py
+++ b/source/codegen/metadata/nirfmxinstr/config.py
@@ -35,6 +35,7 @@ config = {
     ],
     'init_function': 'Initialize',
     'resource_handle_type': 'niRFmxInstrHandle',
+    'status_ok': 'status >= 0',
     'library_info': {
         'Linux': {
             '64bit': {

--- a/source/codegen/metadata/nirfmxspecan/config.py
+++ b/source/codegen/metadata/nirfmxspecan/config.py
@@ -34,6 +34,7 @@ config = {
     ],
     'init_function': 'Initialize',
     'resource_handle_type': 'niRFmxInstrHandle',
+    'status_ok': 'status >= 0',
     'library_info': {
         'Linux': {
             '64bit': {

--- a/source/codegen/metadata/nirfsa/config.py
+++ b/source/codegen/metadata/nirfsa/config.py
@@ -121,6 +121,7 @@ config = {
     'additional_headers': { 'custom/nirfsa_aliases.h': ['service.cpp', 'library_interface.h'] },
     'driver_name': 'NI-RFSA',
     'init_function': 'InitWithOptions',
+    'status_ok': 'status >= 0',
     'code_readiness': 'Release',
     'library_info': {
         'Linux': {

--- a/source/codegen/metadata/nirfsg/config.py
+++ b/source/codegen/metadata/nirfsg/config.py
@@ -19,6 +19,7 @@ config = {
     'extra_errors_used': [
     ],
     'init_function': 'InitWithOptions',
+    'status_ok': 'status >= 0',
     'library_info': {
         'Linux': {
             '64bit': {

--- a/source/codegen/metadata/niscope/config.py
+++ b/source/codegen/metadata/niscope/config.py
@@ -94,6 +94,7 @@ config = {
         'SelfTestError'
     ],
     'init_function': 'InitWithOptions',
+    'status_ok': 'status >= 0',
     'library_info': {
         'Linux': {
             '64bit': {

--- a/source/codegen/metadata/niswitch/config.py
+++ b/source/codegen/metadata/niswitch/config.py
@@ -22,6 +22,7 @@ config = {
         'SelfTestError'
     ],
     'init_function': 'InitWithTopology',
+    'status_ok': 'status >= 0',
     'library_info': {
         'Linux': {
             '64bit': {

--- a/source/codegen/metadata/nisync/config.py
+++ b/source/codegen/metadata/nisync/config.py
@@ -16,6 +16,7 @@ config = {
     "custom_types": [],
     "driver_name": "NI-SYNC",
     "init_function": "init",
+    'status_ok': 'status >= 0',
     "library_info": {
         "Linux": {"64bit": {"name": "nisync", "type": "cdll"}},
         "Windows": {

--- a/source/codegen/metadata/nitclk/config.py
+++ b/source/codegen/metadata/nitclk/config.py
@@ -13,6 +13,7 @@ config = {
     ],
     'driver_name': 'NI-TClk',
     'extra_errors_used': [],
+    'status_ok': 'status >= 0',
     'library_info': {
         'Linux': {
             '64bit': {

--- a/source/codegen/templates/service.cpp.mako
+++ b/source/codegen/templates/service.cpp.mako
@@ -70,6 +70,12 @@ namespace ${config["namespace_component"]}_grpc {
   {
   }
 
+  // Returns true if it's safe to use outputs of a method with the given status.
+  inline bool status_ok(int32 status)
+  {
+    return ${config['status_ok']};
+  }
+
 % if common_helpers.has_enum_array_string_out_param(functions):
   template <typename TEnum>
   void ${service_class_prefix}Service::CopyBytesToEnums(const std::string& input, google::protobuf::RepeatedField<TEnum>* output)

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -33,7 +33,7 @@ ${initialize_output_params(output_parameters_to_initialize)}\
       auto cleanup_lambda = [&] (${resource_handle_type} id) { library_->${close_function_call}; };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       response->set_status(status);
-      if (status == 0) {
+      if (status_ok(status)) {
         response->mutable_${session_output_var_name}()->set_id(session_id);
       }
       return ::grpc::Status::OK;\
@@ -67,7 +67,7 @@ ${initialize_output_params(output_parameters)}\
         }
         response->set_status(status);
 % if output_parameters:
-        if (status == 0) {
+        if (status_ok(status)) {
 <%block filter="common_helpers.indent(1)">\
 ${set_response_values(output_parameters)}\
 </%block>\
@@ -109,7 +109,7 @@ ${initialize_output_params(array_output_parameters)}\
         }
         response->set_status(status);
 % if output_parameters:
-        if (status == 0) {
+        if (status_ok(status)) {
 <%block filter="common_helpers.indent(1)">\
 ${set_response_values(output_parameters)}\
 </%block>\
@@ -198,7 +198,7 @@ ${set_output_vararg_parameter_sizes(parameters)}\
 % endif
       response->set_status(status);
 % if output_parameters:
-      if (status == 0) {
+      if (status_ok(status)) {
 ${set_response_values(output_parameters=output_parameters)}\
       }
 % endif
@@ -219,7 +219,7 @@ ${initialize_output_params(output_parameters)}\
       auto status = library_->${function_name}(${service_helpers.create_args(parameters)});
       response->set_status(status);
 % if output_parameters:
-      if (status == 0) {
+      if (status_ok(status)) {
 ${set_response_values(output_parameters=output_parameters)}\
       }
 % endif

--- a/source/tests/system/nirfmxspecan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxspecan_driver_api_tests.cpp
@@ -314,7 +314,7 @@ TEST_F(NiRFmxSpecAnDriverApiTests, AMPMFromExample_NoError)
   EXPECT_SUCCESS(session, am_to_am_response);
 }
 
-TEST_F(NiRFmxSpecAnDriverApiTests, LutDpdFromExample_SynchronizationNotFoundWarning)
+TEST_F(NiRFmxSpecAnDriverApiTests, LutDpdFromExample_ReturnsSynchronizationNotFoundWarningWithData)
 {
   const auto session = init_session(stub(), PXI_5663);
   EXPECT_SUCCESS(session, client::cfg_frequency_reference(stub(), session, "", FrequencyReferenceSource::FREQUENCY_REFERENCE_SOURCE_ONBOARD_CLOCK, 10e6));
@@ -335,8 +335,9 @@ TEST_F(NiRFmxSpecAnDriverApiTests, LutDpdFromExample_SynchronizationNotFoundWarn
 
   const auto iq_data = load_test_iq_data<float>("LTE20MHz Waveform (Two Subframes).json");
   const auto apply_response = client::dpd_apply_digital_predistortion_split(stub(), session, "", iq_data.t0, iq_data.dt, iq_data.I, iq_data.Q, false, 10.0);
-  // GH #454 grpc-device does not fill in response fields when a warning is returned.
   EXPECT_RFMX_ERROR(377652, "Synchronization not found", session, apply_response);
+  EXPECT_THAT(apply_response.waveform_out_i(), Not(IsEmpty()));
+  EXPECT_THAT(apply_response.waveform_out_q(), Not(IsEmpty()));
 }
 
 // Note: there aren't any complex attributes in attributes.py, but this at least exercises the code.


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update grpc-device to fill in response message on warning.

Make the `status_ok` check configurable by driver in `config.py` so that it's easier to catch if we add an API with a different warning convention (i.e., `S_FALSE` is considered invalid in some APIs that use `HResult`s).

### Why should this Pull Request be merged?

All drivers supported by grpc-device (MI, DAQmx, RFSA/G, RFmx) expect "warning" status codes (`> 0`) to be a valid state. Since grpc-device does not fill in the response message in these cases, clients lose the ability to access valid data.

This specifically broke one of the RFmx tests that I added in a previous change.

### What testing has been done?

Ran and passed new tests and existing system tests.

Looked a: C API macros, nimi-python, RF C# wrappers, C examples for all grpc-device drivers to confirm the handling of warnings. All of these would propagate/log the warning but continue execution and access output data.