### PR TITLE
Update grpc-device to use black auto-formatter

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -57,6 +57,11 @@ jobs:
     - name: Update Submodules
       run: git submodule update --init --recursive --depth=1
 
+    - name: Validate python style with black
+      run: |
+        pip install black
+        black source/codegen examples --check
+
     - name: Configure
       shell: cmake -P {0}
       run: |
@@ -221,4 +226,3 @@ jobs:
         azure-devops-project-url: 'https://dev.azure.com/ni/DevCentral'
         azure-pipeline-name: 'ni-central-grpc-device-release-desktop'
         azure-devops-token: ${{ secrets.AZDO_PIPELINE_TRIGGERS }}
-

--- a/examples/nidaqmx/analog-input-betterproto.py
+++ b/examples/nidaqmx/analog-input-betterproto.py
@@ -24,7 +24,7 @@
 # being used.
 #
 # To run this example without hardware: create a simulated device in NI MAX on the server (Windows only).
-# 
+#
 # Running from command line:
 #
 # Server machine's IP address, port number, and physical channel name can be passed as separate command line arguments.
@@ -58,9 +58,7 @@ async def main():
     # Raise an exception if an error was returned
     async def raise_if_error(response):
         if response.status != 0:
-            response = await daq_service.get_error_string(
-                error_code=response.status
-            )
+            response = await daq_service.get_error_string(error_code=response.status)
             raise Exception(f"Error: {response.error_string}")
 
     try:
@@ -90,10 +88,10 @@ async def main():
         )
 
         await raise_if_error(await daq_service.start_task(task=task))
-        
+
         response = await daq_service.get_task_attribute_u_int32(
-            task=task,
-            attribute_raw=nidaqmx_grpc.TaskUInt32Attribute.TASK_ATTRIBUTE_NUM_CHANS)
+            task=task, attribute_raw=nidaqmx_grpc.TaskUInt32Attribute.TASK_ATTRIBUTE_NUM_CHANS
+        )
         await raise_if_error(response)
         number_of_channels = response.value
 
@@ -108,7 +106,8 @@ async def main():
 
         print(
             f"Acquired {len(response.read_array)} samples.",
-            f"({response.samps_per_chan_read} samples per channel)")
+            f"({response.samps_per_chan_read} samples per channel)",
+        )
         print(f"First 5 samples: {response.read_array[:5]}")
     except GRPCError as e:
         if e.status.name == "UNIMPLEMENTED":

--- a/examples/nidaqmx/analog-output.py
+++ b/examples/nidaqmx/analog-output.py
@@ -46,33 +46,42 @@ task = None
 # Raise an exception if an error was returned
 def RaiseIfError(response):
     if response.status != 0:
-        response = client.GetErrorString(nidaqmx_types.GetErrorStringRequest(
-            error_code=response.status))
+        response = client.GetErrorString(
+            nidaqmx_types.GetErrorStringRequest(error_code=response.status)
+        )
         raise Exception(f"Error: {response.error_string}")
 
 
 try:
-    response = client.CreateTask(
-        nidaqmx_types.CreateTaskRequest(session_name="my task"))
+    response = client.CreateTask(nidaqmx_types.CreateTaskRequest(session_name="my task"))
     RaiseIfError(response)
     task = response.task
 
-    RaiseIfError(client.CreateAOVoltageChan(nidaqmx_types.CreateAOVoltageChanRequest(
-        task=task,
-        physical_channel=physical_channel,
-        min_val=-10.0,
-        max_val=10.0,
-        units=nidaqmx_types.VOLTAGE_UNITS2_VOLTS
-    )))
+    RaiseIfError(
+        client.CreateAOVoltageChan(
+            nidaqmx_types.CreateAOVoltageChanRequest(
+                task=task,
+                physical_channel=physical_channel,
+                min_val=-10.0,
+                max_val=10.0,
+                units=nidaqmx_types.VOLTAGE_UNITS2_VOLTS,
+            )
+        )
+    )
 
     RaiseIfError(client.StartTask(nidaqmx_types.StartTaskRequest(task=task)))
 
-    RaiseIfError(client.WriteAnalogF64(nidaqmx_types.WriteAnalogF64Request(
-        task=task,
-        num_samps_per_chan=1,
-        data_layout=nidaqmx_types.GROUP_BY_GROUP_BY_CHANNEL,
-        write_array=[1.0],
-        timeout=10.0)))
+    RaiseIfError(
+        client.WriteAnalogF64(
+            nidaqmx_types.WriteAnalogF64Request(
+                task=task,
+                num_samps_per_chan=1,
+                data_layout=nidaqmx_types.GROUP_BY_GROUP_BY_CHANNEL,
+                write_array=[1.0],
+                timeout=10.0,
+            )
+        )
+    )
 
     print(f"Output was successfully written to {physical_channel}.")
 except grpc.RpcError as rpc_error:
@@ -80,8 +89,10 @@ except grpc.RpcError as rpc_error:
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
-    print(f"{error_message}") 
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
+    print(f"{error_message}")
 finally:
     if task:
         client.StopTask(nidaqmx_types.StopTaskRequest(task=task))

--- a/examples/nidaqmx/counter-input.py
+++ b/examples/nidaqmx/counter-input.py
@@ -47,34 +47,38 @@ task = None
 # Raise an exception if an error was returned
 def RaiseIfError(response):
     if response.status != 0:
-        response = client.GetErrorString(nidaqmx_types.GetErrorStringRequest(
-            error_code=response.status))
+        response = client.GetErrorString(
+            nidaqmx_types.GetErrorStringRequest(error_code=response.status)
+        )
         raise Exception(f"Error: {response.error_string}")
 
 
 try:
-    response = client.CreateTask(
-        nidaqmx_types.CreateTaskRequest(session_name="my task"))
+    response = client.CreateTask(nidaqmx_types.CreateTaskRequest(session_name="my task"))
     RaiseIfError(response)
     task = response.task
 
-    RaiseIfError(client.CreateCIFreqChan(nidaqmx_types.CreateCIFreqChanRequest(
-        task=task,
-        counter=counter_name,
-        min_val=1.192093,
-        max_val=10000000,
-        units=nidaqmx_types.FREQUENCY_UNITS3_HZ,
-        edge=nidaqmx_types.EDGE1_RISING,
-        meas_method=nidaqmx_types.COUNTER_FREQUENCY_METHOD_LOW_FREQ_1_CTR,
-        meas_time=0.001,
-        divisor=4)))
+    RaiseIfError(
+        client.CreateCIFreqChan(
+            nidaqmx_types.CreateCIFreqChanRequest(
+                task=task,
+                counter=counter_name,
+                min_val=1.192093,
+                max_val=10000000,
+                units=nidaqmx_types.FREQUENCY_UNITS3_HZ,
+                edge=nidaqmx_types.EDGE1_RISING,
+                meas_method=nidaqmx_types.COUNTER_FREQUENCY_METHOD_LOW_FREQ_1_CTR,
+                meas_time=0.001,
+                divisor=4,
+            )
+        )
+    )
 
     RaiseIfError(client.StartTask(nidaqmx_types.StartTaskRequest(task=task)))
 
-    response = client.ReadCounterScalarF64(nidaqmx_types.ReadCounterScalarF64Request(
-        task=task,
-        timeout=10.0
-    ))
+    response = client.ReadCounterScalarF64(
+        nidaqmx_types.ReadCounterScalarF64Request(task=task, timeout=10.0)
+    )
     RaiseIfError(response)
     print(f"Frequency: {response.value} Hz")
 except grpc.RpcError as rpc_error:
@@ -82,8 +86,10 @@ except grpc.RpcError as rpc_error:
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
-    print(f"{error_message}") 
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
+    print(f"{error_message}")
 finally:
     if task:
         client.StopTask(nidaqmx_types.StopTaskRequest(task=task))

--- a/examples/nidaqmx/counter-output.py
+++ b/examples/nidaqmx/counter-output.py
@@ -47,31 +47,38 @@ task = None
 # Raise an exception if an error was returned
 def RaiseIfError(response):
     if response.status != 0:
-        response = client.GetErrorString(nidaqmx_types.GetErrorStringRequest(
-            error_code=response.status))
+        response = client.GetErrorString(
+            nidaqmx_types.GetErrorStringRequest(error_code=response.status)
+        )
         raise Exception(f"Error: {response.error_string}")
 
 
 try:
-    response = client.CreateTask(
-        nidaqmx_types.CreateTaskRequest(session_name="my task"))
+    response = client.CreateTask(nidaqmx_types.CreateTaskRequest(session_name="my task"))
     RaiseIfError(response)
     task = response.task
 
-    RaiseIfError(client.CreateCOPulseChanTime(nidaqmx_types.CreateCOPulseChanTimeRequest(
-        task=task,
-        counter=counter_name,
-        units=nidaqmx_types.DIGITAL_WIDTH_UNITS3_SECONDS,
-        idle_state=nidaqmx_types.LEVEL1_LOW,
-        initial_delay=1.0,
-        low_time=0.5,
-        high_time=1.0)))
+    RaiseIfError(
+        client.CreateCOPulseChanTime(
+            nidaqmx_types.CreateCOPulseChanTimeRequest(
+                task=task,
+                counter=counter_name,
+                units=nidaqmx_types.DIGITAL_WIDTH_UNITS3_SECONDS,
+                idle_state=nidaqmx_types.LEVEL1_LOW,
+                initial_delay=1.0,
+                low_time=0.5,
+                high_time=1.0,
+            )
+        )
+    )
 
     RaiseIfError(client.StartTask(nidaqmx_types.StartTaskRequest(task=task)))
 
-    RaiseIfError(client.WaitUntilTaskDone(nidaqmx_types.WaitUntilTaskDoneRequest(
-        task=task,
-        time_to_wait=10.0)))
+    RaiseIfError(
+        client.WaitUntilTaskDone(
+            nidaqmx_types.WaitUntilTaskDoneRequest(task=task, time_to_wait=10.0)
+        )
+    )
 
     print(f"Output was successfully written to {counter_name}.")
 except grpc.RpcError as rpc_error:
@@ -79,8 +86,10 @@ except grpc.RpcError as rpc_error:
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
-    print(f"{error_message}") 
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
+    print(f"{error_message}")
 finally:
     if task:
         client.StopTask(nidaqmx_types.StopTaskRequest(task=task))

--- a/examples/nidaqmx/digital-input-betterproto.py
+++ b/examples/nidaqmx/digital-input-betterproto.py
@@ -58,9 +58,7 @@ async def main():
     # Raise an exception if an error was returned
     async def raise_if_error(response):
         if response.status != 0:
-            response = await daq_service.get_error_string(
-                error_code=response.status
-            )
+            response = await daq_service.get_error_string(error_code=response.status)
             raise Exception(f"Error: {response.error_string}")
 
     try:

--- a/examples/nidaqmx/digital-input.py
+++ b/examples/nidaqmx/digital-input.py
@@ -47,31 +47,36 @@ task = None
 # Raise an exception if an error was returned
 def RaiseIfError(response):
     if response.status != 0:
-        response = client.GetErrorString(nidaqmx_types.GetErrorStringRequest(
-            error_code=response.status))
+        response = client.GetErrorString(
+            nidaqmx_types.GetErrorStringRequest(error_code=response.status)
+        )
         raise Exception(f"Error: {response.error_string}")
 
 
 try:
-    response = client.CreateTask(
-        nidaqmx_types.CreateTaskRequest(session_name="my task"))
+    response = client.CreateTask(nidaqmx_types.CreateTaskRequest(session_name="my task"))
     RaiseIfError(response)
     task = response.task
 
-    RaiseIfError(client.CreateDIChan(nidaqmx_types.CreateDIChanRequest(
-        task=task,
-        lines=lines,
-        line_grouping=nidaqmx_types.LINE_GROUPING_CHAN_FOR_ALL_LINES
-    )))
+    RaiseIfError(
+        client.CreateDIChan(
+            nidaqmx_types.CreateDIChanRequest(
+                task=task, lines=lines, line_grouping=nidaqmx_types.LINE_GROUPING_CHAN_FOR_ALL_LINES
+            )
+        )
+    )
 
     RaiseIfError(client.StartTask(nidaqmx_types.StartTaskRequest(task=task)))
 
-    response = client.ReadDigitalU32(nidaqmx_types.ReadDigitalU32Request(
-        task=task,
-        num_samps_per_chan=1,
-        array_size_in_samps=1,
-        fill_mode=nidaqmx_types.GROUP_BY_GROUP_BY_CHANNEL,
-        timeout=10.0))
+    response = client.ReadDigitalU32(
+        nidaqmx_types.ReadDigitalU32Request(
+            task=task,
+            num_samps_per_chan=1,
+            array_size_in_samps=1,
+            fill_mode=nidaqmx_types.GROUP_BY_GROUP_BY_CHANNEL,
+            timeout=10.0,
+        )
+    )
     RaiseIfError(response)
     print(f"Data acquired: {hex(response.read_array[0])}")
 except grpc.RpcError as rpc_error:
@@ -79,8 +84,10 @@ except grpc.RpcError as rpc_error:
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
-    print(f"{error_message}") 
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
+    print(f"{error_message}")
 finally:
     if task:
         client.StopTask(nidaqmx_types.StopTaskRequest(task=task))

--- a/examples/nidaqmx/digital-output.py
+++ b/examples/nidaqmx/digital-output.py
@@ -47,33 +47,39 @@ task = None
 # Raise an exception if an error was returned
 def RaiseIfError(response):
     if response.status != 0:
-        response = client.GetErrorString(nidaqmx_types.GetErrorStringRequest(
-            error_code=response.status))
+        response = client.GetErrorString(
+            nidaqmx_types.GetErrorStringRequest(error_code=response.status)
+        )
         raise Exception(f"Error: {response.error_string}")
 
 
 try:
-    response = client.CreateTask(
-        nidaqmx_types.CreateTaskRequest(session_name="my task"))
+    response = client.CreateTask(nidaqmx_types.CreateTaskRequest(session_name="my task"))
     RaiseIfError(response)
     task = response.task
 
-    RaiseIfError(client.CreateDOChan(nidaqmx_types.CreateDOChanRequest(
-        task=task,
-        lines=lines,
-        line_grouping=nidaqmx_types.LINE_GROUPING_CHAN_FOR_ALL_LINES
-    )))
+    RaiseIfError(
+        client.CreateDOChan(
+            nidaqmx_types.CreateDOChanRequest(
+                task=task, lines=lines, line_grouping=nidaqmx_types.LINE_GROUPING_CHAN_FOR_ALL_LINES
+            )
+        )
+    )
 
     RaiseIfError(client.StartTask(nidaqmx_types.StartTaskRequest(task=task)))
 
-    RaiseIfError(client.WriteDigitalU32(nidaqmx_types.WriteDigitalU32Request(
-        task=task,
-        num_samps_per_chan=1,
-        auto_start=True,
-        timeout=10.0,
-        data_layout=nidaqmx_types.GROUP_BY_GROUP_BY_CHANNEL,
-        write_array=[0xffff]
-    )))
+    RaiseIfError(
+        client.WriteDigitalU32(
+            nidaqmx_types.WriteDigitalU32Request(
+                task=task,
+                num_samps_per_chan=1,
+                auto_start=True,
+                timeout=10.0,
+                data_layout=nidaqmx_types.GROUP_BY_GROUP_BY_CHANNEL,
+                write_array=[0xFFFF],
+            )
+        )
+    )
 
     print(f"Output was successfully written to {lines}.")
 except grpc.RpcError as rpc_error:
@@ -81,8 +87,10 @@ except grpc.RpcError as rpc_error:
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
-    print(f"{error_message}") 
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
+    print(f"{error_message}")
 finally:
     if task:
         client.StopTask(nidaqmx_types.StopTaskRequest(task=task))

--- a/examples/nidaqmx/dsa-shared-timebase-and-trig-analog-input-and-output.py
+++ b/examples/nidaqmx/dsa-shared-timebase-and-trig-analog-input-and-output.py
@@ -130,33 +130,55 @@ async def main():
             client = grpc_nidaqmx.NiDAQmxStub(channel)
 
             async def get_terminal_name_with_dev_prefix(task, terminal_name):
-                num_devices_response = await raise_if_error_async(client.GetTaskAttributeUInt32(nidaqmx_types.GetTaskAttributeUInt32Request(
-                    task=task, attribute=nidaqmx_types.TASK_ATTRIBUTE_NUM_DEVICES
-                )))
+                num_devices_response = await raise_if_error_async(
+                    client.GetTaskAttributeUInt32(
+                        nidaqmx_types.GetTaskAttributeUInt32Request(
+                            task=task, attribute=nidaqmx_types.TASK_ATTRIBUTE_NUM_DEVICES
+                        )
+                    )
+                )
                 num_devices = num_devices_response.value
                 for i in range(num_devices):
                     # devices are 1-indexed, so use i + 1 here
-                    device = (await raise_if_error_async(client.GetNthTaskDevice(nidaqmx_types.GetNthTaskDeviceRequest(
-                        task=task, index=i + 1
-                    )))).buffer
-                    device_category = (await raise_if_error_async(client.GetDeviceAttributeInt32(nidaqmx_types.GetDeviceAttributeInt32Request(
-                        device_name=device, attribute=nidaqmx_types.DEVICE_ATTRIBUTE_PRODUCT_CATEGORY
-                    )))).value
-                    if device_category != nidaqmx_types.DEVICE_INT32_PRODUCT_CATEGORY_C_SERIES_MODULE and device_category != nidaqmx_types.DEVICE_INT32_PRODUCT_CATEGORY_SCXI_MODULE:
+                    device = (
+                        await raise_if_error_async(
+                            client.GetNthTaskDevice(
+                                nidaqmx_types.GetNthTaskDeviceRequest(task=task, index=i + 1)
+                            )
+                        )
+                    ).buffer
+                    device_category = (
+                        await raise_if_error_async(
+                            client.GetDeviceAttributeInt32(
+                                nidaqmx_types.GetDeviceAttributeInt32Request(
+                                    device_name=device,
+                                    attribute=nidaqmx_types.DEVICE_ATTRIBUTE_PRODUCT_CATEGORY,
+                                )
+                            )
+                        )
+                    ).value
+                    if (
+                        device_category
+                        != nidaqmx_types.DEVICE_INT32_PRODUCT_CATEGORY_C_SERIES_MODULE
+                        and device_category
+                        != nidaqmx_types.DEVICE_INT32_PRODUCT_CATEGORY_SCXI_MODULE
+                    ):
                         return "/" + device + "/" + terminal_name
                 raise Exception("Unable to get terminal name for timebase!")
 
             def generate_sinewave(elements, amplitude, frequency, phase):
                 sinewave = [
-                    amplitude * math.sin(math.pi/180.0 * (phase + 360.0 * frequency * i)) for i in range(elements)]
+                    amplitude * math.sin(math.pi / 180.0 * (phase + 360.0 * frequency * i))
+                    for i in range(elements)
+                ]
                 new_phase = (phase + frequency * 360.0 * elements) % 360.0
                 return (sinewave, new_phase)
 
             async def raise_if_error(response):
                 if response.status:
                     response = await client.GetErrorString(
-                        nidaqmx_types.GetErrorStringRequest(
-                            error_code=response.status))
+                        nidaqmx_types.GetErrorStringRequest(error_code=response.status)
+                    )
                     raise Exception(f"Error: {response.error_string}")
 
             async def raise_if_error_async(awaitable_call):
@@ -166,175 +188,378 @@ async def main():
 
             # DAQmx Configure Tasks code
             response: nidaqmx_types.CreateTaskResponse = await raise_if_error_async(
-                client.CreateTask(nidaqmx_types.CreateTaskRequest(session_name="Leader input task")))
+                client.CreateTask(nidaqmx_types.CreateTaskRequest(session_name="Leader input task"))
+            )
             leader_input_task = response.task
-            await raise_if_error_async(client.CreateAIVoltageChan(nidaqmx_types.CreateAIVoltageChanRequest(
-                task=leader_input_task, physical_channel=leader_input_channel,
-                min_val=-10.0, max_val=10.0, units=nidaqmx_types.VOLTAGE_UNITS2_VOLTS,
-                terminal_config=nidaqmx_types.INPUT_TERM_CFG_WITH_DEFAULT_CFG_DEFAULT
-            )))
-            await raise_if_error_async(client.CfgSampClkTiming(nidaqmx_types.CfgSampClkTimingRequest(
-                task=leader_input_task, rate=10000, active_edge=nidaqmx_types.EDGE1_RISING,
-                sample_mode=nidaqmx_types.ACQUISITION_TYPE_CONT_SAMPS, samps_per_chan=1000
-            )))
+            await raise_if_error_async(
+                client.CreateAIVoltageChan(
+                    nidaqmx_types.CreateAIVoltageChanRequest(
+                        task=leader_input_task,
+                        physical_channel=leader_input_channel,
+                        min_val=-10.0,
+                        max_val=10.0,
+                        units=nidaqmx_types.VOLTAGE_UNITS2_VOLTS,
+                        terminal_config=nidaqmx_types.INPUT_TERM_CFG_WITH_DEFAULT_CFG_DEFAULT,
+                    )
+                )
+            )
+            await raise_if_error_async(
+                client.CfgSampClkTiming(
+                    nidaqmx_types.CfgSampClkTimingRequest(
+                        task=leader_input_task,
+                        rate=10000,
+                        active_edge=nidaqmx_types.EDGE1_RISING,
+                        sample_mode=nidaqmx_types.ACQUISITION_TYPE_CONT_SAMPS,
+                        samps_per_chan=1000,
+                    )
+                )
+            )
 
             response = await raise_if_error_async(
-                client.CreateTask(nidaqmx_types.CreateTaskRequest(session_name="Leader output task")))
+                client.CreateTask(
+                    nidaqmx_types.CreateTaskRequest(session_name="Leader output task")
+                )
+            )
             leader_output_task = response.task
-            await raise_if_error_async(client.CreateAOVoltageChan(nidaqmx_types.CreateAOVoltageChanRequest(
-                task=leader_output_task, physical_channel=leader_output_channel,
-                min_val=-10.0, max_val=10.0, units=nidaqmx_types.VOLTAGE_UNITS2_VOLTS,
-            )))
-            await raise_if_error_async(client.CfgSampClkTiming(nidaqmx_types.CfgSampClkTimingRequest(
-                task=leader_output_task, rate=10000, active_edge=nidaqmx_types.EDGE1_RISING,
-                sample_mode=nidaqmx_types.ACQUISITION_TYPE_CONT_SAMPS, samps_per_chan=1000
-            )))
+            await raise_if_error_async(
+                client.CreateAOVoltageChan(
+                    nidaqmx_types.CreateAOVoltageChanRequest(
+                        task=leader_output_task,
+                        physical_channel=leader_output_channel,
+                        min_val=-10.0,
+                        max_val=10.0,
+                        units=nidaqmx_types.VOLTAGE_UNITS2_VOLTS,
+                    )
+                )
+            )
+            await raise_if_error_async(
+                client.CfgSampClkTiming(
+                    nidaqmx_types.CfgSampClkTimingRequest(
+                        task=leader_output_task,
+                        rate=10000,
+                        active_edge=nidaqmx_types.EDGE1_RISING,
+                        sample_mode=nidaqmx_types.ACQUISITION_TYPE_CONT_SAMPS,
+                        samps_per_chan=1000,
+                    )
+                )
+            )
 
             response = await raise_if_error_async(
-                client.CreateTask(nidaqmx_types.CreateTaskRequest(session_name="Follower input task")))
+                client.CreateTask(
+                    nidaqmx_types.CreateTaskRequest(session_name="Follower input task")
+                )
+            )
             follower_input_task = response.task
-            await raise_if_error_async(client.CreateAIVoltageChan(nidaqmx_types.CreateAIVoltageChanRequest(
-                task=follower_input_task, physical_channel=follower_input_channel,
-                min_val=-10.0, max_val=10.0, units=nidaqmx_types.VOLTAGE_UNITS2_VOLTS,
-                terminal_config=nidaqmx_types.INPUT_TERM_CFG_WITH_DEFAULT_CFG_DEFAULT
-            )))
-            await raise_if_error_async(client.CfgSampClkTiming(nidaqmx_types.CfgSampClkTimingRequest(
-                task=follower_input_task, rate=10000, active_edge=nidaqmx_types.EDGE1_RISING,
-                sample_mode=nidaqmx_types.ACQUISITION_TYPE_CONT_SAMPS, samps_per_chan=1000
-            )))
+            await raise_if_error_async(
+                client.CreateAIVoltageChan(
+                    nidaqmx_types.CreateAIVoltageChanRequest(
+                        task=follower_input_task,
+                        physical_channel=follower_input_channel,
+                        min_val=-10.0,
+                        max_val=10.0,
+                        units=nidaqmx_types.VOLTAGE_UNITS2_VOLTS,
+                        terminal_config=nidaqmx_types.INPUT_TERM_CFG_WITH_DEFAULT_CFG_DEFAULT,
+                    )
+                )
+            )
+            await raise_if_error_async(
+                client.CfgSampClkTiming(
+                    nidaqmx_types.CfgSampClkTimingRequest(
+                        task=follower_input_task,
+                        rate=10000,
+                        active_edge=nidaqmx_types.EDGE1_RISING,
+                        sample_mode=nidaqmx_types.ACQUISITION_TYPE_CONT_SAMPS,
+                        samps_per_chan=1000,
+                    )
+                )
+            )
 
             response = await raise_if_error_async(
-                client.CreateTask(nidaqmx_types.CreateTaskRequest(session_name="Follower output task")))
+                client.CreateTask(
+                    nidaqmx_types.CreateTaskRequest(session_name="Follower output task")
+                )
+            )
             follower_output_task = response.task
-            await raise_if_error_async(client.CreateAOVoltageChan(nidaqmx_types.CreateAOVoltageChanRequest(
-                task=follower_output_task, physical_channel=follower_output_channel,
-                min_val=-10.0, max_val=10.0, units=nidaqmx_types.VOLTAGE_UNITS2_VOLTS,
-            )))
-            await raise_if_error_async(client.CfgSampClkTiming(nidaqmx_types.CfgSampClkTimingRequest(
-                task=follower_output_task, rate=10000, active_edge=nidaqmx_types.EDGE1_RISING,
-                sample_mode=nidaqmx_types.ACQUISITION_TYPE_CONT_SAMPS, samps_per_chan=1000
-            )))
+            await raise_if_error_async(
+                client.CreateAOVoltageChan(
+                    nidaqmx_types.CreateAOVoltageChanRequest(
+                        task=follower_output_task,
+                        physical_channel=follower_output_channel,
+                        min_val=-10.0,
+                        max_val=10.0,
+                        units=nidaqmx_types.VOLTAGE_UNITS2_VOLTS,
+                    )
+                )
+            )
+            await raise_if_error_async(
+                client.CfgSampClkTiming(
+                    nidaqmx_types.CfgSampClkTimingRequest(
+                        task=follower_output_task,
+                        rate=10000,
+                        active_edge=nidaqmx_types.EDGE1_RISING,
+                        sample_mode=nidaqmx_types.ACQUISITION_TYPE_CONT_SAMPS,
+                        samps_per_chan=1000,
+                    )
+                )
+            )
 
             # DAQmx Clock Synchronization code
             if synchronization_type_is_reference_clock:
                 # Note: Not all DSA devices support reference clock synchronization. Refer to
                 # your hardware device manual for further information on whether this method
                 # of synchronization is supported for your particular device.
-                await raise_if_error_async(client.SetTimingAttributeString(nidaqmx_types.SetTimingAttributeStringRequest(
-                    task=leader_input_task, attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_REF_CLK_SRC,
-                    value="PXI_Clk10")))
-                await raise_if_error_async(client.SetTimingAttributeString(nidaqmx_types.SetTimingAttributeStringRequest(
-                    task=leader_output_task, attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_REF_CLK_SRC,
-                    value="PXI_Clk10")))
-                await raise_if_error_async(client.SetTimingAttributeString(nidaqmx_types.SetTimingAttributeStringRequest(
-                    task=follower_input_task, attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_REF_CLK_SRC,
-                    value="PXI_Clk10")))
-                await raise_if_error_async(client.SetTimingAttributeString(nidaqmx_types.SetTimingAttributeStringRequest(
-                    task=follower_output_task, attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_REF_CLK_SRC,
-                    value="PXI_Clk10")))
+                await raise_if_error_async(
+                    client.SetTimingAttributeString(
+                        nidaqmx_types.SetTimingAttributeStringRequest(
+                            task=leader_input_task,
+                            attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_REF_CLK_SRC,
+                            value="PXI_Clk10",
+                        )
+                    )
+                )
+                await raise_if_error_async(
+                    client.SetTimingAttributeString(
+                        nidaqmx_types.SetTimingAttributeStringRequest(
+                            task=leader_output_task,
+                            attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_REF_CLK_SRC,
+                            value="PXI_Clk10",
+                        )
+                    )
+                )
+                await raise_if_error_async(
+                    client.SetTimingAttributeString(
+                        nidaqmx_types.SetTimingAttributeStringRequest(
+                            task=follower_input_task,
+                            attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_REF_CLK_SRC,
+                            value="PXI_Clk10",
+                        )
+                    )
+                )
+                await raise_if_error_async(
+                    client.SetTimingAttributeString(
+                        nidaqmx_types.SetTimingAttributeStringRequest(
+                            task=follower_output_task,
+                            attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_REF_CLK_SRC,
+                            value="PXI_Clk10",
+                        )
+                    )
+                )
             else:
                 # Sample clock
                 # Note: If you are using PXI DSA devices, the leader device must reside in PXI Slot 2.
