### PR TITLE
Add LTE session tests (cross-driver and session management).

### DIFF
--- a/source/tests/system/nirfmxlte_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxlte_driver_api_tests.cpp
@@ -68,7 +68,7 @@ TEST_F(NiRFmxLTEDriverApiTests, Init_Close_Succeeds)
 
   auto close_response = client::close(stub(), session, 0);
 
-  EXPECT_SUCCESS(session, close_response);
+  EXPECT_RESPONSE_SUCCESS(close_response);
 }
 
 TEST_F(NiRFmxLTEDriverApiTests, InitializeFromNIRFSA_Close_Succeeds)
@@ -82,7 +82,7 @@ TEST_F(NiRFmxLTEDriverApiTests, InitializeFromNIRFSA_Close_Succeeds)
 
   auto close_response = client::close(stub(), session, 0);
 
-  EXPECT_SUCCESS(session, close_response);
+  EXPECT_RESPONSE_SUCCESS(close_response);
 }
 
 }  // namespace


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds some tests covering cross driver sessions in LTE and general session management coverage we want per personality.

### Why should this Pull Request be merged?

Fixes [AB#1804662](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1804662)

### What testing has been done?

LTE system-level tests pass locally.