### PR TITLE
Add TwentydB methods to NiRFmxBluetooth

### DIFF
--- a/generated/nirfmxbluetooth/nirfmxbluetooth.proto
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth.proto
@@ -142,6 +142,9 @@ service NiRFmxBluetooth {
   rpc TXPFetchLECTETransmitSlotPowersArray(TXPFetchLECTETransmitSlotPowersArrayRequest) returns (TXPFetchLECTETransmitSlotPowersArrayResponse);
   rpc TXPFetchPowerTrace(TXPFetchPowerTraceRequest) returns (TXPFetchPowerTraceResponse);
   rpc TXPFetchPowers(TXPFetchPowersRequest) returns (TXPFetchPowersResponse);
+  rpc TwentydBBandwidthCfgAveraging(TwentydBBandwidthCfgAveragingRequest) returns (TwentydBBandwidthCfgAveragingResponse);
+  rpc TwentydBBandwidthFetchMeasurement(TwentydBBandwidthFetchMeasurementRequest) returns (TwentydBBandwidthFetchMeasurementResponse);
+  rpc TwentydBBandwidthFetchSpectrum(TwentydBBandwidthFetchSpectrumRequest) returns (TwentydBBandwidthFetchSpectrumResponse);
   rpc WaitForAcquisitionComplete(WaitForAcquisitionCompleteRequest) returns (WaitForAcquisitionCompleteResponse);
   rpc WaitForMeasurementComplete(WaitForMeasurementCompleteRequest) returns (WaitForMeasurementCompleteResponse);
 }
