### PR TITLE
Fix typo in AcpBasic python example for NI-RFmx Bluetooth.

### DIFF
--- a/examples/nirfmxbluetooth/acp-basic.py
+++ b/examples/nirfmxbluetooth/acp-basic.py
@@ -303,7 +303,7 @@ try:
     print("------------------ACP------------------")
     print(f"Measurement Status                   : {measurement_status_string}")
     print(f"Reference Channel Power (dBm)        : {reference_channel_power}\n")
-    print("------------------Offset Measuremensts------------------")
+    print("------------------Offset Measurements------------------")
     if len(lower_absolute_power) == 0:
         print("No data")
     for i in range(len(lower_absolute_power)):


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes a typo in a print statement in the AcpBasic python example for NI-RFmx Bluetooth.

### Why should this Pull Request be merged?

This typo looks pretty unprofessional, since it's in the output of a public example program.

### What testing has been done?

None--change is trivial.