-                timebase_source = await get_terminal_name_with_dev_prefix(task=leader_input_task, terminal_name="SampleClockTimebase")
-                await raise_if_error_async(client.SetTimingAttributeString(nidaqmx_types.SetTimingAttributeStringRequest(
-                    task=leader_output_task, attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_SAMP_CLK_TIMEBASE_SRC,
-                    value=timebase_source)))
-                await raise_if_error_async(client.SetTimingAttributeString(nidaqmx_types.SetTimingAttributeStringRequest(
-                    task=follower_input_task, attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_SAMP_CLK_TIMEBASE_SRC,
-                    value=timebase_source)))
-                await raise_if_error_async(client.SetTimingAttributeString(nidaqmx_types.SetTimingAttributeStringRequest(
-                    task=follower_output_task, attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_SAMP_CLK_TIMEBASE_SRC,
-                    value=timebase_source)))
+                timebase_source = await get_terminal_name_with_dev_prefix(
+                    task=leader_input_task, terminal_name="SampleClockTimebase"
+                )
+                await raise_if_error_async(
+                    client.SetTimingAttributeString(
+                        nidaqmx_types.SetTimingAttributeStringRequest(
+                            task=leader_output_task,
+                            attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_SAMP_CLK_TIMEBASE_SRC,
+                            value=timebase_source,
+                        )
+                    )
+                )
+                await raise_if_error_async(
+                    client.SetTimingAttributeString(
+                        nidaqmx_types.SetTimingAttributeStringRequest(
+                            task=follower_input_task,
+                            attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_SAMP_CLK_TIMEBASE_SRC,
+                            value=timebase_source,
+                        )
+                    )
+                )
+                await raise_if_error_async(
+                    client.SetTimingAttributeString(
+                        nidaqmx_types.SetTimingAttributeStringRequest(
+                            task=follower_output_task,
+                            attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_SAMP_CLK_TIMEBASE_SRC,
+                            value=timebase_source,
+                        )
+                    )
+                )
 
-            sync_pulse_source = await get_terminal_name_with_dev_prefix(task=leader_input_task, terminal_name="SyncPulse")
-            await raise_if_error_async(client.SetTimingAttributeString(nidaqmx_types.SetTimingAttributeStringRequest(
-                task=leader_output_task, attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_SYNC_PULSE_SRC,
-                value=sync_pulse_source)))
-            await raise_if_error_async(client.SetTimingAttributeString(nidaqmx_types.SetTimingAttributeStringRequest(
-                task=follower_input_task, attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_SYNC_PULSE_SRC,
-                value=sync_pulse_source)))
-            await raise_if_error_async(client.SetTimingAttributeString(nidaqmx_types.SetTimingAttributeStringRequest(
-                task=follower_output_task, attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_SYNC_PULSE_SRC,
-                value=sync_pulse_source)))
+            sync_pulse_source = await get_terminal_name_with_dev_prefix(
+                task=leader_input_task, terminal_name="SyncPulse"
+            )
+            await raise_if_error_async(
+                client.SetTimingAttributeString(
+                    nidaqmx_types.SetTimingAttributeStringRequest(
+                        task=leader_output_task,
+                        attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_SYNC_PULSE_SRC,
+                        value=sync_pulse_source,
+                    )
+                )
+            )
+            await raise_if_error_async(
+                client.SetTimingAttributeString(
+                    nidaqmx_types.SetTimingAttributeStringRequest(
+                        task=follower_input_task,
+                        attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_SYNC_PULSE_SRC,
+                        value=sync_pulse_source,
+                    )
+                )
+            )
+            await raise_if_error_async(
+                client.SetTimingAttributeString(
+                    nidaqmx_types.SetTimingAttributeStringRequest(
+                        task=follower_output_task,
+                        attribute=nidaqmx_types.TimingStringAttribute.TIMING_ATTRIBUTE_SYNC_PULSE_SRC,
+                        value=sync_pulse_source,
+                    )
+                )
+            )
 
             # DAQmx Configure Start Trigger code
-            start_trigger = await get_terminal_name_with_dev_prefix(task=leader_input_task, terminal_name="ai/StartTrigger")
-            await raise_if_error_async(client.CfgDigEdgeStartTrig(nidaqmx_types.CfgDigEdgeStartTrigRequest(
-                task=leader_output_task, trigger_source=start_trigger, trigger_edge=nidaqmx_types.EDGE1_RISING
-            )))
-            await raise_if_error_async(client.CfgDigEdgeStartTrig(nidaqmx_types.CfgDigEdgeStartTrigRequest(
-                task=follower_input_task, trigger_source=start_trigger, trigger_edge=nidaqmx_types.EDGE1_RISING
-            )))
-            await raise_if_error_async(client.CfgDigEdgeStartTrig(nidaqmx_types.CfgDigEdgeStartTrigRequest(
-                task=follower_output_task, trigger_source=start_trigger, trigger_edge=nidaqmx_types.EDGE1_RISING
-            )))
+            start_trigger = await get_terminal_name_with_dev_prefix(
+                task=leader_input_task, terminal_name="ai/StartTrigger"
+            )
+            await raise_if_error_async(
+                client.CfgDigEdgeStartTrig(
+                    nidaqmx_types.CfgDigEdgeStartTrigRequest(
+                        task=leader_output_task,
+                        trigger_source=start_trigger,
+                        trigger_edge=nidaqmx_types.EDGE1_RISING,
+                    )
+                )
+            )
+            await raise_if_error_async(
+                client.CfgDigEdgeStartTrig(
+                    nidaqmx_types.CfgDigEdgeStartTrigRequest(
+                        task=follower_input_task,
+                        trigger_source=start_trigger,
+                        trigger_edge=nidaqmx_types.EDGE1_RISING,
+                    )
+                )
+            )
+            await raise_if_error_async(
+                client.CfgDigEdgeStartTrig(
+                    nidaqmx_types.CfgDigEdgeStartTrigRequest(
+                        task=follower_output_task,
+                        trigger_source=start_trigger,
+                        trigger_edge=nidaqmx_types.EDGE1_RISING,
+                    )
+                )
+            )
 
             (leader_write_data, phase) = generate_sinewave(250, 1.0, 0.02, 0.0)
             (follower_write_data, phase) = generate_sinewave(250, 1.0, 0.02, phase)
 
             # DAQmx Write code
-            num_leader_samples_written = (await raise_if_error_async(client.WriteAnalogF64(nidaqmx_types.WriteAnalogF64Request(
-                task=leader_output_task, num_samps_per_chan=250, auto_start=False, timeout=10.0,
-                data_layout=nidaqmx_types.GROUP_BY_GROUP_BY_CHANNEL, write_array=leader_write_data
-            )))).samps_per_chan_written
-            num_follower_samples_written = (await raise_if_error_async(client.WriteAnalogF64(nidaqmx_types.WriteAnalogF64Request(
-                task=follower_output_task, num_samps_per_chan=250, auto_start=False, timeout=10.0,
-                data_layout=nidaqmx_types.GROUP_BY_GROUP_BY_CHANNEL, write_array=follower_write_data
-            )))).samps_per_chan_written
+            num_leader_samples_written = (
+                await raise_if_error_async(
+                    client.WriteAnalogF64(
+                        nidaqmx_types.WriteAnalogF64Request(
+                            task=leader_output_task,
+                            num_samps_per_chan=250,
+                            auto_start=False,
+                            timeout=10.0,
+                            data_layout=nidaqmx_types.GROUP_BY_GROUP_BY_CHANNEL,
+                            write_array=leader_write_data,
+                        )
+                    )
+                )
+            ).samps_per_chan_written
+            num_follower_samples_written = (
+                await raise_if_error_async(
+                    client.WriteAnalogF64(
+                        nidaqmx_types.WriteAnalogF64Request(
+                            task=follower_output_task,
+                            num_samps_per_chan=250,
+                            auto_start=False,
+                            timeout=10.0,
+                            data_layout=nidaqmx_types.GROUP_BY_GROUP_BY_CHANNEL,
+                            write_array=follower_write_data,
+                        )
+                    )
+                )
+            ).samps_per_chan_written
 
             every_n_samples_stream = client.RegisterEveryNSamplesEvent(
                 nidaqmx_types.RegisterEveryNSamplesEventRequest(
                     task=leader_input_task,
                     n_samples=100,
-                    every_n_samples_event_type=nidaqmx_types.EVERY_N_SAMPLES_EVENT_TYPE_ACQUIRED_INTO_BUFFER))
+                    every_n_samples_event_type=nidaqmx_types.EVERY_N_SAMPLES_EVENT_TYPE_ACQUIRED_INTO_BUFFER,
+                )
+            )
 
             # Wait for initial_metadata to ensure that the callback is registered before starting the task.
             await every_n_samples_stream.initial_metadata()
 
             done_event_stream_list = []
-            done_event_stream_list.append(client.RegisterDoneEvent(
-                nidaqmx_types.RegisterDoneEventRequest(task=leader_input_task)))
-            done_event_stream_list.append(client.RegisterDoneEvent(
-                nidaqmx_types.RegisterDoneEventRequest(task=leader_output_task)))
-            done_event_stream_list.append(client.RegisterDoneEvent(
-                nidaqmx_types.RegisterDoneEventRequest(task=follower_input_task)))
-            done_event_stream_list.append(client.RegisterDoneEvent(
-                nidaqmx_types.RegisterDoneEventRequest(task=follower_output_task)))
+            done_event_stream_list.append(
+                client.RegisterDoneEvent(
+                    nidaqmx_types.RegisterDoneEventRequest(task=leader_input_task)
+                )
+            )
+            done_event_stream_list.append(
+                client.RegisterDoneEvent(
+                    nidaqmx_types.RegisterDoneEventRequest(task=leader_output_task)
+                )
+            )
+            done_event_stream_list.append(
+                client.RegisterDoneEvent(
+                    nidaqmx_types.RegisterDoneEventRequest(task=follower_input_task)
+                )
+            )
+            done_event_stream_list.append(
+                client.RegisterDoneEvent(
+                    nidaqmx_types.RegisterDoneEventRequest(task=follower_output_task)
+                )
+            )
             for done_event_stream in done_event_stream_list:
                 await done_event_stream.initial_metadata()
 
             # DAQmx Start code
-            await raise_if_error_async(client.StartTask(nidaqmx_types.StartTaskRequest(task=leader_output_task)))
-            await raise_if_error_async(client.StartTask(nidaqmx_types.StartTaskRequest(task=follower_input_task)))
-            await raise_if_error_async(client.StartTask(nidaqmx_types.StartTaskRequest(task=follower_output_task)))
+            await raise_if_error_async(
+                client.StartTask(nidaqmx_types.StartTaskRequest(task=leader_output_task))
+            )
+            await raise_if_error_async(
+                client.StartTask(nidaqmx_types.StartTaskRequest(task=follower_input_task))
+            )
+            await raise_if_error_async(
+                client.StartTask(nidaqmx_types.StartTaskRequest(task=follower_output_task))
+            )
             # trigger task must be started last
-            await raise_if_error_async(client.StartTask(nidaqmx_types.StartTaskRequest(task=leader_input_task)))
+            await raise_if_error_async(
+                client.StartTask(nidaqmx_types.StartTaskRequest(task=leader_input_task))
+            )
 
             async def read_data():
                 global num_leader_samples_written, num_follower_samples_written
                 async for every_n_samples_response in every_n_samples_stream:
                     await raise_if_error(every_n_samples_response)
-                    leader_response: nidaqmx_types.ReadAnalogF64Response = await raise_if_error_async(
-                        client.ReadAnalogF64(
-                            nidaqmx_types.ReadAnalogF64Request(
-                                task=leader_input_task,
-                                num_samps_per_chan=2000,
-                                timeout=10.0,
-                                fill_mode=nidaqmx_types.GroupBy.GROUP_BY_GROUP_BY_CHANNEL,
-                                array_size_in_samps=2000)))
+                    leader_response: nidaqmx_types.ReadAnalogF64Response = (
+                        await raise_if_error_async(
+                            client.ReadAnalogF64(
+                                nidaqmx_types.ReadAnalogF64Request(
+                                    task=leader_input_task,
+                                    num_samps_per_chan=2000,
+                                    timeout=10.0,
+                                    fill_mode=nidaqmx_types.GroupBy.GROUP_BY_GROUP_BY_CHANNEL,
+                                    array_size_in_samps=2000,
+                                )
+                            )
+                        )
+                    )
                     num_leader_samples_written += leader_response.samps_per_chan_read
-                    follower_response: nidaqmx_types.ReadAnalogF64Response = await raise_if_error_async(
-                        client.ReadAnalogF64(
-                            nidaqmx_types.ReadAnalogF64Request(
-                                task=follower_input_task,
-                                num_samps_per_chan=2000,
-                                timeout=10.0,
-                                fill_mode=nidaqmx_types.GroupBy.GROUP_BY_GROUP_BY_CHANNEL,
-                                array_size_in_samps=2000)))
+                    follower_response: nidaqmx_types.ReadAnalogF64Response = (
+                        await raise_if_error_async(
+                            client.ReadAnalogF64(
+                                nidaqmx_types.ReadAnalogF64Request(
+                                    task=follower_input_task,
+                                    num_samps_per_chan=2000,
+                                    timeout=10.0,
+                                    fill_mode=nidaqmx_types.GroupBy.GROUP_BY_GROUP_BY_CHANNEL,
+                                    array_size_in_samps=2000,
+                                )
+                            )
+                        )
+                    )
                     num_follower_samples_written += follower_response.samps_per_chan_read
 
                     print(
-                        f"\t{leader_response.samps_per_chan_read}\t{follower_response.samps_per_chan_read}\t\t{num_leader_samples_written}\t{num_follower_samples_written}")
+                        f"\t{leader_response.samps_per_chan_read}\t{follower_response.samps_per_chan_read}\t\t{num_leader_samples_written}\t{num_follower_samples_written}"
+                    )
 
             async def wait_for_done(done_event_stream):
                 async for done_response in done_event_stream:
@@ -350,8 +575,9 @@ async def main():
 
             print("Acquiring samples continuously. Press Enter to interrupt")
             print("\nRead:\tLeader\tFollower\tTotal:\tLeader\tFollower")
-            tasks = [read_data(), wait_for_input()] + [wait_for_done(stream)
-                                                       for stream in done_event_stream_list]
+            tasks = [read_data(), wait_for_input()] + [
+                wait_for_done(stream) for stream in done_event_stream_list
+            ]
             await asyncio.gather(*tasks)
 
         except grpc.RpcError as rpc_error:
@@ -359,7 +585,9 @@ async def main():
             if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
                 error_message = f"Failed to connect to server on {server_address}:{server_port}"
             elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-                error_message = "The operation is not implemented or is not supported/enabled in this service"
+                error_message = (
+                    "The operation is not implemented or is not supported/enabled in this service"
+                )
             print(f"{error_message}")
 
         finally:
@@ -385,6 +613,7 @@ async def cleanup():
             await client.StopTask(nidaqmx_types.StopTaskRequest(task=follower_output_task))
             await client.ClearTask(nidaqmx_types.ClearTaskRequest(task=follower_output_task))
             follower_output_task = None
+
 
 # Run main
 try:

--- a/examples/nidcpower/measure-record.py
+++ b/examples/nidcpower/measure-record.py
@@ -1,5 +1,5 @@
 # This example performs continuous measure record.
-# 
+#
 # The gRPC API is built from the C API. NI-DCPower documentation is installed with the driver at:
 # C:\Program Files (x86)\IVI Foundation\IVI\Drivers\niDCPower\Documentation\NIDCPowerCref.chm
 #
@@ -55,84 +55,98 @@ if len(sys.argv) >= 4:
 
 # Checks for errors. If any, throws an exception to stop the execution.
 any_error = False
-def CheckForError (vi, status) :
-    global any_error
-    if(status != 0 and not any_error):
-        any_error = True
-        ThrowOnError (vi, status)
 
-def ThrowOnError (vi, error_code):
-    error_message_request = nidcpower_types.ErrorMessageRequest(
-        vi = vi,
-        error_code = error_code
-        )
+
+def CheckForError(vi, status):
+    global any_error
+    if status != 0 and not any_error:
+        any_error = True
+        ThrowOnError(vi, status)
+
+
+def ThrowOnError(vi, error_code):
+    error_message_request = nidcpower_types.ErrorMessageRequest(vi=vi, error_code=error_code)
     error_message_response = client.ErrorMessage(error_message_request)
-    raise Exception (error_message_response.error_message)
+    raise Exception(error_message_response.error_message)
+
 
 # Create the communication channel for the remote host and create connections to the NI-DCPower and session services.
 channel = grpc.insecure_channel(f"{server_address}:{server_port}")
 client = grpc_nidcpower.NiDCPowerStub(channel)
 
-try :
+try:
     # Initialize the session.
-    initialize_with_channels_response = client.InitializeWithChannels(nidcpower_types.InitializeWithChannelsRequest(
-        session_name = session_name,
-        resource_name = resource,
-        channels = channels,
-        reset = False,
-        option_string = options
-    ))
+    initialize_with_channels_response = client.InitializeWithChannels(
+        nidcpower_types.InitializeWithChannelsRequest(
+            session_name=session_name,
+            resource_name=resource,
+            channels=channels,
+            reset=False,
+            option_string=options,
+        )
+    )
     vi = initialize_with_channels_response.vi
     CheckForError(vi, initialize_with_channels_response.status)
 
     # Specify when the measure unit should acquire measurements.
-    configure_measure_when = client.SetAttributeViInt32(nidcpower_types.SetAttributeViInt32Request(
-        vi = vi,
-        attribute_id = nidcpower_types.NiDCPowerAttribute.NIDCPOWER_ATTRIBUTE_MEASURE_WHEN,
-        attribute_value = nidcpower_types.NiDCPowerInt32AttributeValues.NIDCPOWER_INT32_MEASURE_WHEN_VAL_AUTOMATICALLY_AFTER_SOURCE_COMPLETE
-    ))
+    configure_measure_when = client.SetAttributeViInt32(
+        nidcpower_types.SetAttributeViInt32Request(
+            vi=vi,
+            attribute_id=nidcpower_types.NiDCPowerAttribute.NIDCPOWER_ATTRIBUTE_MEASURE_WHEN,
+            attribute_value=nidcpower_types.NiDCPowerInt32AttributeValues.NIDCPOWER_INT32_MEASURE_WHEN_VAL_AUTOMATICALLY_AFTER_SOURCE_COMPLETE,
+        )
+    )
     CheckForError(vi, configure_measure_when.status)
 
     # set the voltage level.
-    configure_voltage_level = client.ConfigureVoltageLevel(nidcpower_types.ConfigureVoltageLevelRequest(
-        vi = vi,
-        level = voltage_level
-    ))
+    configure_voltage_level = client.ConfigureVoltageLevel(
+        nidcpower_types.ConfigureVoltageLevelRequest(vi=vi, level=voltage_level)
+    )
     CheckForError(vi, configure_voltage_level.status)
 
     # Sspecify how many measurements compose a measure record.
-    configure_measure_record_length = client.SetAttributeViInt32(nidcpower_types.SetAttributeViInt32Request(
-        vi = vi,
-        attribute_id = nidcpower_types.NiDCPowerAttribute.NIDCPOWER_ATTRIBUTE_MEASURE_RECORD_LENGTH,
-        attribute_value = record_length
-    ))
+    configure_measure_record_length = client.SetAttributeViInt32(
+        nidcpower_types.SetAttributeViInt32Request(
+            vi=vi,
+            attribute_id=nidcpower_types.NiDCPowerAttribute.NIDCPOWER_ATTRIBUTE_MEASURE_RECORD_LENGTH,
+            attribute_value=record_length,
+        )
+    )
     CheckForError(vi, configure_measure_record_length.status)
 
     # Specify whether to take continuous measurements. Set it to False for continuous measurement.
-    configure_measure_record_length_is_finite = client.SetAttributeViBoolean(nidcpower_types.SetAttributeViBooleanRequest(
-        vi = vi,
-        attribute_id = nidcpower_types.NiDCPowerAttribute.NIDCPOWER_ATTRIBUTE_MEASURE_RECORD_LENGTH_IS_FINITE,
-        attribute_value = False
-    ))
+    configure_measure_record_length_is_finite = client.SetAttributeViBoolean(
+        nidcpower_types.SetAttributeViBooleanRequest(
+            vi=vi,
+            attribute_id=nidcpower_types.NiDCPowerAttribute.NIDCPOWER_ATTRIBUTE_MEASURE_RECORD_LENGTH_IS_FINITE,
+            attribute_value=False,
+        )
+    )
     CheckForError(vi, configure_measure_record_length_is_finite.status)
 
     # commit the session.
-    commit_response = client.Commit(nidcpower_types.CommitRequest(
-        vi = vi,
-    ))
+    commit_response = client.Commit(
+        nidcpower_types.CommitRequest(
+            vi=vi,
+        )
+    )
     CheckForError(vi, commit_response.status)
 
     # get measure_record_delta_time.
-    get_measure_record_delta_time = client.GetAttributeViReal64(nidcpower_types.GetAttributeViReal64Request(
-       vi = vi,
-       attribute_id =  nidcpower_types.NiDCPowerAttribute.NIDCPOWER_ATTRIBUTE_MEASURE_RECORD_DELTA_TIME
-    ))
+    get_measure_record_delta_time = client.GetAttributeViReal64(
+        nidcpower_types.GetAttributeViReal64Request(
+            vi=vi,
+            attribute_id=nidcpower_types.NiDCPowerAttribute.NIDCPOWER_ATTRIBUTE_MEASURE_RECORD_DELTA_TIME,
+        )
+    )
     CheckForError(vi, get_measure_record_delta_time.status)
 
     # initiate the session.
-    initiate_response = client.Initiate(nidcpower_types.InitiateRequest(
-        vi = vi,
-    ))
+    initiate_response = client.Initiate(
+        nidcpower_types.InitiateRequest(
+            vi=vi,
+        )
+    )
     CheckForError(vi, initiate_response.status)
 
     # Setup a plot to draw the captured waveform.
@@ -142,10 +156,12 @@ try :
 
     # Handle closing of plot window.
     closed = False
+
     def on_close(event):
         global closed
         closed = True
-    fig.canvas.mpl_connect('close_event', on_close)
+
+    fig.canvas.mpl_connect("close_event", on_close)
 
     print("\nReading values in loop. CTRL+C or Close window to stop.\n")
 
@@ -161,33 +177,33 @@ try :
             plt.xlabel("Samples")
             plt.ylabel("Amplitude")
 
-            fetch_multiple_response = client.FetchMultiple(nidcpower_types.FetchMultipleRequest(
-                vi = vi,
-                timeout = 10,
-                count = record_length
-            ))
+            fetch_multiple_response = client.FetchMultiple(
+                nidcpower_types.FetchMultipleRequest(vi=vi, timeout=10, count=record_length)
+            )
             CheckForError(vi, fetch_multiple_response.status)
-            
+
             # Append the fetched values in the buffer.
             y_axis.extend(fetch_multiple_response.voltage_measurements)
             y_axis = y_axis[record_length:]
-            
+
             # Updating the precision of the fetched values.
             y_axis_new = []
             for value in y_axis:
-                if (value < voltage_level):
+                if value < voltage_level:
                     y_axis_new.append(math.floor(value * 100) / 100)
                 else:
                     y_axis_new.append(math.ceil(value * 100) / 100)
 
             # Plotting
             y_axis = y_axis_new
-            x_axis = np.arange(start = x_start, stop = x_start + record_length * buffer_multiplier, step = 1)
+            x_axis = np.arange(
+                start=x_start, stop=x_start + record_length * buffer_multiplier, step=1
+            )
             x_start = x_start + record_length
             plt.plot(x_axis, y_axis)
             plt.pause(0.001)
             time.sleep(0.1)
-            
+
     except KeyboardInterrupt:
         pass
 
@@ -198,12 +214,12 @@ except grpc.RpcError as rpc_error:
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
     print(f"{error_message}")
 
 finally:
-    if('vi' in vars() and vi.id != 0):
+    if "vi" in vars() and vi.id != 0:
         # close the session.
-        CheckForError(vi, (client.Close(nidcpower_types.CloseRequest(
-            vi = vi
-        ))).status)
+        CheckForError(vi, (client.Close(nidcpower_types.CloseRequest(vi=vi))).status)

--- a/examples/nidigitalpattern/configure-voltage-levels-and-termination-voltage.py
+++ b/examples/nidigitalpattern/configure-voltage-levels-and-termination-voltage.py
@@ -6,11 +6,11 @@
 #
 # The gRPC API is built from the C API. NI-Digital Pattern Driver Pattern documentation is installed with
 # the driver at: C:\Users\Public\Documents\National Instruments\NI-Digital-Pattern-Driver\Documentation\Digital Pattern Help.chm
-# 
+#
 # Copy the .pinmap, .specs, .digitiming & .digipat files that come with this example to a folder on the server machine & copy-paste the path of the folder to the directory_path variable below.
 # Use the NI Digital Pattern Editor to create or modify pin or channel map files.
 # Link : https://www.ni.com/documentation/en/ni-digital/20.6/digital-pattern-editor/pin-channel-map-editor/
-# 
+#
 # Getting Started:
 #
 # To run this example, install "NI-Digital Pattern Driver" on the server machine.
@@ -43,7 +43,9 @@ options = "Simulate=1, DriverSetup=Model:6570"
 # Provide the absolute path to the folder on the server machine containing the .pinmap, .specs, .digitiming & .digipat files.
 directory_path = r""
 if directory_path == "":
-    print("\nProvide the absolute path to the folder on the server machine containing the .pinmap, .specs, .digitiming & .digipat files to the dirctory_path variable in the source code.")
+    print(
+        "\nProvide the absolute path to the folder on the server machine containing the .pinmap, .specs, .digitiming & .digipat files to the dirctory_path variable in the source code."
+    )
     exit(1)
 # Fixed parameters
 channelList = "PinGroup1"
@@ -68,7 +70,7 @@ ioh = -0.024
 # The commutating voltage level at which the active load circuit switches between sourcing current and sinking current
 vcom = 2
 # Device termination mode [High-Z (h), Active Load (a), Three-Level Drive (t)]
-termSelect = 'h'
+termSelect = "h"
 
 # Read in cmd args
 if len(sys.argv) >= 2:
@@ -85,120 +87,160 @@ nidigital_client = grpc_nidigital.NiDigitalStub(channel)
 
 any_error = False
 # Checks for errors.  If any, throws an exception to stop the execution.
-def CheckForError(vi, status) :
+def CheckForError(vi, status):
     global any_error
-    if(status != 0 and not any_error):
+    if status != 0 and not any_error:
         any_error = True
         ThrowOnError(vi, status)
 
+
 # Converts an error code returned by NI-Digital Pattern Driver into a user-readable string.
 def ThrowOnError(vi, error_code):
-    error_message_request = nidigital_types.GetErrorRequest(vi = vi
-    )
+    error_message_request = nidigital_types.GetErrorRequest(vi=vi)
     error_message_response = nidigital_client.GetError(error_message_request)
     raise Exception(error_message_response.error_description)
 
+
 try:
     # Open session to NI-Digital Pattern Driver with options
-     init_with_options_response = nidigital_client.InitWithOptions(nidigital_types.InitWithOptionsRequest(session_name = session_name, 
-         resource_name = resource, 
-         id_query = True,
-         reset_device = True,
-         option_string = options))
-     vi = init_with_options_response.vi
-     CheckForError(vi, init_with_options_response.status)
+    init_with_options_response = nidigital_client.InitWithOptions(
+        nidigital_types.InitWithOptionsRequest(
+            session_name=session_name,
+            resource_name=resource,
+            id_query=True,
+            reset_device=True,
+            option_string=options,
+        )
+    )
+    vi = init_with_options_response.vi
+    CheckForError(vi, init_with_options_response.status)
 
-     load_pin_map_response = nidigital_client.LoadPinMap(nidigital_types.LoadPinMapRequest(vi = vi,
-         file_path = os.path.join(directory_path, 'PinMap.pinmap')))
-     CheckForError(vi, load_pin_map_response.status)
+    load_pin_map_response = nidigital_client.LoadPinMap(
+        nidigital_types.LoadPinMapRequest(
+            vi=vi, file_path=os.path.join(directory_path, "PinMap.pinmap")
+        )
+    )
+    CheckForError(vi, load_pin_map_response.status)
 
-     load_specification_response = nidigital_client.LoadSpecifications(nidigital_types.LoadSpecificationsRequest(vi = vi,
-         file_path = os.path.join(directory_path, "Specifications.specs")))
-     CheckForError(vi, load_specification_response.status)
+    load_specification_response = nidigital_client.LoadSpecifications(
+        nidigital_types.LoadSpecificationsRequest(
+            vi=vi, file_path=os.path.join(directory_path, "Specifications.specs")
+        )
+    )
+    CheckForError(vi, load_specification_response.status)
 
-     load_timing_response = nidigital_client.LoadTiming(nidigital_types.LoadTimingRequest(vi = vi,
-         file_path = os.path.join(directory_path, "Timing.digitiming")))
-     CheckForError(vi, load_timing_response.status)
+    load_timing_response = nidigital_client.LoadTiming(
+        nidigital_types.LoadTimingRequest(
+            vi=vi, file_path=os.path.join(directory_path, "Timing.digitiming")
+        )
+    )
+    CheckForError(vi, load_timing_response.status)
 
-     load_apply_levels_and_timing_response = nidigital_client.ApplyLevelsAndTiming(nidigital_types.ApplyLevelsAndTimingRequest(vi = vi,
-         site_list = "",
-         levels_sheet = "",
-         timing_sheet = os.path.join(directory_path, "Timing.digitiming"),
-         initial_state_high_pins = "",
-         initial_state_low_pins = "",
-         initial_state_tristate_pins = ""))
-     CheckForError(vi, load_apply_levels_and_timing_response.status)
+    load_apply_levels_and_timing_response = nidigital_client.ApplyLevelsAndTiming(
+        nidigital_types.ApplyLevelsAndTimingRequest(
+            vi=vi,
+            site_list="",
+            levels_sheet="",
+            timing_sheet=os.path.join(directory_path, "Timing.digitiming"),
+            initial_state_high_pins="",
+            initial_state_low_pins="",
+            initial_state_tristate_pins="",
+        )
+    )
+    CheckForError(vi, load_apply_levels_and_timing_response.status)
 
-     load_pattern_response = nidigital_client.LoadPattern(nidigital_types.LoadPatternRequest(vi = vi,
-         file_path = os.path.join(directory_path, "Pattern.digipat")))
-     CheckForError(vi, load_pattern_response.status)
+    load_pattern_response = nidigital_client.LoadPattern(
+        nidigital_types.LoadPatternRequest(
+            vi=vi, file_path=os.path.join(directory_path, "Pattern.digipat")
+        )
+    )
+    CheckForError(vi, load_pattern_response.status)
 