@@ -403,6 +406,11 @@ enum Standard {
 enum TriggerMinimumQuietTimeMode {
   TRIGGER_MINIMUM_QUIET_TIME_MODE_MANUAL = 0;
   TRIGGER_MINIMUM_QUIET_TIME_MODE_AUTO = 1;
+}
+
+enum TwentydBBandwidthAveragingEnabled {
+  TWENTY_DB_BANDWIDTH_AVERAGING_ENABLED_FALSE = 0;
+  TWENTY_DB_BANDWIDTH_AVERAGING_ENABLED_TRUE = 1;
 }
 
 enum TxpAveragingEnabled {
@@ -2002,6 +2010,48 @@ message TXPFetchPowersResponse {
   double average_power_maximum = 3;
   double average_power_minimum = 4;
   double peak_to_average_power_ratio_maximum = 5;
+}
+
+message TwentydBBandwidthCfgAveragingRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  oneof averaging_enabled_enum {
+    TwentydBBandwidthAveragingEnabled averaging_enabled = 3;
+    int32 averaging_enabled_raw = 4;
+  }
+  int32 averaging_count = 5;
+}
+
+message TwentydBBandwidthCfgAveragingResponse {
+  int32 status = 1;
+}
+
+message TwentydBBandwidthFetchMeasurementRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  double timeout = 3;
+}
+
+message TwentydBBandwidthFetchMeasurementResponse {
+  int32 status = 1;
+  double peak_power = 2;
+  double bandwidth = 3;
+  double high_frequency = 4;
+  double low_frequency = 5;
+}
+
+message TwentydBBandwidthFetchSpectrumRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  double timeout = 3;
+}
+
+message TwentydBBandwidthFetchSpectrumResponse {
+  int32 status = 1;
+  double x0 = 2;
+  double dx = 3;
+  repeated float spectrum = 4;
+  int32 actual_array_size = 5;
 }
 
 message WaitForAcquisitionCompleteRequest {

--- a/generated/nirfmxbluetooth/nirfmxbluetooth.proto
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth.proto
@@ -1493,8 +1493,8 @@ message ModAccFetchDf1Request {
 
 message ModAccFetchDf1Response {
   int32 status = 1;
-  double df1_avg_maximum = 2;
-  double df1_avg_minimum = 3;
+  double df1avg_maximum = 2;
+  double df1avg_minimum = 3;
 }
 
 message ModAccFetchDf1maxTraceRequest {
@@ -1518,8 +1518,8 @@ message ModAccFetchDf2Request {
 
 message ModAccFetchDf2Response {
   int32 status = 1;
-  double df2_avg_minimum = 2;
-  double percentage_of_symbols_above_df2_max_threshold = 3;
+  double df2avg_minimum = 2;
+  double percentage_of_symbols_above_df2max_threshold = 3;
 }
 
 message ModAccFetchDf2maxTraceRequest {

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_client.cpp
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_client.cpp
@@ -2457,6 +2457,68 @@ txp_fetch_powers(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   return response;
 }
 
+TwentydBBandwidthCfgAveragingResponse
+twentyd_b_bandwidth_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const simple_variant<TwentydBBandwidthAveragingEnabled, pb::int32>& averaging_enabled, const pb::int32& averaging_count)
+{
+  ::grpc::ClientContext context;
+
+  auto request = TwentydBBandwidthCfgAveragingRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  const auto averaging_enabled_ptr = averaging_enabled.get_if<TwentydBBandwidthAveragingEnabled>();
+  const auto averaging_enabled_raw_ptr = averaging_enabled.get_if<pb::int32>();
+  if (averaging_enabled_ptr) {
+    request.set_averaging_enabled(*averaging_enabled_ptr);
+  }
+  else if (averaging_enabled_raw_ptr) {
+    request.set_averaging_enabled_raw(*averaging_enabled_raw_ptr);
+  }
+  request.set_averaging_count(averaging_count);
+
+  auto response = TwentydBBandwidthCfgAveragingResponse{};
+
+  raise_if_error(
+      stub->TwentydBBandwidthCfgAveraging(&context, request, &response));
+
+  return response;
+}
+
+TwentydBBandwidthFetchMeasurementResponse
+twentyd_b_bandwidth_fetch_measurement(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const double& timeout)
+{
+  ::grpc::ClientContext context;
+
+  auto request = TwentydBBandwidthFetchMeasurementRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_timeout(timeout);
+
+  auto response = TwentydBBandwidthFetchMeasurementResponse{};
+
+  raise_if_error(
+      stub->TwentydBBandwidthFetchMeasurement(&context, request, &response));
+
+  return response;
+}
+
+TwentydBBandwidthFetchSpectrumResponse
+twentyd_b_bandwidth_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const double& timeout)
+{
+  ::grpc::ClientContext context;
+
+  auto request = TwentydBBandwidthFetchSpectrumRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_timeout(timeout);
+
+  auto response = TwentydBBandwidthFetchSpectrumResponse{};
+
+  raise_if_error(
+      stub->TwentydBBandwidthFetchSpectrum(&context, request, &response));
+
+  return response;
+}
+
 WaitForAcquisitionCompleteResponse
 wait_for_acquisition_complete(const StubPtr& stub, const nidevice_grpc::Session& instrument, const double& timeout)
 {

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_client.h
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_client.h
@@ -147,6 +147,9 @@ TXPFetchLECTETransmitSlotPowersResponse txp_fetch_lecte_transmit_slot_powers(con
 TXPFetchLECTETransmitSlotPowersArrayResponse txp_fetch_lecte_transmit_slot_powers_array(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const double& timeout);
 TXPFetchPowerTraceResponse txp_fetch_power_trace(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const double& timeout);
 TXPFetchPowersResponse txp_fetch_powers(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const double& timeout);
+TwentydBBandwidthCfgAveragingResponse twentyd_b_bandwidth_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const simple_variant<TwentydBBandwidthAveragingEnabled, pb::int32>& averaging_enabled, const pb::int32& averaging_count);
+TwentydBBandwidthFetchMeasurementResponse twentyd_b_bandwidth_fetch_measurement(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const double& timeout);
+TwentydBBandwidthFetchSpectrumResponse twentyd_b_bandwidth_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const double& timeout);
 WaitForAcquisitionCompleteResponse wait_for_acquisition_complete(const StubPtr& stub, const nidevice_grpc::Session& instrument, const double& timeout);
 WaitForMeasurementCompleteResponse wait_for_measurement_complete(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const double& timeout);
 

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_library.cpp
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_library.cpp
@@ -146,6 +146,9 @@ NiRFmxBluetoothLibrary::NiRFmxBluetoothLibrary() : shared_library_(kLibraryName)
   function_pointers_.TXPFetchLECTETransmitSlotPowersArray = reinterpret_cast<TXPFetchLECTETransmitSlotPowersArrayPtr>(shared_library_.get_function_pointer("RFmxBT_TXPFetchLECTETransmitSlotPowersArray"));
   function_pointers_.TXPFetchPowerTrace = reinterpret_cast<TXPFetchPowerTracePtr>(shared_library_.get_function_pointer("RFmxBT_TXPFetchPowerTrace"));
   function_pointers_.TXPFetchPowers = reinterpret_cast<TXPFetchPowersPtr>(shared_library_.get_function_pointer("RFmxBT_TXPFetchPowers"));
+  function_pointers_.TwentydBBandwidthCfgAveraging = reinterpret_cast<TwentydBBandwidthCfgAveragingPtr>(shared_library_.get_function_pointer("RFmxBT_20dBBandwidthCfgAveraging"));
+  function_pointers_.TwentydBBandwidthFetchMeasurement = reinterpret_cast<TwentydBBandwidthFetchMeasurementPtr>(shared_library_.get_function_pointer("RFmxBT_20dBBandwidthFetchMeasurement"));
+  function_pointers_.TwentydBBandwidthFetchSpectrum = reinterpret_cast<TwentydBBandwidthFetchSpectrumPtr>(shared_library_.get_function_pointer("RFmxBT_20dBBandwidthFetchSpectrum"));
   function_pointers_.WaitForAcquisitionComplete = reinterpret_cast<WaitForAcquisitionCompletePtr>(shared_library_.get_function_pointer("RFmxBT_WaitForAcquisitionComplete"));
   function_pointers_.WaitForMeasurementComplete = reinterpret_cast<WaitForMeasurementCompletePtr>(shared_library_.get_function_pointer("RFmxBT_WaitForMeasurementComplete"));
 }
@@ -1658,6 +1661,42 @@ int32 NiRFmxBluetoothLibrary::TXPFetchPowers(niRFmxInstrHandle instrumentHandle,
   return RFmxBT_TXPFetchPowers(instrumentHandle, selectorString, timeout, averagePowerMean, averagePowerMaximum, averagePowerMinimum, peakToAveragePowerRatioMaximum);
 #else
   return function_pointers_.TXPFetchPowers(instrumentHandle, selectorString, timeout, averagePowerMean, averagePowerMaximum, averagePowerMinimum, peakToAveragePowerRatioMaximum);
+#endif
+}
+
+int32 NiRFmxBluetoothLibrary::TwentydBBandwidthCfgAveraging(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 averagingEnabled, int32 averagingCount)
+{
+  if (!function_pointers_.TwentydBBandwidthCfgAveraging) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxBT_20dBBandwidthCfgAveraging.");
+  }
+#if defined(_MSC_VER)
+  return RFmxBT_20dBBandwidthCfgAveraging(instrumentHandle, selectorString, averagingEnabled, averagingCount);
+#else
+  return function_pointers_.TwentydBBandwidthCfgAveraging(instrumentHandle, selectorString, averagingEnabled, averagingCount);
+#endif
+}
+
+int32 NiRFmxBluetoothLibrary::TwentydBBandwidthFetchMeasurement(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* peakPower, float64* bandwidth, float64* highFrequency, float64* lowFrequency)
+{
+  if (!function_pointers_.TwentydBBandwidthFetchMeasurement) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxBT_20dBBandwidthFetchMeasurement.");
+  }
+#if defined(_MSC_VER)
+  return RFmxBT_20dBBandwidthFetchMeasurement(instrumentHandle, selectorString, timeout, peakPower, bandwidth, highFrequency, lowFrequency);
+#else
+  return function_pointers_.TwentydBBandwidthFetchMeasurement(instrumentHandle, selectorString, timeout, peakPower, bandwidth, highFrequency, lowFrequency);
+#endif
+}
+
+int32 NiRFmxBluetoothLibrary::TwentydBBandwidthFetchSpectrum(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 spectrum[], int32 arraySize, int32* actualArraySize)
+{
+  if (!function_pointers_.TwentydBBandwidthFetchSpectrum) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxBT_20dBBandwidthFetchSpectrum.");
+  }
+#if defined(_MSC_VER)
+  return RFmxBT_20dBBandwidthFetchSpectrum(instrumentHandle, selectorString, timeout, x0, dx, spectrum, arraySize, actualArraySize);
+#else
+  return function_pointers_.TwentydBBandwidthFetchSpectrum(instrumentHandle, selectorString, timeout, x0, dx, spectrum, arraySize, actualArraySize);
 #endif
 }
 

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_library.h
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_library.h
@@ -143,6 +143,9 @@ class NiRFmxBluetoothLibrary : public nirfmxbluetooth_grpc::NiRFmxBluetoothLibra
   int32 TXPFetchLECTETransmitSlotPowersArray(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64 transmitSlotAveragePowerMean[], float64 transmitSlotPeakAbsolutePowerDeviationMaximum[], int32 arraySize, int32* actualArraySize);
   int32 TXPFetchPowerTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 power[], int32 arraySize, int32* actualArraySize);
   int32 TXPFetchPowers(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* averagePowerMean, float64* averagePowerMaximum, float64* averagePowerMinimum, float64* peakToAveragePowerRatioMaximum);
