### PR TITLE
Init _next_id in session_repository

### DIFF
--- a/source/server/session_repository.h
+++ b/source/server/session_repository.h
@@ -87,7 +87,7 @@ class SessionRepository {
   // These entries point at SessionInfo objects that are also contained in sessions_.
   NamedSessionMap named_sessions_;
   ReservationMap reservations_;
-  std::atomic<uint32_t> _next_id;
+  std::atomic<uint32_t> _next_id{0};
 };
 }  // namespace nidevice_grpc
 

--- a/source/tests/unit/session_repository_tests.cpp
+++ b/source/tests/unit/session_repository_tests.cpp
@@ -6,6 +6,10 @@ namespace ni {
 namespace tests {
 namespace unit {
 
+// Starting with session_id 1 isn't functionally important, but we want to start with
+// something intentional. NOT an uninitialized uint.
+constexpr auto EXPECTED_FIRST_SESSION_ID = 1;
+
 TEST(SessionRepositoryTests, AddSessionWithNonZeroStatus_ReturnsStatusAndDoesNotStoreSession)
 {
   nidevice_grpc::SessionRepository session_repository;
@@ -31,7 +35,7 @@ TEST(SessionRepositoryTests, AddSession_StoresSessionWithGivenId)
       session_id);
 
   EXPECT_EQ(status, 0);
-  EXPECT_NE(session_id, 0);
+  EXPECT_EQ(session_id, EXPECTED_FIRST_SESSION_ID);
   EXPECT_EQ(session_repository.access_session(session_id, ""), session_id);
 }
 
@@ -47,7 +51,7 @@ TEST(SessionRepositoryTests, AddNamedSession_StoresSessionWithGivenIdAndName)
       session_id);
 
   EXPECT_EQ(status, 0);
-  EXPECT_NE(session_id, 0);
+  EXPECT_EQ(session_id, EXPECTED_FIRST_SESSION_ID);
   EXPECT_EQ(session_repository.access_session(session_id, ""), session_id);
   EXPECT_EQ(session_repository.access_session(0, session_name), session_id);
 }


### PR DESCRIPTION
### What does this Pull Request accomplish?

Init `_next_id` in `session_repository` to `0`, this ensures that the first server allocated `session_id` is `1`.

Fixes #483 .

### Why should this Pull Request be merged?

Prior to C++20, `std::atomic`s will be created with uninitialized values of the underlying type. This was causing our server to use arbitrary `uint`s as the first `session_id` value.

### What testing has been done?

Ran and passed all unit tests.

Verifies that new assert criteria for `EXPECTED_FIRST_SESSION_ID` fails without fix.

Ran and passed some `RFmx` system tests.