### PR TITLE
Inline the EXPECT_SUCCESS macro; expand error output

### DIFF
--- a/source/tests/system/nirfmxbluetooth_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxbluetooth_driver_api_tests.cpp
@@ -264,9 +264,7 @@ TEST_F(NiRFmxBluetoothDriverApiTests, SetAndGetAttributeInt32_Succeeds)
 {
   auto session = init_session(stub(), kPxi5663e);
   EXPECT_SUCCESS(session, client::select_measurements(stub(), session, "", MeasurementTypes::MEASUREMENT_TYPES_TXP, true));
-  EXPECT_SUCCESS(
-      session,
-      client::set_attribute_i32(stub(), session, "", NiRFmxBluetoothAttribute::NIRFMXBLUETOOTH_ATTRIBUTE_TXP_AVERAGING_ENABLED, NiRFmxBluetoothInt32AttributeValues::NIRFMXBLUETOOTH_INT32_TXP_AVERAGING_ENABLED_TRUE));
+  EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NiRFmxBluetoothAttribute::NIRFMXBLUETOOTH_ATTRIBUTE_TXP_AVERAGING_ENABLED, NiRFmxBluetoothInt32AttributeValues::NIRFMXBLUETOOTH_INT32_TXP_AVERAGING_ENABLED_TRUE));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
   auto get_response = client::get_attribute_i32(stub(), session, "", NiRFmxBluetoothAttribute::NIRFMXBLUETOOTH_ATTRIBUTE_TXP_AVERAGING_ENABLED);
@@ -282,11 +280,9 @@ TEST_F(NiRFmxBluetoothDriverApiTests, ConfigureTwentydBBandwidth_FetchMeasuremen
   EXPECT_SUCCESS(session, client::twentyd_b_bandwidth_cfg_averaging(stub(), session, "", TwentydBBandwidthAveragingEnabled::TWENTY_DB_BANDWIDTH_AVERAGING_ENABLED_FALSE, 10));
 
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
-  const auto fetch_measurement_response = client::twentyd_b_bandwidth_fetch_measurement(stub(), session, "", 10.0);
-  const auto fetch_spectrum_response = client::twentyd_b_bandwidth_fetch_spectrum(stub(), session, "", 10.0);
+  const auto fetch_measurement_response = EXPECT_SUCCESS(session, client::twentyd_b_bandwidth_fetch_measurement(stub(), session, "", 10.0));
+  const auto fetch_spectrum_response = EXPECT_SUCCESS(session, client::twentyd_b_bandwidth_fetch_spectrum(stub(), session, "", 10.0));
 
-  EXPECT_SUCCESS(session, fetch_measurement_response);
-  EXPECT_SUCCESS(session, fetch_spectrum_response);
   EXPECT_NE(0.0, fetch_measurement_response.low_frequency());
   EXPECT_NE(0.0, fetch_measurement_response.peak_power());
   EXPECT_THAT(fetch_spectrum_response.spectrum(), Not(IsEmpty()));

--- a/source/tests/system/nirfmxinstr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxinstr_driver_api_tests.cpp
@@ -138,8 +138,7 @@ TEST_F(NiRFmxInstrDriverApiTests, GetNIRFSASession_SelfTest_Succeeds)
   auto session = init_response.instrument();
   EXPECT_SUCCESS(session, init_response);
 
-  const auto rfsa_response = client::get_nirfsa_session(stub(), session);
-  EXPECT_SUCCESS(session, rfsa_response);
+  const auto rfsa_response = EXPECT_SUCCESS(session, client::get_nirfsa_session(stub(), session));
 
   auto rfsa_stub = create_stub<nirfsa_grpc::NiRFSA>();
   EXPECT_RESPONSE_SUCCESS(nirfsa_client::self_test(rfsa_stub, rfsa_response.nirfsa_session()));
@@ -151,8 +150,7 @@ TEST_F(NiRFmxInstrDriverApiTests, GetNIRFSASessionArrayAnonymous_SelfTest_Succee
   auto session = init_response.instrument();
   EXPECT_SUCCESS(session, init_response);
 
-  const auto get_rfsa_response = client::get_nirfsa_session_array(stub(), session);
-  EXPECT_SUCCESS(session, get_rfsa_response);
+  const auto get_rfsa_response = EXPECT_SUCCESS(session, client::get_nirfsa_session_array(stub(), session));
 
   auto rfsa_stub = create_stub<nirfsa_grpc::NiRFSA>();
   EXPECT_RESPONSE_SUCCESS(nirfsa_client::self_test(rfsa_stub, get_rfsa_response.nirfsa_sessions()[0]));
@@ -258,9 +256,8 @@ TEST_F(NiRFmxInstrDriverApiTests, NoActiveList_GetListNames_ReturnsEmptyLists)
 {
   const auto session = init_session(stub(), PXI_5663E);
 
-  const auto response = client::get_list_names(stub(), session, "", 0);
+  const auto response = EXPECT_SUCCESS(session, client::get_list_names(stub(), session, "", 0));
 
-  EXPECT_SUCCESS(session, response);
   EXPECT_THAT(response.list_names(), IsEmpty());
   EXPECT_THAT(response.personality(), IsEmpty());
 }
@@ -323,9 +320,8 @@ TEST_F(NiRFmxInstrDriverApiTests, SpectrumBasicWithRFmxInstr_DataLooksReasonable
   EXPECT_SUCCESS(session, specan_client::spectrum_cfg_rbw_filter(specan_stub, session, "", true, 100e3, nirfmxspecan_grpc::SpectrumRbwFilterType::SPECTRUM_RBW_FILTER_TYPE_GAUSSIAN));
   EXPECT_SUCCESS(session, specan_client::spectrum_cfg_averaging(specan_stub, session, "", false, 10, nirfmxspecan_grpc::SpectrumAveragingType::SPECTRUM_AVERAGING_TYPE_RMS));
 
-  auto read_response = specan_client::spectrum_read(specan_stub, session, "", 10.0);
+  auto read_response = EXPECT_SUCCESS(session, specan_client::spectrum_read(specan_stub, session, "", 10.0));
 
-  EXPECT_SUCCESS(session, read_response);
   constexpr auto EXPECTED_SPECTRUM_SIZE = 1005;
   EXPECT_EQ(EXPECTED_SPECTRUM_SIZE, read_response.spectrum().size());
   constexpr auto MIDPOINT_X = EXPECTED_SPECTRUM_SIZE / 2;

--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -141,8 +141,7 @@ TEST_F(NiRFmxNRDriverApiTests, AcpNonContiguousMultiCarrierFromExample_FetchData
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_LINK_DIRECTION, NIRFMXNR_INT32_LINK_DIRECTION_UPLINK));
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_NUMBER_OF_SUBBLOCKS, NUMBER_OF_SUBBLOCKS));
   for (int i = 0; i < NUMBER_OF_SUBBLOCKS; i++) {
-    auto subblock_string_response = client::build_subblock_string(stub(), "", i);
-    EXPECT_SUCCESS(session, subblock_string_response);
+    const auto subblock_string_response = EXPECT_SUCCESS(session, client::build_subblock_string(stub(), "", i));
     EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, subblock_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_FREQUENCY_RANGE, NIRFMXNR_INT32_FREQUENCY_RANGE_RANGE1));
     EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, subblock_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_CENTER_FREQUENCY, centerFrequency[i]));
     EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, subblock_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_SUBBLOCK_FREQUENCY_DEFINITION, subblockFrequencyDefinition[i]));
@@ -150,12 +149,10 @@ TEST_F(NiRFmxNRDriverApiTests, AcpNonContiguousMultiCarrierFromExample_FetchData
     EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, subblock_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_CHANNEL_RASTER, 15e3));
     EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, subblock_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_COMPONENT_CARRIER_AT_CENTER_FREQUENCY, -1));
     EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, subblock_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_NUMBER_OF_COMPONENT_CARRIERS, NUMBER_OF_COMPONENT_CARRIERS));
-    auto carrier_string_response = client::build_carrier_string(stub(), subblock_string_response.selector_string_out(), -1);
-    EXPECT_SUCCESS(session, carrier_string_response);
+    const auto carrier_string_response = EXPECT_SUCCESS(session, client::build_carrier_string(stub(), subblock_string_response.selector_string_out(), -1));
     EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, carrier_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_BANDWIDTH_PART_SUBCARRIER_SPACING, 30e3));
     for (int j = 0; j < NUMBER_OF_COMPONENT_CARRIERS; j++) {
-      auto carrier_string_response = client::build_carrier_string(stub(), subblock_string_response.selector_string_out(), j);
-      EXPECT_SUCCESS(session, carrier_string_response);
+      const auto carrier_string_response = EXPECT_SUCCESS(session, client::build_carrier_string(stub(), subblock_string_response.selector_string_out(), j));
       EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, carrier_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_COMPONENT_CARRIER_BANDWIDTH, 20e6));
       EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, carrier_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_COMPONENT_CARRIER_FREQUENCY, componentCarrierFrequency[i][j]));
     }
@@ -172,12 +169,9 @@ TEST_F(NiRFmxNRDriverApiTests, AcpNonContiguousMultiCarrierFromExample_FetchData
   ACPFetchSubblockMeasurementResponse fetch_subblock_responses[NUMBER_OF_SUBBLOCKS];
   ACPFetchOffsetMeasurementResponse fetch_measurement_responses[NUMBER_OF_SUBBLOCKS];
   for (int i = 0; i < NUMBER_OF_SUBBLOCKS; i++) {
-    auto subblock_string_response = client::build_subblock_string(stub(), "", i);
-    EXPECT_SUCCESS(session, subblock_string_response);
-    fetch_subblock_responses[i] = client::acp_fetch_subblock_measurement(stub(), session, subblock_string_response.selector_string_out(), 10.0);
-    EXPECT_SUCCESS(session, fetch_subblock_responses[i]);
-    fetch_measurement_responses[i] = client::acp_fetch_offset_measurement(stub(), session, subblock_string_response.selector_string_out(), 10.0);
-    EXPECT_SUCCESS(session, fetch_measurement_responses[i]);
+    const auto subblock_string_response = EXPECT_SUCCESS(session, client::build_subblock_string(stub(), "", i));
+    fetch_subblock_responses[i] = EXPECT_SUCCESS(session, client::acp_fetch_subblock_measurement(stub(), session, subblock_string_response.selector_string_out(), 10.0));
+    fetch_measurement_responses[i] = EXPECT_SUCCESS(session, client::acp_fetch_offset_measurement(stub(), session, subblock_string_response.selector_string_out(), 10.0));
   }
 
   EXPECT_EQ(0.0, auto_level_response.reference_level());
@@ -210,8 +204,7 @@ TEST_F(NiRFmxNRDriverApiTests, ACPSingleCarrierFromExample_FetchData_DataLooksRe
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_FREQUENCY_RANGE, NIRFMXNR_INT32_FREQUENCY_RANGE_RANGE1));
   EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, "", NIRFMXNR_ATTRIBUTE_COMPONENT_CARRIER_BANDWIDTH, 20e6));
   EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, "", NIRFMXNR_ATTRIBUTE_BANDWIDTH_PART_SUBCARRIER_SPACING, 30e3));
-  auto auto_level_response = client::auto_level(stub(), session, "", 10.0e-3);
-  EXPECT_SUCCESS(session, auto_level_response);
+  auto auto_level_response = EXPECT_SUCCESS(session, client::auto_level(stub(), session, "", 10.0e-3));
   EXPECT_SUCCESS(session, client::select_measurements(stub(), session, "", MEASUREMENT_TYPES_ACP, true));
   EXPECT_SUCCESS(session, client::acp_cfg_measurement_method(stub(), session, "", ACP_MEASUREMENT_METHOD_NORMAL));
   EXPECT_SUCCESS(session, client::acp_cfg_noise_compensation_enabled(stub(), session, "", ACP_NOISE_COMPENSATION_ENABLED_FALSE));
