### PR TITLE
Add python examples for BT

### DIFF
--- a/examples/nirfmxbluetooth/acp-basic.py
+++ b/examples/nirfmxbluetooth/acp-basic.py
@@ -14,19 +14,19 @@
 # 13. Fetch ACP Measurements and Trace.
 # 14. Close RFmx Session.
 #
-# The gRPC API is built from the C API. RFmx BT documentation is installed with the driver at:
-# C:\Program Files (x86)\National Instruments\RFmx\BT\Documentation\btcvi.chm
+# The gRPC API is built from the C API. RFmx Bluetooth documentation is installed with the driver at:
+# C:\Program Files (x86)\National Instruments\RFmx\BT\Documentation\rfmxbtcvi.chm
 #
 # Getting Started:
 #
-# To run this example, install "RFmx BT" on the server machine.
-# Link: https://www.ni.com/en-us/support/downloads/software-products/download.rfmx-bt.html
+# To run this example, install "RFmx Bluetooth" on the server machine.
+# Link: https://www.ni.com/en-us/support/downloads/software-products/download.rfmx-bluetooth.html
 #
 # For instructions on how to use protoc to generate gRPC client interfaces, see our "Creating a gRPC Client" wiki page.
 # Link: https://github.com/ni/grpc-device/wiki/Creating-a-gRPC-Client
 #
-# Refer to the NI-RFmxBT gRPC Wiki for the latest C Function Reference:
-# Link: https://github.com/ni/grpc-device/wiki/NI-RFmxBT-C-Function-Reference
+# Refer to the NI-RFmxBluetooth gRPC Wiki for the latest C Function Reference:
+# Link: https://github.com/ni/grpc-device/wiki/NI-RFmxBluetooth-C-Function-Reference
 #
 # Running from command line:
 #
@@ -38,12 +38,12 @@
 import sys
 
 import grpc
-import nirfmxbt_pb2 as nirfmxbt_types
-import nirfmxbt_pb2_grpc as grpc_nirfmxbt
+import nirfmxbluetooth_pb2 as nirfmxbluetooth_types
+import nirfmxbluetooth_pb2_grpc as grpc_nirfmxbluetooth
 
 server_address = "localhost"
 server_port = "31763"
-session_name = "RFmxBTSession"
+session_name = "RFmxBluetoothSession"
 
 # Resource name and options for a simulated 5663 client.
 resource = "SimulatedDevice"
@@ -60,7 +60,7 @@ if len(sys.argv) >= 4:
 
 # Create a gRPC channel + client.
 channel = grpc.insecure_channel(f"{server_address}:{server_port}")
-client = grpc_nirfmxbt.NiRFmxBTStub(channel)
+client = grpc_nirfmxbluetooth.NiRFmxBluetoothStub(channel)
 instr = None
 
 
