### PR TITLE
Add TxpBasic system-level test for NI-RFmx Bluetooth

### DIFF
--- a/source/tests/system/nirfmxbt_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxbt_driver_api_tests.cpp
@@ -197,6 +197,7 @@ TEST_F(NiRFmxBTDriverApiTests, TxpBasicFromExample_DataLooksReasonable)
   EXPECT_SUCCESS(session, client::txp_cfg_averaging(stub(), session, "", TxpAveragingEnabled::TXP_AVERAGING_ENABLED_FALSE, 10));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
+  // We expect these actions to produce kPreambleSyncPacketStartDetectionFailedWarning since the test uses simulated hardware.
   const auto fetched_powers_response = client::txp_fetch_powers(stub(), session, "", 10.0);
   EXPECT_WARNING(fetched_powers_response, kPreambleSyncPacketStartDetectionFailedWarning);
   const auto fetched_edr_powers_response = client::txp_fetch_edr_powers(stub(), session, "", 10.0);

--- a/source/tests/system/nirfmxbt_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxbt_driver_api_tests.cpp
@@ -17,7 +17,7 @@ namespace tests {
 namespace system {
 namespace {
 
-const auto PXI_5663E = "5663E";
+const auto kPxi5663e = "5663E";
 const int kPreambleSyncPacketStartDetectionFailedWarning = 686280;
 
 template <typename TResponse>
@@ -109,7 +109,7 @@ nirfsa_grpc::InitWithOptionsResponse init_rfsa(const nirfsa_client::StubPtr& stu
 
 TEST_F(NiRFmxBTDriverApiTests, Init_Close_Succeeds)
 {
-  auto init_response = init(stub(), PXI_5663E);
+  auto init_response = init(stub(), kPxi5663e);
   auto session = init_response.instrument();
   EXPECT_SUCCESS(session, init_response);
 
@@ -134,7 +134,7 @@ TEST_F(NiRFmxBTDriverApiTests, InitializeFromNIRFSA_Close_Succeeds)
 
 TEST_F(NiRFmxBTDriverApiTests, AcpBasicFromExample_DataLooksReasonable)
 {
-  auto session = init_session(stub(), PXI_5663E);
+  auto session = init_session(stub(), kPxi5663e);
   EXPECT_SUCCESS(session, client::cfg_frequency_reference(stub(), session, "", FrequencyReferenceSource::FREQUENCY_REFERENCE_SOURCE_ONBOARD_CLOCK, 10e6));
   EXPECT_SUCCESS(session, client::cfg_rf(stub(), session, "", 1e9, 0.0, 0.0));
   EXPECT_SUCCESS(session, client::cfg_iq_power_edge_trigger(stub(), session, "", "0", IQPowerEdgeTriggerSlope::IQ_POWER_EDGE_TRIGGER_SLOPE_RISING_SLOPE, -20.0, 0.0, TriggerMinimumQuietTimeMode::TRIGGER_MINIMUM_QUIET_TIME_MODE_AUTO, 100e-6, IQPowerEdgeTriggerLevelType::IQ_POWER_EDGE_TRIGGER_LEVEL_TYPE_RELATIVE, Boolean::BOOLEAN_TRUE));
@@ -148,15 +148,15 @@ TEST_F(NiRFmxBTDriverApiTests, AcpBasicFromExample_DataLooksReasonable)
   EXPECT_SUCCESS(session, client::acp_cfg_number_of_offsets(stub(), session, "", 5));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  auto reference_channel_power = client::acp_fetch_reference_channel_power(stub(), session, "", 10.0);
+  const auto reference_channel_power = client::acp_fetch_reference_channel_power(stub(), session, "", 10.0);
   EXPECT_SUCCESS(session, reference_channel_power);
-  auto measurement_response = client::acp_fetch_offset_measurement_array(stub(), session, "", 10.0);
+  const auto measurement_response = client::acp_fetch_offset_measurement_array(stub(), session, "", 10.0);
   EXPECT_SUCCESS(session, measurement_response);
-  auto mask_trace = client::acp_fetch_mask_trace(stub(), session, "", 10.0);
+  const auto mask_trace = client::acp_fetch_mask_trace(stub(), session, "", 10.0);
   EXPECT_SUCCESS(session, mask_trace);
-  auto absolute_power_trace = client::acp_fetch_absolute_power_trace(stub(), session, "", 10.0);
+  const auto absolute_power_trace = client::acp_fetch_absolute_power_trace(stub(), session, "", 10.0);
   EXPECT_SUCCESS(session, absolute_power_trace);
-  auto fetched_spectrum = client::acp_fetch_spectrum(stub(), session, "", 10.0);
+  const auto fetched_spectrum = client::acp_fetch_spectrum(stub(), session, "", 10.0);
   EXPECT_SUCCESS(session, fetched_spectrum);
 
   EXPECT_GT(reference_channel_power.reference_channel_power(), 0.0);
@@ -182,7 +182,7 @@ TEST_F(NiRFmxBTDriverApiTests, AcpBasicFromExample_DataLooksReasonable)
 
 TEST_F(NiRFmxBTDriverApiTests, TxpBasicFromExample_DataLooksReasonable)
 {
-  auto session = init_session(stub(), PXI_5663E);
+  auto session = init_session(stub(), kPxi5663e);
   EXPECT_SUCCESS(session, client::cfg_frequency_reference(stub(), session, "", FrequencyReferenceSource::FREQUENCY_REFERENCE_SOURCE_ONBOARD_CLOCK, 10e6));
   EXPECT_SUCCESS(session, client::cfg_frequency(stub(), session, "", 2.402000e9));
   EXPECT_SUCCESS(session, client::cfg_external_attenuation(stub(), session, "", 0.0));
@@ -197,11 +197,11 @@ TEST_F(NiRFmxBTDriverApiTests, TxpBasicFromExample_DataLooksReasonable)
   EXPECT_SUCCESS(session, client::txp_cfg_averaging(stub(), session, "", TxpAveragingEnabled::TXP_AVERAGING_ENABLED_FALSE, 10));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  auto fetched_powers_response = client::txp_fetch_powers(stub(), session, "", 10.0);
+  const auto fetched_powers_response = client::txp_fetch_powers(stub(), session, "", 10.0);
   EXPECT_WARNING(fetched_powers_response, kPreambleSyncPacketStartDetectionFailedWarning);
-  auto fetched_edr_powers_response = client::txp_fetch_edr_powers(stub(), session, "", 10.0);
+  const auto fetched_edr_powers_response = client::txp_fetch_edr_powers(stub(), session, "", 10.0);
   EXPECT_WARNING(fetched_edr_powers_response, kPreambleSyncPacketStartDetectionFailedWarning);
-  auto fetched_lecte_reference_period_powers_response = client::txp_fetch_lecte_reference_period_powers(stub(), session, "", 10.0);
+  const auto fetched_lecte_reference_period_powers_response = client::txp_fetch_lecte_reference_period_powers(stub(), session, "", 10.0);
   EXPECT_WARNING(fetched_lecte_reference_period_powers_response, kPreambleSyncPacketStartDetectionFailedWarning);
 
   EXPECT_GT(fetched_powers_response.average_power_mean(), 0.0);


### PR DESCRIPTION
### What does this Pull Request accomplish?

This pull request adds a system-level test based on the TxpBasic CVI example for NI-RFmx Bluetooth. This is the second of two pull requests (after #498 ) that solves [AB#1784736](https://ni.visualstudio.com/DevCentral/_workitems/edit/1784736).

### Why should this Pull Request be merged?

We want some basic system-level tests that confirm that fetching data with the gRPC API for NI-RFmx Bluetooth returns reasonable-looking results.

### What testing has been done?

grpc-device locally builds successfully with the new test, and the new test passes on a VM with NI-RFSA and NI-RFmx Bluetooth installed:

![image](https://user-images.githubusercontent.com/62964751/152232590-5b3c7ce2-ed58-489c-93a0-a84aac8eaa98.png)