@@ -219,18 +212,15 @@ TEST_F(NiRFmxNRDriverApiTests, ACPSingleCarrierFromExample_FetchData_DataLooksRe
   EXPECT_SUCCESS(session, client::acp_cfg_averaging(stub(), session, "", ACP_AVERAGING_ENABLED_FALSE, 10, ACP_AVERAGING_TYPE_RMS));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  const auto acp_fetch_offset_measurement_array_response = client::acp_fetch_offset_measurement_array(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, acp_fetch_offset_measurement_array_response);
+  const auto acp_fetch_offset_measurement_array_response = EXPECT_SUCCESS(session, client::acp_fetch_offset_measurement_array(stub(), session, "", 10.0));
   int32 arraySize = acp_fetch_offset_measurement_array_response.lower_relative_power_size();
-  const auto acp_fetch_component_carrier_measurement_response = client::acp_fetch_component_carrier_measurement(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, acp_fetch_component_carrier_measurement_response);
+  const auto acp_fetch_component_carrier_measurement_response = EXPECT_SUCCESS(session, client::acp_fetch_component_carrier_measurement(stub(), session, "", 10.0));
   std::vector<ACPFetchRelativePowersTraceResponse> acp_fetch_relative_powers_trace_responses;
   for (int i = 0; i < arraySize; i++) {
     acp_fetch_relative_powers_trace_responses.push_back(client::acp_fetch_relative_powers_trace(stub(), session, "", 10.0, i));
     EXPECT_SUCCESS(session, acp_fetch_relative_powers_trace_responses.back());
   }
-  const auto acp_fetch_spectrum_response = client::acp_fetch_spectrum(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, acp_fetch_spectrum_response);
+  const auto acp_fetch_spectrum_response = EXPECT_SUCCESS(session, client::acp_fetch_spectrum(stub(), session, "", 10.0));
 
   EXPECT_LT(0.0, auto_level_response.reference_level());
   EXPECT_EQ(3, acp_fetch_offset_measurement_array_response.lower_relative_power_size());
@@ -277,10 +267,8 @@ TEST_F(NiRFmxNRDriverApiTests, ChpSingleCarrierFromExample_FetchData_DataLooksRe
   EXPECT_SUCCESS(session, client::chp_cfg_averaging(stub(), session, "", CHP_AVERAGING_ENABLED_FALSE, 10, CHP_AVERAGING_TYPE_RMS));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  const auto chp_fetch_component_carrier_measurement_response = client::chp_fetch_component_carrier_measurement(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, chp_fetch_component_carrier_measurement_response);
-  const auto chp_fetch_spectrum_response = client::chp_fetch_spectrum(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, chp_fetch_spectrum_response);
+  const auto chp_fetch_component_carrier_measurement_response = EXPECT_SUCCESS(session, client::chp_fetch_component_carrier_measurement(stub(), session, "", 10.0));
+  const auto chp_fetch_spectrum_response = EXPECT_SUCCESS(session, client::chp_fetch_spectrum(stub(), session, "", 10.0));
 
   EXPECT_LT(0.0, chp_fetch_component_carrier_measurement_response.absolute_power());
   EXPECT_EQ(0.0, chp_fetch_component_carrier_measurement_response.relative_power());
@@ -310,11 +298,9 @@ TEST_F(NiRFmxNRDriverApiTests, DLModAccContiguousMultiCarrierFromExample_FetchDa
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_COMPONENT_CARRIER_SPACING_TYPE, NIRFMXNR_INT32_COMPONENT_CARRIER_SPACING_TYPE_NOMINAL));
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_COMPONENT_CARRIER_AT_CENTER_FREQUENCY, -1));
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_NUMBER_OF_COMPONENT_CARRIERS, NUMBER_OF_COMPONENT_CARRIERS));
-  auto subblock_string_response = client::build_subblock_string(stub(), "", 0);
-  EXPECT_SUCCESS(session, subblock_string_response);
+  const auto subblock_string_response = EXPECT_SUCCESS(session, client::build_subblock_string(stub(), "", 0));
   for (int i = 0; i < NUMBER_OF_COMPONENT_CARRIERS; i++) {
-    auto carrier_string_response = client::build_carrier_string(stub(), subblock_string_response.selector_string_out(), i);
-    EXPECT_SUCCESS(session, carrier_string_response);
+    const auto carrier_string_response = EXPECT_SUCCESS(session, client::build_carrier_string(stub(), subblock_string_response.selector_string_out(), i));
     EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, carrier_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_COMPONENT_CARRIER_BANDWIDTH, 20e6));
     EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, carrier_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_COMPONENT_CARRIER_FREQUENCY, componentCarrierFrequency[i]));
   }
@@ -344,8 +330,7 @@ TEST_F(NiRFmxNRDriverApiTests, DLModAccContiguousMultiCarrierFromExample_FetchDa
   ModAccFetchRMSEVMPerSubcarrierMeanTraceResponse mod_acc_fetch_rmsevm_per_subcarrier_mean_trace_response[2];
   ModAccFetchRMSEVMPerSymbolMeanTraceResponse mod_acc_fetch_rmsevm_per_symbol_mean_trace_response[2];
   for (int i = 0; i < NUMBER_OF_COMPONENT_CARRIERS; i++) {
-    auto carrier_string_response = client::build_carrier_string(stub(), subblock_string_response.selector_string_out(), i);
-    EXPECT_SUCCESS(session, carrier_string_response);
+    const auto carrier_string_response = EXPECT_SUCCESS(session, client::build_carrier_string(stub(), subblock_string_response.selector_string_out(), i));
     auto modacc_results_composite_rms_evm_mean_response = client::get_attribute_f64(stub(), session, carrier_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_COMPOSITE_RMS_EVM_MEAN);
     if (i == 0) {
       EXPECT_WARNING(NR_SYNC_FAILURE, NR_SYNC_FAILURE_STR, session, modacc_results_composite_rms_evm_mean_response);
@@ -427,10 +412,8 @@ TEST_F(NiRFmxNRDriverApiTests, ObwSingleCarrierFromExample_FetchData_DataLooksRe
   EXPECT_SUCCESS(session, client::obw_cfg_averaging(stub(), session, "", OBW_AVERAGING_ENABLED_FALSE, 10, OBW_AVERAGING_TYPE_RMS));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  const auto obw_fetch_spectrum_response = client::obw_fetch_spectrum(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, obw_fetch_spectrum_response);
-  const auto obw_fetch_measurement_response = client::obw_fetch_measurement(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, obw_fetch_measurement_response);
+  const auto obw_fetch_spectrum_response = EXPECT_SUCCESS(session, client::obw_fetch_spectrum(stub(), session, "", 10.0));
+  const auto obw_fetch_measurement_response = EXPECT_SUCCESS(session, client::obw_fetch_measurement(stub(), session, "", 10.0));
 
   EXPECT_LT(0.0, obw_fetch_spectrum_response.x0());
   EXPECT_LT(0.0, obw_fetch_spectrum_response.dx());
@@ -475,11 +458,9 @@ TEST_F(NiRFmxNRDriverApiTests, SemContiguousMultiCarrierFromExample_FetchData_Da
   strcpy_s(carrierString, sizeof("carrier::all"), "carrier::all");
   EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, carrierString, NIRFMXNR_ATTRIBUTE_BANDWIDTH_PART_SUBCARRIER_SPACING, 30e3));
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_NUMBER_OF_COMPONENT_CARRIERS, NUMBER_OF_COMPONENT_CARRIERS));
-  auto subblock_string_response = client::build_subblock_string(stub(), "", 0);
-  EXPECT_SUCCESS(session, subblock_string_response);
+  const auto subblock_string_response = EXPECT_SUCCESS(session, client::build_subblock_string(stub(), "", 0));
   for (int i = 0; i < NUMBER_OF_COMPONENT_CARRIERS; i++) {
-    auto carrier_string_response = client::build_carrier_string(stub(), subblock_string_response.selector_string_out(), i);
-    EXPECT_SUCCESS(session, carrier_string_response);
+    const auto carrier_string_response = EXPECT_SUCCESS(session, client::build_carrier_string(stub(), subblock_string_response.selector_string_out(), i));
     EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, carrier_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_COMPONENT_CARRIER_BANDWIDTH, 20e6));
     EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, carrier_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_COMPONENT_CARRIER_FREQUENCY, componentCarrierFrequency[i]));
   }
@@ -496,17 +477,12 @@ TEST_F(NiRFmxNRDriverApiTests, SemContiguousMultiCarrierFromExample_FetchData_Da
   EXPECT_SUCCESS(session, client::sem_cfg_averaging(stub(), session, "", SEM_AVERAGING_ENABLED_FALSE, 10, SEM_AVERAGING_TYPE_RMS));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  const auto sem_fetch_upper_offset_margin_array_response = client::sem_fetch_upper_offset_margin_array(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, sem_fetch_upper_offset_margin_array_response);
+  const auto sem_fetch_upper_offset_margin_array_response = EXPECT_SUCCESS(session, client::sem_fetch_upper_offset_margin_array(stub(), session, "", 10.0));
   int32 arraySize = sem_fetch_upper_offset_margin_array_response.measurement_status_size();
-  const auto sem_fetch_lower_offset_margin_array_response = client::sem_fetch_lower_offset_margin_array(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, sem_fetch_lower_offset_margin_array_response);
-  const auto sem_fetch_total_aggregated_power_response = client::sem_fetch_total_aggregated_power(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, sem_fetch_total_aggregated_power_response);
-  const auto sem_fetch_measurement_status_response = client::sem_fetch_measurement_status(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, sem_fetch_measurement_status_response);
-  const auto sem_fetch_spectrum_response = client::sem_fetch_spectrum(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, sem_fetch_spectrum_response);
+  const auto sem_fetch_lower_offset_margin_array_response = EXPECT_SUCCESS(session, client::sem_fetch_lower_offset_margin_array(stub(), session, "", 10.0));
+  const auto sem_fetch_total_aggregated_power_response = EXPECT_SUCCESS(session, client::sem_fetch_total_aggregated_power(stub(), session, "", 10.0));
+  const auto sem_fetch_measurement_status_response = EXPECT_SUCCESS(session, client::sem_fetch_measurement_status(stub(), session, "", 10.0));
+  const auto sem_fetch_spectrum_response = EXPECT_SUCCESS(session, client::sem_fetch_spectrum(stub(), session, "", 10.0));
 
   EXPECT_EQ(4, sem_fetch_upper_offset_margin_array_response.measurement_status_size());
   EXPECT_EQ(4, sem_fetch_upper_offset_margin_array_response.measurement_status().size());
@@ -567,17 +543,12 @@ TEST_F(NiRFmxNRDriverApiTests, SemSingleCarrierFromExample_FetchData_DataLooksRe
   EXPECT_SUCCESS(session, client::sem_cfg_averaging(stub(), session, "", SEM_AVERAGING_ENABLED_FALSE, 10, SEM_AVERAGING_TYPE_RMS));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  const auto sem_fetch_upper_offset_margin_array_response = client::sem_fetch_upper_offset_margin_array(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, sem_fetch_upper_offset_margin_array_response);
+  const auto sem_fetch_upper_offset_margin_array_response = EXPECT_SUCCESS(session, client::sem_fetch_upper_offset_margin_array(stub(), session, "", 10.0));
   int32 arraySize = sem_fetch_upper_offset_margin_array_response.measurement_status_size();
-  const auto sem_fetch_lower_offset_margin_array_response = client::sem_fetch_lower_offset_margin_array(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, sem_fetch_lower_offset_margin_array_response);
-  const auto sem_fetch_component_carrier_measurement_response = client::sem_fetch_component_carrier_measurement(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, sem_fetch_component_carrier_measurement_response);
-  const auto sem_fetch_measurement_status_response = client::sem_fetch_measurement_status(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, sem_fetch_measurement_status_response);
-  const auto sem_fetch_spectrum_response = client::sem_fetch_spectrum(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, sem_fetch_spectrum_response);
+  const auto sem_fetch_lower_offset_margin_array_response = EXPECT_SUCCESS(session, client::sem_fetch_lower_offset_margin_array(stub(), session, "", 10.0));
+  const auto sem_fetch_component_carrier_measurement_response = EXPECT_SUCCESS(session, client::sem_fetch_component_carrier_measurement(stub(), session, "", 10.0));
+  const auto sem_fetch_measurement_status_response = EXPECT_SUCCESS(session, client::sem_fetch_measurement_status(stub(), session, "", 10.0));
+  const auto sem_fetch_spectrum_response = EXPECT_SUCCESS(session, client::sem_fetch_spectrum(stub(), session, "", 10.0));
 
   EXPECT_EQ(4, sem_fetch_upper_offset_margin_array_response.measurement_status_size());
   EXPECT_EQ(4, sem_fetch_upper_offset_margin_array_response.measurement_status().size());
@@ -641,11 +612,9 @@ TEST_F(NiRFmxNRDriverApiTests, TxpContiguousMultiCarrierFromExample_FetchData_Da
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_COMPONENT_CARRIER_SPACING_TYPE, NIRFMXNR_INT32_COMPONENT_CARRIER_SPACING_TYPE_NOMINAL));
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_COMPONENT_CARRIER_AT_CENTER_FREQUENCY, -1));
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_NUMBER_OF_COMPONENT_CARRIERS, NUMBER_OF_COMPONENT_CARRIERS));
-  auto subblock_string_response = client::build_subblock_string(stub(), "", 0);
-  EXPECT_SUCCESS(session, subblock_string_response);
+  const auto subblock_string_response = EXPECT_SUCCESS(session, client::build_subblock_string(stub(), "", 0));
   for (int i = 0; i < NUMBER_OF_COMPONENT_CARRIERS; i++) {
-    auto carrier_string_response = client::build_carrier_string(stub(), subblock_string_response.selector_string_out(), i);
-    EXPECT_SUCCESS(session, carrier_string_response);
+    const auto carrier_string_response = EXPECT_SUCCESS(session, client::build_carrier_string(stub(), subblock_string_response.selector_string_out(), i));
     EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, carrier_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_COMPONENT_CARRIER_BANDWIDTH, 20e6));
     EXPECT_SUCCESS(session, client::set_attribute_f64(stub(), session, carrier_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_COMPONENT_CARRIER_FREQUENCY, componentCarrierFrequency[i]));
   }