-     configure_voltage_response = nidigital_client.ConfigureVoltageLevels(nidigital_types.ConfigureVoltageLevelsRequest(vi = vi,
-         channel_list = channelList,
-         vil = vil,
-         vih = vih,
-         vol = vol,
-         voh = voh,
-         vterm = vterm))
-     CheckForError(vi, configure_voltage_response.status)
-     
-     if termSelect == 'h':
-        configure_termination_Mode_response = nidigital_client.ConfigureTerminationMode(nidigital_types.ConfigureTerminationModeRequest(vi = vi,
-            channel_list = channelList,
-            mode = nidigital_types.TerminationMode.TERMINATION_MODE_NIDIGITAL_VAL_HIGH_Z))
+    configure_voltage_response = nidigital_client.ConfigureVoltageLevels(
+        nidigital_types.ConfigureVoltageLevelsRequest(
+            vi=vi, channel_list=channelList, vil=vil, vih=vih, vol=vol, voh=voh, vterm=vterm
+        )
+    )
+    CheckForError(vi, configure_voltage_response.status)
+
+    if termSelect == "h":
+        configure_termination_Mode_response = nidigital_client.ConfigureTerminationMode(
+            nidigital_types.ConfigureTerminationModeRequest(
+                vi=vi,
+                channel_list=channelList,
+                mode=nidigital_types.TerminationMode.TERMINATION_MODE_NIDIGITAL_VAL_HIGH_Z,
+            )
+        )
         CheckForError(vi, configure_termination_Mode_response.status)
 
-     if termSelect == 'a':
-        configure_termination_Mode_response = nidigital_client.ConfigureTerminationMode(nidigital_types.ConfigureTerminationModeRequest(vi = vi,
-            channel_list = channelList,
-            mode = nidigital_types.TerminationMode.TERMINATION_MODE_NIDIGITAL_VAL_ACTIVE_LOAD))
+    if termSelect == "a":
+        configure_termination_Mode_response = nidigital_client.ConfigureTerminationMode(
+            nidigital_types.ConfigureTerminationModeRequest(
+                vi=vi,
+                channel_list=channelList,
+                mode=nidigital_types.TerminationMode.TERMINATION_MODE_NIDIGITAL_VAL_ACTIVE_LOAD,
+            )
+        )
         CheckForError(vi, configure_termination_Mode_response.status)
 
-        
-        configure_active_load_levels_response = nidigital_client.ConfigureActiveLoadLevels(nidigital_types.ConfigureActiveLoadLevelsRequest(vi = vi,
-            channel_list = channelList,
-            iol = iol,
-            ioh = ioh,
-            vcom = vcom))
+        configure_active_load_levels_response = nidigital_client.ConfigureActiveLoadLevels(
+            nidigital_types.ConfigureActiveLoadLevelsRequest(
+                vi=vi, channel_list=channelList, iol=iol, ioh=ioh, vcom=vcom
+            )
+        )
         CheckForError(vi, configure_active_load_levels_response.status)
 
-     if termSelect == 't':
-        configure_termination_mode_response = nidigital_client.ConfigureTerminationMode(nidigital_types.ConfigureTerminationModeRequest(vi = vi,
-            channel_list = channelList,
-            mode = nidigital_types.TerminationMode.TERMINATION_MODE_NIDIGITAL_VAL_VTERM))
+    if termSelect == "t":
+        configure_termination_mode_response = nidigital_client.ConfigureTerminationMode(
+            nidigital_types.ConfigureTerminationModeRequest(
+                vi=vi,
+                channel_list=channelList,
+                mode=nidigital_types.TerminationMode.TERMINATION_MODE_NIDIGITAL_VAL_VTERM,
+            )
+        )
         CheckForError(vi, configure_termination_mode_response.status)
 
-     if(termSelect != 'h' and termSelect != 'a' and termSelect != 't'):
-        print('The value of termSelect is invalid. Please set it to one of \'h\', \'a\', or \'t\' values.')
+    if termSelect != "h" and termSelect != "a" and termSelect != "t":
+        print(
+            "The value of termSelect is invalid. Please set it to one of 'h', 'a', or 't' values."
+        )
         exit(0)
-     
-     burst_pattern_response = nidigital_client.BurstPattern(nidigital_types.BurstPatternRequest(vi = vi,
-        site_list = "",
-        start_label = "new_pattern",
-        select_digital_function = True,
-        wait_until_done = True,
-        timeout = 10))
-     CheckForError(vi, burst_pattern_response.status)
 
-     select_function_response = nidigital_client.SelectFunction(nidigital_types.SelectFunctionRequest(vi = vi,
-        channel_list = channelList,
-        function_raw = nidigital_types.SelectedFunction.SELECTED_FUNCTION_NIDIGITAL_VAL_DISCONNECT))
-     CheckForError(vi, select_function_response.status)
+    burst_pattern_response = nidigital_client.BurstPattern(
+        nidigital_types.BurstPatternRequest(
+            vi=vi,
+            site_list="",
+            start_label="new_pattern",
+            select_digital_function=True,
+            wait_until_done=True,
+            timeout=10,
+        )
+    )
+    CheckForError(vi, burst_pattern_response.status)
 
-     print('The NI-Digital Pattern device was configured successfully.\n')
+    select_function_response = nidigital_client.SelectFunction(
+        nidigital_types.SelectFunctionRequest(
+            vi=vi,
+            channel_list=channelList,
+            function_raw=nidigital_types.SelectedFunction.SELECTED_FUNCTION_NIDIGITAL_VAL_DISCONNECT,
+        )
+    )
+    CheckForError(vi, select_function_response.status)
 
-# If NI-Digital Pattern Driver API throws an exception, print the error message  
+    print("The NI-Digital Pattern device was configured successfully.\n")
+
+# If NI-Digital Pattern Driver API throws an exception, print the error message
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
-    print(f"{error_message}") 
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
+    print(f"{error_message}")
 finally:
-    if('vi' in vars() and vi.id != 0):      
+    if "vi" in vars() and vi.id != 0:
         # Close NI-Digital Pattern Driver session
-        close_session_response = nidigital_client.Close(nidigital_types.CloseRequest(
-            vi = vi
-        ))
+        close_session_response = nidigital_client.Close(nidigital_types.CloseRequest(vi=vi))
         CheckForError(vi, close_session_response.status)

--- a/examples/nidmm/continuous-acquire-graph-multiple-points.py
+++ b/examples/nidmm/continuous-acquire-graph-multiple-points.py
@@ -1,6 +1,6 @@
-# 
+#
 # This example performs continuous multipoint acquisition and prints the number of points read and average value of measurements.
-# 
+#
 # The gRPC API is built from the C API. NI-DMM documentation is installed with the driver at:
 # C:\Program Files (x86)\IVI Foundation\IVI\Drivers\niDMM\Documentation\English\DMM.chm
 #
@@ -41,11 +41,11 @@ resource = "SimulatedDMM"
 options = "Simulate=1, DriverSetup=Model:4080; BoardType:PXIe"
 
 # parameters
-MAXPTSTOREAD        = 1000
-config_range        = 10.0
-resolution          = 5.5
-measurementType     = nidmm_types.Function.FUNCTION_NIDMM_VAL_DC_VOLTS
-powerlineFreq       = nidmm_types.PowerLineFrequencies.POWER_LINE_FREQUENCIES_NIDMM_VAL_60_HERTZ
+MAXPTSTOREAD = 1000
+config_range = 10.0
+resolution = 5.5
+measurementType = nidmm_types.Function.FUNCTION_NIDMM_VAL_DC_VOLTS
+powerlineFreq = nidmm_types.PowerLineFrequencies.POWER_LINE_FREQUENCIES_NIDMM_VAL_60_HERTZ
 
 # Read in cmd args
 if len(sys.argv) >= 2:
@@ -62,62 +62,61 @@ nidmm_client = grpc_nidmm.NiDmmStub(channel)
 
 any_error = False
 # Checks for errors. If any, throws an exception to stop the execution.
-def CheckForError (vi, status) :
+def CheckForError(vi, status):
     global any_error
-    if(status != 0 and not any_error):
+    if status != 0 and not any_error:
         any_error = True
-        ThrowOnError (vi, status)
+        ThrowOnError(vi, status)
+
 
 # Converts an error code returned by NI-DMM into a user-readable string.
-def ThrowOnError (vi, error_code):
-    error_message_request = nidmm_types.GetErrorMessageRequest(
-        vi = vi,
-        error_code = error_code
-    )
+def ThrowOnError(vi, error_code):
+    error_message_request = nidmm_types.GetErrorMessageRequest(vi=vi, error_code=error_code)
     error_message_response = nidmm_client.GetErrorMessage(error_message_request)
-    raise Exception (error_message_response.error_message)
+    raise Exception(error_message_response.error_message)
+
 
 try:
     # Open session to NI-DMM with options
-    init_with_options_response = nidmm_client.InitWithOptions(nidmm_types.InitWithOptionsRequest(
-        session_name = session_name,
-        resource_name = resource,
-        id_query = False,
-        option_string = options
-    ))
+    init_with_options_response = nidmm_client.InitWithOptions(
+        nidmm_types.InitWithOptionsRequest(
+            session_name=session_name, resource_name=resource, id_query=False, option_string=options
+        )
+    )
     vi = init_with_options_response.vi
     CheckForError(vi, init_with_options_response.status)
 
     # Configure measurement
-    config_measurement_response = nidmm_client.ConfigureMeasurementDigits(nidmm_types.ConfigureMeasurementDigitsRequest(
-        vi = vi,
-        measurement_function = measurementType,
-        range = config_range,
-        resolution_digits = resolution
-    ))
+    config_measurement_response = nidmm_client.ConfigureMeasurementDigits(
+        nidmm_types.ConfigureMeasurementDigitsRequest(
+            vi=vi,
+            measurement_function=measurementType,
+            range=config_range,
+            resolution_digits=resolution,
+        )
+    )
     CheckForError(vi, config_measurement_response.status)
 
     # Configure a multipoint acquisition
-    config_multipoint_response = nidmm_client.ConfigureMultiPoint(nidmm_types.ConfigureMultiPointRequest(
-        vi = vi,
-        trigger_count_raw = 1,
-        sample_count = nidmm_types.SampleCount.SAMPLE_COUNT_NIDMM_VAL_SAMPLE_COUNT_INFINITE,
-        sample_trigger = nidmm_types.SampleTrigger.SAMPLE_TRIGGER_NIDMM_VAL_IMMEDIATE,
-        sample_interval_raw = 0.0
-    ))
+    config_multipoint_response = nidmm_client.ConfigureMultiPoint(
+        nidmm_types.ConfigureMultiPointRequest(
+            vi=vi,
+            trigger_count_raw=1,
+            sample_count=nidmm_types.SampleCount.SAMPLE_COUNT_NIDMM_VAL_SAMPLE_COUNT_INFINITE,
+            sample_trigger=nidmm_types.SampleTrigger.SAMPLE_TRIGGER_NIDMM_VAL_IMMEDIATE,
+            sample_interval_raw=0.0,
+        )
+    )
     CheckForError(vi, config_multipoint_response.status)
 
     # Configure powerline frequency
-    config_powlinefreq_response = nidmm_client.ConfigurePowerLineFrequency(nidmm_types.ConfigurePowerLineFrequencyRequest(
-        vi = vi,
-        power_line_frequency_hz = powerlineFreq
-    ))
+    config_powlinefreq_response = nidmm_client.ConfigurePowerLineFrequency(
+        nidmm_types.ConfigurePowerLineFrequencyRequest(vi=vi, power_line_frequency_hz=powerlineFreq)
+    )
     CheckForError(vi, config_powlinefreq_response.status)
 
     # Initiate Acquisition
-    initiate_acquisition_response = nidmm_client.Initiate(nidmm_types.InitiateRequest(
-        vi = vi
-    ))
+    initiate_acquisition_response = nidmm_client.Initiate(nidmm_types.InitiateRequest(vi=vi))
     CheckForError(vi, initiate_acquisition_response.status)
 
     # Set while loop control
@@ -131,14 +130,16 @@ try:
     fig = plt.gcf()
     fig.show()
     fig.canvas.draw()
-    fig.canvas.manager.set_window_title('Measurements')
+    fig.canvas.manager.set_window_title("Measurements")
 
     # Handle closing of plot window
     closed = False
+
     def on_close(event):
         global closed
         closed = True
-    fig.canvas.mpl_connect('close_event', on_close)
+
+    fig.canvas.mpl_connect("close_event", on_close)
 
     print("\nReading values in loop. CTRL+C or Close window to stop.\n")
 
@@ -146,9 +147,7 @@ try:
         while not closed:
             pts_available = 0
             # Check available data
-            read_status_response = nidmm_client.ReadStatus(nidmm_types.ReadStatusRequest(
-                vi = vi
-            ))
+            read_status_response = nidmm_client.ReadStatus(nidmm_types.ReadStatusRequest(vi=vi))
             CheckForError(vi, read_status_response.status)
             pts_available = read_status_response.acquisition_backlog
 
@@ -160,19 +159,19 @@ try:
                 # Clear the plot and setup the axis
                 plt.clf()
                 plt.axis()
-                plt.xlabel('Samples')
-                plt.ylabel('Amplitude')
+                plt.xlabel("Samples")
+                plt.ylabel("Amplitude")
 
                 # Fetch data
-                fetch_multipoints_response = nidmm_client.FetchMultiPoint(nidmm_types.FetchMultiPointRequest(
-                    vi = vi,
-                    maximum_time = -1,
-                    array_size = pts_available
-                ))
+                fetch_multipoints_response = nidmm_client.FetchMultiPoint(
+                    nidmm_types.FetchMultiPointRequest(
+                        vi=vi, maximum_time=-1, array_size=pts_available
+                    )
+                )
                 CheckForError(vi, fetch_multipoints_response.status)
                 num_pts_read = fetch_multipoints_response.actual_number_of_points
                 measurements = np.array(fetch_multipoints_response.reading_array)
-                
+
                 # retain data to 2 decimals
                 measurements = np.floor(measurements * 100) / 100.0
 
@@ -187,28 +186,28 @@ try:
                 # Calculate sum
                 for i in range(num_pts_read):
                     sum_measurements += measurements[i]
-                
+
                 time.sleep(0.1)
     except KeyboardInterrupt:
         pass
 
-    print(f'Number of measurements = {num_measurements}')
+    print(f"Number of measurements = {num_measurements}")
     # Calculate average
-    average = sum_measurements/num_measurements
-    print(f'Average = {average}')
+    average = sum_measurements / num_measurements
+    print(f"Average = {average}")
 
-# If NI-DMM API throws an exception, print the error message  
+# If NI-DMM API throws an exception, print the error message
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
-    print(f"{error_message}") 
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
+    print(f"{error_message}")
 finally:
-    if('vi' in vars() and vi.id != 0):
+    if "vi" in vars() and vi.id != 0:
         # Close NI-DMM session
-        close_session_response = nidmm_client.Close(nidmm_types.CloseRequest(
-            vi = vi
-        ))
+        close_session_response = nidmm_client.Close(nidmm_types.CloseRequest(vi=vi))
         CheckForError(vi, close_session_response.status)

--- a/examples/nifgen/basic-arbitrary-waveform.py
+++ b/examples/nifgen/basic-arbitrary-waveform.py
@@ -1,5 +1,5 @@
 # Demonstrates how to configure an NI Arbitrary Waveform Generator to generate a basic arbitrary waveform with Arbitrary Waveform Mode.
-# 
+#
 # The gRPC API is built from the C API. NI-FGEN documentation is installed with the driver at:
 # C:\Program Files (x86)\IVI Foundation\IVI\Drivers\niFgen\documentation\English\SigGenHelp.chm
 #
@@ -36,7 +36,7 @@ options = "Simulate=1, DriverSetup=Model:5441; BoardType:PXI"
 
 # parameters
 channel_name = "0"
-sample_rate = 40e+6
+sample_rate = 40e6
 gain = 1.0
 dc_offset = 0.0
 waveform_size = 64
@@ -44,7 +44,7 @@ waveform_size = 64
 # initialize sine waveform data
 sine = []
 for i in range(waveform_size):
-    sine.append(math.sin((i/waveform_size)*2*math.pi))
+    sine.append(math.sin((i / waveform_size) * 2 * math.pi))
 
 # Read in cmd args
 if len(sys.argv) >= 2:
@@ -61,119 +61,116 @@ nifgen_service = grpc_nifgen.NiFgenStub(channel)
 
 any_error = False
 # Checks for errors. If any, throws an exception to stop the execution.
-def CheckForError (vi, status) :
+def CheckForError(vi, status):
     global any_error
     if status != 0 and not any_error:
         any_error = True
-        ThrowOnError (vi, status)
+        ThrowOnError(vi, status)
+
 
 # Converts an error code returned by NI-FGEN into a user-readable string.
-def ThrowOnError (vi, error_code):
-    error_handler_request = nifgen_types.ErrorHandlerRequest(
-        vi = vi,
-        error_code = error_code
-    )
+def ThrowOnError(vi, error_code):
+    error_handler_request = nifgen_types.ErrorHandlerRequest(vi=vi, error_code=error_code)
     error_handler_response = nifgen_service.ErrorHandler(error_handler_request)
-    raise Exception (error_handler_response.error_message)
+    raise Exception(error_handler_response.error_message)
+
 
 try:
     # Initalize NI-FGEN session
-    init_with_options_resp = nifgen_service.InitWithOptions(nifgen_types.InitWithOptionsRequest(
-        session_name = session_name,
-        resource_name = resource,
-        option_string = options
-    ))
+    init_with_options_resp = nifgen_service.InitWithOptions(
+        nifgen_types.InitWithOptionsRequest(
+            session_name=session_name, resource_name=resource, option_string=options
+        )
+    )
     vi = init_with_options_resp.vi
     CheckForError(vi, init_with_options_resp.status)
 
     # Configure channels
-    config_channels_resp = nifgen_service.ConfigureChannels(nifgen_types.ConfigureChannelsRequest(
-        vi = vi,
-        channels = channel_name
-    ))
+    config_channels_resp = nifgen_service.ConfigureChannels(
+        nifgen_types.ConfigureChannelsRequest(vi=vi, channels=channel_name)
+    )
     CheckForError(vi, config_channels_resp.status)
 
     # Configure output mode
-    config_out_resp = nifgen_service.ConfigureOutputMode(nifgen_types.ConfigureOutputModeRequest(
-        vi = vi,
-        output_mode = nifgen_types.OutputMode.OUTPUT_MODE_NIFGEN_VAL_OUTPUT_ARB
-    ))
+    config_out_resp = nifgen_service.ConfigureOutputMode(
+        nifgen_types.ConfigureOutputModeRequest(
+            vi=vi, output_mode=nifgen_types.OutputMode.OUTPUT_MODE_NIFGEN_VAL_OUTPUT_ARB
+        )
+    )
     CheckForError(vi, config_out_resp.status)
 
     # Create waveform
-    create_waveform_resp = nifgen_service.CreateWaveformF64(nifgen_types.CreateWaveformF64Request(
-        vi = vi,
-        channel_name = channel_name,
-        waveform_data_array = sine
-    ))
+    create_waveform_resp = nifgen_service.CreateWaveformF64(
+        nifgen_types.CreateWaveformF64Request(
+            vi=vi, channel_name=channel_name, waveform_data_array=sine
+        )
+    )
     waveform_handle = create_waveform_resp.waveform_handle
     CheckForError(vi, create_waveform_resp.status)
 
     # Configure arbitrary waveform
-    config_waveform_resp = nifgen_service.ConfigureArbWaveform(nifgen_types.ConfigureArbWaveformRequest(
-        vi = vi,
-        channel_name = channel_name,
-        waveform_handle = waveform_handle,
-        gain = gain,
-        offset = dc_offset
-    ))
+    config_waveform_resp = nifgen_service.ConfigureArbWaveform(
+        nifgen_types.ConfigureArbWaveformRequest(
+            vi=vi,
+            channel_name=channel_name,
+            waveform_handle=waveform_handle,
+            gain=gain,
+            offset=dc_offset,
+        )
+    )
     CheckForError(vi, config_waveform_resp.status)
 
     # Configure clockmode to VAL_HIGH_RESOLUTION
-    config_clckmode_resp = nifgen_service.ConfigureClockMode(nifgen_types.ConfigureClockModeRequest(
-        vi = vi,
-        clock_mode = nifgen_types.ClockMode.CLOCK_MODE_NIFGEN_VAL_HIGH_RESOLUTION
-    ))
+    config_clckmode_resp = nifgen_service.ConfigureClockMode(
+        nifgen_types.ConfigureClockModeRequest(
+            vi=vi, clock_mode=nifgen_types.ClockMode.CLOCK_MODE_NIFGEN_VAL_HIGH_RESOLUTION
+        )
+    )
     CheckForError(vi, config_clckmode_resp.status)
 
     # Configure sample rate
-    config_sample_rate_resp = nifgen_service.ConfigureSampleRate(nifgen_types.ConfigureSampleRateRequest(
-        vi = vi,
-        sample_rate = sample_rate
-    ))
+    config_sample_rate_resp = nifgen_service.ConfigureSampleRate(
+        nifgen_types.ConfigureSampleRateRequest(vi=vi, sample_rate=sample_rate)
+    )
     CheckForError(vi, config_sample_rate_resp.status)
 
     # Configure output enabled
-    config_outenbl_resp = nifgen_service.ConfigureOutputEnabled(nifgen_types.ConfigureOutputEnabledRequest(
-        vi = vi,
-        channel_name = channel_name,
-        enabled = True
-    ))
+    config_outenbl_resp = nifgen_service.ConfigureOutputEnabled(
+        nifgen_types.ConfigureOutputEnabledRequest(vi=vi, channel_name=channel_name, enabled=True)
+    )
     CheckForError(vi, config_outenbl_resp.status)
 
     # Initiate generation
-    init_gen_resp = nifgen_service.InitiateGeneration(nifgen_types.InitiateGenerationRequest(
-        vi = vi
-    ))
+    init_gen_resp = nifgen_service.InitiateGeneration(nifgen_types.InitiateGenerationRequest(vi=vi))
     CheckForError(vi, init_gen_resp.status)
 
     print(f"Generating sine wave at {sample_rate} Hz...")
-    print('Close the window or press Ctrl+C to stop generation')
+    print("Close the window or press Ctrl+C to stop generation")
 
     try:
         # Plot the sine wave
         fig = plt.gcf()
-        fig.canvas.manager.set_window_title('Sample Waveform')
+        fig.canvas.manager.set_window_title("Sample Waveform")
         plt.plot(sine)
-        plt.suptitle("Close the window to stop generation", fontsize = 10)
+        plt.suptitle("Close the window to stop generation", fontsize=10)
         plt.xlabel("Samples")
         plt.ylabel("Amplitude")
         plt.show()
     except KeyboardInterrupt:
         pass
 
-# If NI-FGEN API throws an exception, print the error message  
+# If NI-FGEN API throws an exception, print the error message
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
-    print(f"{error_message}") 
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
+    print(f"{error_message}")
 finally:
-    if 'vi' in vars() and vi.id != 0:
+    if "vi" in vars() and vi.id != 0:
         # Close NI-FGEN session
-        close_session_response = nifgen_service.Close(nifgen_types.CloseRequest(
-            vi = vi
-        ))
+        close_session_response = nifgen_service.Close(nifgen_types.CloseRequest(vi=vi))
         CheckForError(vi, close_session_response.status)

--- a/examples/nirfmxspecan/spectrum-basic.py
+++ b/examples/nirfmxspecan/spectrum-basic.py
@@ -96,8 +96,11 @@ try:
     raise_if_error(
         client.CfgRF(
             nirfmxspecan_types.CfgRFRequest(
-                instrument=instr, selector_string="",
-                center_frequency=1e9, reference_level=0, external_attenuation=0
+                instrument=instr,
+                selector_string="",
+                center_frequency=1e9,
+                reference_level=0,
+                external_attenuation=0,
             )
         )
     )
@@ -113,10 +116,11 @@ try:
     raise_if_error(
         client.SpectrumCfgRBWFilter(
             nirfmxspecan_types.SpectrumCfgRBWFilterRequest(
-                instrument=instr, selector_string="",
+                instrument=instr,
+                selector_string="",
                 rbw_auto=nirfmxspecan_types.SPECTRUM_RBW_AUTO_BANDWIDTH_TRUE,
                 rbw=100e3,
-                rbw_filter_type=nirfmxspecan_types.SPECTRUM_RBW_FILTER_TYPE_GAUSSIAN
+                rbw_filter_type=nirfmxspecan_types.SPECTRUM_RBW_FILTER_TYPE_GAUSSIAN,
             )
         )
     )
@@ -124,10 +128,11 @@ try:
     raise_if_error(
         client.SpectrumCfgAveraging(
             nirfmxspecan_types.SpectrumCfgAveragingRequest(
-                instrument=instr, selector_string="",
+                instrument=instr,
+                selector_string="",
                 averaging_enabled=nirfmxspecan_types.SPECTRUM_AVERAGING_ENABLED_FALSE,
                 averaging_count=10,
-                averaging_type=nirfmxspecan_types.SPECTRUM_AVERAGING_TYPE_RMS
+                averaging_type=nirfmxspecan_types.SPECTRUM_AVERAGING_TYPE_RMS,
             )
         )
     )
@@ -141,14 +146,16 @@ try:
     )
 
     print(
-        f"min frequency: {format_frequency(read_response.x0)}: {read_response.spectrum[0]:.1f} dBm")
+        f"min frequency: {format_frequency(read_response.x0)}: {read_response.spectrum[0]:.1f} dBm"
+    )
     midpoint_x = floor(read_response.actual_array_size / 2)
     print(
-        f"midpoint frequency: {format_frequency(read_response.x0 + read_response.dx * midpoint_x)}: {read_response.spectrum[midpoint_x]:.1f} dBm")
+        f"midpoint frequency: {format_frequency(read_response.x0 + read_response.dx * midpoint_x)}: {read_response.spectrum[midpoint_x]:.1f} dBm"
+    )
     print(
-        f"max frequency: {format_frequency(read_response.x0 + read_response.dx * (read_response.actual_array_size - 1))}: {read_response.spectrum[-1]:.1f} dBm")
+        f"max frequency: {format_frequency(read_response.x0 + read_response.dx * (read_response.actual_array_size - 1))}: {read_response.spectrum[-1]:.1f} dBm"
+    )
 
 finally:
     if instr:
-        client.Close(nirfmxspecan_types.CloseRequest(
-            instrument=instr, force_destroy=False))
+        client.Close(nirfmxspecan_types.CloseRequest(instrument=instr, force_destroy=False))

--- a/examples/nirfsa/getting-started-iq.py
+++ b/examples/nirfsa/getting-started-iq.py
@@ -120,7 +120,7 @@ try:
 
     accumulator = 0.0
     for sample in read_response.data:
-        magnitude_squared = sample.real ** 2 + sample.imaginary ** 2
+        magnitude_squared = sample.real**2 + sample.imaginary**2
         # We need to handle this because log(0) returns a range error.
         magnitude_squared = magnitude_squared or 1e-8
         accumulator += 10.0 * math.log10((magnitude_squared / (2.0 * 50.0)) * 1000.0)

--- a/examples/nirfsg/getting-started-single-tone-generation.py
+++ b/examples/nirfsg/getting-started-single-tone-generation.py
@@ -53,30 +53,30 @@ vi = None
 # Raise an exception if an error was returned
 def raise_if_error(response):
     if response.status != 0:
-        response = client.ErrorMessage(
-            nirfsg_types.ErrorMessageRequest(error_code=response.status))
+        response = client.ErrorMessage(nirfsg_types.ErrorMessageRequest(error_code=response.status))
         raise Exception(f"Error: {response.error_string}")
 
 
 try:
     response = client.InitWithOptions(
         nirfsg_types.InitWithOptionsRequest(
-            session_name=session_name, resource_name=resource, option_string=options)
+            session_name=session_name, resource_name=resource, option_string=options
+        )
     )
     raise_if_error(response)
     vi = response.vi
-    raise_if_error(client.ConfigureRF(
-        nirfsg_types.ConfigureRFRequest(vi=vi, frequency=1e9, power_level=-5)
-    ))
+    raise_if_error(
+        client.ConfigureRF(nirfsg_types.ConfigureRFRequest(vi=vi, frequency=1e9, power_level=-5))
+    )
     raise_if_error(client.Initiate(nirfsg_types.InitiateRequest(vi=vi)))
     print("Generating tone...")
     # Wait for two seconds and change frequency
     time.sleep(2)
     print("Changing frequency")
     raise_if_error(client.Abort(nirfsg_types.AbortRequest(vi=vi)))
-    raise_if_error(client.ConfigureRF(
-        nirfsg_types.ConfigureRFRequest(vi=vi, frequency=1.5e9, power_level=-5)
-    ))
+    raise_if_error(
+        client.ConfigureRF(nirfsg_types.ConfigureRFRequest(vi=vi, frequency=1.5e9, power_level=-5))
+    )
     raise_if_error(client.Initiate(nirfsg_types.InitiateRequest(vi=vi)))
     print("Generating tone...")
     time.sleep(2)
@@ -85,10 +85,13 @@ except grpc.RpcError as rpc_error:
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
     print(f"{error_message}")
 finally:
     if vi:
         client.ConfigureOutputEnabled(
-            nirfsg_types.ConfigureOutputEnabledRequest(output_enabled=False))
+            nirfsg_types.ConfigureOutputEnabledRequest(output_enabled=False)
+        )
         client.Close(nirfsg_types.CloseRequest(vi=vi))

--- a/examples/niscope/fetch-continuous.py
+++ b/examples/niscope/fetch-continuous.py
@@ -1,4 +1,4 @@
-# 
+#
 # This example initiates an acquisition and continuously fetches waveform samples per channel.
 #
 # The gRPC API is built from the C API.  NI-SCOPE documentation is installed with the driver at:
@@ -8,7 +8,7 @@
 # Link: https://zone.ni.com/reference/en-XX/help/370592AB-01/
 #
 # Getting Started:
-# 
+#
 # To run this example, install "NI-SCOPE Driver" on the server machine.
 # Link : https://www.ni.com/en-us/support/downloads/drivers/download.ni-scope.html
 #
