### PR TITLE
Be consistent with constants usage

### DIFF
--- a/source/tests/system/nirfmxbluetooth_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxbluetooth_driver_api_tests.cpp
@@ -31,8 +31,10 @@ namespace system {
 namespace {
 
 constexpr auto PXI_5663E = "5663E";
-constexpr auto PREAMBLE_BURST_SYNC = 686280;  // The Preamble Sync failed to detect start of the packet
+constexpr auto PREAMBLE_BURST_SYNC_WARNING = 686280;
+constexpr auto PREAMBLE_BURST_SYNC_WARNING_STR = "The Preamble Sync failed to detect start of the packet";
 constexpr auto TYPE_MISMATCH_ERROR = -380251;
+constexpr auto TYPE_MISMATCH_ERROR_STR = "Incorrect data type specified";
 
 class NiRFmxBluetoothDriverApiTests : public Test {
  protected:
@@ -193,13 +195,13 @@ TEST_F(NiRFmxBluetoothDriverApiTests, TxpBasicFromExample_DataLooksReasonable)
   EXPECT_SUCCESS(session, client::txp_cfg_averaging(stub(), session, "", TxpAveragingEnabled::TXP_AVERAGING_ENABLED_FALSE, 10));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  // We expect these actions to produce PREAMBLE_BURST_SYNC since the test uses simulated hardware.
+  // We expect these actions to produce PREAMBLE_BURST_SYNC_WARNING since the test uses simulated hardware.
   const auto fetched_powers_response = client::txp_fetch_powers(stub(), session, "", 10.0);
-  EXPECT_RESPONSE_WARNING(PREAMBLE_BURST_SYNC, fetched_powers_response);
+  EXPECT_WARNING(PREAMBLE_BURST_SYNC_WARNING, PREAMBLE_BURST_SYNC_WARNING_STR, session, fetched_powers_response);
   const auto fetched_edr_powers_response = client::txp_fetch_edr_powers(stub(), session, "", 10.0);
-  EXPECT_RESPONSE_WARNING(PREAMBLE_BURST_SYNC, fetched_edr_powers_response);
+  EXPECT_WARNING(PREAMBLE_BURST_SYNC_WARNING, PREAMBLE_BURST_SYNC_WARNING_STR, session, fetched_edr_powers_response);
   const auto fetched_lecte_reference_period_powers_response = client::txp_fetch_lecte_reference_period_powers(stub(), session, "", 10.0);
-  EXPECT_RESPONSE_WARNING(PREAMBLE_BURST_SYNC, fetched_lecte_reference_period_powers_response);
+  EXPECT_WARNING(PREAMBLE_BURST_SYNC_WARNING, PREAMBLE_BURST_SYNC_WARNING_STR, session, fetched_lecte_reference_period_powers_response);
 
   EXPECT_GT(fetched_powers_response.average_power_mean(), 0.0);
   EXPECT_GT(fetched_powers_response.average_power_maximum(), 0.0);
@@ -220,9 +222,9 @@ TEST_F(NiRFmxBluetoothDriverApiTests, ModAccMeasurement_FetchConstellationTrace_
   EXPECT_SUCCESS(session, client::mod_acc_cfg_averaging(stub(), session, "", ModAccAveragingEnabled::MODACC_AVERAGING_ENABLED_FALSE, 10));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
-  // We expect this action to produce PREAMBLE_BURST_SYNC since the test uses simulated hardware.
+  // We expect this action to produce PREAMBLE_BURST_SYNC_WARNING since the test uses simulated hardware.
   const auto constellation_trace_response = client::mod_acc_fetch_constellation_trace(stub(), session, "", 10.0);
-  EXPECT_RESPONSE_WARNING(PREAMBLE_BURST_SYNC, constellation_trace_response);
+  EXPECT_WARNING(PREAMBLE_BURST_SYNC_WARNING, PREAMBLE_BURST_SYNC_WARNING_STR, session, constellation_trace_response);
 
   // We expect the results to be empty since the measurement did not complete successfully.
   EXPECT_THAT(constellation_trace_response.constellation(), Each(Eq(complex_number(0.0, 0.0))));
@@ -235,16 +237,16 @@ TEST_F(NiRFmxBluetoothDriverApiTests, SetAttributeInt8_ExpectedError)
   const auto session = init_session(stub(), PXI_5663E);
 
   EXPECT_ERROR(
-      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, TYPE_MISMATCH_ERROR_STR, session,
       client::set_attribute_i8(stub(), session, "", NiRFmxBluetoothAttribute::NIRFMXBLUETOOTH_ATTRIBUTE_TXP_AVERAGING_ENABLED, 1));
   EXPECT_ERROR(
-      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, TYPE_MISMATCH_ERROR_STR, session,
       client::set_attribute_u8(stub(), session, "", NiRFmxBluetoothAttribute::NIRFMXBLUETOOTH_ATTRIBUTE_TXP_AVERAGING_ENABLED, 1));
   EXPECT_ERROR(
-      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, TYPE_MISMATCH_ERROR_STR, session,
       client::set_attribute_i8_array(stub(), session, "", NiRFmxBluetoothAttribute::NIRFMXBLUETOOTH_ATTRIBUTE_TXP_AVERAGING_ENABLED, {1, 0, -1, 0}));
   EXPECT_ERROR(
-      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, TYPE_MISMATCH_ERROR_STR, session,
       client::set_attribute_u8_array(stub(), session, "", NiRFmxBluetoothAttribute::NIRFMXBLUETOOTH_ATTRIBUTE_TXP_AVERAGING_ENABLED, {1, 0, 1, 0}));
 }
 
@@ -254,10 +256,10 @@ TEST_F(NiRFmxBluetoothDriverApiTests, SetAttributeInt16_ExpectedError)
   const auto session = init_session(stub(), PXI_5663E);
 
   EXPECT_ERROR(
-      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, TYPE_MISMATCH_ERROR_STR, session,
       client::set_attribute_i16(stub(), session, "", NiRFmxBluetoothAttribute::NIRFMXBLUETOOTH_ATTRIBUTE_TXP_AVERAGING_ENABLED, -400));
   EXPECT_ERROR(
-      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, TYPE_MISMATCH_ERROR_STR, session,
       client::set_attribute_u16(stub(), session, "", NiRFmxBluetoothAttribute::NIRFMXBLUETOOTH_ATTRIBUTE_TXP_AVERAGING_ENABLED, 400));
 }
 

--- a/source/tests/system/nirfmxinstr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxinstr_driver_api_tests.cpp
@@ -1,5 +1,5 @@
 #include <gmock/gmock.h>
-#include <gtest/gtest.h>  // For EXPECT matchers.
+#include <gtest/gtest.h>
 
 #include "device_server.h"
 #include "niRFmxInstr.h"
@@ -20,8 +20,8 @@ namespace tests {
 namespace system {
 namespace {
 
-const auto PXI_5663 = "5663";
-const auto PXI_5663E = "5663E";
+constexpr auto PXI_5663 = "5663";
+constexpr auto PXI_5663E = "5663E";
 
 class NiRFmxInstrDriverApiTests : public Test {
  protected:
@@ -128,7 +128,8 @@ TEST_F(NiRFmxInstrDriverApiTests, Init_Close_Succeeds)
 
   auto close_response = client::close(stub(), session, 0);
 
-  // Don't check_error because this can report stale errors from previous tests.
+  // Don't use EXPECT_STATUS because that checks the error text, which can report stale errors from
+  // previous tests.
   EXPECT_RESPONSE_SUCCESS(close_response);
 }
 

--- a/source/tests/system/nirfmxlte_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxlte_driver_api_tests.cpp
@@ -14,7 +14,7 @@ namespace tests {
 namespace system {
 namespace {
 
-const auto PXI_5663E = "5663E";
+constexpr auto PXI_5663E = "5663E";
 
 class NiRFmxLTEDriverApiTests : public Test {
  protected:
@@ -58,6 +58,7 @@ TEST_F(NiRFmxLTEDriverApiTests, Init_Close_Succeeds)
 {
   auto init_response = init(stub(), PXI_5663E);
   auto session = init_response.instrument();
+  // TODO: use EXPECT_SUCCESS here when LTE has get_error and get_error_string
   EXPECT_RESPONSE_SUCCESS(init_response);
 
   auto close_response = client::close(stub(), session, 0);

--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -22,12 +22,12 @@ namespace system {
 namespace {
 
 constexpr auto PXI_5663E = "5663E";
-constexpr auto NR_SYNC_FAILURE = 684300;
-constexpr auto NR_SYNC_FAILURE_STR = "Failed to synchronize to the signal";
+constexpr auto NR_SYNC_FAILURE_WARNING = 684300;
+constexpr auto NR_SYNC_FAILURE_WARNING_STR = "Failed to synchronize to the signal";
 constexpr auto IVI_ERROR_INVALID_VALUE = -1074135024;
 constexpr auto IVI_ERROR_INVALID_VALUE_STR = "Invalid value for parameter or property";
-constexpr auto INCORRECT_TYPE_ERROR_CODE = -380251;
-constexpr auto INCORRECT_TYPE_ERROR_STR = "Incorrect data type specified";
+constexpr auto TYPE_MISMATCH_ERROR = -380251;
+constexpr auto TYPE_MISMATCH_ERROR_STR = "Incorrect data type specified";
 
 class NiRFmxNRDriverApiTests : public Test {
  protected:
@@ -348,7 +348,7 @@ TEST_F(NiRFmxNRDriverApiTests, DLModAccContiguousMultiCarrierFromExample_FetchDa
     EXPECT_SUCCESS(session, carrier_string_response);
     auto modacc_results_composite_rms_evm_mean_response = client::get_attribute_f64(stub(), session, carrier_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_COMPOSITE_RMS_EVM_MEAN);
     if (i == 0) {
-      EXPECT_WARNING(NR_SYNC_FAILURE, NR_SYNC_FAILURE_STR, session, modacc_results_composite_rms_evm_mean_response);
+      EXPECT_WARNING(NR_SYNC_FAILURE_WARNING, NR_SYNC_FAILURE_WARNING_STR, session, modacc_results_composite_rms_evm_mean_response);
     }
     else {
       EXPECT_SUCCESS(session, modacc_results_composite_rms_evm_mean_response);
@@ -364,9 +364,9 @@ TEST_F(NiRFmxNRDriverApiTests, DLModAccContiguousMultiCarrierFromExample_FetchDa
     componentCarrierQuadratureErrorMean[i] = GET_ATTR_F64(session, carrier_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_COMPONENT_CARRIER_QUADRATURE_ERROR_MEAN);
     pdschRMSEVMMean[i] = GET_ATTR_F64(session, carrier_string_response.selector_string_out(), NIRFMXNR_ATTRIBUTE_MODACC_RESULTS_PDSCH_QPSK_RMS_EVM_MEAN);
     mod_acc_fetch_rmsevm_per_subcarrier_mean_trace_response[i] = client::mod_acc_fetch_rmsevm_per_subcarrier_mean_trace(stub(), session, carrier_string_response.selector_string_out(), 10.000000);
-    EXPECT_WARNING(NR_SYNC_FAILURE, NR_SYNC_FAILURE_STR, session, mod_acc_fetch_rmsevm_per_subcarrier_mean_trace_response[i]);
+    EXPECT_WARNING(NR_SYNC_FAILURE_WARNING, NR_SYNC_FAILURE_WARNING_STR, session, mod_acc_fetch_rmsevm_per_subcarrier_mean_trace_response[i]);
     mod_acc_fetch_rmsevm_per_symbol_mean_trace_response[i] = client::mod_acc_fetch_rmsevm_per_symbol_mean_trace(stub(), session, carrier_string_response.selector_string_out(), 10.000000);
-    EXPECT_WARNING(NR_SYNC_FAILURE, NR_SYNC_FAILURE_STR, session, mod_acc_fetch_rmsevm_per_symbol_mean_trace_response[i]);
+    EXPECT_WARNING(NR_SYNC_FAILURE_WARNING, NR_SYNC_FAILURE_WARNING_STR, session, mod_acc_fetch_rmsevm_per_symbol_mean_trace_response[i]);
   }
 
   EXPECT_TRUE(isnan(compositeRMSEVMMean[0]));
@@ -678,7 +678,7 @@ TEST_F(NiRFmxNRDriverApiTests, SetAttributeComplex_ExpectedError)
   const auto session = init_session(stub(), PXI_5663E);
 
   EXPECT_ERROR(
-      INCORRECT_TYPE_ERROR_CODE, INCORRECT_TYPE_ERROR_STR, session,
+      TYPE_MISMATCH_ERROR, TYPE_MISMATCH_ERROR_STR, session,
       client::set_attribute_ni_complex_double_array(stub(), session, "", NIRFMXNR_ATTRIBUTE_SEM_OFFSET_START_FREQUENCY, complex_number_array({1.2, 2.2}, {1e6, 1.01e6})));
 }
 

--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -21,13 +21,13 @@ namespace tests {
 namespace system {
 namespace {
 
-const auto PXI_5663E = "5663E";
-const auto NR_SYNC_FAILURE = 684300;
-const auto NR_SYNC_FAILURE_STR = "Failed to synchronize to the signal";
-const auto IVI_ERROR_INVALID_VALUE = -1074135024;
-const auto IVI_ERROR_INVALID_VALUE_STR = "Invalid value for parameter or property";
-const auto INCORRECT_TYPE_ERROR_CODE = -380251;
-const auto INCORRECT_TYPE_ERROR_STR = "Incorrect data type specified";
+constexpr auto PXI_5663E = "5663E";
+constexpr auto NR_SYNC_FAILURE = 684300;
+constexpr auto NR_SYNC_FAILURE_STR = "Failed to synchronize to the signal";
+constexpr auto IVI_ERROR_INVALID_VALUE = -1074135024;
+constexpr auto IVI_ERROR_INVALID_VALUE_STR = "Invalid value for parameter or property";
+constexpr auto INCORRECT_TYPE_ERROR_CODE = -380251;
+constexpr auto INCORRECT_TYPE_ERROR_STR = "Incorrect data type specified";
 
 class NiRFmxNRDriverApiTests : public Test {
  protected:

--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -24,8 +24,8 @@ namespace {
 constexpr auto PXI_5663E = "5663E";
 constexpr auto NR_SYNC_FAILURE_WARNING = 684300;
 constexpr auto NR_SYNC_FAILURE_WARNING_STR = "Failed to synchronize to the signal";
-constexpr auto IVI_ERROR_INVALID_VALUE = -1074135024;
-constexpr auto IVI_ERROR_INVALID_VALUE_STR = "Invalid value for parameter or property";
+constexpr auto IVI_INVALID_VALUE_ERROR = -1074135024;
+constexpr auto IVI_INVALID_VALUE_ERROR_STR = "Invalid value for parameter or property";
 constexpr auto TYPE_MISMATCH_ERROR = -380251;
 constexpr auto TYPE_MISMATCH_ERROR_STR = "Incorrect data type specified";
 
@@ -161,7 +161,7 @@ TEST_F(NiRFmxNRDriverApiTests, AcpNonContiguousMultiCarrierFromExample_FetchData
     }
   }
   auto auto_level_response = client::auto_level(stub(), session, "", 10.0e-3);
-  EXPECT_ERROR(IVI_ERROR_INVALID_VALUE, IVI_ERROR_INVALID_VALUE_STR, session, auto_level_response);
+  EXPECT_ERROR(IVI_INVALID_VALUE_ERROR, IVI_INVALID_VALUE_ERROR_STR, session, auto_level_response);
   EXPECT_SUCCESS(session, client::select_measurements(stub(), session, "", MEASUREMENT_TYPES_ACP, true));
   EXPECT_SUCCESS(session, client::acp_cfg_measurement_method(stub(), session, "", ACP_MEASUREMENT_METHOD_NORMAL));
   EXPECT_SUCCESS(session, client::acp_cfg_noise_compensation_enabled(stub(), session, "", ACP_NOISE_COMPENSATION_ENABLED_FALSE));

--- a/source/tests/system/nirfmxspecan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxspecan_driver_api_tests.cpp
@@ -25,6 +25,9 @@ namespace {
 constexpr auto PXI_5663 = "5663";
 constexpr auto INVALID_DRIVER_SESSION = -380598;
 constexpr auto DEVICE_IN_USE = -380489;
+constexpr auto READ_ONLY_ATTRIBUTE = -380231;
+constexpr auto SYNCHRONIZTION_NOT_FOUND = 377652;
+constexpr auto TYPE_MISMATCH_ERROR = -380251;
 constexpr auto SUCCESS = 0;
 
 class NiRFmxSpecAnDriverApiTests : public ::testing::Test {
@@ -258,7 +261,7 @@ TEST_F(NiRFmxSpecAnDriverApiTests, LutDpdFromExample_ReturnsSynchronizationNotFo
   EXPECT_SUCCESS(session, client::dpd_cfg_apply_dpd_lookup_table_correction_type(stub(), session, "", DpdApplyDpdLookupTableCorrectionType::DPD_APPLY_DPD_LOOKUP_TABLE_CORRECTION_TYPE_MAGNITUDE_AND_PHASE));
 
   const auto apply_response = client::dpd_apply_digital_predistortion(stub(), session, "", waveform.t0, waveform.dt, waveform.data, false, 10.0);
-  EXPECT_WARNING(377652, "Synchronization not found", session, apply_response);
+  EXPECT_WARNING(SYNCHRONIZTION_NOT_FOUND, "Synchronization not found", session, apply_response);
   EXPECT_THAT(apply_response.waveform_out(), Not(IsEmpty()));
 }
 
@@ -268,7 +271,7 @@ TEST_F(NiRFmxSpecAnDriverApiTests, SetAttributeComplex_ExpectedError)
   const auto session = init_session(stub(), PXI_5663);
 
   EXPECT_ERROR(
-      -380231, "This attribute is read-only and cannot be written", session,
+      READ_ONLY_ATTRIBUTE, "This attribute is read-only and cannot be written", session,
       client::set_attribute_ni_complex_double_array(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_SEM_RESULTS_CARRIER_FREQUENCY, complex_number_array({1.2, 2.2}, {1e6, 1.01e6})));
 }
 
@@ -278,16 +281,16 @@ TEST_F(NiRFmxSpecAnDriverApiTests, SetAttributeInt8_ExpectedError)
   const auto session = init_session(stub(), PXI_5663);
 
   EXPECT_ERROR(
-      -380251, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
       client::set_attribute_i8(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, 1));
   EXPECT_ERROR(
-      -380251, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
       client::set_attribute_u8(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, 1));
   EXPECT_ERROR(
-      -380251, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
       client::set_attribute_i8_array(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, {1, 0, -1, 0}));
   EXPECT_ERROR(
-      -380251, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
       client::set_attribute_u8_array(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, {1, 0, 1, 0}));
 }
 
@@ -297,10 +300,10 @@ TEST_F(NiRFmxSpecAnDriverApiTests, SetAttributeInt16_ExpectedError)
   const auto session = init_session(stub(), PXI_5663);
 
   EXPECT_ERROR(
-      -380251, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
       client::set_attribute_i16(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, -400));
   EXPECT_ERROR(
-      -380251, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
       client::set_attribute_u16(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, 400));
 }
 

--- a/source/tests/system/nirfmxspecan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxspecan_driver_api_tests.cpp
@@ -23,12 +23,16 @@ namespace system {
 namespace {
 
 constexpr auto PXI_5663 = "5663";
-constexpr auto INVALID_DRIVER_SESSION = -380598;
-constexpr auto DEVICE_IN_USE = -380489;
-constexpr auto READ_ONLY_ATTRIBUTE = -380231;
-constexpr auto SYNCHRONIZTION_NOT_FOUND = 377652;
+constexpr auto INVALID_SESSION_HANDLE_ERROR = -380598;
+constexpr auto DEVICE_IN_USE_ERROR = -380489;
+constexpr auto IQ_FETCH_DELETED_RECORD_ERROR = -379451;
+constexpr auto IQ_FETCH_DELETED_RECORD_ERROR_STR = "The requested record number is invalid";
+constexpr auto READ_ONLY_ATTRIBUTE_ERROR = -380231;
+constexpr auto READ_ONLY_ATTRIBUTE_ERROR_STR = "This attribute is read-only and cannot be written";
+constexpr auto SYNCHRONIZATION_WARNING = 377652;
+constexpr auto SYNCHRONIZATION_WARNING_STR = "Synchronization not found";
 constexpr auto TYPE_MISMATCH_ERROR = -380251;
-constexpr auto SUCCESS = 0;
+constexpr auto TYPE_MISMATCH_ERROR_STR = "Incorrect data type specified";
 
 class NiRFmxSpecAnDriverApiTests : public ::testing::Test {
  protected:
@@ -59,7 +63,7 @@ class NiRFmxSpecAnDriverApiTests : public ::testing::Test {
   bool is_driver_session_valid(const instr_client::StubPtr& stub, const nidevice_grpc::Session& session)
   {
     auto response = instr_client::get_attribute_string(stub, session, "", nirfmxinstr_grpc::NiRFmxInstrAttribute::NIRFMXINSTR_ATTRIBUTE_INSTRUMENT_MODEL);
-    return response.status() != INVALID_DRIVER_SESSION;
+    return response.status() != INVALID_SESSION_HANDLE_ERROR;
   }
 
  private:
@@ -261,7 +265,7 @@ TEST_F(NiRFmxSpecAnDriverApiTests, LutDpdFromExample_ReturnsSynchronizationNotFo
   EXPECT_SUCCESS(session, client::dpd_cfg_apply_dpd_lookup_table_correction_type(stub(), session, "", DpdApplyDpdLookupTableCorrectionType::DPD_APPLY_DPD_LOOKUP_TABLE_CORRECTION_TYPE_MAGNITUDE_AND_PHASE));
 
   const auto apply_response = client::dpd_apply_digital_predistortion(stub(), session, "", waveform.t0, waveform.dt, waveform.data, false, 10.0);
-  EXPECT_WARNING(SYNCHRONIZTION_NOT_FOUND, "Synchronization not found", session, apply_response);
+  EXPECT_WARNING(SYNCHRONIZATION_WARNING, SYNCHRONIZATION_WARNING_STR, session, apply_response);
   EXPECT_THAT(apply_response.waveform_out(), Not(IsEmpty()));
 }
 
@@ -271,7 +275,7 @@ TEST_F(NiRFmxSpecAnDriverApiTests, SetAttributeComplex_ExpectedError)
   const auto session = init_session(stub(), PXI_5663);
 
   EXPECT_ERROR(
-      READ_ONLY_ATTRIBUTE, "This attribute is read-only and cannot be written", session,
+      READ_ONLY_ATTRIBUTE_ERROR, READ_ONLY_ATTRIBUTE_ERROR_STR, session,
       client::set_attribute_ni_complex_double_array(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_SEM_RESULTS_CARRIER_FREQUENCY, complex_number_array({1.2, 2.2}, {1e6, 1.01e6})));
 }
 
@@ -281,16 +285,16 @@ TEST_F(NiRFmxSpecAnDriverApiTests, SetAttributeInt8_ExpectedError)
   const auto session = init_session(stub(), PXI_5663);
 
   EXPECT_ERROR(
-      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, TYPE_MISMATCH_ERROR_STR, session,
       client::set_attribute_i8(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, 1));
   EXPECT_ERROR(
-      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, TYPE_MISMATCH_ERROR_STR, session,
       client::set_attribute_u8(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, 1));
   EXPECT_ERROR(
-      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, TYPE_MISMATCH_ERROR_STR, session,
       client::set_attribute_i8_array(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, {1, 0, -1, 0}));
   EXPECT_ERROR(
-      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, TYPE_MISMATCH_ERROR_STR, session,
       client::set_attribute_u8_array(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, {1, 0, 1, 0}));
 }
 
@@ -300,10 +304,10 @@ TEST_F(NiRFmxSpecAnDriverApiTests, SetAttributeInt16_ExpectedError)
   const auto session = init_session(stub(), PXI_5663);
 
   EXPECT_ERROR(
-      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, TYPE_MISMATCH_ERROR_STR, session,
       client::set_attribute_i16(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, -400));
   EXPECT_ERROR(
-      TYPE_MISMATCH_ERROR, "Incorrect data type specified", session,
+      TYPE_MISMATCH_ERROR, TYPE_MISMATCH_ERROR_STR, session,
       client::set_attribute_u16(stub(), session, "", NiRFmxSpecAnAttribute::NIRFMXSPECAN_ATTRIBUTE_NF_EXTERNAL_PREAMP_PRESENT, 400));
 }
 
@@ -363,7 +367,6 @@ TEST_F(NiRFmxSpecAnDriverApiTests, BuildIntermodString_ReturnsIntermodString)
 
 TEST_F(NiRFmxSpecAnDriverApiTests, DefaultConfiguration_IQFetchData_RecordIsDeleted)
 {
-  constexpr auto INVALID_RECORD = -379451;
   const auto session = init_session(stub(), PXI_5663);
   EXPECT_SUCCESS(session, client::select_measurements(stub(), session, "", MeasurementTypes::MEASUREMENT_TYPES_IQ, true));
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
@@ -373,15 +376,12 @@ TEST_F(NiRFmxSpecAnDriverApiTests, DefaultConfiguration_IQFetchData_RecordIsDele
   EXPECT_THAT(fetch_response.data(), Not(IsEmpty()));
 
   EXPECT_ERROR(
-      INVALID_RECORD,
-      "The requested record number is invalid. The desired record was already fetched and deleted.",
-      session,
+      IQ_FETCH_DELETED_RECORD_ERROR, IQ_FETCH_DELETED_RECORD_ERROR_STR, session,
       client::iq_fetch_data(stub(), session, "", 10.0, 0, 1000));
 }
 
 TEST_F(NiRFmxSpecAnDriverApiTests, DefaultConfiguration_IQFetchDataFetchAllAvailable_DataIsFetched)
 {
-  constexpr auto INVALID_RECORD = -379451;
   constexpr auto FETCH_ALL_AVAILABLE = -1;
   constexpr auto EXPECTED_RECORD_COUNT = 50000;
   const auto session = init_session(stub(), PXI_5663);
@@ -603,7 +603,7 @@ TEST_P(NiRFmxSpecAnDriverApiConflictingResourceInitTests, InitializeResource_Ini
 
   const auto second_init_response = init(stub(), PXI_5663, std::get<1>(GetParam()));
 
-  EXPECT_RESPONSE_ERROR(DEVICE_IN_USE, second_init_response);
+  EXPECT_RESPONSE_ERROR(DEVICE_IN_USE_ERROR, second_init_response);
 }
 
 TEST_P(NiRFmxSpecAnDriverApiConflictingResourceInitTests, InitializeAndCloseResource_InitializeResourceThatWouldHaveConflicted_Succeeds)

--- a/source/tests/system/nirfmxwlan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxwlan_driver_api_tests.cpp
@@ -21,10 +21,10 @@ namespace tests {
 namespace system {
 namespace {
 
-const auto PXI_5663E = "5663E";
-const int RISING_EDGE_DETECTION_FAILED_WARNING = 379206;
-const int EVM_CHIPS_MUST_BE_300_WARNING = 685353;
-const int INCORRECT_TYPE_ERROR_CODE = -380251;
+constexpr auto PXI_5663E = "5663E";
+constexpr int RISING_EDGE_DETECTION_FAILED_WARNING = 379206;
+constexpr int EVM_CHIPS_MUST_BE_300_WARNING = 685353;
+constexpr int INCORRECT_TYPE_ERROR_CODE = -380251;
 
 class NiRFmxWLANDriverApiTests : public Test {
  protected:

--- a/source/tests/system/nirfmxwlan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxwlan_driver_api_tests.cpp
@@ -22,9 +22,12 @@ namespace system {
 namespace {
 
 constexpr auto PXI_5663E = "5663E";
-constexpr int RISING_EDGE_DETECTION_FAILED_WARNING = 379206;
-constexpr int EVM_CHIPS_MUST_BE_300_WARNING = 685353;
-constexpr int INCORRECT_TYPE_ERROR_CODE = -380251;
+constexpr auto RISING_EDGE_DETECTION_FAILED_WARNING = 379206;
+constexpr auto RISING_EDGE_DETECTION_FAILED_WARNING_STR = "Rising edge detection failed for the acquired waveform";
+constexpr auto EVM_CHIPS_MUST_BE_300_WARNING = 685353;
+constexpr auto EVM_CHIPS_MUST_BE_300_WARNING_STR = "Number of available payload chips for EVM measurements";
+constexpr auto INCORRECT_TYPE_ERROR = -380251;
+constexpr auto INCORRECT_TYPE_ERROR_STR = "Incorrect data type specified";
 
 class NiRFmxWLANDriverApiTests : public Test {
  protected:
@@ -186,7 +189,7 @@ TEST_F(NiRFmxWLANDriverApiTests, OFDMModAccTXPCompositeFromExample_FetchData_Dat
   const auto ofdm_mod_acc_fetch_composite_rmsevm_response = client::ofdm_mod_acc_fetch_composite_rmsevm(stub(), session, "", 10.0);
   EXPECT_SUCCESS(session, ofdm_mod_acc_fetch_composite_rmsevm_response);
   const auto txp_fetch_measurement_response = client::txp_fetch_measurement(stub(), session, "", 10.0);
-  EXPECT_RESPONSE_WARNING(RISING_EDGE_DETECTION_FAILED_WARNING, txp_fetch_measurement_response);
+  EXPECT_WARNING(RISING_EDGE_DETECTION_FAILED_WARNING, RISING_EDGE_DETECTION_FAILED_WARNING_STR, session, txp_fetch_measurement_response);
 
   EXPECT_LT(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_rms_evm_mean());
   EXPECT_LT(0.0, ofdm_mod_acc_fetch_composite_rmsevm_response.composite_data_rms_evm_mean());
@@ -362,15 +365,15 @@ TEST_F(NiRFmxWLANDriverApiTests, TXPFromExample_FetchData_DataLooksReasonable)
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
   const auto txp_fetch_power_trace_response = client::txp_fetch_power_trace(stub(), session, "", 10.0);
+  EXPECT_WARNING(RISING_EDGE_DETECTION_FAILED_WARNING, RISING_EDGE_DETECTION_FAILED_WARNING_STR, session, txp_fetch_power_trace_response);
   const auto txp_fetch_measurement_response = client::txp_fetch_measurement(stub(), session, "", 10.0);
+  EXPECT_WARNING(RISING_EDGE_DETECTION_FAILED_WARNING, RISING_EDGE_DETECTION_FAILED_WARNING_STR, session, txp_fetch_measurement_response);
 
-  EXPECT_RESPONSE_WARNING(RISING_EDGE_DETECTION_FAILED_WARNING, txp_fetch_power_trace_response);
   EXPECT_GT(0.0, txp_fetch_power_trace_response.x0());
   EXPECT_LT(0.0, txp_fetch_power_trace_response.dx());
   EXPECT_EQ(25250, txp_fetch_power_trace_response.power_size());
   EXPECT_EQ(25250, txp_fetch_power_trace_response.power().size());
   EXPECT_LT(0.0, txp_fetch_power_trace_response.power(0));
-  EXPECT_RESPONSE_WARNING(RISING_EDGE_DETECTION_FAILED_WARNING, txp_fetch_measurement_response);
   EXPECT_LT(0.0, txp_fetch_measurement_response.average_power_mean());
   EXPECT_LT(0.0, txp_fetch_measurement_response.peak_power_maximum());
 }
@@ -395,12 +398,16 @@ TEST_F(NiRFmxWLANDriverApiTests, DSSSModAccFromExample_FetchData_DataLooksReason
   EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
   const auto dsss_mod_acc_fetch_evm_response = client::dsss_mod_acc_fetch_evm(stub(), session, "", 10.0);
+  EXPECT_WARNING(EVM_CHIPS_MUST_BE_300_WARNING, EVM_CHIPS_MUST_BE_300_WARNING_STR, session, dsss_mod_acc_fetch_evm_response);
   const auto dsss_mod_acc_fetch_ppdu_information_response = client::dsss_mod_acc_fetch_ppdu_information(stub(), session, "", 10.0);
+  EXPECT_WARNING(EVM_CHIPS_MUST_BE_300_WARNING, EVM_CHIPS_MUST_BE_300_WARNING_STR, session, dsss_mod_acc_fetch_ppdu_information_response);
   const auto dsss_mod_acc_fetch_iq_impairments_response = client::dsss_mod_acc_fetch_iq_impairments(stub(), session, "", 10.0);
+  EXPECT_WARNING(EVM_CHIPS_MUST_BE_300_WARNING, EVM_CHIPS_MUST_BE_300_WARNING_STR, session, dsss_mod_acc_fetch_iq_impairments_response);
   const auto dsss_mod_acc_fetch_evm_per_chip_mean_trace_response = client::dsss_mod_acc_fetch_evm_per_chip_mean_trace(stub(), session, "", 10.0);
+  EXPECT_WARNING(EVM_CHIPS_MUST_BE_300_WARNING, EVM_CHIPS_MUST_BE_300_WARNING_STR, session, dsss_mod_acc_fetch_evm_per_chip_mean_trace_response);
   const auto dsss_mod_acc_fetch_constellation_trace_response = client::dsss_mod_acc_fetch_constellation_trace(stub(), session, "", 10.0);
+  EXPECT_WARNING(EVM_CHIPS_MUST_BE_300_WARNING, EVM_CHIPS_MUST_BE_300_WARNING_STR, session, dsss_mod_acc_fetch_constellation_trace_response);
 
-  EXPECT_RESPONSE_WARNING(EVM_CHIPS_MUST_BE_300_WARNING, dsss_mod_acc_fetch_evm_response);
   EXPECT_EQ(0.0, dsss_mod_acc_fetch_evm_response.rms_evm_mean());
   EXPECT_EQ(0.0, dsss_mod_acc_fetch_evm_response.peak_evm_80211_2016_maximum());
   EXPECT_EQ(0.0, dsss_mod_acc_fetch_evm_response.peak_evm_80211_2007_maximum());
@@ -408,23 +415,19 @@ TEST_F(NiRFmxWLANDriverApiTests, DSSSModAccFromExample_FetchData_DataLooksReason
   EXPECT_EQ(0.0, dsss_mod_acc_fetch_evm_response.frequency_error_mean());
   EXPECT_NE(0.0, dsss_mod_acc_fetch_evm_response.chip_clock_error_mean());
   EXPECT_EQ(0, dsss_mod_acc_fetch_evm_response.number_of_chips_used());
-  EXPECT_RESPONSE_WARNING(EVM_CHIPS_MUST_BE_300_WARNING, dsss_mod_acc_fetch_ppdu_information_response);
   EXPECT_EQ(3, dsss_mod_acc_fetch_ppdu_information_response.data_modulation_format());
   EXPECT_EQ(0, dsss_mod_acc_fetch_ppdu_information_response.payload_length());
   EXPECT_EQ(1, dsss_mod_acc_fetch_ppdu_information_response.preamble_type());
   EXPECT_EQ(0, dsss_mod_acc_fetch_ppdu_information_response.locked_clocks_bit());
   EXPECT_EQ(0, dsss_mod_acc_fetch_ppdu_information_response.header_crc_status());
   EXPECT_EQ(0, dsss_mod_acc_fetch_ppdu_information_response.psdu_crc_status());
-  EXPECT_RESPONSE_WARNING(EVM_CHIPS_MUST_BE_300_WARNING, dsss_mod_acc_fetch_iq_impairments_response);
   EXPECT_EQ(0.0, dsss_mod_acc_fetch_iq_impairments_response.iq_origin_offset_mean());
   EXPECT_EQ(0.0, dsss_mod_acc_fetch_iq_impairments_response.iq_gain_imbalance_mean());
   EXPECT_EQ(0.0, dsss_mod_acc_fetch_iq_impairments_response.iq_quadrature_error_mean());
-  EXPECT_RESPONSE_WARNING(EVM_CHIPS_MUST_BE_300_WARNING, dsss_mod_acc_fetch_evm_per_chip_mean_trace_response);
   EXPECT_EQ(0.0, dsss_mod_acc_fetch_evm_per_chip_mean_trace_response.x0());
   EXPECT_EQ(1, dsss_mod_acc_fetch_evm_per_chip_mean_trace_response.dx());
   EXPECT_EQ(0, dsss_mod_acc_fetch_evm_per_chip_mean_trace_response.evm_per_chip_mean_size());
   EXPECT_EQ(0, dsss_mod_acc_fetch_evm_per_chip_mean_trace_response.evm_per_chip_mean().size());
-  EXPECT_RESPONSE_WARNING(EVM_CHIPS_MUST_BE_300_WARNING, dsss_mod_acc_fetch_constellation_trace_response);
   EXPECT_EQ(0, dsss_mod_acc_fetch_constellation_trace_response.actual_array_size());
 }
 
@@ -1103,14 +1106,14 @@ TEST_F(NiRFmxWLANDriverApiTests, TXPMIMOFromExample_FetchData_DataLooksReasonabl
     for (int j = 0; j < NUMBER_OF_RECEIVE_CHAINS; ++j) {
       auto chain_string_response = client::build_chain_string(stub(), segment_string_response.selector_string_out(), j);
       txp_fetch_measurement_response = client::txp_fetch_measurement(stub(), session, chain_string_response.selector_string_out(), 10.0);
+      EXPECT_WARNING(RISING_EDGE_DETECTION_FAILED_WARNING, RISING_EDGE_DETECTION_FAILED_WARNING_STR, session, txp_fetch_measurement_response);
       txp_fetch_power_trace_response = client::txp_fetch_power_trace(stub(), session, chain_string_response.selector_string_out(), 10.0);
+      EXPECT_WARNING(RISING_EDGE_DETECTION_FAILED_WARNING, RISING_EDGE_DETECTION_FAILED_WARNING_STR, session, txp_fetch_power_trace_response);
     }
   }
 
-  EXPECT_RESPONSE_WARNING(RISING_EDGE_DETECTION_FAILED_WARNING, txp_fetch_measurement_response);
   EXPECT_LT(0.0, txp_fetch_measurement_response.average_power_mean());
   EXPECT_LT(0.0, txp_fetch_measurement_response.peak_power_maximum());
-  EXPECT_RESPONSE_WARNING(RISING_EDGE_DETECTION_FAILED_WARNING, txp_fetch_power_trace_response);
   EXPECT_GT(0.0, txp_fetch_power_trace_response.x0());
   EXPECT_LT(0.0, txp_fetch_power_trace_response.dx());
   EXPECT_EQ(25250, txp_fetch_power_trace_response.power_size());
@@ -1171,7 +1174,7 @@ TEST_F(NiRFmxWLANDriverApiTests, SetAttributeComplex_ExpectedError)
   const auto session = init_session(stub(), PXI_5663E);
 
   EXPECT_ERROR(
-      INCORRECT_TYPE_ERROR_CODE, "Incorrect data type specified", session,
+      INCORRECT_TYPE_ERROR, INCORRECT_TYPE_ERROR_STR, session,
       client::set_attribute_ni_complex_double_array(stub(), session, "", NiRFmxWLANAttribute::NIRFMXWLAN_ATTRIBUTE_REFERENCE_LEVEL, complex_number_array({1.2, 2.2}, {1e6, 1.01e6})));
 }
 
@@ -1181,16 +1184,16 @@ TEST_F(NiRFmxWLANDriverApiTests, SetAttributeInt8_ExpectedError)
   const auto session = init_session(stub(), PXI_5663E);
 
   EXPECT_ERROR(
-      INCORRECT_TYPE_ERROR_CODE, "Incorrect data type specified", session,
+      INCORRECT_TYPE_ERROR, INCORRECT_TYPE_ERROR_STR, session,
       client::set_attribute_i8(stub(), session, "", NiRFmxWLANAttribute::NIRFMXWLAN_ATTRIBUTE_OFDM_DCM_ENABLED, 1));
   EXPECT_ERROR(
-      INCORRECT_TYPE_ERROR_CODE, "Incorrect data type specified", session,
+      INCORRECT_TYPE_ERROR, INCORRECT_TYPE_ERROR_STR, session,
       client::set_attribute_u8(stub(), session, "", NiRFmxWLANAttribute::NIRFMXWLAN_ATTRIBUTE_OFDM_DCM_ENABLED, 1));
   EXPECT_ERROR(
-      INCORRECT_TYPE_ERROR_CODE, "Incorrect data type specified", session,
+      INCORRECT_TYPE_ERROR, INCORRECT_TYPE_ERROR_STR, session,
       client::set_attribute_i8_array(stub(), session, "", NiRFmxWLANAttribute::NIRFMXWLAN_ATTRIBUTE_OFDM_DCM_ENABLED, {1, 0, -1, 0}));
   EXPECT_ERROR(
-      INCORRECT_TYPE_ERROR_CODE, "Incorrect data type specified", session,
+      INCORRECT_TYPE_ERROR, INCORRECT_TYPE_ERROR_STR, session,
       client::set_attribute_u8_array(stub(), session, "", NiRFmxWLANAttribute::NIRFMXWLAN_ATTRIBUTE_OFDM_DCM_ENABLED, {1, 0, 1, 0}));
 }
 
@@ -1200,10 +1203,10 @@ TEST_F(NiRFmxWLANDriverApiTests, SetAttributeInt16_ExpectedError)
   const auto session = init_session(stub(), PXI_5663E);
 
   EXPECT_ERROR(
-      INCORRECT_TYPE_ERROR_CODE, "Incorrect data type specified", session,
+      INCORRECT_TYPE_ERROR, INCORRECT_TYPE_ERROR_STR, session,
       client::set_attribute_i16(stub(), session, "", NiRFmxWLANAttribute::NIRFMXWLAN_ATTRIBUTE_OFDM_DCM_ENABLED, -400));
   EXPECT_ERROR(
-      INCORRECT_TYPE_ERROR_CODE, "Incorrect data type specified", session,
+      INCORRECT_TYPE_ERROR, INCORRECT_TYPE_ERROR_STR, session,
       client::set_attribute_u16(stub(), session, "", NiRFmxWLANAttribute::NIRFMXWLAN_ATTRIBUTE_OFDM_DCM_ENABLED, 400));
 }
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Always use CAPS for constants. Always use constants for warning/error numbers. Always use `constexpr` for constants that can do so.
(Also, removes/adds/modifies a few comments.)

### Why should this Pull Request be merged?

Consistency

### What testing has been done?

```
Z:\dev\grpc-device\build\debug>SystemTestsRunner.exe --gtest_filter=*RFmx*DriverApi*
Note: Google Test filter = *RFmx*DriverApi*
[==========] Running 103 tests from 10 test suites.
[----------] Global test environment set-up.
[----------] 10 tests from NiRFmxBluetoothDriverApiTests
[ RUN      ] NiRFmxBluetoothDriverApiTests.Init_Close_Succeeds
[       OK ] NiRFmxBluetoothDriverApiTests.Init_Close_Succeeds (15613 ms)
...
...
...
[ RUN      ] ConflictingTestCases/NiRFmxSpecAnDriverApiConflictingResourceInitTests.InitializeAndCloseResource_InitializeResourceThatWouldHaveConflicted_Succeeds/specan1_specan2__specan1_specan2_specan3
[       OK ] ConflictingTestCases/NiRFmxSpecAnDriverApiConflictingResourceInitTests.InitializeAndCloseResource_InitializeResourceThatWouldHaveConflicted_Succeeds/specan1_specan2__specan1_specan2_specan3 (7441 ms)
[----------] 6 tests from ConflictingTestCases/NiRFmxSpecAnDriverApiConflictingResourceInitTests (23607 ms total)

[----------] Global test environment tear-down
[==========] 103 tests from 10 test suites ran. (375841 ms total)
[  PASSED  ] 103 tests.

  YOU HAVE 2 DISABLED TESTS
```