@@ -658,10 +627,8 @@ TEST_F(NiRFmxNRDriverApiTests, TxpContiguousMultiCarrierFromExample_FetchData_Da
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_TXP_AVERAGING_COUNT, 10));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  const auto txp_fetch_measurement_response = client::txp_fetch_measurement(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, txp_fetch_measurement_response);
-  const auto txp_fetch_power_trace_response = client::txp_fetch_power_trace(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, txp_fetch_power_trace_response);
+  const auto txp_fetch_measurement_response = EXPECT_SUCCESS(session, client::txp_fetch_measurement(stub(), session, "", 10.0));
+  const auto txp_fetch_power_trace_response = EXPECT_SUCCESS(session, client::txp_fetch_power_trace(stub(), session, "", 10.0));
 
   EXPECT_LT(0.0, txp_fetch_measurement_response.average_power_mean());
   EXPECT_LT(0.0, txp_fetch_measurement_response.peak_power_maximum());
@@ -704,19 +671,13 @@ TEST_F(NiRFmxNRDriverApiTests, ULModAccSpeedOptimizedFromExample_FetchData_DataL
   EXPECT_SUCCESS(session, client::set_attribute_string(stub(), session, "", NIRFMXNR_ATTRIBUTE_PUSCH_SYMBOL_ALLOCATION, std::string("0-Last")));
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_PUSCH_MODULATION_TYPE, NIRFMXNR_INT32_PUSCH_MODULATION_TYPE_QPSK));
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXNR_ATTRIBUTE_PUSCH_NUMBER_OF_RESOURCE_BLOCK_CLUSTERS, NUMBER_OF_RESOURCE_BLOCK_CLUSTERS));
-  auto subblock_string_response = client::build_subblock_string(stub(), "", 0);
-  EXPECT_SUCCESS(session, subblock_string_response);
-  auto carrier_string_response = client::build_carrier_string(stub(), subblock_string_response.selector_string_out(), 0);
-  EXPECT_SUCCESS(session, carrier_string_response);
-  auto bandwidth_part_string_response = client::build_bandwidth_part_string(stub(), carrier_string_response.selector_string_out(), 0);
-  EXPECT_SUCCESS(session, bandwidth_part_string_response);
-  auto user_string_response = client::build_user_string(stub(), bandwidth_part_string_response.selector_string_out(), 0);
-  EXPECT_SUCCESS(session, user_string_response);
-  auto pusch_string_response = client::build_pusch_string(stub(), user_string_response.selector_string_out(), 0);
-  EXPECT_SUCCESS(session, pusch_string_response);
+  const auto subblock_string_response = EXPECT_SUCCESS(session, client::build_subblock_string(stub(), "", 0));
+  const auto carrier_string_response = EXPECT_SUCCESS(session, client::build_carrier_string(stub(), subblock_string_response.selector_string_out(), 0));
+  const auto bandwidth_part_string_response = EXPECT_SUCCESS(session, client::build_bandwidth_part_string(stub(), carrier_string_response.selector_string_out(), 0));
+  const auto user_string_response = EXPECT_SUCCESS(session, client::build_user_string(stub(), bandwidth_part_string_response.selector_string_out(), 0));
+  const auto pusch_string_response = EXPECT_SUCCESS(session, client::build_pusch_string(stub(), user_string_response.selector_string_out(), 0));
   for (int i = 0; i < NUMBER_OF_RESOURCE_BLOCK_CLUSTERS; i++) {
-    auto pusch_cluster_string_response = client::build_pusch_cluster_string(stub(), pusch_string_response.selector_string_out(), i);
-    EXPECT_SUCCESS(session, pusch_cluster_string_response);
+    const auto pusch_cluster_string_response = EXPECT_SUCCESS(session, client::build_pusch_cluster_string(stub(), pusch_string_response.selector_string_out(), i));
     EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, pusch_cluster_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_PUSCH_RESOURCE_BLOCK_OFFSET, pusch_resource_block_offset[i]));
     EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, pusch_cluster_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_PUSCH_NUMBER_OF_RESOURCE_BLOCKS, pusch_number_of_resource_blocks[i]));
   }

--- a/source/tests/system/nirfmxspecan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxspecan_driver_api_tests.cpp
@@ -111,10 +111,8 @@ TEST_F(NiRFmxSpecAnDriverApiTests, SpectrumBasicFromExample_DataLooksReasonable)
   EXPECT_SUCCESS(session, client::spectrum_cfg_rbw_filter(stub(), session, "", true, 100e3, SpectrumRbwFilterType::SPECTRUM_RBW_FILTER_TYPE_GAUSSIAN));
   EXPECT_SUCCESS(session, client::spectrum_cfg_averaging(stub(), session, "", false, 10, SpectrumAveragingType::SPECTRUM_AVERAGING_TYPE_RMS));
 
-  auto read_response = client::spectrum_read(stub(), session, "", 10.0);
+  auto read_response = EXPECT_SUCCESS(session, client::spectrum_read(stub(), session, "", 10.0));
 
-  EXPECT_SUCCESS(session, read_response);
-  // Make sure the data looks roughly correct
   EXPECT_EQ(1005, read_response.actual_array_size());
   EXPECT_EQ(1005, read_response.spectrum_size());
   EXPECT_EQ(1005, read_response.spectrum().size());
@@ -131,8 +129,7 @@ TEST_F(NiRFmxSpecAnDriverApiTests, AcpBasicFromExample_DataLooksReasonable)
   EXPECT_SUCCESS(session, client::acp_cfg_averaging(stub(), session, "", false, 10, AcpAveragingType::ACP_AVERAGING_TYPE_RMS));
   EXPECT_SUCCESS(session, client::acp_cfg_carrier_and_offsets(stub(), session, "", 1e6, 2, 1e6));
 
-  const auto read_response = client::acp_read(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, read_response);
+  const auto read_response = EXPECT_SUCCESS(session, client::acp_read(stub(), session, "", 10.0));
 
   EXPECT_GT(read_response.carrier_absolute_power(), 0.0);
   EXPECT_LT(read_response.offset_ch0_lower_relative_power(), 0.0);
@@ -149,8 +146,7 @@ TEST_F(NiRFmxSpecAnDriverApiTests, FcntBasicFromExample_DataLooksReasonable)
   EXPECT_SUCCESS(session, client::f_cnt_cfg_averaging(stub(), session, "", false, 10, FcntAveragingType::FCNT_AVERAGING_TYPE_MEAN));
   EXPECT_SUCCESS(session, client::f_cnt_cfg_rbw_filter(stub(), session, "", 100e3, FcntRbwFilterType::FCNT_RBW_FILTER_TYPE_NONE, 0.1));
 
-  const auto read_response = client::f_cnt_read(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, read_response);
+  const auto read_response = EXPECT_SUCCESS(session, client::f_cnt_read(stub(), session, "", 10.0));
 
   EXPECT_GT(read_response.average_relative_frequency(), 0.0);
   EXPECT_GT(read_response.average_absolute_frequency(), read_response.average_relative_frequency());
@@ -168,8 +164,7 @@ TEST_F(NiRFmxSpecAnDriverApiTests, SpurBasicFromExample_ReturnsMeasurementStatus
   EXPECT_SUCCESS(session, client::spur_cfg_range_absolute_limit_array(stub(), session, "", {}, {-10.0}, {}));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  const auto fetch_response = client::spur_fetch_measurement_status(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, fetch_response);
+  const auto fetch_response = EXPECT_SUCCESS(session, client::spur_fetch_measurement_status(stub(), session, "", 10.0));
   EXPECT_EQ(SpurMeasurementStatus::SPUR_MEASUREMENT_STATUS_FAIL, fetch_response.measurement_status());
 }
 
@@ -187,15 +182,11 @@ TEST_F(NiRFmxSpecAnDriverApiTests, HarmFromExample_NoError)
   EXPECT_SUCCESS(session, client::harm_cfg_averaging(stub(), session, "", false, 10, HarmAveragingType::HARM_AVERAGING_TYPE_RMS));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  const auto fetch_thd_response = client::harm_fetch_thd(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, fetch_thd_response);
-  const auto fetch_measurement_response = client::harm_fetch_harmonic_measurement_array(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, fetch_measurement_response);
+  const auto fetch_thd_response = EXPECT_SUCCESS(session, client::harm_fetch_thd(stub(), session, "", 10.0));
+  const auto fetch_measurement_response = EXPECT_SUCCESS(session, client::harm_fetch_harmonic_measurement_array(stub(), session, "", 10.0));
   for (auto i = 0; i < NUMBER_OF_HARMONICS; ++i) {
-    const auto harmonic_string_response = client::build_harmonic_string(stub(), "", i);
-    EXPECT_SUCCESS(session, harmonic_string_response);
-    const auto power_trace_response = client::harm_fetch_harmonic_power_trace(stub(), session, harmonic_string_response.selector_string_out(), 10.0);
-    EXPECT_SUCCESS(session, power_trace_response);
+    const auto harmonic_string_response = EXPECT_SUCCESS(session, client::build_harmonic_string(stub(), "", i));
+    const auto power_trace_response = EXPECT_SUCCESS(session, client::harm_fetch_harmonic_power_trace(stub(), session, harmonic_string_response.selector_string_out(), 10.0));
   }
 }
 
@@ -228,14 +219,10 @@ TEST_F(NiRFmxSpecAnDriverApiTests, AMPMFromExample_NoError)
   EXPECT_SUCCESS(session, client::auto_level(stub(), session, "", 20e6, 100e-6));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  const auto dut_char_response = client::ampm_fetch_dut_characteristics(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, dut_char_response);
