### PR TITLE
Add NR system tests using Complex data types.

### DIFF
--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -793,10 +793,18 @@ TEST_F(NiRFmxNRDriverApiTests, ULModAccSpeedOptimizedFromExample_FetchData_DataL
   EXPECT_SUCCESS(session, client::mod_acc_cfg_reference_waveform(stub(), session, "", waveform.t0, waveform.dt, waveform.data));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
   float64 composite_rms_evm_mean = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_COMPOSITE_RMS_EVM_MEAN);
-  float64 in_band_emission_margin = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_IN_BAND_EMISSION_MARGIN);
+  float64 composite_peak_evm_maximum = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_COMPOSITE_PEAK_EVM_MAXIMUM);
+  float64 pusch_data_rms_evm_mean = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_PUSCH_DATA_RMS_EVM_MEAN);
+  float64 pusch_data_peak_evm_maximum = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_PUSCH_DATA_PEAK_EVM_MAXIMUM);
+  float64 pusch_dmrs_rms_evm_mean = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_PUSCH_DMRS_RMS_EVM_MEAN);
+  float64 pusch_dmrs_peak_evm_maximum = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_PUSCH_DMRS_PEAK_EVM_MAXIMUM);
 
   EXPECT_LT(0.0, composite_rms_evm_mean);
-  EXPECT_TRUE(isnan(in_band_emission_margin));
+  EXPECT_LT(0.0, composite_peak_evm_maximum);
+  EXPECT_LT(0.0, pusch_data_rms_evm_mean);
+  EXPECT_LT(0.0, pusch_data_peak_evm_maximum);
+  EXPECT_LT(0.0, pusch_dmrs_rms_evm_mean);
+  EXPECT_LT(0.0, pusch_dmrs_peak_evm_maximum);
 }
 
 }  // namespace

--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -792,11 +792,11 @@ TEST_F(NiRFmxNRDriverApiTests, ULModAccSpeedOptimizedFromExample_FetchData_DataL
   auto waveform = load_test_waveform_data<float, nidevice_grpc::NIComplexNumberF32>("NR_FR2_UL_SISO_CC-1_BW-50MHz_SCS-120kHz.json");
   EXPECT_SUCCESS(session, client::mod_acc_cfg_reference_waveform(stub(), session, "", waveform.t0, waveform.dt, waveform.data));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
-  float64 composite_rms_evm_mean_first = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_COMPOSITE_RMS_EVM_MEAN);
-  float64 in_band_emission_margin_first = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_IN_BAND_EMISSION_MARGIN);
+  float64 composite_rms_evm_mean = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_COMPOSITE_RMS_EVM_MEAN);
+  float64 in_band_emission_margin = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_IN_BAND_EMISSION_MARGIN);
 
-  EXPECT_LT(0.0, composite_rms_evm_mean_first);
-  EXPECT_TRUE(isnan(in_band_emission_margin_first));
+  EXPECT_LT(0.0, composite_rms_evm_mean);
+  EXPECT_TRUE(isnan(in_band_emission_margin));
 }
 
 }  // namespace

--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -800,8 +800,8 @@ TEST_F(NiRFmxNRDriverApiTests, ULModAccSpeedOptimizedFromExample_FetchData_DataL
   float64 composite_rms_evm_mean_second = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_COMPOSITE_RMS_EVM_MEAN);
   float64 in_band_emission_margin_second = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_IN_BAND_EMISSION_MARGIN);
 
-  EXPECT_GT(0.0, composite_rms_evm_mean_first);
-  EXPECT_GT(0.0, composite_rms_evm_mean_second);
+  EXPECT_LT(0.0, composite_rms_evm_mean_first);
+  EXPECT_LT(0.0, composite_rms_evm_mean_second);
   EXPECT_NE(composite_rms_evm_mean_first, composite_rms_evm_mean_second);
   EXPECT_TRUE(isnan(in_band_emission_margin_first));
   EXPECT_TRUE(isnan(in_band_emission_margin_second));

