### PR TITLE
Enable black for metadata_*.py files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 100
-exclude = "source/codegen/metadata"
+exclude = "source/codegen/metadata/"

--- a/source/codegen/metadata_mutation.py
+++ b/source/codegen/metadata_mutation.py
@@ -3,52 +3,118 @@ from typing import Optional
 import common_helpers
 
 RESERVED_WORDS = [
-    'abstract', 'as',
-    'base', 'bool', 'break','byte',
-    'case', 'catch', 'char', 'checked', 'class', 'const', 'continue',
-    'decimal', 'default', 'delegate', 'do', 'double',
-    'else', 'enum', 'event', 'explicit', 'extern',
-    'false', 'finally', 'fixed', 'float', 'for', 'foreach',
-    'goto',
-    'if', 'implicit', 'in', 'int', 'interface', 'internal', 'is',
-    'lock', 'long',
-    'namespace', 'new', 'null',
-    'object', 'operator', 'out', 'override',
-    'params', 'private', 'protected', 'public',
-    'readonly', 'ref', 'return',
-    'sbyte', 'sealed', 'short', 'sizeof', 'stackalloc', 'static', 'string', 'struct', 'switch',
-    'this', 'throw', 'true', 'try', 'typeof',
-    'uint', 'ulong', 'unchecked', 'unsafe', 'ushort', 'using',
-    'virtual', 'void', 'volatile',
-    'while'
+    "abstract",
+    "as",
+    "base",
+    "bool",
+    "break",
+    "byte",
+    "case",
+    "catch",
+    "char",
+    "checked",
+    "class",
+    "const",
+    "continue",
+    "decimal",
+    "default",
+    "delegate",
+    "do",
+    "double",
+    "else",
+    "enum",
+    "event",
+    "explicit",
+    "extern",
+    "false",
+    "finally",
+    "fixed",
+    "float",
+    "for",
+    "foreach",
+    "goto",
+    "if",
+    "implicit",
+    "in",
+    "int",
+    "interface",
+    "internal",
+    "is",
+    "lock",
+    "long",
+    "namespace",
+    "new",
+    "null",
+    "object",
+    "operator",
+    "out",
+    "override",
+    "params",
+    "private",
+    "protected",
+    "public",
+    "readonly",
+    "ref",
+    "return",
+    "sbyte",
+    "sealed",
+    "short",
+    "sizeof",
+    "stackalloc",
+    "static",
+    "string",
+    "struct",
+    "switch",
+    "this",
+    "throw",
+    "true",
+    "try",
+    "typeof",
+    "uint",
+    "ulong",
+    "unchecked",
+    "unsafe",
+    "ushort",
+    "using",
+    "virtual",
+    "void",
+    "volatile",
+    "while",
 ]
+
 
 def sanitize_names(parameters):
     """Sanitizes name fields on a list of parameter objects and populates the cppname field with the sanitized value."""
     for parameter in parameters:
-        if 'callback_params' in parameter:
-            sanitize_names(parameter['callback_params'])
-        parameter['cppName'] = parameter['name']
-        if parameter['cppName'] in RESERVED_WORDS:
-            parameter['cppName'] += 'Parameter'
+        if "callback_params" in parameter:
+            sanitize_names(parameter["callback_params"])
+        parameter["cppName"] = parameter["name"]
+        if parameter["cppName"] in RESERVED_WORDS:
+            parameter["cppName"] += "Parameter"
 
 
 def set_var_args_types(parameters, config):
     """Sets information about varargs parameters in the metadata."""
     for parameter in parameters:
         if common_helpers.is_repeated_varargs_parameter(parameter):
-            parameter['type'] = '...'
+            parameter["type"] = "..."
 
 
 def mark_size_params(parameters):
     """Marks the size parameters in the metadata."""
     for param in parameters:
         mechanism = common_helpers.get_size_mechanism(param)
-        if mechanism in {'len', 'ivi-dance', 'passed-in', 'passed-in-by-ptr', 'ivi-dance-with-a-twist'}:
+        if mechanism in {
+            "len",
+            "ivi-dance",
+            "passed-in",
+            "passed-in-by-ptr",
+            "ivi-dance-with-a-twist",
+        }:
             size_param = get_size_param(param, parameters)
-            size_param['is_size_param'] = True
-            if mechanism == 'passed-in-by-ptr':
-                size_param['pointer'] = True
+            size_param["is_size_param"] = True
+            if mechanism == "passed-in-by-ptr":
+                size_param["pointer"] = True
 
 
 # These are all of the coerced narrow numerics used in RFmx and DAQmx.
@@ -56,6 +122,7 @@ def mark_size_params(parameters):
 # Note that params can also be marked coerced instead of updating this list.
 # uint8 is not included because it can be represented as a byte.
 KNOWN_COERCED_NARROW_NUMERIC_TYPES = ["int16", "uInt16", "int8"]
+
 
 def mark_coerced_narrow_numeric_parameters(parameters: dict) -> None:
     for param in parameters:
@@ -66,54 +133,58 @@ def mark_coerced_narrow_numeric_parameters(parameters: dict) -> None:
 
 def mark_non_proto_params(parameters):
     """Mark the parameters that shouldn't be included in the proto request message.
-       Their values should be derived from other sources in the service handlers."""
+    Their values should be derived from other sources in the service handlers."""
     for param in parameters:
         mechanism = common_helpers.get_size_mechanism(param)
-        if mechanism in {'len', 'ivi-dance', 'ivi-dance-with-a-twist'}:
+        if mechanism in {"len", "ivi-dance", "ivi-dance-with-a-twist"}:
             size_param = get_size_param(param, parameters)
-            if size_param['direction'] == 'in':
+            if size_param["direction"] == "in":
                 # Output size_params can still be included in the proto
                 # as information.
-                size_param['include_in_proto'] = False
-            if mechanism == 'len':
-                if 'determine_size_from' not in size_param:
-                    size_param['determine_size_from'] = []
-                size_param['determine_size_from'].append(param['name'])
+                size_param["include_in_proto"] = False
+            if mechanism == "len":
+                if "determine_size_from" not in size_param:
+                    size_param["determine_size_from"] = []
+                size_param["determine_size_from"].append(param["name"])
                 is_optional = common_helpers.is_optional(param)
-                if is_optional != size_param.get('linked_params_are_optional', is_optional):
-                    raise Exception("Code generator does not support linked params that are a mix of optional and required", size_param)
-                size_param['linked_params_are_optional'] = is_optional
+                if is_optional != size_param.get("linked_params_are_optional", is_optional):
+                    raise Exception(
+                        "Code generator does not support linked params that are a mix of optional and required",
+                        size_param,
+                    )
+                size_param["linked_params_are_optional"] = is_optional
+
 
 def get_size_param(param, parameters):
-    named_params = { p['name'] : p for p in parameters }
-    return named_params.get(param['size']['value'], None)
+    named_params = {p["name"]: p for p in parameters}
+    return named_params.get(param["size"]["value"], None)
+
 
 def mark_mapped_enum_params(parameters, enums):
-    for param in (p for p in parameters if 'enum' in p):
-        enum_name = param['enum']
+    for param in (p for p in parameters if "enum" in p):
+        enum_name = param["enum"]
         enum = enums[enum_name]
-        if 'generate-mappings' in enum:
-            del param['enum']
-            param['mapped-enum'] = enum_name
+        if "generate-mappings" in enum:
+            del param["enum"]
+            param["mapped-enum"] = enum_name
 
 
 def populate_grpc_types(parameters, config):
-  for parameter in parameters:
-    if 'callback_params' in parameter:
-        populate_grpc_types(
-            parameter['callback_params'], config)
-    if 'grpc_type' in parameter:
-        continue
-    parameter['grpc_type'] = common_helpers.get_grpc_type(
-        parameter['type'],
-        config)
+    for parameter in parameters:
+        if "callback_params" in parameter:
+            populate_grpc_types(parameter["callback_params"], config)
+        if "grpc_type" in parameter:
+            continue
+        parameter["grpc_type"] = common_helpers.get_grpc_type(parameter["type"], config)
 
 
 def get_short_enum_type_name(typename: str) -> str:
     if typename in ["char[]", "const char[]", "char"]:
         return "String"
     stripped_name = common_helpers.strip_prefix(typename, "Vi")
-    return common_helpers.ensure_pascal_case(stripped_name,)
+    return common_helpers.ensure_pascal_case(
+        stripped_name,
+    )
 
 
 def remove_leading_group_name(enum_value_name, group_name):
@@ -121,7 +192,9 @@ def remove_leading_group_name(enum_value_name, group_name):
 
 
 def add_leading_enum_name(enum_value_name, enum_name, enum):
-    enum_value_prefix = enum.get("enum-value-prefix", common_helpers.pascal_to_snake(enum_name).upper())
+    enum_value_prefix = enum.get(
+        "enum-value-prefix", common_helpers.pascal_to_snake(enum_name).upper()
+    )
     return f"{enum_value_prefix}_{enum_value_name}"
 
 
@@ -151,7 +224,10 @@ def add_attribute_values_enums(enums, attribute_enums_by_type, group_name):
         add_enum(mapped_enum_name, mapped_values, enums, enum_value_prefix, is_mapped=True)
 
 
-AttributeReferencingParameter = namedtuple("AttributeReferencingParameter", ["attribute_group", "parameter"])
+AttributeReferencingParameter = namedtuple(
+    "AttributeReferencingParameter", ["attribute_group", "parameter"]
+)
+
 
 class AttributeAccessorExpander:
     """
