### PR TITLE
Add system-level test to get and set I32 attribute in NiRFmxBT.

### DIFF
--- a/source/tests/system/nirfmxbt_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxbt_driver_api_tests.cpp
@@ -211,6 +211,32 @@ TEST_F(NiRFmxBTDriverApiTests, TxpBasicFromExample_DataLooksReasonable)
   EXPECT_GT(fetched_powers_response.peak_to_average_power_ratio_maximum(), 0.0);
 }
 
+TEST_F(NiRFmxBTDriverApiTests, SetAndGetAttributeInt32_Succeeds)
+{
+  auto session = init_session(stub(), kPxi5663e);
+  EXPECT_SUCCESS(session, client::cfg_frequency_reference(stub(), session, "", FrequencyReferenceSource::FREQUENCY_REFERENCE_SOURCE_ONBOARD_CLOCK, 10e6));
+  EXPECT_SUCCESS(session, client::cfg_frequency(stub(), session, "", 2.402000e9));
+  EXPECT_SUCCESS(session, client::cfg_external_attenuation(stub(), session, "", 0.0));
+  EXPECT_SUCCESS(session, client::cfg_iq_power_edge_trigger(stub(), session, "", "0", IQPowerEdgeTriggerSlope::IQ_POWER_EDGE_TRIGGER_SLOPE_RISING_SLOPE, -20.0, 0.0, TriggerMinimumQuietTimeMode::TRIGGER_MINIMUM_QUIET_TIME_MODE_AUTO, 100e-6, IQPowerEdgeTriggerLevelType::IQ_POWER_EDGE_TRIGGER_LEVEL_TYPE_RELATIVE, Boolean::BOOLEAN_TRUE));
+  EXPECT_SUCCESS(session, client::cfg_packet_type(stub(), session, "", PacketType::PACKET_TYPE_DH1));
+  EXPECT_SUCCESS(session, client::cfg_data_rate(stub(), session, "", 1000000));
+  EXPECT_SUCCESS(session, client::cfg_payload_length(stub(), session, "", PayloadLengthMode::PAYLOAD_LENGTH_MODE_AUTO, 10));
+  EXPECT_SUCCESS(session, client::cfg_le_direction_finding(stub(), session, "", DirectionFindingMode::DIRECTION_FINDING_MODE_DISABLED, 160e-6, 1e-6));
+  EXPECT_SUCCESS(session, client::auto_level(stub(), session, "", 10e-3));
+  EXPECT_SUCCESS(session, client::select_measurements(stub(), session, "", MeasurementTypes::MEASUREMENT_TYPES_TXP, Boolean::BOOLEAN_TRUE));
+  EXPECT_SUCCESS(session, client::txp_cfg_burst_synchronization_type(stub(), session, "", TxpBurstSynchronizationType::TXP_BURST_SYNCHRONIZATION_TYPE_PREAMBLE));
+  EXPECT_SUCCESS(session, client::txp_cfg_averaging(stub(), session, "", TxpAveragingEnabled::TXP_AVERAGING_ENABLED_FALSE, 10));
+  EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
+  EXPECT_SUCCESS(
+      session,
+      client::set_attribute_i32(stub(), session, "", NiRFmxBTAttribute::NIRFMXBT_ATTRIBUTE_ACP_AVERAGING_ENABLED, NiRFmxBTInt32AttributeValues::NIRFMXBT_INT32_ACP_AVERAGING_ENABLED_TRUE));
+
+  auto get_response = client::get_attribute_i32(stub(), session, "", NiRFmxBTAttribute::NIRFMXBT_ATTRIBUTE_ACP_AVERAGING_ENABLED);
+
+  EXPECT_SUCCESS(session, get_response);
+  EXPECT_EQ(NiRFmxBTInt32AttributeValues::NIRFMXBT_INT32_ACP_AVERAGING_ENABLED_TRUE, get_response.attr_val());
+}
+
 }  // namespace
 }  // namespace system
 }  // namespace tests


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR adds a system-level test that proves that we can get and set I32 attributes in the RFmx Bluetooth service.
Fixes [AB#1830039](https://ni.visualstudio.com/DevCentral/_workitems/edit/1830039).

### Why should this Pull Request be merged?

We want to be certain that getting and setting I32 attributes works as expected in the RFmx Bluetooth service.

### What testing has been done?

grpc-device builds locally with this test, and the test passes on a VM with NI-RFSA and NI-RFmx Bluetooth installed.
