### PR TITLE
Add cross-driver and regular session tests for WLAN.

### DIFF
--- a/source/tests/system/nirfmxwlan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxwlan_driver_api_tests.cpp
@@ -3,10 +3,12 @@
 #include "device_server.h"
 #include "niRFmxWLAN.h"
 #include "nirfmxwlan/nirfmxwlan_client.h"
+#include "nirfsa/nirfsa_client.h"
 
 using namespace ::testing;
 using namespace nirfmxwlan_grpc;
 namespace client = nirfmxwlan_grpc::experimental::client;
+namespace nirfsa_client = nirfsa_grpc::experimental::client;
 
 namespace ni {
 namespace tests {
@@ -42,10 +44,17 @@ class NiRFmxWLANDriverApiTests : public Test {
     return stub_;
   }
 
+  void check_error(const nidevice_grpc::Session& session)
+  {
+    auto response = client::get_error(stub(), session);
+    EXPECT_EQ("", std::string(response.error_description().c_str()));
+  }
+
   template <typename TResponse>
   void EXPECT_SUCCESS(const nidevice_grpc::Session& session, const TResponse& response)
   {
     ni::tests::system::EXPECT_SUCCESS(response);
+    check_error(session);
   }
 
   template <typename TService>
@@ -65,9 +74,28 @@ InitializeResponse init(const client::StubPtr& stub, const std::string& model)
   return client::initialize(stub, "FakeDevice", options);
 }
 
+nirfsa_grpc::InitWithOptionsResponse init_rfsa(const nirfsa_client::StubPtr& stub, const std::string& resource_name)
+{
+  return nirfsa_client::init_with_options(stub, resource_name, false, false, "Simulate=1, DriverSetup=Model:5663E");
+}
+
 TEST_F(NiRFmxWLANDriverApiTests, Init_Close_Succeeds)
 {
   auto init_response = init(stub(), PXI_5663E);
+  auto session = init_response.instrument();
+  EXPECT_SUCCESS(session, init_response);
+
+  auto close_response = client::close(stub(), session, 0);
+
+  ni::tests::system::EXPECT_SUCCESS(close_response);
+}
+
+TEST_F(NiRFmxWLANDriverApiTests, InitializeFromNIRFSA_Close_Succeeds)
+{
+  auto rfsa_stub = create_stub<nirfsa_grpc::NiRFSA>();
+  auto init_rfsa_response = init_rfsa(rfsa_stub, "Sim");
+  ni::tests::system::EXPECT_SUCCESS(init_rfsa_response);
+  auto init_response = client::initialize_from_nirfsa_session(stub(), init_rfsa_response.vi());
   auto session = init_response.instrument();
   EXPECT_SUCCESS(session, init_response);
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Adds test coverage for the one cross-driver init function for WLAN and adds an additional session test
- Fixes [AB#1794516](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1794516)

### Why should this Pull Request be merged?

We want to be confident in the WLAN personality's cross-driver session method and that the session management is working as expected.

### What testing has been done?

WLAN system level tests are passing:

![image](https://user-images.githubusercontent.com/77176215/151610778-7045cb11-8b24-45c0-95c9-b4aef0d696f6.png)