-  const auto error_response = client::ampm_fetch_error(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, error_response);
-  const auto curve_fit_response = client::ampm_fetch_curve_fit_residual(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, curve_fit_response);
-  const auto am_to_am_response = client::ampm_fetch_am_to_am_trace(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, am_to_am_response);
+  const auto dut_char_response = EXPECT_SUCCESS(session, client::ampm_fetch_dut_characteristics(stub(), session, "", 10.0));
+  const auto error_response = EXPECT_SUCCESS(session, client::ampm_fetch_error(stub(), session, "", 10.0));
+  const auto curve_fit_response = EXPECT_SUCCESS(session, client::ampm_fetch_curve_fit_residual(stub(), session, "", 10.0));
+  const auto am_to_am_response = EXPECT_SUCCESS(session, client::ampm_fetch_am_to_am_trace(stub(), session, "", 10.0));
 }
 
 TEST_F(NiRFmxSpecAnDriverApiTests, LutDpdFromExample_ReturnsSynchronizationNotFoundWarningWithData)
@@ -342,10 +329,9 @@ TEST_F(NiRFmxSpecAnDriverApiTests, SetAndGetAttributeString_Succeeds)
 TEST_F(NiRFmxSpecAnDriverApiTests, BuildSpurString_ReturnsSpurString)
 {
   auto session = init_session(stub(), PXI_5663);
-  const auto spur_string_response = client::build_spur_string(stub(), "", 0);
+  const auto spur_string_response = EXPECT_SUCCESS(session, client::build_spur_string(stub(), "", 0));
 
   EXPECT_EQ(spur_string_response.selector_string_out(), "spur0");
-  EXPECT_SUCCESS(session, spur_string_response);
 }
 
 TEST_F(NiRFmxSpecAnDriverApiTests, BuildIntermodString_ReturnsIntermodString)

--- a/source/tests/system/nirfmxwlan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxwlan_driver_api_tests.cpp
@@ -183,8 +183,7 @@ TEST_F(NiRFmxWLANDriverApiTests, OFDMModAccTXPCompositeFromExample_FetchData_Dat
   EXPECT_SUCCESS(session, client::txp_cfg_maximum_measurement_interval(stub(), session, "", 1e-3));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  const auto ofdm_mod_acc_fetch_composite_rmsevm_response = client::ofdm_mod_acc_fetch_composite_rmsevm(stub(), session, "", 10.0);
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_composite_rmsevm_response);
+  const auto ofdm_mod_acc_fetch_composite_rmsevm_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_composite_rmsevm(stub(), session, "", 10.0));
   const auto txp_fetch_measurement_response = client::txp_fetch_measurement(stub(), session, "", 10.0);
   EXPECT_RESPONSE_WARNING(RISING_EDGE_DETECTION_FAILED_WARNING, txp_fetch_measurement_response);
 
@@ -212,18 +211,15 @@ TEST_F(NiRFmxWLANDriverApiTests, SemFromExample_FetchData_DataLooksReasonable)
   EXPECT_SUCCESS(session, client::sem_cfg_span(stub(), session, "", SEM_SPAN_AUTO_TRUE, 66.0e6));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  const auto sem_fetch_measurement_status_response = client::sem_fetch_measurement_status(stub(), session, "", 10.0);
-  const auto sem_fetch_carrier_measurement_response = client::sem_fetch_carrier_measurement(stub(), session, "", 10.0);
-  const auto sem_fetch_lower_offset_margin_array_response = client::sem_fetch_lower_offset_margin_array(stub(), session, "", 10.0);
-  const auto sem_fetch_upper_offset_margin_array_response = client::sem_fetch_upper_offset_margin_array(stub(), session, "", 10.0);
-  const auto sem_fetch_spectrum_response = client::sem_fetch_spectrum(stub(), session, "", 10.0);
+  const auto sem_fetch_measurement_status_response = EXPECT_SUCCESS(session, client::sem_fetch_measurement_status(stub(), session, "", 10.0));
+  const auto sem_fetch_carrier_measurement_response = EXPECT_SUCCESS(session, client::sem_fetch_carrier_measurement(stub(), session, "", 10.0));
+  const auto sem_fetch_lower_offset_margin_array_response = EXPECT_SUCCESS(session, client::sem_fetch_lower_offset_margin_array(stub(), session, "", 10.0));
+  const auto sem_fetch_upper_offset_margin_array_response = EXPECT_SUCCESS(session, client::sem_fetch_upper_offset_margin_array(stub(), session, "", 10.0));
+  const auto sem_fetch_spectrum_response = EXPECT_SUCCESS(session, client::sem_fetch_spectrum(stub(), session, "", 10.0));
 
-  EXPECT_SUCCESS(session, sem_fetch_measurement_status_response);
   EXPECT_EQ(1, sem_fetch_measurement_status_response.measurement_status());
-  EXPECT_SUCCESS(session, sem_fetch_carrier_measurement_response);
   EXPECT_LT(0.0, sem_fetch_carrier_measurement_response.absolute_power());
   EXPECT_LT(0.0, sem_fetch_carrier_measurement_response.relative_power());
-  EXPECT_SUCCESS(session, sem_fetch_lower_offset_margin_array_response);
   EXPECT_EQ(4, sem_fetch_lower_offset_margin_array_response.measurement_status_size());
   EXPECT_EQ(4, sem_fetch_lower_offset_margin_array_response.measurement_status().size());
   EXPECT_EQ(1, sem_fetch_lower_offset_margin_array_response.measurement_status(0));
@@ -239,7 +235,6 @@ TEST_F(NiRFmxWLANDriverApiTests, SemFromExample_FetchData_DataLooksReasonable)
   EXPECT_EQ(4, sem_fetch_lower_offset_margin_array_response.margin_relative_power_size());
   EXPECT_EQ(4, sem_fetch_lower_offset_margin_array_response.margin_relative_power().size());
   EXPECT_GT(0.0, sem_fetch_lower_offset_margin_array_response.margin_relative_power(0));
-  EXPECT_SUCCESS(session, sem_fetch_upper_offset_margin_array_response);
   EXPECT_EQ(4, sem_fetch_upper_offset_margin_array_response.measurement_status_size());
   EXPECT_EQ(4, sem_fetch_upper_offset_margin_array_response.measurement_status().size());
   EXPECT_EQ(1, sem_fetch_upper_offset_margin_array_response.measurement_status(0));
@@ -255,7 +250,6 @@ TEST_F(NiRFmxWLANDriverApiTests, SemFromExample_FetchData_DataLooksReasonable)
   EXPECT_EQ(4, sem_fetch_upper_offset_margin_array_response.margin_relative_power_size());
   EXPECT_EQ(4, sem_fetch_upper_offset_margin_array_response.margin_relative_power().size());
   EXPECT_GT(0.0, sem_fetch_upper_offset_margin_array_response.margin_relative_power(0));
-  EXPECT_SUCCESS(session, sem_fetch_spectrum_response);
   EXPECT_LT(0.0, sem_fetch_spectrum_response.x0());
   EXPECT_LT(0.0, sem_fetch_spectrum_response.dx());
   EXPECT_EQ(2454, sem_fetch_spectrum_response.spectrum_size());