@@ -44,20 +44,19 @@ sample_rate_in_hz = 1000
 
 any_error = False
 # Checks for errors. If any, throws an exception to stop the execution.
-def CheckForError (vi, status) :
+def CheckForError(vi, status):
     global any_error
-    if(status != 0 and not any_error):
+    if status != 0 and not any_error:
         any_error = True
-        ThrowOnError (vi, status)
+        ThrowOnError(vi, status)
+
 
 # Converts an error code returned by NI-SCOPE into a user-readable string.
-def ThrowOnError (vi, error_code):
-    error_message_request = niscope_types.GetErrorMessageRequest(
-        vi = vi,
-        error_code = error_code
-        )
+def ThrowOnError(vi, error_code):
+    error_message_request = niscope_types.GetErrorMessageRequest(vi=vi, error_code=error_code)
     error_message_response = client.GetErrorMessage(error_message_request)
-    raise Exception (error_message_response.error_message)
+    raise Exception(error_message_response.error_message)
+
 
 # Read in cmd args
 if len(sys.argv) >= 2:
@@ -72,65 +71,89 @@ if len(sys.argv) >= 4:
 channel = grpc.insecure_channel(f"{server_address}:{server_port}")
 client = grpc_niscope.NiScopeStub(channel)
 
-try :
+try:
     # Open session to NI-SCOPE module with options.
-    init_with_options_response = client.InitWithOptions(niscope_types.InitWithOptionsRequest(
-        resource_name=resource,
-        id_query = False,
-        option_string=options
-        ))
+    init_with_options_response = client.InitWithOptions(
+        niscope_types.InitWithOptionsRequest(
+            resource_name=resource, id_query=False, option_string=options
+        )
+    )
     vi = init_with_options_response.vi
     CheckForError(vi, init_with_options_response.status)
 
     # Configure vertical.
     voltage = 10.0
-    CheckForError(vi, (client.ConfigureVertical(niscope_types.ConfigureVerticalRequest(
-        vi = vi,
-        channel_list = channels,
-        range = voltage,
-        offset = 0.0,
-        coupling = niscope_types.VerticalCoupling.VERTICAL_COUPLING_NISCOPE_VAL_DC,
-        probe_attenuation = 1.0,
-        enabled = True
-        ))).status)
+    CheckForError(
+        vi,
+        (
+            client.ConfigureVertical(
+                niscope_types.ConfigureVerticalRequest(
+                    vi=vi,
+                    channel_list=channels,
+                    range=voltage,
+                    offset=0.0,
+                    coupling=niscope_types.VerticalCoupling.VERTICAL_COUPLING_NISCOPE_VAL_DC,
+                    probe_attenuation=1.0,
+                    enabled=True,
+                )
+            )
+        ).status,
+    )
 
     # Configure horizontal timing.
-    CheckForError(vi, (client.ConfigureHorizontalTiming(niscope_types.ConfigureHorizontalTimingRequest(
-        vi = vi,
-        min_sample_rate = sample_rate_in_hz,
-        min_num_pts = 1,
-        ref_position = 0.0,
-        num_records = 1,
-        enforce_realtime = True
-        ))).status)
+    CheckForError(
+        vi,
+        (
+            client.ConfigureHorizontalTiming(
+                niscope_types.ConfigureHorizontalTimingRequest(
+                    vi=vi,
+                    min_sample_rate=sample_rate_in_hz,
+                    min_num_pts=1,
+                    ref_position=0.0,
+                    num_records=1,
+                    enforce_realtime=True,
+                )
+            )
+        ).status,
+    )
 
     # Configure software trigger, but never send the trigger.
     # This starts an infinite acquisition, until you call Abort or Close
-    CheckForError(vi, (client.ConfigureTriggerSoftware(niscope_types.ConfigureTriggerSoftwareRequest(
-        vi = vi,
-        holdoff = 0.0,
-        delay = 0.0
-        ))).status)
+    CheckForError(
+        vi,
+        (
+            client.ConfigureTriggerSoftware(
+                niscope_types.ConfigureTriggerSoftwareRequest(vi=vi, holdoff=0.0, delay=0.0)
+            )
+        ).status,
+    )
 
     # Initiate acquisition
-    CheckForError(vi, (client.InitiateAcquisition(niscope_types.InitiateAcquisitionRequest(
-        vi = vi
-        ))).status)
+    CheckForError(
+        vi, (client.InitiateAcquisition(niscope_types.InitiateAcquisitionRequest(vi=vi))).status
+    )
 
     # Allocate space for the waveform according to the max number of
     # points to fetch and the number of waveforms.
-    channel_list = channels.split(',')
+    channel_list = channels.split(",")
     total_samples = int(total_acquisition_time_in_seconds * sample_rate_in_hz)
     waveforms = [np.ndarray(total_samples, dtype=np.float64) for c in channel_list]
 
     # Set fetch relative to attribute.
-    CheckForError(vi, (client.SetAttributeViInt32(niscope_types.SetAttributeViInt32Request(
-        vi = vi,
-        channel_list = "",
-        attribute_id = niscope_types.NiScopeAttribute.NISCOPE_ATTRIBUTE_FETCH_RELATIVE_TO,
-        value = niscope_types.NiScopeInt32AttributeValues.NISCOPE_INT32_FETCH_RELATIVE_TO_VAL_READ_POINTER
-        ))).status)
- 
+    CheckForError(
+        vi,
+        (
+            client.SetAttributeViInt32(
+                niscope_types.SetAttributeViInt32Request(
+                    vi=vi,
+                    channel_list="",
+                    attribute_id=niscope_types.NiScopeAttribute.NISCOPE_ATTRIBUTE_FETCH_RELATIVE_TO,
+                    value=niscope_types.NiScopeInt32AttributeValues.NISCOPE_INT32_FETCH_RELATIVE_TO_VAL_READ_POINTER,
+                )
+            )
+        ).status,
+    )
+
     # Fetch continuously until all samples are acquired.
     current_pos = 0
     samples_per_fetch = 100
@@ -140,18 +163,22 @@ try :
             # We fetch each channel at a time so we don't have to de-interleave afterwards.
             # We do not keep the wfm_info returned from fetch.
             for channel_name, waveform in zip(channel_list, waveforms):
-                fetch_response = client.Fetch(niscope_types.FetchRequest(
-                    vi = vi,
-                    channel_list = channel_name,
-                    timeout = 500000,
-                    num_samples = samples_per_fetch
-                    ))
+                fetch_response = client.Fetch(
+                    niscope_types.FetchRequest(
+                        vi=vi,
+                        channel_list=channel_name,
+                        timeout=500000,
+                        num_samples=samples_per_fetch,
+                    )
+                )
                 CheckForError(vi, fetch_response.status)
                 waveform[current_pos : current_pos + samples_per_fetch] = fetch_response.waveform
-                print(f'Fetching channel {channel_name}\'s waveform for indices {current_pos} to {current_pos + samples_per_fetch - 1}')
+                print(
+                    f"Fetching channel {channel_name}'s waveform for indices {current_pos} to {current_pos + samples_per_fetch - 1}"
+                )
             print()
             current_pos += samples_per_fetch
-            
+
     except KeyboardInterrupt:
         pass
 
@@ -161,12 +188,12 @@ except grpc.RpcError as rpc_error:
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
     print(f"{error_message}")
 
 finally:
-    if('vi' in vars() and vi.id != 0):
+    if "vi" in vars() and vi.id != 0:
         # close the session.
-        CheckForError(vi, (client.Close(niscope_types.CloseRequest(
-            vi = vi
-        ))).status)
+        CheckForError(vi, (client.Close(niscope_types.CloseRequest(vi=vi))).status)

--- a/examples/niscope/graph-measurement.py
+++ b/examples/niscope/graph-measurement.py
@@ -44,19 +44,20 @@ channels = "0"
 
 # Checks for errors. If any, throws an exception to stop the execution.
 any_error = False
-def CheckForError (vi, status) :
-    global any_error
-    if(status != 0 and not any_error):
-        any_error = True
-        ThrowOnError (vi, status)
 
-def ThrowOnError (vi, error_code):
-    error_message_request = niscope_types.GetErrorMessageRequest(
-        vi = vi,
-        error_code = error_code
-        )
+
+def CheckForError(vi, status):
+    global any_error
+    if status != 0 and not any_error:
+        any_error = True
+        ThrowOnError(vi, status)
+
+
+def ThrowOnError(vi, error_code):
+    error_message_request = niscope_types.GetErrorMessageRequest(vi=vi, error_code=error_code)
     error_message_response = scope_service.GetErrorMessage(error_message_request)
-    raise Exception (error_message_response.error_message)
+    raise Exception(error_message_response.error_message)
+
 
 # Read in cmd args
 if len(sys.argv) >= 2:
@@ -74,62 +75,71 @@ scope_service = grpc_scope.NiScopeStub(channel)
 
 try:
     # Initialize the scope
-    init_result = scope_service.InitWithOptions(niscope_types.InitWithOptionsRequest(
-        session_name = "demo",
-        resource_name = resource, 
-        id_query = False, 
-        option_string = options
-        ))
+    init_result = scope_service.InitWithOptions(
+        niscope_types.InitWithOptionsRequest(
+            session_name="demo", resource_name=resource, id_query=False, option_string=options
+        )
+    )
     vi = init_result.vi
     CheckForError(vi, init_result.status)
 
     # Configure Vertical
-    vertical_result = scope_service.ConfigureVertical(niscope_types.ConfigureVerticalRequest(
-        vi = vi,
-        channel_list = channels,
-        range = 10.0,
-        offset = 0,
-        coupling = niscope_types.VerticalCoupling.VERTICAL_COUPLING_NISCOPE_VAL_DC,
-        enabled = True,
-        probe_attenuation = 1
-        ))
+    vertical_result = scope_service.ConfigureVertical(
+        niscope_types.ConfigureVerticalRequest(
+            vi=vi,
+            channel_list=channels,
+            range=10.0,
+            offset=0,
+            coupling=niscope_types.VerticalCoupling.VERTICAL_COUPLING_NISCOPE_VAL_DC,
+            enabled=True,
+            probe_attenuation=1,
+        )
+    )
     CheckForError(vi, vertical_result.status)
 
     # Configure Horizontal Timing
-    config_result = scope_service.ConfigureHorizontalTiming(niscope_types.ConfigureHorizontalTimingRequest(
-        vi = vi,
-        min_sample_rate = 1000000,
-        min_num_pts = 1000,
-        ref_position = 50,
-        num_records = 1,
-        enforce_realtime = True
-        ))
+    config_result = scope_service.ConfigureHorizontalTiming(
+        niscope_types.ConfigureHorizontalTimingRequest(
+            vi=vi,
+            min_sample_rate=1000000,
+            min_num_pts=1000,
+            ref_position=50,
+            num_records=1,
+            enforce_realtime=True,
+        )
+    )
     CheckForError(vi, config_result.status)
 
     # Setup an Edge Trigger
-    result = scope_service.SetAttributeViInt32(niscope_types.SetAttributeViInt32Request(
-        vi = vi,
-        attribute_id = niscope_types.NiScopeAttribute.NISCOPE_ATTRIBUTE_TRIGGER_TYPE,
-        value = niscope_types.NiScopeInt32AttributeValues.NISCOPE_INT32_TRIGGER_TYPE_VAL_EDGE_TRIGGER
-    ))
+    result = scope_service.SetAttributeViInt32(
+        niscope_types.SetAttributeViInt32Request(
+            vi=vi,
+            attribute_id=niscope_types.NiScopeAttribute.NISCOPE_ATTRIBUTE_TRIGGER_TYPE,
+            value=niscope_types.NiScopeInt32AttributeValues.NISCOPE_INT32_TRIGGER_TYPE_VAL_EDGE_TRIGGER,
+        )
+    )
     CheckForError(vi, result.status)
 
-    conf_trigger_edge_result = scope_service.ConfigureTriggerEdge(niscope_types.ConfigureTriggerEdgeRequest(
-        vi = vi,
-        trigger_source = channels,
-        level = 0.00,
-        slope = niscope_types.TriggerSlope.TRIGGER_SLOPE_NISCOPE_VAL_POSITIVE,
-        trigger_coupling = niscope_types.TriggerCoupling.TRIGGER_COUPLING_NISCOPE_VAL_DC,
-        holdoff = 0.0
-    ))
+    conf_trigger_edge_result = scope_service.ConfigureTriggerEdge(
+        niscope_types.ConfigureTriggerEdgeRequest(
+            vi=vi,
+            trigger_source=channels,
+            level=0.00,
+            slope=niscope_types.TriggerSlope.TRIGGER_SLOPE_NISCOPE_VAL_POSITIVE,
+            trigger_coupling=niscope_types.TriggerCoupling.TRIGGER_COUPLING_NISCOPE_VAL_DC,
+            holdoff=0.0,
+        )
+    )
     CheckForError(vi, conf_trigger_edge_result.status)
 
-    result = scope_service.SetAttributeViInt32(niscope_types.SetAttributeViInt32Request(
-        vi = vi,
-        channel_list = channels,
-        attribute_id = niscope_types.NiScopeAttribute.NISCOPE_ATTRIBUTE_MEAS_REF_LEVEL_UNITS,
-        value = niscope_types.NiScopeInt32AttributeValues.NISCOPE_INT32_REF_LEVEL_UNITS_VAL_PERCENTAGE
-    ))
+    result = scope_service.SetAttributeViInt32(
+        niscope_types.SetAttributeViInt32Request(
+            vi=vi,
+            channel_list=channels,
+            attribute_id=niscope_types.NiScopeAttribute.NISCOPE_ATTRIBUTE_MEAS_REF_LEVEL_UNITS,
+            value=niscope_types.NiScopeInt32AttributeValues.NISCOPE_INT32_REF_LEVEL_UNITS_VAL_PERCENTAGE,
+        )
+    )
     CheckForError(vi, result.status)
 
     # Setup a plot to draw the captured waveform
@@ -144,12 +154,11 @@ try:
             plt.clf()
             plt.axis([0, 100, -6, 6])
             # Read a waveform from the scope
-            read_result = scope_service.Read(niscope_types.ReadRequest(
-                vi = vi,
-                channel_list = channels,
-                timeout = 1,
-                num_samples = 10000
-            ))
+            read_result = scope_service.Read(
+                niscope_types.ReadRequest(
+                    vi=vi, channel_list=channels, timeout=1, num_samples=10000
+                )
+            )
             CheckForError(vi, read_result.status)
             values = read_result.waveform[0:10]
             print(values)
@@ -160,12 +169,14 @@ try:
             plt.pause(0.001)
 
             # Fetch the measured average frequency
-            fetch_result = scope_service.FetchMeasurementStats(niscope_types.FetchMeasurementStatsRequest(
-                vi = vi,
-                channel_list = channels,
-                timeout = 1,
-                scalar_meas_function = niscope_types.ScalarMeasurement.SCALAR_MEASUREMENT_NISCOPE_VAL_AVERAGE_FREQUENCY
-            ))
+            fetch_result = scope_service.FetchMeasurementStats(
+                niscope_types.FetchMeasurementStatsRequest(
+                    vi=vi,
+                    channel_list=channels,
+                    timeout=1,
+                    scalar_meas_function=niscope_types.ScalarMeasurement.SCALAR_MEASUREMENT_NISCOPE_VAL_AVERAGE_FREQUENCY,
+                )
+            )
             CheckForError(vi, fetch_result.status)
             print("Average Frequency: " + str("%.2f" % round(fetch_result.result[0], 2)) + " Hz")
             print("")
@@ -179,12 +190,12 @@ except grpc.RpcError as rpc_error:
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
     print(f"{error_message}")
 
 finally:
-    if('vi' in vars() and vi.id != 0):
+    if "vi" in vars() and vi.id != 0:
         # close the session.
-        CheckForError(vi, (scope_service.Close(niscope_types.CloseRequest(
-            vi = vi
-        ))).status)
+        CheckForError(vi, (scope_service.Close(niscope_types.CloseRequest(vi=vi))).status)

--- a/examples/niscope/plot-read-waveform-betterproto.py
+++ b/examples/niscope/plot-read-waveform-betterproto.py
@@ -59,9 +59,10 @@ if len(sys.argv) == 4:
 
 # Error Reporting
 async def CheckStatus(scope_service, vi, result):
-    if (result.status != 0):
-        error_result = await scope_service.get_error_message(vi = vi, error_code = result.status)
-        raise Exception (error_result.error_message)
+    if result.status != 0:
+        error_result = await scope_service.get_error_message(vi=vi, error_code=result.status)
+        raise Exception(error_result.error_message)
+
 
 async def PerformAcquire():
     try:
@@ -72,68 +73,65 @@ async def PerformAcquire():
 
         # Initialize the scope
         init_result = await scope_service.init_with_options(
-            session_name = "demoSession",
-            resource_name = resource,
-            id_query = False,
+            session_name="demoSession",
+            resource_name=resource,
+            id_query=False,
             reset_device=False,
-            option_string = options
+            option_string=options,
         )
         vi = init_result.vi
         await CheckStatus(scope_service, vi, init_result)
 
         # Configure horizontal timing
         config_result = await scope_service.configure_horizontal_timing(
-            vi = vi,
-            min_sample_rate = 5000000,
-            min_num_pts = 100000,
-            ref_position = 50,
-            num_records = 1,
-            enforce_realtime = True
+            vi=vi,
+            min_sample_rate=5000000,
+            min_num_pts=100000,
+            ref_position=50,
+            num_records=1,
+            enforce_realtime=True,
         )
         await CheckStatus(scope_service, vi, config_result)
 
         # Configure vertical timing
         vertical_result = await scope_service.configure_vertical(
-            vi = vi,
-            channel_list = channels,
-            range = 10.0,
-            offset = 0,
-            coupling_raw = niscope_grpc.VerticalCoupling.VERTICAL_COUPLING_NISCOPE_VAL_DC,
-            enabled = True,
-            probe_attenuation = 1
+            vi=vi,
+            channel_list=channels,
+            range=10.0,
+            offset=0,
+            coupling_raw=niscope_grpc.VerticalCoupling.VERTICAL_COUPLING_NISCOPE_VAL_DC,
+            enabled=True,
+            probe_attenuation=1,
         )
         await CheckStatus(scope_service, vi, vertical_result)
 
         confTrigger_edge_result = await scope_service.configure_trigger_edge(
-            vi = vi,
-            trigger_source = channels,
-            level = 0.00,
-            holdoff = 0.0,
-            trigger_coupling_raw = niscope_grpc.TriggerCoupling.TRIGGER_COUPLING_NISCOPE_VAL_DC,
-            slope_raw = niscope_grpc.TriggerSlope.TRIGGER_SLOPE_NISCOPE_VAL_POSITIVE
+            vi=vi,
+            trigger_source=channels,
+            level=0.00,
+            holdoff=0.0,
+            trigger_coupling_raw=niscope_grpc.TriggerCoupling.TRIGGER_COUPLING_NISCOPE_VAL_DC,
+            slope_raw=niscope_grpc.TriggerSlope.TRIGGER_SLOPE_NISCOPE_VAL_POSITIVE,
         )
         await CheckStatus(scope_service, vi, confTrigger_edge_result)
 
         set_result = await scope_service.set_attribute_vi_int32(
-            vi = vi,
-            channel_list = channels,
-            attribute_id = niscope_grpc.NiScopeAttribute.NISCOPE_ATTRIBUTE_MEAS_REF_LEVEL_UNITS,
-            value_raw = niscope_grpc.NiScopeInt32AttributeValues.NISCOPE_INT32_REF_LEVEL_UNITS_VAL_PERCENTAGE
+            vi=vi,
+            channel_list=channels,
+            attribute_id=niscope_grpc.NiScopeAttribute.NISCOPE_ATTRIBUTE_MEAS_REF_LEVEL_UNITS,
+            value_raw=niscope_grpc.NiScopeInt32AttributeValues.NISCOPE_INT32_REF_LEVEL_UNITS_VAL_PERCENTAGE,
         )
         await CheckStatus(scope_service, vi, set_result)
 
         read_result = await scope_service.read(
-            vi = vi,
-            channel_list = channels,
-            timeout = 10000,
-            num_samples = 100000
+            vi=vi, channel_list=channels, timeout=10000, num_samples=100000
         )
         await CheckStatus(scope_service, vi, read_result)
 
         # print the value of the first few samples
         values = read_result.waveform[0:10]
         print(values)
-    
+
     except GRPCError as e:
         if e.status.name == "UNIMPLEMENTED":
             print("The operation is not implemented or is not supported/enabled in this service")
@@ -142,9 +140,10 @@ async def PerformAcquire():
     except Exception as e:
         print(str(e))
     finally:
-        if('vi' in vars() and vi.id != 0):
-            await scope_service.close(vi = vi)
+        if "vi" in vars() and vi.id != 0:
+            await scope_service.close(vi=vi)
         channel.close()
+
 
 loop = asyncio.get_event_loop()
 future = asyncio.ensure_future(PerformAcquire())

--- a/examples/niscope/plot-read-waveform.py
+++ b/examples/niscope/plot-read-waveform.py
@@ -40,19 +40,20 @@ channels = "0"
 
 # Checks for errors. If any, throws an exception to stop the execution.
 any_error = False
-def CheckForError (vi, status) :
-    global any_error
-    if(status != 0 and not any_error):
-        any_error = True
-        ThrowOnError (vi, status)
 
-def ThrowOnError (vi, error_code):
-    error_message_request = niscope_types.GetErrorMessageRequest(
-        vi = vi,
-        error_code = error_code
-        )
+
+def CheckForError(vi, status):
+    global any_error
+    if status != 0 and not any_error:
+        any_error = True
+        ThrowOnError(vi, status)
+
+
+def ThrowOnError(vi, error_code):
+    error_message_request = niscope_types.GetErrorMessageRequest(vi=vi, error_code=error_code)
     error_message_response = scope_service.GetErrorMessage(error_message_request)
-    raise Exception (error_message_response.error_message)
+    raise Exception(error_message_response.error_message)
+
 
 # Read in cmd args
 if len(sys.argv) >= 2:
@@ -70,62 +71,66 @@ scope_service = grpc_scope.NiScopeStub(channel)
 
 try:
     # Initialize the scope
-    init_result = scope_service.InitWithOptions(niscope_types.InitWithOptionsRequest(
-        session_name = "demo",
-        resource_name = resource, 
-        id_query = False, 
-        option_string = options
-        ))
+    init_result = scope_service.InitWithOptions(
+        niscope_types.InitWithOptionsRequest(
+            session_name="demo", resource_name=resource, id_query=False, option_string=options
+        )
+    )
     vi = init_result.vi
     CheckForError(vi, init_result.status)
 
     # Configure horizontal timing
-    config_result = scope_service.ConfigureHorizontalTiming(niscope_types.ConfigureHorizontalTimingRequest(
-        vi = vi,
-        min_sample_rate = 1000000,
-        min_num_pts = 100000,
-        ref_position = 50,
-        num_records = 1,
-        enforce_realtime = True
-    ))
+    config_result = scope_service.ConfigureHorizontalTiming(
+        niscope_types.ConfigureHorizontalTimingRequest(
+            vi=vi,
+            min_sample_rate=1000000,
+            min_num_pts=100000,
+            ref_position=50,
+            num_records=1,
+            enforce_realtime=True,
+        )
+    )
     CheckForError(vi, config_result.status)
 
     # Configure vertical timing
-    vertical_result = scope_service.ConfigureVertical(niscope_types.ConfigureVerticalRequest(
-        vi = vi,
-        channel_list = channels,
-        range = 10.0,
-        offset = 0,
-        coupling = niscope_types.VerticalCoupling.VERTICAL_COUPLING_NISCOPE_VAL_DC,
-        enabled = True,
-        probe_attenuation = 1
-    ))
+    vertical_result = scope_service.ConfigureVertical(
+        niscope_types.ConfigureVerticalRequest(
+            vi=vi,
+            channel_list=channels,
+            range=10.0,
+            offset=0,
+            coupling=niscope_types.VerticalCoupling.VERTICAL_COUPLING_NISCOPE_VAL_DC,
+            enabled=True,
+            probe_attenuation=1,
+        )
+    )
     CheckForError(vi, vertical_result.status)
 
-    confTrigger_edge_result = scope_service.ConfigureTriggerEdge(niscope_types.ConfigureTriggerEdgeRequest(
-        vi = vi,
-        trigger_source = channels,
-        level = 0.00,
-        trigger_coupling = niscope_types.TriggerCoupling.TRIGGER_COUPLING_NISCOPE_VAL_DC,
-        slope = niscope_types.TriggerSlope.TRIGGER_SLOPE_NISCOPE_VAL_POSITIVE
-    ))
+    confTrigger_edge_result = scope_service.ConfigureTriggerEdge(
+        niscope_types.ConfigureTriggerEdgeRequest(
+            vi=vi,
+            trigger_source=channels,
+            level=0.00,
+            trigger_coupling=niscope_types.TriggerCoupling.TRIGGER_COUPLING_NISCOPE_VAL_DC,
+            slope=niscope_types.TriggerSlope.TRIGGER_SLOPE_NISCOPE_VAL_POSITIVE,
+        )
+    )
     CheckForError(vi, confTrigger_edge_result.status)
 
-    result = scope_service.SetAttributeViInt32(niscope_types.SetAttributeViInt32Request(
-        vi = vi,
-        channel_list = channels,
-        attribute_id = niscope_types.NiScopeAttribute.NISCOPE_ATTRIBUTE_MEAS_REF_LEVEL_UNITS,
-        value = niscope_types.NiScopeInt32AttributeValues.NISCOPE_INT32_REF_LEVEL_UNITS_VAL_VOLTS
-    ))
+    result = scope_service.SetAttributeViInt32(
+        niscope_types.SetAttributeViInt32Request(
+            vi=vi,
+            channel_list=channels,
+            attribute_id=niscope_types.NiScopeAttribute.NISCOPE_ATTRIBUTE_MEAS_REF_LEVEL_UNITS,
+            value=niscope_types.NiScopeInt32AttributeValues.NISCOPE_INT32_REF_LEVEL_UNITS_VAL_VOLTS,
+        )
+    )
     CheckForError(vi, result.status)
 
     # Read a waveform from the scope
-    read_result = scope_service.Read(niscope_types.ReadRequest(
-        vi = vi,
-        channel_list = channels,
-        timeout = 10000,
-        num_samples = 100000
-    ))
+    read_result = scope_service.Read(
+        niscope_types.ReadRequest(vi=vi, channel_list=channels, timeout=10000, num_samples=100000)
+    )
     CheckForError(vi, read_result.status)
     values = read_result.waveform[0:10]
     print(values)
@@ -135,12 +140,12 @@ except grpc.RpcError as rpc_error:
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
     print(f"{error_message}")
 
 finally:
-    if('vi' in vars() and vi.id != 0):
+    if "vi" in vars() and vi.id != 0:
         # close the session.
-        CheckForError(vi, (scope_service.Close(niscope_types.CloseRequest(
-            vi = vi
-        ))).status)
+        CheckForError(vi, (scope_service.Close(niscope_types.CloseRequest(vi=vi))).status)

--- a/examples/niswitch/software-scanning.py
+++ b/examples/niswitch/software-scanning.py
@@ -54,87 +54,110 @@ number_of_triggers = 5
 anyError = False
 
 # Checks for errors. If any, throws an exception to stop the execution.
-def CheckForError (vi, status) :
+def CheckForError(vi, status):
     global anyError
-    if(status != 0 and not anyError):
+    if status != 0 and not anyError:
         anyError = True
-        ThrowOnError (vi, status)
+        ThrowOnError(vi, status)
+
 
 # Converts an error code returned by NI-SWITCH into a user-readable string
-def ThrowOnError (vi, errorCode):
-    error_message_request = niswitch_types.ErrorMessageRequest(
-        vi=vi,
-        error_code = errorCode
-        )
+def ThrowOnError(vi, errorCode):
+    error_message_request = niswitch_types.ErrorMessageRequest(vi=vi, error_code=errorCode)
     error_message_response = niswitch_client.ErrorMessage(error_message_request)
-    raise Exception (error_message_response.error_message)
-try :
+    raise Exception(error_message_response.error_message)
+
+
+try:
     # Open session to NI-SWITCH and set topology.
-    init_with_topology_response = niswitch_client.InitWithTopology(niswitch_types.InitWithTopologyRequest(
-        session_name=session_name,
-        resource_name=resource,
-        topology = topology_string,
-        simulate=simulation,
-        reset_device=False
-        ))
+    init_with_topology_response = niswitch_client.InitWithTopology(
+        niswitch_types.InitWithTopologyRequest(
+            session_name=session_name,
+            resource_name=resource,
+            topology=topology_string,
+            simulate=simulation,
+            reset_device=False,
+        )
+    )
     vi = init_with_topology_response.vi
-    CheckForError(vi,init_with_topology_response.status)
-    print("Topology set to : ",topology_string)
+    CheckForError(vi, init_with_topology_response.status)
+    print("Topology set to : ", topology_string)
 
     # Configure the scan list.
-    CheckForError(vi, (niswitch_client.ConfigureScanList(niswitch_types.ConfigureScanListRequest(
-        vi=vi,
-        scanlist = scan_list,
-        scan_mode = niswitch_types.ScanMode.SCAN_MODE_NISWITCH_VAL_BREAK_BEFORE_MAKE
-        ))).status)
+    CheckForError(
+        vi,
+        (
+            niswitch_client.ConfigureScanList(
+                niswitch_types.ConfigureScanListRequest(
+                    vi=vi,
+                    scanlist=scan_list,
+                    scan_mode=niswitch_types.ScanMode.SCAN_MODE_NISWITCH_VAL_BREAK_BEFORE_MAKE,
+                )
+            )
+        ).status,
+    )
 
     # Configures the trigger to be software trigger.
