### PR TITLE
Add support for GetNIRFSASessionArray to RFmxInstr

### DIFF
--- a/generated/nirfmxinstr/nirfmxinstr.proto
+++ b/generated/nirfmxinstr/nirfmxinstr.proto
@@ -968,12 +968,13 @@ message GetNIRFSASessionResponse {
 }
 
 message GetNIRFSASessionArrayRequest {
-  nidevice_grpc.Session instrument = 1;
+  repeated string session_names = 1;
+  nidevice_grpc.Session instrument = 2;
 }
 
 message GetNIRFSASessionArrayResponse {
   int32 status = 1;
-  repeated uint32 nirfsa_sessions = 2;
+  repeated nidevice_grpc.Session nirfsa_sessions = 2;
   int32 actual_array_size = 3;
 }
 

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -1756,44 +1756,6 @@ namespace nirfmxinstr_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiRFmxInstrService::GetNIRFSASessionArray(::grpc::ServerContext* context, const GetNIRFSASessionArrayRequest* request, GetNIRFSASessionArrayResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
-      int32 actual_array_size {};
-      while (true) {
-        auto status = library_->GetNIRFSASessionArray(instrument, nullptr, 0, &actual_array_size);
-        if (status < 0) {
-          response->set_status(status);
-          return ::grpc::Status::OK;
-        }
-        response->mutable_nirfsa_sessions()->Resize(actual_array_size, 0);
-        uInt32* nirfsa_sessions = reinterpret_cast<uInt32*>(response->mutable_nirfsa_sessions()->mutable_data());
-        auto array_size = actual_array_size;
-        status = library_->GetNIRFSASessionArray(instrument, nirfsa_sessions, array_size, &actual_array_size);
-        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
-          // buffer is now too small, try again
-          continue;
-        }
-        response->set_status(status);
-        if (status_ok(status)) {
-          response->mutable_nirfsa_sessions()->Resize(actual_array_size, 0);
-          response->set_actual_array_size(actual_array_size);
-        }
-        return ::grpc::Status::OK;
-      }
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiRFmxInstrService::GetSelfCalibrateLastDateAndTime(::grpc::ServerContext* context, const GetSelfCalibrateLastDateAndTimeRequest* request, GetSelfCalibrateLastDateAndTimeResponse* response)
   {
     if (context->IsCancelled()) {

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -609,6 +609,18 @@ def is_init_method(function_data):
     return function_data.get('init_method', False)
 
 
+def _get_session_output_param(function_data):
+    return next(
+        p 
+        for p in function_data["parameters"] 
+        if p["direction"] == "out" and "nidevice_grpc.Session" in p["grpc_type"]
+    )
+
+
+def is_init_array_method(function_data):
+    return is_init_method(function_data) and "repeated" in _get_session_output_param(function_data)["grpc_type"]
+
+
 def is_cross_driver_init_method(function_data: dict) -> bool:
     return (
         is_init_method(function_data) 

--- a/source/codegen/metadata/nirfmxinstr/functions.py
+++ b/source/codegen/metadata/nirfmxinstr/functions.py
@@ -1500,6 +1500,8 @@ functions = {
         'returns': 'int32'
     },
     'GetNIRFSASessionArray': {
+        'codegen_method': 'CustomCode',
+        'init_method': True,
         'parameters': [
             {
                 'direction': 'in',
@@ -1508,7 +1510,9 @@ functions = {
                 'type': 'niRFmxInstrHandle'
             },
             {
+                'cross_driver_session': 'ViSession',
                 'direction': 'out',
+                'grpc_type': 'repeated nidevice_grpc.Session',
                 'name': 'nirfsaSessions',
                 'size': {
                     'mechanism': 'ivi-dance-with-a-twist',

--- a/source/custom/nirfmxinstr_service.custom.cpp
+++ b/source/custom/nirfmxinstr_service.custom.cpp
@@ -1,2 +1,65 @@
+#include <nirfmxinstr/nirfmxinstr_service.h>
+#include <server/converters.h>
+
+#include <sstream>
+
 namespace nirfmxinstr_grpc {
+const auto kErrorReadBufferTooSmall = -200229;
+const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiRFmxInstrService::GetNIRFSASessionArray(::grpc::ServerContext* context, const GetNIRFSASessionArrayRequest* request, GetNIRFSASessionArrayResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto instrument_grpc_session = request->instrument();
+    auto instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+    auto initiating_session_id = session_repository_->access_session_id(instrument_grpc_session.id(), instrument_grpc_session.name());
+    auto nirfsa_sessions = std::vector<ViSession>{};
+
+    int32 array_size{};
+    int32 actual_array_size{};
+
+    while (true) {
+      auto status = library_->GetNIRFSASessionArray(instrument, nullptr, 0, &actual_array_size);
+      if (status < 0) {
+        response->set_status(status);
+        return ::grpc::Status::OK;
+      }
+      array_size = actual_array_size;
+      nirfsa_sessions.resize(array_size);
+      status = library_->GetNIRFSASessionArray(instrument, nirfsa_sessions.data(), array_size, &actual_array_size);
+      if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
+        // buffer is now too small, try again
+        continue;
+      }
+
+      if (request->session_names_size() != 0 && request->session_names_size() != array_size) {
+        std::stringstream stream;
+        stream << "Number of session_names must be zero or match actual array size (" << array_size << ").";
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, stream.str());
+      }
+      response->set_status(status);
+      if (status == 0) {
+        for (auto i = 0; i < array_size; ++i) {
+          auto init_lambda = [&]() {
+            return std::make_tuple(0, nirfsa_sessions[i]);
+          };
+          uint32_t session_id = 0;
+          const auto session_name = request->session_names_size() ? request->session_names(i) : "";
+          int status = vi_session_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_id, session_id);
+          auto session = response->add_nirfsa_sessions();
+          session->set_id(session_id);
+        }
+      }
+      return ::grpc::Status::OK;
+    }
+  }
+  catch (nidevice_grpc::LibraryLoadException& ex) {
+    return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+  }
+}
 }  // namespace nirfmxinstr_grpc

--- a/source/tests/system/nirfmxinstr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxinstr_driver_api_tests.cpp
@@ -89,7 +89,7 @@ InitializeResponse init(const client::StubPtr& stub, const std::string& model)
   return client::initialize(stub, "FakeDevice", options);
 }
 
-nirfsa_grpc::InitWithOptionsResponse init_rfsa(const std::unique_ptr<nirfsa_grpc::NiRFSA::Stub>& stub, const std::string& resource_name)
+nirfsa_grpc::InitWithOptionsResponse init_rfsa(const nirfsa_client::StubPtr& stub, const std::string& resource_name)
 {
   return nirfsa_client::init_with_options(stub, resource_name, false, false, "Simulate=1, DriverSetup=Model:5663E");
 }
@@ -99,6 +99,43 @@ nidevice_grpc::Session init_session(const client::StubPtr& stub, const std::stri
   auto response = init(stub, model);
   auto session = response.instrument();
   EXPECT_SUCCESS(response);
+  return session;
+}
+
+::grpc::Status get_rfsa_session_array(const client::StubPtr& stub, const nidevice_grpc::Session& session, const std::vector<std::string>& session_names, GetNIRFSASessionArrayResponse& response)
+{
+  auto request = GetNIRFSASessionArrayRequest{};
+
+  for (const auto& name : session_names) {
+    request.add_session_names(name);
+  }
+  request.mutable_instrument()->CopyFrom(session);
+  ::grpc::ClientContext context;
+  // Note: this can't use the experimental::client APIs, because those omit the session name
+  // for simplicity (for most cases that we test).
+  return stub->GetNIRFSASessionArray(&context, request, &response);
+}
+
+void EXPECT_GET_RFSA_ARRAY_WRONG_NUMBER_OF_SESSIONS_ERROR(const ::grpc::Status& actual_status, size_t expected_number_of_sessions)
+{
+  EXPECT_EQ(::grpc::INVALID_ARGUMENT, actual_status.error_code());
+  std::stringstream stream;
+  stream << "Number of session_names must be zero or match actual array size (" << expected_number_of_sessions << ").";
+  EXPECT_EQ(stream.str(), actual_status.error_message());
+}
+
+nidevice_grpc::Session init_from_rfsa_session_array(const client::StubPtr& stub, const nirfsa_client::StubPtr& rfsa_stub, const std::vector<std::string>& rfsa_resource_names)
+{
+  auto rfsa_sessions = std::vector<nidevice_grpc::Session>{};
+  for (const auto& resource_name : rfsa_resource_names) {
+    auto init_rfsa_response = init_rfsa(rfsa_stub, resource_name);
+    ni::tests::system::EXPECT_SUCCESS(init_rfsa_response);
+    rfsa_sessions.push_back(init_rfsa_response.vi());
+  }
+
+  auto init_response = client::initialize_from_nirfsa_session_array(stub, rfsa_sessions);
+  auto session = init_response.instrument();
+  ni::tests::system::EXPECT_SUCCESS(init_response);
   return session;
 }
 
@@ -127,6 +164,44 @@ TEST_F(NiRFmxInstrDriverApiTests, GetNIRFSASession_SelfTest_Succeeds)
   ni::tests::system::EXPECT_SUCCESS(nirfsa_client::self_test(rfsa_stub, rfsa_response.ni_rfsa_session()));
 }
 
+TEST_F(NiRFmxInstrDriverApiTests, GetNIRFSASessionArrayAnonymous_SelfTest_Succeeds)
+{
+  auto init_response = init(stub(), PXI_5663E);
+  auto session = init_response.instrument();
+  EXPECT_SUCCESS(session, init_response);
+
+  const auto get_rfsa_response = client::get_nirfsa_session_array(stub(), session);
+  EXPECT_SUCCESS(session, get_rfsa_response);
+
+  auto rfsa_stub = create_stub<nirfsa_grpc::NiRFSA>();
+  ni::tests::system::EXPECT_SUCCESS(nirfsa_client::self_test(rfsa_stub, get_rfsa_response.nirfsa_sessions()[0]));
+}
+
+TEST_F(NiRFmxInstrDriverApiTests, GetNIRFSASessionArray_SelfTest_Succeeds)
+{
+  constexpr auto RFSA_SESSION_NAME = "test_rfsa_session";
+  auto session = init_session(stub(), PXI_5663E);
+
+  auto get_rfsa_response = GetNIRFSASessionArrayResponse{};
+  const auto status = get_rfsa_session_array(stub(), session, {RFSA_SESSION_NAME}, get_rfsa_response);
+  EXPECT_SUCCESS(session, get_rfsa_response);
+
+  auto rfsa_stub = create_stub<nirfsa_grpc::NiRFSA>();
+  auto rfsa_named_session = nidevice_grpc::Session{};
+  rfsa_named_session.set_name(RFSA_SESSION_NAME);
+  ni::tests::system::EXPECT_SUCCESS(nirfsa_client::self_test(rfsa_stub, rfsa_named_session));
+}
+
+TEST_F(NiRFmxInstrDriverApiTests, GetNIRFSASessionArrayWithTooManyNames_Fails)
+{
+  auto session = init_session(stub(), PXI_5663E);
+
+  auto get_rfsa_response = GetNIRFSASessionArrayResponse{};
+  const auto status = get_rfsa_session_array(stub(), session, {"rfsa_1", "one_too_many"}, get_rfsa_response);
+
+  EXPECT_GET_RFSA_ARRAY_WRONG_NUMBER_OF_SESSIONS_ERROR(status, 1);
+}
+
 TEST_F(NiRFmxInstrDriverApiTests, InitializeFromNIRFSA_SelfCalibrate_Succeeds)
 {
   auto rfsa_stub = create_stub<nirfsa_grpc::NiRFSA>();
@@ -141,16 +216,60 @@ TEST_F(NiRFmxInstrDriverApiTests, InitializeFromNIRFSA_SelfCalibrate_Succeeds)
 
 TEST_F(NiRFmxInstrDriverApiTests, InitializeFromNIRFSAArray_SelfCalibrate_Succeeds)
 {
-  auto rfsa_stub = create_stub<nirfsa_grpc::NiRFSA>();
-  auto init_rfsa_response = init_rfsa(rfsa_stub, "Sim");
-  auto init_rfsa_response_2 = init_rfsa(rfsa_stub, "Sim2");
-  ni::tests::system::EXPECT_SUCCESS(init_rfsa_response);
-  ni::tests::system::EXPECT_SUCCESS(init_rfsa_response_2);
-  auto init_response = client::initialize_from_nirfsa_session_array(stub(), {init_rfsa_response.vi(), init_rfsa_response_2.vi()});
-  auto session = init_response.instrument();
-  EXPECT_SUCCESS(session, init_response);
+  const auto session = init_from_rfsa_session_array(stub(), create_stub<nirfsa_grpc::NiRFSA>(), {"Sim1", "Sim2"});
 
   EXPECT_SUCCESS(session, client::self_calibrate(stub(), session, "", 0));
+}
+
+TEST_F(NiRFmxInstrDriverApiTests, InitializeFromNIRFSAArray_GetNIRFSASessionArrayAnonymous_SelfTestEachSessionSucceeds)
+{
+  const auto rfsa_stub = create_stub<nirfsa_grpc::NiRFSA>();
+  const auto session = init_from_rfsa_session_array(stub(), rfsa_stub, {"Sim1", "Sim2"});
+
+  const auto get_rfsa_response = EXPECT_SUCCESS(session, client::get_nirfsa_session_array(stub(), session));
+
+  EXPECT_EQ(2, get_rfsa_response.nirfsa_sessions_size());
+  for (const auto& session : get_rfsa_response.nirfsa_sessions()) {
+    ni::tests::system::EXPECT_SUCCESS(nirfsa_client::self_test(rfsa_stub, session));
+  }
+}
+
+TEST_F(NiRFmxInstrDriverApiTests, InitializeFromTwoRFSASessions_GetNIRFSASessionArrayWithTooFewNames_ReturnsBadStatus)
+{
+  const auto session = init_from_rfsa_session_array(stub(), create_stub<nirfsa_grpc::NiRFSA>(), {"Sim1", "Sim2"});
+
+  auto get_rfsa_response = GetNIRFSASessionArrayResponse{};
+  const auto status = get_rfsa_session_array(stub(), session, {"rfsa_1"}, get_rfsa_response);
+
+  EXPECT_GET_RFSA_ARRAY_WRONG_NUMBER_OF_SESSIONS_ERROR(status, 2);
+}
+
+TEST_F(NiRFmxInstrDriverApiTests, InitializeFromTwoRFSASessions_GetNIRFSASessionArrayWithTooManyNames_ReturnsBadStatus)
+{
+  const auto session = init_from_rfsa_session_array(stub(), create_stub<nirfsa_grpc::NiRFSA>(), {"Sim1", "Sim2"});
+
+  auto get_rfsa_response = GetNIRFSASessionArrayResponse{};
+  const auto status = get_rfsa_session_array(stub(), session, {"rfsa_1", "rfsa_2", "rfsa_one_too_many"}, get_rfsa_response);
+
+  EXPECT_GET_RFSA_ARRAY_WRONG_NUMBER_OF_SESSIONS_ERROR(status, 2);
+}
+
+TEST_F(NiRFmxInstrDriverApiTests, InitializeFromTwoRFSASessions_GetNIRFSAArrayNamed_ReturnsTwoSessions)
+{
+  const auto RFSA_SESSION_NAMES = std::vector<std::string>{"rfsa_1", "rfsa_2"};
+  const auto rfsa_stub = create_stub<nirfsa_grpc::NiRFSA>();
+  const auto session = init_from_rfsa_session_array(stub(), rfsa_stub, {"Sim1", "Sim2"});
+
+  auto get_rfsa_response = GetNIRFSASessionArrayResponse{};
+  const auto status = get_rfsa_session_array(stub(), session, RFSA_SESSION_NAMES, get_rfsa_response);
+
+  EXPECT_EQ(::grpc::OK, status.error_code());
+  EXPECT_EQ(2, get_rfsa_response.nirfsa_sessions_size());
+  for (const auto& session_name : RFSA_SESSION_NAMES) {
+    auto session = nidevice_grpc::Session{};
+    session.set_name(session_name);
+    ni::tests::system::EXPECT_SUCCESS(nirfsa_client::self_test(rfsa_stub, session));
+  }
 }
 
 TEST_F(NiRFmxInstrDriverApiTests, NoActiveList_GetListNames_ReturnsEmptyLists)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add support for GetNIRFSASessionArray to RFmxInstr.

Fixes AB#1781503.

### Why should this Pull Request be merged?

Enables accessing multiple RFSA sessions from a grpc-device RFmx session and giving those sessions a name.

### What testing has been done?

Ran and passed all RFmxInstr tests.