@@ -291,19 +285,16 @@ TEST_F(NiRFmxWLANDriverApiTests, SEMCustomMaskFromExample_FetchData_DataLooksRea
   EXPECT_SUCCESS(session, client::sem_cfg_offset_relative_limit_array(stub(), session, "", relative_limit_start, relative_limit_stop));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  const auto sem_fetch_measurement_status_response = client::sem_fetch_measurement_status(stub(), session, "", 10.0);
-  const auto sem_fetch_carrier_measurement_response = client::sem_fetch_carrier_measurement(stub(), session, "", 10.0);
-  const auto sem_fetch_lower_offset_margin_array_response = client::sem_fetch_lower_offset_margin_array(stub(), session, "", 10.0);
-  const auto sem_fetch_upper_offset_margin_array_response = client::sem_fetch_upper_offset_margin_array(stub(), session, "", 10.0);
+  const auto sem_fetch_measurement_status_response = EXPECT_SUCCESS(session, client::sem_fetch_measurement_status(stub(), session, "", 10.0));
+  const auto sem_fetch_carrier_measurement_response = EXPECT_SUCCESS(session, client::sem_fetch_carrier_measurement(stub(), session, "", 10.0));
+  const auto sem_fetch_lower_offset_margin_array_response = EXPECT_SUCCESS(session, client::sem_fetch_lower_offset_margin_array(stub(), session, "", 10.0));
+  const auto sem_fetch_upper_offset_margin_array_response = EXPECT_SUCCESS(session, client::sem_fetch_upper_offset_margin_array(stub(), session, "", 10.0));
   int32 array_size = sem_fetch_upper_offset_margin_array_response.measurement_status_size();
-  const auto sem_fetch_spectrum_response = client::sem_fetch_spectrum(stub(), session, "", 10.0);
+  const auto sem_fetch_spectrum_response = EXPECT_SUCCESS(session, client::sem_fetch_spectrum(stub(), session, "", 10.0));
 
-  EXPECT_SUCCESS(session, sem_fetch_measurement_status_response);
   EXPECT_EQ(0, sem_fetch_measurement_status_response.measurement_status());
-  EXPECT_SUCCESS(session, sem_fetch_carrier_measurement_response);
   EXPECT_LT(0.0, sem_fetch_carrier_measurement_response.absolute_power());
   EXPECT_LT(0.0, sem_fetch_carrier_measurement_response.relative_power());
-  EXPECT_SUCCESS(session, sem_fetch_lower_offset_margin_array_response);
   EXPECT_EQ(3, sem_fetch_lower_offset_margin_array_response.measurement_status_size());
   EXPECT_EQ(3, sem_fetch_lower_offset_margin_array_response.measurement_status().size());
   EXPECT_EQ(1, sem_fetch_lower_offset_margin_array_response.measurement_status(0));
@@ -319,7 +310,6 @@ TEST_F(NiRFmxWLANDriverApiTests, SEMCustomMaskFromExample_FetchData_DataLooksRea
   EXPECT_EQ(3, sem_fetch_lower_offset_margin_array_response.margin_relative_power_size());
   EXPECT_EQ(3, sem_fetch_lower_offset_margin_array_response.margin_relative_power().size());
   EXPECT_GT(0.0, sem_fetch_lower_offset_margin_array_response.margin_relative_power(0));
-  EXPECT_SUCCESS(session, sem_fetch_upper_offset_margin_array_response);
   EXPECT_EQ(3, sem_fetch_upper_offset_margin_array_response.measurement_status_size());
   EXPECT_EQ(3, sem_fetch_upper_offset_margin_array_response.measurement_status().size());
   EXPECT_EQ(1, sem_fetch_upper_offset_margin_array_response.measurement_status(0));
@@ -335,7 +325,6 @@ TEST_F(NiRFmxWLANDriverApiTests, SEMCustomMaskFromExample_FetchData_DataLooksRea
   EXPECT_EQ(3, sem_fetch_upper_offset_margin_array_response.margin_relative_power_size());
   EXPECT_EQ(3, sem_fetch_upper_offset_margin_array_response.margin_relative_power().size());
   EXPECT_GT(0.0, sem_fetch_upper_offset_margin_array_response.margin_relative_power(0));
-  EXPECT_SUCCESS(session, sem_fetch_spectrum_response);
   EXPECT_LT(0.0, sem_fetch_spectrum_response.x0());
   EXPECT_LT(0.0, sem_fetch_spectrum_response.dx());
   EXPECT_EQ(2974, sem_fetch_spectrum_response.spectrum_size());
@@ -449,16 +438,14 @@ TEST_F(NiRFmxWLANDriverApiTests, DISABLED_DSSSPowerRampFromExample_FetchData_Dat
 
   float64 x0 = 0;
   float64 dx = 0;
-  const auto power_ramp_fetch_measurement_response = client::power_ramp_fetch_measurement(stub(), session, "", 10.0);
-  const auto power_ramp_fetch_rise_trace_response = client::power_ramp_fetch_rise_trace(stub(), session, "", 10.0);
+  const auto power_ramp_fetch_measurement_response = EXPECT_SUCCESS(session, client::power_ramp_fetch_measurement(stub(), session, "", 10.0));
+  const auto power_ramp_fetch_rise_trace_response = EXPECT_SUCCESS(session, client::power_ramp_fetch_rise_trace(stub(), session, "", 10.0));
   x0 = 0;
   dx = 0;
-  const auto power_ramp_fetch_fall_trace_response = client::power_ramp_fetch_fall_trace(stub(), session, "", 10.0);
+  const auto power_ramp_fetch_fall_trace_response = EXPECT_SUCCESS(session, client::power_ramp_fetch_fall_trace(stub(), session, "", 10.0));
 
-  EXPECT_SUCCESS(session, power_ramp_fetch_measurement_response);
   EXPECT_EQ(0.0, power_ramp_fetch_measurement_response.rise_time_mean());
   EXPECT_EQ(0.0, power_ramp_fetch_measurement_response.fall_time_mean());
-  EXPECT_SUCCESS(session, power_ramp_fetch_rise_trace_response);
   EXPECT_EQ(0.0, power_ramp_fetch_rise_trace_response.x0());
   EXPECT_EQ(0.0, power_ramp_fetch_rise_trace_response.dx());
   EXPECT_EQ(0, power_ramp_fetch_rise_trace_response.raw_waveform_size());
@@ -473,7 +460,6 @@ TEST_F(NiRFmxWLANDriverApiTests, DISABLED_DSSSPowerRampFromExample_FetchData_Dat
   EXPECT_EQ(999, power_ramp_fetch_rise_trace_response.power_reference_size());
   EXPECT_EQ(999, power_ramp_fetch_rise_trace_response.power_reference().size());
   EXPECT_EQ(0.0, power_ramp_fetch_rise_trace_response.power_reference(0));
-  EXPECT_SUCCESS(session, power_ramp_fetch_fall_trace_response);
   EXPECT_EQ(0.0, power_ramp_fetch_fall_trace_response.x0());
   EXPECT_EQ(0.0, power_ramp_fetch_fall_trace_response.dx());
   EXPECT_EQ(999, power_ramp_fetch_fall_trace_response.raw_waveform_size());
@@ -512,54 +498,40 @@ TEST_F(NiRFmxWLANDriverApiTests, OFDMModAccFromExample_FetchData_DataLooksReason
   EXPECT_SUCCESS(session, client::ofdm_mod_acc_cfg_averaging(stub(), session, "", OFDMMODACC_AVERAGING_ENABLED_FALSE, 10));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  const auto ofdm_mod_acc_fetch_composite_rmsevm_response = client::ofdm_mod_acc_fetch_composite_rmsevm(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_numberof_symbols_used_response = client::ofdm_mod_acc_fetch_numberof_symbols_used(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_frequency_error_mean_response = client::ofdm_mod_acc_fetch_frequency_error_mean(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_symbol_clock_error_mean_response = client::ofdm_mod_acc_fetch_symbol_clock_error_mean(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_iq_impairments_response = client::ofdm_mod_acc_fetch_iq_impairments(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_ppdu_type_response = client::ofdm_mod_acc_fetch_ppdu_type(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_mcs_index_response = client::ofdm_mod_acc_fetch_mcs_index(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_guard_interval_type_response = client::ofdm_mod_acc_fetch_guard_interval_type(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_lsig_parity_check_status_response = client::ofdm_mod_acc_fetch_lsig_parity_check_status(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_sigcrc_status_response = client::ofdm_mod_acc_fetch_sigcrc_status(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_sigbcrc_status_response = client::ofdm_mod_acc_fetch_sigbcrc_status(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_pilot_constellation_trace_response = client::ofdm_mod_acc_fetch_pilot_constellation_trace(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_data_constellation_trace_response = client::ofdm_mod_acc_fetch_data_constellation_trace(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_chain_rmsevm_per_subcarrier_mean_trace_response = client::ofdm_mod_acc_fetch_chain_rmsevm_per_subcarrier_mean_trace(stub(), session, "", 10.0);
+  const auto ofdm_mod_acc_fetch_composite_rmsevm_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_composite_rmsevm(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_numberof_symbols_used_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_numberof_symbols_used(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_frequency_error_mean_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_frequency_error_mean(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_symbol_clock_error_mean_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_symbol_clock_error_mean(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_iq_impairments_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_iq_impairments(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_ppdu_type_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_ppdu_type(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_mcs_index_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_mcs_index(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_guard_interval_type_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_guard_interval_type(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_lsig_parity_check_status_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_lsig_parity_check_status(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_sigcrc_status_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_sigcrc_status(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_sigbcrc_status_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_sigbcrc_status(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_pilot_constellation_trace_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_pilot_constellation_trace(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_data_constellation_trace_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_data_constellation_trace(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_chain_rmsevm_per_subcarrier_mean_trace_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_chain_rmsevm_per_subcarrier_mean_trace(stub(), session, "", 10.0));
 
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_composite_rmsevm_response);
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_rms_evm_mean());
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_data_rms_evm_mean());
   EXPECT_LT(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_pilot_rms_evm_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_numberof_symbols_used_response);
   EXPECT_EQ(16, ofdm_mod_acc_fetch_numberof_symbols_used_response.number_of_symbols_used());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_frequency_error_mean_response);
   EXPECT_GT(0.0, ofdm_mod_acc_fetch_frequency_error_mean_response.frequency_error_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_symbol_clock_error_mean_response);
   EXPECT_GT(0.0, ofdm_mod_acc_fetch_symbol_clock_error_mean_response.symbol_clock_error_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_iq_impairments_response);
   EXPECT_GT(0.0, ofdm_mod_acc_fetch_iq_impairments_response.relative_iq_origin_offset_mean());
   EXPECT_LT(0.0, ofdm_mod_acc_fetch_iq_impairments_response.iq_gain_imbalance_mean());
   EXPECT_GT(0.0, ofdm_mod_acc_fetch_iq_impairments_response.iq_quadrature_error_mean());
   EXPECT_GT(0.0, ofdm_mod_acc_fetch_iq_impairments_response.absolute_iq_origin_offset_mean());
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_iq_impairments_response.iq_timing_skew_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_ppdu_type_response);
   EXPECT_EQ(0, ofdm_mod_acc_fetch_ppdu_type_response.ppdu_type());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_mcs_index_response);
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_guard_interval_type_response);
   EXPECT_EQ(0, ofdm_mod_acc_fetch_guard_interval_type_response.guard_interval_type());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_lsig_parity_check_status_response);
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_sigcrc_status_response);
   EXPECT_EQ(-1, ofdm_mod_acc_fetch_sigcrc_status_response.sig_crc_status());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_sigbcrc_status_response);
   EXPECT_EQ(-1, ofdm_mod_acc_fetch_sigbcrc_status_response.sig_b_crc_status());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_pilot_constellation_trace_response);
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_pilot_constellation_trace_response.pilot_constellation(0).real());
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_pilot_constellation_trace_response.pilot_constellation(0).imaginary());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_data_constellation_trace_response);
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_data_constellation_trace_response.data_constellation(0).real());
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_data_constellation_trace_response.data_constellation(0).imaginary());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_chain_rmsevm_per_subcarrier_mean_trace_response);
   EXPECT_EQ(-26, ofdm_mod_acc_fetch_chain_rmsevm_per_subcarrier_mean_trace_response.x0());
   EXPECT_EQ(1, ofdm_mod_acc_fetch_chain_rmsevm_per_subcarrier_mean_trace_response.dx());
   EXPECT_EQ(53, ofdm_mod_acc_fetch_chain_rmsevm_per_subcarrier_mean_trace_response.chain_rms_evm_per_subcarrier_mean_size());
@@ -586,16 +558,13 @@ TEST_F(NiRFmxWLANDriverApiTests, OFDMModAccMIMOFromExample_FetchData_DataLooksRe
   EXPECT_SUCCESS(session, client::cfg_frequency_reference(stub(), session, "", FREQUENCY_REFERENCE_SOURCE_PXI_CLK, 10e6));
   EXPECT_SUCCESS(session, client::cfg_number_of_frequency_segments_and_receive_chains(stub(), session, "", NUMBER_OF_FREQUENCY_SEGMENTS, NUMBER_OF_RECEIVE_CHAINS));
   for (int i = 0; i < NUMBER_OF_FREQUENCY_SEGMENTS; ++i) {
-    auto segment_string_response = client::build_segment_string(stub(), "", i);
-    EXPECT_SUCCESS(session, segment_string_response);
+    const auto segment_string_response = EXPECT_SUCCESS(session, client::build_segment_string(stub(), "", i));
     EXPECT_SUCCESS(session, client::cfg_frequency(stub(), session, segment_string_response.selector_string_out(), center_frequency_array[i]));
   }
   for (int i = 0; i < NUMBER_OF_DEVICES; ++i) {
-    auto port_string_response = instr_client::build_port_string(instr_stub, "", selected_ports[i], resource_names[i], 0);
-    EXPECT_SUCCESS(session, port_string_response);
+    auto port_string_response = EXPECT_SUCCESS(session, instr_client::build_port_string(instr_stub, "", selected_ports[i], resource_names[i], 0));
     selected_ports_strings[i] = port_string_response.selector_string_out();
-    port_string_response = instr_client::build_port_string(instr_stub, "", "", resource_names[i], 0);
-    EXPECT_SUCCESS(session, port_string_response);
+    port_string_response = EXPECT_SUCCESS(session, instr_client::build_port_string(instr_stub, "", "", resource_names[i], 0));
     port_string[i] = port_string_response.selector_string_out();
     EXPECT_SUCCESS(session, client::cfg_reference_level(stub(), session, port_string[i], reference_level_array[i]));
     EXPECT_SUCCESS(session, client::cfg_external_attenuation(stub(), session, port_string[i], external_attenuation_array[i]));
@@ -635,24 +604,23 @@ TEST_F(NiRFmxWLANDriverApiTests, OFDMModAccMIMOFromExample_FetchData_DataLooksRe
   OFDMModAccFetchDataConstellationTraceResponse ofdm_mod_acc_fetch_data_constellation_trace_response;
   OFDMModAccFetchCrossPowerResponse ofdm_mod_acc_fetch_cross_power_response;
   OFDMModAccFetchIQImpairmentsResponse ofdm_mod_acc_fetch_iq_impairments_response;
-  const auto ofdm_mod_acc_fetch_composite_rmsevm_response = client::ofdm_mod_acc_fetch_composite_rmsevm(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_numberof_symbols_used_response = client::ofdm_mod_acc_fetch_numberof_symbols_used(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_ppdu_type_response = client::ofdm_mod_acc_fetch_ppdu_type(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_guard_interval_type_response = client::ofdm_mod_acc_fetch_guard_interval_type(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_lsig_parity_check_status_response = client::ofdm_mod_acc_fetch_lsig_parity_check_status(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_sigcrc_status_response = client::ofdm_mod_acc_fetch_sigcrc_status(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_sigbcrc_status_response = client::ofdm_mod_acc_fetch_sigbcrc_status(stub(), session, "", 10.0);
-  ofdm_mod_acc_fetch_number_of_users_response = client::ofdm_mod_acc_fetch_number_of_users(stub(), session, "", 10.0);
+  const auto ofdm_mod_acc_fetch_composite_rmsevm_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_composite_rmsevm(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_numberof_symbols_used_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_numberof_symbols_used(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_ppdu_type_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_ppdu_type(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_guard_interval_type_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_guard_interval_type(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_lsig_parity_check_status_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_lsig_parity_check_status(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_sigcrc_status_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_sigcrc_status(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_sigbcrc_status_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_sigbcrc_status(stub(), session, "", 10.0));
+  ofdm_mod_acc_fetch_number_of_users_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_number_of_users(stub(), session, "", 10.0));
   mcs_index_array_length = number_of_users;
   mcs_index_array = (int32*)malloc(mcs_index_array_length * sizeof(int32));
   number_of_space_time_streams_array_length = number_of_users;
   number_of_space_time_streams_array = (int32*)malloc(number_of_space_time_streams_array_length * sizeof(int32));
   space_time_stream_offset_array = (int32*)malloc(number_of_users * sizeof(int32));
   for (int i = 0; i < number_of_users; i++) {
-    auto user_string_response = client::build_user_string(stub(), "", i);
-    EXPECT_SUCCESS(session, user_string_response);
-    ofdm_mod_acc_fetch_mcs_index_response = client::ofdm_mod_acc_fetch_mcs_index(stub(), session, user_string_response.selector_string_out(), 10.0);
-    ofdm_mod_acc_fetch_number_of_space_time_streams_response = client::ofdm_mod_acc_fetch_number_of_space_time_streams(stub(), session, user_string_response.selector_string_out(), 10.0);
+    const auto user_string_response = EXPECT_SUCCESS(session, client::build_user_string(stub(), "", i));
+    ofdm_mod_acc_fetch_mcs_index_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_mcs_index(stub(), session, user_string_response.selector_string_out(), 10.0));
+    ofdm_mod_acc_fetch_number_of_space_time_streams_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_number_of_space_time_streams(stub(), session, user_string_response.selector_string_out(), 10.0));
     space_time_stream_offset_array[i] = get_attr_i32(session, user_string_response.selector_string_out(), NIRFMXWLAN_ATTRIBUTE_OFDMMODACC_RESULTS_SPACE_TIME_STREAM_OFFSET);
     if (mcs_index_array == NULL || number_of_space_time_streams_array == NULL) {
       FAIL() << "Could not allocate array";
@@ -662,77 +630,54 @@ TEST_F(NiRFmxWLANDriverApiTests, OFDMModAccMIMOFromExample_FetchData_DataLooksRe
     }
   }
   for (int i = 0; i < NUMBER_OF_FREQUENCY_SEGMENTS; i++) {
-    auto segment_string_response = client::build_segment_string(stub(), "", i);
-    EXPECT_SUCCESS(session, segment_string_response);
-    ofdm_mod_acc_fetch_frequency_error_mean_response = client::ofdm_mod_acc_fetch_frequency_error_mean(stub(), session, segment_string_response.selector_string_out(), 10.0);
-    ofdm_mod_acc_fetch_symbol_clock_error_mean_response = client::ofdm_mod_acc_fetch_symbol_clock_error_mean(stub(), session, segment_string_response.selector_string_out(), 10.0);
+    const auto segment_string_response = EXPECT_SUCCESS(session, client::build_segment_string(stub(), "", i));
+    ofdm_mod_acc_fetch_frequency_error_mean_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_frequency_error_mean(stub(), session, segment_string_response.selector_string_out(), 10.0));
+    ofdm_mod_acc_fetch_symbol_clock_error_mean_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_symbol_clock_error_mean(stub(), session, segment_string_response.selector_string_out(), 10.0));
     for (int j = 0; j < number_of_stream_results; j++) {
-      auto stream_string_response = client::build_stream_string(stub(), segment_string_response.selector_string_out(), j);
-      EXPECT_SUCCESS(session, stream_string_response);
-      ofdm_mod_acc_fetch_stream_rmsevm_response = client::ofdm_mod_acc_fetch_stream_rmsevm(stub(), session, stream_string_response.selector_string_out(), 10.0);
-      ofdm_mod_acc_fetch_stream_rmsevm_per_subcarrier_mean_trace_response = client::ofdm_mod_acc_fetch_stream_rmsevm_per_subcarrier_mean_trace(stub(), session, stream_string_response.selector_string_out(), 10.0);
-      ofdm_mod_acc_fetch_pilot_constellation_trace_response = client::ofdm_mod_acc_fetch_pilot_constellation_trace(stub(), session, stream_string_response.selector_string_out(), 10.0);
-      ofdm_mod_acc_fetch_data_constellation_trace_response = client::ofdm_mod_acc_fetch_data_constellation_trace(stub(), session, stream_string_response.selector_string_out(), 10.0);
+      const auto stream_string_response = EXPECT_SUCCESS(session, client::build_stream_string(stub(), segment_string_response.selector_string_out(), j));
+      ofdm_mod_acc_fetch_stream_rmsevm_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_stream_rmsevm(stub(), session, stream_string_response.selector_string_out(), 10.0));
+      ofdm_mod_acc_fetch_stream_rmsevm_per_subcarrier_mean_trace_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_stream_rmsevm_per_subcarrier_mean_trace(stub(), session, stream_string_response.selector_string_out(), 10.0));
+      ofdm_mod_acc_fetch_pilot_constellation_trace_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_pilot_constellation_trace(stub(), session, stream_string_response.selector_string_out(), 10.0));
+      ofdm_mod_acc_fetch_data_constellation_trace_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_data_constellation_trace(stub(), session, stream_string_response.selector_string_out(), 10.0));
     }
     for (int j = 0; j < NUMBER_OF_RECEIVE_CHAINS; j++) {
-      auto chain_string_response = client::build_chain_string(stub(), segment_string_response.selector_string_out(), j);
-      EXPECT_SUCCESS(session, chain_string_response);
-      ofdm_mod_acc_fetch_cross_power_response = client::ofdm_mod_acc_fetch_cross_power(stub(), session, chain_string_response.selector_string_out(), 10.0);
-      ofdm_mod_acc_fetch_iq_impairments_response = client::ofdm_mod_acc_fetch_iq_impairments(stub(), session, chain_string_response.selector_string_out(), 10.0);
+      const auto chain_string_response = EXPECT_SUCCESS(session, client::build_chain_string(stub(), segment_string_response.selector_string_out(), j));
+      ofdm_mod_acc_fetch_cross_power_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_cross_power(stub(), session, chain_string_response.selector_string_out(), 10.0));
+      ofdm_mod_acc_fetch_iq_impairments_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_iq_impairments(stub(), session, chain_string_response.selector_string_out(), 10.0));
     }
   }
 
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_composite_rmsevm_response);
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_rms_evm_mean());
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_data_rms_evm_mean());
   EXPECT_LT(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_pilot_rms_evm_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_numberof_symbols_used_response);
   EXPECT_EQ(16, ofdm_mod_acc_fetch_numberof_symbols_used_response.number_of_symbols_used());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_ppdu_type_response);
   EXPECT_EQ(2, ofdm_mod_acc_fetch_ppdu_type_response.ppdu_type());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_guard_interval_type_response);
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_lsig_parity_check_status_response);
   EXPECT_EQ(-1, ofdm_mod_acc_fetch_lsig_parity_check_status_response.l_sig_parity_check_status());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_sigcrc_status_response);
   EXPECT_EQ(0, ofdm_mod_acc_fetch_sigcrc_status_response.sig_crc_status());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_sigbcrc_status_response);
   EXPECT_EQ(-1, ofdm_mod_acc_fetch_sigbcrc_status_response.sig_b_crc_status());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_number_of_users_response);
   EXPECT_EQ(1, ofdm_mod_acc_fetch_number_of_users_response.number_of_users());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_mcs_index_response);
   EXPECT_EQ(0, ofdm_mod_acc_fetch_mcs_index_response.mcs_index());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_number_of_space_time_streams_response);
   for (int i = 0; i < number_of_users; i++) {
     EXPECT_EQ(0, space_time_stream_offset_array[i]);
   }
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_mcs_index_response);
   EXPECT_EQ(0, ofdm_mod_acc_fetch_mcs_index_response.mcs_index());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_number_of_space_time_streams_response);
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_frequency_error_mean_response);
   EXPECT_GT(0.0, ofdm_mod_acc_fetch_frequency_error_mean_response.frequency_error_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_symbol_clock_error_mean_response);
   EXPECT_GT(0.0, ofdm_mod_acc_fetch_symbol_clock_error_mean_response.symbol_clock_error_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_stream_rmsevm_response);
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_stream_rmsevm_response.stream_rms_evm_mean());
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_stream_rmsevm_response.stream_data_rms_evm_mean());
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_stream_rmsevm_response.stream_pilot_rms_evm_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_stream_rmsevm_per_subcarrier_mean_trace_response);
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_stream_rmsevm_per_subcarrier_mean_trace_response.x0());
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_stream_rmsevm_per_subcarrier_mean_trace_response.dx());
   EXPECT_EQ(0, ofdm_mod_acc_fetch_stream_rmsevm_per_subcarrier_mean_trace_response.stream_rms_evm_per_subcarrier_mean_size());
   EXPECT_EQ(0, ofdm_mod_acc_fetch_stream_rmsevm_per_subcarrier_mean_trace_response.stream_rms_evm_per_subcarrier_mean().size());
   // EXPECT_EQ(0.0, ofdm_mod_acc_fetch_stream_rmsevm_per_subcarrier_mean_trace_response.stream_rms_evm_per_subcarrier_mean(0));
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_pilot_constellation_trace_response);
   EXPECT_EQ(0, ofdm_mod_acc_fetch_pilot_constellation_trace_response.pilot_constellation().size());
   // EXPECT_EQ(0.0, ofdm_mod_acc_fetch_pilot_constellation_trace_response.pilot_constellation(0).real());
   // EXPECT_EQ(0.0, ofdm_mod_acc_fetch_pilot_constellation_trace_response.pilot_constellation(0).imaginary());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_data_constellation_trace_response);
   EXPECT_EQ(0, ofdm_mod_acc_fetch_data_constellation_trace_response.data_constellation().size());
   // EXPECT_EQ(0.0, ofdm_mod_acc_fetch_data_constellation_trace_response.data_constellation(0).real());
   // EXPECT_EQ(0.0, ofdm_mod_acc_fetch_data_constellation_trace_response.data_constellation(0).imaginary());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_cross_power_response);
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_cross_power_response.cross_power_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_iq_impairments_response);
   EXPECT_GT(0.0, ofdm_mod_acc_fetch_iq_impairments_response.relative_iq_origin_offset_mean());
   EXPECT_LT(0.0, ofdm_mod_acc_fetch_iq_impairments_response.iq_gain_imbalance_mean());
   EXPECT_GT(0.0, ofdm_mod_acc_fetch_iq_impairments_response.iq_quadrature_error_mean());