-    CheckForError(vi, (niswitch_client.ConfigureScanTrigger(niswitch_types.ConfigureScanTriggerRequest(
-        vi=vi,
-        trigger_input = niswitch_types.TriggerInput.TRIGGER_INPUT_NISWITCH_VAL_SOFTWARE_TRIG,
-        scan_advanced_output = niswitch_types.ScanAdvancedOutput.SCAN_ADVANCED_OUTPUT_NISWITCH_VAL_NONE
-        ))).status)
+    CheckForError(
+        vi,
+        (
+            niswitch_client.ConfigureScanTrigger(
+                niswitch_types.ConfigureScanTriggerRequest(
+                    vi=vi,
+                    trigger_input=niswitch_types.TriggerInput.TRIGGER_INPUT_NISWITCH_VAL_SOFTWARE_TRIG,
+                    scan_advanced_output=niswitch_types.ScanAdvancedOutput.SCAN_ADVANCED_OUTPUT_NISWITCH_VAL_NONE,
+                )
+            )
+        ).status,
+    )
     print("Configured the trigger as Software Trigger")
 
     # Loop through scan list continuously
-    CheckForError(vi, (niswitch_client.SetContinuousScan(niswitch_types.SetContinuousScanRequest(
-        vi=vi,
-        continuous_scan = True
-        ))).status)
+    CheckForError(
+        vi,
+        (
+            niswitch_client.SetContinuousScan(
+                niswitch_types.SetContinuousScanRequest(vi=vi, continuous_scan=True)
+            )
+        ).status,
+    )
 
-    #Initiate scanning
-    CheckForError(vi, (niswitch_client.InitiateScan(niswitch_types.InitiateScanRequest(
-        vi=vi
-        ))).status)
+    # Initiate scanning
+    CheckForError(
+        vi, (niswitch_client.InitiateScan(niswitch_types.InitiateScanRequest(vi=vi))).status
+    )
     print("Scanning initiated...")
 
-    #Send software trigger to module in a loop
+    # Send software trigger to module in a loop
     for x in range(number_of_triggers):
-        #Wait for 500 ms
+        # Wait for 500 ms
         time.sleep(0.5)
-        CheckForError(vi, (niswitch_client.SendSoftwareTrigger(niswitch_types.SendSoftwareTriggerRequest(
-            vi=vi
-            ))).status)
-        number_of_triggers = number_of_triggers - 1    
+        CheckForError(
+            vi,
+            (
+                niswitch_client.SendSoftwareTrigger(
+                    niswitch_types.SendSoftwareTriggerRequest(vi=vi)
+                )
+            ).status,
+        )
+        number_of_triggers = number_of_triggers - 1
 
-    #Abort Scanning
-    CheckForError(vi, (niswitch_client.AbortScan(niswitch_types.AbortScanRequest(
-        vi=vi
-        ))).status)
+    # Abort Scanning
+    CheckForError(vi, (niswitch_client.AbortScan(niswitch_types.AbortScanRequest(vi=vi))).status)
     print("Scanning completed.")
 
-# If NI-SWITCH API throws an exception, print the error message  
+# If NI-SWITCH API throws an exception, print the error message
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
-    print(f"{error_message}") 
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
+    print(f"{error_message}")
 
 finally:
-    if('vi' in vars() and vi.id != 0):
+    if "vi" in vars() and vi.id != 0:
         # close the session.
-        CheckForError(vi, (niswitch_client.Close(niswitch_types.CloseRequest(
-            vi = vi
-        ))).status)
+        CheckForError(vi, (niswitch_client.Close(niswitch_types.CloseRequest(vi=vi))).status)

--- a/examples/nitclk/synchronize-tclk.py
+++ b/examples/nitclk/synchronize-tclk.py
@@ -1,5 +1,5 @@
 # Demonstrates how to configure multiple NI Arbitrary Waveform Generators to generate synchronized waveforms with TClk
-# 
+#
 # The gRPC API is built from the C API. NI-FGEN documentation is installed with the driver at:
 # C:\Program Files (x86)\IVI Foundation\IVI\Drivers\niFgen\documentation\English\SigGenHelp.chm
 #