@@ -162,24 +238,22 @@ class AttributeAccessorExpander:
     and implements the metadata_mutations to add_attribute_values_enums, expand_attribute_function_value_param,
     and patch_attribute_enum_type.
     """
+
     def __init__(self, metadata):
-        self._config = metadata['config']
-        self._enums = metadata['enums']
+        self._config = metadata["config"]
+        self._enums = metadata["enums"]
         self._attribute_type_map = {}
 
         for group in common_helpers.get_attribute_groups(metadata):
-            attribute_enums_by_type = common_helpers.get_attribute_enums_by_type(
-                group.attributes)
-            add_attribute_values_enums(
-                self._enums,
-                attribute_enums_by_type,
-                group.name)
+            attribute_enums_by_type = common_helpers.get_attribute_enums_by_type(group.attributes)
+            add_attribute_values_enums(self._enums, attribute_enums_by_type, group.name)
             self._attribute_type_map[group.name] = attribute_enums_by_type
 
-
-    def get_attribute_reference_parameter(self, parameters) -> Optional[AttributeReferencingParameter]:
+    def get_attribute_reference_parameter(
+        self, parameters
+    ) -> Optional[AttributeReferencingParameter]:
         def try_resolve_attribute_reference(parameter) -> Optional[AttributeReferencingParameter]:
-            param_type = parameter['grpc_type']
+            param_type = parameter["grpc_type"]
             # All attribute parameters must have a grpc_type of {group_name}Attributes.
             # In MI, this is added during metadata mutation of ViAttr types.
             attr_suffix = common_helpers.get_attribute_enum_suffix(self._config)
@@ -193,7 +267,6 @@ class AttributeAccessorExpander:
         valid_references = (ref for ref in attribute_resolve_results if ref)
         return next(valid_references, None)
 
-
     def patch_attribute_enum_type(self, function_name, func):
         """
         If a driver splits attribute enums by type,
