### PR TITLE
Fix area path in sync_github_issues_to_azdo.yml

### DIFF
--- a/.github/workflows/sync_github_issues_to_azdo.yml
+++ b/.github/workflows/sync_github_issues_to_azdo.yml
@@ -15,7 +15,7 @@ jobs:
           github_token: "${{ secrets.GH_REPO_TOKEN }}"
           ado_organization: "ni"
           ado_project: "DevCentral"
-          ado_area_path: "DevCentral\\Product RnD\\SWP\\CBS\\HW Config"
+          ado_area_path: "DevCentral\\Product RnD\\PlatformSW\\CBS\\HW Config"
           ado_wit: "Bug"
           ado_new_state: "New"
           ado_active_state: "Active"


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fix area path in sync_github_issues_to_azdo.yml

### Why should this Pull Request be merged?

github issues have been failing to sync to AzDO because the area path has changed. ([Example](https://github.com/ni/grpc-device/actions/runs/1763486385))

### What testing has been done?

None. I don't know how to test this.