@@ -40,12 +40,16 @@ for i in range(waveform_size // 2, waveform_size):
 
 # Read in cmd args
 if len(sys.argv) < 4:
-    print("This example is not supported in simulation mode. Please provide server address, server port and resource name as follows:")
-    sys.exit("python synchronize-tclk.py <server_address> <port_number> <resource_name1,resource_name2>")
+    print(
+        "This example is not supported in simulation mode. Please provide server address, server port and resource name as follows:"
+    )
+    sys.exit(
+        "python synchronize-tclk.py <server_address> <port_number> <resource_name1,resource_name2>"
+    )
 else:
     server_address = sys.argv[1]
     server_port = sys.argv[2]
-    resources = list(map(str.strip, sys.argv[3].split(',')))
+    resources = list(map(str.strip, sys.argv[3].split(",")))
 
 # Create the communication channel for the remote host and create connections to the NI-FGEN and session services.
 channel = grpc.insecure_channel(f"{server_address}:{server_port}")
@@ -54,25 +58,24 @@ nitclk_service = grpc_nitclk.NiTClkStub(channel)
 
 any_error = False
 # Checks for errors. If any, throws an exception to stop the execution.
-def CheckForError (service, vi, status) :
+def CheckForError(service, vi, status):
     global any_error
     if status != 0 and not any_error:
         any_error = True
-        ThrowOnError (service, vi, status)
+        ThrowOnError(service, vi, status)
+
 
 # Converts an error code returned by NI-FGEN into a user-readable string.
-def ThrowOnError (service, vi, error_code):
+def ThrowOnError(service, vi, error_code):
     if service == nifgen_service:
-        error_handler_request = nifgen_types.ErrorHandlerRequest(
-            vi = vi,
-            error_code = error_code
-        )
+        error_handler_request = nifgen_types.ErrorHandlerRequest(vi=vi, error_code=error_code)
         error_handler_response = nifgen_service.ErrorHandler(error_handler_request)
-        raise Exception (error_handler_response.error_message)
+        raise Exception(error_handler_response.error_message)
     else:
         error_info_request = nitclk_types.GetExtendedErrorInfoRequest()
-        error_info_response = nitclk_service.GetExtendedErrorInfo(error_info_request)           
-        raise Exception (error_info_response.error_string)
+        error_info_response = nitclk_service.GetExtendedErrorInfo(error_info_request)
+        raise Exception(error_info_response.error_string)
+
 
 try:
     # list of sessions
@@ -80,59 +83,55 @@ try:
     i = 0
     for resource in resources:
         # Initalize NI-FGEN session
-        init_with_options_resp = nifgen_service.InitWithOptions(nifgen_types.InitWithOptionsRequest(
-            session_name = "session" + str(i),
-            resource_name = resource,
-            option_string = ""
-        ))
+        init_with_options_resp = nifgen_service.InitWithOptions(
+            nifgen_types.InitWithOptionsRequest(
+                session_name="session" + str(i), resource_name=resource, option_string=""
+            )
+        )
         vi = init_with_options_resp.vi
         sessions.append(vi)
         CheckForError(nifgen_service, vi, init_with_options_resp.status)
 
         # Configure channels
-        config_channels_resp = nifgen_service.ConfigureChannels(nifgen_types.ConfigureChannelsRequest(
-            vi = vi,
-            channels = "0"
-        ))
+        config_channels_resp = nifgen_service.ConfigureChannels(
+            nifgen_types.ConfigureChannelsRequest(vi=vi, channels="0")
+        )
         CheckForError(nifgen_service, vi, config_channels_resp.status)
 
         # Configure output mode
-        config_out_resp = nifgen_service.ConfigureOutputMode(nifgen_types.ConfigureOutputModeRequest(
-            vi = vi,
-            output_mode = nifgen_types.OutputMode.OUTPUT_MODE_NIFGEN_VAL_OUTPUT_ARB
-        ))
-        
+        config_out_resp = nifgen_service.ConfigureOutputMode(
+            nifgen_types.ConfigureOutputModeRequest(
+                vi=vi, output_mode=nifgen_types.OutputMode.OUTPUT_MODE_NIFGEN_VAL_OUTPUT_ARB
+            )
+        )
+
         # Configure sample rate
-        config_sample_rate_resp = nifgen_service.ConfigureSampleRate(nifgen_types.ConfigureSampleRateRequest(
-            vi = vi,
-            sample_rate = sample_rate
-        ))
+        config_sample_rate_resp = nifgen_service.ConfigureSampleRate(
+            nifgen_types.ConfigureSampleRateRequest(vi=vi, sample_rate=sample_rate)
+        )
         CheckForError(nifgen_service, vi, config_sample_rate_resp.status)
 
         # Create waveform
-        create_waveform_resp = nifgen_service.CreateWaveformF64(nifgen_types.CreateWaveformF64Request(
-            vi = vi,
-            channel_name = "0",
-            waveform_data_array = waveform_data
-        ))
+        create_waveform_resp = nifgen_service.CreateWaveformF64(
+            nifgen_types.CreateWaveformF64Request(
+                vi=vi, channel_name="0", waveform_data_array=waveform_data
+            )
+        )
         CheckForError(nifgen_service, vi, create_waveform_resp.status)
 
         i += 1
 
-    config_hom_trig_resp = nitclk_service.ConfigureForHomogeneousTriggers(nitclk_types.ConfigureForHomogeneousTriggersRequest(
-        sessions = sessions
-    ))
+    config_hom_trig_resp = nitclk_service.ConfigureForHomogeneousTriggers(
+        nitclk_types.ConfigureForHomogeneousTriggersRequest(sessions=sessions)
+    )
     CheckForError(nitclk_service, None, config_hom_trig_resp.status)
 
     # Synchronize and start generation
-    sync_resp = nitclk_service.Synchronize(nitclk_types.SynchronizeRequest(
-        sessions = sessions,
-        min_tclk_period = 0
-    ))
+    sync_resp = nitclk_service.Synchronize(
+        nitclk_types.SynchronizeRequest(sessions=sessions, min_tclk_period=0)
+    )
     CheckForError(nitclk_service, None, sync_resp.status)
-    initiate_resp = nitclk_service.Initiate(nitclk_types.InitiateRequest(
-        sessions = sessions
-    ))
+    initiate_resp = nitclk_service.Initiate(nitclk_types.InitiateRequest(sessions=sessions))
     CheckForError(nitclk_service, None, initiate_resp.status)
 
     print(f"Generating square wave with sample rate {sample_rate} on {resources}...")
@@ -141,28 +140,28 @@ try:
     try:
         # Plot waveform
         fig = plt.gcf()
-        fig.canvas.manager.set_window_title('Sample Waveform')
+        fig.canvas.manager.set_window_title("Sample Waveform")
         plt.plot(waveform_data)
-        plt.suptitle("Close the window to stop generation", fontsize = 10)
+        plt.suptitle("Close the window to stop generation", fontsize=10)
         plt.xlabel("Samples")
         plt.ylabel("Amplitude")
         plt.show()
     except KeyboardInterrupt:
         pass
 
-# If NI-FGEN API throws an exception, print the error message  
+# If NI-FGEN API throws an exception, print the error message
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
-    print(error_message) 
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
+    print(error_message)
 finally:
     for vi in sessions:
         if vi.id != 0:
             # Close NI-FGEN session
-            close_session_response = nifgen_service.Close(nifgen_types.CloseRequest(
-                vi = vi
-            ))
+            close_session_response = nifgen_service.Close(nifgen_types.CloseRequest(vi=vi))
             CheckForError(nifgen_service, vi, close_session_response.status)

--- a/examples/session/enumerate-device.py
+++ b/examples/session/enumerate-device.py
@@ -24,19 +24,24 @@ import session_pb2_grpc as grpc_session
 server_address = "localhost"
 server_port = "31763"
 
-# Helper to print the devices 
-def print_devices(devices) :
+# Helper to print the devices
+def print_devices(devices):
     if not devices:
         print("No devices are connected.")
         return
-    print("\n-----------------------------------------------------------------------------------------------------\n")
+    print(
+        "\n-----------------------------------------------------------------------------------------------------\n"
+    )
     print("  List of devices connected to the server: \n")
-    print("-----------------------------------------------------------------------------------------------------\n")
-    for device in devices :
+    print(
+        "-----------------------------------------------------------------------------------------------------\n"
+    )
+    for device in devices:
         print(f"    {device.name}")
         print(f"        Model: {device.model}")
         print(f"        Vendor: {device.vendor}")
         print(f"        Serial Number: {device.serial_number} \n")
+
 
 # Read in cmd args
 if len(sys.argv) >= 2:
@@ -48,12 +53,12 @@ if len(sys.argv) >= 3:
 channel = grpc.insecure_channel(f"{server_address}:{server_port}")
 client = grpc_session.SessionUtilitiesStub(channel)
 
-try :
+try:
     # EnumerateDevices API gives a list of devices (simulated and physical) connected to the server machine.
     enumerate_devices_response = client.EnumerateDevices(session_types.EnumerateDevicesRequest())
 
     # Display devices connected to the server machine.
-    print_devices(enumerate_devices_response.devices)     
+    print_devices(enumerate_devices_response.devices)
 
 # If EnumerateDevices API throws an exception, print the error message.
 except grpc.RpcError as rpc_error:
@@ -61,5 +66,7 @@ except grpc.RpcError as rpc_error:
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
     print(f"{error_message}")

--- a/examples/session/session-reservation.py
+++ b/examples/session/session-reservation.py
@@ -1,4 +1,4 @@
-# 
+#
 # This example initiates a session and uses the session API to exercise some common reservation operations on the session.
 # This particular example is using NI-SCOPE but the session reservation API should work for any driver session.
 #
@@ -46,20 +46,19 @@ client_2_id = "Client2"
 
 any_error = False
 # Checks for errors. If any, throws an exception to stop the execution.
-def CheckForError (vi, status) :
+def CheckForError(vi, status):
     global any_error
-    if(status != 0 and not any_error):
+    if status != 0 and not any_error:
         any_error = True
-        ThrowOnError (vi, status)
+        ThrowOnError(vi, status)
+
 
 # Converts an error code returned by NI-SCOPE into a user-readable string.
-def ThrowOnError (vi, error_code):
-    error_message_request = niscope_types.GetErrorMessageRequest(
-        vi = vi,
-        error_code = error_code
-        )
+def ThrowOnError(vi, error_code):
+    error_message_request = niscope_types.GetErrorMessageRequest(vi=vi, error_code=error_code)
     error_message_response = niscope_client.GetErrorMessage(error_message_request)
-    raise Exception (error_message_response.error_message)
+    raise Exception(error_message_response.error_message)
+
 
 # Read in cmd args
 if len(sys.argv) >= 2:
@@ -75,96 +74,86 @@ channel = grpc.insecure_channel(f"{server_address}:{server_port}")
 niscope_client = grpc_niscope.NiScopeStub(channel)
 session_client = grpc_session.SessionUtilitiesStub(channel)
 
-try :
+try:
     # Reset server to start in a fresh state.
     reset_server_response = session_client.ResetServer(session_types.ResetServerRequest())
-    assert(reset_server_response.is_server_reset)
+    assert reset_server_response.is_server_reset
 
     # Open session to NI-SCOPE module with options.
     session_name = "NI-Scope-Session-1"
-    print('\nInitializing session...')
-    init_with_options_response = niscope_client.InitWithOptions(niscope_types.InitWithOptionsRequest(
-        session_name = session_name,
-        resource_name = resource,
-        id_query = False,
-        option_string = options
-        ))
+    print("\nInitializing session...")
+    init_with_options_response = niscope_client.InitWithOptions(
+        niscope_types.InitWithOptionsRequest(
+            session_name=session_name, resource_name=resource, id_query=False, option_string=options
+        )
+    )
     vi = init_with_options_response.vi
     CheckForError(vi, init_with_options_response.status)
-    print(f'Session initialized with name {session_name} and id {vi.id}.\n')
+    print(f"Session initialized with name {session_name} and id {vi.id}.\n")
 
     # Check if session is reserved by client 1.
     # Note: The reservation_id is defined by and has meaning only for the client + Session Reservation API.
-    print(f'Checking if {session_name} is reserved by {client_1_id}...')
-    is_reserved_response = session_client.IsReservedByClient(session_types.IsReservedByClientRequest(
-        reservation_id = session_name,
-        client_id = client_1_id
-        ))
-    assert(not is_reserved_response.is_reserved)
-    print(f'{session_name} is not reserved by {client_1_id}.\n')
+    print(f"Checking if {session_name} is reserved by {client_1_id}...")
+    is_reserved_response = session_client.IsReservedByClient(
+        session_types.IsReservedByClientRequest(reservation_id=session_name, client_id=client_1_id)
+    )
+    assert not is_reserved_response.is_reserved
+    print(f"{session_name} is not reserved by {client_1_id}.\n")
 
     # Reserve session for client 1.
-    print(f'Reserving {session_name} for {client_1_id}...')
-    reserve_response = session_client.Reserve(session_types.ReserveRequest(
-        reservation_id = session_name,
-        client_id = client_1_id
-        ))
+    print(f"Reserving {session_name} for {client_1_id}...")
+    reserve_response = session_client.Reserve(
+        session_types.ReserveRequest(reservation_id=session_name, client_id=client_1_id)
+    )
     is_reserved = reserve_response.is_reserved
-    assert(is_reserved)
-    is_reserved_by_client1_response = session_client.IsReservedByClient(session_types.IsReservedByClientRequest(
-        reservation_id = session_name,
-        client_id = client_1_id
-        ))
-    assert(is_reserved_by_client1_response.is_reserved)
-    print(f'{session_name} is reserved by {client_1_id}.\n')
+    assert is_reserved
+    is_reserved_by_client1_response = session_client.IsReservedByClient(
+        session_types.IsReservedByClientRequest(reservation_id=session_name, client_id=client_1_id)
+    )
+    assert is_reserved_by_client1_response.is_reserved
+    print(f"{session_name} is reserved by {client_1_id}.\n")
 
     # Check reservation on client 2.
-    print(f'Checking if {session_name} is reserved by {client_2_id}...')
-    is_reserved_by_client2_response = session_client.IsReservedByClient(session_types.IsReservedByClientRequest(
-        reservation_id = session_name,
-        client_id = client_2_id
-        ))
-    assert(not is_reserved_by_client2_response.is_reserved)
-    print(f'{session_name} is not reserved by {client_2_id}.\n')
+    print(f"Checking if {session_name} is reserved by {client_2_id}...")
+    is_reserved_by_client2_response = session_client.IsReservedByClient(
+        session_types.IsReservedByClientRequest(reservation_id=session_name, client_id=client_2_id)
+    )
+    assert not is_reserved_by_client2_response.is_reserved
+    print(f"{session_name} is not reserved by {client_2_id}.\n")
 
     # Unreserve on client 1.
-    print(f'Unreserving {session_name} reserved by {client_1_id}...')
-    is_unreserved_response = session_client.Unreserve(session_types.UnreserveRequest(
-        reservation_id = session_name,
-        client_id = client_1_id
-        ))
-    assert(is_unreserved_response.is_unreserved)
-    is_reserved_by_client1_response = session_client.IsReservedByClient(session_types.IsReservedByClientRequest(
-        reservation_id = session_name,
-        client_id = client_1_id
-        ))
-    assert(not is_reserved_by_client1_response.is_reserved)
-    print(f'{session_name} is no longer reserved by {client_1_id}.\n')
+    print(f"Unreserving {session_name} reserved by {client_1_id}...")
+    is_unreserved_response = session_client.Unreserve(
+        session_types.UnreserveRequest(reservation_id=session_name, client_id=client_1_id)
+    )
+    assert is_unreserved_response.is_unreserved
+    is_reserved_by_client1_response = session_client.IsReservedByClient(
+        session_types.IsReservedByClientRequest(reservation_id=session_name, client_id=client_1_id)
+    )
+    assert not is_reserved_by_client1_response.is_reserved
+    print(f"{session_name} is no longer reserved by {client_1_id}.\n")
 
-    print(f'Reserving {session_name} for {client_2_id}...')
-    reserve_response = session_client.Reserve(session_types.ReserveRequest(
-        reservation_id = session_name,
-        client_id = client_2_id
-        ))
+    print(f"Reserving {session_name} for {client_2_id}...")
+    reserve_response = session_client.Reserve(
+        session_types.ReserveRequest(reservation_id=session_name, client_id=client_2_id)
+    )
     is_reserved = reserve_response.is_reserved
-    assert(is_reserved)
-    is_reserved_by_client2_response = session_client.IsReservedByClient(session_types.IsReservedByClientRequest(
-        reservation_id = session_name,
-        client_id = client_2_id
-        ))
-    assert(is_reserved_by_client2_response.is_reserved)
-    print(f'{session_name} is reserved by {client_2_id}.\n')
+    assert is_reserved
+    is_reserved_by_client2_response = session_client.IsReservedByClient(
+        session_types.IsReservedByClientRequest(reservation_id=session_name, client_id=client_2_id)
+    )
+    assert is_reserved_by_client2_response.is_reserved
+    print(f"{session_name} is reserved by {client_2_id}.\n")
 
     # Reset server.
-    print(f'Resetting the server...')
+    print(f"Resetting the server...")
     reset_server_response = session_client.ResetServer(session_types.ResetServerRequest())
-    assert(reset_server_response.is_server_reset)
-    is_reserved_by_client2_response = session_client.IsReservedByClient(session_types.IsReservedByClientRequest(
-        reservation_id = session_name,
-        client_id = client_2_id
-        ))
-    assert(not is_reserved_by_client2_response.is_reserved)
-    print(f'All sessions have been closed and reservations have been cleared.\n')
+    assert reset_server_response.is_server_reset
+    is_reserved_by_client2_response = session_client.IsReservedByClient(
+        session_types.IsReservedByClientRequest(reservation_id=session_name, client_id=client_2_id)
+    )
+    assert not is_reserved_by_client2_response.is_reserved
+    print(f"All sessions have been closed and reservations have been cleared.\n")
 
 # If NI-SCOPE API or Session API throws an exception, print the error message.
 except grpc.RpcError as rpc_error:
@@ -172,5 +161,7 @@ except grpc.RpcError as rpc_error:
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {server_address}:{server_port}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
     print(f"{error_message}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 100
+exclude = "source/codegen/metadata"

--- a/python_build_requirements.txt
+++ b/python_build_requirements.txt
@@ -2,3 +2,4 @@ contextlib2==21.6.0
 Mako==1.1.5
 MarkupSafe==2.0.1
 schema==0.7.4
+black>=21.10b0

--- a/source/codegen/client_helpers.py
+++ b/source/codegen/client_helpers.py
@@ -5,178 +5,164 @@ from collections import namedtuple
 from copy import deepcopy
 from enum import Enum
 
-class ParamMechanism(Enum):
-  BASIC = 0
-  ARRAY = 1
-  ENUM = 2
-  MAPPED_ENUM = 3
-  COPY = 4
 
-ClientParam = namedtuple(
-  "ClientParam", 
-  [
-    "name", 
-    "type", 
-    "mechanism"
-  ])
+class ParamMechanism(Enum):
+    BASIC = 0
+    ARRAY = 1
+    ENUM = 2
+    MAPPED_ENUM = 3
+    COPY = 4
+
+
+ClientParam = namedtuple("ClientParam", ["name", "type", "mechanism"])
 
 
 def to_parameter_list(client_params: List[ClientParam]) -> List[str]:
 
-  param_list = [
-    f"{p.type} {p.name}"
-    for p in client_params
-  ]
+    param_list = [f"{p.type} {p.name}" for p in client_params]
 
-  return param_list
+    return param_list
 
 
 def stub_param() -> str:
-  return f"const {stub_ptr_alias()}& stub"
+    return f"const {stub_ptr_alias()}& stub"
 
 
 def create_streaming_params(client_params: List[ClientParam]) -> str:
-  params = to_parameter_list(client_params)
-  client_context_param = "::grpc::ClientContext& context"
-  params = [stub_param()] + [client_context_param] + params
-  return str.join(", ", params)
+    params = to_parameter_list(client_params)
+    client_context_param = "::grpc::ClientContext& context"
+    params = [stub_param()] + [client_context_param] + params
+    return str.join(", ", params)
 
 
 def create_unary_params(client_params: List[ClientParam]) -> str:
-  params = to_parameter_list(client_params)
-  params = [stub_param()] + params
-  return str.join(", ", params)
+    params = to_parameter_list(client_params)
+    params = [stub_param()] + params
+    return str.join(", ", params)
 
 
 PROTOBUF_PRIM_TYPES = ["bool", "double", "float"]
 
 PROTOBUF_TYPE_TO_CPP_TYPE = {
-"double": "double",
-"float": "float",
-"int32": "int32",
-"int64": "int64",
-"uint32": "uint32",
-"uint64": "uint64",
-"sint32": "int32",
-"sint64": "int64",
-"fixed32": "uint32",
-"fixed64": "uint64",
-"sfixed32": "int32",
-"sfixed64": "int64",
-"bool": "bool",
-"string": "string",
-"bytes": "string"
+    "double": "double",
+    "float": "float",
+    "int32": "int32",
+    "int64": "int64",
+    "uint32": "uint32",
+    "uint64": "uint64",
+    "sint32": "int32",
+    "sint64": "int64",
+    "fixed32": "uint32",
+    "fixed64": "uint64",
+    "sfixed32": "int32",
+    "sfixed64": "int64",
+    "bool": "bool",
+    "string": "string",
+    "bytes": "string",
 }
 
+
 def is_basic_type(grpc_type: str) -> bool:
-  return (
-    grpc_type in PROTOBUF_PRIM_TYPES
-    or grpc_type in PROTOBUF_TYPE_TO_CPP_TYPE
-    or grpc_type.endswith("Attributes")
-    or grpc_type.endswith("Attribute")
-  )
+    return (
+        grpc_type in PROTOBUF_PRIM_TYPES
+        or grpc_type in PROTOBUF_TYPE_TO_CPP_TYPE
+        or grpc_type.endswith("Attributes")
+        or grpc_type.endswith("Attribute")
+    )
 
 
 def protobuf_namespace_alias() -> str:
-  return "pb"
+    return "pb"
 
 
 def get_cpp_client_param_type(param: dict, enums: dict) -> str:
-  grpc_type = param["grpc_type"]
+    grpc_type = param["grpc_type"]
 
-  if is_grpc_array(param):
-    underlying_type = common_helpers.strip_prefix(grpc_type, "repeated ")
-    underlying_type = get_cpp_type_for_protobuf_type(underlying_type)
-    return f"std::vector<{underlying_type}>"
+    if is_grpc_array(param):
+        underlying_type = common_helpers.strip_prefix(grpc_type, "repeated ")
+        underlying_type = get_cpp_type_for_protobuf_type(underlying_type)
+        return f"std::vector<{underlying_type}>"
 
+    if "enum" in param:
+        base_type = get_cpp_type_for_protobuf_type(grpc_type)
+        if base_type:
+            return f"simple_variant<{param['enum']}, {base_type}>"
+        return param["enum"]
 
-  if "enum" in param:
-    base_type = get_cpp_type_for_protobuf_type(grpc_type)
-    if base_type:
-      return f"simple_variant<{param['enum']}, {base_type}>"
-    return param["enum"]
+    if "mapped-enum" in param:
+        enum = param["mapped-enum"]
+        base_type = common_helpers.get_enum_value_cpp_type(enums[enum])
+        return f"simple_variant<{enum}, {base_type}>"
 
-  if "mapped-enum" in param:
-    enum = param["mapped-enum"]
-    base_type = common_helpers.get_enum_value_cpp_type(enums[enum])
-    return f"simple_variant<{enum}, {base_type}>"
-
-  return get_cpp_type_for_protobuf_type(grpc_type)
+    return get_cpp_type_for_protobuf_type(grpc_type)
 
 
 def get_cpp_type_for_protobuf_type(protobuf_type: str) -> str:
-  if protobuf_type in PROTOBUF_PRIM_TYPES:
-    return protobuf_type
+    if protobuf_type in PROTOBUF_PRIM_TYPES:
+        return protobuf_type
 
-  if protobuf_type in PROTOBUF_TYPE_TO_CPP_TYPE:
-    cpp_type = PROTOBUF_TYPE_TO_CPP_TYPE[protobuf_type]
-    return f"{protobuf_namespace_alias()}::{cpp_type}"
+    if protobuf_type in PROTOBUF_TYPE_TO_CPP_TYPE:
+        cpp_type = PROTOBUF_TYPE_TO_CPP_TYPE[protobuf_type]
+        return f"{protobuf_namespace_alias()}::{cpp_type}"
 
-  return protobuf_type.replace(".", "::")
+    return protobuf_type.replace(".", "::")
 
 
 def const_ref_t(t: str) -> str:
-  return f"const {t}&"
+    return f"const {t}&"
 
 
 def get_param_mechanism(param: dict) -> ParamMechanism:
-  if is_grpc_array(param):
-    return ParamMechanism.ARRAY
-  if "enum" in param:
-    return ParamMechanism.ENUM
-  if "mapped-enum" in param:
-    return ParamMechanism.MAPPED_ENUM
-  if is_basic_type(param["grpc_type"]):
-    return ParamMechanism.BASIC
-  return ParamMechanism.COPY
+    if is_grpc_array(param):
+        return ParamMechanism.ARRAY
+    if "enum" in param:
+        return ParamMechanism.ENUM
+    if "mapped-enum" in param:
+        return ParamMechanism.MAPPED_ENUM
+    if is_basic_type(param["grpc_type"]):
+        return ParamMechanism.BASIC
+    return ParamMechanism.COPY
 
 
 def create_client_param(param: dict, enums: dict) -> ClientParam:
-  name = common_helpers.get_grpc_field_name(param)
-  param_type = get_cpp_client_param_type(param, enums)
-  param_type = const_ref_t(param_type)
-  param_mechanism = get_param_mechanism(param)
+    name = common_helpers.get_grpc_field_name(param)
+    param_type = get_cpp_client_param_type(param, enums)
+    param_type = const_ref_t(param_type)
+    param_mechanism = get_param_mechanism(param)
 
-  return ClientParam(name, param_type, param_mechanism)
+    return ClientParam(name, param_type, param_mechanism)
 
 
 def is_grpc_array(param: dict) -> bool:
-  return param["grpc_type"].startswith("repeated ")
+    return param["grpc_type"].startswith("repeated ")
 
 
 def stub_ptr_alias():
-  return "StubPtr"
+    return "StubPtr"
 
 
 def get_client_parameters(func: dict, enums: dict) -> List[ClientParam]:
-  inputs = [
-    p
-    for p in func["parameters"]
-    if common_helpers.is_input_parameter(p)
-  ]
+    inputs = [p for p in func["parameters"] if common_helpers.is_input_parameter(p)]
 
-  inputs = common_helpers.filter_parameters_for_grpc_fields(inputs)
+    inputs = common_helpers.filter_parameters_for_grpc_fields(inputs)
 
-  return [
-    create_client_param(p, enums)
-    for p in inputs
-  ]
+    return [create_client_param(p, enums) for p in inputs]
 
 
 def split_types_from_variant(variant_type: str) -> Tuple[str, str]:
-  match = re.match(r".*simple_variant<([^,]+), ([^>]+)>", variant_type)
-  return (match[1], match[2])
+    match = re.match(r".*simple_variant<([^,]+), ([^>]+)>", variant_type)
+    return (match[1], match[2])
 
 
 def get_enum_value_type(param: ClientParam) -> str:
-  enum, _ = split_types_from_variant(param.type)
-  return enum
+    enum, _ = split_types_from_variant(param.type)
+    return enum
 
 
 def get_enum_raw_type(param: ClientParam) -> str:
-  _, raw = split_types_from_variant(param.type)
-  return raw
+    _, raw = split_types_from_variant(param.type)
+    return raw
 
 
 def streaming_response_type(response_type: str) -> str:
-  return f"std::unique_ptr<grpc::ClientReader<{response_type}>>"
+    return f"std::unique_ptr<grpc::ClientReader<{response_type}>>"

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -13,25 +13,27 @@ def is_input_parameter(parameter):
 
 
 def is_callback_token_parameter(parameter):
-    return parameter.get('callback_token', False)
+    return parameter.get("callback_token", False)
 
 
 def is_pointer_parameter(parameter):
-    return is_output_parameter(parameter) or parameter.get('pointer', False)
+    return is_output_parameter(parameter) or parameter.get("pointer", False)
+
 
 # This means the parameter follows a specific varargs convention where
 # the user can pass in an arbitrary repetition of fixed arguments.
 
 
 def is_repeated_varargs_parameter(parameter: dict):
-    return parameter.get('repeated_var_args', False)
+    return parameter.get("repeated_var_args", False)
+
 
 # This means the parameter can be repeated as many times as desired.
 # See also is_repeatied_varargs_parameter()
 
 
 def is_repeating_parameter(parameter: dict):
-    return parameter.get('repeating_argument', False)
+    return parameter.get("repeating_argument", False)
 
 
 def is_array(dataType: str):
@@ -40,9 +42,7 @@ def is_array(dataType: str):
 
 def is_enum(parameter: dict):
     return (
-        "enum" in parameter
-        or "mapped-enum" in parameter
-        or "bitfield_as_enum_array" in parameter
+        "enum" in parameter or "mapped-enum" in parameter or "bitfield_as_enum_array" in parameter
     )
 
 
@@ -52,10 +52,7 @@ def is_custom_struct(parameter: dict) -> bool:
 
 def uses_nidevice_common_message_types(functions: dict) -> bool:
     return any(
-        p
-        for f in functions.values()
-        for p in f["parameters"]
-        if is_nidevice_common_message_type(p)
+        p for f in functions.values() for p in f["parameters"] if is_nidevice_common_message_type(p)
     )
 
 
@@ -66,9 +63,7 @@ _NIDEVICE_COMMON_MESSAGE_TYPES = (
     "nidevice_grpc.SmtSpectrumInfo",
 )
 
-_WELL_KNOWN_MESSAGE_TYPES = (
-    "google.protobuf.Timestamp",
-)
+_WELL_KNOWN_MESSAGE_TYPES = ("google.protobuf.Timestamp",)
 
 
 def is_nidevice_common_message_type(parameter: dict) -> bool:
@@ -98,7 +93,9 @@ def supports_standard_copy_conversion_routines(parameter: dict) -> bool:
 
 def any_function_uses_timestamp(functions):
     for function in functions:
-        if any(p['grpc_type'] == 'google.protobuf.Timestamp' for p in functions[function]['parameters']):
+        if any(
+            p["grpc_type"] == "google.protobuf.Timestamp" for p in functions[function]["parameters"]
+        ):
             return True
     return False
 
@@ -108,42 +105,36 @@ def get_custom_types(config: dict) -> dict:
 
 
 def get_input_and_output_custom_types(functions):
-    '''Returns a set of custom types used by input and output parameters separately.'''
+    """Returns a set of custom types used by input and output parameters separately."""
     input_custom_types = set()
     output_custom_types = set()
     for function in functions:
-        struct_params = [
-            p
-            for p in functions[function]["parameters"]
-            if is_custom_struct(p)
-        ]
+        struct_params = [p for p in functions[function]["parameters"] if is_custom_struct(p)]
         for parameter in struct_params:
             if is_input_parameter(parameter):
-                input_custom_types.add(
-                    get_underlying_type_name(parameter["type"]))
+                input_custom_types.add(get_underlying_type_name(parameter["type"]))
             elif is_output_parameter(parameter):
-                output_custom_types.add(
-                    get_underlying_type_name(parameter["type"]))
+                output_custom_types.add(get_underlying_type_name(parameter["type"]))
     return (input_custom_types, output_custom_types)
 
 
 def is_null_terminated_in_c(parameter):
-    return parameter['grpc_type'] == 'string'
+    return parameter["grpc_type"] == "string"
 
 
 def is_string_arg(parameter):
-    return parameter['grpc_type'] in ['string', 'bytes']
+    return parameter["grpc_type"] in ["string", "bytes"]
 
 
 def strip_repeated_from_grpc_type(grpc_type):
-    if not grpc_type.startswith('repeated '):
+    if not grpc_type.startswith("repeated "):
         raise Exception("varargs grpc_type " + grpc_type + " must be repeated")
-    return grpc_type[len('repeated '):]
+    return grpc_type[len("repeated ") :]
 
 
 def get_underlying_type_name(parameter_type: str) -> str:
-    '''Strip away information from type name like brackets for arrays, leading "struct ", etc. leaving just the underlying type name.'''
-    return parameter_type.replace("struct ", "").replace('[]', '')
+    """Strip away information from type name like brackets for arrays, leading "struct ", etc. leaving just the underlying type name."""
+    return parameter_type.replace("struct ", "").replace("[]", "")
 
 
 def get_underlying_grpc_type_name(grpc_type: str) -> str:
@@ -159,12 +150,11 @@ def get_underlying_grpc_type(parameter: dict) -> str:
 
 
 def has_unsupported_parameter(function):
-    return any(is_unsupported_parameter(p) for p in function['parameters'])
+    return any(is_unsupported_parameter(p) for p in function["parameters"])
 
 
 def is_unsupported_parameter(parameter):
-    return is_unsupported_size_mechanism(parameter) \
-        or is_unsupported_scalar_array(parameter)
+    return is_unsupported_size_mechanism(parameter) or is_unsupported_scalar_array(parameter)
 
 
 def is_unsupported_size_mechanism(parameter: dict) -> bool:
@@ -172,6 +162,7 @@ def is_unsupported_size_mechanism(parameter: dict) -> bool:
     if size_mechanism is None:
         return False
     return is_unsupported_size_mechanism_type(size_mechanism)
+
 
 # These are the mechanisms that are used to specify the size of arrays/strings. Here's what they mean:
 # - fixed: the array is of a constant size. The size is specified in the 'value' member.
@@ -205,11 +196,20 @@ def is_unsupported_size_mechanism(parameter: dict) -> bool:
 
 
 def is_unsupported_size_mechanism_type(size_mechanism: str) -> bool:
-    return not size_mechanism in {'fixed', 'len', 'ivi-dance', 'passed-in', 'passed-in-by-ptr', 'ivi-dance-with-a-twist', 'two-dimension', 'custom-code'}
+    return not size_mechanism in {
+        "fixed",
+        "len",
+        "ivi-dance",
+        "passed-in",
+        "passed-in-by-ptr",
+        "ivi-dance-with-a-twist",
+        "two-dimension",
+        "custom-code",
+    }
 
 
 def is_unsupported_scalar_array(parameter):
-    return is_array(parameter['type']) and is_unsupported_enum_array(parameter)
+    return is_array(parameter["type"]) and is_unsupported_enum_array(parameter)
 
 
 def is_unsupported_enum_array(parameter):
@@ -230,55 +230,52 @@ def is_static_castable_enum_type(parameter):
     # Note: sint32 could work here but causes issue with existing attribute output accessors
     # because it's not wire-compatible with enum. If it's added here, we need to make sure that
     # we're handling compatibility issues on those methods.
-    return grpc_type in ['int32', 'uint32']
+    return grpc_type in ["int32", "uint32"]
 
 
-PascalTokenSubstitution = namedtuple('PascalTokenSubstitution', [
-                                     'pascal_representation', 'preferred_representation'])
+PascalTokenSubstitution = namedtuple(
+    "PascalTokenSubstitution", ["pascal_representation", "preferred_representation"]
+)
 SPECIAL_CASE_PASCAL_TOKENS = [
     # NI uses UInt, not Uint, and never U_INT when converting to snake.
-    PascalTokenSubstitution('Uint', 'UInt')
+    PascalTokenSubstitution("Uint", "UInt")
 ]
 
 
 def normalize_special_pascal_tokens(pascal_or_camel_string: str) -> str:
     for pascal_token, special_case_override in SPECIAL_CASE_PASCAL_TOKENS:
-        pascal_or_camel_string = pascal_or_camel_string.replace(
-            special_case_override, pascal_token)
+        pascal_or_camel_string = pascal_or_camel_string.replace(special_case_override, pascal_token)
     return pascal_or_camel_string
 
 
 def insert_special_case_pascal_tokens(normal_pascal_string: str) -> str:
     for pascal_token, special_case_override in SPECIAL_CASE_PASCAL_TOKENS:
-        normal_pascal_string = normal_pascal_string.replace(
-            pascal_token, special_case_override)
+        normal_pascal_string = normal_pascal_string.replace(pascal_token, special_case_override)
     return normal_pascal_string
 
 
 def insert_leading_special_case_pascal_tokens(camel_string: str) -> str:
     for pascal_token, special_case_override in SPECIAL_CASE_PASCAL_TOKENS:
-        camel_string = replace_prefix(
-            camel_string, pascal_token.lower(), special_case_override)
+        camel_string = replace_prefix(camel_string, pascal_token.lower(), special_case_override)
     return camel_string
 
 
 def normalize_leading_special_case_pascal_tokens(pascal_string: str) -> str:
     for pascal_token, special_case_override in SPECIAL_CASE_PASCAL_TOKENS:
-        pascal_string = replace_prefix(
-            pascal_string, special_case_override, pascal_token)
+        pascal_string = replace_prefix(pascal_string, special_case_override, pascal_token)
     return pascal_string
 
 
 def is_actually_pascal(camel_or_pascal_string: str) -> bool:
-    return 'A' <= camel_or_pascal_string[0] <= 'Z'
+    return "A" <= camel_or_pascal_string[0] <= "Z"
 
 
 def _camel_to_snake(camel_string: str) -> str:
-    '''
+    """
     Returns a snake_string for a given camelString.
 
     External callers should use/create a wrapper instead (i.e. get_grpc_field_name).
-    '''
+    """
     if is_actually_pascal(camel_string):
         camel_string = pascal_to_camel(camel_string)
 
@@ -293,21 +290,21 @@ def _camel_to_snake(camel_string: str) -> str:
 
 
 def snake_to_pascal(snake_string):
-    '''Returns a PascalString for a given snake_string.'''
+    """Returns a PascalString for a given snake_string."""
     snake_string = list(snake_string)
     index = 0
     snake_string[index] = snake_string[index].upper()
     for x in snake_string:
-        if x == '_':
+        if x == "_":
             snake_string[index + 1] = snake_string[index + 1].upper()
             del snake_string[index]
         index = index + 1
-    result = ("".join(snake_string))
+    result = "".join(snake_string)
     return insert_special_case_pascal_tokens(result)
 
 
 def pascal_to_camel(pascal_string):
-    '''Returns a camelString for a given PascalString.'''
+    """Returns a camelString for a given PascalString."""
     pascal_string = normalize_leading_special_case_pascal_tokens(pascal_string)
     if not is_actually_pascal(pascal_string):
         return pascal_string
@@ -328,12 +325,11 @@ def pascal_to_camel(pascal_string):
 
 
 def ensure_pascal_case(pascal_or_camel_string):
-    '''Ensures that a camel/pascal case string is pascal case
-    NOTE: does not distinguish leading all-caps acronyms.'''
-    pascal_or_camel_string = insert_leading_special_case_pascal_tokens(
-        pascal_or_camel_string)
+    """Ensures that a camel/pascal case string is pascal case
+    NOTE: does not distinguish leading all-caps acronyms."""
+    pascal_or_camel_string = insert_leading_special_case_pascal_tokens(pascal_or_camel_string)
 
-    match = re.fullmatch(r'^([a-z])(.*)$', pascal_or_camel_string)
+    match = re.fullmatch(r"^([a-z])(.*)$", pascal_or_camel_string)
     if match:
         return match[1].upper() + match[2]
 
@@ -341,60 +337,64 @@ def ensure_pascal_case(pascal_or_camel_string):
 
 
 def pascal_to_snake(pascal_string):
-    '''Returns a snake_string for a given PascalString.'''
+    """Returns a snake_string for a given PascalString."""
     camel_string = pascal_to_camel(pascal_string)
     snake_string = _camel_to_snake(camel_string)
-    return ("".join(snake_string))
+    return "".join(snake_string)
 
 
 def filter_proto_rpc_functions(functions):
-    '''Returns function metadata only for those functions to include for generating proto rpc methods'''
-    functions_for_proto = {'public', 'CustomCode'}
-    return [name for name, function in functions.items() if function.get('codegen_method', 'public') in functions_for_proto]
+    """Returns function metadata only for those functions to include for generating proto rpc methods"""
+    functions_for_proto = {"public", "CustomCode"}
+    return [
+        name
+        for name, function in functions.items()
+        if function.get("codegen_method", "public") in functions_for_proto
+    ]
 
 
 def get_attribute_enums_by_type(attributes):
-    '''Returns a dictionary of different attribute data types that use enum alongwith set of enums used'''
+    """Returns a dictionary of different attribute data types that use enum alongwith set of enums used"""
     attribute_enums_by_type = defaultdict(set)
     # For Compatibility: Pre-adding the following types to the map causes them to use value_raw
     # params even if they have no enum values. This is part of the shipping API for MI drivers.
-    for enum_type in ['ViInt32', 'ViInt64', 'ViReal64', 'ViString']:
+    for enum_type in ["ViInt32", "ViInt64", "ViReal64", "ViString"]:
         attribute_enums_by_type[enum_type] = set()
 
     for attribute_name in attributes:
         attribute = attributes[attribute_name]
-        if 'enum' in attribute:
+        if "enum" in attribute:
             attribute_type = get_underlying_type(attribute)
-            enum_name = attribute['enum']
+            enum_name = attribute["enum"]
             attribute_enums_by_type[attribute_type].add(enum_name)
     return attribute_enums_by_type
 
 
 def get_function_enums(functions):
-    '''Returns a set of enums used with functions.'''
+    """Returns a set of enums used with functions."""
     function_enums = set()
     for function in functions:
-        for parameter in functions[function]['parameters']:
-            if 'enum' in parameter:
-                function_enums.add(parameter['enum'])
-            if 'mapped-enum' in parameter:
-                function_enums.add(parameter['mapped-enum'])
-            if 'bitfield_as_enum_array' in parameter:
-                function_enums.add(parameter['bitfield_as_enum_array'])
+        for parameter in functions[function]["parameters"]:
+            if "enum" in parameter:
+                function_enums.add(parameter["enum"])
+            if "mapped-enum" in parameter:
+                function_enums.add(parameter["mapped-enum"])
+            if "bitfield_as_enum_array" in parameter:
+                function_enums.add(parameter["bitfield_as_enum_array"])
     return sorted(function_enums)
 
 
 def has_viboolean_array_param(functions):
-    '''Returns True if atleast one function has parameter of type ViBoolean[]'''
+    """Returns True if atleast one function has parameter of type ViBoolean[]"""
     for function in functions:
         for parameter in functions[function]["parameters"]:
-            if parameter['type'] == 'ViBoolean[]':
+            if parameter["type"] == "ViBoolean[]":
                 return True
     return False
 
 
 def has_enum_array_string_out_param(functions):
-    '''Returns True if atleast one function has output parameter of type ViChar[], ViInt8[] or ViUInt8[] that uses enum'''
+    """Returns True if atleast one function has output parameter of type ViChar[], ViInt8[] or ViUInt8[] that uses enum"""
     for function in functions:
         for parameter in functions[function]["parameters"]:
             if is_output_parameter(parameter) and is_string_arg(parameter) and is_enum(parameter):
@@ -403,20 +403,22 @@ def has_enum_array_string_out_param(functions):
 
 
 def get_size_mechanism(parameter: dict) -> Optional[str]:
-    size = parameter.get('size', {})
-    return size.get('mechanism', None)
+    size = parameter.get("size", {})
+    return size.get("mechanism", None)
+
 
 def get_size_param(parameter: dict) -> Optional[str]:
-    size = parameter.get('size', {})
-    return size.get('value', None)
+    size = parameter.get("size", {})
+    return size.get("value", None)
+
 
 def _get_ivi_dance_twist_param_name(parameter: dict) -> Optional[str]:
-    return parameter.get('size', {}).get('value_twist')
+    return parameter.get("size", {}).get("value_twist")
 
 
 def has_size_mechanism_tag(parameter: dict, tag: str) -> bool:
-    size_request = parameter.get('size', {})
-    tags = size_request.get('tags', {})
+    size_request = parameter.get("size", {})
+    tags = size_request.get("tags", {})
     return tag in tags
 
 
@@ -425,7 +427,7 @@ def has_strlen_bug(parameter: dict) -> bool:
     mechanism implementation has the 'strlen bug':
         Reports strlen instead of strlen + 1 for the required
         buffersize
-    We assume that this bug may some day be fixed, so the 
+    We assume that this bug may some day be fixed, so the
     implementation needs to allocate the extra character but also
     trim it off if it's an extra null.
     """
@@ -443,20 +445,20 @@ def get_buffer_size_expression(parameter: dict) -> str:
     for strings (which is in the size reported by driver APIs).
     """
     size_mechanism = get_size_mechanism(parameter)
-    if 'size' not in parameter:
+    if "size" not in parameter:
         raise Exception("No size for parameter " + parameter["name"])
-    if size_mechanism == 'fixed':
-        return parameter['size']['value']
-    elif size_mechanism == 'ivi-dance-with-a-twist':
-        return get_grpc_field_name_from_str(parameter['size']['value_twist'])
-    elif size_mechanism == 'passed-in-by-ptr':
-        return get_grpc_field_name_from_str(parameter['size']['value']) + '_copy'
+    if size_mechanism == "fixed":
+        return parameter["size"]["value"]
+    elif size_mechanism == "ivi-dance-with-a-twist":
+        return get_grpc_field_name_from_str(parameter["size"]["value_twist"])
+    elif size_mechanism == "passed-in-by-ptr":
+        return get_grpc_field_name_from_str(parameter["size"]["value"]) + "_copy"
     else:
-        return get_grpc_field_name_from_str(parameter['size']['value'])
+        return get_grpc_field_name_from_str(parameter["size"]["value"])
 
 
 def get_size_expression(parameter: dict) -> str:
-    """"Returns the C++ size expression for sizing the C++ container type
+    """ "Returns the C++ size expression for sizing the C++ container type
     for a given parameter."""
     expression = get_buffer_size_expression(parameter)
     if is_null_terminated_in_c(parameter):
@@ -469,20 +471,24 @@ def get_size_expression(parameter: dict) -> str:
 
 
 def is_ivi_dance_array_param(parameter):
-    return get_size_mechanism(parameter) == 'ivi-dance'
+    return get_size_mechanism(parameter) == "ivi-dance"
 
 
 def has_ivi_dance_param(parameters):
     return any(is_ivi_dance_array_param(p) for p in parameters)
 
+
 def is_two_dimension_array_param(parameter):
-    return get_size_mechanism(parameter) == 'two-dimension'
+    return get_size_mechanism(parameter) == "two-dimension"
+
 
 def has_two_dimension_array_param(parameters):
     return any(is_two_dimension_array_param(p) for p in parameters)
 
+
 def has_repeated_varargs_parameter(parameters):
     return any(is_repeated_varargs_parameter(p) for p in parameters)
+
 
 # Google Mock can't handle the case where a function has a variable number of arguments
 # and there's also a limit on the max number of arguments.
@@ -492,38 +498,43 @@ def can_mock_function(parameters):
     # I'm not sure this is exactly right, but it does enough to distinguish between
     # non-varargs functions and varargs functions that take > 100 parameters.
     MAX_MOCK_PARAM_LEN = 20
-    repeated_varargs_parameters = [
-        p for p in parameters if is_repeated_varargs_parameter(p)]
-    first_repeating_parameters = len(
-        [p for p in parameters if is_repeating_parameter(p)])
+    repeated_varargs_parameters = [p for p in parameters if is_repeated_varargs_parameter(p)]
+    first_repeating_parameters = len([p for p in parameters if is_repeating_parameter(p)])
     if not any(repeated_varargs_parameters):
         return len(parameters) - first_repeating_parameters <= MAX_MOCK_PARAM_LEN
     varargs_parameter = repeated_varargs_parameters[0]
-    return len(parameters) - first_repeating_parameters - len(repeated_varargs_parameters) + (first_repeating_parameters * varargs_parameter['max_length']) <= MAX_MOCK_PARAM_LEN
+    return (
+        len(parameters)
+        - first_repeating_parameters
+        - len(repeated_varargs_parameters)
+        + (first_repeating_parameters * varargs_parameter["max_length"])
+        <= MAX_MOCK_PARAM_LEN
+    )
 
 
 def get_ivi_dance_params(parameters):
-    array_param = next(
-        (p for p in parameters if is_ivi_dance_array_param(p)), None)
-    size_param = next(
-        p for p in parameters if p['name'] == array_param['size']['value']) if array_param else None
-    other_params = (p for p in parameters if p !=
-                    array_param and p != size_param)
+    array_param = next((p for p in parameters if is_ivi_dance_array_param(p)), None)
+    size_param = (
+        next(p for p in parameters if p["name"] == array_param["size"]["value"])
+        if array_param
+        else None
+    )
+    other_params = (p for p in parameters if p != array_param and p != size_param)
     return (size_param, array_param, other_params)
 
 
 def get_twist_value(parameters):
     for p in parameters:
-        if is_array(p['type']):
-            size = p.get('size', {})
-            value_twist = size.get('value_twist', None)
+        if is_array(p["type"]):
+            size = p.get("size", {})
+            value_twist = size.get("value_twist", None)
             if value_twist is not None:
                 return value_twist
     return None
 
 
 def is_ivi_dance_array_with_a_twist_param(parameter):
-    return get_size_mechanism(parameter) == 'ivi-dance-with-a-twist'
+    return get_size_mechanism(parameter) == "ivi-dance-with-a-twist"
 
 
 def has_ivi_dance_with_a_twist_param(parameters):
@@ -531,19 +542,12 @@ def has_ivi_dance_with_a_twist_param(parameters):
 
 
 def get_param_with_name(parameters: List[dict], name: str) -> dict:
-    matched_params = (
-        p
-        for p in parameters
-        if p['name'] == name
-    )
+    matched_params = (p for p in parameters if p["name"] == name)
     return next(matched_params)
 
+
 def get_first_session_param(parameters: List[dict]) -> dict:
-    matched_params = (
-        p
-        for p in parameters
-        if p.get('grpc_type', None) == 'nidevice_grpc.Session'
-    )
+    matched_params = (p for p in parameters if p.get("grpc_type", None) == "nidevice_grpc.Session")
     return next(matched_params)
 
 
@@ -561,7 +565,7 @@ class IviDanceWithATwistParamSet(NamedTuple):
         return get_cpp_local_name(self.size_param)
 
     @property
-    def twist_param_name(self) -> str: 
+    def twist_param_name(self) -> str:
         return get_cpp_local_name(self.twist_param)
 
     @property
@@ -574,16 +578,16 @@ class IviDanceWithATwistParamSet(NamedTuple):
         return self.size_param_name == self.twist_param_name
 
 
-def _make_ivi_twist_param_set(twist_param_name: str, parameters: List[dict]) -> IviDanceWithATwistParamSet:
+def _make_ivi_twist_param_set(
+    twist_param_name: str, parameters: List[dict]
+) -> IviDanceWithATwistParamSet:
     matched_array_params = [
-        p 
-        for p in parameters 
-        if _get_ivi_dance_twist_param_name(p) == twist_param_name
+        p for p in parameters if _get_ivi_dance_twist_param_name(p) == twist_param_name
     ]
     return IviDanceWithATwistParamSet(
         matched_array_params,
-        get_param_with_name(parameters, matched_array_params[0]['size']['value']),
-        get_param_with_name(parameters, twist_param_name)
+        get_param_with_name(parameters, matched_array_params[0]["size"]["value"]),
+        get_param_with_name(parameters, twist_param_name),
     )
 
 
@@ -597,59 +601,52 @@ def _unique_twist_params(parameters) -> List[str]:
 def get_ivi_dance_with_a_twist_params(parameters):
     return [
         _make_ivi_twist_param_set(twist_name, parameters)
-        for twist_name in _unique_twist_params(parameters) 
+        for twist_name in _unique_twist_params(parameters)
     ]
 
 
 def get_params_not_in_ivi_twist(
     parameters: List[dict], ivi_param_sets: List[IviDanceWithATwistParamSet]
 ) -> List[dict]:
-    
-    all_params_in_ivi_set = {
-        p['name']
-        for ivi_set in ivi_param_sets
-        for p in ivi_set.all_params
-    }
 
-    return (
-        p
-        for p in parameters
-        if p['name'] not in all_params_in_ivi_set
-    )
+    all_params_in_ivi_set = {p["name"] for ivi_set in ivi_param_sets for p in ivi_set.all_params}
+
+    return (p for p in parameters if p["name"] not in all_params_in_ivi_set)
 
 
 def is_init_method(function_data):
-    return function_data.get('init_method', False)
+    return function_data.get("init_method", False)
 
 
 def _get_session_output_param(function_data):
     return next(
-        p 
-        for p in function_data["parameters"] 
+        p
+        for p in function_data["parameters"]
         if p["direction"] == "out" and "nidevice_grpc.Session" in p["grpc_type"]
     )
 
 
 def is_init_array_method(function_data):
-    return is_init_method(function_data) and "repeated" in _get_session_output_param(function_data)["grpc_type"]
+    return (
+        is_init_method(function_data)
+        and "repeated" in _get_session_output_param(function_data)["grpc_type"]
+    )
 
 
 def is_cross_driver_init_method(function_data: dict) -> bool:
-    return (
-        is_init_method(function_data) 
-        and any(
-            p 
-            for p in function_data["parameters"] 
-            if "cross_driver_session" in p and p["direction"] == "out"
-        )
+    return is_init_method(function_data) and any(
+        p
+        for p in function_data["parameters"]
+        if "cross_driver_session" in p and p["direction"] == "out"
     )
 
+
 def has_streaming_response(function_data):
-    return function_data.get('stream_response', False)
+    return function_data.get("stream_response", False)
 
 
 def has_callback_param(function_data):
-    return any((p for p in function_data['parameters'] if 'callback_params' in p))
+    return any((p for p in function_data["parameters"] if "callback_params" in p))
 
 
 def has_async_streaming_response(function_data):
@@ -658,12 +655,13 @@ def has_async_streaming_response(function_data):
 
 def get_library_interface_type_name(config):
     service_class_prefix = config["service_class_prefix"]
-    return f'{service_class_prefix}LibraryInterface'
+    return f"{service_class_prefix}LibraryInterface"
 
 
 def indent(level):
     """For use as a mako filter.
-       Returns a function that indents a block of text to the provided level."""
+    Returns a function that indents a block of text to the provided level."""
+
     def indent_text_to_level(text, level):
         result = ""
         indentation = level * "  "
@@ -676,11 +674,12 @@ def indent(level):
 
 def trim_trailing_comma():
     """For use as a mako filter.
-        Returns a function that removes the last comma from a block of text (preserves newlines).
-        Consider this as an alternative to str.join when it allows preserving context in the mako file."""
+    Returns a function that removes the last comma from a block of text (preserves newlines).
+    Consider this as an alternative to str.join when it allows preserving context in the mako file."""
+
     def trim_trailing_comma_impl(text: str) -> str:
         i = text.rfind(",")
-        return text[:i] + text[i+1:]
+        return text[:i] + text[i + 1 :]
 
     return lambda text: trim_trailing_comma_impl(text)
 
@@ -689,23 +688,26 @@ def os_conditional_compile_block(config):
     windows_only = config.get("windows_only", False)
     """For use as a mako filter.
         That wraps a block of text in #if blocks based on the config's OS support."""
+
     def windows_only_block_impl(text):
         # Pure python code, by default, will convert to platform-specific linesep characters on save.
-        # But mako uses the platform-specific linesep characters from the template file in the template string. 
+        # But mako uses the platform-specific linesep characters from the template file in the template string.
         # This is balanced by the newline="" args in template_helpers, which preserve newlines from the input.
         #
         # We use os.linesep here for consistency with makos template strings and to ensure that we don't
         # get a mix of CRLF and LF on windows.
         return f"#if defined(_MSC_VER){os.linesep}{text}#endif // defined(_MSC_VER){os.linesep}"
+
     if windows_only:
-        return lambda text : windows_only_block_impl(text)
-    
+        return lambda text: windows_only_block_impl(text)
+
     return lambda text: text
+
 
 def filter_parameters_for_grpc_fields(parameters_or_fields: List[dict]):
     """Filter out the parameters that shouldn't be represented by a field on a grpc message.
-        For example, get rid of any parameters whose values should be determined from another parameter."""
-    return [p for p in parameters_or_fields if p.get('include_in_proto', True)]
+    For example, get rid of any parameters whose values should be determined from another parameter."""
+    return [p for p in parameters_or_fields if p.get("include_in_proto", True)]
 
 
 class AttributeGroup:
@@ -720,15 +722,14 @@ class AttributeGroup:
         for resettable attributes.
         """
         if not get_split_attributes_by_type(self._config):
-            return {'': self.attributes}
+            return {"": self.attributes}
 
         categorized_attributes = defaultdict(dict)
         for id, data in self.attributes.items():
-            data_type = get_grpc_type_name_for_identifier(
-                data['type'], self._config)
+            data_type = get_grpc_type_name_for_identifier(data["type"], self._config)
             categorized_attributes[data_type][id] = data
-            if data.get('resettable', False):
-                categorized_attributes['Reset'][id] = data
+            if data.get("resettable", False):
+                categorized_attributes["Reset"][id] = data
         return categorized_attributes
 
 
@@ -739,12 +740,12 @@ def get_attribute_enum_suffix(config: dict) -> str:
 
 def get_attribute_enum_name(group_name: str, data_type: str, config: dict) -> str:
     attribute_suffix = get_attribute_enum_suffix(config)
-    return f'{group_name}{data_type}{attribute_suffix}'
+    return f"{group_name}{data_type}{attribute_suffix}"
 
 
 def get_attribute_groups(data):
-    attributes = data['attributes']
-    config = data['config']
+    attributes = data["attributes"]
+    config = data["config"]
 
     # If the attributes are already in string categories: those are the groups. Return as-is.
     first_key = next(iter(attributes), None)
@@ -752,12 +753,12 @@ def get_attribute_groups(data):
         return [AttributeGroup(name, attributes, config) for name, attributes in attributes.items()]
 
     # If there's just one level of attributes: use the service_class_prefix as the group.
-    service_class_prefix = config['service_class_prefix']
+    service_class_prefix = config["service_class_prefix"]
     return [AttributeGroup(service_class_prefix, attributes, config)]
 
 
 def strip_prefix(s: str, prefix: str) -> str:
-    return s[len(prefix):] if s.startswith(prefix) else s
+    return s[len(prefix) :] if s.startswith(prefix) else s
 
 
 def strip_suffix(s: str, suffix: str) -> str:
@@ -765,7 +766,7 @@ def strip_suffix(s: str, suffix: str) -> str:
 
 
 def replace_prefix(s: str, prefix: str, sub: str) -> str:
-    return sub + s[len(prefix):] if s.startswith(prefix) else s
+    return sub + s[len(prefix) :] if s.startswith(prefix) else s
 
 
 def get_grpc_type_name_for_identifier(data_type, config):
@@ -774,72 +775,68 @@ def get_grpc_type_name_for_identifier(data_type, config):
     i.e., double -> Double. repeated double -> DoubleArray.
     """
     grpc_type = get_grpc_type(data_type, config)
-    grpc_type = re.sub(r'^(repeated )(\w+)$', r'\2Array', grpc_type)
+    grpc_type = re.sub(r"^(repeated )(\w+)$", r"\2Array", grpc_type)
     # take the last identifier if the type is namespaced (i.e., Timestamp)
     grpc_type = grpc_type.split(".")[-1]
     return ensure_pascal_case(grpc_type)
 
 
-def get_grpc_type_from_ivi(
-        type: str,
-        is_array: bool,
-        driver_name_pascal: str,
-        config: dict) -> str:
+def get_grpc_type_from_ivi(type: str, is_array: bool, driver_name_pascal: str, config: dict) -> str:
     add_repeated = is_array
-    if 'ViSession' in type:
-        type = 'nidevice_grpc.Session'
-    if 'ViBoolean' in type:
-        type = 'bool'
-    if 'ViReal64' in type:
-        type = 'double'
-    if 'ViInt32' in type:
-        type = 'sint32'
-    if 'ViConstString' in type:
-        type = 'string'
-    if 'ViString' in type:
-        type = 'string'
-    if 'ViRsrc' in type:
-        type = 'string'
-    if 'ViChar' in type:
+    if "ViSession" in type:
+        type = "nidevice_grpc.Session"
+    if "ViBoolean" in type:
+        type = "bool"
+    if "ViReal64" in type:
+        type = "double"
+    if "ViInt32" in type:
+        type = "sint32"
+    if "ViConstString" in type:
+        type = "string"
+    if "ViString" in type:
+        type = "string"
+    if "ViRsrc" in type:
+        type = "string"
+    if "ViChar" in type:
         if is_array:
             add_repeated = False
-            type = 'string'
+            type = "string"
         else:
-            type = 'uint32'
-    if 'ViReal32' in type:
-        type = 'float'
-    if 'ViAttr' in type:
+            type = "uint32"
+    if "ViReal32" in type:
+        type = "float"
+    if "ViAttr" in type:
         type = get_attribute_enum_name(driver_name_pascal, "", config)
-    if 'ViInt8' in type:
+    if "ViInt8" in type:
         if is_array:
             type = "bytes"
             add_repeated = False
         else:
-            type = 'uint32'
-    if 'void*' in type:
-        type = 'fixed64'
-    if 'ViInt16' in type:
-        type = 'sint32'
-    if 'ViInt64' in type:
-        type = 'int64'
-    if 'ViUInt16' in type:
-        type = 'uint32'
-    if 'ViUInt32' in type:
-        type = 'uint32'
-    if 'ViUInt64' in type:
-        type = 'uint64'
-    if 'ViUInt8' in type:
+            type = "uint32"
+    if "void*" in type:
+        type = "fixed64"
+    if "ViInt16" in type:
+        type = "sint32"
+    if "ViInt64" in type:
+        type = "int64"
+    if "ViUInt16" in type:
+        type = "uint32"
+    if "ViUInt32" in type:
+        type = "uint32"
+    if "ViUInt64" in type:
+        type = "uint64"
+    if "ViUInt8" in type:
         if is_array:
             type = "bytes"
             add_repeated = False
         else:
-            type = 'uint32'
-    if 'ViStatus' in type:
-        type = 'sint32'
-    if 'ViAddr' in type:
-        type = 'fixed64'
-    if 'int' == type:
-        type = 'sint32'
+            type = "uint32"
+    if "ViStatus" in type:
+        type = "sint32"
+    if "ViAddr" in type:
+        type = "fixed64"
+    if "int" == type:
+        type = "sint32"
     if "[]" in type:
         type = type.replace("[]", "")
 
@@ -847,41 +844,37 @@ def get_grpc_type_from_ivi(
 
 
 def get_grpc_type(data_type, config):
-    service_class_prefix = config['service_class_prefix']
-    if 'type_to_grpc_type' in config:
-        type_map = config['type_to_grpc_type']
-        stripped_type = strip_prefix(data_type, 'const ')
+    service_class_prefix = config["service_class_prefix"]
+    if "type_to_grpc_type" in config:
+        type_map = config["type_to_grpc_type"]
+        stripped_type = strip_prefix(data_type, "const ")
         if stripped_type in type_map:
             return type_map[stripped_type]
 
         repeated = is_array(data_type)
 
-        stripped_type = strip_suffix(stripped_type, '*')
-        stripped_type = strip_suffix(stripped_type, '[]')
+        stripped_type = strip_suffix(stripped_type, "*")
+        stripped_type = strip_suffix(stripped_type, "[]")
 
         # Note: if we never resolve or strip anything, this will fallback
         # to the original datatype.
         resolved_type = type_map.get(stripped_type, stripped_type)
 
-        return f'repeated {resolved_type}' if repeated else resolved_type
+        return f"repeated {resolved_type}" if repeated else resolved_type
 
-    return get_grpc_type_from_ivi(
-        data_type,
-        is_array(data_type),
-        service_class_prefix,
-        config)
+    return get_grpc_type_from_ivi(data_type, is_array(data_type), service_class_prefix, config)
 
 
 def use_legacy_attribute_prefix(config: dict) -> bool:
-    return config.get('use_legacy_attribute_prefix', False)
+    return config.get("use_legacy_attribute_prefix", False)
 
 
 def get_split_attributes_by_type(config):
-    return config.get('split_attributes_by_type', False)
+    return config.get("split_attributes_by_type", False)
 
 
 def supports_raw_attributes(config: dict) -> bool:
-    return config.get('supports_raw_attributes', False)
+    return config.get("supports_raw_attributes", False)
 
 
 def get_enum_value_cpp_type(enum: dict) -> str:
@@ -923,11 +916,11 @@ def get_enum_value_prefix(enum_name: str, enum: dict) -> str:
 
 
 def get_driver_readiness(config: dict) -> str:
-    return config.get('code_readiness', 'Release')
+    return config.get("code_readiness", "Release")
 
 
 def get_grpc_field_name(param: dict) -> str:
-    """"
+    """ "
     Returns the name of the protobuf field for the given param.
 
     This will be a snake_case_string, that can be used in the proto
@@ -946,14 +939,14 @@ def get_grpc_field_name_from_str(field_name: str) -> str:
 
 
 def get_cpp_local_name(param: dict) -> str:
-    """"
+    """ "
     Returns a similar token to get_grpc_field_name, but will ensure
     that the name is valid as a C++ variable name.
 
     NOTE: this is not used consistently to differentiate from get_grpc_field_name.
     For that reason, the field respects the "grpc_name" override so that the two
     will match in the vast majority of cases where "name" is not a reserved keyword.
-    If "grpc_name" is a reserved keyword, this may be an issue (but don't use 
+    If "grpc_name" is a reserved keyword, this may be an issue (but don't use
     reserved grpc_name!).
     """
     return param.get("grpc_name", _camel_to_snake(param["cppName"]))

--- a/source/codegen/generate_service.py
+++ b/source/codegen/generate_service.py
@@ -16,9 +16,7 @@ def generate_service_file(metadata, template_file_name, generated_file_suffix, g
 
     os.makedirs(output_dir, exist_ok=True)
     template = instantiate_mako_template(template_file_name)
-    write_if_changed(
-        output_file_path,
-        template.render(data=metadata))
+    write_if_changed(output_file_path, template.render(data=metadata))
 
 
 def mutate_metadata(metadata: dict):
@@ -34,8 +32,7 @@ def mutate_metadata(metadata: dict):
         metadata_mutation.set_var_args_types(parameters, config)
         metadata_mutation.mark_size_params(parameters)
         metadata_mutation.mark_non_proto_params(parameters)
-        metadata_mutation.mark_mapped_enum_params(
-            parameters, metadata["enums"])
+        metadata_mutation.mark_mapped_enum_params(parameters, metadata["enums"])
         metadata_mutation.populate_grpc_types(parameters, config)
         metadata_mutation.mark_coerced_narrow_numeric_parameters(parameters)
         attribute_expander.expand_attribute_value_params(function)
@@ -53,39 +50,36 @@ def generate_all(metadata_dir: str, gen_dir: str, validate_only: bool):
     mutate_metadata(metadata)
     generate_service_file(metadata, "proto.mako", ".proto", gen_dir)
     generate_service_file(metadata, "service.h.mako", "_service.h", gen_dir)
-    generate_service_file(metadata, "service.cpp.mako",
-                          "_service.cpp", gen_dir)
-    generate_service_file(
-        metadata,
-        "service_registrar.h.mako",
-        "_service_registrar.h",
-        gen_dir)
-    generate_service_file(
-        metadata,
-        "service_registrar.cpp.mako",
-        "_service_registrar.cpp", 
-        gen_dir)
-    generate_service_file(metadata, "library_interface.h.mako",
-                          "_library_interface.h", gen_dir)
-    generate_service_file(metadata, "library.cpp.mako",
-                          "_library.cpp", gen_dir)
+    generate_service_file(metadata, "service.cpp.mako", "_service.cpp", gen_dir)
+    generate_service_file(metadata, "service_registrar.h.mako", "_service_registrar.h", gen_dir)
+    generate_service_file(metadata, "service_registrar.cpp.mako", "_service_registrar.cpp", gen_dir)
+    generate_service_file(metadata, "library_interface.h.mako", "_library_interface.h", gen_dir)
+    generate_service_file(metadata, "library.cpp.mako", "_library.cpp", gen_dir)
     generate_service_file(metadata, "library.h.mako", "_library.h", gen_dir)
-    generate_service_file(metadata, "mock_library.h.mako",
-                          "_mock_library.h", gen_dir)
+    generate_service_file(metadata, "mock_library.h.mako", "_mock_library.h", gen_dir)
     generate_service_file(metadata, "client.h.mako", "_client.h", gen_dir)
     generate_service_file(metadata, "client.cpp.mako", "_client.cpp", gen_dir)
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description="Generate files for specified NI driver API gRPC service.")
+        description="Generate files for specified NI driver API gRPC service."
+    )
     parser.add_argument(
-        "metadata", help="The path to the directory containing the metadata for the API being generated.")
+        "metadata",
+        help="The path to the directory containing the metadata for the API being generated.",
+    )
     parser.add_argument(
-        "--output", "-o", help="The path to the top-level directory to save the generated files. The API-specific sub-directories will be automatically created.")
+        "--output",
+        "-o",
+        help="The path to the top-level directory to save the generated files. The API-specific sub-directories will be automatically created.",
+    )
     parser.add_argument(
-        "--validate", "-v", dest="validate", action="store_true", help="Just validate the metadata and don't generate any files",
+        "--validate",
+        "-v",
+        dest="validate",
+        action="store_true",
+        help="Just validate the metadata and don't generate any files",
     )
     args = parser.parse_args()