@@ -769,20 +714,16 @@ TEST_F(NiRFmxWLANDriverApiTests, OFDMModAccSpeedOptimizedFromExample_FetchData_D
   EXPECT_SUCCESS(session, client::set_attribute_i32(stub(), session, "", NIRFMXWLAN_ATTRIBUTE_OFDMMODACC_IQ_IMPAIRMENTS_ESTIMATION_ENABLED, NIRFMXWLAN_INT32_OFDMMODACC_IQ_IMPAIRMENTS_ESTIMATION_ENABLED_FALSE));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  const auto ofdm_mod_acc_fetch_composite_rmsevm_response = client::ofdm_mod_acc_fetch_composite_rmsevm(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_numberof_symbols_used_response = client::ofdm_mod_acc_fetch_numberof_symbols_used(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_frequency_error_mean_response = client::ofdm_mod_acc_fetch_frequency_error_mean(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_symbol_clock_error_mean_response = client::ofdm_mod_acc_fetch_symbol_clock_error_mean(stub(), session, "", 10.0);
+  const auto ofdm_mod_acc_fetch_composite_rmsevm_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_composite_rmsevm(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_numberof_symbols_used_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_numberof_symbols_used(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_frequency_error_mean_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_frequency_error_mean(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_symbol_clock_error_mean_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_symbol_clock_error_mean(stub(), session, "", 10.0));
 
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_composite_rmsevm_response);
   EXPECT_LT(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_rms_evm_mean());
   EXPECT_LT(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_data_rms_evm_mean());
   EXPECT_LT(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_pilot_rms_evm_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_numberof_symbols_used_response);
   EXPECT_EQ(16, ofdm_mod_acc_fetch_numberof_symbols_used_response.number_of_symbols_used());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_frequency_error_mean_response);
   EXPECT_GT(0.0, ofdm_mod_acc_fetch_frequency_error_mean_response.frequency_error_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_symbol_clock_error_mean_response);
   EXPECT_GT(0.0, ofdm_mod_acc_fetch_symbol_clock_error_mean_response.symbol_clock_error_mean());
 }
 
@@ -810,42 +751,32 @@ TEST_F(NiRFmxWLANDriverApiTests, OFDMModAccTriggerBasedPPDUFromExample_FetchData
   EXPECT_SUCCESS(session, client::ofdm_mod_acc_cfg_averaging(stub(), session, "", OFDMMODACC_AVERAGING_ENABLED_FALSE, 10));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  const auto ofdm_mod_acc_fetch_composite_rmsevm_response = client::ofdm_mod_acc_fetch_composite_rmsevm(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_unused_tone_error_response = client::ofdm_mod_acc_fetch_unused_tone_error(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_unused_tone_error_margin_per_ru_response = client::ofdm_mod_acc_fetch_unused_tone_error_margin_per_ru(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_frequency_error_mean_response = client::ofdm_mod_acc_fetch_frequency_error_mean(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_frequency_error_ccdf10_percent_response = client::ofdm_mod_acc_fetch_frequency_error_ccdf10_percent(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_symbol_clock_error_mean_response = client::ofdm_mod_acc_fetch_symbol_clock_error_mean(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_ppdu_type_response = client::ofdm_mod_acc_fetch_ppdu_type(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_pilot_constellation_trace_response = client::ofdm_mod_acc_fetch_pilot_constellation_trace(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_data_constellation_trace_response = client::ofdm_mod_acc_fetch_data_constellation_trace(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_unused_tone_error_mean_trace_response = client::ofdm_mod_acc_fetch_unused_tone_error_mean_trace(stub(), session, "", 10.0);
+  const auto ofdm_mod_acc_fetch_composite_rmsevm_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_composite_rmsevm(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_unused_tone_error_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_unused_tone_error(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_unused_tone_error_margin_per_ru_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_unused_tone_error_margin_per_ru(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_frequency_error_mean_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_frequency_error_mean(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_frequency_error_ccdf10_percent_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_frequency_error_ccdf10_percent(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_symbol_clock_error_mean_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_symbol_clock_error_mean(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_ppdu_type_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_ppdu_type(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_pilot_constellation_trace_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_pilot_constellation_trace(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_data_constellation_trace_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_data_constellation_trace(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_unused_tone_error_mean_trace_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_unused_tone_error_mean_trace(stub(), session, "", 10.0));
 
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_composite_rmsevm_response);
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_rms_evm_mean());
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_data_rms_evm_mean());
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_pilot_rms_evm_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_unused_tone_error_response);
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_unused_tone_error_response.unused_tone_error_margin());
   EXPECT_EQ(-1, ofdm_mod_acc_fetch_unused_tone_error_response.unused_tone_error_margin_ru_index());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_unused_tone_error_margin_per_ru_response);
   EXPECT_EQ(1, ofdm_mod_acc_fetch_unused_tone_error_margin_per_ru_response.unused_tone_error_margin_per_ru_size());
   EXPECT_EQ(1, ofdm_mod_acc_fetch_unused_tone_error_margin_per_ru_response.unused_tone_error_margin_per_ru().size());
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_unused_tone_error_margin_per_ru_response.unused_tone_error_margin_per_ru(0));
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_frequency_error_mean_response);
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_frequency_error_mean_response.frequency_error_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_frequency_error_ccdf10_percent_response);
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_symbol_clock_error_mean_response);
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_symbol_clock_error_mean_response.symbol_clock_error_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_ppdu_type_response);
   EXPECT_EQ(3, ofdm_mod_acc_fetch_ppdu_type_response.ppdu_type());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_pilot_constellation_trace_response);
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_pilot_constellation_trace_response.pilot_constellation(0).real());
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_pilot_constellation_trace_response.pilot_constellation(0).imaginary());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_data_constellation_trace_response);
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_data_constellation_trace_response.data_constellation(0).real());
   EXPECT_NE(0.0, ofdm_mod_acc_fetch_data_constellation_trace_response.data_constellation(0).imaginary());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_unused_tone_error_mean_trace_response);
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_unused_tone_error_mean_trace_response.x0());
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_unused_tone_error_mean_trace_response.dx());
   EXPECT_EQ(0, ofdm_mod_acc_fetch_unused_tone_error_mean_trace_response.unused_tone_error_size());
@@ -880,56 +811,42 @@ TEST_F(NiRFmxWLANDriverApiTests, DISABLED_OFDMModAccWithEVMBasedAutoLevelFromExa
   EXPECT_SUCCESS(session, client::ofdm_mod_acc_auto_level(stub(), session, "", 10.0));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  const auto ofdm_mod_acc_fetch_composite_rmsevm_response = client::ofdm_mod_acc_fetch_composite_rmsevm(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_numberof_symbols_used_response = client::ofdm_mod_acc_fetch_numberof_symbols_used(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_frequency_error_mean_response = client::ofdm_mod_acc_fetch_frequency_error_mean(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_symbol_clock_error_mean_response = client::ofdm_mod_acc_fetch_symbol_clock_error_mean(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_iq_impairments_response = client::ofdm_mod_acc_fetch_iq_impairments(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_ppdu_type_response = client::ofdm_mod_acc_fetch_ppdu_type(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_mcs_index_response = client::ofdm_mod_acc_fetch_mcs_index(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_guard_interval_type_response = client::ofdm_mod_acc_fetch_guard_interval_type(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_lsig_parity_check_status_response = client::ofdm_mod_acc_fetch_lsig_parity_check_status(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_sigcrc_status_response = client::ofdm_mod_acc_fetch_sigcrc_status(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_sigbcrc_status_response = client::ofdm_mod_acc_fetch_sigbcrc_status(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_pilot_constellation_trace_response = client::ofdm_mod_acc_fetch_pilot_constellation_trace(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_data_constellation_trace_response = client::ofdm_mod_acc_fetch_data_constellation_trace(stub(), session, "", 10.0);
-  const auto ofdm_mod_acc_fetch_chain_rmsevm_per_subcarrier_mean_trace_response = client::ofdm_mod_acc_fetch_chain_rmsevm_per_subcarrier_mean_trace(stub(), session, "", 10.0);
+  const auto ofdm_mod_acc_fetch_composite_rmsevm_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_composite_rmsevm(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_numberof_symbols_used_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_numberof_symbols_used(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_frequency_error_mean_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_frequency_error_mean(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_symbol_clock_error_mean_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_symbol_clock_error_mean(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_iq_impairments_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_iq_impairments(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_ppdu_type_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_ppdu_type(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_mcs_index_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_mcs_index(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_guard_interval_type_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_guard_interval_type(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_lsig_parity_check_status_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_lsig_parity_check_status(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_sigcrc_status_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_sigcrc_status(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_sigbcrc_status_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_sigbcrc_status(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_pilot_constellation_trace_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_pilot_constellation_trace(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_data_constellation_trace_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_data_constellation_trace(stub(), session, "", 10.0));
+  const auto ofdm_mod_acc_fetch_chain_rmsevm_per_subcarrier_mean_trace_response = EXPECT_SUCCESS(session, client::ofdm_mod_acc_fetch_chain_rmsevm_per_subcarrier_mean_trace(stub(), session, "", 10.0));
 
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_composite_rmsevm_response);
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_rms_evm_mean());
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_data_rms_evm_mean());
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_pilot_rms_evm_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_numberof_symbols_used_response);
   EXPECT_EQ(0, ofdm_mod_acc_fetch_numberof_symbols_used_response.number_of_symbols_used());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_frequency_error_mean_response);
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_frequency_error_mean_response.frequency_error_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_symbol_clock_error_mean_response);
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_symbol_clock_error_mean_response.symbol_clock_error_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_iq_impairments_response);
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_iq_impairments_response.relative_iq_origin_offset_mean());
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_iq_impairments_response.iq_gain_imbalance_mean());
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_iq_impairments_response.iq_quadrature_error_mean());
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_iq_impairments_response.absolute_iq_origin_offset_mean());
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_iq_impairments_response.iq_timing_skew_mean());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_ppdu_type_response);
   EXPECT_EQ(0, ofdm_mod_acc_fetch_ppdu_type_response.ppdu_type());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_mcs_index_response);
   EXPECT_EQ(0, ofdm_mod_acc_fetch_mcs_index_response.mcs_index());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_guard_interval_type_response);
   EXPECT_EQ(0, ofdm_mod_acc_fetch_guard_interval_type_response.guard_interval_type());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_lsig_parity_check_status_response);
   EXPECT_EQ(0, ofdm_mod_acc_fetch_lsig_parity_check_status_response.l_sig_parity_check_status());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_sigcrc_status_response);
   EXPECT_EQ(0, ofdm_mod_acc_fetch_sigcrc_status_response.sig_crc_status());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_sigbcrc_status_response);
   EXPECT_EQ(0, ofdm_mod_acc_fetch_sigbcrc_status_response.sig_b_crc_status());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_pilot_constellation_trace_response);
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_pilot_constellation_trace_response.pilot_constellation(0).real());
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_pilot_constellation_trace_response.pilot_constellation(0).imaginary());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_data_constellation_trace_response);
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_data_constellation_trace_response.data_constellation(0).real());
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_data_constellation_trace_response.data_constellation(0).imaginary());
-  EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_chain_rmsevm_per_subcarrier_mean_trace_response);
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_chain_rmsevm_per_subcarrier_mean_trace_response.x0());
   EXPECT_EQ(0.0, ofdm_mod_acc_fetch_chain_rmsevm_per_subcarrier_mean_trace_response.dx());
   EXPECT_EQ(999, ofdm_mod_acc_fetch_chain_rmsevm_per_subcarrier_mean_trace_response.chain_rms_evm_per_subcarrier_mean_size());
