### PR TITLE
Add missing tests for RFmxInstr

### DIFF
--- a/source/tests/system/nirfmxinstr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxinstr_driver_api_tests.cpp
@@ -165,6 +165,28 @@ TEST_F(NiRFmxInstrDriverApiTests, SetAndGetFrequencyReferenceSource_ReturnsFrequ
   EXPECT_EQ(response.attr_val(), "OnboardClock");
 }
 
+TEST_F(NiRFmxInstrDriverApiTests, GetModelName_ReturnsModelName)
+{
+  const auto session = init_session(stub(), PXI_5663E);
+  const auto response = client::get_attribute_string(stub(), session, "", NiRFmxInstrAttribute::NIRFMXINSTR_ATTRIBUTE_INSTRUMENT_MODEL);
+
+  EXPECT_SUCCESS(session, response);
+  EXPECT_EQ(response.attr_val(), "NI PXIe-5663E");
+}
+
+TEST_F(NiRFmxInstrDriverApiTests, TimestampFromValuesRoundTrip_SucceedsWithOriginalValues)
+{
+  constexpr auto SECONDS_SINCE_1970 = 10000;
+  constexpr auto FRACTIONAL_SECONDS = .75;
+  const auto timestamp_response = client::timestamp_from_values(stub(), SECONDS_SINCE_1970, FRACTIONAL_SECONDS);
+  const auto values_response = client::values_from_timestamp(stub(), timestamp_response.timestamp());
+
+  ni::tests::system::EXPECT_SUCCESS(timestamp_response);
+  ni::tests::system::EXPECT_SUCCESS(values_response);
+  EXPECT_EQ(SECONDS_SINCE_1970, values_response.seconds_since1970());
+  EXPECT_NEAR(FRACTIONAL_SECONDS, values_response.fractional_seconds(), .001);
+}
+
 }  // namespace
 }  // namespace system
 }  // namespace tests

--- a/source/tests/system/nirfmxinstr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxinstr_driver_api_tests.cpp
@@ -176,14 +176,14 @@ TEST_F(NiRFmxInstrDriverApiTests, GetModelName_ReturnsModelName)
 
 TEST_F(NiRFmxInstrDriverApiTests, TimestampFromValuesRoundTrip_SucceedsWithOriginalValues)
 {
-  constexpr auto SECONDS_SINCE_1970 = 10000;
+  constexpr auto UNIX_TIMESTAMP = 10000;
   constexpr auto FRACTIONAL_SECONDS = .75;
-  const auto timestamp_response = client::timestamp_from_values(stub(), SECONDS_SINCE_1970, FRACTIONAL_SECONDS);
+  const auto timestamp_response = client::timestamp_from_values(stub(), UNIX_TIMESTAMP, FRACTIONAL_SECONDS);
   const auto values_response = client::values_from_timestamp(stub(), timestamp_response.timestamp());
 
   ni::tests::system::EXPECT_SUCCESS(timestamp_response);
   ni::tests::system::EXPECT_SUCCESS(values_response);
-  EXPECT_EQ(SECONDS_SINCE_1970, values_response.seconds_since1970());
+  EXPECT_EQ(UNIX_TIMESTAMP, values_response.seconds_since1970());
   EXPECT_NEAR(FRACTIONAL_SECONDS, values_response.fractional_seconds(), .001);
 }
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add tests for `CVIAbsoluteTime` and attributes with unknown (not known in metadata) types in RFmxInstr.

Fixes [AB#1801138](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1801138).

### Why should this Pull Request be merged?

Completes missing rows in AcceptanceTable and ensures that those features/assumptions of the API work.

### What testing has been done?

Ran and passed all RFmxInstr tests.