### PR TITLE
Tag coerced numerics in metadata_mutation

### DIFF
--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -2471,13 +2471,25 @@ namespace nirfmxinstr_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
-      int16 attr_val = request->attr_val();
+      auto attr_val_raw = request->attr_val();
+      if (attr_val_raw < std::numeric_limits<int16>::min() || attr_val_raw > std::numeric_limits<int16>::max()) {
+          std::string message("value ");
+          message.append(std::to_string(attr_val_raw));
+          message.append(" doesn't fit in datatype ");
+          message.append("int16");
+          throw nidevice_grpc::ValueOutOfRangeException(message);
+      }
+      auto attr_val = static_cast<int16>(attr_val_raw);
+
       auto status = library_->SetAttributeI16(instrument, channel_name, attribute_id, attr_val);
       response->set_status(status);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::ValueOutOfRangeException& ex) {
+      return ::grpc::Status(::grpc::OUT_OF_RANGE, ex.what());
     }
   }
 
@@ -2770,13 +2782,25 @@ namespace nirfmxinstr_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
-      uInt16 attr_val = request->attr_val();
+      auto attr_val_raw = request->attr_val();
+      if (attr_val_raw < std::numeric_limits<uInt16>::min() || attr_val_raw > std::numeric_limits<uInt16>::max()) {
+          std::string message("value ");
+          message.append(std::to_string(attr_val_raw));
+          message.append(" doesn't fit in datatype ");
+          message.append("uInt16");
+          throw nidevice_grpc::ValueOutOfRangeException(message);
+      }
+      auto attr_val = static_cast<uInt16>(attr_val_raw);
+
       auto status = library_->SetAttributeU16(instrument, channel_name, attribute_id, attr_val);
       response->set_status(status);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::ValueOutOfRangeException& ex) {
+      return ::grpc::Status(::grpc::OUT_OF_RANGE, ex.what());
     }
   }
 

--- a/source/codegen/generate_service.py
+++ b/source/codegen/generate_service.py
@@ -35,6 +35,7 @@ def mutate_metadata(metadata: dict):
         metadata_mutation.mark_mapped_enum_params(
             parameters, metadata["enums"])
         metadata_mutation.populate_grpc_types(parameters, config)
+        metadata_mutation.mark_coerced_narrow_numeric_parameters(parameters)
         attribute_expander.expand_attribute_value_params(function)
         attribute_expander.patch_attribute_enum_type(function_name, function)
 

--- a/source/codegen/metadata/nirfmxinstr/functions.py
+++ b/source/codegen/metadata/nirfmxinstr/functions.py
@@ -930,7 +930,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'out',
                 'name': 'attrVal',
                 'type': 'int8'
@@ -958,7 +957,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'out',
                 'name': 'attrVal',
                 'size': {
@@ -2281,7 +2279,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'in',
                 'name': 'attrVal',
                 'type': 'int8'
@@ -2309,7 +2306,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'in',
                 'name': 'attrVal',
                 'size': {

--- a/source/codegen/metadata/nirfmxnr/functions.py
+++ b/source/codegen/metadata/nirfmxnr/functions.py
@@ -2317,7 +2317,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'out',
                 'name': 'attrVal',
                 'type': 'int16'
@@ -2483,7 +2482,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'out',
                 'name': 'attrVal',
                 'type': 'int8'
@@ -2511,7 +2509,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'out',
                 'name': 'attrVal',
                 'size': {
@@ -2674,7 +2671,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'out',
                 'name': 'attrVal',
                 'type': 'uInt16'
@@ -3917,7 +3913,6 @@ functions = {
                 'type': 'float64'
             },
             {
-                'coerced': True,
                 'direction': 'out',
                 'name': 'bits',
                 'size': {
@@ -4266,7 +4261,6 @@ functions = {
                 'type': 'float64'
             },
             {
-                'coerced': True,
                 'direction': 'out',
                 'name': 'bits',
                 'size': {
@@ -7075,7 +7069,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'in',
                 'name': 'attrVal',
                 'type': 'int16'
@@ -7229,7 +7222,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'in',
                 'name': 'attrVal',
                 'type': 'int8'
@@ -7257,7 +7249,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'in',
                 'name': 'attrVal',
                 'size': {
@@ -7393,7 +7384,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'in',
                 'name': 'attrVal',
                 'type': 'uInt16'

--- a/source/codegen/metadata/nirfmxspecan/functions.py
+++ b/source/codegen/metadata/nirfmxspecan/functions.py
@@ -5345,7 +5345,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'out',
                 'name': 'attrVal',
                 'type': 'int16'
@@ -5511,7 +5510,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'out',
                 'name': 'attrVal',
                 'type': 'int8'
@@ -5539,7 +5537,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'out',
                 'name': 'attrVal',
                 'size': {
@@ -5702,7 +5699,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'out',
                 'name': 'attrVal',
                 'type': 'uInt16'
@@ -11633,7 +11629,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'in',
                 'name': 'attrVal',
                 'type': 'int16'
@@ -11787,7 +11782,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'in',
                 'name': 'attrVal',
                 'type': 'int8'
@@ -11815,7 +11809,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'in',
                 'name': 'attrVal',
                 'size': {
@@ -11951,7 +11944,6 @@ functions = {
                 'type': 'int32'
             },
             {
-                'coerced': True,
                 'direction': 'in',
                 'name': 'attrVal',
                 'type': 'uInt16'

--- a/source/codegen/metadata_mutation.py
+++ b/source/codegen/metadata_mutation.py
@@ -50,6 +50,20 @@ def mark_size_params(parameters):
             if mechanism == 'passed-in-by-ptr':
                 size_param['pointer'] = True
 
+
+# These are all of the coerced narrow numerics used in RFmx and DAQmx.
+# This will not account for other aliases of narrow numerics.
+# Note that params can also be marked coerced instead of updating this list.
+# uint8 is not included because it can be represented as a byte.
+KNOWN_COERCED_NARROW_NUMERIC_TYPES = ["int16", "uInt16", "int8"]
+
+def mark_coerced_narrow_numeric_parameters(parameters: dict) -> None:
+    for param in parameters:
+        param_type = common_helpers.get_underlying_type(param)
+        if param_type in KNOWN_COERCED_NARROW_NUMERIC_TYPES:
+            param["coerced"] = True
+
+
 def mark_non_proto_params(parameters):
     """Mark the parameters that shouldn't be included in the proto request message. 
        Their values should be derived from other sources in the service handlers."""


### PR DESCRIPTION
### What does this Pull Request accomplish?

Tag coerced narrow numerics in grpc-device `metadata_mutation` instead of requiring it to be set on all params in metadata.

Fixes [AB#1801143](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1801143).

### Why should this Pull Request be merged?

I noticed narrow numerics that we missed in RFmxInstr. This will be hard to keep track of in other RFmx personalities. The preexisting logic has a lot of duplicate and sketchy code that is not very helpful.

### What testing has been done?

Ran build with `coerced` tags removed from rfmx metadata and ensured only change to output was the coerced numerics in RFmxInstr.