-    generate_all(
-        args.metadata, "." if args.output is None else args.output, args.validate)
+    generate_all(args.metadata, "." if args.output is None else args.output, args.validate)

--- a/source/codegen/generate_shared_service_files.py
+++ b/source/codegen/generate_shared_service_files.py
@@ -3,35 +3,35 @@ from pathlib import Path
 
 from template_helpers import instantiate_mako_template, write_if_changed, load_metadata
 
+
 def generate_register_all_services(metadata_dir: Path, output_dir: Path) -> None:
-  driver_modules = [
-    load_metadata(p)
-    for p in sorted(metadata_dir.iterdir())
-    if p.is_dir() and not "fake" in p.name
-  ]
+    driver_modules = [
+        load_metadata(p)
+        for p in sorted(metadata_dir.iterdir())
+        if p.is_dir() and not "fake" in p.name
+    ]
 
-  template = instantiate_mako_template("register_all_services.h.mako")
+    template = instantiate_mako_template("register_all_services.h.mako")
 
-  write_if_changed(
-    output_dir / "register_all_services.h",
-    template.render(drivers=driver_modules)
-  )
+    write_if_changed(
+        output_dir / "register_all_services.h", template.render(drivers=driver_modules)
+    )
 
-  template = instantiate_mako_template("register_all_services.cpp.mako")
+    template = instantiate_mako_template("register_all_services.cpp.mako")
 
-  write_if_changed(
-    output_dir / "register_all_services.cpp",
-    template.render(drivers=driver_modules)
-  )
+    write_if_changed(
+        output_dir / "register_all_services.cpp", template.render(drivers=driver_modules)
+    )
 
 
 if __name__ == "__main__":
-    parser = ArgumentParser(
-        description="Generate shared service files for grpc-device.")
+    parser = ArgumentParser(description="Generate shared service files for grpc-device.")
     parser.add_argument(
-        "metadata", help="The path to the root directory containing all API metadata.")
+        "metadata", help="The path to the root directory containing all API metadata."
+    )
     parser.add_argument(
-        "--output", "-o", help="The path to the top-level directory to save the generated files..")
+        "--output", "-o", help="The path to the top-level directory to save the generated files.."
+    )
 
     args = parser.parse_args()
     output_path = "." if args.output is None else args.output

--- a/source/codegen/proto_helpers.py
+++ b/source/codegen/proto_helpers.py
@@ -3,212 +3,247 @@ import common_helpers
 
 
 def _is_attribute_values(enum_name):
-  return enum_name.endswith("AttributeValues") 
+    return enum_name.endswith("AttributeValues")
 
 
 def _should_add_unspecified_enum_value(enum_name, enum_values_metadata):
-  """
-  Returns True if an UNSPECIFIED zero-value enum should be added to enum_values_metadata.
+    """
+    Returns True if an UNSPECIFIED zero-value enum should be added to enum_values_metadata.
 
-  UNSPECIFIED zero-values are a best practice in protobuf. BUT they're not helpful if there
-  is some other zero-value. In that case they introduce an unnecessary alias and don't serve
-  their purpose of ensuring a neutral default value.
+    UNSPECIFIED zero-values are a best practice in protobuf. BUT they're not helpful if there
+    is some other zero-value. In that case they introduce an unnecessary alias and don't serve
+    their purpose of ensuring a neutral default value.
 
-  AttributeValues are aggregate enums that maybe have multiple zero value enums that may not
-  be at the front of the list (also a requirement for protobuf). They always get an UNSPECIFIED
-  value.
-  """
-  return _is_attribute_values(enum_name) or 0 not in (v["value"] for v in enum_values_metadata)
+    AttributeValues are aggregate enums that maybe have multiple zero value enums that may not
+    be at the front of the list (also a requirement for protobuf). They always get an UNSPECIFIED
+    value.
+    """
+    return _is_attribute_values(enum_name) or 0 not in (v["value"] for v in enum_values_metadata)
 
 
 def should_allow_alias(enum_values_metadata):
-  # if enum.get("generate-mappings", False):
-  #   return False
-  enum_values = [e["value"] for e in enum_values_metadata]
-  return len(enum_values) != len(set(enum_values))
+    # if enum.get("generate-mappings", False):
+    #   return False
+    enum_values = [e["value"] for e in enum_values_metadata]
+    return len(enum_values) != len(set(enum_values))
 
 
 def generate_parameter_field_number(parameter, used_indexes, field_name_suffix=""):
-  """Get unique field number for field corresponding to this parameter in proto file.
-     If field number is not stored in metadata of parameter, get the next unused integer value."""
-  field_name_key = f"grpc{field_name_suffix}_field_number"
-  if field_name_key in parameter:
-    field_number = parameter[field_name_key]
-  else:
-    field_number = next(i for i in range(1, 100) if i not in used_indexes)
-  used_indexes.append(field_number)
-  return field_number
+    """Get unique field number for field corresponding to this parameter in proto file.
+    If field number is not stored in metadata of parameter, get the next unused integer value."""
+    field_name_key = f"grpc{field_name_suffix}_field_number"
+    if field_name_key in parameter:
+        field_number = parameter[field_name_key]
+    else:
+        field_number = next(i for i in range(1, 100) if i not in used_indexes)
+    used_indexes.append(field_number)
+    return field_number
+
 
 def get_enum_definitions(enums_to_define, enums):
-  """Get simplified definition for enums and values in it that can be used for defining enums in proto file."""
-  enum_definitions = {}
-  for enum_name in (e for e in enums if e in enums_to_define):
-    enum = enums[enum_name]
-    enum_value_prefix = common_helpers.get_enum_value_prefix(enum_name, enum)
-    if enum.get("generate-mappings", False):
-      values = [{"name": f"{enum_value_prefix}_{value['name']}", "value": index + 1} for index, value in enumerate(enum["values"])]
-    else:
-      values = [{"name": f"{enum_value_prefix}_{value['name']}", "value": value["value"]} for value in enum["values"]]
+    """Get simplified definition for enums and values in it that can be used for defining enums in proto file."""
+    enum_definitions = {}
+    for enum_name in (e for e in enums if e in enums_to_define):
+        enum = enums[enum_name]
+        enum_value_prefix = common_helpers.get_enum_value_prefix(enum_name, enum)
+        if enum.get("generate-mappings", False):
+            values = [
+                {"name": f"{enum_value_prefix}_{value['name']}", "value": index + 1}
+                for index, value in enumerate(enum["values"])
+            ]
+        else:
+            values = [
+                {"name": f"{enum_value_prefix}_{value['name']}", "value": value["value"]}
+                for value in enum["values"]
+            ]
 
-    if _should_add_unspecified_enum_value(enum_name, values):
-      unspecified_value_name = f"{enum_value_prefix}_MAPPED_UNSPECIFIED" if enum_name.endswith("AttributeValuesMapped") else f"{enum_value_prefix}_UNSPECIFIED"
-      values.insert(0, {"name": unspecified_value_name, "value": 0})
+        if _should_add_unspecified_enum_value(enum_name, values):
+            unspecified_value_name = (
+                f"{enum_value_prefix}_MAPPED_UNSPECIFIED"
+                if enum_name.endswith("AttributeValuesMapped")
+                else f"{enum_value_prefix}_UNSPECIFIED"
+            )
+            values.insert(0, {"name": unspecified_value_name, "value": 0})
 
-    allow_alias = should_allow_alias(values)
-    enum_definition = {
-      "allow_alias": allow_alias,
-      "values": values
-    }
+        allow_alias = should_allow_alias(values)
+        enum_definition = {"allow_alias": allow_alias, "values": values}
 
-    enum_definitions.update({enum_name: enum_definition})
-  
-  return enum_definitions
+        enum_definitions.update({enum_name: enum_definition})
+
+    return enum_definitions
 
 
 def is_array_input(parameter: dict):
-  return common_helpers.is_array(parameter["type"]) and common_helpers.is_input_parameter(parameter)
+    return common_helpers.is_array(parameter["type"]) and common_helpers.is_input_parameter(
+        parameter
+    )
 
 
 def is_decomposable_enum(parameter: dict):
-  """
-  Enums are typically decomposed from a single param into an enum param and an _raw param.
-  The exception is array_inputs which are left as single enum param.
-  This is because protobuf does not support oneof on repeated types, so the standard
-  input decomposition does not work for arrays.
-  """
-  return common_helpers.is_enum(parameter) and not (is_array_input(parameter) and parameter["grpc_type"] != "string")
+    """
+    Enums are typically decomposed from a single param into an enum param and an _raw param.
+    The exception is array_inputs which are left as single enum param.
+    This is because protobuf does not support oneof on repeated types, so the standard
+    input decomposition does not work for arrays.
+    """
+    return common_helpers.is_enum(parameter) and not (
+        is_array_input(parameter) and parameter["grpc_type"] != "string"
+    )
 
 
 def get_message_parameter_definitions(parameters):
-  """Get simplified list of all parameters that can be used for defining request/respones messages in proto file."""
-  parameter_definitions = []
-  used_indexes = []
-  for parameter in parameters:
-    is_array = common_helpers.is_array(
-        parameter["type"]) and not parameter["grpc_type"] == "string"
-    parameter_name = common_helpers.get_grpc_field_name(parameter)
-    parameter_type = get_parameter_type(parameter)
-    if is_decomposable_enum(parameter):
-      is_request_message = common_helpers.is_input_parameter(parameter)
-      enum_parameters = get_enum_parameters(parameter, parameter_name, parameter_type, is_array, used_indexes)
-      if is_request_message:
-        # use oneof for enums in request messages
-        parameter_definitions.append({
-          "name": f"{parameter_name}_enum",
-          "use_oneof": True,
-          "parameters": enum_parameters
-        })
-      else:
-        # we define all enum fields in response messages
-        parameter_definitions.extend(enum_parameters)
-    else:
-      if common_helpers.is_enum(parameter):
-        # For input arrays of enums, don't generate a raw type, but do use the correct enum type.
-        parameter_type = f'repeated {parameter["enum"]}'
-      grpc_field_number = generate_parameter_field_number(parameter, used_indexes)
-      parameter_definitions.append({
-        "name": parameter_name,
-        "type": parameter_type,
-        "grpc_field_number": grpc_field_number
-      })
-  return parameter_definitions
+    """Get simplified list of all parameters that can be used for defining request/respones messages in proto file."""
+    parameter_definitions = []
+    used_indexes = []
+    for parameter in parameters:
+        is_array = (
+            common_helpers.is_array(parameter["type"]) and not parameter["grpc_type"] == "string"
+        )
+        parameter_name = common_helpers.get_grpc_field_name(parameter)
+        parameter_type = get_parameter_type(parameter)
+        if is_decomposable_enum(parameter):
+            is_request_message = common_helpers.is_input_parameter(parameter)
+            enum_parameters = get_enum_parameters(
+                parameter, parameter_name, parameter_type, is_array, used_indexes
+            )
+            if is_request_message:
+                # use oneof for enums in request messages
+                parameter_definitions.append(
+                    {
+                        "name": f"{parameter_name}_enum",
+                        "use_oneof": True,
+                        "parameters": enum_parameters,
+                    }
+                )
+            else:
+                # we define all enum fields in response messages
+                parameter_definitions.extend(enum_parameters)
+        else:
+            if common_helpers.is_enum(parameter):
+                # For input arrays of enums, don't generate a raw type, but do use the correct enum type.
+                parameter_type = f'repeated {parameter["enum"]}'
+            grpc_field_number = generate_parameter_field_number(parameter, used_indexes)
+            parameter_definitions.append(
+                {
+                    "name": parameter_name,
+                    "type": parameter_type,
+                    "grpc_field_number": grpc_field_number,
+                }
+            )
+    return parameter_definitions
+
 
 def get_enum_parameters(parameter, parameter_name, parameter_type, is_array, used_indexes):
-  """Get list of mapped/unmapped/raw parameters for enums as applicable."""
-  enum_parameters = []
-  if parameter.get('enum', None):
-    enum_parameter_type = f"repeated {parameter['enum']}" if is_array else parameter['enum']
-    grpc_enum_field_number = generate_parameter_field_number(parameter, used_indexes)
-    enum_parameters.append({
-      "name": parameter_name,
-      "type": enum_parameter_type,
-      "grpc_field_number": grpc_enum_field_number
-    })
-  if parameter.get('mapped-enum', None):
-    mapped_type = f"repeated {parameter['mapped-enum']}" if is_array else parameter['mapped-enum']
-    grpc_mapped_field_number = generate_parameter_field_number(parameter, used_indexes, "_mapped")
-    enum_parameters.append({
-      "name": f"{parameter_name}_mapped",
-      "type": mapped_type,
-      "grpc_field_number": grpc_mapped_field_number
-    })
-  if 'bitfield_as_enum_array' in parameter:
-    enum_parameters.append({
-      "name": f"{parameter_name}_array",
-      "type": f"repeated {parameter['bitfield_as_enum_array']}",
-      "grpc_field_number": generate_parameter_field_number(parameter, used_indexes, "_array")
-    })
+    """Get list of mapped/unmapped/raw parameters for enums as applicable."""
+    enum_parameters = []
+    if parameter.get("enum", None):
+        enum_parameter_type = f"repeated {parameter['enum']}" if is_array else parameter["enum"]
+        grpc_enum_field_number = generate_parameter_field_number(parameter, used_indexes)
+        enum_parameters.append(
+            {
+                "name": parameter_name,
+                "type": enum_parameter_type,
+                "grpc_field_number": grpc_enum_field_number,
+            }
+        )
+    if parameter.get("mapped-enum", None):
+        mapped_type = (
+            f"repeated {parameter['mapped-enum']}" if is_array else parameter["mapped-enum"]
+        )
+        grpc_mapped_field_number = generate_parameter_field_number(
+            parameter, used_indexes, "_mapped"
+        )
+        enum_parameters.append(
+            {
+                "name": f"{parameter_name}_mapped",
+                "type": mapped_type,
+                "grpc_field_number": grpc_mapped_field_number,
+            }
+        )
+    if "bitfield_as_enum_array" in parameter:
+        enum_parameters.append(
+            {
+                "name": f"{parameter_name}_array",
+                "type": f"repeated {parameter['bitfield_as_enum_array']}",
+                "grpc_field_number": generate_parameter_field_number(
+                    parameter, used_indexes, "_array"
+                ),
+            }
+        )
 
-  grpc_raw_field_number = generate_parameter_field_number(parameter, used_indexes, "_raw")
-  enum_parameters.append({
-    "name": f"{parameter_name}_raw",
-    "type": parameter_type,
-    "grpc_field_number": grpc_raw_field_number
-  })
-  return enum_parameters
+    grpc_raw_field_number = generate_parameter_field_number(parameter, used_indexes, "_raw")
+    enum_parameters.append(
+        {
+            "name": f"{parameter_name}_raw",
+            "type": parameter_type,
+            "grpc_field_number": grpc_raw_field_number,
+        }
+    )
+    return enum_parameters
 
 
 def get_parameter_type(parameter):
-  if 'grpc_type' not in parameter:
-    raise KeyError(f"grpc_type not in {parameter['name']} with {parameter['type']}")
-  return parameter['grpc_type']
+    if "grpc_type" not in parameter:
+        raise KeyError(f"grpc_type not in {parameter['name']} with {parameter['type']}")
+    return parameter["grpc_type"]
 
 
 def is_session_name(parameter):
-  return parameter.get('is_session_name', False)
+    return parameter.get("is_session_name", False)
 
 
-def _prepend_proto_only_session_name_parameter_if_necessary(func, input_parameters: List[dict]) -> None:
+def _prepend_proto_only_session_name_parameter_if_necessary(
+    func, input_parameters: List[dict]
+) -> None:
     has_session_input = any(is_session_name(param) for param in input_parameters)
     # If the API defines a "session_name" param, we don't need to add another one.
     if not has_session_input:
-      is_array_init = common_helpers.is_init_array_method(func)
-      session_name_param = {
-        'direction': 'in',
-        'name': 'session_names' if is_array_init else 'session_name',
-        'type': 'ViString', # Not really used since this is proto/service-only
-        'grpc_type': 'repeated string' if is_array_init else 'string'
-      }
-      input_parameters.insert(0, session_name_param)
+        is_array_init = common_helpers.is_init_array_method(func)
+        session_name_param = {
+            "direction": "in",
+            "name": "session_names" if is_array_init else "session_name",
+            "type": "ViString",  # Not really used since this is proto/service-only
+            "grpc_type": "repeated string" if is_array_init else "string",
+        }
+        input_parameters.insert(0, session_name_param)
 
 
 def get_parameters(function):
-  parameter_array = common_helpers.filter_parameters_for_grpc_fields(function['parameters'])
-  input_parameters = [p for p in parameter_array if common_helpers.is_input_parameter(p)]
-  if common_helpers.is_init_method(function):
-    _prepend_proto_only_session_name_parameter_if_necessary(function, input_parameters)
+    parameter_array = common_helpers.filter_parameters_for_grpc_fields(function["parameters"])
+    input_parameters = [p for p in parameter_array if common_helpers.is_input_parameter(p)]
+    if common_helpers.is_init_method(function):
+        _prepend_proto_only_session_name_parameter_if_necessary(function, input_parameters)
 