+  int32 TwentydBBandwidthCfgAveraging(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 averagingEnabled, int32 averagingCount);
+  int32 TwentydBBandwidthFetchMeasurement(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* peakPower, float64* bandwidth, float64* highFrequency, float64* lowFrequency);
+  int32 TwentydBBandwidthFetchSpectrum(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 spectrum[], int32 arraySize, int32* actualArraySize);
   int32 WaitForAcquisitionComplete(niRFmxInstrHandle instrumentHandle, float64 timeout);
   int32 WaitForMeasurementComplete(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout);
 
@@ -272,6 +275,9 @@ class NiRFmxBluetoothLibrary : public nirfmxbluetooth_grpc::NiRFmxBluetoothLibra
   using TXPFetchLECTETransmitSlotPowersArrayPtr = decltype(&RFmxBT_TXPFetchLECTETransmitSlotPowersArray);
   using TXPFetchPowerTracePtr = decltype(&RFmxBT_TXPFetchPowerTrace);
   using TXPFetchPowersPtr = decltype(&RFmxBT_TXPFetchPowers);
+  using TwentydBBandwidthCfgAveragingPtr = decltype(&RFmxBT_20dBBandwidthCfgAveraging);
+  using TwentydBBandwidthFetchMeasurementPtr = decltype(&RFmxBT_20dBBandwidthFetchMeasurement);
+  using TwentydBBandwidthFetchSpectrumPtr = decltype(&RFmxBT_20dBBandwidthFetchSpectrum);
   using WaitForAcquisitionCompletePtr = decltype(&RFmxBT_WaitForAcquisitionComplete);
   using WaitForMeasurementCompletePtr = decltype(&RFmxBT_WaitForMeasurementComplete);
 
