### PR TITLE
Update raise_if_error to use the correct package when calling getErrorRequest

### DIFF
--- a/examples/nirfmxnr/acp-single-carrier.py
+++ b/examples/nirfmxnr/acp-single-carrier.py
@@ -69,7 +69,7 @@ instr = None
 def raise_if_error(response):
     if response.status != 0:
         error_response = client.GetError(
-            nirfmxwlan_types.GetErrorRequest(
+            nirfmxnr_types.GetErrorRequest(
                 instrument=instr,
             )
         )

--- a/examples/nirfmxnr/txp-single-carrier.py
+++ b/examples/nirfmxnr/txp-single-carrier.py
@@ -65,7 +65,7 @@ instr = None
 def raise_if_error(response):
     if response.status != 0:
         error_response = client.GetError(
-            nirfmxwlan_types.GetErrorRequest(
+            nirfmxnr_types.GetErrorRequest(
                 instrument=instr,
             )
         )

--- a/examples/nirfmxspecan/acp-basic.py
+++ b/examples/nirfmxspecan/acp-basic.py
@@ -63,7 +63,7 @@ instr = None
 def raise_if_error(response):
     if response.status != 0:
         error_response = client.GetError(
-            nirfmxwlan_types.GetErrorRequest(
+            nirfmxspecan_types.GetErrorRequest(
                 instrument=instr,
             )
         )

--- a/examples/nirfmxspecan/spectrum-basic.py
+++ b/examples/nirfmxspecan/spectrum-basic.py
@@ -71,7 +71,7 @@ def format_frequency(f):
 def raise_if_error(response):
     if response.status != 0:
         error_response = client.GetError(
-            nirfmxwlan_types.GetErrorRequest(
+            nirfmxspecan_types.GetErrorRequest(
                 instrument=instr,
             )
         )

--- a/examples/nirfmxspecan/txp-basic.py
+++ b/examples/nirfmxspecan/txp-basic.py
@@ -62,7 +62,7 @@ instr = None
 def raise_if_error(response):
     if response.status != 0:
         error_response = client.GetError(
-            nirfmxwlan_types.GetErrorRequest(
+            nirfmxspecan_types.GetErrorRequest(
                 instrument=instr,
             )
         )


### PR DESCRIPTION
### What does this Pull Request accomplish?

Copy paste error where we were using the wlan type in specan and nr

### Why should this Pull Request be merged?

Throwing error method throws its own error
 -> Running example with simulated hardware: acp-single-carrier.py
Reference level (dBm)        : 22.5
Traceback (most recent call last):
  File "build\validate_examples\examples\nirfmxnr\acp-single-carrier.py", line 270, in <module>
    acp_fetch_offset_measurement_array_response = raise_if_error(
  File "build\validate_examples\examples\nirfmxnr\acp-single-carrier.py", line 72, in raise_if_error
    nirfmxwlan_types.GetErrorRequest(
NameError: name 'nirfmxwlan_types' is not defined
 -> Running example with real hardware: txp-single-carrier.py

### What testing has been done?

Now correctly throws error