@@ -68,7 +68,7 @@ instr = None
 def raise_if_error(response):
     if response.status != 0:
         error_response = client.GetError(
-            nirfmxbt_types.GetErrorRequest(
+            nirfmxbluetooth_types.GetErrorRequest(
                 instrument=instr,
             )
         )
@@ -81,11 +81,11 @@ def raise_if_error(response):
 
 
 try:
-    offset_channel_mode = nirfmxbt_types.ACP_OFFSET_CHANNEL_MODE_SYMMETRIC
+    offset_channel_mode = nirfmxbluetooth_types.ACP_OFFSET_CHANNEL_MODE_SYMMETRIC
 
     initialize_response = raise_if_error(
         client.Initialize(
-            nirfmxbt_types.InitializeRequest(
+            nirfmxbluetooth_types.InitializeRequest(
                 session_name=session_name, resource_name=resource, option_string=options
             )
         )
@@ -93,17 +93,17 @@ try:
     instr = initialize_response.instrument
     raise_if_error(
         client.CfgFrequencyReference(
-            nirfmxbt_types.CfgFrequencyReferenceRequest(
+            nirfmxbluetooth_types.CfgFrequencyReferenceRequest(
                 instrument=instr,
                 channel_name="",
-                frequency_reference_source_mapped=nirfmxbt_types.FREQUENCY_REFERENCE_SOURCE_ONBOARD_CLOCK,
+                frequency_reference_source_mapped=nirfmxbluetooth_types.FREQUENCY_REFERENCE_SOURCE_ONBOARD_CLOCK,
                 frequency_reference_frequency=10e6,
             )
         )
     )
     raise_if_error(
         client.CfgRF(
-            nirfmxbt_types.CfgRFRequest(
+            nirfmxbluetooth_types.CfgRFRequest(
                 instrument=instr,
                 selector_string="",
                 center_frequency=2.402e9,
@@ -114,101 +114,105 @@ try:
     )
     raise_if_error(
         client.CfgIQPowerEdgeTrigger(
-            nirfmxbt_types.CfgIQPowerEdgeTriggerRequest(
+            nirfmxbluetooth_types.CfgIQPowerEdgeTriggerRequest(
                 instrument=instr,
                 selector_string="",
                 iq_power_edge_source="0",
-                iq_power_edge_slope=nirfmxbt_types.IQ_POWER_EDGE_TRIGGER_SLOPE_RISING_SLOPE,
+                iq_power_edge_slope=nirfmxbluetooth_types.IQ_POWER_EDGE_TRIGGER_SLOPE_RISING_SLOPE,
                 iq_power_edge_level=-20.0,
                 trigger_delay=0.0,
-                trigger_min_quiet_time_mode=nirfmxbt_types.TRIGGER_MINIMUM_QUIET_TIME_MODE_AUTO,
+                trigger_min_quiet_time_mode=nirfmxbluetooth_types.TRIGGER_MINIMUM_QUIET_TIME_MODE_AUTO,
                 trigger_min_quiet_time_duration=100e-6,
-                iq_power_edge_level_type=nirfmxbt_types.IQ_POWER_EDGE_TRIGGER_LEVEL_TYPE_RELATIVE,
+                iq_power_edge_level_type=nirfmxbluetooth_types.IQ_POWER_EDGE_TRIGGER_LEVEL_TYPE_RELATIVE,
                 enable_trigger=True,
             )
         )
     )
     raise_if_error(
         client.CfgPacketType(
-            nirfmxbt_types.CfgPacketTypeRequest(
-                instrument=instr, selector_string="", packet_type=nirfmxbt_types.PACKET_TYPE_DH1
+            nirfmxbluetooth_types.CfgPacketTypeRequest(
+                instrument=instr,
+                selector_string="",
+                packet_type=nirfmxbluetooth_types.PACKET_TYPE_DH1,
             )
         )
     )
     raise_if_error(
         client.CfgDataRate(
-            nirfmxbt_types.CfgDataRateRequest(
+            nirfmxbluetooth_types.CfgDataRateRequest(
                 instrument=instr, selector_string="", data_rate=1000000
             )
         )
     )
     raise_if_error(
         client.CfgPayloadLength(
-            nirfmxbt_types.CfgPayloadLengthRequest(
+            nirfmxbluetooth_types.CfgPayloadLengthRequest(
                 instrument=instr,
                 selector_string="",
-                payload_length_mode=nirfmxbt_types.PAYLOAD_LENGTH_MODE_AUTO,
+                payload_length_mode=nirfmxbluetooth_types.PAYLOAD_LENGTH_MODE_AUTO,
                 payload_length=10,
             )
         )
     )
     raise_if_error(
         client.SelectMeasurements(
-            nirfmxbt_types.SelectMeasurementsRequest(
+            nirfmxbluetooth_types.SelectMeasurementsRequest(
                 instrument=instr,
                 selector_string="",
-                measurements=nirfmxbt_types.MEASUREMENT_TYPES_ACP,
+                measurements=nirfmxbluetooth_types.MEASUREMENT_TYPES_ACP,
                 enable_all_traces=True,
             )
         )
     )
     raise_if_error(
         client.ACPCfgBurstSynchronizationType(
-            nirfmxbt_types.ACPCfgBurstSynchronizationTypeRequest(
+            nirfmxbluetooth_types.ACPCfgBurstSynchronizationTypeRequest(
                 instrument=instr,
                 selector_string="",
-                burst_synchronization_type=nirfmxbt_types.ACP_BURST_SYNCHRONIZATION_TYPE_PREAMBLE,
+                burst_synchronization_type=nirfmxbluetooth_types.ACP_BURST_SYNCHRONIZATION_TYPE_PREAMBLE,
             )
         )
     )
     raise_if_error(
         client.ACPCfgAveraging(
-            nirfmxbt_types.ACPCfgAveragingRequest(
+            nirfmxbluetooth_types.ACPCfgAveragingRequest(
                 instrument=instr,
                 selector_string="",
-                averaging_enabled=nirfmxbt_types.ACP_AVERAGING_ENABLED_FALSE,
+                averaging_enabled=nirfmxbluetooth_types.ACP_AVERAGING_ENABLED_FALSE,
                 averaging_count=10,
             )
         )
     )
     raise_if_error(
         client.ACPCfgOffsetChannelMode(
-            nirfmxbt_types.ACPCfgOffsetChannelModeRequest(
+            nirfmxbluetooth_types.ACPCfgOffsetChannelModeRequest(
                 instrument=instr,
                 selector_string="",
                 offset_channel_mode=offset_channel_mode,
             )
         )
     )
-    if offset_channel_mode == nirfmxbt_types.ACP_OFFSET_CHANNEL_MODE_SYMMETRIC:
+    if offset_channel_mode == nirfmxbluetooth_types.ACP_OFFSET_CHANNEL_MODE_SYMMETRIC:
         raise_if_error(
             client.ACPCfgNumberOfOffsets(
-                nirfmxbt_types.ACPCfgNumberOfOffsetsRequest(
+                nirfmxbluetooth_types.ACPCfgNumberOfOffsetsRequest(
                     instrument=instr, selector_string="", number_of_offsets=5
                 )
             )
         )
-    elif offset_channel_mode == nirfmxbt_types.ACP_OFFSET_CHANNEL_MODE_INBAND:
+    elif offset_channel_mode == nirfmxbluetooth_types.ACP_OFFSET_CHANNEL_MODE_INBAND:
         raise_if_error(
             client.CfgChannelNumber(
-                nirfmxbt_types.CfgChannelNumberRequest(
+                nirfmxbluetooth_types.CfgChannelNumberRequest(
                     instrument=instr, selector_string="", channel_number=0
                 )
             )
         )
     raise_if_error(
         client.Initiate(
-            nirfmxbt_types.InitiateRequest(instrument=instr, selector_string="", result_name="")
+            nirfmxbluetooth_types.InitiateRequest(
+                instrument=instr, selector_string="", result_name=""
+            )
         )
     )
 
@@ -216,7 +220,7 @@ try:
 
     acp_fetch_measurement_status_response = raise_if_error(
         client.ACPFetchMeasurementStatus(
-            nirfmxbt_types.ACPFetchMeasurementStatusRequest(
+            nirfmxbluetooth_types.ACPFetchMeasurementStatusRequest(
                 instrument=instr, selector_string="", timeout=10.0
             )
         )
@@ -224,17 +228,20 @@ try:
     measurement_status = acp_fetch_measurement_status_response.measurement_status
     if (
         measurement_status
-        == nirfmxbt_types.NIRFMXBT_INT32_ACP_RESULTS_MEASUREMENT_STATUS_NOT_APPLICABLE
+        == nirfmxbluetooth_types.NIRFMXBLUETOOTH_INT32_ACP_RESULTS_MEASUREMENT_STATUS_NOT_APPLICABLE
     ):
         measurement_status_string = "Not Applicable"
-    elif measurement_status == nirfmxbt_types.NIRFMXBT_INT32_ACP_RESULTS_MEASUREMENT_STATUS_PASS:
+    elif (
+        measurement_status
+        == nirfmxbluetooth_types.NIRFMXBLUETOOTH_INT32_ACP_RESULTS_MEASUREMENT_STATUS_PASS
+    ):
         measurement_status_string = "Pass"
     else:
         measurement_status_string = "Fail"
 
     acp_fetch_reference_channel_power_response = raise_if_error(
         client.ACPFetchReferenceChannelPower(
-            nirfmxbt_types.ACPFetchReferenceChannelPowerRequest(
+            nirfmxbluetooth_types.ACPFetchReferenceChannelPowerRequest(
                 instrument=instr, selector_string="", timeout=10.0
             )
         )
@@ -243,7 +250,7 @@ try:
 
     acp_fetch_offset_measurement_array_response = raise_if_error(
         client.ACPFetchOffsetMeasurementArray(
-            nirfmxbt_types.ACPFetchOffsetMeasurementArrayRequest(
+            nirfmxbluetooth_types.ACPFetchOffsetMeasurementArrayRequest(
                 instrument=instr, selector_string="", timeout=10.0
             )
         )
@@ -257,7 +264,7 @@ try:
 
     acp_fetch_mask_trace_response = raise_if_error(
         client.ACPFetchMaskTrace(
-            nirfmxbt_types.ACPFetchMaskTraceRequest(
+            nirfmxbluetooth_types.ACPFetchMaskTraceRequest(
                 instrument=instr, selector_string="", timeout=10.0
             )
         )
@@ -271,7 +278,7 @@ try:
     dx = 0.0
     acp_fetch_absolute_power_trace_response = raise_if_error(
         client.ACPFetchAbsolutePowerTrace(
-            nirfmxbt_types.ACPFetchAbsolutePowerTraceRequest(
+            nirfmxbluetooth_types.ACPFetchAbsolutePowerTraceRequest(
                 instrument=instr, selector_string="", timeout=10.0
             )
         )
@@ -284,7 +291,7 @@ try:
     dx = 0.0
     acp_fetch_spectrum_response = raise_if_error(
         client.ACPFetchSpectrum(
-            nirfmxbt_types.ACPFetchSpectrumRequest(
+            nirfmxbluetooth_types.ACPFetchSpectrumRequest(
                 instrument=instr, selector_string="", timeout=10.0
             )
         )
@@ -309,4 +316,4 @@ try:
         print(f"Upper Margin (dB)                    : {upper_margin[i]}\n")
 finally:
     if instr:
-        client.Close(nirfmxbt_types.CloseRequest(instrument=instr, force_destroy=False))
+        client.Close(nirfmxbluetooth_types.CloseRequest(instrument=instr, force_destroy=False))

--- a/examples/nirfmxbluetooth/txp-basic.py
+++ b/examples/nirfmxbluetooth/txp-basic.py
@@ -15,19 +15,19 @@
 # 14. Fetch TXP Measurements and Trace.
 # 15. Close RFmx Session.
 #
-# The gRPC API is built from the C API. RFmx BT documentation is installed with the driver at:
-# C:\Program Files (x86)\National Instruments\RFmx\BT\Documentation\btcvi.chm
+# The gRPC API is built from the C API. RFmx Bluetooth documentation is installed with the driver at:
+# C:\Program Files (x86)\National Instruments\RFmx\BT\Documentation\rfmxbtcvi.chm
 #
 # Getting Started:
 #
-# To run this example, install "RFmx BT" on the server machine.
-# Link: https://www.ni.com/en-us/support/downloads/software-products/download.rfmx-bt.html
+# To run this example, install "RFmx Bluetooth" on the server machine.
+# Link: https://www.ni.com/en-us/support/downloads/software-products/download.rfmx-bluetooth.html
 #
 # For instructions on how to use protoc to generate gRPC client interfaces, see our "Creating a gRPC Client" wiki page.
 # Link: https://github.com/ni/grpc-device/wiki/Creating-a-gRPC-Client
 #
-# Refer to the NI-RFmxBT gRPC Wiki for the latest C Function Reference:
-# Link: https://github.com/ni/grpc-device/wiki/NI-RFmxBT-C-Function-Reference
+# Refer to the NI-RFmxBluetooth gRPC Wiki for the latest C Function Reference:
+# Link: https://github.com/ni/grpc-device/wiki/NI-RFmxBluetooth-C-Function-Reference
 #
 # Running from command line:
 #
@@ -39,12 +39,12 @@
 import sys
 
 import grpc
-import nirfmxbt_pb2 as nirfmxbt_types
-import nirfmxbt_pb2_grpc as grpc_nirfmxbt
+import nirfmxbluetooth_pb2 as nirfmxbluetooth_types
+import nirfmxbluetooth_pb2_grpc as grpc_nirfmxbluetooth
 
 server_address = "localhost"
 server_port = "31763"
-session_name = "RFmxBTSession"
+session_name = "RFmxBluetoothSession"
 
 # Resource name and options for a simulated 5663 client.
 resource = "SimulatedDevice"
@@ -61,7 +61,7 @@ if len(sys.argv) >= 4:
 
 # Create a gRPC channel + client.
 channel = grpc.insecure_channel(f"{server_address}:{server_port}")
-client = grpc_nirfmxbt.NiRFmxBTStub(channel)
+client = grpc_nirfmxbluetooth.NiRFmxBluetoothStub(channel)
 instr = None
 
 
@@ -69,7 +69,7 @@ instr = None
 def raise_if_error(response):
     if response.status != 0:
         error_response = client.GetError(
-            nirfmxbt_types.GetErrorRequest(
+            nirfmxbluetooth_types.GetErrorRequest(
                 instrument=instr,
             )
         )
@@ -86,7 +86,7 @@ try:
 
     initialize_response = raise_if_error(
         client.Initialize(
-            nirfmxbt_types.InitializeRequest(
+            nirfmxbluetooth_types.InitializeRequest(
                 session_name=session_name, resource_name=resource, option_string=options
             )
         )
@@ -94,74 +94,76 @@ try:
     instr = initialize_response.instrument
     raise_if_error(
         client.CfgFrequencyReference(
-            nirfmxbt_types.CfgFrequencyReferenceRequest(
+            nirfmxbluetooth_types.CfgFrequencyReferenceRequest(
                 instrument=instr,
                 channel_name="",
-                frequency_reference_source_mapped=nirfmxbt_types.FREQUENCY_REFERENCE_SOURCE_ONBOARD_CLOCK,
+                frequency_reference_source_mapped=nirfmxbluetooth_types.FREQUENCY_REFERENCE_SOURCE_ONBOARD_CLOCK,
                 frequency_reference_frequency=10e6,
             )
         )
     )
     raise_if_error(
         client.CfgFrequency(
-            nirfmxbt_types.CfgFrequencyRequest(
+            nirfmxbluetooth_types.CfgFrequencyRequest(
                 instrument=instr, selector_string="", center_frequency=2.402000e9
             )
         )
     )
     raise_if_error(
         client.CfgExternalAttenuation(
-            nirfmxbt_types.CfgExternalAttenuationRequest(
+            nirfmxbluetooth_types.CfgExternalAttenuationRequest(
                 instrument=instr, selector_string="", external_attenuation=0.0
             )
         )
     )
     raise_if_error(
         client.CfgIQPowerEdgeTrigger(
-            nirfmxbt_types.CfgIQPowerEdgeTriggerRequest(
+            nirfmxbluetooth_types.CfgIQPowerEdgeTriggerRequest(
                 instrument=instr,
                 selector_string="",
                 iq_power_edge_source="0",
-                iq_power_edge_slope=nirfmxbt_types.IQ_POWER_EDGE_TRIGGER_SLOPE_RISING_SLOPE,
+                iq_power_edge_slope=nirfmxbluetooth_types.IQ_POWER_EDGE_TRIGGER_SLOPE_RISING_SLOPE,
                 iq_power_edge_level=-20.0,
                 trigger_delay=0.0,
-                trigger_min_quiet_time_mode=nirfmxbt_types.TRIGGER_MINIMUM_QUIET_TIME_MODE_AUTO,
+                trigger_min_quiet_time_mode=nirfmxbluetooth_types.TRIGGER_MINIMUM_QUIET_TIME_MODE_AUTO,
                 trigger_min_quiet_time_duration=100e-6,
-                iq_power_edge_level_type=nirfmxbt_types.IQ_POWER_EDGE_TRIGGER_LEVEL_TYPE_RELATIVE,
+                iq_power_edge_level_type=nirfmxbluetooth_types.IQ_POWER_EDGE_TRIGGER_LEVEL_TYPE_RELATIVE,
                 enable_trigger=True,
             )
         )
     )
     raise_if_error(
         client.CfgPacketType(
-            nirfmxbt_types.CfgPacketTypeRequest(
-                instrument=instr, selector_string="", packet_type=nirfmxbt_types.PACKET_TYPE_DH1
+            nirfmxbluetooth_types.CfgPacketTypeRequest(
+                instrument=instr,
+                selector_string="",
+                packet_type=nirfmxbluetooth_types.PACKET_TYPE_DH1,
             )
         )
     )
     raise_if_error(
         client.CfgDataRate(
-            nirfmxbt_types.CfgDataRateRequest(
+            nirfmxbluetooth_types.CfgDataRateRequest(
                 instrument=instr, selector_string="", data_rate=1000000
             )
         )
     )
     raise_if_error(
         client.CfgPayloadLength(
-            nirfmxbt_types.CfgPayloadLengthRequest(
+            nirfmxbluetooth_types.CfgPayloadLengthRequest(
                 instrument=instr,
                 selector_string="",
-                payload_length_mode=nirfmxbt_types.PAYLOAD_LENGTH_MODE_AUTO,
+                payload_length_mode=nirfmxbluetooth_types.PAYLOAD_LENGTH_MODE_AUTO,
                 payload_length=10,
             )
         )
     )
     raise_if_error(
         client.CfgLEDirectionFinding(
-            nirfmxbt_types.CfgLEDirectionFindingRequest(
+            nirfmxbluetooth_types.CfgLEDirectionFindingRequest(
                 instrument=instr,
                 selector_string="",
-                direction_finding_mode=nirfmxbt_types.DIRECTION_FINDING_MODE_DISABLED,
+                direction_finding_mode=nirfmxbluetooth_types.DIRECTION_FINDING_MODE_DISABLED,
                 cte_length=160e-6,
                 cte_slot_duration=1e-6,
             )
@@ -170,7 +172,7 @@ try:
     if auto_level:
         auto_level_response = raise_if_error(
             client.AutoLevel(
-                nirfmxbt_types.AutoLevelRequest(
+                nirfmxbluetooth_types.AutoLevelRequest(
                     instrument=instr, selector_string="", measurement_interval=10e-3
                 )
             )
@@ -179,43 +181,45 @@ try:
     else:
         raise_if_error(
             client.CfgReferenceLevel(
-                nirfmxbt_types.CfgReferenceLevelRequest(
+                nirfmxbluetooth_types.CfgReferenceLevelRequest(
                     instrument=instr, selector_string="", reference_level=0.0
                 )
             )
         )
     raise_if_error(
         client.SelectMeasurements(
-            nirfmxbt_types.SelectMeasurementsRequest(
+            nirfmxbluetooth_types.SelectMeasurementsRequest(
                 instrument=instr,
                 selector_string="",
-                measurements=nirfmxbt_types.MEASUREMENT_TYPES_TXP,
+                measurements=nirfmxbluetooth_types.MEASUREMENT_TYPES_TXP,
                 enable_all_traces=True,
             )
         )
     )
     raise_if_error(
         client.TXPCfgBurstSynchronizationType(
-            nirfmxbt_types.TXPCfgBurstSynchronizationTypeRequest(
+            nirfmxbluetooth_types.TXPCfgBurstSynchronizationTypeRequest(
                 instrument=instr,
                 selector_string="",
-                burst_synchronization_type=nirfmxbt_types.TXP_BURST_SYNCHRONIZATION_TYPE_PREAMBLE,
+                burst_synchronization_type=nirfmxbluetooth_types.TXP_BURST_SYNCHRONIZATION_TYPE_PREAMBLE,
             )
         )
     )
     raise_if_error(
         client.TXPCfgAveraging(
-            nirfmxbt_types.TXPCfgAveragingRequest(
+            nirfmxbluetooth_types.TXPCfgAveragingRequest(
                 instrument=instr,
                 selector_string="",
-                averaging_enabled=nirfmxbt_types.TXP_AVERAGING_ENABLED_FALSE,
+                averaging_enabled=nirfmxbluetooth_types.TXP_AVERAGING_ENABLED_FALSE,
                 averaging_count=10,
             )
         )
     )
     raise_if_error(
         client.Initiate(
-            nirfmxbt_types.InitiateRequest(instrument=instr, selector_string="", result_name="")
+            nirfmxbluetooth_types.InitiateRequest(
+                instrument=instr, selector_string="", result_name=""
+            )
         )
     )
 
@@ -223,7 +227,9 @@ try:
 
     txp_fetch_powers_response = raise_if_error(
         client.TXPFetchPowers(
-            nirfmxbt_types.TXPFetchPowersRequest(instrument=instr, selector_string="", timeout=10.0)
+            nirfmxbluetooth_types.TXPFetchPowersRequest(
+                instrument=instr, selector_string="", timeout=10.0
+            )
         )
     )
     average_power_mean = txp_fetch_powers_response.average_power_mean
@@ -234,7 +240,7 @@ try:
     )
     txp_fetch_edr_powers_response = raise_if_error(
         client.TXPFetchEDRPowers(
-            nirfmxbt_types.TXPFetchEDRPowersRequest(
+            nirfmxbluetooth_types.TXPFetchEDRPowersRequest(
                 instrument=instr, selector_string="", timeout=10.0
             )
         )
@@ -246,7 +252,7 @@ try:
     )
     txp_fetch_lecte_reference_period_powers_response = raise_if_error(
         client.TXPFetchLECTEReferencePeriodPowers(
-            nirfmxbt_types.TXPFetchLECTEReferencePeriodPowersRequest(
+            nirfmxbluetooth_types.TXPFetchLECTEReferencePeriodPowersRequest(
                 instrument=instr, selector_string="", timeout=10.0
             )
         )
@@ -260,7 +266,7 @@ try:
 
     txp_fetch_lecte_transmit_slot_powers_array_response = raise_if_error(
         client.TXPFetchLECTETransmitSlotPowersArray(
-            nirfmxbt_types.TXPFetchLECTETransmitSlotPowersArrayRequest(
+            nirfmxbluetooth_types.TXPFetchLECTETransmitSlotPowersArrayRequest(
                 instrument=instr, selector_string="", timeout=10.0
             )
         )
@@ -274,7 +280,7 @@ try:
 
     txp_fetch_power_trace_response = raise_if_error(
         client.TXPFetchPowerTrace(
-            nirfmxbt_types.TXPFetchPowerTraceRequest(
+            nirfmxbluetooth_types.TXPFetchPowerTraceRequest(
                 instrument=instr, selector_string="", timeout=10.0
             )
         )
@@ -298,10 +304,10 @@ try:
 
     print("------------------LE CTE Reference Period Measurement------------------")
     print(
-        f"Average Power Mean (dBm)                        : {reference_period_average_power_mean}"
+        f"Average Power Mean (dBm)                                         : {reference_period_average_power_mean}"
     )
     print(
-        f"Peak Absolute Power Deviation Maximum (%)       : {reference_period_peak_absolute_power_deviation_maximum}\n"
+        f"Peak Absolute Power Deviation Maximum (%)                         : {reference_period_peak_absolute_power_deviation_maximum}\n"
     )
 
     print("------------------LE CTE Transmit Slot Power Measurement------------------")
@@ -309,11 +315,11 @@ try:
         print("No data")
     for i in range(len(transmit_slot_average_power_mean)):
         print(
-            f"Average Power Mean (dBm)[{i}]                   : {transmit_slot_average_power_mean[i]}\n"
+            f"Average Power Mean (dBm)[{i}]                     : {transmit_slot_average_power_mean[i]}\n"
         )
         print(
-            f"Peak Absolute Power Deviation Maximum (%)[{i}]  : {transmit_slot_peak_absolute_power_deviation_maximum[i]}\n"
+            f"Peak Absolute Power Deviation Maximum (%)[{i}]     : {transmit_slot_peak_absolute_power_deviation_maximum[i]}\n"
         )
 finally:
     if instr:
-        client.Close(nirfmxbt_types.CloseRequest(instrument=instr, force_destroy=False))
+        client.Close(nirfmxbluetooth_types.CloseRequest(instrument=instr, force_destroy=False))


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds python examples for BT

### Why should this Pull Request be merged?

[AB#1838233](https://ni.visualstudio.com/DevCentral/_workitems/edit/1838233), [AB#1838234](https://ni.visualstudio.com/DevCentral/_workitems/edit/1838234)

### What testing has been done?

```
>python acp-basic.py
------------------ACP------------------
Measurement Status                   : Not Applicable
Reference Channel Power (dBm)        : 3.4482650756835938

------------------Offset Measuremensts------------------
Offset 0
Lower Absolute Powers (dBm)          : -37.464412689208984
Upper Absolute Powers (dBm)          : -37.464412689208984
Lower Relative Powers (dB)           : -40.91267776489258
Upper Relative Powers (dB)           : -40.91267776489258
Lower Margin (dB)                    : nan
Upper Margin (dB)                    : nan

Offset 1
Lower Absolute Powers (dBm)          : -37.34642028808594
Upper Absolute Powers (dBm)          : -37.34642028808594
Lower Relative Powers (dB)           : -40.79468536376953
Upper Relative Powers (dB)           : -40.79468536376953
Lower Margin (dB)                    : nan
Upper Margin (dB)                    : nan

Offset 2
Lower Absolute Powers (dBm)          : -37.32515335083008
Upper Absolute Powers (dBm)          : -37.32515335083008
Lower Relative Powers (dB)           : -40.77341842651367
Upper Relative Powers (dB)           : -40.77341842651367
Lower Margin (dB)                    : nan
Upper Margin (dB)                    : nan

Offset 3
Lower Absolute Powers (dBm)          : -37.26522445678711
Upper Absolute Powers (dBm)          : -37.26522445678711
Lower Relative Powers (dB)           : -40.7134895324707
Upper Relative Powers (dB)           : -40.7134895324707
Lower Margin (dB)                    : nan
Upper Margin (dB)                    : nan

Offset 4
Lower Absolute Powers (dBm)          : -37.360591888427734
Upper Absolute Powers (dBm)          : -37.360595703125
Lower Relative Powers (dB)           : -40.80885696411133
Upper Relative Powers (dB)           : -40.808860778808594
Lower Margin (dB)                    : nan
Upper Margin (dB)                    : nan
```
---
```
>python txp-basic.py
Warning: 686280: The Preamble Sync failed to detect start of the packet.
Warning: 686280: The Preamble Sync failed to detect start of the packet.
Warning: 686280: The Preamble Sync failed to detect start of the packet.
Warning: 686280: The Preamble Sync failed to detect start of the packet.
Warning: 686280: The Preamble Sync failed to detect start of the packet.
------------------Measurement------------------
Average Power Mean (dBm)                        : 18.591169357299805
Average Power Maximum (dBm)                     : 18.591169357299805
Average Power Minimum (dBm)                     : 18.591169357299805
Peak to Average Power Ratio Maximum (dB)        : 3.425236701965332
EDR GFSK Average Power Mean (dBm)               : nan
EDR DPSK Average Power Mean (dBm)               : nan
EDR DPSK GFSK Average Power Ratio Mean (dB)     : nan
------------------LE CTE Reference Period Measurement------------------
Average Power Mean (dBm)                        : nan
Peak Absolute Power Deviation Maximum (%)       : nan

------------------LE CTE Transmit Slot Power Measurement------------------
No data
```