-  default_status_param = {'name': 'status', 'type': 'int32', 'grpc_type': 'int32'}
-  output_parameters = [default_status_param]
+    default_status_param = {"name": "status", "type": "int32", "grpc_type": "int32"}
+    output_parameters = [default_status_param]
 
-  callback_parameters = get_callback_output_params(function)
+    callback_parameters = get_callback_output_params(function)
 
-  if callback_parameters:
-    if any((p for p in callback_parameters if p['name'] == 'status')):
-      # if the callback provides a status, it can override default_status_param.
-      output_parameters = callback_parameters
+    if callback_parameters:
+        if any((p for p in callback_parameters if p["name"] == "status")):
+            # if the callback provides a status, it can override default_status_param.
+            output_parameters = callback_parameters
+        else:
+            output_parameters.extend(callback_parameters)
     else:
-      output_parameters.extend(callback_parameters)
-  else:
-    output_parameters.extend(
-      [p for p in parameter_array if common_helpers.is_output_parameter(p)]
-    )
+        output_parameters.extend(
+            [p for p in parameter_array if common_helpers.is_output_parameter(p)]
+        )
 
-  return (input_parameters, output_parameters)
+    return (input_parameters, output_parameters)
 
 
 def get_callback_output_params(function):
-  """
-  Looks for a parameter that specifies callback_params and returns those params
-  These will be used as the outputs of a streaming response.
-  """
-  params = [p for p in function['parameters'] if 'callback_params' in p]
-  if params:
-    return common_helpers.filter_parameters_for_grpc_fields(
-      params[0]['callback_params'])
-  else:
-    return []
+    """
+    Looks for a parameter that specifies callback_params and returns those params
+    These will be used as the outputs of a streaming response.
+    """
+    params = [p for p in function["parameters"] if "callback_params" in p]
+    if params:
+        return common_helpers.filter_parameters_for_grpc_fields(params[0]["callback_params"])
+    else:
+        return []
 
 
 def get_streaming_response_qualifier(function):
-  return 'stream ' if common_helpers.has_streaming_response(function) else ''
+    return "stream " if common_helpers.has_streaming_response(function) else ""

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -3,63 +3,67 @@ import common_helpers
 
 
 def get_include_guard_name(config, suffix):
-    include_guard_name = config['namespace_component'] + "_grpc" + suffix
+    include_guard_name = config["namespace_component"] + "_grpc" + suffix
     return include_guard_name.upper()
 
 
 def get_c_element_type_for_array_that_needs_coercion(parameter):
-    if not parameter.get('coerced', False):
+    if not parameter.get("coerced", False):
         return None
-    if not common_helpers.is_array(parameter['type']):
+    if not common_helpers.is_array(parameter["type"]):
         return None
     return get_c_element_type(parameter)
 
 
 def get_c_element_type(parameter):
-    stripped_type = parameter['type']
-    stripped_type = common_helpers.strip_prefix(stripped_type, 'const ')
-    stripped_type = common_helpers.strip_suffix(stripped_type, '*')
-    stripped_type = common_helpers.strip_suffix(stripped_type, '[]')
+    stripped_type = parameter["type"]
+    stripped_type = common_helpers.strip_prefix(stripped_type, "const ")
+    stripped_type = common_helpers.strip_suffix(stripped_type, "*")
+    stripped_type = common_helpers.strip_suffix(stripped_type, "[]")
     return stripped_type
 
 
 def is_scalar_input_that_needs_coercion(parameter: dict) -> bool:
     return (
-        common_helpers.is_input_parameter(parameter) 
-        and parameter.get('coerced', False)
-        and not common_helpers.is_array(parameter['type'])
+        common_helpers.is_input_parameter(parameter)
+        and parameter.get("coerced", False)
+        and not common_helpers.is_array(parameter["type"])
     )
 
+
 def is_input_array_that_needs_coercion(parameter):
-    return common_helpers.is_input_parameter(parameter) and get_c_element_type_for_array_that_needs_coercion(parameter) is not None
+    return (
+        common_helpers.is_input_parameter(parameter)
+        and get_c_element_type_for_array_that_needs_coercion(parameter) is not None
+    )
 
 
 def is_input_that_needs_coercion(parameter, custom_types: list):
     if not common_helpers.is_input_parameter(parameter):
         return False
-    if parameter.get('coerced', False):
+    if parameter.get("coerced", False):
         return True
     if not common_helpers.is_struct(parameter):
         return False
-    underlying_struct_name = common_helpers.get_underlying_type_name(
-        parameter["type"])
+    underlying_struct_name = common_helpers.get_underlying_type_name(parameter["type"])
     underlying_structs = [
-        custom_type for custom_type in custom_types if custom_type['name'] == underlying_struct_name]
+        custom_type for custom_type in custom_types if custom_type["name"] == underlying_struct_name
+    ]
     if not any([underlying_structs]):
         return False
     custom_type = underlying_structs[0]
-    return any([field.get('coerced', False) for field in custom_type['fields']])
+    return any([field.get("coerced", False) for field in custom_type["fields"]])
 
 
 def is_output_array_that_needs_coercion(parameter):
-    return common_helpers.is_output_parameter(parameter) and get_c_element_type_for_array_that_needs_coercion(parameter) is not None
+    return (
+        common_helpers.is_output_parameter(parameter)
+        and get_c_element_type_for_array_that_needs_coercion(parameter) is not None
+    )
 
 
 def create_args_for_callback(parameters):
-    return ", ".join([
-        f'{p["type"]} {common_helpers.get_grpc_field_name(p)}'
-        for p in parameters
-    ])
+    return ", ".join([f'{p["type"]} {common_helpers.get_grpc_field_name(p)}' for p in parameters])
 
 
 def _is_array_that_requires_conversion(parameter):
@@ -67,47 +71,51 @@ def _is_array_that_requires_conversion(parameter):
     Returns True for any array parameter where the protobuf representation is not the same
     as the C API representation.
     """
-    is_array = common_helpers.is_array(parameter['type'])
+    is_array = common_helpers.is_array(parameter["type"])
 
     if is_array:
         return (
             common_helpers.supports_standard_copy_conversion_routines(parameter)
             or get_c_element_type_for_array_that_needs_coercion(parameter) is not None
             # Sessions are "converted" by accessing the session repository.
-            or parameter['grpc_type'] == 'repeated nidevice_grpc.Session'
+            or parameter["grpc_type"] == "repeated nidevice_grpc.Session"
             # ViInt16s have a hardcoded copy convert routine that predates the coerced flag.
-            or parameter['type'] == 'ViInt16[]'
+            or parameter["type"] == "ViInt16[]"
         )
 
     return False
 
+
 def create_standard_arg(parameter):
     parameter_name = common_helpers.get_cpp_local_name(parameter)
-    is_array = common_helpers.is_array(parameter['type'])
+    is_array = common_helpers.is_array(parameter["type"])
     is_output = common_helpers.is_output_parameter(parameter)
     if is_output and common_helpers.is_string_arg(parameter):
-        type_without_brackets = common_helpers.get_underlying_type_name(
-            parameter['type'])
-        return f'({type_without_brackets}*){parameter_name}.data(), '
+        type_without_brackets = common_helpers.get_underlying_type_name(parameter["type"])
+        return f"({type_without_brackets}*){parameter_name}.data(), "
     elif _is_array_that_requires_conversion(parameter):
         # Converted arrays are allocated into a std::vector. Access the C array via data().
-        return f'{parameter_name}.data(), '
-    elif 'callback_params' in parameter:
-        return f'CallbackRouter::handle_callback, '
-    elif 'callback_token' in parameter:
-        return f'handler->token(), '
-    elif not is_output and common_helpers.is_pointer_parameter(parameter) and 'hardcoded_value' not in parameter:
-        return f'&{parameter_name}_copy, '
+        return f"{parameter_name}.data(), "
+    elif "callback_params" in parameter:
+        return f"CallbackRouter::handle_callback, "
+    elif "callback_token" in parameter:
+        return f"handler->token(), "
+    elif (
+        not is_output
+        and common_helpers.is_pointer_parameter(parameter)
+        and "hardcoded_value" not in parameter
+    ):
+        return f"&{parameter_name}_copy, "
     elif not is_array and is_output:
-        return f'&{parameter_name}, '
-    return f'{parameter_name}, '
+        return f"&{parameter_name}, "
+    return f"{parameter_name}, "
 
 
 def create_args(parameters):
-    result = ''
+    result = ""
     have_expanded_varargs = False
     for parameter in parameters:
-        if parameter.get('repeating_argument', False):
+        if parameter.get("repeating_argument", False):
             continue
         parameter_name = common_helpers.get_cpp_local_name(parameter)
         if common_helpers.is_repeated_varargs_parameter(parameter):
@@ -117,10 +125,11 @@ def create_args(parameters):
                 continue
             have_expanded_varargs = True
             repeated_parameters = [
-                p for p in parameters if common_helpers.is_repeating_parameter(p)]
+                p for p in parameters if common_helpers.is_repeating_parameter(p)
+            ]
             # We need to pass one extra set of arguments because the last parameters have to be nullptr's
             # so the callee knows we're done passing arguments.
-            max_length = parameter['max_length'] + 1
+            max_length = parameter["max_length"] + 1
             for i in range(max_length):
                 for parameter in repeated_parameters:
                     if common_helpers.is_input_parameter(parameter):
@@ -128,112 +137,108 @@ def create_args(parameters):
                     else:
                         result += f'get_{parameter["name"]}_if({parameter["name"]}Vector, {i}), '
         else:
-            result = f'{result}{create_standard_arg(parameter)}'
+            result = f"{result}{create_standard_arg(parameter)}"
     return result[:-2]
 
 
 def create_args_for_ivi_dance(parameters):
-    result = ''
+    result = ""
     for parameter in parameters:
-        if parameter.get('is_size_param', False):
-            result = f'{result}0, '
+        if parameter.get("is_size_param", False):
+            result = f"{result}0, "
         elif common_helpers.is_output_parameter(parameter):
-            result = f'{result}nullptr, '
+            result = f"{result}nullptr, "
         else:
             result = result + create_standard_arg(parameter)
     return result[:-2]
 
 
 def create_args_for_ivi_dance_with_a_twist(parameters):
-    result = ''
+    result = ""
     ivi_twist_array_params = [
-        p 
-        for p in parameters 
-        if common_helpers.get_size_mechanism(p) == "ivi-dance-with-a-twist"
+        p for p in parameters if common_helpers.get_size_mechanism(p) == "ivi-dance-with-a-twist"
     ]
-    arrays = { p["name"] for p in ivi_twist_array_params }
-    twists = { p["size"]["value_twist"] for p in ivi_twist_array_params }
-    sizes = { p["size"]["value"] for p in ivi_twist_array_params }
+    arrays = {p["name"] for p in ivi_twist_array_params}
+    twists = {p["size"]["value_twist"] for p in ivi_twist_array_params}
+    sizes = {p["size"]["value"] for p in ivi_twist_array_params}
 
     for parameter in parameters:
         c_name = common_helpers.get_cpp_local_name(parameter)
         name = parameter["name"]
         if name in arrays:
-            result = f'{result}nullptr, '
+            result = f"{result}nullptr, "
         elif name in twists:
             # Pass the twist output param by pointer.
-            result = result + f'&{c_name}' + ', '
+            result = result + f"&{c_name}" + ", "
         elif name in sizes:
-            result = f'{result}0, '
+            result = f"{result}0, "
         else:
             result = result + create_standard_arg(parameter)
     return result[:-2]
 
 
 def create_params(parameters, expand_varargs=True):
-    repeated_parameters = [
-        p for p in parameters if common_helpers.is_repeating_parameter(p)]
+    repeated_parameters = [p for p in parameters if common_helpers.is_repeating_parameter(p)]
     # Some methods have both input and output repeated varargs parameters,
     # so only expand them once.
-    if common_helpers.is_repeated_varargs_parameter(parameters[-1]) and common_helpers.is_repeated_varargs_parameter(parameters[-2]):
+    if common_helpers.is_repeated_varargs_parameter(
+        parameters[-1]
+    ) and common_helpers.is_repeated_varargs_parameter(parameters[-2]):
         parameters = parameters[:-1]
-    return ', '.join(create_param(p, expand_varargs, repeated_parameters) for p in parameters)
+    return ", ".join(create_param(p, expand_varargs, repeated_parameters) for p in parameters)
 
 
 def get_array_param_size(parameter) -> str:
-    if 'size' in parameter and parameter['size']['mechanism'] == 'fixed':
-        return parameter['size']['value']
+    if "size" in parameter and parameter["size"]["mechanism"] == "fixed":
+        return parameter["size"]["value"]
 
-    return ''
+    return ""
 
 
 def expand_varargs_parameters(parameters):
     if not common_helpers.has_repeated_varargs_parameter(parameters):
         return parameters
     # omit the varargs parameters that we're going to expand
-    new_parameters = [
-        p for p in parameters if not common_helpers.is_repeated_varargs_parameter(p)]
-    varargs_parameters = [
-        p for p in parameters if common_helpers.is_repeated_varargs_parameter(p)]
-    max_length = varargs_parameters[0]['max_length']
-    repeated_parameters = [
-        p for p in parameters if common_helpers.is_repeating_parameter(p)]
+    new_parameters = [p for p in parameters if not common_helpers.is_repeated_varargs_parameter(p)]
+    varargs_parameters = [p for p in parameters if common_helpers.is_repeated_varargs_parameter(p)]
+    max_length = varargs_parameters[0]["max_length"]
+    repeated_parameters = [p for p in parameters if common_helpers.is_repeating_parameter(p)]
     for i in range(max_length):
         for p in repeated_parameters:
-            new_parameters.append({'cppName': f'{p["name"]}{i}'})
+            new_parameters.append({"cppName": f'{p["name"]}{i}'})
     return new_parameters
 
 
 def create_param(parameter, expand_varargs=True, repeated_parameters=None):
-    type = parameter['type']
-    name = parameter['cppName']
+    type = parameter["type"]
+    name = parameter["cppName"]
     if common_helpers.is_struct(parameter):
         type = type.replace("struct ", "")
     if common_helpers.is_repeated_varargs_parameter(parameter):
         if expand_varargs:
-            max_length = parameter['max_length']
-            s = ''
+            max_length = parameter["max_length"]
+            s = ""
             for i in range(max_length):
                 for parameter in repeated_parameters:
-                    real_field_name = parameter['cppName']
-                    parameter['cppName'] = f'{real_field_name}{i}'
-                    s += create_param(parameter, expand_varargs=False) + ', '
-                    parameter['cppName'] = real_field_name
+                    real_field_name = parameter["cppName"]
+                    parameter["cppName"] = f"{real_field_name}{i}"
+                    s += create_param(parameter, expand_varargs=False) + ", "
+                    parameter["cppName"] = real_field_name
             return s[:-2]
         else:
-            return '...'
+            return "..."
     elif common_helpers.is_array(type):
         array_size = get_array_param_size(parameter)
-        return f'{type[:-2]} {name}[{array_size}]'
+        return f"{type[:-2]} {name}[{array_size}]"
     elif common_helpers.is_pointer_parameter(parameter):
-        return f'{type}* {name}'
+        return f"{type}* {name}"
     else:
-        return f'{type} {name}'
+        return f"{type} {name}"
 
 
 def format_value(value):
     if isinstance(value, str):
-        value = f"\"{value}\""
+        value = f'"{value}"'
     if isinstance(value, float):
         value = f"{value}f"
     return value
@@ -247,9 +252,8 @@ def get_input_lookup_values(enum_data):
         out_value_format = "{0, 0},"
     for value in enum_data["values"]:
         formated_value = str(format_value(value["value"]))
-        out_value_format = out_value_format + \
-            "{" + str(index) + ", " + formated_value + "},"
-        index = index+1
+        out_value_format = out_value_format + "{" + str(index) + ", " + formated_value + "},"
+        index = index + 1
     return out_value_format
 
 
@@ -261,41 +265,46 @@ def get_output_lookup_values(enum_data):
         out_value_format = "{0, 0},"
     for value in enum_data["values"]:
         formated_value = format_value(value["value"])
-        out_value_format = out_value_format + \
-            "{" + str(formated_value) + ", " + str(index) + "},"
-        index = index+1
+        out_value_format = out_value_format + "{" + str(formated_value) + ", " + str(index) + "},"
+        index = index + 1
     return out_value_format
 
 
 def filter_api_functions(functions, only_mockable_functions=True):
-    '''Returns function metadata only for those functions to include for generating the function types to the API library'''
+    """Returns function metadata only for those functions to include for generating the function types to the API library"""
+
     def filter_function(function):
-        if function.get('codegen_method', '') == 'no':
+        if function.get("codegen_method", "") == "no":
             return False
-        if only_mockable_functions and not common_helpers.can_mock_function(function['parameters']):
+        if only_mockable_functions and not common_helpers.can_mock_function(function["parameters"]):
             return False
         return True
+
     return [name for name, function in functions.items() if filter_function(function)]
 
 
 def filter_proto_rpc_functions_to_generate(functions):
-    '''Returns function metadata only for those functions to include for generating proto rpc methods'''
-    functions_for_code_gen = {'public'}
-    return [name for name, function in functions.items() if function.get('codegen_method', 'public') in functions_for_code_gen]
+    """Returns function metadata only for those functions to include for generating proto rpc methods"""
+    functions_for_code_gen = {"public"}
+    return [
+        name
+        for name, function in functions.items()
+        if function.get("codegen_method", "public") in functions_for_code_gen
+    ]
 
 
 def get_cname(functions, method_name, c_function_prefix):
-    if 'cname' in functions[method_name]:
-        return functions[method_name]['cname']
+    if "cname" in functions[method_name]:
+        return functions[method_name]["cname"]
     return c_function_prefix + method_name
 
 
 def is_private_method(function_data):
-    return function_data.get('codegen_method', '') == 'private'
+    return function_data.get("codegen_method", "") == "private"
 
 
 def is_custom_close_method(function_data):
-    return function_data.get('custom_close_method', False)
+    return function_data.get("custom_close_method", False)
 
 
 def requires_checked_conversion(parameters, custom_types):
@@ -303,7 +312,7 @@ def requires_checked_conversion(parameters, custom_types):
 
 
 def get_request_param(method_name):
-    return f'const {get_request_type(method_name)}* request'
+    return f"const {get_request_type(method_name)}* request"
 
 
 def get_request_type(method_name):
@@ -311,11 +320,11 @@ def get_request_type(method_name):
 
 
 def get_response_param(method_name):
-    return f'{get_response_type(method_name)}* response'
+    return f"{get_response_type(method_name)}* response"
 
 
 def get_response_type(method_name):
-    return f'{method_name}Response'
+    return f"{method_name}Response"
 
 
 def get_async_functions(functions):
@@ -325,38 +334,35 @@ def get_async_functions(functions):
         if common_helpers.has_streaming_response(data)
     }
 
+
 def get_functions_with_two_dimension_param(functions):
     return {
         name: data
         for name, data in functions.items()
-        if common_helpers.has_two_dimension_array_param(data['parameters'])
+        if common_helpers.has_two_dimension_array_param(data["parameters"])
     }
 
+
 def get_callback_method_parameters(function_data):
-    parameters = function_data['parameters']
-    input_parameters = [
-        p
-        for p in parameters
-        if common_helpers.is_input_parameter(p)
-    ]
-    callback_ptr_parameter = next(
-        (p for p in parameters if 'callback_params' in p))
-    output_parameters = callback_ptr_parameter['callback_params']
+    parameters = function_data["parameters"]
+    input_parameters = [p for p in parameters if common_helpers.is_input_parameter(p)]
+    callback_ptr_parameter = next((p for p in parameters if "callback_params" in p))
+    output_parameters = callback_ptr_parameter["callback_params"]
 
     return input_parameters, output_parameters
 
 
 def create_param_type_list(parameters):
-    return ', '.join([p['type'] for p in parameters])
+    return ", ".join([p["type"] for p in parameters])
 
 
 def get_feature_toggles(config: dict) -> Dict[str, str]:
-    return config.get('feature_toggles', {})
+    return config.get("feature_toggles", {})
 
 
 def get_toggle_member_name(fully_qualified_toggle_name: str) -> str:
-    toggle_name = fully_qualified_toggle_name.split('.')[-1]
-    return f'is_{toggle_name}_enabled'
+    toggle_name = fully_qualified_toggle_name.split(".")[-1]
+    return f"is_{toggle_name}_enabled"
 
 
 def get_driver_service_readiness(config: dict) -> str:
@@ -365,7 +371,7 @@ def get_driver_service_readiness(config: dict) -> str:
 
 
 def to_cpp_readiness(user_readiness: str) -> str:
-    return f'CodeReadiness::k{user_readiness}'
+    return f"CodeReadiness::k{user_readiness}"
 
 
 def get_enums_to_map(functions: dict, enums: dict) -> List[str]:
@@ -379,11 +385,7 @@ def get_enums_to_map(functions: dict, enums: dict) -> List[str]:
         return enum.get("generate-mappings", False)
 
     function_enums = common_helpers.get_function_enums(functions)
-    return [
-        e
-        for e in function_enums
-        if should_generate_mappings(e)
-    ]
+    return [e for e in function_enums if should_generate_mappings(e)]
 
 
 def get_bitfield_value_to_name_mapping(parameter: dict, enums: dict) -> Dict[int, str]:
@@ -405,13 +407,12 @@ def get_resource_handle_type(config: dict) -> str:
 
 def get_shared_resource_repository_ptr_type(resource_handle_type: str) -> str:
     resource_repository_type = f"nidevice_grpc::SessionResourceRepository<{resource_handle_type}>"
-    return f"std::shared_ptr<{resource_repository_type}>" 
+    return f"std::shared_ptr<{resource_repository_type}>"
 
 
 def get_driver_shared_resource_repository_ptr_type(driver_config: dict) -> str:
-    return get_shared_resource_repository_ptr_type(
-        get_resource_handle_type(driver_config)
-    )
+    return get_shared_resource_repository_ptr_type(get_resource_handle_type(driver_config))
+
 
 class CrossDriverSessionDependency(NamedTuple):
     resource_handle_type: str
@@ -421,7 +422,9 @@ class CrossDriverSessionDependency(NamedTuple):
     local_name: str
 
 
-def _create_cross_driver_session_dependency(resource_handle_type: str) -> CrossDriverSessionDependency:
+def _create_cross_driver_session_dependency(
+    resource_handle_type: str,
+) -> CrossDriverSessionDependency:
     return CrossDriverSessionDependency(
         resource_handle_type,
         f"{resource_handle_type}ResourceRepositorySharedPtr",
@@ -430,17 +433,25 @@ def _create_cross_driver_session_dependency(resource_handle_type: str) -> CrossD
         f"{common_helpers.pascal_to_snake(resource_handle_type)}_resource_repository",
     )
 
+
 def get_cross_driver_session_type(parameter: dict) -> Optional[str]:
     return parameter.get("cross_driver_session")
 
 
-def get_cross_driver_session_dependencies(functions: List[dict]) -> List[CrossDriverSessionDependency]:
-    return sorted(set([
-        _create_cross_driver_session_dependency(get_cross_driver_session_type(p))
-        for f in functions.values()
-        for p in f["parameters"]
-        if get_cross_driver_session_type(p)
-    ]))
+def get_cross_driver_session_dependencies(
+    functions: List[dict],
+) -> List[CrossDriverSessionDependency]:
+    return sorted(
+        set(
+            [
+                _create_cross_driver_session_dependency(get_cross_driver_session_type(p))
+                for f in functions.values()
+                for p in f["parameters"]
+                if get_cross_driver_session_type(p)
+            ]
+        )
+    )
+
 
 def get_cross_driver_session_dependency(parameter: dict) -> CrossDriverSessionDependency:
     return _create_cross_driver_session_dependency(parameter["cross_driver_session"])
@@ -454,10 +465,13 @@ def session_repository_field_name(param: dict) -> str:
     else:
         return "session_repository_"
 
+
 SessionRepositoryHandleTypeMap = Dict[str, Dict[str, Any]]
 
 
-def list_session_repository_handle_types(driver_configs: List[dict]) -> SessionRepositoryHandleTypeMap:
+def list_session_repository_handle_types(
+    driver_configs: List[dict],
+) -> SessionRepositoryHandleTypeMap:
     session_repository_handle_type_map = {}
     for config in driver_configs:
         handle_type = get_resource_handle_type(config)
@@ -468,6 +482,6 @@ def list_session_repository_handle_types(driver_configs: List[dict]) -> SessionR
         else:
             session_repository_handle_type_map[handle_type] = {
                 "local_name": f"{common_helpers.pascal_to_snake(handle_type)}_repository",
-                "windows_only": config.get("windows_only", False)
+                "windows_only": config.get("windows_only", False),
             }
     return session_repository_handle_type_map

--- a/source/codegen/template_helpers.py
+++ b/source/codegen/template_helpers.py
@@ -6,11 +6,11 @@ from mako.template import Template, Template
 
 
 def instantiate_mako_template(template_file_name: str) -> Template:
-  current_dir = Path(__file__).parent
-  template_directory = current_dir / "templates"
-  template_file_path = template_directory / template_file_name
-  template_lookup = TemplateLookup(directories = str(template_directory))
-  return Template(filename=str(template_file_path), lookup=template_lookup)
+    current_dir = Path(__file__).parent
+    template_directory = current_dir / "templates"
+    template_file_path = template_directory / template_file_name
+    template_lookup = TemplateLookup(directories=str(template_directory))
+    return Template(filename=str(template_file_path), lookup=template_lookup)
 
 
 def write_if_changed(output_file_path: str, new_contents: str) -> None:

--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -6,63 +6,63 @@ from shutil import rmtree
 
 from stage_client_files import stage_client_files
 
+
 @contextmanager
 def _create_stage_dir(staging_dir):
-  initial_dir = getcwd()
-  try:
-    rmtree(staging_dir, ignore_errors=True)
-    staging_dir.mkdir(parents=True)
-    chdir(staging_dir)
-    yield
-  finally:
-    chdir(initial_dir)
+    initial_dir = getcwd()
+    try:
+        rmtree(staging_dir, ignore_errors=True)
+        staging_dir.mkdir(parents=True)
+        chdir(staging_dir)
+        yield
+    finally:
+        chdir(initial_dir)
+
 
 def validate_examples(driver_glob_expression: str, ip_address: str) -> None:
-  staging_dir = Path(__file__).parent.parent.parent / "build" / "validate_examples"
+    staging_dir = Path(__file__).parent.parent.parent / "build" / "validate_examples"
 
-  print(f"Validating examples using staging_dir: {staging_dir}")
+    print(f"Validating examples using staging_dir: {staging_dir}")
 
-  with _create_stage_dir(staging_dir):
-    system("poetry new .")
-    system("poetry add grpcio")
-    system("poetry add --dev grpcio-tools black mypy mypy-protobuf types-protobuf grpc-stubs")
-    system("poetry install")
+    with _create_stage_dir(staging_dir):
+        system("poetry new .")
+        system("poetry add grpcio")
+        system("poetry add --dev grpcio-tools black mypy mypy-protobuf types-protobuf grpc-stubs")
+        system("poetry install")
 
-    stage_client_files(staging_dir, True)
-    examples_dir = staging_dir / "examples"
-    proto_dir = staging_dir / "proto"
-    proto_files_str = str.join(" ", [file.name for file in proto_dir.glob("*.proto")])
+        stage_client_files(staging_dir, True)
+        examples_dir = staging_dir / "examples"
+        proto_dir = staging_dir / "proto"
+        proto_files_str = str.join(" ", [file.name for file in proto_dir.glob("*.proto")])
 
-    system(
-      rf"poetry run python -m grpc_tools.protoc -I{proto_dir} --python_out=. --grpc_python_out=. --mypy_out=. --mypy_grpc_out=. {proto_files_str}"
-    )
-    for dir in examples_dir.glob(driver_glob_expression):
-      print()
-      print(f"-- Validating: {dir.name} --")
-      
-      print(f" -> Running black line-length 100")
-      system(f"poetry run black --check --line-length 100 {dir}")
-      
-      print(f" -> Running mypy")
-      system(f"poetry run mypy {dir}")
+        system(
+            rf"poetry run python -m grpc_tools.protoc -I{proto_dir} --python_out=. --grpc_python_out=. --mypy_out=. --mypy_grpc_out=. {proto_files_str}"
+        )
+        for dir in examples_dir.glob(driver_glob_expression):
+            print()
+            print(f"-- Validating: {dir.name} --")
 
-      for file in dir.glob("*.py"):
-        print(f" -> Running example: {file.name}")
-        system(rf"poetry run python {file} {ip_address}")
+            print(f" -> Running black line-length 100")
+            system(f"poetry run black --check --line-length 100 {dir}")
+
+            print(f" -> Running mypy")
+            system(f"poetry run mypy {dir}")
+
+            for file in dir.glob("*.py"):
+                print(f" -> Running example: {file.name}")
+                system(rf"poetry run python {file} {ip_address}")
 
 
 if __name__ == "__main__":
-  parser = ArgumentParser(description="Validate grpc-device examples.")
-  parser.add_argument(
-      "-p", 
-      "--pattern", 
-      help="Glob expression for scrapigen driver names to validate (i.e., *rfmx*).")
+    parser = ArgumentParser(description="Validate grpc-device examples.")
+    parser.add_argument(
+        "-p",
+        "--pattern",
+        help="Glob expression for scrapigen driver names to validate (i.e., *rfmx*).",
+    )
 
-  parser.add_argument(
-      "-s",
-      "--server", 
-      help="grpc-device server IP address.")
+    parser.add_argument("-s", "--server", help="grpc-device server IP address.")
 
-  args = parser.parse_args()
+    args = parser.parse_args()
 
-  validate_examples(args.pattern, args.server)
+    validate_examples(args.pattern, args.server)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update grpc-device to use black auto-formatter.

Exclude metadata, which uses a different "pretty printed" python style.

### Why should this Pull Request be merged?

* `black` 100 is the [ni standard python style](https://github.com/ni/python-styleguide#formatting).
* `grpc-device` has very inconsistent python style, which is frustrating for developers.
* `grpc-device` uses an auto-formatter for C++ code, which makes IDE config challenging to exclude python.
* `black` is great!

### What testing has been done?

Ran and passed `black source\codegen examples` .