### PR TITLE
Check untyped defs in validate examples

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -57,14 +57,15 @@ jobs:
     - name: Update Submodules
       run: git submodule update --init --recursive --depth=1
 
+    - name: Install build dependencies
+      run: python -m pip install -r python_build_requirements.txt
+
     - name: Validate python style with black
       run: |
-        pip install black
         black source/codegen examples --check
 
     - name: Validate RFmx and XNET examples
       run: |
-        pip install mypy
         python source/codegen/validate_examples.py -p *rfmx*
         python source/codegen/validate_examples.py -p *xnet*
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -14,7 +14,10 @@ env:
   BUILD_TYPE: Release
 
 jobs:
+  validate_python:
+    uses: ./.github/workflows/validate_python.yml
   build:
+    needs: validate_python
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     strategy:
@@ -53,7 +56,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.x'
-
+    
     - name: Update Submodules
       run: git submodule update --init --recursive --depth=1
 

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -64,6 +64,11 @@ jobs:
       run: |
         black source/codegen examples --check
 
+    - name: Install poetry for validate_examples.py
+      uses: abatilo/actions-poetry@v2.0.0
+      with:
+        poetry-version: 1.1.5
+
     - name: Validate RFmx and XNET examples
       run: |
         python source/codegen/validate_examples.py -p *rfmx*

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -62,6 +62,12 @@ jobs:
         pip install black
         black source/codegen examples --check
 
+    - name: Validate RFmx and XNET examples
+      run: |
+        pip install mypy
+        python source/codegen/validate_examples.py -p *rfmx*
+        python source/codegen/validate_examples.py -p *xnet*
+
     - name: Configure
       shell: cmake -P {0}
       run: |

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -57,23 +57,6 @@ jobs:
     - name: Update Submodules
       run: git submodule update --init --recursive --depth=1
 
-    - name: Install build dependencies
-      run: python -m pip install -r python_build_requirements.txt
-
-    - name: Validate python style with black
-      run: |
-        black source/codegen examples --check
-
-    - name: Install poetry for validate_examples.py
-      uses: abatilo/actions-poetry@v2.0.0
-      with:
-        poetry-version: 1.1.5
-
-    - name: Validate RFmx and XNET examples
-      run: |
-        python source/codegen/validate_examples.py -p *rfmx*
-        python source/codegen/validate_examples.py -p *xnet*
-
     - name: Configure
       shell: cmake -P {0}
       run: |

--- a/.github/workflows/validate_python.yml
+++ b/.github/workflows/validate_python.yml
@@ -1,0 +1,39 @@
+name: Validate Python Code
+
+on:
+  push:
+    branches:
+      - main
+      - 'releases/**'
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+
+    - name: Setup python3
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install build dependencies
+      run: python -m pip install -r python_build_requirements.txt
+
+    - name: Validate python style with black
+      run: |
+        black source/codegen examples --check
+
+    - name: Install poetry for validate_examples.py
+      uses: abatilo/actions-poetry@v2.0.0
+      with:
+        poetry-version: 1.1.5
+
+    - name: Validate RFmx and XNET examples
+      run: |
+        python source/codegen/validate_examples.py -p *rfmx*
+        python source/codegen/validate_examples.py -p *xnet*

--- a/.github/workflows/validate_python.yml
+++ b/.github/workflows/validate_python.yml
@@ -1,12 +1,7 @@
 name: Validate Python Code
 
 on:
-  push:
-    branches:
-      - main
-      - 'releases/**'
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_call:
   workflow_dispatch:
 
 jobs:
@@ -35,5 +30,5 @@ jobs:
 
     - name: Validate RFmx and XNET examples
       run: |
-        python source/codegen/validate_examples.py -p *rfmx*
-        python source/codegen/validate_examples.py -p *xnet*
+        python source/codegen/validate_examples.py -p "*rfmx*"
+        python source/codegen/validate_examples.py -p "*xnet*"

--- a/python_build_requirements.txt
+++ b/python_build_requirements.txt
@@ -3,3 +3,4 @@ Mako==1.1.5
 MarkupSafe==2.0.1
 schema==0.7.4
 black>=21.10b0
+mypy>=0.910