@@ -401,6 +407,9 @@ class NiRFmxBluetoothLibrary : public nirfmxbluetooth_grpc::NiRFmxBluetoothLibra
     TXPFetchLECTETransmitSlotPowersArrayPtr TXPFetchLECTETransmitSlotPowersArray;
     TXPFetchPowerTracePtr TXPFetchPowerTrace;
     TXPFetchPowersPtr TXPFetchPowers;
+    TwentydBBandwidthCfgAveragingPtr TwentydBBandwidthCfgAveraging;
+    TwentydBBandwidthFetchMeasurementPtr TwentydBBandwidthFetchMeasurement;
+    TwentydBBandwidthFetchSpectrumPtr TwentydBBandwidthFetchSpectrum;
     WaitForAcquisitionCompletePtr WaitForAcquisitionComplete;
     WaitForMeasurementCompletePtr WaitForMeasurementComplete;
   } FunctionLoadStatus;

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_library_interface.h
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_library_interface.h
@@ -140,6 +140,9 @@ class NiRFmxBluetoothLibraryInterface {
   virtual int32 TXPFetchLECTETransmitSlotPowersArray(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64 transmitSlotAveragePowerMean[], float64 transmitSlotPeakAbsolutePowerDeviationMaximum[], int32 arraySize, int32* actualArraySize) = 0;
   virtual int32 TXPFetchPowerTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 power[], int32 arraySize, int32* actualArraySize) = 0;
   virtual int32 TXPFetchPowers(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* averagePowerMean, float64* averagePowerMaximum, float64* averagePowerMinimum, float64* peakToAveragePowerRatioMaximum) = 0;