@@ -956,16 +873,13 @@ TEST_F(NiRFmxWLANDriverApiTests, SemMIMOFromExample_FetchData_DataLooksReasonabl
   EXPECT_SUCCESS(session, client::cfg_frequency_reference(stub(), session, "", FREQUENCY_REFERENCE_SOURCE_PXI_CLK, 10e6));
   EXPECT_SUCCESS(session, client::cfg_number_of_frequency_segments_and_receive_chains(stub(), session, "", NUMBER_OF_FREQUENCY_SEGMENTS, NUMBER_OF_RECEIVE_CHAINS));
   for (int i = 0; i < NUMBER_OF_FREQUENCY_SEGMENTS; ++i) {
-    auto segment_string_response = client::build_segment_string(stub(), "", i);
-    EXPECT_SUCCESS(session, segment_string_response);
+    const auto segment_string_response = EXPECT_SUCCESS(session, client::build_segment_string(stub(), "", i));
     EXPECT_SUCCESS(session, client::cfg_frequency(stub(), session, segment_string_response.selector_string_out(), center_frequency_array[i]));
   }
   for (int i = 0; i < NUMBER_OF_DEVICES; ++i) {
-    auto port_string_response = instr_client::build_port_string(instr_stub, "", selected_ports[i], resource_names[i], 0);
-    EXPECT_SUCCESS(session, port_string_response);
+    auto port_string_response = EXPECT_SUCCESS(session, instr_client::build_port_string(instr_stub, "", selected_ports[i], resource_names[i], 0));
     selected_ports_string[i] = port_string_response.selector_string_out();
-    port_string_response = instr_client::build_port_string(instr_stub, "", "", resource_names[i], 0);
-    EXPECT_SUCCESS(session, port_string_response);
+    port_string_response = EXPECT_SUCCESS(session, instr_client::build_port_string(instr_stub, "", "", resource_names[i], 0));
     port_string[i] = port_string_response.selector_string_out();
     EXPECT_SUCCESS(session, client::cfg_reference_level(stub(), session, port_string[i], reference_level_array[i]));
     EXPECT_SUCCESS(session, client::cfg_external_attenuation(stub(), session, port_string[i], external_attenuation_array[i]));
@@ -987,27 +901,22 @@ TEST_F(NiRFmxWLANDriverApiTests, SemMIMOFromExample_FetchData_DataLooksReasonabl
   SEMFetchLowerOffsetMarginArrayResponse sem_fetch_lower_offset_margin_array_response;
   SEMFetchUpperOffsetMarginArrayResponse sem_fetch_upper_offset_margin_array_response;
   SEMFetchSpectrumResponse sem_fetch_spectrum_response;
-  const auto sem_fetch_measurement_status_response = client::sem_fetch_measurement_status(stub(), session, "", 10.0);
+  const auto sem_fetch_measurement_status_response = EXPECT_SUCCESS(session, client::sem_fetch_measurement_status(stub(), session, "", 10.0));
   for (int i = 0; i < NUMBER_OF_FREQUENCY_SEGMENTS; ++i) {
-    auto segment_string_response = client::build_segment_string(stub(), "", i);
-    EXPECT_SUCCESS(session, segment_string_response);
+    const auto segment_string_response = EXPECT_SUCCESS(session, client::build_segment_string(stub(), "", i));
     for (int j = 0; j < NUMBER_OF_RECEIVE_CHAINS; ++j) {
-      auto chain_string_response = client::build_chain_string(stub(), segment_string_response.selector_string_out(), j);
-      EXPECT_SUCCESS(session, chain_string_response);
-      sem_fetch_carrier_measurement_response = client::sem_fetch_carrier_measurement(stub(), session, chain_string_response.selector_string_out(), 10.0);
-      sem_fetch_lower_offset_margin_array_response = client::sem_fetch_lower_offset_margin_array(stub(), session, chain_string_response.selector_string_out(), 10.0);
-      sem_fetch_upper_offset_margin_array_response = client::sem_fetch_upper_offset_margin_array(stub(), session, chain_string_response.selector_string_out(), 10.0);
+      const auto chain_string_response = EXPECT_SUCCESS(session, client::build_chain_string(stub(), segment_string_response.selector_string_out(), j));
+      sem_fetch_carrier_measurement_response = EXPECT_SUCCESS(session, client::sem_fetch_carrier_measurement(stub(), session, chain_string_response.selector_string_out(), 10.0));
+      sem_fetch_lower_offset_margin_array_response = EXPECT_SUCCESS(session, client::sem_fetch_lower_offset_margin_array(stub(), session, chain_string_response.selector_string_out(), 10.0));
+      sem_fetch_upper_offset_margin_array_response = EXPECT_SUCCESS(session, client::sem_fetch_upper_offset_margin_array(stub(), session, chain_string_response.selector_string_out(), 10.0));
       array_size = sem_fetch_upper_offset_margin_array_response.measurement_status_size();
-      sem_fetch_spectrum_response = client::sem_fetch_spectrum(stub(), session, chain_string_response.selector_string_out(), 10.0);
+      sem_fetch_spectrum_response = EXPECT_SUCCESS(session, client::sem_fetch_spectrum(stub(), session, chain_string_response.selector_string_out(), 10.0));
     }
   }
 
-  EXPECT_SUCCESS(session, sem_fetch_measurement_status_response);
   EXPECT_EQ(1, sem_fetch_measurement_status_response.measurement_status());
-  EXPECT_SUCCESS(session, sem_fetch_carrier_measurement_response);
   EXPECT_LT(0.0, sem_fetch_carrier_measurement_response.absolute_power());
   EXPECT_LT(0.0, sem_fetch_carrier_measurement_response.relative_power());
-  EXPECT_SUCCESS(session, sem_fetch_lower_offset_margin_array_response);
   EXPECT_EQ(4, sem_fetch_lower_offset_margin_array_response.measurement_status_size());
   EXPECT_EQ(4, sem_fetch_lower_offset_margin_array_response.measurement_status().size());
   EXPECT_EQ(1, sem_fetch_lower_offset_margin_array_response.measurement_status(0));
@@ -1023,7 +932,6 @@ TEST_F(NiRFmxWLANDriverApiTests, SemMIMOFromExample_FetchData_DataLooksReasonabl
   EXPECT_EQ(4, sem_fetch_lower_offset_margin_array_response.margin_relative_power_size());
   EXPECT_EQ(4, sem_fetch_lower_offset_margin_array_response.margin_relative_power().size());
   EXPECT_GT(0.0, sem_fetch_lower_offset_margin_array_response.margin_relative_power(0));
-  EXPECT_SUCCESS(session, sem_fetch_upper_offset_margin_array_response);
   EXPECT_EQ(4, sem_fetch_upper_offset_margin_array_response.measurement_status_size());
   EXPECT_EQ(4, sem_fetch_upper_offset_margin_array_response.measurement_status().size());
   EXPECT_EQ(1, sem_fetch_upper_offset_margin_array_response.measurement_status(0));
@@ -1039,7 +947,6 @@ TEST_F(NiRFmxWLANDriverApiTests, SemMIMOFromExample_FetchData_DataLooksReasonabl
   EXPECT_EQ(4, sem_fetch_upper_offset_margin_array_response.margin_relative_power_size());
   EXPECT_EQ(4, sem_fetch_upper_offset_margin_array_response.margin_relative_power().size());
   EXPECT_GT(0.0, sem_fetch_upper_offset_margin_array_response.margin_relative_power(0));
-  EXPECT_SUCCESS(session, sem_fetch_spectrum_response);
   EXPECT_LT(0.0, sem_fetch_spectrum_response.x0());
   EXPECT_LT(0.0, sem_fetch_spectrum_response.dx());
   EXPECT_EQ(2454, sem_fetch_spectrum_response.spectrum_size());
@@ -1069,16 +976,13 @@ TEST_F(NiRFmxWLANDriverApiTests, TXPMIMOFromExample_FetchData_DataLooksReasonabl
   EXPECT_SUCCESS(session, client::cfg_frequency_reference(stub(), session, "", FREQUENCY_REFERENCE_SOURCE_PXI_CLK, 10e6));
   EXPECT_SUCCESS(session, client::cfg_number_of_frequency_segments_and_receive_chains(stub(), session, "", NUMBER_OF_FREQUENCY_SEGMENTS, NUMBER_OF_RECEIVE_CHAINS));
   for (int i = 0; i < NUMBER_OF_FREQUENCY_SEGMENTS; ++i) {
-    auto segment_string_response = client::build_segment_string(stub(), "", i);
-    EXPECT_SUCCESS(session, segment_string_response);
+    const auto segment_string_response = EXPECT_SUCCESS(session, client::build_segment_string(stub(), "", i));
     EXPECT_SUCCESS(session, client::cfg_frequency(stub(), session, segment_string_response.selector_string_out(), center_frequency_array[i]));
   }
   for (int i = 0; i < NUMBER_OF_DEVICES; ++i) {
-    auto port_string_response = instr_client::build_port_string(instr_stub, "", selected_ports[i], resource_names[i], 0);
-    EXPECT_SUCCESS(session, port_string_response);
+    auto port_string_response = EXPECT_SUCCESS(session, instr_client::build_port_string(instr_stub, "", selected_ports[i], resource_names[i], 0));
     selected_ports_string[i] = port_string_response.selector_string_out();
-    port_string_response = instr_client::build_port_string(instr_stub, "", "", resource_names[i], 0);
-    EXPECT_SUCCESS(session, port_string_response);
+    port_string_response = EXPECT_SUCCESS(session, instr_client::build_port_string(instr_stub, "", "", resource_names[i], 0));
     port_string[i] = port_string_response.selector_string_out();
   }
   selected_ports_string_comma_separated = get_comma_seperated_string(selected_ports_string);
@@ -1098,10 +1002,12 @@ TEST_F(NiRFmxWLANDriverApiTests, TXPMIMOFromExample_FetchData_DataLooksReasonabl
   TXPFetchMeasurementResponse txp_fetch_measurement_response;
   TXPFetchPowerTraceResponse txp_fetch_power_trace_response;
   for (int i = 0; i < NUMBER_OF_FREQUENCY_SEGMENTS; ++i) {
-    auto segment_string_response = client::build_segment_string(stub(), "", i);
-    EXPECT_SUCCESS(session, segment_string_response);
+    const auto segment_string_response = EXPECT_SUCCESS(session, client::build_segment_string(stub(), "", i));
     for (int j = 0; j < NUMBER_OF_RECEIVE_CHAINS; ++j) {
-      auto chain_string_response = client::build_chain_string(stub(), segment_string_response.selector_string_out(), j);
+      // Note: using EXPECT_RESPONSE_SUCCESS here instead of EXPECT_SUCCESS because get_error() is
+      // returning the text for RISING_EDGE_DETECTION_FAILED_WARNING
+      const auto chain_string_response = client::build_chain_string(stub(), segment_string_response.selector_string_out(), j);
+      EXPECT_RESPONSE_SUCCESS(chain_string_response);
       txp_fetch_measurement_response = client::txp_fetch_measurement(stub(), session, chain_string_response.selector_string_out(), 10.0);
       txp_fetch_power_trace_response = client::txp_fetch_power_trace(stub(), session, chain_string_response.selector_string_out(), 10.0);
     }

--- a/source/tests/system/rfmx_expect_macros.h
+++ b/source/tests/system/rfmx_expect_macros.h
@@ -1,10 +1,14 @@
 #ifndef NIDEVICE_GRPC_TESTS_RFMX_EXPECT_MACROS
 #define NIDEVICE_GRPC_TESTS_RFMX_EXPECT_MACROS
 
-#define CHECK_ERROR(session)                                          \
-  if (1) {                                                            \
-    auto response = client::get_error(stub(), session);               \
-    EXPECT_EQ("", std::string(response.error_description().c_str())); \
+#define EXPECT_NO_ERROR_MESSAGE(session, response)                                                \
+  if (1) {                                                                                        \
+    if (response.status() != 0) {                                                                 \
+      auto error_message_response = client::get_error_string(stub(), session, response.status()); \
+      EXPECT_EQ("", std::string(error_message_response.error_description().c_str()));             \
+    }                                                                                             \
+    auto error_response = client::get_error(stub(), session);                                     \
+    EXPECT_EQ("", std::string(error_response.error_description().c_str()));                       \
   }
 
 #define EXPECT_RESPONSE_SUCCESS(response) \
@@ -24,11 +28,12 @@
     EXPECT_EQ(expected_error, response.status());       \
   }
 
-#define EXPECT_SUCCESS(session, response) \
-  if (1) {                                \
-    EXPECT_RESPONSE_SUCCESS(response)     \
-    CHECK_ERROR(session);                 \
-  }
+#define EXPECT_SUCCESS(session_, response_)     \
+  ([this](auto& session, auto& response) {      \
+    EXPECT_RESPONSE_SUCCESS(response);          \
+    EXPECT_NO_ERROR_MESSAGE(session, response); \
+    return response;                            \
+  })((session_), (response_))
 
 #define EXPECT_ERROR(expected_error, message_substring, session, response) \
   if (1) {                                                                 \


### PR DESCRIPTION
### What does this Pull Request accomplish?

Inline calls to the EXPECT_SUCCESS macro.
When EXPECT_SUCCESS is called an a non-zero status is found, also dump the error description.

### Why should this Pull Request be merged?

Code cleanup.
In cases where EXPECT_SUCCESS was being run after other calls happened, the get_error() call would return out-of-date info.

### What testing has been done?

```
Z:\dev\grpc-device\build\debug>SystemTestsRunner.exe --gtest_filter=*RFmx*DriverApi*
Note: Google Test filter = *RFmx*DriverApi*
[==========] Running 103 tests from 10 test suites.
[----------] Global test environment set-up.
[----------] 10 tests from NiRFmxBluetoothDriverApiTests
[ RUN      ] NiRFmxBluetoothDriverApiTests.Init_Close_Succeeds
[       OK ] NiRFmxBluetoothDriverApiTests.Init_Close_Succeeds (15228 ms)
...
...
...
[ RUN      ] ConflictingTestCases/NiRFmxSpecAnDriverApiConflictingResourceInitTests.InitializeAndCloseResource_InitializeResourceThatWouldHaveConflicted_Succeeds/specan1_specan2__specan1_specan2_specan3
[       OK ] ConflictingTestCases/NiRFmxSpecAnDriverApiConflictingResourceInitTests.InitializeAndCloseResource_InitializeResourceThatWouldHaveConflicted_Succeeds/specan1_specan2__specan1_specan2_specan3 (7684 ms)
[----------] 6 tests from ConflictingTestCases/NiRFmxSpecAnDriverApiConflictingResourceInitTests (25205 ms total)

[----------] Global test environment tear-down
[==========] 103 tests from 10 test suites ran. (405654 ms total)
[  PASSED  ] 103 tests.
```