### PR TITLE
Add tests for IQFetchData

### DIFF
--- a/source/tests/system/nirfmxspecan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxspecan_driver_api_tests.cpp
@@ -483,7 +483,14 @@ TEST_F(NiRFmxSpecAnDriverApiTests, DisableDeleteRecordOnFetch_IQFetchData_Record
 {
   const auto session = init_session(stub(), PXI_5663);
   EXPECT_SUCCESS(session, client::select_measurements(stub(), session, "", MeasurementTypes::MEASUREMENT_TYPES_IQ, true));
-  EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_IQ_DELETE_RECORD_ON_FETCH, 0));
+  EXPECT_SUCCESS(
+      session,
+      client::set_attribute_i32(
+          stub(),
+          session,
+          "",
+          NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_IQ_DELETE_RECORD_ON_FETCH,
+          NiRFmxSpecAnInt32AttributeValues::NIRFMXSPECAN_INT32_IQ_DELETE_RECORD_ON_FETCH_FALSE));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
   const auto fetch_response = EXPECT_SUCCESS(session, client::iq_fetch_data(stub(), session, "", 10.0, 0, 1000));

--- a/source/tests/system/nirfmxspecan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxspecan_driver_api_tests.cpp
@@ -464,6 +464,21 @@ TEST_F(NiRFmxSpecAnDriverApiTests, DefaultConfiguration_IQFetchData_RecordIsDele
       client::iq_fetch_data(stub(), session, "", 10.0, 0, 1000));
 }
 
+TEST_F(NiRFmxSpecAnDriverApiTests, DefaultConfiguration_IQFetchDataFetchAllAvailable_DataIsFetched)
+{
+  constexpr auto INVALID_RECORD = -379451;
+  constexpr auto FETCH_ALL_AVAILABLE = -1;
+  constexpr auto EXPECTED_RECORD_COUNT = 50000;
+  const auto session = init_session(stub(), PXI_5663);
+  EXPECT_SUCCESS(session, client::select_measurements(stub(), session, "", MeasurementTypes::MEASUREMENT_TYPES_IQ, true));
+  EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
+
+  const auto fetch_response = EXPECT_SUCCESS(session, client::iq_fetch_data(stub(), session, "", 10.0, 0, FETCH_ALL_AVAILABLE));
+
+  EXPECT_THAT(fetch_response.data(), Not(IsEmpty()));
+  EXPECT_EQ(EXPECTED_RECORD_COUNT, fetch_response.data().size());
+}
+
 TEST_F(NiRFmxSpecAnDriverApiTests, DisableDeleteRecordOnFetch_IQFetchData_RecordIsStillAvailable)
 {
   const auto session = init_session(stub(), PXI_5663);

--- a/source/tests/system/nirfmxspecan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxspecan_driver_api_tests.cpp
@@ -447,7 +447,7 @@ TEST_F(NiRFmxSpecAnDriverApiTests, BuildSpurString_ReturnsSpurString)
   EXPECT_SUCCESS(session, spur_string_response);
 }
 
-TEST_F(NiRFmxSpecAnDriverApiTests, DefaultConfiguration_FetchIQData_RecordIsDeleted)
+TEST_F(NiRFmxSpecAnDriverApiTests, DefaultConfiguration_IQFetchData_RecordIsDeleted)
 {
   constexpr auto INVALID_RECORD = -379451;
   const auto session = init_session(stub(), PXI_5663);
@@ -464,7 +464,7 @@ TEST_F(NiRFmxSpecAnDriverApiTests, DefaultConfiguration_FetchIQData_RecordIsDele
       client::iq_fetch_data(stub(), session, "", 10.0, 0, 1000));
 }
 
-TEST_F(NiRFmxSpecAnDriverApiTests, DisableDeleteRecordOnFetch_FetchIQData_RecordIsStillAvailable)
+TEST_F(NiRFmxSpecAnDriverApiTests, DisableDeleteRecordOnFetch_IQFetchData_RecordIsStillAvailable)
 {
   const auto session = init_session(stub(), PXI_5663);
   EXPECT_SUCCESS(session, client::select_measurements(stub(), session, "", MeasurementTypes::MEASUREMENT_TYPES_IQ, true));


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add tests for IQFetchData "delete record on fetch" behavior.

Fixes [AB#1784631](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1784631).

### Why should this Pull Request be merged?

The default "delete record on fetch" behavior for IQFetchData is a gotcha in the C API, especially if you don't read the entire record. Adding test coverage for the common workarounds:
1. Fetch all available by passing `-1` for `samples_to_read`.
2. Set the `NIRFMXSPECAN_ATTRIBUTE_IQ_DELETE_RECORD_ON_FETCH` attribute before fetching.

### Alternative

We could expose a way to override the default as an additional field in the fetch request message. Reason rejected: this can be added easily later. Existing behavior is good enough and is consistent with the C API.

### What testing has been done?

Ran and passed all IQWFetchData tests.