+  virtual int32 TwentydBBandwidthCfgAveraging(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 averagingEnabled, int32 averagingCount) = 0;
+  virtual int32 TwentydBBandwidthFetchMeasurement(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* peakPower, float64* bandwidth, float64* highFrequency, float64* lowFrequency) = 0;
+  virtual int32 TwentydBBandwidthFetchSpectrum(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 spectrum[], int32 arraySize, int32* actualArraySize) = 0;
   virtual int32 WaitForAcquisitionComplete(niRFmxInstrHandle instrumentHandle, float64 timeout) = 0;
   virtual int32 WaitForMeasurementComplete(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout) = 0;
 };

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_mock_library.h
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_mock_library.h
@@ -142,6 +142,9 @@ class NiRFmxBluetoothMockLibrary : public nirfmxbluetooth_grpc::NiRFmxBluetoothL
   MOCK_METHOD(int32, TXPFetchLECTETransmitSlotPowersArray, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64 transmitSlotAveragePowerMean[], float64 transmitSlotPeakAbsolutePowerDeviationMaximum[], int32 arraySize, int32* actualArraySize), (override));
   MOCK_METHOD(int32, TXPFetchPowerTrace, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 power[], int32 arraySize, int32* actualArraySize), (override));
   MOCK_METHOD(int32, TXPFetchPowers, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* averagePowerMean, float64* averagePowerMaximum, float64* averagePowerMinimum, float64* peakToAveragePowerRatioMaximum), (override));
+  MOCK_METHOD(int32, TwentydBBandwidthCfgAveraging, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 averagingEnabled, int32 averagingCount), (override));
+  MOCK_METHOD(int32, TwentydBBandwidthFetchMeasurement, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* peakPower, float64* bandwidth, float64* highFrequency, float64* lowFrequency), (override));
+  MOCK_METHOD(int32, TwentydBBandwidthFetchSpectrum, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 spectrum[], int32 arraySize, int32* actualArraySize), (override));
   MOCK_METHOD(int32, WaitForAcquisitionComplete, (niRFmxInstrHandle instrumentHandle, float64 timeout), (override));
   MOCK_METHOD(int32, WaitForMeasurementComplete, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout), (override));
 };

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
@@ -2725,13 +2725,13 @@ namespace nirfmxbluetooth_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
-      float64 df1_avg_maximum {};
-      float64 df1_avg_minimum {};
-      auto status = library_->ModAccFetchDf1(instrument, selector_string, timeout, &df1_avg_maximum, &df1_avg_minimum);
+      float64 df1avg_maximum {};
+      float64 df1avg_minimum {};
+      auto status = library_->ModAccFetchDf1(instrument, selector_string, timeout, &df1avg_maximum, &df1avg_minimum);
       response->set_status(status);
       if (status_ok(status)) {
-        response->set_df1_avg_maximum(df1_avg_maximum);
-        response->set_df1_avg_minimum(df1_avg_minimum);
+        response->set_df1avg_maximum(df1avg_maximum);
+        response->set_df1avg_minimum(df1avg_minimum);
       }
       return ::grpc::Status::OK;
     }
