### PR TITLE
Use platform newlines in os_conditional_compile_block

### DIFF
--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -1,3 +1,4 @@
+import os
 import re
 from collections import defaultdict, namedtuple
 from typing import List, NamedTuple, Optional
@@ -665,9 +666,7 @@ def os_conditional_compile_block(config):
     """For use as a mako filter.
         That wraps a block of text in #if blocks based on the config's OS support."""
     def windows_only_block_impl(text):
-        return f"""#if defined(_MSC_VER)
-{text}#endif // defined(_MSC_VER)
-"""
+        return f"#if defined(_MSC_VER){os.linesep}{text}#endif // defined(_MSC_VER){os.linesep}"
     if windows_only:
         return lambda text : windows_only_block_impl(text)
     

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -666,6 +666,12 @@ def os_conditional_compile_block(config):
     """For use as a mako filter.
         That wraps a block of text in #if blocks based on the config's OS support."""
     def windows_only_block_impl(text):
+        # Pure python code, by default, will convert to platform-specific linesep characters on save.
+        # But mako uses the platform-specific linesep characters from the template file in the template string. 
+        # This is balanced by the newline="" args in template_helpers, which preserve newlines from the input.
+        #
+        # We use os.linesep here for consistency with makos template strings and to ensure that we don't
+        # get a mix of CRLF and LF on windows.
         return f"#if defined(_MSC_VER){os.linesep}{text}#endif // defined(_MSC_VER){os.linesep}"
     if windows_only:
         return lambda text : windows_only_block_impl(text)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Use platform newlines in `os_conditional_compile_block`.

### Why should this Pull Request be merged?

Building locally causes spurious (local-only) diffs in `register_all_services.cpp` because of the newlne difference.

### What testing has been done?

Re-generated `register_all_services.cpp` with-and-without this change and confirmed the spurious diffs are gone.