--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -788,23 +788,13 @@ TEST_F(NiRFmxNRDriverApiTests, ULModAccSpeedOptimizedFromExample_FetchData_DataL
 
   // READ TDMS File
   auto waveform = load_test_waveform_data<float, nidevice_grpc::NIComplexNumberF32>("NR_FR2_UL_SISO_CC-1_BW-50MHz_SCS-120kHz.json");
-  // Split waveform data in two so it can fit within message limits.
-  std::vector<nidevice_grpc::NIComplexNumberF32> waveform_data_first_half(waveform.data.begin(), waveform.data.begin() + 300000);
-  std::vector<nidevice_grpc::NIComplexNumberF32> waveform_data_second_half(waveform.data.begin() + 300000, waveform.data.begin() + 600000);
-  EXPECT_SUCCESS(session, client::mod_acc_cfg_reference_waveform(stub(), session, "", waveform.t0, waveform.dt, waveform_data_first_half));
+  EXPECT_SUCCESS(session, client::mod_acc_cfg_reference_waveform(stub(), session, "", waveform.t0, waveform.dt, waveform.data));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
   float64 composite_rms_evm_mean_first = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_COMPOSITE_RMS_EVM_MEAN);
   float64 in_band_emission_margin_first = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_IN_BAND_EMISSION_MARGIN);
-  EXPECT_SUCCESS(session, client::mod_acc_cfg_reference_waveform(stub(), session, "", waveform.t0, waveform.dt, waveform_data_second_half));
-  EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
-  float64 composite_rms_evm_mean_second = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_COMPOSITE_RMS_EVM_MEAN);
-  float64 in_band_emission_margin_second = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_IN_BAND_EMISSION_MARGIN);
 
   EXPECT_LT(0.0, composite_rms_evm_mean_first);
-  EXPECT_LT(0.0, composite_rms_evm_mean_second);
-  EXPECT_NE(composite_rms_evm_mean_first, composite_rms_evm_mean_second);
   EXPECT_TRUE(isnan(in_band_emission_margin_first));
-  EXPECT_TRUE(isnan(in_band_emission_margin_second));
 }
 
 }  // namespace

--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -800,8 +800,9 @@ TEST_F(NiRFmxNRDriverApiTests, ULModAccSpeedOptimizedFromExample_FetchData_DataL
   float64 composite_rms_evm_mean_second = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_COMPOSITE_RMS_EVM_MEAN);
   float64 in_band_emission_margin_second = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_IN_BAND_EMISSION_MARGIN);
 
-  EXPECT_NEAR(801.389, composite_rms_evm_mean_first, .001);
-  EXPECT_NEAR(1041.894, composite_rms_evm_mean_second, .001);
+  EXPECT_GT(0.0, composite_rms_evm_mean_first);
+  EXPECT_GT(0.0, composite_rms_evm_mean_second);
+  EXPECT_NE(composite_rms_evm_mean_first, composite_rms_evm_mean_second);
   EXPECT_TRUE(isnan(in_band_emission_margin_first));
   EXPECT_TRUE(isnan(in_band_emission_margin_second));
 }

--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -733,13 +733,11 @@ TEST_F(NiRFmxNRDriverApiTests, ULModAccSpeedOptimizedFromExample_FetchData_DataL
   std::vector<int> PUSCHNumberOfResourceBlocks{-1};
   auto session = init_session(stub(), PXI_5663E);
   EXPECT_SUCCESS(session, client::cfg_frequency_reference(stub(), session, "", FREQUENCY_REFERENCE_SOURCE_ONBOARD_CLOCK, 10.0e6));
-  //RFmxCheckWarn(RFmxInstr_SetLOSource(instrumentHandle, "", RFMXINSTR_VAL_LO_SOURCE_AUTOMATIC_SG_SA_SHARED));
-  // EXPECT_SUCCESS(session, instr_client::set_attribute_string(instr_stub, session, "", nirfmxinstr_grpc::NIRFMXINSTR_ATTRIBUTE_LO_SOURCE, nirfmxinstr_grpc::NIRFMXINSTR_STRING_LO_SOURCE_LO_IN))
   EXPECT_SUCCESS(session, client::set_attribute_string(stub(), session, "", NIRFMXNR_ATTRIBUTE_SELECTED_PORTS, std::string()));
   EXPECT_SUCCESS(session, client::cfg_rf(stub(), session, "", 3.5e9, 0.0, 0.0));
   EXPECT_SUCCESS(session, client::cfg_digital_edge_trigger(stub(), session, "", DIGITAL_EDGE_TRIGGER_SOURCE_PXI_TRIG0, DIGITAL_EDGE_TRIGGER_EDGE_RISING_EDGE, 0.0, true));
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_FREQUENCY_RANGE, NIRFMXNR_INT32_FREQUENCY_RANGE_RANGE1));
-  EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, "", NIRFMXNR_ATTRIBUTE_COMPONENT_CARRIER_BANDWIDTH, 100e6));
+  EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, "", NIRFMXNR_ATTRIBUTE_COMPONENT_CARRIER_BANDWIDTH, 50e6));  // Adjusted from 100e6 because it complained IQ Rate was too high.
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_CELL_ID, 0));
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_BAND, 78));
   EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, "", NIRFMXNR_ATTRIBUTE_BANDWIDTH_PART_SUBCARRIER_SPACING, 30e3));
