### PR TITLE
Add "two session on one device" test to both RFmx Bluetooth and WLAN.

### DIFF
--- a/source/codegen/metadata/nirfmxbt/config.py
+++ b/source/codegen/metadata/nirfmxbt/config.py
@@ -58,5 +58,6 @@ config = {
     'module_name': 'nirfmxbt',
     'session_class_description': 'An NI-RFmxBT instrument handle',
     'session_handle_parameter_name': 'instrumentHandle',
-    'windows_only': True
+    'windows_only': True,
+    'duplicate_resource_handles_allowed': True
 }

--- a/source/codegen/metadata/nirfmxwlan/config.py
+++ b/source/codegen/metadata/nirfmxwlan/config.py
@@ -58,5 +58,6 @@ config = {
     'metadata_version': '0.1',
     'module_name': 'nirfmxwlan',
     'session_class_description': 'An NI-RFmxWLAN instrument handle',
-    'session_handle_parameter_name': 'instrumentHandle'
+    'session_handle_parameter_name': 'instrumentHandle',
+    'duplicate_resource_handles_allowed': True
 }


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds tests to cover the two sessions initialized on same device for both RFmx BT and WLAN.

Fixes [AB#1794497](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1794497). Fixes [AB#1794286](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1794286)

### Why should this Pull Request be merged?

#471 went in which addressed the session management issue for RFmx.
Previously, the close implementations were trying to find the grpc Session by the instrument handle but this reverse mapping isn't valid for RFmx.
We wanted to add similar session tests covering the previously problematic scenario for BT and WLAN personalities, namely that opening and closing two sessions to the same simulated device works properly.

### What testing has been done?

System level tests (including new ones) pass locally with drivers installed.
