### PR TITLE
Use protobuf bools instead of Boolean enum

### DIFF
--- a/examples/nirfmxspecan/spectrum-basic.py
+++ b/examples/nirfmxspecan/spectrum-basic.py
@@ -148,4 +148,4 @@ try:
 finally:
     if instr:
         client.Close(nirfmxspecan_types.CloseRequest(
-            instrument=instr, force_destroy=nirfmxspecan_types.BOOLEAN_FALSE))
+            instrument=instr, force_destroy=False))

--- a/generated/nirfmxinstr/nirfmxinstr.proto
+++ b/generated/nirfmxinstr/nirfmxinstr.proto
@@ -211,11 +211,6 @@ enum NiRFmxInstrAttribute {
   NIRFMXINSTR_ATTRIBUTE_THERMAL_CORRECTION_TEMPERATURE_RESOLUTION = 120;
 }
 
-enum Boolean {
-  BOOLEAN_FALSE = 0;
-  BOOLEAN_TRUE = 1;
-}
-
 enum ExportSignalSource {
   EXPORT_SIGNAL_SOURCE_START_TRIGGER = 0;
   EXPORT_SIGNAL_SOURCE_REFERENCE_TRIGGER = 1;
@@ -559,8 +554,7 @@ message CheckAcquisitionStatusRequest {
 
 message CheckAcquisitionStatusResponse {
   int32 status = 1;
-  Boolean acquisition_done = 2;
-  int32 acquisition_done_raw = 3;
+  bool acquisition_done = 2;
 }
 
 message CheckIfListExistsRequest {
@@ -570,10 +564,9 @@ message CheckIfListExistsRequest {
 
 message CheckIfListExistsResponse {
   int32 status = 1;
-  Boolean list_exists = 2;
-  int32 list_exists_raw = 3;
-  Personality personality = 4;
-  int32 personality_raw = 5;
+  bool list_exists = 2;
+  Personality personality = 3;
+  int32 personality_raw = 4;
 }
 
 message CheckIfSignalConfigurationExistsRequest {
@@ -583,18 +576,14 @@ message CheckIfSignalConfigurationExistsRequest {
 
 message CheckIfSignalConfigurationExistsResponse {
   int32 status = 1;
-  Boolean signal_configuration_exists = 2;
-  int32 signal_configuration_exists_raw = 3;
-  Personality personality = 4;
-  int32 personality_raw = 5;
+  bool signal_configuration_exists = 2;
+  Personality personality = 3;
+  int32 personality_raw = 4;
 }
 
 message CloseRequest {
   nidevice_grpc.Session instrument = 1;
-  oneof force_destroy_enum {
-    Boolean force_destroy = 2;
-    int32 force_destroy_raw = 3;
-  }
+  bool force_destroy = 2;
 }
 
 message CloseResponse {
@@ -1046,10 +1035,9 @@ message IsSelfCalibrateValidRequest {
 
 message IsSelfCalibrateValidResponse {
   int32 status = 1;
-  Boolean self_calibrate_valid = 2;
-  int32 self_calibrate_valid_raw = 3;
-  repeated SelfCalStep valid_steps_array = 4;
-  int32 valid_steps_raw = 5;
+  bool self_calibrate_valid = 2;
+  repeated SelfCalStep valid_steps_array = 3;
+  int32 valid_steps_raw = 4;
 }
 
 message LoadAllConfigurationsRequest {

--- a/generated/nirfmxinstr/nirfmxinstr_client.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_client.cpp
@@ -368,20 +368,13 @@ check_if_signal_configuration_exists(const StubPtr& stub, const nidevice_grpc::S
 }
 
 CloseResponse
-close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const simple_variant<Boolean, pb::int32>& force_destroy)
+close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const bool& force_destroy)
 {
   ::grpc::ClientContext context;
 
   auto request = CloseRequest{};
   request.mutable_instrument()->CopyFrom(instrument);
-  const auto force_destroy_ptr = force_destroy.get_if<Boolean>();
-  const auto force_destroy_raw_ptr = force_destroy.get_if<pb::int32>();
-  if (force_destroy_ptr) {
-    request.set_force_destroy(*force_destroy_ptr);
-  }
-  else if (force_destroy_raw_ptr) {
-    request.set_force_destroy_raw(*force_destroy_raw_ptr);
-  }
+  request.set_force_destroy(force_destroy);
 
   auto response = CloseResponse{};
 

--- a/generated/nirfmxinstr/nirfmxinstr_client.h
+++ b/generated/nirfmxinstr/nirfmxinstr_client.h
@@ -39,7 +39,7 @@ CfgSParameterExternalAttenuationTypeResponse cfg_s_parameter_external_attenuatio
 CheckAcquisitionStatusResponse check_acquisition_status(const StubPtr& stub, const nidevice_grpc::Session& instrument);
 CheckIfListExistsResponse check_if_list_exists(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& list_name);
 CheckIfSignalConfigurationExistsResponse check_if_signal_configuration_exists(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& signal_name);
-CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const simple_variant<Boolean, pb::int32>& force_destroy);
+CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const bool& force_destroy);
 DeleteAllExternalAttenuationTablesResponse delete_all_external_attenuation_tables(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string);
 DeleteExternalAttenuationTableResponse delete_external_attenuation_table(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const pb::string& table_name);
 DisableCalibrationPlaneResponse disable_calibration_plane(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string);

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -572,8 +572,7 @@ namespace nirfmxinstr_grpc {
       auto status = library_->CheckAcquisitionStatus(instrument, &acquisition_done);
       response->set_status(status);
       if (status_ok(status)) {
-        response->set_acquisition_done(static_cast<nirfmxinstr_grpc::Boolean>(acquisition_done));
-        response->set_acquisition_done_raw(acquisition_done);
+        response->set_acquisition_done(acquisition_done);
       }
       return ::grpc::Status::OK;
     }
@@ -598,8 +597,7 @@ namespace nirfmxinstr_grpc {
       auto status = library_->CheckIfListExists(instrument, list_name, &list_exists, &personality);
       response->set_status(status);
       if (status_ok(status)) {
-        response->set_list_exists(static_cast<nirfmxinstr_grpc::Boolean>(list_exists));
-        response->set_list_exists_raw(list_exists);
+        response->set_list_exists(list_exists);
         response->set_personality(static_cast<nirfmxinstr_grpc::Personality>(personality));
         response->set_personality_raw(personality);
       }
@@ -626,8 +624,7 @@ namespace nirfmxinstr_grpc {
       auto status = library_->CheckIfSignalConfigurationExists(instrument, signal_name, &signal_configuration_exists, &personality);
       response->set_status(status);
       if (status_ok(status)) {
-        response->set_signal_configuration_exists(static_cast<nirfmxinstr_grpc::Boolean>(signal_configuration_exists));
-        response->set_signal_configuration_exists_raw(signal_configuration_exists);
+        response->set_signal_configuration_exists(signal_configuration_exists);
         response->set_personality(static_cast<nirfmxinstr_grpc::Personality>(personality));
         response->set_personality_raw(personality);
       }
@@ -648,22 +645,7 @@ namespace nirfmxinstr_grpc {
     try {
       auto instrument_grpc_session = request->instrument();
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
-      int32 force_destroy;
-      switch (request->force_destroy_enum_case()) {
-        case nirfmxinstr_grpc::CloseRequest::ForceDestroyEnumCase::kForceDestroy: {
-          force_destroy = static_cast<int32>(request->force_destroy());
-          break;
-        }
-        case nirfmxinstr_grpc::CloseRequest::ForceDestroyEnumCase::kForceDestroyRaw: {
-          force_destroy = static_cast<int32>(request->force_destroy_raw());
-          break;
-        }
-        case nirfmxinstr_grpc::CloseRequest::ForceDestroyEnumCase::FORCE_DESTROY_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for force_destroy was not specified or out of range");
-          break;
-        }
-      }
-
+      int32 force_destroy = request->force_destroy();
       session_repository_->remove_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->Close(instrument, force_destroy);
       response->set_status(status);
@@ -2014,8 +1996,7 @@ namespace nirfmxinstr_grpc {
       auto status = library_->IsSelfCalibrateValid(instrument, selector_string, &self_calibrate_valid, &valid_steps);
       response->set_status(status);
       if (status_ok(status)) {
-        response->set_self_calibrate_valid(static_cast<nirfmxinstr_grpc::Boolean>(self_calibrate_valid));
-        response->set_self_calibrate_valid_raw(self_calibrate_valid);
+        response->set_self_calibrate_valid(self_calibrate_valid);
         if (valid_steps & 0x20)
           response->add_valid_steps_array(SelfCalStep::SELF_CAL_STEP_AMPLITUDE_ACCURACY);
         if (valid_steps & 0x200)

--- a/generated/nirfmxnr/nirfmxnr.proto
+++ b/generated/nirfmxnr/nirfmxnr.proto
@@ -733,11 +733,6 @@ enum AcpSweepTimeAuto {
   ACP_SWEEP_TIME_AUTO_TRUE = 1;
 }
 
-enum Boolean {
-  BOOLEAN_FALSE = 0;
-  BOOLEAN_TRUE = 1;
-}
-
 enum ChpAveragingEnabled {
   CHP_AVERAGING_ENABLED_FALSE = 0;
   CHP_AVERAGING_ENABLED_TRUE = 1;
@@ -2139,7 +2134,7 @@ message CheckMeasurementStatusRequest {
 
 message CheckMeasurementStatusResponse {
   int32 status = 1;
-  int32 is_done = 2;
+  bool is_done = 2;
 }
 
 message ClearAllNamedResultsRequest {
@@ -2181,10 +2176,7 @@ message CloneSignalConfigurationResponse {
 
 message CloseRequest {
   nidevice_grpc.Session instrument = 1;
-  oneof force_destroy_enum {
-    Boolean force_destroy = 2;
-    int32 force_destroy_raw = 3;
-  }
+  bool force_destroy = 2;
 }
 
 message CloseResponse {

--- a/generated/nirfmxnr/nirfmxnr_client.cpp
+++ b/generated/nirfmxnr/nirfmxnr_client.cpp
@@ -1341,20 +1341,13 @@ clone_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& in
 }
 
 CloseResponse
-close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const simple_variant<Boolean, pb::int32>& force_destroy)
+close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const bool& force_destroy)
 {
   ::grpc::ClientContext context;
 
   auto request = CloseRequest{};
   request.mutable_instrument()->CopyFrom(instrument);
-  const auto force_destroy_ptr = force_destroy.get_if<Boolean>();
-  const auto force_destroy_raw_ptr = force_destroy.get_if<pb::int32>();
-  if (force_destroy_ptr) {
-    request.set_force_destroy(*force_destroy_ptr);
-  }
-  else if (force_destroy_raw_ptr) {
-    request.set_force_destroy_raw(*force_destroy_raw_ptr);
-  }
+  request.set_force_destroy(force_destroy);
 
   auto response = CloseResponse{};
 

--- a/generated/nirfmxnr/nirfmxnr_client.h
+++ b/generated/nirfmxnr/nirfmxnr_client.h
@@ -86,7 +86,7 @@ ClearAllNamedResultsResponse clear_all_named_results(const StubPtr& stub, const 
 ClearNamedResultResponse clear_named_result(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string);
 ClearNoiseCalibrationDatabaseResponse clear_noise_calibration_database(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string);
 CloneSignalConfigurationResponse clone_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& old_signal_name, const pb::string& new_signal_name);
-CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const simple_variant<Boolean, pb::int32>& force_destroy);
+CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const bool& force_destroy);
 CommitResponse commit(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string);
 CreateListResponse create_list(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& list_name);
 CreateListStepResponse create_list_step(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string);

--- a/generated/nirfmxnr/nirfmxnr_service.cpp
+++ b/generated/nirfmxnr/nirfmxnr_service.cpp
@@ -2295,22 +2295,7 @@ namespace nirfmxnr_grpc {
     try {
       auto instrument_grpc_session = request->instrument();
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
-      int32 force_destroy;
-      switch (request->force_destroy_enum_case()) {
-        case nirfmxnr_grpc::CloseRequest::ForceDestroyEnumCase::kForceDestroy: {
-          force_destroy = static_cast<int32>(request->force_destroy());
-          break;
-        }
-        case nirfmxnr_grpc::CloseRequest::ForceDestroyEnumCase::kForceDestroyRaw: {
-          force_destroy = static_cast<int32>(request->force_destroy_raw());
-          break;
-        }
-        case nirfmxnr_grpc::CloseRequest::ForceDestroyEnumCase::FORCE_DESTROY_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for force_destroy was not specified or out of range");
-          break;
-        }
-      }
-
+      int32 force_destroy = request->force_destroy();
       session_repository_->remove_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->Close(instrument, force_destroy);
       response->set_status(status);

--- a/generated/nirfmxspecan/nirfmxspecan.proto
+++ b/generated/nirfmxspecan/nirfmxspecan.proto
@@ -1247,11 +1247,6 @@ enum AmpmThresholdType {
   AMPM_THRESHOLD_TYPE_ABSOLUTE = 1;
 }
 
-enum Boolean {
-  BOOLEAN_FALSE = 0;
-  BOOLEAN_TRUE = 1;
-}
-
 enum CcdfRbwFilterType {
   CCDF_RBW_FILTER_TYPE_UNSPECIFIED = 0;
   CCDF_RBW_FILTER_TYPE_GAUSSIAN = 1;
@@ -4078,7 +4073,7 @@ message CheckMeasurementStatusRequest {
 
 message CheckMeasurementStatusResponse {
   int32 status = 1;
-  int32 is_done = 2;
+  bool is_done = 2;
 }
 
 message ClearAllNamedResultsRequest {
@@ -4120,10 +4115,7 @@ message CloneSignalConfigurationResponse {
 
 message CloseRequest {
   nidevice_grpc.Session instrument = 1;
-  oneof force_destroy_enum {
-    Boolean force_destroy = 2;
-    int32 force_destroy_raw = 3;
-  }
+  bool force_destroy = 2;
 }
 
 message CloseResponse {

--- a/generated/nirfmxspecan/nirfmxspecan_client.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_client.cpp
@@ -2377,20 +2377,13 @@ clone_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& in
 }
 
 CloseResponse
-close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const simple_variant<Boolean, pb::int32>& force_destroy)
+close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const bool& force_destroy)
 {
   ::grpc::ClientContext context;
 
   auto request = CloseRequest{};
   request.mutable_instrument()->CopyFrom(instrument);
-  const auto force_destroy_ptr = force_destroy.get_if<Boolean>();
-  const auto force_destroy_raw_ptr = force_destroy.get_if<pb::int32>();
-  if (force_destroy_ptr) {
-    request.set_force_destroy(*force_destroy_ptr);
-  }
-  else if (force_destroy_raw_ptr) {
-    request.set_force_destroy_raw(*force_destroy_raw_ptr);
-  }
+  request.set_force_destroy(force_destroy);
 
   auto response = CloseResponse{};
 

--- a/generated/nirfmxspecan/nirfmxspecan_client.h
+++ b/generated/nirfmxspecan/nirfmxspecan_client.h
@@ -133,7 +133,7 @@ ClearAllNamedResultsResponse clear_all_named_results(const StubPtr& stub, const 
 ClearNamedResultResponse clear_named_result(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string);
 ClearNoiseCalibrationDatabaseResponse clear_noise_calibration_database(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string);
 CloneSignalConfigurationResponse clone_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& old_signal_name, const pb::string& new_signal_name);
-CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const simple_variant<Boolean, pb::int32>& force_destroy);
+CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const bool& force_destroy);
 CommitResponse commit(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string);
 CreateListResponse create_list(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& list_name);
 CreateListStepResponse create_list_step(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string);

--- a/generated/nirfmxspecan/nirfmxspecan_service.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_service.cpp
@@ -3908,22 +3908,7 @@ namespace nirfmxspecan_grpc {
     try {
       auto instrument_grpc_session = request->instrument();
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
-      int32 force_destroy;
-      switch (request->force_destroy_enum_case()) {
-        case nirfmxspecan_grpc::CloseRequest::ForceDestroyEnumCase::kForceDestroy: {
-          force_destroy = static_cast<int32>(request->force_destroy());
-          break;
-        }
-        case nirfmxspecan_grpc::CloseRequest::ForceDestroyEnumCase::kForceDestroyRaw: {
-          force_destroy = static_cast<int32>(request->force_destroy_raw());
-          break;
-        }
-        case nirfmxspecan_grpc::CloseRequest::ForceDestroyEnumCase::FORCE_DESTROY_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for force_destroy was not specified or out of range");
-          break;
-        }
-      }
-
+      int32 force_destroy = request->force_destroy();
       session_repository_->remove_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->Close(instrument, force_destroy);
       response->set_status(status);

--- a/source/codegen/metadata/nirfmxinstr/enums.py
+++ b/source/codegen/metadata/nirfmxinstr/enums.py
@@ -27,18 +27,6 @@ enums = {
             }
         ]
     },
-    'Boolean': {
-        'values': [
-            {
-                'name': 'TRUE',
-                'value': 1
-            },
-            {
-                'name': 'FALSE',
-                'value': 0
-            }
-        ]
-    },
     'ChannelCoupling': {
         'values': [
             {

--- a/source/codegen/metadata/nirfmxinstr/functions.py
+++ b/source/codegen/metadata/nirfmxinstr/functions.py
@@ -436,7 +436,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'enum': 'Boolean',
+                'grpc_type': 'bool',
                 'name': 'acquisitionDone',
                 'type': 'int32'
             }
@@ -458,7 +458,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'enum': 'Boolean',
+                'grpc_type': 'bool',
                 'name': 'listExists',
                 'type': 'int32'
             },
@@ -486,7 +486,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'enum': 'Boolean',
+                'grpc_type': 'bool',
                 'name': 'signalConfigurationExists',
                 'type': 'int32'
             },
@@ -509,7 +509,7 @@ functions = {
             },
             {
                 'direction': 'in',
-                'enum': 'Boolean',
+                'grpc_type': 'bool',
                 'name': 'forceDestroy',
                 'type': 'int32'
             }
@@ -1742,7 +1742,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'enum': 'Boolean',
+                'grpc_type': 'bool',
                 'name': 'selfCalibrateValid',
                 'type': 'int32'
             },

--- a/source/codegen/metadata/nirfmxnr/enums.py
+++ b/source/codegen/metadata/nirfmxnr/enums.py
@@ -331,18 +331,6 @@ enums = {
             }
         ]
     },
-    'Boolean': {
-        'values': [
-            {
-                'name': 'FALSE',
-                'value': 0
-            },
-            {
-                'name': 'TRUE',
-                'value': 1
-            }
-        ]
-    },
     'ChpAmplitudeCorrectionType': {
         'values': [
             {

--- a/source/codegen/metadata/nirfmxnr/functions.py
+++ b/source/codegen/metadata/nirfmxnr/functions.py
@@ -1911,6 +1911,7 @@ functions = {
             },
             {
                 'direction': 'out',
+                'grpc_type': 'bool',
                 'name': 'isDone',
                 'type': 'int32'
             }
@@ -1996,7 +1997,7 @@ functions = {
             },
             {
                 'direction': 'in',
-                'enum': 'Boolean',
+                'grpc_type': 'bool',
                 'name': 'forceDestroy',
                 'type': 'int32'
             }

--- a/source/codegen/metadata/nirfmxspecan/enums.py
+++ b/source/codegen/metadata/nirfmxspecan/enums.py
@@ -595,18 +595,6 @@ enums = {
             }
         ]
     },
-    'Boolean': {
-        'values': [
-            {
-                'name': 'FALSE',
-                'value': 0
-            },
-            {
-                'name': 'TRUE',
-                'value': 1
-            }
-        ]
-    },
     'CcdfRbwFilterType': {
         'values': [
             {

--- a/source/codegen/metadata/nirfmxspecan/functions.py
+++ b/source/codegen/metadata/nirfmxspecan/functions.py
@@ -3542,6 +3542,7 @@ functions = {
             },
             {
                 'direction': 'out',
+                'grpc_type': 'bool',
                 'name': 'isDone',
                 'type': 'int32'
             }
@@ -3627,7 +3628,7 @@ functions = {
             },
             {
                 'direction': 'in',
-                'enum': 'Boolean',
+                'grpc_type': 'bool',
                 'name': 'forceDestroy',
                 'type': 'int32'
             }

--- a/source/tests/system/nirfmxinstr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxinstr_driver_api_tests.cpp
@@ -320,10 +320,10 @@ TEST_F(NiRFmxInstrDriverApiTests, CallCheckMethods_SucceedsWithReasonableRespons
   const auto list_exists_response = EXPECT_SUCCESS(session, client::check_if_list_exists(stub(), session, "NOTALIST"));
   const auto self_cal_response = EXPECT_SUCCESS(session, client::is_self_calibrate_valid(stub(), session, ""));
 
-  EXPECT_EQ(status_response.acquisition_done(), Boolean::BOOLEAN_TRUE);
-  EXPECT_EQ(list_exists_response.list_exists(), Boolean::BOOLEAN_FALSE);
+  EXPECT_EQ(status_response.acquisition_done(), true);
+  EXPECT_EQ(list_exists_response.list_exists(), false);
   EXPECT_EQ(list_exists_response.personality(), Personality::PERSONALITY_NONE);
-  EXPECT_EQ(self_cal_response.self_calibrate_valid(), Boolean::BOOLEAN_TRUE);
+  EXPECT_EQ(self_cal_response.self_calibrate_valid(), true);
   EXPECT_THAT(self_cal_response.valid_steps_array(), ElementsAreArray(std::vector<SelfCalStep>{SelfCalStep::SELF_CAL_STEP_DIGITIZER_SELF_CAL}));
 }
 

--- a/source/tests/system/nirfmxnr_session_tests.cpp
+++ b/source/tests/system/nirfmxnr_session_tests.cpp
@@ -46,7 +46,7 @@ class NiRFmxNRSessionTest : public ::testing::Test {
     return status;
   }
 
-  ::grpc::Status call_close(nidevice_grpc::Session session, nirfmxnr_grpc::Boolean force_destroy, rfmxnr::CloseResponse* response)
+  ::grpc::Status call_close(nidevice_grpc::Session session, bool force_destroy, rfmxnr::CloseResponse* response)
   {
     ::grpc::ClientContext context;
     rfmxnr::CloseRequest request;
@@ -101,7 +101,7 @@ TEST_F(NiRFmxNRSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
   ::grpc::ClientContext context;
   rfmxnr::CloseRequest close_request;
   close_request.mutable_instrument()->set_id(session.id());
-  close_request.set_force_destroy(nirfmxnr_grpc::Boolean::BOOLEAN_FALSE);
+  close_request.set_force_destroy(false);
   rfmxnr::CloseResponse close_response;
   ::grpc::Status status = GetStub()->Close(&context, close_request, &close_response);
 
@@ -123,8 +123,8 @@ TEST_F(NiRFmxNRSessionTest, TwoInitializedSessionsOnSameDevice_CloseSessions_Clo
   nidevice_grpc::Session session_one = init_response_one.instrument();
   nidevice_grpc::Session session_two = init_response_two.instrument();
   rfmxnr::CloseResponse close_response_one, close_response_two;
-  status_one = call_close(session_one, nirfmxnr_grpc::Boolean::BOOLEAN_FALSE, &close_response_one);
-  status_two = call_close(session_two, nirfmxnr_grpc::Boolean::BOOLEAN_FALSE, &close_response_two);
+  status_one = call_close(session_one, false, &close_response_one);
+  status_two = call_close(session_two, false, &close_response_two);
 
   EXPECT_TRUE(status_one.ok());
   EXPECT_EQ(0, close_response_one.status());
@@ -146,8 +146,8 @@ TEST_F(NiRFmxNRSessionTest, CallInitializeTwiceWithSameSessionNameOnSameDevice_C
   nidevice_grpc::Session session_one = init_response_one.instrument();
   nidevice_grpc::Session session_two = init_response_two.instrument();
   rfmxnr::CloseResponse close_response_one, close_response_two;
-  status_one = call_close(session_one, nirfmxnr_grpc::Boolean::BOOLEAN_FALSE, &close_response_one);
-  status_two = call_close(session_two, nirfmxnr_grpc::Boolean::BOOLEAN_FALSE, &close_response_two);
+  status_one = call_close(session_one, false, &close_response_one);
+  status_two = call_close(session_two, false, &close_response_two);
 
   EXPECT_TRUE(status_one.ok());
   EXPECT_EQ(0, close_response_one.status());
@@ -165,7 +165,7 @@ TEST_F(NiRFmxNRSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionErr
   ::grpc::ClientContext context;
   rfmxnr::CloseRequest request;
   request.mutable_instrument()->set_id(session.id());
-  request.set_force_destroy(nirfmxnr_grpc::Boolean::BOOLEAN_FALSE);
+  request.set_force_destroy(false);
   rfmxnr::CloseResponse response;
   ::grpc::Status status = GetStub()->Close(&context, request, &response);
 

--- a/source/tests/system/nirfmxspecan_session_tests.cpp
+++ b/source/tests/system/nirfmxspecan_session_tests.cpp
@@ -101,7 +101,7 @@ TEST_F(NiRFmxSpecAnSessionTest, InitializedSession_CloseSession_ClosesDriverSess
   ::grpc::ClientContext context;
   rfmxspecan::CloseRequest close_request;
   close_request.mutable_instrument()->set_id(session.id());
-  close_request.set_force_destroy(rfmxspecan::Boolean::BOOLEAN_FALSE);
+  close_request.set_force_destroy(false);
   rfmxspecan::CloseResponse close_response;
   ::grpc::Status status = GetStub()->Close(&context, close_request, &close_response);
 
@@ -127,7 +127,7 @@ TEST_F(NiRFmxSpecAnSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessio
   ::grpc::ClientContext context;
   rfmxspecan::CloseRequest request;
   request.mutable_instrument()->set_id(session.id());
-  request.set_force_destroy(rfmxspecan::Boolean::BOOLEAN_FALSE);
+  request.set_force_destroy(false);
   rfmxspecan::CloseResponse response;
   ::grpc::Status status = GetStub()->Close(&context, request, &response);
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Use protobuf bools instead of Boolean enum.

Use an enum for `isDone` output on `CheckMeasurementStatus`.

### Why should this Pull Request be merged?

Previously, I overzealously converted all `TRUE`/`FALSE` enums to `bool`s. This was rejected. However, the `Boolean` enum is really just ` bool` and represented that way in both C# and LV.

### What testing has been done?

Ran and passed all RFmx tests.