@@ -767,7 +765,6 @@ TEST_F(NiRFmxNRDriverApiTests, ULModAccSpeedOptimizedFromExample_FetchData_DataL
   }
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_PUSCH_DMRS_POWER_MODE, NIRFMXNR_INT32_PUSCH_DMRS_POWER_MODE_CDM_GROUPS));
   EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, "", NIRFMXNR_ATTRIBUTE_PUSCH_DMRS_POWER, 0.0));
-  // EXPECT_SUCCESS(session, instr_client::set_attribute_f64(instr_stub, session, "", nirfmxinstr_grpc::NIRFMXINSTR_ATTRIBUTE_RECOMMENDED_IQ_MINIMUM_SAMPLE_RATE, 70e6));
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_PUSCH_DMRS_CONFIGURATION_TYPE, NIRFMXNR_INT32_PUSCH_DMRS_CONFIGURATION_TYPE_TYPE1));
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_PUSCH_MAPPING_TYPE, NIRFMXNR_INT32_PUSCH_MAPPING_TYPE_A));
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_PUSCH_DMRS_TYPE_A_POSITION, 2));
@@ -791,12 +788,12 @@ TEST_F(NiRFmxNRDriverApiTests, ULModAccSpeedOptimizedFromExample_FetchData_DataL
 
   // READ TDMS File
   auto waveforms = load_test_multiple_waveforms_data<float, nidevice_grpc::NIComplexNumberF32>("WLAN_80211n_20MHz_1Seg_2Chain_MIMO.json", 2);
-  EXPECT_SUCCESS(session, client::mod_acc_cfg_reference_waveform(stub(), session, "", waveforms[0].t0, waveforms[0].dt, waveforms[0].data));
+  EXPECT_SUCCESS(session, client::mod_acc_cfg_reference_waveform(stub(), session, "", waveforms[1].t0, waveforms[1].dt, waveforms[1].data));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
   float64 compositeRMSEVMMean = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_COMPOSITE_RMS_EVM_MEAN);
   float64 inBandEmissionMargin = GET_ATTR_F64(session, "", NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_IN_BAND_EMISSION_MARGIN);
-  EXPECT_EQ(0.0, compositeRMSEVMMean);
-  EXPECT_EQ(0.0, inBandEmissionMargin);
+  EXPECT_NEAR(67.9375, compositeRMSEVMMean, .0001);
+  EXPECT_TRUE(isnan(inBandEmissionMargin));
 }
 
 }  // namespace

--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -25,6 +25,8 @@ const auto NR_SYNC_FAILURE = 684300;
 const auto NR_SYNC_FAILURE_STR = "Failed to synchronize to the signal";
 const auto IVI_ERROR_INVALID_VALUE = -1074135024;
 const auto IVI_ERROR_INVALID_VALUE_STR = "Invalid value for parameter or property";
+const auto INCORRECT_TYPE_ERROR_CODE = -380251;
+const auto INCORRECT_TYPE_ERROR_STR = "Incorrect data type specified";
 
 template <typename TResponse>
 void EXPECT_RESPONSE_SUCCESS(const TResponse& response)
@@ -721,7 +723,7 @@ TEST_F(NiRFmxNRDriverApiTests, SetAttributeComplex_ExpectedError)
   const auto session = init_session(stub(), PXI_5663E);
 
   EXPECT_ERROR(
-      -380251, "Incorrect data type specified", session,
+      INCORRECT_TYPE_ERROR_CODE, INCORRECT_TYPE_ERROR_STR, session,
       client::set_attribute_ni_complex_double_array(stub(), session, "", NIRFMXNR_ATTRIBUTE_SEM_OFFSET_START_FREQUENCY, complex_number_array({1.2, 2.2}, {1e6, 1.01e6})));
 }
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Adding JSON file for an NR waveform (converted from TDMS file in C Examples)
- Added a SetComplexAttribute test to cover using NIComplexNumber
- Adapted ULModAccSpeedOptimized C Example to system-level test using the JSON file for the waveform. Covers using NIComplexNumberF32

### Why should this Pull Request be merged?

Fixes [AB#1836621](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1836621).
We want some system-level tests in NR covering passing around Complex data types (NIComplexNumber and NIComplexNumberF32).

### What testing has been done?

NR system-level tests pass including two new ones:

![image](https://user-images.githubusercontent.com/77176215/153313238-d316e4ad-cd43-489b-a215-4fb52b5674b4.png)