### PR TITLE
Add support for setting code_readiness in server config file

### DIFF
--- a/source/server/server_configuration_parser.cpp
+++ b/source/server/server_configuration_parser.cpp
@@ -23,6 +23,7 @@ static const char* kSecurityJsonKey = "security";
 static const char* kCertsFolderName = "certs";
 static const char* kMaxMessageSizeKey = "max_message_size";
 static const char* kFeatureTogglesKey = "feature_toggles";
+static const char* kCodeReadinessKey = "code_readiness";
 #if defined(_MSC_VER)
 static const char* kPathDelimitter = "\\";
 #else
@@ -161,7 +162,41 @@ FeatureToggles ServerConfigurationParser::parse_feature_toggles() const
       throw InvalidFeatureToggleException(ex.what());
     }
   }
-  return FeatureToggles(std::move(map), FeatureToggles::CodeReadiness::kRelease);
+  return FeatureToggles(std::move(map), parse_code_readiness());
+}
+
+FeatureToggles::CodeReadiness ServerConfigurationParser::parse_code_readiness() const
+{
+  auto code_readiness_it = config_file_.find(kCodeReadinessKey);
+  if (code_readiness_it != config_file_.end()) {
+    try {
+      auto readiness_token_value = code_readiness_it->get<std::string>();
+      std::transform(
+          readiness_token_value.begin(),
+          readiness_token_value.end(),
+          readiness_token_value.begin(),
+          [](unsigned char c) { return std::tolower(c); });
+
+      using ReadinessMap = std::unordered_map<std::string, FeatureToggles::CodeReadiness>;
+      const auto READINESS_MAP = ReadinessMap{
+          {"release", FeatureToggles::CodeReadiness::kRelease},
+          {"nextrelease", FeatureToggles::CodeReadiness::kNextRelease},
+          {"incomplete", FeatureToggles::CodeReadiness::kIncomplete},
+          {"prototype", FeatureToggles::CodeReadiness::kPrototype}};
+
+      const auto readiness_map_iter = READINESS_MAP.find(readiness_token_value);
+      if (readiness_map_iter != READINESS_MAP.end()) {
+        return readiness_map_iter->second;
+      }
+
+      throw InvalidCodeReadinessException(readiness_token_value);
+    }
+    catch (const nlohmann::json::type_error& ex) {
+      throw InvalidCodeReadinessException(ex.what());
+    }
+  }
+
+  return FeatureToggles::CodeReadiness::kRelease;
 }
 
 std::string ServerConfigurationParser::parse_key_from_security_section(const char* key) const
@@ -239,6 +274,11 @@ ServerConfigurationParser::InvalidExePathException::InvalidExePathException()
 
 ServerConfigurationParser::InvalidFeatureToggleException::InvalidFeatureToggleException(const std::string& type_error_details)
     : std::runtime_error(kInvalidFeatureToggleMessage + type_error_details)
+{
+}
+
+ServerConfigurationParser::InvalidCodeReadinessException::InvalidCodeReadinessException(const std::string& type_error_details)
+    : std::runtime_error(kInvalidCodeReadinessMessage + type_error_details)
 {
 }
 

--- a/source/server/server_configuration_parser.cpp
+++ b/source/server/server_configuration_parser.cpp
@@ -181,6 +181,7 @@ FeatureToggles::CodeReadiness ServerConfigurationParser::parse_code_readiness() 
       const auto READINESS_MAP = ReadinessMap{
           {"release", FeatureToggles::CodeReadiness::kRelease},
           {"nextrelease", FeatureToggles::CodeReadiness::kNextRelease},
+          {"next_release", FeatureToggles::CodeReadiness::kNextRelease},
           {"incomplete", FeatureToggles::CodeReadiness::kIncomplete},
           {"prototype", FeatureToggles::CodeReadiness::kPrototype}};
 

--- a/source/server/server_configuration_parser.h
+++ b/source/server/server_configuration_parser.h
@@ -18,6 +18,7 @@ static const char* kFileNotFoundMessage = "The following certificate file was no
 static const char* kInvalidExePathMessage = "The server was unable to resolve the current executable path.";
 static const char* kInvalidMaxMessageSizeMessage = "The max message size must be an integer.";
 static const char* kInvalidFeatureToggleMessage = "Feature Toggles must be specified as boolean fields in the form \"feature_toggles\": { \"feature1\": true, \"feature2\": false }. \n\n";
+static const char* kInvalidCodeReadinessMessage = "code_readiness must be a string in [Release, NextRelease, Incomplete, Prototype].\n\n";
 static const char* kDefaultAddressPrefix = "[::]:";
 constexpr int UNLIMITED_MAX_MESSAGE_SIZE = -1;
 
@@ -36,6 +37,7 @@ class ServerConfigurationParser {
   std::string parse_root_cert() const;
   int parse_max_message_size() const;
   FeatureToggles parse_feature_toggles() const;
+  FeatureToggles::CodeReadiness parse_code_readiness() const;
 
   struct ConfigFileNotFoundException : public std::runtime_error {
     ConfigFileNotFoundException(const std::string& config_file_path);
@@ -71,6 +73,10 @@ class ServerConfigurationParser {
 
   struct InvalidFeatureToggleException : std::runtime_error {
     InvalidFeatureToggleException(const std::string& type_error_details);
+  };
+
+  struct InvalidCodeReadinessException : std::runtime_error {
+    InvalidCodeReadinessException(const std::string& type_error_details);
   };
 
   struct InvalidMaxMessageSizeException : std::runtime_error {

--- a/source/tests/unit/server_configuration_parser_tests.cpp
+++ b/source/tests/unit/server_configuration_parser_tests.cpp
@@ -546,6 +546,7 @@ INSTANTIATE_TEST_SUITE_P(
         {R"({"code_readiness": "release"})", Readiness::kRelease},
         {R"({})", Readiness::kRelease},
         {R"({"code_readiness": "NEXTRELEASE"})", Readiness::kNextRelease},
+        {R"({"code_readiness": "next_release"})", Readiness::kNextRelease},
         {R"({"code_readiness": "NextRelease"})", Readiness::kNextRelease},
         {R"({"code_readiness": "Prototype"})", Readiness::kPrototype},
         {R"({"code_readiness": "prototype"})", Readiness::kPrototype},
@@ -582,7 +583,7 @@ INSTANTIATE_TEST_SUITE_P(
     ::testing::ValuesIn(std::vector<std::string>{
         R"({"code_readiness": 10})",
         R"({"code_readiness": "notAReadiness"})",
-        R"({"code_readiness": "next_release"})",
+        R"({"code_readiness": "next-release"})",
         R"({"code_readiness": {}})"}));
 
 TEST_P(ServerConfigurationParserInvalidCodeReadinessTests, InvalidCodeReadinessConfiguration_ParseCodeReadiness_ThrowsInvalidCodeReadinessException)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add support for setting code_readiness in server config file.

Example config:

```json
{
   "port": 31763,
   "code_readiness": "nextrelease",
   "security" : {
      "server_cert": "",
      "server_key": "",
      "root_cert": ""
   }
}
```

Note that the values are case-insensitive.

### Why should this Pull Request be merged?

It's tedious to enable the `feature_toggle` for each prerelease driver, especially when there are multiple.

### What testing has been done?

Ran and passed new unit tests locally.

Manual testing with RFmx examples.