--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -65,7 +65,7 @@ def validate_examples(driver_glob_expression: str, ip_address: str, device_name:
             _system(f"poetry run black --check --line-length 100 {dir}")
 
             print(f" -> Running mypy")
-            _system(f"poetry run mypy {dir} --check-untyped-defs")
+            _system(f"poetry run mypy {dir} --strict")
 
             if ip_address:
                 for file in dir.glob("*.py"):

--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -1,9 +1,9 @@
 from argparse import ArgumentParser
 from contextlib import contextmanager
-from sys import exit
 from os import getcwd, chdir, system as _system_core
 from pathlib import Path
 from shutil import rmtree
+from sys import exit
 from typing import NamedTuple
 
 from stage_client_files import stage_client_files

--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -1,10 +1,29 @@
 from argparse import ArgumentParser
 from contextlib import contextmanager
-from os import system, getcwd, chdir
+from sys import exit
+from os import getcwd, chdir, system as _system_core
 from pathlib import Path
 from shutil import rmtree
+from typing import NamedTuple
 
 from stage_client_files import stage_client_files
+
+
+class _CommandRecord(NamedTuple):
+    exit_code: int
+    command: str
+
+
+_FAILED_COMMANDS: list[_CommandRecord] = []
+
+
+def _system(command):
+    """
+    Capture the result of any failed system calls in _FAILED_COMMANDS.
+    """
+    exit_code = _system_core(command)
+    if exit_code:
+        _FAILED_COMMANDS.append(_CommandRecord(exit_code, command))
 
 
 @contextmanager
@@ -25,17 +44,17 @@ def validate_examples(driver_glob_expression: str, ip_address: str, device_name:
     print(f"Validating examples using staging_dir: {staging_dir}")
 
     with _create_stage_dir(staging_dir):
-        system("poetry new .")
-        system("poetry add grpcio")
-        system("poetry add --dev grpcio-tools black mypy mypy-protobuf types-protobuf grpc-stubs")
-        system("poetry install")
+        _system("poetry new .")
+        _system("poetry add grpcio")
+        _system("poetry add --dev grpcio-tools black mypy mypy-protobuf types-protobuf grpc-stubs")
+        _system("poetry install")
 
         stage_client_files(staging_dir, True)
         examples_dir = staging_dir / "examples"
         proto_dir = staging_dir / "proto"
         proto_files_str = str.join(" ", [file.name for file in proto_dir.glob("*.proto")])
 
-        system(
+        _system(
             rf"poetry run python -m grpc_tools.protoc -I{proto_dir} --python_out=. --grpc_python_out=. --mypy_out=. --mypy_grpc_out=. {proto_files_str}"
         )
         for dir in examples_dir.glob(driver_glob_expression):
@@ -43,16 +62,16 @@ def validate_examples(driver_glob_expression: str, ip_address: str, device_name:
             print(f"-- Validating: {dir.name}")
 
             print(f" -> Running black line-length 100")
-            system(f"poetry run black --check --line-length 100 {dir}")
+            _system(f"poetry run black --check --line-length 100 {dir}")
 
             print(f" -> Running mypy")
-            system(f"poetry run mypy {dir} --check-untyped-defs")
+            _system(f"poetry run mypy {dir} --check-untyped-defs")
 
             if ip_address:
                 for file in dir.glob("*.py"):
                     print(f" -> Running example: {file.name}")
                     PORT = 31763
-                    system(rf"poetry run python {file} {ip_address} {PORT} {device_name}")
+                    _system(rf"poetry run python {file} {ip_address} {PORT} {device_name}")
 
 
 if __name__ == "__main__":
@@ -79,3 +98,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     validate_examples(args.pattern, args.server, args.device)
+
+    if any(_FAILED_COMMANDS):
+        for code, command in _FAILED_COMMANDS:
+            print(f"FAILED STEP ({code}): [{command}]")
+
+        exit(_FAILED_COMMANDS[-1].exit_code)

--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -65,7 +65,7 @@ def validate_examples(driver_glob_expression: str, ip_address: str, device_name:
             _system(f"poetry run black --check --line-length 100 {dir}")
 
             print(f" -> Running mypy")
-            _system(f"poetry run mypy {dir} --strict")
+            _system(f"poetry run mypy {dir} --check-untyped-defs")
 
             if ip_address:
                 for file in dir.glob("*.py"):

--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -40,18 +40,19 @@ def validate_examples(driver_glob_expression: str, ip_address: str, device_name:
         )
         for dir in examples_dir.glob(driver_glob_expression):
             print()
-            print(f"-- Validating: {dir.name} --")
+            print(f"-- Validating: {dir.name}")
 
             print(f" -> Running black line-length 100")
             system(f"poetry run black --check --line-length 100 {dir}")
 
             print(f" -> Running mypy")
-            system(f"poetry run mypy {dir}")
+            system(f"poetry run mypy {dir} --check-untyped-defs")
 
-            for file in dir.glob("*.py"):
-                print(f" -> Running example: {file.name}")
-                PORT = 31763
-                system(rf"poetry run python {file} {ip_address} {PORT} {device_name}")
+            if ip_address:
+                for file in dir.glob("*.py"):
+                    print(f" -> Running example: {file.name}")
+                    PORT = 31763
+                    system(rf"poetry run python {file} {ip_address} {PORT} {device_name}")
 
 
 if __name__ == "__main__":
@@ -62,7 +63,11 @@ if __name__ == "__main__":
         help="Glob expression for scrapigen driver names to validate (i.e., *rfmx*).",
     )
 
-    parser.add_argument("-s", "--server", help="grpc-device server IP address.")
+    parser.add_argument(
+        "-s",
+        "--server",
+        help="grpc-device server IP address. If not specified, skip running examples.",
+    )
 
     parser.add_argument(
         "-d",

--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -103,4 +103,4 @@ if __name__ == "__main__":
         for code, command in _FAILED_COMMANDS:
             print(f"FAILED STEP ({code}): [{command}]")
 
-        exit(_FAILED_COMMANDS[-1].exit_code)
+        exit(1)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Pass `--check-untyped-defs` to `mypy` in `validate_examples`.

Add `validate_examples` for `*rfmx*` and `*xnet*` to github workflow.

Add ability to run `validate_examples` without a server address and skip the run-time check.

### Why should this Pull Request be merged?

Ensure that we catch issues like #540 in services that are under development.
* Note that shipping drivers don't all pass `mypy` for various reasons, but are less likely to be broken for API changes.

### What testing has been done?

Ran and passed `python source\codegen\validate_examples.py -p *rfmx*`.

Manual testing of code with bogus references similar to the fixed cases in #540 and ensure they pass.

Tested validate_examples in failed workflow.                                                                                                      