### PR TITLE
Add some session and cross-driver session test coverage for RFmx NR.

### DIFF
--- a/generated/nirfmxnr/nirfmxnr.proto
+++ b/generated/nirfmxnr/nirfmxnr.proto
@@ -2583,7 +2583,7 @@ message InitializeResponse {
 
 message InitializeFromNIRFSASessionRequest {
   string session_name = 1;
-  uint32 nirfsa_session = 2;
+  nidevice_grpc.Session nirfsa_session = 2;
 }
 
 message InitializeFromNIRFSASessionResponse {

--- a/generated/nirfmxnr/nirfmxnr_client.cpp
+++ b/generated/nirfmxnr/nirfmxnr_client.cpp
@@ -1904,12 +1904,12 @@ initialize(const StubPtr& stub, const pb::string& resource_name, const pb::strin
 }
 
 InitializeFromNIRFSASessionResponse
-initialize_from_nirfsa_session(const StubPtr& stub, const pb::uint32& nirfsa_session)
+initialize_from_nirfsa_session(const StubPtr& stub, const nidevice_grpc::Session& nirfsa_session)
 {
   ::grpc::ClientContext context;
 
   auto request = InitializeFromNIRFSASessionRequest{};
-  request.set_nirfsa_session(nirfsa_session);
+  request.mutable_nirfsa_session()->CopyFrom(nirfsa_session);
 
   auto response = InitializeFromNIRFSASessionResponse{};
 

--- a/generated/nirfmxnr/nirfmxnr_client.h
+++ b/generated/nirfmxnr/nirfmxnr_client.h
@@ -118,7 +118,7 @@ GetAttributeU8ArrayResponse get_attribute_u8_array(const StubPtr& stub, const ni
 GetErrorResponse get_error(const StubPtr& stub, const nidevice_grpc::Session& instrument);
 GetErrorStringResponse get_error_string(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::int32& error_code);
 InitializeResponse initialize(const StubPtr& stub, const pb::string& resource_name, const pb::string& option_string);
-InitializeFromNIRFSASessionResponse initialize_from_nirfsa_session(const StubPtr& stub, const pb::uint32& nirfsa_session);
+InitializeFromNIRFSASessionResponse initialize_from_nirfsa_session(const StubPtr& stub, const nidevice_grpc::Session& nirfsa_session);
 InitiateResponse initiate(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const pb::string& result_name);
 ModAccAutoLevelResponse mod_acc_auto_level(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const double& timeout);
 ModAccCfgMeasurementModeResponse mod_acc_cfg_measurement_mode(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const simple_variant<ModAccMeasurementMode, pb::int32>& measurement_mode);

--- a/generated/nirfmxnr/nirfmxnr_service.cpp
+++ b/generated/nirfmxnr/nirfmxnr_service.cpp
@@ -26,9 +26,11 @@ namespace nirfmxnr_grpc {
   NiRFmxNRService::NiRFmxNRService(
       NiRFmxNRLibraryInterface* library,
       ResourceRepositorySharedPtr session_repository, 
+      ViSessionResourceRepositorySharedPtr vi_session_resource_repository,
       const NiRFmxNRFeatureToggles& feature_toggles)
       : library_(library),
       session_repository_(session_repository),
+      vi_session_resource_repository_(vi_session_resource_repository),
       feature_toggles_(feature_toggles)
   {
   }
@@ -3321,7 +3323,8 @@ namespace nirfmxnr_grpc {
       return ::grpc::Status::CANCELLED;
     }
     try {
-      uInt32 nirfsa_session = request->nirfsa_session();
+      auto nirfsa_session_grpc_session = request->nirfsa_session();
+      uInt32 nirfsa_session = vi_session_resource_repository_->access_session(nirfsa_session_grpc_session.id(), nirfsa_session_grpc_session.name());
 
       auto init_lambda = [&] () {
         niRFmxInstrHandle instrument;

--- a/generated/nirfmxnr/nirfmxnr_service.h
+++ b/generated/nirfmxnr/nirfmxnr_service.h
@@ -34,10 +34,12 @@ struct NiRFmxNRFeatureToggles
 class NiRFmxNRService final : public NiRFmxNR::Service {
 public:
   using ResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<niRFmxInstrHandle>>;
+  using ViSessionResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViSession>>;
 
   NiRFmxNRService(
     NiRFmxNRLibraryInterface* library,
     ResourceRepositorySharedPtr session_repository,
+    ViSessionResourceRepositorySharedPtr vi_session_resource_repository,
     const NiRFmxNRFeatureToggles& feature_toggles = {});
   virtual ~NiRFmxNRService();
   
@@ -261,6 +263,7 @@ public:
 private:
   NiRFmxNRLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
+  ViSessionResourceRepositorySharedPtr vi_session_resource_repository_;
   std::map<std::int32_t, std::string> frequencyreferencesource_input_map_ { {1, "OnboardClock"},{2, "RefIn"},{3, "PXI_Clk"},{4, "ClkIn"},{5, "RefIn2"},{6, "PXI_Clk_Master"}, };
   std::map<std::string, std::int32_t> frequencyreferencesource_output_map_ { {"OnboardClock", 1},{"RefIn", 2},{"PXI_Clk", 3},{"ClkIn", 4},{"RefIn2", 5},{"PXI_Clk_Master", 6}, };
 

--- a/generated/nirfmxnr/nirfmxnr_service_registrar.cpp
+++ b/generated/nirfmxnr/nirfmxnr_service_registrar.cpp
@@ -17,11 +17,13 @@ namespace {
 struct LibraryAndService {
   LibraryAndService(
     const std::shared_ptr<nidevice_grpc::SessionResourceRepository<niRFmxInstrHandle>>& resource_repository,
+    const std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViSession>>& vi_session_resource_repository,
     const NiRFmxNRFeatureToggles& feature_toggles) 
       : library(), 
       service(
         &library, 
         resource_repository, 
+        vi_session_resource_repository,
         feature_toggles) {
   }
   NiRFmxNRLibrary library;
@@ -32,6 +34,7 @@ struct LibraryAndService {
 std::shared_ptr<void> register_service(
   grpc::ServerBuilder& builder, 
   const std::shared_ptr<nidevice_grpc::SessionResourceRepository<niRFmxInstrHandle>>& resource_repository,
+  const std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViSession>>& vi_session_resource_repository,
   const nidevice_grpc::FeatureToggles& feature_toggles)
 {
   auto toggles = NiRFmxNRFeatureToggles(feature_toggles);
@@ -40,6 +43,7 @@ std::shared_ptr<void> register_service(
   {
     auto library_and_service_ptr = std::make_shared<LibraryAndService>(
       resource_repository,
+      vi_session_resource_repository,
       toggles);
     auto& service = library_and_service_ptr->service;
     builder.RegisterService(&service);

--- a/generated/nirfmxnr/nirfmxnr_service_registrar.h
+++ b/generated/nirfmxnr/nirfmxnr_service_registrar.h
@@ -23,6 +23,7 @@ using CodeReadiness = nidevice_grpc::FeatureToggles::CodeReadiness;
 std::shared_ptr<void> register_service(
   grpc::ServerBuilder& server_builder, 
   const std::shared_ptr<nidevice_grpc::SessionResourceRepository<niRFmxInstrHandle>>& resource_repository,
+  const std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViSession>>& vi_session_resource_repository,
   const nidevice_grpc::FeatureToggles& feature_toggles);
 
 } // nirfmxnr_grpc

--- a/generated/register_all_services.cpp
+++ b/generated/register_all_services.cpp
@@ -113,6 +113,7 @@ std::shared_ptr<void> register_all_services(
     nirfmxnr_grpc::register_service(
       server_builder, 
       ni_r_fmx_instr_handle_repository,
+      vi_session_repository,
       feature_toggles));
 #endif // defined(_MSC_VER)
 #if defined(_MSC_VER)

--- a/source/codegen/metadata/nirfmxnr/functions.py
+++ b/source/codegen/metadata/nirfmxnr/functions.py
@@ -2951,7 +2951,9 @@ functions = {
         'init_method': True,
         'parameters': [
             {
+                'cross_driver_session': 'ViSession',
                 'direction': 'in',
+                'grpc_type': 'nidevice_grpc.Session',
                 'name': 'nirfsaSession',
                 'type': 'uInt32'
             },

--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -44,10 +44,17 @@ class NiRFmxNRDriverApiTests : public Test {
     return stub_;
   }
 
+  void check_error(const nidevice_grpc::Session& session)
+  {
+    auto response = client::get_error(stub(), session);
+    EXPECT_EQ("", std::string(response.error_description().c_str()));
+  }
+
   template <typename TResponse>
   void EXPECT_SUCCESS(const nidevice_grpc::Session& session, const TResponse& response)
   {
     ni::tests::system::EXPECT_SUCCESS(response);
+    check_error(session);
   }
 
   template <typename TService>
@@ -83,7 +90,7 @@ TEST_F(NiRFmxNRDriverApiTests, Init_Close_Succeeds)
   ni::tests::system::EXPECT_SUCCESS(close_response);
 }
 
-TEST_F(NiRFmxNRDriverApiTests, InitializeFromNIRFSA_SelfCalibrate_Succeeds)
+TEST_F(NiRFmxNRDriverApiTests, InitializeFromNIRFSA_Close_Succeeds)
 {
   auto rfsa_stub = create_stub<nirfsa_grpc::NiRFSA>();
   auto init_rfsa_response = init_rfsa(rfsa_stub, "Sim");
@@ -92,7 +99,9 @@ TEST_F(NiRFmxNRDriverApiTests, InitializeFromNIRFSA_SelfCalibrate_Succeeds)
   auto session = init_response.instrument();
   EXPECT_SUCCESS(session, init_response);
 
-  EXPECT_SUCCESS(session, client::close(stub(), session, false));
+  auto close_response = client::close(stub(), session, 0);
+
+  ni::tests::system::EXPECT_SUCCESS(close_response);
 }
 
 }  // namespace

--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -3,10 +3,12 @@
 #include "device_server.h"
 #include "niRFmxNR.h"
 #include "nirfmxnr/nirfmxnr_client.h"
+#include "nirfsa/nirfsa_client.h"
 
 using namespace ::testing;
 using namespace nirfmxnr_grpc;
 namespace client = nirfmxnr_grpc::experimental::client;
+namespace nirfsa_client = nirfsa_grpc::experimental::client;
 
 namespace ni {
 namespace tests {
@@ -65,6 +67,11 @@ InitializeResponse init(const client::StubPtr& stub, const std::string& model)
   return client::initialize(stub, "FakeDevice", options);
 }
 
+nirfsa_grpc::InitWithOptionsResponse init_rfsa(const nirfsa_client::StubPtr& stub, const std::string& resource_name)
+{
+  return nirfsa_client::init_with_options(stub, resource_name, false, false, "Simulate=1, DriverSetup=Model:5663E");
+}
+
 TEST_F(NiRFmxNRDriverApiTests, Init_Close_Succeeds)
 {
   auto init_response = init(stub(), PXI_5663E);
@@ -74,6 +81,18 @@ TEST_F(NiRFmxNRDriverApiTests, Init_Close_Succeeds)
   auto close_response = client::close(stub(), session, 0);
 
   ni::tests::system::EXPECT_SUCCESS(close_response);
+}
+
+TEST_F(NiRFmxNRDriverApiTests, InitializeFromNIRFSA_SelfCalibrate_Succeeds)
+{
+  auto rfsa_stub = create_stub<nirfsa_grpc::NiRFSA>();
+  auto init_rfsa_response = init_rfsa(rfsa_stub, "Sim");
+  ni::tests::system::EXPECT_SUCCESS(init_rfsa_response);
+  auto init_response = client::initialize_from_nirfsa_session(stub(), init_rfsa_response.vi());
+  auto session = init_response.instrument();
+  EXPECT_SUCCESS(session, init_response);
+
+  EXPECT_SUCCESS(session, client::close(stub(), session, false));
 }
 
 }  // namespace

--- a/source/tests/system/nirfmxnr_session_tests.cpp
+++ b/source/tests/system/nirfmxnr_session_tests.cpp
@@ -132,7 +132,7 @@ TEST_F(NiRFmxNRSessionTest, TwoInitializedSessionsOnSameDevice_CloseSessions_Clo
   EXPECT_EQ(0, close_response_two.status());
 }
 
-TEST_F(NiRFmxNRSessionTest, InitializeTwiceWithSameSessionNameOnSameDevice_CloseSessionTwice_SecondCloseReturnsInvalidSessionError)
+TEST_F(NiRFmxNRSessionTest, CallInitializeTwiceWithSameSessionNameOnSameDevice_CloseSessionTwice_SecondCloseReturnsInvalidSessionError)
 {
   rfmxnr::InitializeResponse init_response_one, init_response_two;
   ::grpc::Status status_one = call_initialize(kRFmxNRTestRsrc, kRFmxNROptionsString, kRFmxNRTestSessionOne, &init_response_one);

--- a/source/tests/system/nirfmxnr_session_tests.cpp
+++ b/source/tests/system/nirfmxnr_session_tests.cpp
@@ -118,6 +118,7 @@ TEST_F(NiRFmxNRSessionTest, TwoInitializedSessionsOnSameDevice_CloseSessions_Clo
   EXPECT_EQ(0, init_response_one.status());
   EXPECT_TRUE(status_two.ok());
   EXPECT_EQ(0, init_response_two.status());
+  EXPECT_NE(init_response_one.instrument().id(), init_response_two.instrument().id());
 
   nidevice_grpc::Session session_one = init_response_one.instrument();
   nidevice_grpc::Session session_two = init_response_two.instrument();
@@ -129,6 +130,31 @@ TEST_F(NiRFmxNRSessionTest, TwoInitializedSessionsOnSameDevice_CloseSessions_Clo
   EXPECT_EQ(0, close_response_one.status());
   EXPECT_TRUE(status_two.ok());
   EXPECT_EQ(0, close_response_two.status());
+}
+
+TEST_F(NiRFmxNRSessionTest, InitializeTwiceWithSameSessionNameOnSameDevice_CloseSessionTwice_SecondCloseReturnsInvalidSessionError)
+{
+  rfmxnr::InitializeResponse init_response_one, init_response_two;
+  ::grpc::Status status_one = call_initialize(kRFmxNRTestRsrc, kRFmxNROptionsString, kRFmxNRTestSessionOne, &init_response_one);
+  ::grpc::Status status_two = call_initialize(kRFmxNRTestRsrc, kRFmxNROptionsString, kRFmxNRTestSessionOne, &init_response_two);
+  EXPECT_TRUE(status_one.ok());
+  EXPECT_EQ(0, init_response_one.status());
+  EXPECT_TRUE(status_two.ok());
+  EXPECT_EQ(0, init_response_two.status());
+  EXPECT_EQ(init_response_one.instrument().id(), init_response_two.instrument().id());
+
+  nidevice_grpc::Session session_one = init_response_one.instrument();
+  nidevice_grpc::Session session_two = init_response_two.instrument();
+  rfmxnr::CloseResponse close_response_one, close_response_two;
+  status_one = call_close(session_one, nirfmxnr_grpc::Boolean::BOOLEAN_FALSE, &close_response_one);
+  status_two = call_close(session_two, nirfmxnr_grpc::Boolean::BOOLEAN_FALSE, &close_response_two);
+
+  EXPECT_TRUE(status_one.ok());
+  EXPECT_EQ(0, close_response_one.status());
+  EXPECT_TRUE(status_two.ok());
+  // Initialize was only called once in the driver since the second init call to the service found the Session by the same name and returned it.
+  // Therefore if we try to close the session again the driver will respond that it's not a valid session (it's already been closed).
+  EXPECT_EQ(kInvalidRFmxNRSession, close_response_two.status());
 }
 
 TEST_F(NiRFmxNRSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Fixes NR metadata to denote `InitializeFromNIRFSASession`'s `nirfsaSession` parameter as a cross driver session param.
- Adds test coverage for the one cross-driver init function and adds an additional session test.

### Why should this Pull Request be merged?

We want to be confident in the session management and cross-driver session handling for RFmx NR.
Fixes [AB#1794284](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1794284)

### What testing has been done?

NR system-level tests (including new ones) pass.

### Follow-up work
- Get updated metadata generating in scrapigen
  - I'll update BT and WLAN at the same time
  - Done with [this PR](https://github.com/ni/grpc-device-scrapigen/pull/28) in scrapigen
- Make similar test additions for BT and WLAN after their cross-driver init methods are in grpc-device
  - Will be handled with [AB#1794516](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1794516) and [AB#1814907](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1814907)