@@ -202,31 +275,28 @@ class AttributeAccessorExpander:
         """
         if not common_helpers.get_split_attributes_by_type(self._config):
             return
-        parameters = func['parameters']
+        parameters = func["parameters"]
         attribute_reference = self.get_attribute_reference_parameter(parameters)
         if attribute_reference:
             group = attribute_reference.attribute_group
             attribute_param = attribute_reference.parameter
-            if function_name.startswith('Reset'):
-                sub_group = 'Reset'
+            if function_name.startswith("Reset"):
+                sub_group = "Reset"
             else:
                 value_param = get_attribute_function_value_param(func)
                 sub_group = common_helpers.get_grpc_type_name_for_identifier(
-                    value_param['type'],
-                    self._config)
+                    value_param["type"], self._config
+                )
             if common_helpers.supports_raw_attributes(self._config):
-                attribute_param['enum'] = common_helpers.get_attribute_enum_name(
-                    group,
-                    sub_group,
-                    self._config)
-                attribute_param['grpc_type'] = 'int32'
-                attribute_param['raw_attribute'] = True
+                attribute_param["enum"] = common_helpers.get_attribute_enum_name(
+                    group, sub_group, self._config
+                )
+                attribute_param["grpc_type"] = "int32"
+                attribute_param["raw_attribute"] = True
             else:
-                attribute_param['grpc_type'] = common_helpers.get_attribute_enum_name(
-                    group,
-                    sub_group,
-                    self._config)
-
+                attribute_param["grpc_type"] = common_helpers.get_attribute_enum_name(
+                    group, sub_group, self._config
+                )
 
     def expand_attribute_value_params(self, func):
         parameters = func["parameters"]
@@ -236,17 +306,20 @@ class AttributeAccessorExpander:
                 func,
                 self._enums,
                 self._attribute_type_map[attribute_reference.attribute_group],
-                attribute_reference.attribute_group)
+                attribute_reference.attribute_group,
+            )
 
 
-def expand_attribute_function_value_param(function, enums, attribute_enums_by_type, service_class_prefix):
+def expand_attribute_function_value_param(
+    function, enums, attribute_enums_by_type, service_class_prefix
+):
     """For SetAttribute and CheckAttribute APIs, update function metadata to mark value parameter as enum."""
     value_param = get_attribute_function_value_param(function)
     if not value_param:
         return
-    if value_param['direction'] == 'out':
+    if value_param["direction"] == "out":
         if common_helpers.is_static_castable_enum_type(value_param):
-            value_param['use_checked_enum_conversion'] = True
+            value_param["use_checked_enum_conversion"] = True
         else:
             return
 
@@ -256,34 +329,46 @@ def expand_attribute_function_value_param(function, enums, attribute_enums_by_ty
         param_type = common_helpers.get_underlying_type(value_param)
     if param_type in attribute_enums_by_type:
         enum_name = get_attribute_values_enum_name(service_class_prefix, param_type)
-        mapped_enum_name = get_attribute_values_enum_name(service_class_prefix, param_type, is_mapped=True)
+        mapped_enum_name = get_attribute_values_enum_name(
+            service_class_prefix, param_type, is_mapped=True
+        )
         enum_exists = enum_name in enums
         mapped_enum_exists = mapped_enum_name in enums
         if enum_exists:
-            value_param['enum'] = enum_name
+            value_param["enum"] = enum_name
         if mapped_enum_exists:
-            value_param['mapped-enum'] = mapped_enum_name
+            value_param["mapped-enum"] = mapped_enum_name
         if not enum_exists and not mapped_enum_exists:
             # Ideally there must be an enum associated with this parameter for SetAttribute* API.
             # Since the enum is empty, users will be passing in raw values. Make it clear via naming.
-            value_param['name'] = value_param['name'] + "_raw"
+            value_param["name"] = value_param["name"] + "_raw"
+
 
 def get_attribute_function_value_param(function):
-    return next((param for param in function["parameters"] if param["name"] in {"value", "attributeValue", "attrVal"}), None)
+    return next(
+        (
+            param
+            for param in function["parameters"]
+            if param["name"] in {"value", "attributeValue", "attrVal"}
+        ),
+        None,
+    )
+
 
 def get_attribute_values_enum_name(group_name, type, is_mapped=False):
     enum_name_suffix = "Mapped" if is_mapped else ""
     shortened_type_name = get_short_enum_type_name(type)
     return group_name + shortened_type_name + "AttributeValues" + enum_name_suffix
 
+
 def add_enum(enum_name, enum_values, enums, enum_value_prefix, is_mapped=False):
     if not enum_values:
         return
     values = [{"name": name, "value": enum_values[name]} for name in enum_values]
     new_enum = {
-        'enum-value-prefix': enum_value_prefix,
-        'generate-mappings': is_mapped,
-        'values': values
+        "enum-value-prefix": enum_value_prefix,
+        "generate-mappings": is_mapped,
+        "values": values,
     }
     enums.update({enum_name: new_enum})
 

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -18,20 +18,18 @@ class RULES:
 
 def validate_metadata(metadata: dict):
     try:
-        for function_name in metadata['functions']:
+        for function_name in metadata["functions"]:
             validate_function(function_name, metadata)
         for attribute_group in common_helpers.get_attribute_groups(metadata):
             for attribute_id in attribute_group.attributes:
-                validate_attribute(
-                    attribute_group.attributes[attribute_id], metadata)
-        function_enums = get_function_enums(metadata['functions'])
+                validate_attribute(attribute_group.attributes[attribute_id], metadata)
+        function_enums = get_function_enums(metadata["functions"])
         attribute_enums = get_attribute_enums(metadata)
         used_enums = function_enums.union(attribute_enums)
-        for enum_name in metadata['enums']:
+        for enum_name in metadata["enums"]:
             validate_enum(enum_name, used_enums, metadata)
     except Exception as e:
-        raise Exception(
-            f"Failed to validate {metadata['config']['namespace_component']}") from e
+        raise Exception(f"Failed to validate {metadata['config']['namespace_component']}") from e
 
 
 DOCUMENTATION_SCHEMA = Schema(
@@ -45,70 +43,72 @@ DOCUMENTATION_SCHEMA = Schema(
 
 SIZE_SCHEMA = Schema(
     {
-        'mechanism': And(str, lambda s: not common_helpers.is_unsupported_size_mechanism_type(s)),
-        'value': Or(str, int),
-        Optional('value_twist'): str,
-        Optional('tags'): [str],
+        "mechanism": And(str, lambda s: not common_helpers.is_unsupported_size_mechanism_type(s)),
+        "value": Or(str, int),
+        Optional("value_twist"): str,
+        Optional("tags"): [str],
     },
 )
 
 PARAM_SCHEMA = Schema(
     {
-        'direction': And(str, lambda s: s in ('in', 'out')),
-        'name': str,
-        Optional('type'): str,
-        Optional('grpc_type'): str,
-        Optional('documentation'): DOCUMENTATION_SCHEMA,
-        Optional('bitfield_as_enum_array'): str,
-        Optional('enum'): str,
-        Optional('size'): SIZE_SCHEMA,
-        Optional('default_value'): Or(str, bool, int, float, None),
-        Optional('is_repeated_capability'): bool,
-        Optional('repeated_capability_type'): str,
-        Optional('use_array'): bool,
-        Optional('numpy'): bool,
+        "direction": And(str, lambda s: s in ("in", "out")),
+        "name": str,
+        Optional("type"): str,
+        Optional("grpc_type"): str,
+        Optional("documentation"): DOCUMENTATION_SCHEMA,
+        Optional("bitfield_as_enum_array"): str,
+        Optional("enum"): str,
+        Optional("size"): SIZE_SCHEMA,
+        Optional("default_value"): Or(str, bool, int, float, None),
+        Optional("is_repeated_capability"): bool,
+        Optional("repeated_capability_type"): str,
+        Optional("use_array"): bool,
+        Optional("numpy"): bool,
         # integer in string form, make sure int(x) doesn't raise
-        Optional('grpc_field_number'): And(str, Use(int)),
+        Optional("grpc_field_number"): And(str, Use(int)),
         # integer in string form, make sure int(x) doesn't raise
-        Optional('grpc_raw_field_number'): And(str, Use(int)),
-        Optional('type_in_documentation'): str,
-        Optional('include_in_proto'): bool,
-        Optional('is_session_handle'): bool,
-        Optional('is_session_name'): bool,
-        Optional('repeating_argument'): bool,
-        Optional('python_api_converter_name'): str,
-        Optional('attribute'): str,
-        Optional('hardcoded_value'): str,
-        Optional('is_compound_type'): bool,
-        Optional('max_length'): int,
-        Optional('repeated_var_args'): bool,
-        Optional('pointer'): bool,
-        Optional('coerced'): bool,
-        Optional('callback_params'): [dict],
-        Optional('callback_token'): bool,
-        Optional('use_in_python_api'): bool,
-        Optional('cross_driver_session'): str,
-        Optional('grpc_name'): str,
+        Optional("grpc_raw_field_number"): And(str, Use(int)),
+        Optional("type_in_documentation"): str,
+        Optional("include_in_proto"): bool,
+        Optional("is_session_handle"): bool,
+        Optional("is_session_name"): bool,
+        Optional("repeating_argument"): bool,
+        Optional("python_api_converter_name"): str,
+        Optional("attribute"): str,
+        Optional("hardcoded_value"): str,
+        Optional("is_compound_type"): bool,
+        Optional("max_length"): int,
+        Optional("repeated_var_args"): bool,
+        Optional("pointer"): bool,
+        Optional("coerced"): bool,
+        Optional("callback_params"): [dict],
+        Optional("callback_token"): bool,
+        Optional("use_in_python_api"): bool,
+        Optional("cross_driver_session"): str,
+        Optional("grpc_name"): str,
     }
 )
 
 
 FUNCTION_SCHEMA = Schema(
     {
-        'parameters': [PARAM_SCHEMA],
-        'returns': str,
-        Optional('cname'): str,
-        Optional('codegen_method'): And(str, lambda s: s in ('public', 'private', 'CustomCode', 'no', 'python-only')),
-        Optional('init_method'): bool,
-        Optional('stream_response'): bool,
-        Optional('is_error_handling'): bool,
-        Optional('render_in_session_base'): bool,
-        Optional('method_name_for_documentation'): str,
-        Optional('use_session_lock'): bool,
-        Optional('documentation'): DOCUMENTATION_SCHEMA,
-        Optional('method_templates'): list,
-        Optional('custom_close'): str,
-        Optional('custom_close_method'): bool,
+        "parameters": [PARAM_SCHEMA],
+        "returns": str,
+        Optional("cname"): str,
+        Optional("codegen_method"): And(
+            str, lambda s: s in ("public", "private", "CustomCode", "no", "python-only")
+        ),
+        Optional("init_method"): bool,
+        Optional("stream_response"): bool,
+        Optional("is_error_handling"): bool,
+        Optional("render_in_session_base"): bool,
+        Optional("method_name_for_documentation"): str,
+        Optional("use_session_lock"): bool,
+        Optional("documentation"): DOCUMENTATION_SCHEMA,
+        Optional("method_templates"): list,
+        Optional("custom_close"): str,
+        Optional("custom_close_method"): bool,
         Optional("python_name"): str,
     }
 )
@@ -117,7 +117,9 @@ FUNCTION_SCHEMA = Schema(
 ATTRIBUTE_SCHEMA = Schema(
     {
         "name": str,
-        Optional("access"): And(str, lambda s: s in ['read', 'read only', 'write', 'write only', 'read-write']),
+        Optional("access"): And(
+            str, lambda s: s in ["read", "read only", "write", "write only", "read-write"]
+        ),
         "type": str,
         Optional("resettable"): bool,
         Optional("enum"): str,
@@ -133,20 +135,18 @@ ATTRIBUTE_SCHEMA = Schema(
     }
 )
 
-SIMPLE_ATTRIBUTE_SCHEMA = Schema(
-    {
-        "name": str
-    }
-)
+SIMPLE_ATTRIBUTE_SCHEMA = Schema({"name": str})
 
 ENUM_SCHEMA = Schema(
     {
-        "values": [{
-            "name": str,
-            "value": Or(str, int, float),
-            Optional("python_name"): str,
-            Optional("documentation"): DOCUMENTATION_SCHEMA,
-        }],
+        "values": [
+            {
+                "name": str,
+                "value": Or(str, int, float),
+                Optional("python_name"): str,
+                Optional("documentation"): DOCUMENTATION_SCHEMA,
+            }
+        ],
         Optional("generate-mappings"): bool,
         Optional("enum-value-prefix"): str,
     }
@@ -165,170 +165,210 @@ def rule_is_suppressed(metadata: dict, rule: str, path: List[str]) -> bool:
 
 
 def parameter_name_exists(function: dict, name: str) -> bool:
-    return any([param for param in function['parameters'] if param['name'] == name])
+    return any([param for param in function["parameters"] if param["name"] == name])
 
 
 def validate_function(function_name: str, metadata: dict):
     try:
-        function: Dict[str, Any] = metadata['functions'][function_name]
+        function: Dict[str, Any] = metadata["functions"][function_name]
         ivi_dance_with_a_twist_params = []
         ivi_dance_with_a_twist_sizes = set()
         ivi_dance_with_a_twist_twists = set()
-        if function.get('codegen_method', 'public') != 'no':
+        if function.get("codegen_method", "public") != "no":
             FUNCTION_SCHEMA.validate(function)
-            if 'documentation' in function:
-                DOCUMENTATION_SCHEMA.validate(function['documentation'])
-            duplicate_resource_handles_allowed = metadata['config'].get('duplicate_resource_handles_allowed', False)
-            is_init_method = function.get('init_method', False)
-            for parameter in function['parameters']:
+            if "documentation" in function:
+                DOCUMENTATION_SCHEMA.validate(function["documentation"])
+            duplicate_resource_handles_allowed = metadata["config"].get(
+                "duplicate_resource_handles_allowed", False
+            )
+            is_init_method = function.get("init_method", False)
+            for parameter in function["parameters"]:
                 validate_parameter_size(parameter, function_name, metadata)
-                if 'type' not in parameter:
-                    if 'grpc_type' not in parameter:
+                if "type" not in parameter:
+                    if "grpc_type" not in parameter:
+                        raise Exception(f"parameter {parameter['name']} has no type or grpc_type!")
+                    if not parameter.get("repeated_var_args", False):
                         raise Exception(
-                            f"parameter {parameter['name']} has no type or grpc_type!")
-                    if not parameter.get('repeated_var_args', False):
+                            f"parameter {parameter['name']} has no type and repeated_var_args is not set!"
+                        )
+                if "enum" in parameter:
+                    if parameter["enum"] not in metadata["enums"]:
                         raise Exception(
-                            f"parameter {parameter['name']} has no type and repeated_var_args is not set!")
-                if 'enum' in parameter:
-                    if parameter['enum'] not in metadata['enums']:
+                            f"parameter {parameter['name']} has enum {parameter['enum']} that was not found!"
+                        )
+                if "max_length" in parameter:
+                    if "repeated_var_args" not in parameter:
                         raise Exception(
-                            f"parameter {parameter['name']} has enum {parameter['enum']} that was not found!")
-                if 'max_length' in parameter:
-                    if 'repeated_var_args' not in parameter:
-                        raise Exception(
-                            f"parameter {parameter['name']} has max_length but no repeated_var_args!")
-                if 'callback_params' in parameter:
-                    for callback_param in parameter['callback_params']:
+                            f"parameter {parameter['name']} has max_length but no repeated_var_args!"
+                        )
+                if "callback_params" in parameter:
+                    for callback_param in parameter["callback_params"]:
                         try:
                             PARAM_SCHEMA.validate(callback_param)
                         except Exception as e:
                             raise Exception(
-                                f"Failed to validate callback_param with name {callback_param['name']}")
-                if parameter.get('pointer', False):
+                                f"Failed to validate callback_param with name {callback_param['name']}"
+                            )
+                if parameter.get("pointer", False):
                     # This is technically legal in other cdses but we should only need it for hardcoded values/callback tokens
-                    if 'hardcoded_value' not in parameter and 'callback_token' not in parameter:
+                    if "hardcoded_value" not in parameter and "callback_token" not in parameter:
                         raise Exception(
-                            f"parameter {parameter['name']} is pointer but not hardcoded_value or callback_token!")
-                    if parameter.get('include_in_proto', True):
+                            f"parameter {parameter['name']} is pointer but not hardcoded_value or callback_token!"
+                        )
+                    if parameter.get("include_in_proto", True):
                         raise Exception(
-                            f"parameter {parameter['name']} is pointer but is include_in_proto!")
-                if 'hardcoded_value' in parameter:
-                    if parameter.get('include_in_proto', True):
+                            f"parameter {parameter['name']} is pointer but is include_in_proto!"
+                        )
+                if "hardcoded_value" in parameter:
+                    if parameter.get("include_in_proto", True):
                         raise Exception(
-                            f"parameter {parameter['name']} has hardcoded_value but is include_in_proto!")
-                if 'cross_driver_session' in parameter:
+                            f"parameter {parameter['name']} has hardcoded_value but is include_in_proto!"
+                        )
+                if "cross_driver_session" in parameter:
                     # Assumption: there's no code that automatically sets the grpc_type for cross_driver_sessions and nidevice_grpc.Session
                     # is the only type that works.
-                    if parameter.get('grpc_type', None) not in ['nidevice_grpc.Session', 'repeated nidevice_grpc.Session']:
-                        raise  Exception(
-                           f"parameter {parameter['name']} is a cross_driver_session but does not have a grpc_type of nidevice_grpc.Session!")
+                    if parameter.get("grpc_type", None) not in [
+                        "nidevice_grpc.Session",
+                        "repeated nidevice_grpc.Session",
+                    ]:
+                        raise Exception(
+                            f"parameter {parameter['name']} is a cross_driver_session but does not have a grpc_type of nidevice_grpc.Session!"
+                        )
                     # Assumption: a method that creates a session (via accessing a cross-driver session) must be an init_method to ensure
                     # that the session is tracked in the session repository.
-                    if parameter['direction'] == 'out' and not function.get('init_method'):
-                        raise  Exception(
-                           f"parameter {parameter['name']} is a cross_driver_session output but {function_name} is not an init_method!")
-                if parameter.get('size', {}).get('mechanism', None) == 'ivi-dance-with-a-twist':
-                    size = parameter['size']
-                    ivi_dance_with_a_twist_params.append(parameter['name'])
-                    ivi_dance_with_a_twist_sizes.add(size['value'])
-                    ivi_dance_with_a_twist_twists.add(size['value_twist'])
+                    if parameter["direction"] == "out" and not function.get("init_method"):
+                        raise Exception(
+                            f"parameter {parameter['name']} is a cross_driver_session output but {function_name} is not an init_method!"
+                        )
+                if parameter.get("size", {}).get("mechanism", None) == "ivi-dance-with-a-twist":
+                    size = parameter["size"]
+                    ivi_dance_with_a_twist_params.append(parameter["name"])
+                    ivi_dance_with_a_twist_sizes.add(size["value"])
+                    ivi_dance_with_a_twist_twists.add(size["value_twist"])
                 if duplicate_resource_handles_allowed:
                     if not is_init_method:
-                        if parameter['direction'] == 'out' and parameter['type'] == service_helpers.get_resource_handle_type(metadata['config']):
-                            raise  Exception(
-                               f"{metadata['config']['namespace_component']} allows duplicate resource handles in the session repository. Therefore, the handle we'd get for \"{parameter['name']}\" can't be mapped back to a Session to provide to the client!")
+                        if parameter["direction"] == "out" and parameter[
+                            "type"
+                        ] == service_helpers.get_resource_handle_type(metadata["config"]):
+                            raise Exception(
+                                f"{metadata['config']['namespace_component']} allows duplicate resource handles in the session repository. Therefore, the handle we'd get for \"{parameter['name']}\" can't be mapped back to a Session to provide to the client!"
+                            )
     except Exception as e:
         raise Exception(f"Failed to validate function {function_name}") from e
 
 
 def validate_attribute(attribute: dict, metadata: dict):
     try:
-        if metadata['config']['module_name'] == 'nisync':
+        if metadata["config"]["module_name"] == "nisync":
             # The attributes for nisync only have a name
             SIMPLE_ATTRIBUTE_SCHEMA.validate(attribute)
         else:
             ATTRIBUTE_SCHEMA.validate(attribute)
-        if 'enum' in attribute:
-            if attribute['enum'] not in metadata['enums']:
+        if "enum" in attribute:
+            if attribute["enum"] not in metadata["enums"]:
                 raise Exception(
-                    f"attribute {attribute['name']} has enum {attribute['enum']} that was not found!")
+                    f"attribute {attribute['name']} has enum {attribute['enum']} that was not found!"
+                )
 
     except Exception as e:
         raise Exception(
-            f"Failed to validate attribute with name {attribute.get('name', '(none)')}") from e
+            f"Failed to validate attribute with name {attribute.get('name', '(none)')}"
+        ) from e
 
 
 def validate_enum(enum_name: str, used_enums: Set[str], metadata: dict):
     try:
-        enum: Dict[str, Any] = metadata['enums'][enum_name]
+        enum: Dict[str, Any] = metadata["enums"][enum_name]
         ENUM_SCHEMA.validate(enum)
         if enum_name in used_enums:
-            generate_mappings = enum.get('generate-mappings', False)
-            value_types = set([type(value['value'])
-                              for value in enum['values']])
+            generate_mappings = enum.get("generate-mappings", False)
+            value_types = set([type(value["value"]) for value in enum["values"]])
             if not generate_mappings:
                 value_types.remove(type(1))
                 if any(value_types):
                     raise Exception(
-                        f"generate-mappings is False, but values have non-int types: {value_types}")
-            values = [value['value'] for value in enum['values']]
+                        f"generate-mappings is False, but values have non-int types: {value_types}"
+                    )
+            values = [value["value"] for value in enum["values"]]
             values_set = set(values)
             if len(values) != len(values_set):
-                if not rule_is_suppressed(metadata, RULES.ENUMS_SHOULD_NOT_HAVE_DUPLICATE_VALUES, ["enums", enum_name]):
+                if not rule_is_suppressed(
+                    metadata, RULES.ENUMS_SHOULD_NOT_HAVE_DUPLICATE_VALUES, ["enums", enum_name]
+                ):
                     raise Exception(f"Duplicate values in enum!")
     except Exception as e:
-        raise Exception(
-            f"Failed to validate enum with name {enum_name}") from e
+        raise Exception(f"Failed to validate enum with name {enum_name}") from e
 
 
 def validate_parameter_size(parameter: dict, function_name: str, metadata: dict):
-    function: Dict[str, Any] = metadata['functions'][function_name]
-    size = parameter.get('size', None)
+    function: Dict[str, Any] = metadata["functions"][function_name]
+    size = parameter.get("size", None)
     if size is None:
-        if common_helpers.is_array(parameter.get('type', '')) and not is_string_type(parameter, metadata):
-            if not rule_is_suppressed(metadata, RULES.ARRAY_PARAMETER_NEEDS_SIZE, ["functions", function_name, 'parameters', parameter['name']]):
-                raise Exception(
-                    f"parameter {parameter['name']} is an array but has no size!")
+        if common_helpers.is_array(parameter.get("type", "")) and not is_string_type(
+            parameter, metadata
+        ):
+            if not rule_is_suppressed(
+                metadata,
+                RULES.ARRAY_PARAMETER_NEEDS_SIZE,
+                ["functions", function_name, "parameters", parameter["name"]],
+            ):
+                raise Exception(f"parameter {parameter['name']} is an array but has no size!")
     if size is not None:
         SIZE_SCHEMA.validate(size)
-        mechanism = size['mechanism']
-        if mechanism in ['len', 'ivi-dance', 'ivi-dance-with-a-twist', 'passed-in', 'passed-in-by-ptr']:
-            if not parameter_name_exists(function, size['value']):
+        mechanism = size["mechanism"]
+        if mechanism in [
+            "len",
+            "ivi-dance",
+            "ivi-dance-with-a-twist",
+            "passed-in",
+            "passed-in-by-ptr",
+        ]:
+            if not parameter_name_exists(function, size["value"]):
                 raise Exception(
-                    f"parameter {parameter['name']} refers to nonexistant parameter {size['value']} in its size value!")
-        if mechanism == 'ivi-dance-with-a-twist':
-            if 'value_twist' not in size:
+                    f"parameter {parameter['name']} refers to nonexistant parameter {size['value']} in its size value!"
+                )
+        if mechanism == "ivi-dance-with-a-twist":
+            if "value_twist" not in size:
                 raise Exception(
-                    f"parameter {parameter['name']} doesn't have value_twist in its size parameter!")
-            if not parameter_name_exists(function, size['value_twist']):
+                    f"parameter {parameter['name']} doesn't have value_twist in its size parameter!"
+                )
+            if not parameter_name_exists(function, size["value_twist"]):
                 raise Exception(
-                    f"parameter {parameter['name']} refers to nonexistant parameter {size['value_twist']} in its size value_twist!")
+                    f"parameter {parameter['name']} refers to nonexistant parameter {size['value_twist']} in its size value_twist!"
+                )
         else:
-            if 'value_twist' in size:
+            if "value_twist" in size:
                 raise Exception(
-                    f"parameter {parameter['name']} has value_twist in its size parameter but is not ivi-dance-with-a-twist!")
-        if parameter['direction'] == 'in':
-            if mechanism == 'passed-in' or mechanism == 'passed-in-by-ptr':
-                if not rule_is_suppressed(metadata, RULES.INPUT_ARRAY_SHOULD_NOT_HAVE_PASSED_IN_SIZE,
-                                          ["functions", function_name, "parameters", parameter["name"]]):
+                    f"parameter {parameter['name']} has value_twist in its size parameter but is not ivi-dance-with-a-twist!"
+                )
+        if parameter["direction"] == "in":
+            if mechanism == "passed-in" or mechanism == "passed-in-by-ptr":
+                if not rule_is_suppressed(
+                    metadata,
+                    RULES.INPUT_ARRAY_SHOULD_NOT_HAVE_PASSED_IN_SIZE,
+                    ["functions", function_name, "parameters", parameter["name"]],
+                ):
                     raise Exception(
-                        f"parameter {parameter['name']} is an input but has mechanism {mechanism}! Use mechanism len instead so the user doesn't have to explicitly pass in the size.")
-            if mechanism in ['ivi-dance', 'ivi-dance-with-a-twist']:
+                        f"parameter {parameter['name']} is an input but has mechanism {mechanism}! Use mechanism len instead so the user doesn't have to explicitly pass in the size."
+                    )
+            if mechanism in ["ivi-dance", "ivi-dance-with-a-twist"]:
                 raise Exception(
-                    f"parameter {parameter['name']} is an input but has mechanism {mechanism}!")
+                    f"parameter {parameter['name']} is an input but has mechanism {mechanism}!"
+                )
         else:
             if mechanism == "len":
                 raise Exception(
-                    f"parameter {parameter['name']} is an output but has mechanism {mechanism}!")
+                    f"parameter {parameter['name']} is an output but has mechanism {mechanism}!"
+                )
 
 
 def get_function_enums(functions_metadata: dict) -> Set[str]:
     function_enums = set()
     for function_name in functions_metadata:
         function = functions_metadata[function_name]
-        for param in function['parameters']:
-            if 'enum' in param:
-                function_enums.add(param['enum'])
+        for param in function["parameters"]:
+            if "enum" in param:
+                function_enums.add(param["enum"])
     return function_enums
 
 
@@ -337,16 +377,15 @@ def get_attribute_enums(metadata: dict) -> Set[str]:
     for attribute_group in common_helpers.get_attribute_groups(metadata):
         for attribute_id in attribute_group.attributes:
             attribute = attribute_group.attributes[attribute_id]
-            if 'enum' in attribute:
-                attribute_enums.add(attribute['enum'])
+            if "enum" in attribute:
+                attribute_enums.add(attribute["enum"])
     return attribute_enums
 
 
 def is_string_type(parameter: dict, metadata: dict) -> bool:
-    if parameter.get('is_compound_type', False):
+    if parameter.get("is_compound_type", False):
         return False
-    grpc_type = parameter.get('grpc_type', None)
+    grpc_type = parameter.get("grpc_type", None)
     if grpc_type is None:
-        grpc_type = common_helpers.get_grpc_type(
-            parameter['type'], metadata['config'])
-    return grpc_type == 'string'
+        grpc_type = common_helpers.get_grpc_type(parameter["type"], metadata["config"])
+    return grpc_type == "string"


### PR DESCRIPTION
### What does this Pull Request accomplish?

Enable `black` for `metadata_*.py` files.

These were excluded because of the pattern matching the `metadata` folder.

### Why should this Pull Request be merged?

Consistent formatting.

### What testing has been done?

Ran `black` on `source/codegen`: formatted `metadata_*.py` files but not `metadata/*.py` files