### PR TITLE
Add optional linked arrays for RFmx

### DIFF
--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -306,10 +306,15 @@ namespace nirfmxinstr_grpc {
         request->frequency_size(),
         request->external_attenuation_size()
       };
-      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, false);
+      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, true);
 
       if (array_size_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [frequency, external_attenuation] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (array_size_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        frequency = request->frequency_size() ? std::move(frequency) : nullptr;
+        external_attenuation = request->external_attenuation_size() ? std::move(external_attenuation) : nullptr;
       }
       auto array_size = array_size_size_calculation.size;
 

--- a/generated/nirfmxnr/nirfmxnr_service.cpp
+++ b/generated/nirfmxnr/nirfmxnr_service.cpp
@@ -6064,10 +6064,15 @@ namespace nirfmxnr_grpc {
         request->absolute_limit_start_size(),
         request->absolute_limit_stop_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [absolute_limit_start, absolute_limit_stop] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        absolute_limit_start = request->absolute_limit_start_size() ? std::move(absolute_limit_start) : nullptr;
+        absolute_limit_stop = request->absolute_limit_stop_size() ? std::move(absolute_limit_stop) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -6189,10 +6194,16 @@ namespace nirfmxnr_grpc {
         request->offset_stop_frequency_size(),
         request->offset_sideband_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [offset_start_frequency, offset_stop_frequency, offset_sideband] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        offset_start_frequency = request->offset_start_frequency_size() ? std::move(offset_start_frequency) : nullptr;
+        offset_stop_frequency = request->offset_stop_frequency_size() ? std::move(offset_stop_frequency) : nullptr;
+        offset_sideband = request->offset_sideband_size() ? std::move(offset_sideband) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -6334,10 +6345,15 @@ namespace nirfmxnr_grpc {
         request->offset_rbw_size(),
         request->offset_rbw_filter_type_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [offset_rbw, offset_rbw_filter_type] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        offset_rbw = request->offset_rbw_size() ? std::move(offset_rbw) : nullptr;
+        offset_rbw_filter_type = request->offset_rbw_filter_type_size() ? std::move(offset_rbw_filter_type) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -6390,10 +6406,15 @@ namespace nirfmxnr_grpc {
         request->relative_limit_start_size(),
         request->relative_limit_stop_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [relative_limit_start, relative_limit_stop] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        relative_limit_start = request->relative_limit_start_size() ? std::move(relative_limit_start) : nullptr;
+        relative_limit_stop = request->relative_limit_stop_size() ? std::move(relative_limit_stop) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 

--- a/generated/nirfmxspecan/nirfmxspecan_service.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_service.cpp
@@ -476,10 +476,16 @@ namespace nirfmxspecan_grpc {
         request->offset_sideband_size(),
         request->offset_enabled_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [offset_frequency, offset_sideband, offset_enabled] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        offset_frequency = request->offset_frequency_size() ? std::move(offset_frequency) : nullptr;
+        offset_sideband = request->offset_sideband_size() ? std::move(offset_sideband) : nullptr;
+        offset_enabled = request->offset_enabled_size() ? std::move(offset_enabled) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -634,10 +640,15 @@ namespace nirfmxspecan_grpc {
         request->offset_power_reference_carrier_size(),
         request->offset_power_reference_specific_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [offset_power_reference_carrier, offset_power_reference_specific] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        offset_power_reference_carrier = request->offset_power_reference_carrier_size() ? std::move(offset_power_reference_carrier) : nullptr;
+        offset_power_reference_specific = request->offset_power_reference_specific_size() ? std::move(offset_power_reference_specific) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -713,10 +724,15 @@ namespace nirfmxspecan_grpc {
         request->rrc_filter_enabled_size(),
         request->rrc_alpha_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [rrc_filter_enabled, rrc_alpha] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        rrc_filter_enabled = request->rrc_filter_enabled_size() ? std::move(rrc_filter_enabled) : nullptr;
+        rrc_alpha = request->rrc_alpha_size() ? std::move(rrc_alpha) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -4316,10 +4332,15 @@ namespace nirfmxspecan_grpc {
         request->lut_input_powers_size(),
         request->lut_complex_gains_size()
       };
-      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, false);
+      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, true);
 
       if (array_size_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [lut_input_powers, lut_complex_gains] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (array_size_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        lut_input_powers = request->lut_input_powers_size() ? std::move(lut_input_powers) : nullptr;
+        lut_complex_gains = request->lut_complex_gains_size() ? std::move(lut_complex_gains) : nullptr;
       }
       auto array_size = array_size_size_calculation.size;
 
@@ -6630,10 +6651,17 @@ namespace nirfmxspecan_grpc {
         request->harmonic_enabled_size(),
         request->harmonic_measurement_interval_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [harmonic_order, harmonic_bandwidth, harmonic_enabled, harmonic_measurement_interval] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        harmonic_order = request->harmonic_order_size() ? std::move(harmonic_order) : nullptr;
+        harmonic_bandwidth = request->harmonic_bandwidth_size() ? std::move(harmonic_bandwidth) : nullptr;
+        harmonic_enabled = request->harmonic_enabled_size() ? std::move(harmonic_enabled) : nullptr;
+        harmonic_measurement_interval = request->harmonic_measurement_interval_size() ? std::move(harmonic_measurement_interval) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -7127,10 +7155,18 @@ namespace nirfmxspecan_grpc {
         request->intermod_side_size(),
         request->intermod_enabled_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [intermod_order, lower_intermod_frequency, upper_intermod_frequency, intermod_side, intermod_enabled] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        intermod_order = request->intermod_order_size() ? std::move(intermod_order) : nullptr;
+        lower_intermod_frequency = request->lower_intermod_frequency_size() ? std::move(lower_intermod_frequency) : nullptr;
+        upper_intermod_frequency = request->upper_intermod_frequency_size() ? std::move(upper_intermod_frequency) : nullptr;
+        intermod_side = request->intermod_side_size() ? std::move(intermod_side) : nullptr;
+        intermod_enabled = request->intermod_enabled_size() ? std::move(intermod_enabled) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -8109,10 +8145,15 @@ namespace nirfmxspecan_grpc {
         request->calibration_loss_frequency_size(),
         request->calibration_loss_size()
       };
-      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, false);
+      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, true);
 
       if (array_size_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [calibration_loss_frequency, calibration_loss] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (array_size_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        calibration_loss_frequency = request->calibration_loss_frequency_size() ? std::move(calibration_loss_frequency) : nullptr;
+        calibration_loss = request->calibration_loss_size() ? std::move(calibration_loss) : nullptr;
       }
       auto array_size = array_size_size_calculation.size;
 
@@ -8149,10 +8190,18 @@ namespace nirfmxspecan_grpc {
         request->dut_s11_size(),
         request->dut_s22_size()
       };
-      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, false);
+      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, true);
 
       if (array_size_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [dut_s_parameters_frequency, dut_s21, dut_s12, dut_s11, dut_s22] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (array_size_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        dut_s_parameters_frequency = request->dut_s_parameters_frequency_size() ? std::move(dut_s_parameters_frequency) : nullptr;
+        dut_s21 = request->dut_s21_size() ? std::move(dut_s21) : nullptr;
+        dut_s12 = request->dut_s12_size() ? std::move(dut_s12) : nullptr;
+        dut_s11 = request->dut_s11_size() ? std::move(dut_s11) : nullptr;
+        dut_s22 = request->dut_s22_size() ? std::move(dut_s22) : nullptr;
       }
       auto array_size = array_size_size_calculation.size;
 
@@ -8184,10 +8233,15 @@ namespace nirfmxspecan_grpc {
         request->termination_vswr_size(),
         request->termination_vswr_frequency_size()
       };
-      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, false);
+      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, true);
 
       if (array_size_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [termination_vswr, termination_vswr_frequency] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (array_size_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        termination_vswr = request->termination_vswr_size() ? std::move(termination_vswr) : nullptr;
+        termination_vswr_frequency = request->termination_vswr_frequency_size() ? std::move(termination_vswr_frequency) : nullptr;
       }
       auto array_size = array_size_size_calculation.size;
 
@@ -8271,10 +8325,15 @@ namespace nirfmxspecan_grpc {
         request->dut_input_loss_frequency_size(),
         request->dut_input_loss_size()
       };
-      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, false);
+      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, true);
 
       if (array_size_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [dut_input_loss_frequency, dut_input_loss] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (array_size_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        dut_input_loss_frequency = request->dut_input_loss_frequency_size() ? std::move(dut_input_loss_frequency) : nullptr;
+        dut_input_loss = request->dut_input_loss_size() ? std::move(dut_input_loss) : nullptr;
       }
       auto array_size = array_size_size_calculation.size;
 
@@ -8322,10 +8381,15 @@ namespace nirfmxspecan_grpc {
         request->dut_output_loss_frequency_size(),
         request->dut_output_loss_size()
       };
-      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, false);
+      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, true);
 
       if (array_size_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [dut_output_loss_frequency, dut_output_loss] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (array_size_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        dut_output_loss_frequency = request->dut_output_loss_frequency_size() ? std::move(dut_output_loss_frequency) : nullptr;
+        dut_output_loss = request->dut_output_loss_size() ? std::move(dut_output_loss) : nullptr;
       }
       auto array_size = array_size_size_calculation.size;
 
@@ -8540,10 +8604,15 @@ namespace nirfmxspecan_grpc {
         request->enr_frequency_size(),
         request->enr_size()
       };
-      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, false);
+      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, true);
 
       if (array_size_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [enr_frequency, enr] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (array_size_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        enr_frequency = request->enr_frequency_size() ? std::move(enr_frequency) : nullptr;
+        enr = request->enr_size() ? std::move(enr) : nullptr;
       }
       auto array_size = array_size_size_calculation.size;
 
@@ -8591,10 +8660,15 @@ namespace nirfmxspecan_grpc {
         request->noise_source_loss_frequency_size(),
         request->noise_source_loss_size()
       };
-      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, false);
+      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, true);
 
       if (array_size_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [noise_source_loss_frequency, noise_source_loss] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (array_size_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        noise_source_loss_frequency = request->noise_source_loss_frequency_size() ? std::move(noise_source_loss_frequency) : nullptr;
+        noise_source_loss = request->noise_source_loss_size() ? std::move(noise_source_loss) : nullptr;
       }
       auto array_size = array_size_size_calculation.size;
 
@@ -9455,10 +9529,15 @@ namespace nirfmxspecan_grpc {
         request->segment_measurement_offset_size(),
         request->segment_measurement_length_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [segment_measurement_offset, segment_measurement_length] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        segment_measurement_offset = request->segment_measurement_offset_size() ? std::move(segment_measurement_offset) : nullptr;
+        segment_measurement_length = request->segment_measurement_length_size() ? std::move(segment_measurement_length) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -9831,10 +9910,15 @@ namespace nirfmxspecan_grpc {
         request->frequency_size(),
         request->reference_phase_noise_size()
       };
-      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, false);
+      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, true);
 
       if (array_size_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [frequency, reference_phase_noise] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (array_size_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        frequency = request->frequency_size() ? std::move(frequency) : nullptr;
+        reference_phase_noise = request->reference_phase_noise_size() ? std::move(reference_phase_noise) : nullptr;
       }
       auto array_size = array_size_size_calculation.size;
 
@@ -9881,10 +9965,15 @@ namespace nirfmxspecan_grpc {
         request->integrated_noise_start_frequency_size(),
         request->integrated_noise_stop_frequency_size()
       };
-      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, false);
+      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, true);
 
       if (array_size_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [integrated_noise_start_frequency, integrated_noise_stop_frequency] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (array_size_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        integrated_noise_start_frequency = request->integrated_noise_start_frequency_size() ? std::move(integrated_noise_start_frequency) : nullptr;
+        integrated_noise_stop_frequency = request->integrated_noise_stop_frequency_size() ? std::move(integrated_noise_stop_frequency) : nullptr;
       }
       auto array_size = array_size_size_calculation.size;
 
@@ -9940,10 +10029,17 @@ namespace nirfmxspecan_grpc {
         request->range_rbw_percentage_size(),
         request->range_averaging_count_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [range_start_frequency, range_stop_frequency, range_rbw_percentage, range_averaging_count] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        range_start_frequency = request->range_start_frequency_size() ? std::move(range_start_frequency) : nullptr;
+        range_stop_frequency = request->range_stop_frequency_size() ? std::move(range_stop_frequency) : nullptr;
+        range_rbw_percentage = request->range_rbw_percentage_size() ? std::move(range_rbw_percentage) : nullptr;
+        range_averaging_count = request->range_averaging_count_size() ? std::move(range_averaging_count) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -10721,10 +10817,16 @@ namespace nirfmxspecan_grpc {
         request->absolute_limit_start_size(),
         request->absolute_limit_stop_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [absolute_limit_mode, absolute_limit_start, absolute_limit_stop] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        absolute_limit_mode = request->absolute_limit_mode_size() ? std::move(absolute_limit_mode) : nullptr;
+        absolute_limit_start = request->absolute_limit_start_size() ? std::move(absolute_limit_start) : nullptr;
+        absolute_limit_stop = request->absolute_limit_stop_size() ? std::move(absolute_limit_stop) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -10850,10 +10952,17 @@ namespace nirfmxspecan_grpc {
         request->offset_enabled_size(),
         request->offset_sideband_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [offset_start_frequency, offset_stop_frequency, offset_enabled, offset_sideband] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        offset_start_frequency = request->offset_start_frequency_size() ? std::move(offset_start_frequency) : nullptr;
+        offset_stop_frequency = request->offset_stop_frequency_size() ? std::move(offset_stop_frequency) : nullptr;
+        offset_enabled = request->offset_enabled_size() ? std::move(offset_enabled) : nullptr;
+        offset_sideband = request->offset_sideband_size() ? std::move(offset_sideband) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -11027,10 +11136,16 @@ namespace nirfmxspecan_grpc {
         request->rbw_size(),
         request->rbw_filter_type_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [rbw_auto, rbw, rbw_filter_type] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        rbw_auto = request->rbw_auto_size() ? std::move(rbw_auto) : nullptr;
+        rbw = request->rbw_size() ? std::move(rbw) : nullptr;
+        rbw_filter_type = request->rbw_filter_type_size() ? std::move(rbw_filter_type) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -11152,10 +11267,16 @@ namespace nirfmxspecan_grpc {
         request->relative_limit_start_size(),
         request->relative_limit_stop_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [relative_limit_mode, relative_limit_start, relative_limit_stop] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        relative_limit_mode = request->relative_limit_mode_size() ? std::move(relative_limit_mode) : nullptr;
+        relative_limit_start = request->relative_limit_start_size() ? std::move(relative_limit_start) : nullptr;
+        relative_limit_stop = request->relative_limit_stop_size() ? std::move(relative_limit_stop) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -13297,10 +13418,15 @@ namespace nirfmxspecan_grpc {
         request->detector_type_size(),
         request->detector_points_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [detector_type, detector_points] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        detector_type = request->detector_type_size() ? std::move(detector_type) : nullptr;
+        detector_points = request->detector_points_size() ? std::move(detector_points) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -13379,10 +13505,16 @@ namespace nirfmxspecan_grpc {
         request->stop_frequency_size(),
         request->range_enabled_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [start_frequency, stop_frequency, range_enabled] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        start_frequency = request->start_frequency_size() ? std::move(start_frequency) : nullptr;
+        stop_frequency = request->stop_frequency_size() ? std::move(stop_frequency) : nullptr;
+        range_enabled = request->range_enabled_size() ? std::move(range_enabled) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -13478,10 +13610,15 @@ namespace nirfmxspecan_grpc {
         request->threshold_size(),
         request->excursion_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [threshold, excursion] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        threshold = request->threshold_size() ? std::move(threshold) : nullptr;
+        excursion = request->excursion_size() ? std::move(excursion) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -13530,10 +13667,16 @@ namespace nirfmxspecan_grpc {
         request->rbw_size(),
         request->rbw_filter_type_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [rbw_auto, rbw, rbw_filter_type] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        rbw_auto = request->rbw_auto_size() ? std::move(rbw_auto) : nullptr;
+        rbw = request->rbw_size() ? std::move(rbw) : nullptr;
+        rbw_filter_type = request->rbw_filter_type_size() ? std::move(rbw_filter_type) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -13705,10 +13848,15 @@ namespace nirfmxspecan_grpc {
         request->sweep_time_auto_size(),
         request->sweep_time_interval_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [sweep_time_auto, sweep_time_interval] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        sweep_time_auto = request->sweep_time_auto_size() ? std::move(sweep_time_auto) : nullptr;
+        sweep_time_interval = request->sweep_time_interval_size() ? std::move(sweep_time_interval) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -13787,10 +13935,16 @@ namespace nirfmxspecan_grpc {
         request->vbw_size(),
         request->vbw_to_rbw_ratio_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [vbw_auto, vbw, vbw_to_rbw_ratio] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        vbw_auto = request->vbw_auto_size() ? std::move(vbw_auto) : nullptr;
+        vbw = request->vbw_size() ? std::move(vbw) : nullptr;
+        vbw_to_rbw_ratio = request->vbw_to_rbw_ratio_size() ? std::move(vbw_to_rbw_ratio) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 

--- a/generated/nirfmxwlan/nirfmxwlan_service.cpp
+++ b/generated/nirfmxwlan/nirfmxwlan_service.cpp
@@ -1269,10 +1269,15 @@ namespace nirfmxwlan_grpc {
         request->start_time_size(),
         request->stop_time_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [start_time, stop_time] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        start_time = request->start_time_size() ? std::move(start_time) : nullptr;
+        stop_time = request->stop_time_size() ? std::move(stop_time) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -6389,10 +6394,16 @@ namespace nirfmxwlan_grpc {
         request->offset_stop_frequency_size(),
         request->offset_sideband_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [offset_start_frequency, offset_stop_frequency, offset_sideband] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        offset_start_frequency = request->offset_start_frequency_size() ? std::move(offset_start_frequency) : nullptr;
+        offset_stop_frequency = request->offset_stop_frequency_size() ? std::move(offset_stop_frequency) : nullptr;
+        offset_sideband = request->offset_sideband_size() ? std::move(offset_sideband) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 
@@ -6423,10 +6434,15 @@ namespace nirfmxwlan_grpc {
         request->relative_limit_start_size(),
         request->relative_limit_stop_size()
       };
-      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, false);
+      const auto number_of_elements_size_calculation = calculate_linked_array_size(number_of_elements_determine_from_sizes, true);
 
       if (number_of_elements_size_calculation.match_state == MatchState::MISMATCH) {
         return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [relative_limit_start, relative_limit_stop] do not match");
+      }
+      // NULL out optional params with zero sizes.
+      if (number_of_elements_size_calculation.match_state == MatchState::MATCH_OR_ZERO) {
+        relative_limit_start = request->relative_limit_start_size() ? std::move(relative_limit_start) : nullptr;
+        relative_limit_stop = request->relative_limit_stop_size() ? std::move(relative_limit_stop) : nullptr;
       }
       auto number_of_elements = number_of_elements_size_calculation.size;
 

--- a/source/codegen/metadata/nirfmxinstr/functions.py
+++ b/source/codegen/metadata/nirfmxinstr/functions.py
@@ -243,6 +243,9 @@ functions = {
                 'name': 'frequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -252,6 +255,9 @@ functions = {
                 'name': 'externalAttenuation',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'

--- a/source/codegen/metadata/nirfmxnr/functions.py
+++ b/source/codegen/metadata/nirfmxnr/functions.py
@@ -5747,6 +5747,9 @@ functions = {
                 'name': 'absoluteLimitStart',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -5756,6 +5759,9 @@ functions = {
                 'name': 'absoluteLimitStop',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -5869,6 +5875,9 @@ functions = {
                 'name': 'offsetStartFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -5878,6 +5887,9 @@ functions = {
                 'name': 'offsetStopFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -5888,6 +5900,9 @@ functions = {
                 'name': 'offsetSideband',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -5998,6 +6013,9 @@ functions = {
                 'name': 'offsetRBW',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -6008,6 +6026,9 @@ functions = {
                 'name': 'offsetRBWFilterType',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -6064,6 +6085,9 @@ functions = {
                 'name': 'relativeLimitStart',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -6073,6 +6097,9 @@ functions = {
                 'name': 'relativeLimitStop',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'

--- a/source/codegen/metadata/nirfmxspecan/functions.py
+++ b/source/codegen/metadata/nirfmxspecan/functions.py
@@ -318,6 +318,9 @@ functions = {
                 'name': 'offsetFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -328,6 +331,9 @@ functions = {
                 'name': 'offsetSideband',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -338,6 +344,9 @@ functions = {
                 'name': 'offsetEnabled',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -469,6 +478,9 @@ functions = {
                 'name': 'offsetPowerReferenceCarrier',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -478,6 +490,9 @@ functions = {
                 'name': 'offsetPowerReferenceSpecific',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -536,6 +551,9 @@ functions = {
                 'name': 'rrcFilterEnabled',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -545,6 +563,9 @@ functions = {
                 'name': 'rrcAlpha',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -3994,6 +4015,9 @@ functions = {
                 'name': 'lutInputPowers',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float32[]'
@@ -4003,6 +4027,9 @@ functions = {
                 'name': 'lutComplexGains',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'NIComplexSingle[]'
@@ -6115,6 +6142,9 @@ functions = {
                 'name': 'harmonicOrder',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -6124,6 +6154,9 @@ functions = {
                 'name': 'harmonicBandwidth',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -6134,6 +6167,9 @@ functions = {
                 'name': 'harmonicEnabled',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -6143,6 +6179,9 @@ functions = {
                 'name': 'harmonicMeasurementInterval',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -6602,6 +6641,9 @@ functions = {
                 'name': 'intermodOrder',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -6611,6 +6653,9 @@ functions = {
                 'name': 'lowerIntermodFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -6620,6 +6665,9 @@ functions = {
                 'name': 'upperIntermodFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -6630,6 +6678,9 @@ functions = {
                 'name': 'intermodSide',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -6640,6 +6691,9 @@ functions = {
                 'name': 'intermodEnabled',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -7551,6 +7605,9 @@ functions = {
                 'name': 'calibrationLossFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -7560,6 +7617,9 @@ functions = {
                 'name': 'calibrationLoss',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -7596,6 +7656,9 @@ functions = {
                 'name': 'dutsParametersFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -7606,6 +7669,9 @@ functions = {
                 'name': 'duts21',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -7616,6 +7682,9 @@ functions = {
                 'name': 'duts12',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -7626,6 +7695,9 @@ functions = {
                 'name': 'duts11',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -7636,6 +7708,9 @@ functions = {
                 'name': 'duts22',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -7666,6 +7741,9 @@ functions = {
                 'name': 'terminationVSWR',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -7675,6 +7753,9 @@ functions = {
                 'name': 'terminationVSWRFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -7738,6 +7819,9 @@ functions = {
                 'name': 'dutInputLossFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -7747,6 +7831,9 @@ functions = {
                 'name': 'dutInputLoss',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -7788,6 +7875,9 @@ functions = {
                 'name': 'dutOutputLossFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -7797,6 +7887,9 @@ functions = {
                 'name': 'dutOutputLoss',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -8012,6 +8105,9 @@ functions = {
                 'name': 'enrFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -8021,6 +8117,9 @@ functions = {
                 'name': 'enr',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -8067,6 +8166,9 @@ functions = {
                 'name': 'noiseSourceLossFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -8076,6 +8178,9 @@ functions = {
                 'name': 'noiseSourceLoss',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -8911,6 +9016,9 @@ functions = {
                 'name': 'segmentMeasurementOffset',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -8920,6 +9028,9 @@ functions = {
                 'name': 'segmentMeasurementLength',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -9351,6 +9462,9 @@ functions = {
                 'name': 'frequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float32[]'
@@ -9360,6 +9474,9 @@ functions = {
                 'name': 'referencePhaseNoise',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float32[]'
@@ -9396,6 +9513,9 @@ functions = {
                 'name': 'integratedNoiseStartFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -9405,6 +9525,9 @@ functions = {
                 'name': 'integratedNoiseStopFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'arraySize'
                 },
                 'type': 'float64[]'
@@ -9456,6 +9579,9 @@ functions = {
                 'name': 'rangeStartFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -9465,6 +9591,9 @@ functions = {
                 'name': 'rangeStopFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -9474,6 +9603,9 @@ functions = {
                 'name': 'rangeRBWPercentage',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -9483,6 +9615,9 @@ functions = {
                 'name': 'rangeAveragingCount',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -10192,6 +10327,9 @@ functions = {
                 'name': 'absoluteLimitMode',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -10201,6 +10339,9 @@ functions = {
                 'name': 'absoluteLimitStart',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -10210,6 +10351,9 @@ functions = {
                 'name': 'absoluteLimitStop',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -10299,6 +10443,9 @@ functions = {
                 'name': 'offsetStartFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -10308,6 +10455,9 @@ functions = {
                 'name': 'offsetStopFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -10318,6 +10468,9 @@ functions = {
                 'name': 'offsetEnabled',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -10328,6 +10481,9 @@ functions = {
                 'name': 'offsetSideband',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -10436,6 +10592,9 @@ functions = {
                 'name': 'rbwAuto',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -10445,6 +10604,9 @@ functions = {
                 'name': 'rbw',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -10455,6 +10617,9 @@ functions = {
                 'name': 'rbwFilterType',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -10569,6 +10734,9 @@ functions = {
                 'name': 'relativeLimitMode',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -10578,6 +10746,9 @@ functions = {
                 'name': 'relativeLimitStart',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -10587,6 +10758,9 @@ functions = {
                 'name': 'relativeLimitStop',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -12817,6 +12991,9 @@ functions = {
                 'name': 'detectorType',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -12826,6 +13003,9 @@ functions = {
                 'name': 'detectorPoints',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -12888,6 +13068,9 @@ functions = {
                 'name': 'startFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -12897,6 +13080,9 @@ functions = {
                 'name': 'stopFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -12907,6 +13093,9 @@ functions = {
                 'name': 'rangeEnabled',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -13014,6 +13203,9 @@ functions = {
                 'name': 'threshold',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -13023,6 +13215,9 @@ functions = {
                 'name': 'excursion',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -13054,6 +13249,9 @@ functions = {
                 'name': 'rbwAuto',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -13063,6 +13261,9 @@ functions = {
                 'name': 'rbw',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -13073,6 +13274,9 @@ functions = {
                 'name': 'rbwFilterType',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -13215,6 +13419,9 @@ functions = {
                 'name': 'sweepTimeAuto',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -13224,6 +13431,9 @@ functions = {
                 'name': 'sweepTimeInterval',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -13287,6 +13497,9 @@ functions = {
                 'name': 'vbwAuto',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -13296,6 +13509,9 @@ functions = {
                 'name': 'vbw',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -13305,6 +13521,9 @@ functions = {
                 'name': 'vbwToRBWRatio',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'

--- a/source/codegen/metadata/nirfmxwlan/functions.py
+++ b/source/codegen/metadata/nirfmxwlan/functions.py
@@ -1136,6 +1136,9 @@ functions = {
                 'name': 'startTime',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -1145,6 +1148,9 @@ functions = {
                 'name': 'stopTime',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -6582,6 +6588,9 @@ functions = {
                 'name': 'offsetStartFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -6591,6 +6600,9 @@ functions = {
                 'name': 'offsetStopFrequency',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -6601,6 +6613,9 @@ functions = {
                 'name': 'offsetSideband',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'int32[]'
@@ -6631,6 +6646,9 @@ functions = {
                 'name': 'relativeLimitStart',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'
@@ -6640,6 +6658,9 @@ functions = {
                 'name': 'relativeLimitStop',
                 'size': {
                     'mechanism': 'len',
+                    'tags': [
+                        'optional'
+                    ],
                     'value': 'numberOfElements'
                 },
                 'type': 'float64[]'


### PR DESCRIPTION
### What does this Pull Request accomplish?

Set `optional` tag on all linked input arrays in `RFmx` *except* arrays used in `two-dimension` size mechanism.

### Why should this Pull Request be merged?

This matches how `RFmx` handles linked in put arrays in the .NET API and is required-by/documented-for some methods that allow it.

### What testing has been done?

Ran and passed all RFmx tests. Added some new test cases.