@@ -2795,13 +2795,13 @@ namespace nirfmxbluetooth_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
-      float64 df2_avg_minimum {};
-      float64 percentage_of_symbols_above_df2_max_threshold {};
-      auto status = library_->ModAccFetchDf2(instrument, selector_string, timeout, &df2_avg_minimum, &percentage_of_symbols_above_df2_max_threshold);
+      float64 df2avg_minimum {};
+      float64 percentage_of_symbols_above_df2max_threshold {};
+      auto status = library_->ModAccFetchDf2(instrument, selector_string, timeout, &df2avg_minimum, &percentage_of_symbols_above_df2max_threshold);
       response->set_status(status);
       if (status_ok(status)) {
-        response->set_df2_avg_minimum(df2_avg_minimum);
-        response->set_percentage_of_symbols_above_df2_max_threshold(percentage_of_symbols_above_df2_max_threshold);
+        response->set_df2avg_minimum(df2avg_minimum);
+        response->set_percentage_of_symbols_above_df2max_threshold(percentage_of_symbols_above_df2max_threshold);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
@@ -4076,6 +4076,118 @@ namespace nirfmxbluetooth_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxBluetoothService::TwentydBBandwidthCfgAveraging(::grpc::ServerContext* context, const TwentydBBandwidthCfgAveragingRequest* request, TwentydBBandwidthCfgAveragingResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      char* selector_string = (char*)request->selector_string().c_str();
+      int32 averaging_enabled;
+      switch (request->averaging_enabled_enum_case()) {
+        case nirfmxbluetooth_grpc::TwentydBBandwidthCfgAveragingRequest::AveragingEnabledEnumCase::kAveragingEnabled: {
+          averaging_enabled = static_cast<int32>(request->averaging_enabled());
+          break;
+        }
+        case nirfmxbluetooth_grpc::TwentydBBandwidthCfgAveragingRequest::AveragingEnabledEnumCase::kAveragingEnabledRaw: {
+          averaging_enabled = static_cast<int32>(request->averaging_enabled_raw());
+          break;
+        }
+        case nirfmxbluetooth_grpc::TwentydBBandwidthCfgAveragingRequest::AveragingEnabledEnumCase::AVERAGING_ENABLED_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for averaging_enabled was not specified or out of range");
+          break;
+        }
+      }
+
+      int32 averaging_count = request->averaging_count();
+      auto status = library_->TwentydBBandwidthCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxBluetoothService::TwentydBBandwidthFetchMeasurement(::grpc::ServerContext* context, const TwentydBBandwidthFetchMeasurementRequest* request, TwentydBBandwidthFetchMeasurementResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      char* selector_string = (char*)request->selector_string().c_str();
+      float64 timeout = request->timeout();
+      float64 peak_power {};
+      float64 bandwidth {};
+      float64 high_frequency {};
+      float64 low_frequency {};
+      auto status = library_->TwentydBBandwidthFetchMeasurement(instrument, selector_string, timeout, &peak_power, &bandwidth, &high_frequency, &low_frequency);
+      response->set_status(status);
+      if (status_ok(status)) {
+        response->set_peak_power(peak_power);
+        response->set_bandwidth(bandwidth);
+        response->set_high_frequency(high_frequency);
+        response->set_low_frequency(low_frequency);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxBluetoothService::TwentydBBandwidthFetchSpectrum(::grpc::ServerContext* context, const TwentydBBandwidthFetchSpectrumRequest* request, TwentydBBandwidthFetchSpectrumResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      char* selector_string = (char*)request->selector_string().c_str();
+      float64 timeout = request->timeout();
+      float64 x0 {};
+      float64 dx {};
+      int32 actual_array_size {};
+      while (true) {
+        auto status = library_->TwentydBBandwidthFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        response->mutable_spectrum()->Resize(actual_array_size, 0);
+        float32* spectrum = response->mutable_spectrum()->mutable_data();
+        auto array_size = actual_array_size;
+        status = library_->TwentydBBandwidthFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, spectrum, array_size, &actual_array_size);
+        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
+          // buffer is now too small, try again
+          continue;
+        }
+        response->set_status(status);
+        if (status_ok(status)) {
+          response->set_x0(x0);
+          response->set_dx(dx);
+          response->mutable_spectrum()->Resize(actual_array_size, 0);
+          response->set_actual_array_size(actual_array_size);
+        }
+        return ::grpc::Status::OK;
+      }
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiRFmxBluetoothService::WaitForAcquisitionComplete(::grpc::ServerContext* context, const WaitForAcquisitionCompleteRequest* request, WaitForAcquisitionCompleteResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_service.h
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_service.h
@@ -168,6 +168,9 @@ public:
   ::grpc::Status TXPFetchLECTETransmitSlotPowersArray(::grpc::ServerContext* context, const TXPFetchLECTETransmitSlotPowersArrayRequest* request, TXPFetchLECTETransmitSlotPowersArrayResponse* response) override;
   ::grpc::Status TXPFetchPowerTrace(::grpc::ServerContext* context, const TXPFetchPowerTraceRequest* request, TXPFetchPowerTraceResponse* response) override;
   ::grpc::Status TXPFetchPowers(::grpc::ServerContext* context, const TXPFetchPowersRequest* request, TXPFetchPowersResponse* response) override;
+  ::grpc::Status TwentydBBandwidthCfgAveraging(::grpc::ServerContext* context, const TwentydBBandwidthCfgAveragingRequest* request, TwentydBBandwidthCfgAveragingResponse* response) override;
+  ::grpc::Status TwentydBBandwidthFetchMeasurement(::grpc::ServerContext* context, const TwentydBBandwidthFetchMeasurementRequest* request, TwentydBBandwidthFetchMeasurementResponse* response) override;
+  ::grpc::Status TwentydBBandwidthFetchSpectrum(::grpc::ServerContext* context, const TwentydBBandwidthFetchSpectrumRequest* request, TwentydBBandwidthFetchSpectrumResponse* response) override;
   ::grpc::Status WaitForAcquisitionComplete(::grpc::ServerContext* context, const WaitForAcquisitionCompleteRequest* request, WaitForAcquisitionCompleteResponse* response) override;
   ::grpc::Status WaitForMeasurementComplete(::grpc::ServerContext* context, const WaitForMeasurementCompleteRequest* request, WaitForMeasurementCompleteResponse* response) override;
 private:

--- a/source/codegen/metadata/nirfmxbluetooth/functions.py
+++ b/source/codegen/metadata/nirfmxbluetooth/functions.py
@@ -4056,6 +4056,128 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'TwentydBBandwidthCfgAveraging': {
+        'cname': 'RFmxBT_20dBBandwidthCfgAveraging',
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'enum': 'TwentydBBandwidthAveragingEnabled',
+                'name': 'averagingEnabled',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'name': 'averagingCount',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'TwentydBBandwidthFetchMeasurement': {
+        'cname': 'RFmxBT_20dBBandwidthFetchMeasurement',
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'timeout',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'peakPower',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'bandwidth',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'highFrequency',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'lowFrequency',
+                'type': 'float64'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'TwentydBBandwidthFetchSpectrum': {
+        'cname': 'RFmxBT_20dBBandwidthFetchSpectrum',
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'timeout',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'x0',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'dx',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'spectrum',
+                'size': {
+                    'mechanism': 'ivi-dance-with-a-twist',
+                    'value': 'arraySize',
+                    'value_twist': 'actualArraySize'
+                },
+                'type': 'float32[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'arraySize',
+                'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'name': 'actualArraySize',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
     'WaitForAcquisitionComplete': {
         'parameters': [
             {

--- a/source/codegen/metadata/nirfmxbluetooth/functions.py
+++ b/source/codegen/metadata/nirfmxbluetooth/functions.py
@@ -2545,13 +2545,11 @@ functions = {
             },
             {
                 'direction': 'out',
-                'grpc_name': 'df1_avg_maximum',
                 'name': 'df1avgMaximum',
                 'type': 'float64'
             },
             {
                 'direction': 'out',
-                'grpc_name': 'df1_avg_minimum',
                 'name': 'df1avgMinimum',
                 'type': 'float64'
             }
@@ -2629,13 +2627,11 @@ functions = {
             },
             {
                 'direction': 'out',
-                'grpc_name': 'df2_avg_minimum',
                 'name': 'df2avgMinimum',
                 'type': 'float64'
             },
             {
                 'direction': 'out',
-                'grpc_name': 'percentage_of_symbols_above_df2_max_threshold',
                 'name': 'percentageOfSymbolsAboveDf2maxThreshold',
                 'type': 'float64'
             }


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add `TwentydB` methods to `NiRFmxBluetooth` service.
* These methods were originally excluded because they begin with a numeral (`20dB`) in the C API. `20` has been replace with `Twenty`.

### Why should this Pull Request be merged?

Complete `NiRFmxBluetooth` API.

Fixes [AB#1811501](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1811501).

Fixes [AB#1843746](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1843746).

### What testing has been done?

Ran and passed all Bluetooth tests.