### PR TITLE
Allow enum-value-prefix in incoming schema

### DIFF
--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -148,6 +148,7 @@ ENUM_SCHEMA = Schema(
             Optional("documentation"): DOCUMENTATION_SCHEMA,
         }],
         Optional("generate-mappings"): bool,
+        Optional("enum-value-prefix"): str,
     }
 )
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Allows enum-value-prefix (which is already used internally) in the incoming schema

### Why should this Pull Request be merged?

Upcoming changes will be using this to force a more user-friendly prefix for several enums

### What testing has been done?

Did a local build with some enum-value-prefix values in the codegen metadata, and verified that the output was modified and that a subsequent build was successful
