### PR TITLE
Exclude cross-driver sessions from reverse lookup

### DIFF
--- a/source/server/session_repository.h
+++ b/source/server/session_repository.h
@@ -19,6 +19,7 @@ namespace nidevice_grpc {
 class SessionRepository {
  public:
   SessionRepository();
+  ~SessionRepository();
 
   typedef std::function<int32_t()> InitFunc;
   typedef std::function<void(uint32_t)> CleanupSessionFunc;
@@ -36,7 +37,7 @@ class SessionRepository {
       ::grpc::Status& status);
   bool is_reserved_by_client(const std::string& reservation_id, const std::string& client_id);
   bool unreserve(const std::string& reservation_id, const std::string& client_id);
-  bool reset_server();
+  bool reset_server(bool cleanup=true);
 
  private:
   struct ReservationInfo {
@@ -76,7 +77,7 @@ class SessionRepository {
 
   std::shared_ptr<ReservationInfo> find_or_create_reservation(const std::string& reservation_id, const std::string& client_id);
   void clear_reservations();
-  bool close_sessions();
+  bool close_sessions(bool cleanup);
   void cleanup_session(const std::shared_ptr<SessionInfo>& session_info);
   bool release_reservation(const ReservationInfo* reservation_info);
   uint32_t next_id() { return ++_next_id; }

--- a/source/server/session_resource_repository.h
+++ b/source/server/session_resource_repository.h
@@ -91,12 +91,13 @@ int SessionResourceRepository<TResourceHandle>::add_session(
   uint32_t session_from_repository = 0;
 
   auto session_creator = SessionResourceCreator(init_func);
+  auto resource_map = resource_map_;
   auto status = session_repository_->add_session(
       session_name,
       [&]() { return session_creator.init_resource_handle(); },
       // By val capture to keep cleanup_func in memory.
-      [=](uint32_t id) {
-        auto handle = resource_map_->remove_session_id(id);
+      [resource_map, cleanup_func](uint32_t id) {
+        auto handle = resource_map->remove_session_id(id);
         return cleanup_func(handle);
       },
       session_from_repository);

--- a/source/server/session_resource_repository.h
+++ b/source/server/session_resource_repository.h
@@ -237,8 +237,8 @@ TResourceHandle SessionResourceRepository<TResourceHandle>::ResourceMap::remove_
 {
   MapLock lock(map_mutex_);
   auto handle = get_handle(session_id);
-  map_.erase(session_id);
   if (handle != TResourceHandle()) {
+    map_.erase(session_id);
     reverse_map_.erase(handle);
   }
   return handle;

--- a/source/server/session_resource_repository.h
+++ b/source/server/session_resource_repository.h
@@ -237,8 +237,8 @@ TResourceHandle SessionResourceRepository<TResourceHandle>::ResourceMap::remove_
 {
   MapLock lock(map_mutex_);
   auto handle = get_handle(session_id);
+  map_.erase(session_id);
   if (handle != TResourceHandle()) {
-    map_.erase(session_id);
     reverse_map_.erase(handle);
   }
   return handle;

--- a/source/tests/unit/session_resource_repository_tests.cpp
+++ b/source/tests/unit/session_resource_repository_tests.cpp
@@ -338,6 +338,35 @@ TEST(SessionResourceRepositoryTests, AddDependentSession_DependentSessionIsNotRe
   EXPECT_EQ(0, resource_repository.resolve_session_id(DEPENDENT_SESSION_HANDLE));
 }
 
+TEST(SessionResourceRepositoryTests, AddDependentSession_RemoveDependentSession_SessionIsRemoved)
+{
+  constexpr auto DEPENDENT_SESSION_HANDLE = 1234U;
+  constexpr auto INITIATING_SESSION_HANDLE = 5678U;
+  SessionRepository repository;
+  SessionResourceRepository<uint32_t> resource_repository(&repository);
+  const auto initiating_session_id = simple_add_session(resource_repository, "initiating_session", INITIATING_SESSION_HANDLE);
+  const auto dependent_session_id = simple_add_dependent_session(resource_repository, "dependent_session", initiating_session_id, DEPENDENT_SESSION_HANDLE);
+
+  resource_repository.remove_session(dependent_session_id, "");
+
+  EXPECT_EQ(0, resource_repository.access_session(dependent_session_id, ""));
+}
+
+TEST(SessionResourceRepositoryTests, AddDependentSession_RemoveInitiatingSession_BothSessionsAreRemoved)
+{
+  constexpr auto DEPENDENT_SESSION_HANDLE = 1234U;
+  constexpr auto INITIATING_SESSION_HANDLE = 5678U;
+  SessionRepository repository;
+  SessionResourceRepository<uint32_t> resource_repository(&repository);
+  const auto initiating_session_id = simple_add_session(resource_repository, "initiating_session", INITIATING_SESSION_HANDLE);
+  const auto dependent_session_id = simple_add_dependent_session(resource_repository, "dependent_session", initiating_session_id, DEPENDENT_SESSION_HANDLE);
+
+  resource_repository.remove_session(initiating_session_id, "");
+
+  EXPECT_EQ(0, resource_repository.access_session(initiating_session_id, ""));
+  EXPECT_EQ(0, resource_repository.access_session(dependent_session_id, ""));
+}
+
 }  // namespace unit
 }  // namespace tests
 }  // namespace ni

--- a/source/tests/unit/session_resource_repository_tests.cpp
+++ b/source/tests/unit/session_resource_repository_tests.cpp
@@ -275,6 +275,69 @@ TEST(SessionResourceRepositoryTests, AddSessionResource_AddSessionWithSameNameFr
   EXPECT_EQ(kNoSession, second_session_id);
   EXPECT_NE(kNoError, result);
 }
+
+template <typename TResource>
+uint32_t simple_add_session(SessionResourceRepository<TResource> resource_repository, const std::string& session_name, TResource new_resource_handle)
+{
+  auto session_id = uint32_t{};
+  const auto status = resource_repository.add_session(
+      session_name,
+      [new_resource_handle]() { return std::make_tuple(0, new_resource_handle); },
+      [](TResource handle) {},
+      session_id);
+  EXPECT_EQ(0, status);
+  return session_id;
+}
+
+template <typename TResource>
+uint32_t simple_add_dependent_session(
+    SessionResourceRepository<TResource> resource_repository,
+    const std::string& session_name,
+    uint32_t initiating_session_id,
+    TResource new_resource_handle)
+{
+  auto session_id = uint32_t{};
+  const auto status = resource_repository.add_dependent_session(
+      session_name,
+      [new_resource_handle]() { return std::make_tuple(0, new_resource_handle); },
+      initiating_session_id,
+      session_id);
+  EXPECT_EQ(0, status);
+  return session_id;
+}
+
+// Note: this is the key functional criteria. Make sure that dependent sessions can't "overwrite" primary sessions in the reverse lookup.
+// This ensures that any reverse lookups are consistently scoped to the owning service's lifetime management/etc.
+TEST(SessionResourceRepositoryTests, SessionAlreadyInResourceRepository_AddDependentSessionWithSameHandle_ResolveSessionByHandleGivesOriginalSession)
+{
+  constexpr auto DUPE_SESSION_HANDLE = 1234U;
+  constexpr auto INITIATING_SESSION_HANDLE = 5678U;
+  auto repository = SessionRepository{};
+  auto resource_repository = SessionResourceRepository<uint32_t>(&repository);
+  const auto initiating_session_id = simple_add_session(resource_repository, "initiating_session", INITIATING_SESSION_HANDLE);
+  const auto primary_with_dupe_session_id = simple_add_session(resource_repository, "primary_session_with_dupe_handle", DUPE_SESSION_HANDLE);
+
+  const auto dupe_dependent_session_id = simple_add_dependent_session(resource_repository, "dependent_session", initiating_session_id, DUPE_SESSION_HANDLE);
+
+  EXPECT_EQ(primary_with_dupe_session_id, resource_repository.resolve_session_id(DUPE_SESSION_HANDLE));
+}
+
+// Note: This is how the above criteria (SessionAlreadyInResourceRepository_AddDependentSessionWithSameHandle_ResolveSessionByHandleGivesOriginalSession)
+// is implemented.
+// If there is no dupe primary session, it's probably OK to include the dependent session in the reverse lookup. But it's simpler to leave it out
+// completely. This also gives us more wiggle room to change behavior in the future because we are exposing less functionality.
+TEST(SessionResourceRepositoryTests, AddDependentSession_DependentSessionIsNotResolvableByHandle)
+{
+  constexpr auto DEPENDENT_SESSION_HANDLE = 1234U;
+  constexpr auto INITIATING_SESSION_HANDLE = 5678U;
+  auto repository = SessionRepository{};
+  auto resource_repository = SessionResourceRepository<uint32_t>(&repository);
+  const auto initiating_session_id = simple_add_session(resource_repository, "initiating_session", INITIATING_SESSION_HANDLE);
+  const auto dupe_dependent_session_id = simple_add_dependent_session(resource_repository, "dependent_session", initiating_session_id, DEPENDENT_SESSION_HANDLE);
+
+  EXPECT_EQ(0, resource_repository.resolve_session_id(DEPENDENT_SESSION_HANDLE));
+}
+
 }  // namespace unit
 }  // namespace tests
 }  // namespace ni

--- a/source/tests/unit/session_resource_repository_tests.cpp
+++ b/source/tests/unit/session_resource_repository_tests.cpp
@@ -312,8 +312,8 @@ TEST(SessionResourceRepositoryTests, SessionAlreadyInResourceRepository_AddDepen
 {
   constexpr auto DUPE_SESSION_HANDLE = 1234U;
   constexpr auto INITIATING_SESSION_HANDLE = 5678U;
-  auto repository = SessionRepository{};
-  auto resource_repository = SessionResourceRepository<uint32_t>(&repository);
+  SessionRepository repository;
+  SessionResourceRepository<uint32_t> resource_repository(&repository);
   const auto initiating_session_id = simple_add_session(resource_repository, "initiating_session", INITIATING_SESSION_HANDLE);
   const auto primary_with_dupe_session_id = simple_add_session(resource_repository, "primary_session_with_dupe_handle", DUPE_SESSION_HANDLE);
 
@@ -330,8 +330,8 @@ TEST(SessionResourceRepositoryTests, AddDependentSession_DependentSessionIsNotRe
 {
   constexpr auto DEPENDENT_SESSION_HANDLE = 1234U;
   constexpr auto INITIATING_SESSION_HANDLE = 5678U;
-  auto repository = SessionRepository{};
-  auto resource_repository = SessionResourceRepository<uint32_t>(&repository);
+  SessionRepository repository;
+  SessionResourceRepository<uint32_t> resource_repository(&repository);
   const auto initiating_session_id = simple_add_session(resource_repository, "initiating_session", INITIATING_SESSION_HANDLE);
   const auto dupe_dependent_session_id = simple_add_dependent_session(resource_repository, "dependent_session", initiating_session_id, DEPENDENT_SESSION_HANDLE);
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Exclude cross-driver sessions from reverse lookup.

Fixes [AB#1807465](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1807465)

### Why should this Pull Request be merged?

If cross-driver sessions can be added to the reverse lookup, it can introduce ambiguity about which session should be returned from reverse lookup methods if there are multiple sessions with the same resource handle. If we exclude cross-driver sessions from reverse lookup, only primary sessions can be returned.

Methods that reverse lookup sessions are very rare. In RFSA, for example, there is a `GetAttributeViSession` method, but no actual public `ViSession` attributes. We could attempt more complicated features that make it possible to access cross-driver sessions under some conditions. But this provides little value. By restricting reverse lookups completely, we have more options to change/add behavior in the future.

### What testing has been done?

Ran and passed all RFmx and RFSA test.
