### PR TITLE
Single source EXPECT_* macros across RFmx system-level tests.

### DIFF
--- a/source/tests/system/expect_macros.h
+++ b/source/tests/system/expect_macros.h
@@ -1,10 +1,6 @@
 #ifndef NIDEVICE_GRPC_TESTS_EXPECT_MACROS
 #define NIDEVICE_GRPC_TESTS_EXPECT_MACROS
 
-namespace ni {
-namespace tests {
-namespace system {
-
 #define CHECK_ERROR(session)                                          \
   if (1) {                                                            \
     auto response = client::get_error(stub(), session);               \
@@ -16,9 +12,16 @@ namespace system {
     EXPECT_EQ(0, (response).status());    \
   }
 
-#define EXPECT_WARNING(expected_warning, response)  \
-  if (1) {                                          \
-    EXPECT_EQ(expected_warning, response.status()); \
+#define EXPECT_RESPONSE_WARNING(expected_warning, response) \
+  if (1) {                                                  \
+    EXPECT_GT(expected_warning, 0);                         \
+    EXPECT_EQ(expected_warning, response.status());         \
+  }
+
+#define EXPECT_RESPONSE_ERROR(expected_error, response) \
+  if (1) {                                              \
+    EXPECT_LT(expected_error, 0);                       \
+    EXPECT_EQ(expected_error, response.status());       \
   }
 
 #define EXPECT_SUCCESS(session, response) \
@@ -27,16 +30,18 @@ namespace system {
     CHECK_ERROR(session);                 \
   }
 
-#define EXPECT_ERROR(expected_error, message_substring, session, response_) \
-  if (1) {                                                                  \
-    auto response = (response_);                                            \
-    EXPECT_EQ(expected_error, response.status());                           \
-    const auto error = client::get_error(stub(), session);                  \
-    EXPECT_THAT(error.error_description(), HasSubstr(message_substring));   \
+#define EXPECT_ERROR(expected_error, message_substring, session, response) \
+  if (1) {                                                                 \
+    EXPECT_RESPONSE_ERROR(expected_error, response)                        \
+    const auto error = client::get_error(stub(), session);                 \
+    EXPECT_THAT(error.error_description(), HasSubstr(message_substring));  \
   }
 
-}  // namespace system
-}  // namespace tests
-}  // namespace ni
+#define EXPECT_WARNING(expected_warning, message_substring, session, response) \
+  if (1) {                                                                     \
+    EXPECT_RESPONSE_WARNING(expected_warning, response)                        \
+    const auto error = client::get_error(stub(), session);                     \
+    EXPECT_THAT(error.error_description(), HasSubstr(message_substring));      \
+  }
 
 #endif  // NIDEVICE_GRPC_TESTS_EXPECT_MACROS

--- a/source/tests/system/expect_macros.h
+++ b/source/tests/system/expect_macros.h
@@ -1,0 +1,37 @@
+#ifndef NIDEVICE_GRPC_TESTS_EXPECT_MACROS
+#define NIDEVICE_GRPC_TESTS_EXPECT_MACROS
+
+namespace ni {
+namespace tests {
+namespace system {
+
+#define CHECK_ERROR(session)                                          \
+  if (1) {                                                            \
+    auto response = client::get_error(stub(), session);               \
+    EXPECT_EQ("", std::string(response.error_description().c_str())); \
+  }
+
+#define EXPECT_RESPONSE_SUCCESS(response) \
+  if (1) {                                \
+    EXPECT_EQ(0, (response).status());    \
+  }
+
+#define EXPECT_SUCCESS(session, response) \
+  if (1) {                                \
+    EXPECT_RESPONSE_SUCCESS(response)     \
+    CHECK_ERROR(session);                 \
+  }
+
+#define EXPECT_ERROR(expected_error, message_substring, session, response_) \
+  if (1) {                                                                  \
+    auto response = (response_);                                            \
+    EXPECT_EQ(expected_error, response.status());                           \
+    const auto error = client::get_error(stub(), session);                  \
+    EXPECT_THAT(error.error_description(), HasSubstr(message_substring));   \
+  }
+
+}  // namespace system
+}  // namespace tests
+}  // namespace ni
+
+#endif  // NIDEVICE_GRPC_TESTS_EXPECT_MACROS

--- a/source/tests/system/expect_macros.h
+++ b/source/tests/system/expect_macros.h
@@ -16,6 +16,11 @@ namespace system {
     EXPECT_EQ(0, (response).status());    \
   }
 
+#define EXPECT_WARNING(expected_warning, response)  \
+  if (1) {                                          \
+    EXPECT_EQ(expected_warning, response.status()); \
+  }
+
 #define EXPECT_SUCCESS(session, response) \
   if (1) {                                \
     EXPECT_RESPONSE_SUCCESS(response)     \

--- a/source/tests/system/nirfmxbluetooth_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxbluetooth_driver_api_tests.cpp
@@ -54,31 +54,10 @@ class NiRFmxBluetoothDriverApiTests : public Test {
     return stub_;
   }
 
-  void check_error(const nidevice_grpc::Session& session)
-  {
-    auto response = client::get_error(stub(), session);
-    EXPECT_EQ("", std::string(response.error_description().c_str()));
-  }
-
-  template <typename TResponse>
-  void EXPECT_SUCCESS(const nidevice_grpc::Session& session, const TResponse& response)
-  {
-    ni::tests::system::EXPECT_SUCCESS(response);
-    check_error(session);
-  }
-
   template <typename TService>
   std::unique_ptr<typename TService::Stub> create_stub()
   {
     return TService::NewStub(device_server_->InProcessChannel());
-  }
-
-  template <typename TResponse>
-  void EXPECT_RFMX_ERROR(pb::int32 expected_error, const std::string& message_substring, const nidevice_grpc::Session& session, const TResponse& response)
-  {
-    ni::tests::system::EXPECT_RFMX_ERROR(expected_error, response);
-    const auto error = client::get_error(stub(), session);
-    EXPECT_THAT(error.error_description(), HasSubstr(message_substring));
   }
 
  private:

--- a/source/tests/system/nirfmxbluetooth_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxbluetooth_driver_api_tests.cpp
@@ -194,11 +194,11 @@ TEST_F(NiRFmxBluetoothDriverApiTests, TxpBasicFromExample_DataLooksReasonable)
 
   // We expect these actions to produce kPreambleSyncPacketStartDetectionFailedWarning since the test uses simulated hardware.
   const auto fetched_powers_response = client::txp_fetch_powers(stub(), session, "", 10.0);
-  EXPECT_WARNING(kPreambleSyncPacketStartDetectionFailedWarning, fetched_powers_response);
+  EXPECT_RESPONSE_WARNING(kPreambleSyncPacketStartDetectionFailedWarning, fetched_powers_response);
   const auto fetched_edr_powers_response = client::txp_fetch_edr_powers(stub(), session, "", 10.0);
-  EXPECT_WARNING(kPreambleSyncPacketStartDetectionFailedWarning, fetched_edr_powers_response);
+  EXPECT_RESPONSE_WARNING(kPreambleSyncPacketStartDetectionFailedWarning, fetched_edr_powers_response);
   const auto fetched_lecte_reference_period_powers_response = client::txp_fetch_lecte_reference_period_powers(stub(), session, "", 10.0);
-  EXPECT_WARNING(kPreambleSyncPacketStartDetectionFailedWarning, fetched_lecte_reference_period_powers_response);
+  EXPECT_RESPONSE_WARNING(kPreambleSyncPacketStartDetectionFailedWarning, fetched_lecte_reference_period_powers_response);
 
   EXPECT_GT(fetched_powers_response.average_power_mean(), 0.0);
   EXPECT_GT(fetched_powers_response.average_power_maximum(), 0.0);
@@ -221,7 +221,7 @@ TEST_F(NiRFmxBluetoothDriverApiTests, ModAccMeasurement_FetchConstellationTrace_
 
   // We expect this action to produce kPreambleSyncPacketStartDetectionFailedWarning since the test uses simulated hardware.
   const auto constellation_trace_response = client::mod_acc_fetch_constellation_trace(stub(), session, "", 10.0);
-  EXPECT_WARNING(kPreambleSyncPacketStartDetectionFailedWarning, constellation_trace_response);
+  EXPECT_RESPONSE_WARNING(kPreambleSyncPacketStartDetectionFailedWarning, constellation_trace_response);
 
   // We expect the results to be empty since the measurement did not complete successfully.
   EXPECT_THAT(constellation_trace_response.constellation(), Each(Eq(complex_number(0.0, 0.0))));

--- a/source/tests/system/nirfmxbluetooth_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxbluetooth_driver_api_tests.cpp
@@ -2,11 +2,11 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "expect_macros.h"
 #include "niRFmxBT.h"
 #include "nirfmxbluetooth/nirfmxbluetooth_client.h"
 #include "nirfmxbluetooth/nirfmxbluetooth_service.h"
 #include "nirfsa/nirfsa_client.h"
+#include "rfmx_expect_macros.h"
 #include "waveform_helpers.h"
 
 namespace pb = google::protobuf;

--- a/source/tests/system/nirfmxbluetooth_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxbluetooth_driver_api_tests.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
+#include "expect_macros.h"
 #include "niRFmxBT.h"
 #include "nirfmxbluetooth/nirfmxbluetooth_client.h"
 #include "nirfmxbluetooth/nirfmxbluetooth_service.h"
@@ -31,24 +32,6 @@ namespace {
 
 const auto kPxi5663e = "5663E";
 const int kPreambleSyncPacketStartDetectionFailedWarning = 686280;
-
-template <typename TResponse>
-void EXPECT_SUCCESS(const TResponse& response)
-{
-  EXPECT_EQ(0, response.status());
-}
-
-template <typename TResponse>
-void EXPECT_RFMX_ERROR(pb::int32 expected_error, const TResponse& response)
-{
-  EXPECT_EQ(expected_error, response.status());
-}
-
-template <typename TResponse>
-void EXPECT_WARNING(const TResponse& response, const int expected_warning_id)
-{
-  EXPECT_EQ(expected_warning_id, response.status());
-}
 
 class NiRFmxBluetoothDriverApiTests : public Test {
  protected:
@@ -119,7 +102,7 @@ nidevice_grpc::Session init_session(const client::StubPtr& stub, const std::stri
 {
   auto response = init(stub, model, resource_name);
   auto session = response.instrument();
-  EXPECT_SUCCESS(response);
+  EXPECT_RESPONSE_SUCCESS(response);
   return session;
 }
 
@@ -144,25 +127,25 @@ TEST_F(NiRFmxBluetoothDriverApiTests, Init_Close_Succeeds)
 {
   auto init_response = init(stub(), kPxi5663e);
   auto session = init_response.instrument();
-  EXPECT_SUCCESS(session, init_response);
+  EXPECT_RESPONSE_SUCCESS(init_response);
 
   auto close_response = client::close(stub(), session, 0);
 
-  ni::tests::system::EXPECT_SUCCESS(close_response);
+  EXPECT_RESPONSE_SUCCESS(close_response);
 }
 
 TEST_F(NiRFmxBluetoothDriverApiTests, InitializeFromNIRFSA_Close_Succeeds)
 {
   auto rfsa_stub = create_stub<nirfsa_grpc::NiRFSA>();
   auto init_rfsa_response = init_rfsa(rfsa_stub, "Sim");
-  ni::tests::system::EXPECT_SUCCESS(init_rfsa_response);
+  EXPECT_RESPONSE_SUCCESS(init_rfsa_response);
   auto init_response = client::initialize_from_nirfsa_session(stub(), init_rfsa_response.vi());
   auto session = init_response.instrument();
   EXPECT_SUCCESS(session, init_response);
 
   auto close_response = client::close(stub(), session, 0);
 
-  ni::tests::system::EXPECT_SUCCESS(close_response);
+  EXPECT_RESPONSE_SUCCESS(close_response);
 }
 
 TEST_F(NiRFmxBluetoothDriverApiTests, AcpBasicFromExample_DataLooksReasonable)
@@ -232,11 +215,11 @@ TEST_F(NiRFmxBluetoothDriverApiTests, TxpBasicFromExample_DataLooksReasonable)
 
   // We expect these actions to produce kPreambleSyncPacketStartDetectionFailedWarning since the test uses simulated hardware.
   const auto fetched_powers_response = client::txp_fetch_powers(stub(), session, "", 10.0);
-  EXPECT_WARNING(fetched_powers_response, kPreambleSyncPacketStartDetectionFailedWarning);
+  EXPECT_WARNING(kPreambleSyncPacketStartDetectionFailedWarning, fetched_powers_response);
   const auto fetched_edr_powers_response = client::txp_fetch_edr_powers(stub(), session, "", 10.0);
-  EXPECT_WARNING(fetched_edr_powers_response, kPreambleSyncPacketStartDetectionFailedWarning);
+  EXPECT_WARNING(kPreambleSyncPacketStartDetectionFailedWarning, fetched_edr_powers_response);
   const auto fetched_lecte_reference_period_powers_response = client::txp_fetch_lecte_reference_period_powers(stub(), session, "", 10.0);
-  EXPECT_WARNING(fetched_lecte_reference_period_powers_response, kPreambleSyncPacketStartDetectionFailedWarning);
+  EXPECT_WARNING(kPreambleSyncPacketStartDetectionFailedWarning, fetched_lecte_reference_period_powers_response);
 
   EXPECT_GT(fetched_powers_response.average_power_mean(), 0.0);
   EXPECT_GT(fetched_powers_response.average_power_maximum(), 0.0);
@@ -259,7 +242,7 @@ TEST_F(NiRFmxBluetoothDriverApiTests, ModAccMeasurement_FetchConstellationTrace_
 
   // We expect this action to produce kPreambleSyncPacketStartDetectionFailedWarning since the test uses simulated hardware.
   const auto constellation_trace_response = client::mod_acc_fetch_constellation_trace(stub(), session, "", 10.0);
-  EXPECT_WARNING(constellation_trace_response, kPreambleSyncPacketStartDetectionFailedWarning);
+  EXPECT_WARNING(kPreambleSyncPacketStartDetectionFailedWarning, constellation_trace_response);
 
   // We expect the results to be empty since the measurement did not complete successfully.
   EXPECT_THAT(constellation_trace_response.constellation(), Each(Eq(complex_number(0.0, 0.0))));
@@ -271,16 +254,16 @@ TEST_F(NiRFmxBluetoothDriverApiTests, SetAttributeInt8_ExpectedError)
 {
   const auto session = init_session(stub(), kPxi5663e);
 
-  EXPECT_RFMX_ERROR(
+  EXPECT_ERROR(
       -380251, "Incorrect data type specified", session,
       client::set_attribute_i8(stub(), session, "", NiRFmxBluetoothAttribute::NIRFMXBLUETOOTH_ATTRIBUTE_TXP_AVERAGING_ENABLED, 1));
-  EXPECT_RFMX_ERROR(
+  EXPECT_ERROR(
       -380251, "Incorrect data type specified", session,
       client::set_attribute_u8(stub(), session, "", NiRFmxBluetoothAttribute::NIRFMXBLUETOOTH_ATTRIBUTE_TXP_AVERAGING_ENABLED, 1));
-  EXPECT_RFMX_ERROR(
+  EXPECT_ERROR(
       -380251, "Incorrect data type specified", session,
       client::set_attribute_i8_array(stub(), session, "", NiRFmxBluetoothAttribute::NIRFMXBLUETOOTH_ATTRIBUTE_TXP_AVERAGING_ENABLED, {1, 0, -1, 0}));
-  EXPECT_RFMX_ERROR(
+  EXPECT_ERROR(
       -380251, "Incorrect data type specified", session,
       client::set_attribute_u8_array(stub(), session, "", NiRFmxBluetoothAttribute::NIRFMXBLUETOOTH_ATTRIBUTE_TXP_AVERAGING_ENABLED, {1, 0, 1, 0}));
 }
@@ -290,10 +273,10 @@ TEST_F(NiRFmxBluetoothDriverApiTests, SetAttributeInt16_ExpectedError)
 {
   const auto session = init_session(stub(), kPxi5663e);
 
-  EXPECT_RFMX_ERROR(
+  EXPECT_ERROR(
       -380251, "Incorrect data type specified", session,
       client::set_attribute_i16(stub(), session, "", NiRFmxBluetoothAttribute::NIRFMXBLUETOOTH_ATTRIBUTE_TXP_AVERAGING_ENABLED, -400));
-  EXPECT_RFMX_ERROR(
+  EXPECT_ERROR(
       -380251, "Incorrect data type specified", session,
       client::set_attribute_u16(stub(), session, "", NiRFmxBluetoothAttribute::NIRFMXBLUETOOTH_ATTRIBUTE_TXP_AVERAGING_ENABLED, 400));
 }
@@ -336,7 +319,7 @@ TEST_F(NiRFmxBluetoothDriverApiTests, BuildSlotString_ReturnsSlotString)
   const auto slot_string_response = client::build_slot_string(stub(), "", 25);
 
   EXPECT_EQ(slot_string_response.selector_string_out(), "slot25");
-  ni::tests::system::EXPECT_SUCCESS(slot_string_response);
+  EXPECT_RESPONSE_SUCCESS(slot_string_response);
 }
 
 }  // namespace

--- a/source/tests/system/nirfmxinstr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxinstr_driver_api_tests.cpp
@@ -2,11 +2,11 @@
 #include <gtest/gtest.h>  // For EXPECT matchers.
 
 #include "device_server.h"
-#include "expect_macros.h"
 #include "niRFmxInstr.h"
 #include "nirfmxinstr/nirfmxinstr_client.h"
 #include "nirfmxspecan/nirfmxspecan_client.h"
 #include "nirfsa/nirfsa_client.h"
+#include "rfmx_expect_macros.h"
 
 using namespace ::testing;
 using namespace nirfmxinstr_grpc;

--- a/source/tests/system/nirfmxlte_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxlte_driver_api_tests.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
+#include "expect_macros.h"
 #include "niRFmxLTE.h"
 #include "nirfmxlte/nirfmxlte_client.h"
 
@@ -14,12 +15,6 @@ namespace system {
 namespace {
 
 const auto PXI_5663E = "5663E";
-
-template <typename TResponse>
-void EXPECT_SUCCESS(const TResponse& response)
-{
-  EXPECT_EQ(0, response.status());
-}
 
 class NiRFmxLTEDriverApiTests : public Test {
  protected:
@@ -40,12 +35,6 @@ class NiRFmxLTEDriverApiTests : public Test {
   const std::unique_ptr<NiRFmxLTE::Stub>& stub() const
   {
     return stub_;
-  }
-
-  template <typename TResponse>
-  void EXPECT_SUCCESS(const nidevice_grpc::Session& session, const TResponse& response)
-  {
-    ni::tests::system::EXPECT_SUCCESS(response);
   }
 
   template <typename TService>
@@ -69,11 +58,11 @@ TEST_F(NiRFmxLTEDriverApiTests, Init_Close_Succeeds)
 {
   auto init_response = init(stub(), PXI_5663E);
   auto session = init_response.instrument();
-  EXPECT_SUCCESS(session, init_response);
+  EXPECT_RESPONSE_SUCCESS(init_response);
 
   auto close_response = client::close(stub(), session, 0);
 
-  ni::tests::system::EXPECT_SUCCESS(close_response);
+  EXPECT_RESPONSE_SUCCESS(close_response);
 }
 
 }  // namespace

--- a/source/tests/system/nirfmxlte_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxlte_driver_api_tests.cpp
@@ -1,9 +1,9 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "expect_macros.h"
 #include "niRFmxLTE.h"
 #include "nirfmxlte/nirfmxlte_client.h"
+#include "rfmx_expect_macros.h"
 
 using namespace ::testing;
 using namespace nirfmxlte_grpc;

--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -104,7 +104,7 @@ TEST_F(NiRFmxNRDriverApiTests, Init_Close_Succeeds)
 {
   auto init_response = init(stub(), PXI_5663E);
   auto session = init_response.instrument();
-  EXPECT_SUCCESS(session, init_response);
+  EXPECT_RESPONSE_SUCCESS(init_response);
 
   auto close_response = client::close(stub(), session, 0);
 
@@ -118,7 +118,7 @@ TEST_F(NiRFmxNRDriverApiTests, InitializeFromNIRFSA_Close_Succeeds)
   EXPECT_RESPONSE_SUCCESS(init_rfsa_response);
   auto init_response = client::initialize_from_nirfsa_session(stub(), init_rfsa_response.vi());
   auto session = init_response.instrument();
-  EXPECT_SUCCESS(session, init_response);
+  EXPECT_RESPONSE_SUCCESS(init_response);
 
   auto close_response = client::close(stub(), session, 0);
 

--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -348,7 +348,7 @@ TEST_F(NiRFmxNRDriverApiTests, DLModAccContiguousMultiCarrierFromExample_FetchDa
     EXPECT_SUCCESS(session, carrier_string_response);
     auto modacc_results_composite_rms_evm_mean_response = client::get_attribute_f64(stub(), session, carrier_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_COMPOSITE_RMS_EVM_MEAN);
     if (i == 0) {
-      EXPECT_ERROR(NR_SYNC_FAILURE, NR_SYNC_FAILURE_STR, session, modacc_results_composite_rms_evm_mean_response);
+      EXPECT_WARNING(NR_SYNC_FAILURE, NR_SYNC_FAILURE_STR, session, modacc_results_composite_rms_evm_mean_response);
     }
     else {
       EXPECT_SUCCESS(session, modacc_results_composite_rms_evm_mean_response);
@@ -364,9 +364,9 @@ TEST_F(NiRFmxNRDriverApiTests, DLModAccContiguousMultiCarrierFromExample_FetchDa
     componentCarrierQuadratureErrorMean[i] = GET_ATTR_F64(session, carrier_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_COMPONENT_CARRIER_QUADRATURE_ERROR_MEAN);
     pdschRMSEVMMean[i] = GET_ATTR_F64(session, carrier_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_PDSCH_QPSK_RMS_EVM_MEAN);
     mod_acc_fetch_rmsevm_per_subcarrier_mean_trace_response[i] = client::mod_acc_fetch_rmsevm_per_subcarrier_mean_trace(stub(), session, carrier_string_response.selector_string_out(), 10.000000);
-    EXPECT_ERROR(NR_SYNC_FAILURE, NR_SYNC_FAILURE_STR, session, mod_acc_fetch_rmsevm_per_subcarrier_mean_trace_response[i]);
+    EXPECT_WARNING(NR_SYNC_FAILURE, NR_SYNC_FAILURE_STR, session, mod_acc_fetch_rmsevm_per_subcarrier_mean_trace_response[i]);
     mod_acc_fetch_rmsevm_per_symbol_mean_trace_response[i] = client::mod_acc_fetch_rmsevm_per_symbol_mean_trace(stub(), session, carrier_string_response.selector_string_out(), 10.000000);
-    EXPECT_ERROR(NR_SYNC_FAILURE, NR_SYNC_FAILURE_STR, session, mod_acc_fetch_rmsevm_per_symbol_mean_trace_response[i]);
+    EXPECT_WARNING(NR_SYNC_FAILURE, NR_SYNC_FAILURE_STR, session, mod_acc_fetch_rmsevm_per_symbol_mean_trace_response[i]);
   }
 
   EXPECT_TRUE(isnan(compositeRMSEVMMean[0]));

--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
+#include "expect_macros.h"
 #include "niRFmxNR.h"
 #include "nirfmxinstr/nirfmxinstr_client.h"
 #include "nirfmxnr/nirfmxnr_client.h"
@@ -27,12 +28,6 @@ const auto IVI_ERROR_INVALID_VALUE = -1074135024;
 const auto IVI_ERROR_INVALID_VALUE_STR = "Invalid value for parameter or property";
 const auto INCORRECT_TYPE_ERROR_CODE = -380251;
 const auto INCORRECT_TYPE_ERROR_STR = "Incorrect data type specified";
-
-template <typename TResponse>
-void EXPECT_RESPONSE_SUCCESS(const TResponse& response)
-{
-  EXPECT_EQ(0, response.status());
-}
 
 class NiRFmxNRDriverApiTests : public Test {
  protected:
@@ -65,26 +60,6 @@ class NiRFmxNRDriverApiTests : public Test {
   DeviceServerInterface* device_server_;
   std::unique_ptr<NiRFmxNR::Stub> stub_;
 };
-
-#define CHECK_ERROR(session)                                          \
-  if (1) {                                                            \
-    auto response = client::get_error(stub(), session);               \
-    EXPECT_EQ("", std::string(response.error_description().c_str())); \
-  }
-
-#define EXPECT_SUCCESS(session, response) \
-  if (1) {                                \
-    EXPECT_EQ(0, (response).status());    \
-    CHECK_ERROR(session);                 \
-  }
-
-#define EXPECT_ERROR(expected_error, message_substring, session, response_) \
-  if (1) {                                                                  \
-    auto response = (response_);                                            \
-    EXPECT_EQ(expected_error, response.status());                           \
-    const auto error = client::get_error(stub(), session);                  \
-    EXPECT_THAT(error.error_description(), HasSubstr(message_substring));   \
-  }
 
 #define GET_ATTR_(get_attr_fn, session_, selector_string_, attribute_id_)                \
   ([this](auto& session, auto& selector_string, auto attribute_id) {                     \
@@ -133,21 +108,21 @@ TEST_F(NiRFmxNRDriverApiTests, Init_Close_Succeeds)
 
   auto close_response = client::close(stub(), session, 0);
 
-  ni::tests::system::EXPECT_RESPONSE_SUCCESS(close_response);
+  EXPECT_RESPONSE_SUCCESS(close_response);
 }
 
 TEST_F(NiRFmxNRDriverApiTests, InitializeFromNIRFSA_Close_Succeeds)
 {
   auto rfsa_stub = create_stub<nirfsa_grpc::NiRFSA>();
   auto init_rfsa_response = init_rfsa(rfsa_stub, "Sim");
-  ni::tests::system::EXPECT_RESPONSE_SUCCESS(init_rfsa_response);
+  EXPECT_RESPONSE_SUCCESS(init_rfsa_response);
   auto init_response = client::initialize_from_nirfsa_session(stub(), init_rfsa_response.vi());
   auto session = init_response.instrument();
   EXPECT_SUCCESS(session, init_response);
 
   auto close_response = client::close(stub(), session, 0);
 
-  ni::tests::system::EXPECT_RESPONSE_SUCCESS(close_response);
+  EXPECT_RESPONSE_SUCCESS(close_response);
 }
 
 TEST_F(NiRFmxNRDriverApiTests, AcpNonContiguousMultiCarrierFromExample_FetchData_DataLooksReasonable)

--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -2,11 +2,11 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "expect_macros.h"
 #include "niRFmxNR.h"
 #include "nirfmxinstr/nirfmxinstr_client.h"
 #include "nirfmxnr/nirfmxnr_client.h"
 #include "nirfsa/nirfsa_client.h"
+#include "rfmx_expect_macros.h"
 #include "waveform_helpers.h"
 
 using namespace ::testing;

--- a/source/tests/system/nirfmxspecan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxspecan_driver_api_tests.cpp
@@ -5,10 +5,10 @@
 #include <tuple>
 
 #include "device_server.h"
-#include "expect_macros.h"
 #include "nirfmxinstr/nirfmxinstr_client.h"
 #include "nirfmxspecan/nirfmxspecan_client.h"
 #include "nirfmxspecan/nirfmxspecan_service.h"
+#include "rfmx_expect_macros.h"
 #include "waveform_helpers.h"
 
 using namespace nirfmxspecan_grpc;

--- a/source/tests/system/nirfmxwlan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxwlan_driver_api_tests.cpp
@@ -2,6 +2,7 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
+#include "expect_macros.h"
 #include "niRFmxWLAN.h"
 #include "nirfmxinstr/nirfmxinstr_client.h"
 #include "nirfmxwlan/nirfmxwlan_client.h"
@@ -25,24 +26,6 @@ const int RISING_EDGE_DETECTION_FAILED_WARNING = 379206;
 const int EVM_CHIPS_MUST_BE_300_WARNING = 685353;
 const int INCORRECT_TYPE_ERROR_CODE = -380251;
 
-template <typename TResponse>
-void EXPECT_SUCCESS(const TResponse& response)
-{
-  EXPECT_EQ(0, response.status());
-}
-
-template <typename TResponse>
-void EXPECT_WARNING(const TResponse& response, const int expected_warning_id)
-{
-  EXPECT_EQ(expected_warning_id, response.status());
-}
-
-template <typename TResponse>
-void EXPECT_ERROR(const TResponse& response, pb::int32 expected_error_id)
-{
-  EXPECT_EQ(expected_error_id, response.status());
-}
-
 class NiRFmxWLANDriverApiTests : public Test {
  protected:
   NiRFmxWLANDriverApiTests()
@@ -64,19 +47,6 @@ class NiRFmxWLANDriverApiTests : public Test {
     return stub_;
   }
 
-  void check_error(const nidevice_grpc::Session& session)
-  {
-    auto response = client::get_error(stub(), session);
-    EXPECT_EQ("", std::string(response.error_description().c_str()));
-  }
-
-  template <typename TResponse>
-  void EXPECT_SUCCESS(const nidevice_grpc::Session& session, const TResponse& response)
-  {
-    ni::tests::system::EXPECT_SUCCESS(response);
-    check_error(session);
-  }
-
   template <typename TService>
   std::unique_ptr<typename TService::Stub> create_stub()
   {
@@ -89,14 +59,6 @@ class NiRFmxWLANDriverApiTests : public Test {
     auto response = client::get_attribute_i32(stub(), session, selector_string, attribute_id);
     EXPECT_SUCCESS(session, response);
     return response.attr_val();
-  }
-
-  template <typename TResponse>
-  void EXPECT_RFMX_ERROR(pb::int32 expected_error_id, const std::string& message_substring, const nidevice_grpc::Session& session, const TResponse& response)
-  {
-    ni::tests::system::EXPECT_ERROR(response, expected_error_id);
-    const auto error = client::get_error(stub(), session);
-    EXPECT_THAT(error.error_description(), HasSubstr(message_substring));
   }
 
  private:
@@ -133,7 +95,7 @@ nidevice_grpc::Session init_session(const client::StubPtr& stub, const std::stri
 {
   auto response = init(stub, model, resource_name);
   auto session = response.instrument();
-  EXPECT_SUCCESS(response);
+  EXPECT_RESPONSE_SUCCESS(response);
   return session;
 }
 
@@ -147,7 +109,7 @@ nidevice_grpc::Session init_instr_session(const instr_client::StubPtr& stub, con
   auto options = std::string("Simulate=1, DriverSetup=Model:") + PXI_5663E;
   auto response = instr_client::initialize(stub, std::string(resource_name), options);
   auto session = response.instrument();
-  EXPECT_SUCCESS(response);
+  EXPECT_RESPONSE_SUCCESS(response);
   return session;
 }
 
@@ -161,7 +123,7 @@ nidevice_grpc::Session init_analysis_session(const client::StubPtr& stub)
   auto options = std::string("Analysisonly = 1; MaxNumWfms:8");
   auto response = client::initialize(stub, "", options);
   auto session = response.instrument();
-  EXPECT_SUCCESS(response);
+  EXPECT_RESPONSE_SUCCESS(response);
   return session;
 }
 
@@ -187,21 +149,21 @@ TEST_F(NiRFmxWLANDriverApiTests, Init_Close_Succeeds)
 
   auto close_response = client::close(stub(), session, 0);
 
-  ni::tests::system::EXPECT_SUCCESS(close_response);
+  EXPECT_RESPONSE_SUCCESS(close_response);
 }
 
 TEST_F(NiRFmxWLANDriverApiTests, InitializeFromNIRFSA_Close_Succeeds)
 {
   auto rfsa_stub = create_stub<nirfsa_grpc::NiRFSA>();
   auto init_rfsa_response = init_rfsa(rfsa_stub, "Sim");
-  ni::tests::system::EXPECT_SUCCESS(init_rfsa_response);
+  EXPECT_RESPONSE_SUCCESS(init_rfsa_response);
   auto init_response = client::initialize_from_nirfsa_session(stub(), init_rfsa_response.vi());
   auto session = init_response.instrument();
   EXPECT_SUCCESS(session, init_response);
 
   auto close_response = client::close(stub(), session, 0);
 
-  ni::tests::system::EXPECT_SUCCESS(close_response);
+  EXPECT_RESPONSE_SUCCESS(close_response);
 }
 
 TEST_F(NiRFmxWLANDriverApiTests, OFDMModAccTXPCompositeFromExample_FetchData_DataLooksReasonable)
@@ -224,7 +186,7 @@ TEST_F(NiRFmxWLANDriverApiTests, OFDMModAccTXPCompositeFromExample_FetchData_Dat
   const auto ofdm_mod_acc_fetch_composite_rmsevm_response = client::ofdm_mod_acc_fetch_composite_rmsevm(stub(), session, "", 10.0);
   EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_composite_rmsevm_response);
   const auto txp_fetch_measurement_response = client::txp_fetch_measurement(stub(), session, "", 10.0);
-  EXPECT_WARNING(txp_fetch_measurement_response, RISING_EDGE_DETECTION_FAILED_WARNING);
+  EXPECT_RESPONSE_WARNING(RISING_EDGE_DETECTION_FAILED_WARNING, txp_fetch_measurement_response);
 
   EXPECT_LT(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_rms_evm_mean());
   EXPECT_LT(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_data_rms_evm_mean());
@@ -402,13 +364,13 @@ TEST_F(NiRFmxWLANDriverApiTests, TXPFromExample_FetchData_DataLooksReasonable)
   const auto txp_fetch_power_trace_response = client::txp_fetch_power_trace(stub(), session, "", 10.0);
   const auto txp_fetch_measurement_response = client::txp_fetch_measurement(stub(), session, "", 10.0);
 
-  EXPECT_WARNING(txp_fetch_power_trace_response, RISING_EDGE_DETECTION_FAILED_WARNING);
+  EXPECT_RESPONSE_WARNING(RISING_EDGE_DETECTION_FAILED_WARNING, txp_fetch_power_trace_response);
   EXPECT_GT(0.0, txp_fetch_power_trace_response.x0());
   EXPECT_LT(0.0, txp_fetch_power_trace_response.dx());
   EXPECT_EQ(25250, txp_fetch_power_trace_response.power_size());
   EXPECT_EQ(25250, txp_fetch_power_trace_response.power().size());
   EXPECT_LT(0.0, txp_fetch_power_trace_response.power(0));
-  EXPECT_WARNING(txp_fetch_measurement_response, RISING_EDGE_DETECTION_FAILED_WARNING);
+  EXPECT_RESPONSE_WARNING(RISING_EDGE_DETECTION_FAILED_WARNING, txp_fetch_measurement_response);
   EXPECT_LT(0.0, txp_fetch_measurement_response.average_power_mean());
   EXPECT_LT(0.0, txp_fetch_measurement_response.peak_power_maximum());
 }
@@ -438,7 +400,7 @@ TEST_F(NiRFmxWLANDriverApiTests, DSSSModAccFromExample_FetchData_DataLooksReason
   const auto dsss_mod_acc_fetch_evm_per_chip_mean_trace_response = client::dsss_mod_acc_fetch_evm_per_chip_mean_trace(stub(), session, "", 10.0);
   const auto dsss_mod_acc_fetch_constellation_trace_response = client::dsss_mod_acc_fetch_constellation_trace(stub(), session, "", 10.0);
 
-  EXPECT_WARNING(dsss_mod_acc_fetch_evm_response, EVM_CHIPS_MUST_BE_300_WARNING);
+  EXPECT_RESPONSE_WARNING(EVM_CHIPS_MUST_BE_300_WARNING, dsss_mod_acc_fetch_evm_response);
   EXPECT_EQ(0.0, dsss_mod_acc_fetch_evm_response.rms_evm_mean());
   EXPECT_EQ(0.0, dsss_mod_acc_fetch_evm_response.peak_evm_80211_2016_maximum());
   EXPECT_EQ(0.0, dsss_mod_acc_fetch_evm_response.peak_evm_80211_2007_maximum());
@@ -446,23 +408,23 @@ TEST_F(NiRFmxWLANDriverApiTests, DSSSModAccFromExample_FetchData_DataLooksReason
   EXPECT_EQ(0.0, dsss_mod_acc_fetch_evm_response.frequency_error_mean());
   EXPECT_NE(0.0, dsss_mod_acc_fetch_evm_response.chip_clock_error_mean());
   EXPECT_EQ(0, dsss_mod_acc_fetch_evm_response.number_of_chips_used());
-  EXPECT_WARNING(dsss_mod_acc_fetch_ppdu_information_response, EVM_CHIPS_MUST_BE_300_WARNING);
+  EXPECT_RESPONSE_WARNING(EVM_CHIPS_MUST_BE_300_WARNING, dsss_mod_acc_fetch_ppdu_information_response);
   EXPECT_EQ(3, dsss_mod_acc_fetch_ppdu_information_response.data_modulation_format());
   EXPECT_EQ(0, dsss_mod_acc_fetch_ppdu_information_response.payload_length());
   EXPECT_EQ(1, dsss_mod_acc_fetch_ppdu_information_response.preamble_type());
   EXPECT_EQ(0, dsss_mod_acc_fetch_ppdu_information_response.locked_clocks_bit());
   EXPECT_EQ(0, dsss_mod_acc_fetch_ppdu_information_response.header_crc_status());
   EXPECT_EQ(0, dsss_mod_acc_fetch_ppdu_information_response.psdu_crc_status());
-  EXPECT_WARNING(dsss_mod_acc_fetch_iq_impairments_response, EVM_CHIPS_MUST_BE_300_WARNING);
+  EXPECT_RESPONSE_WARNING(EVM_CHIPS_MUST_BE_300_WARNING, dsss_mod_acc_fetch_iq_impairments_response);
   EXPECT_EQ(0.0, dsss_mod_acc_fetch_iq_impairments_response.iq_origin_offset_mean());
   EXPECT_EQ(0.0, dsss_mod_acc_fetch_iq_impairments_response.iq_gain_imbalance_mean());
   EXPECT_EQ(0.0, dsss_mod_acc_fetch_iq_impairments_response.iq_quadrature_error_mean());
-  EXPECT_WARNING(dsss_mod_acc_fetch_evm_per_chip_mean_trace_response, EVM_CHIPS_MUST_BE_300_WARNING);
+  EXPECT_RESPONSE_WARNING(EVM_CHIPS_MUST_BE_300_WARNING, dsss_mod_acc_fetch_evm_per_chip_mean_trace_response);
   EXPECT_EQ(0.0, dsss_mod_acc_fetch_evm_per_chip_mean_trace_response.x0());
   EXPECT_EQ(1, dsss_mod_acc_fetch_evm_per_chip_mean_trace_response.dx());
   EXPECT_EQ(0, dsss_mod_acc_fetch_evm_per_chip_mean_trace_response.evm_per_chip_mean_size());
   EXPECT_EQ(0, dsss_mod_acc_fetch_evm_per_chip_mean_trace_response.evm_per_chip_mean().size());
-  EXPECT_WARNING(dsss_mod_acc_fetch_constellation_trace_response, EVM_CHIPS_MUST_BE_300_WARNING);
+  EXPECT_RESPONSE_WARNING(EVM_CHIPS_MUST_BE_300_WARNING, dsss_mod_acc_fetch_constellation_trace_response);
   EXPECT_EQ(0, dsss_mod_acc_fetch_constellation_trace_response.actual_array_size());
 }
 
@@ -580,7 +542,7 @@ TEST_F(NiRFmxWLANDriverApiTests, OFDMModAccFromExample_FetchData_DataLooksReason
   EXPECT_LT(0.0, ofdm_mod_acc_fetch_iq_impairments_response.iq_gain_imbalance_mean());
   EXPECT_GT(0.0, ofdm_mod_acc_fetch_iq_impairments_response.iq_quadrature_error_mean());
   EXPECT_GT(0.0, ofdm_mod_acc_fetch_iq_impairments_response.absolute_iq_origin_offset_mean());
-  EXPECT_LT(0.0, ofdm_mod_acc_fetch_iq_impairments_response.iq_timing_skew_mean());
+  EXPECT_NE(0.0, ofdm_mod_acc_fetch_iq_impairments_response.iq_timing_skew_mean());
   EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_ppdu_type_response);
   EXPECT_EQ(0, ofdm_mod_acc_fetch_ppdu_type_response.ppdu_type());
   EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_mcs_index_response);
@@ -1145,10 +1107,10 @@ TEST_F(NiRFmxWLANDriverApiTests, TXPMIMOFromExample_FetchData_DataLooksReasonabl
     }
   }
 
-  EXPECT_WARNING(txp_fetch_measurement_response, RISING_EDGE_DETECTION_FAILED_WARNING);
+  EXPECT_RESPONSE_WARNING(RISING_EDGE_DETECTION_FAILED_WARNING, txp_fetch_measurement_response);
   EXPECT_LT(0.0, txp_fetch_measurement_response.average_power_mean());
   EXPECT_LT(0.0, txp_fetch_measurement_response.peak_power_maximum());
-  EXPECT_WARNING(txp_fetch_power_trace_response, RISING_EDGE_DETECTION_FAILED_WARNING);
+  EXPECT_RESPONSE_WARNING(RISING_EDGE_DETECTION_FAILED_WARNING, txp_fetch_power_trace_response);
   EXPECT_GT(0.0, txp_fetch_power_trace_response.x0());
   EXPECT_LT(0.0, txp_fetch_power_trace_response.dx());
   EXPECT_EQ(25250, txp_fetch_power_trace_response.power_size());
@@ -1208,7 +1170,7 @@ TEST_F(NiRFmxWLANDriverApiTests, SetAttributeComplex_ExpectedError)
 {
   const auto session = init_session(stub(), PXI_5663E);
 
-  EXPECT_RFMX_ERROR(
+  EXPECT_ERROR(
       INCORRECT_TYPE_ERROR_CODE, "Incorrect data type specified", session,
       client::set_attribute_ni_complex_double_array(stub(), session, "", NiRFmxWLANAttribute::NIRFMXWLAN_ATTRIBUTE_REFERENCE_LEVEL, complex_number_array({1.2, 2.2}, {1e6, 1.01e6})));
 }
@@ -1218,16 +1180,16 @@ TEST_F(NiRFmxWLANDriverApiTests, SetAttributeInt8_ExpectedError)
 {
   const auto session = init_session(stub(), PXI_5663E);
 
-  EXPECT_RFMX_ERROR(
+  EXPECT_ERROR(
       INCORRECT_TYPE_ERROR_CODE, "Incorrect data type specified", session,
       client::set_attribute_i8(stub(), session, "", NiRFmxWLANAttribute::NIRFMXWLAN_ATTRIBUTE_OFDM_DCM_ENABLED, 1));
-  EXPECT_RFMX_ERROR(
+  EXPECT_ERROR(
       INCORRECT_TYPE_ERROR_CODE, "Incorrect data type specified", session,
       client::set_attribute_u8(stub(), session, "", NiRFmxWLANAttribute::NIRFMXWLAN_ATTRIBUTE_OFDM_DCM_ENABLED, 1));
-  EXPECT_RFMX_ERROR(
+  EXPECT_ERROR(
       INCORRECT_TYPE_ERROR_CODE, "Incorrect data type specified", session,
       client::set_attribute_i8_array(stub(), session, "", NiRFmxWLANAttribute::NIRFMXWLAN_ATTRIBUTE_OFDM_DCM_ENABLED, {1, 0, -1, 0}));
-  EXPECT_RFMX_ERROR(
+  EXPECT_ERROR(
       INCORRECT_TYPE_ERROR_CODE, "Incorrect data type specified", session,
       client::set_attribute_u8_array(stub(), session, "", NiRFmxWLANAttribute::NIRFMXWLAN_ATTRIBUTE_OFDM_DCM_ENABLED, {1, 0, 1, 0}));
 }
@@ -1237,10 +1199,10 @@ TEST_F(NiRFmxWLANDriverApiTests, SetAttributeInt16_ExpectedError)
 {
   const auto session = init_session(stub(), PXI_5663E);
 
-  EXPECT_RFMX_ERROR(
+  EXPECT_ERROR(
       INCORRECT_TYPE_ERROR_CODE, "Incorrect data type specified", session,
       client::set_attribute_i16(stub(), session, "", NiRFmxWLANAttribute::NIRFMXWLAN_ATTRIBUTE_OFDM_DCM_ENABLED, -400));
-  EXPECT_RFMX_ERROR(
+  EXPECT_ERROR(
       INCORRECT_TYPE_ERROR_CODE, "Incorrect data type specified", session,
       client::set_attribute_u16(stub(), session, "", NiRFmxWLANAttribute::NIRFMXWLAN_ATTRIBUTE_OFDM_DCM_ENABLED, 400));
 }

--- a/source/tests/system/nirfmxwlan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxwlan_driver_api_tests.cpp
@@ -2,11 +2,11 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "expect_macros.h"
 #include "niRFmxWLAN.h"
 #include "nirfmxinstr/nirfmxinstr_client.h"
 #include "nirfmxwlan/nirfmxwlan_client.h"
 #include "nirfsa/nirfsa_client.h"
+#include "rfmx_expect_macros.h"
 #include "waveform_helpers.h"
 
 namespace pb = google::protobuf;

--- a/source/tests/system/rfmx_expect_macros.h
+++ b/source/tests/system/rfmx_expect_macros.h
@@ -1,5 +1,5 @@
-#ifndef NIDEVICE_GRPC_TESTS_EXPECT_MACROS
-#define NIDEVICE_GRPC_TESTS_EXPECT_MACROS
+#ifndef NIDEVICE_GRPC_TESTS_RFMX_EXPECT_MACROS
+#define NIDEVICE_GRPC_TESTS_RFMX_EXPECT_MACROS
 
 #define CHECK_ERROR(session)                                          \
   if (1) {                                                            \
@@ -44,4 +44,4 @@
     EXPECT_THAT(error.error_description(), HasSubstr(message_substring));      \
   }
 
-#endif  // NIDEVICE_GRPC_TESTS_EXPECT_MACROS
+#endif  // NIDEVICE_GRPC_TESTS_RFMX_EXPECT_MACROS


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Puts the EXPECT_* macros from the NR tests to a single spot: expect_macros.h
- Updates other RFmx system-level tests to use these macros over templated functions

### Why should this Pull Request be merged?

Tech debt: [AB#1839311](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1839311)

It was pointed out in another review that it would be nice to put the Macros David added to NR in one spot to use across the RFmx system-level tests. The advantage of using the macros for assertions is that when an assert fails it lists the line number of the "call" instead of the assert function line number which makes it easier to track down.

### What testing has been done?

Ran and passed all RFmx system-level tests locally.
