### PR TITLE
Add system-level tests of complex and unused numeric data types to NiRFmxBT service.

### DIFF
--- a/source/tests/system/nirfmxbt_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxbt_driver_api_tests.cpp
@@ -133,8 +133,8 @@ TComplex complex(TFloat real, TFloat imaginary)
 
 template <typename TFloat, typename TComplex>
 std::vector<TComplex> complex_array(
-    std::vector<TFloat> reals,
-    std::vector<TFloat> imaginaries)
+    const std::vector<TFloat> reals,
+    const std::vector<TFloat> imaginaries)
 {
   auto c = std::vector<TComplex>{};
   c.reserve(reals.size());
@@ -148,8 +148,8 @@ std::vector<TComplex> complex_array(
 }
 
 std::vector<nidevice_grpc::NIComplexNumber> complex_number_array(
-    std::vector<double> reals,
-    std::vector<double> imaginaries)
+    const std::vector<double> reals,
+    const std::vector<double> imaginaries)
 {
   return complex_array<double, nidevice_grpc::NIComplexNumber>(reals, imaginaries);
 }
@@ -258,7 +258,7 @@ TEST_F(NiRFmxBTDriverApiTests, TxpBasicFromExample_DataLooksReasonable)
   EXPECT_GT(fetched_powers_response.peak_to_average_power_ratio_maximum(), 0.0);
 }
 
-// Note: there aren't any complex attributes in attributes.py, but this at least exercises the code.
+// TODO -- AB#1835516: Add system-level test using an API function that uses complex data types.
 TEST_F(NiRFmxBTDriverApiTests, SetAttributeComplex_ExpectedError)
 {
   const auto session = init_session(stub(), kPxi5663e);

--- a/source/tests/system/nirfmxbt_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxbt_driver_api_tests.cpp
@@ -268,6 +268,38 @@ TEST_F(NiRFmxBTDriverApiTests, SetAttributeComplex_ExpectedError)
       client::set_attribute_ni_complex_double_array(stub(), session, "", NiRFmxBTAttribute::NIRFMXBT_ATTRIBUTE_ACP_RESULTS_REFERENCE_CHANNEL_POWER, complex_number_array({1.2, 2.2}, {1e6, 1.01e6})));
 }
 
+// Note: there aren't any i8 attributes in attributes.py, but this at least exercises the code.
+TEST_F(NiRFmxBTDriverApiTests, SetAttributeInt8_ExpectedError)
+{
+  const auto session = init_session(stub(), kPxi5663e);
+
+  EXPECT_RFMX_ERROR(
+      -380251, "Incorrect data type specified", session,
+      client::set_attribute_i8(stub(), session, "", NiRFmxBTAttribute::NIRFMXBT_ATTRIBUTE_TXP_AVERAGING_ENABLED, 1));
+  EXPECT_RFMX_ERROR(
+      -380251, "Incorrect data type specified", session,
+      client::set_attribute_u8(stub(), session, "", NiRFmxBTAttribute::NIRFMXBT_ATTRIBUTE_TXP_AVERAGING_ENABLED, 1));
+  EXPECT_RFMX_ERROR(
+      -380251, "Incorrect data type specified", session,
+      client::set_attribute_i8_array(stub(), session, "", NiRFmxBTAttribute::NIRFMXBT_ATTRIBUTE_TXP_AVERAGING_ENABLED, {1, 0, -1, 0}));
+  EXPECT_RFMX_ERROR(
+      -380251, "Incorrect data type specified", session,
+      client::set_attribute_u8_array(stub(), session, "", NiRFmxBTAttribute::NIRFMXBT_ATTRIBUTE_TXP_AVERAGING_ENABLED, {1, 0, 1, 0}));
+}
+
+// Note: there aren't any i16 attributes in attributes.py, but this at least exercises the code.
+TEST_F(NiRFmxBTDriverApiTests, SetAttributeInt16_ExpectedError)
+{
+  const auto session = init_session(stub(), kPxi5663e);
+
+  EXPECT_RFMX_ERROR(
+      -380251, "Incorrect data type specified", session,
+      client::set_attribute_i16(stub(), session, "", NiRFmxBTAttribute::NIRFMXBT_ATTRIBUTE_TXP_AVERAGING_ENABLED, -400));
+  EXPECT_RFMX_ERROR(
+      -380251, "Incorrect data type specified", session,
+      client::set_attribute_u16(stub(), session, "", NiRFmxBTAttribute::NIRFMXBT_ATTRIBUTE_TXP_AVERAGING_ENABLED, 400));
+}
+
 TEST_F(NiRFmxBTDriverApiTests, SetAndGetAttributeInt32_Succeeds)
 {
   auto session = init_session(stub(), kPxi5663e);


### PR DESCRIPTION
### What does this Pull Request accomplish?

This pull request adds system-level tests that set attributes with complex numeric data types, and with 8- and 16-bit integer data types. All of these data types are not present in `attributes.py`, but these tests at least exercise the code.
Fixes [AB#1834560](https://ni.visualstudio.com/DevCentral/_workitems/edit/1834560).

### Why should this Pull Request be merged?

We want to be certain that it is theoretically possible to set attributes of these data types in order to be more confident in the quality of the Bluetooth service.

### What testing has been done?

The new tests build locally and pass on a VM with NI-RFSA and NI-RFmx Bluetooth installed:

![image](https://user-images.githubusercontent.com/62964751/153005421-1a4a4bba-61ec-4a04-a3c7-4cef69de2ab7.png)

