### PR TITLE
Avoid using driver or service headers in system-level tests.

### DIFF
--- a/source/tests/system/enumerate_devices.cpp
+++ b/source/tests/system/enumerate_devices.cpp
@@ -2,7 +2,6 @@
 
 #include <stdexcept>
 
-#include <server/session_utilities_service.h>
 #include "device_server.h"
 
 namespace ni {

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -1,4 +1,3 @@
-#include <NIDAQmx.h>
 #include <gmock/gmock.h>
 #include <google/protobuf/util/time_util.h>
 #include <gtest/gtest.h>  // For EXPECT matchers.
@@ -17,10 +16,29 @@ using namespace ::testing;
 using namespace nidaqmx_grpc;
 using google::protobuf::uint32;
 namespace client = nidaqmx_grpc::experimental::client;
+namespace pb = ::google::protobuf;
 
 namespace ni {
 namespace tests {
 namespace system {
+namespace {
+
+typedef pb::int16 int16;
+typedef pb::int32 int32;
+typedef pb::int64 int64;
+typedef pb::uint64 uInt64;
+typedef double float64;
+
+constexpr auto DAQmxSuccess = 0;
+constexpr auto DAQmxErrorSpecifiedAttrNotValid = -200233;
+constexpr auto DAQmxErrorInvalidAODataWrite = -200561;
+constexpr auto DAQmxErrorDoneEventAlreadyRegistered = -200950;
+constexpr auto DAQmxErrorWaitForValidTimestampNotSupported = -209833;
+constexpr auto DAQmxErrorInvalidAttributeValue = -200077;
+constexpr auto DAQmxErrorRetrievingNetworkDeviceProperties = -201401;
+constexpr auto DAQmxErrorTEDSSensorNotDetected = -200709;
+constexpr auto DAQmxErrorInvalidTerm_Routing = -89129;
+constexpr auto DAQmxErrorDeviceDoesNotSupportCDAQSyncConnections = -201450;
 
 // Creates a static TResponse instance that can be used as a default/in-line value (because it's not a temporary).
 template <typename TResponse>
@@ -1680,18 +1698,19 @@ TEST_F(NiDAQmxDriverApiTests, AIChannel_ReconfigureSampQuantSampsPerChan_Updates
 
 TEST_F(NiDAQmxDriverApiTests, SetWrongCategoryAttribute_ReturnsNotValidError)
 {
-  auto response = client::get_device_attribute_bool(stub(), DEVICE_NAME, DAQmx_Scale_Lin_Slope);
+  auto response = client::get_device_attribute_bool(stub(), DEVICE_NAME, ScaleDoubleAttribute::SCALE_ATTRIBUTE_LIN_SLOPE);
 
   EXPECT_DAQ_ERROR(DAQmxErrorSpecifiedAttrNotValid, response);
 }
 
 TEST_F(NiDAQmxDriverApiTests, SetWrongDataTypeAttribute_ReturnsNotValidError)
 {
-  auto response = client::get_device_attribute_bool(stub(), DEVICE_NAME, DAQmx_Dev_AO_PhysicalChans);
+  auto response = client::get_device_attribute_bool(stub(), DEVICE_NAME, DeviceStringAttribute::DEVICE_ATTRIBUTE_AO_PHYSICAL_CHANS);
 
   EXPECT_DAQ_ERROR(DAQmxErrorSpecifiedAttrNotValid, response);
 }
 
+}  // namespace
 }  // namespace system
 }  // namespace tests
 }  // namespace ni

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -29,16 +29,16 @@ typedef pb::int64 int64;
 typedef pb::uint64 uInt64;
 typedef double float64;
 
-constexpr auto DAQmxSuccess = 0;
-constexpr auto DAQmxErrorSpecifiedAttrNotValid = -200233;
-constexpr auto DAQmxErrorInvalidAODataWrite = -200561;
-constexpr auto DAQmxErrorDoneEventAlreadyRegistered = -200950;
-constexpr auto DAQmxErrorWaitForValidTimestampNotSupported = -209833;
-constexpr auto DAQmxErrorInvalidAttributeValue = -200077;
-constexpr auto DAQmxErrorRetrievingNetworkDeviceProperties = -201401;
-constexpr auto DAQmxErrorTEDSSensorNotDetected = -200709;
-constexpr auto DAQmxErrorInvalidTerm_Routing = -89129;
-constexpr auto DAQmxErrorDeviceDoesNotSupportCDAQSyncConnections = -201450;
+constexpr auto DAQMX_SUCCESS = 0;
+constexpr auto SPECIFIED_ATTRIBUTE_NOT_VALID_ERROR = -200233;
+constexpr auto INVALID_AO_DATA_WRITE_ERROR = -200561;
+constexpr auto DONE_EVENT_ALREADY_REGISTERED_ERROR = -200950;
+constexpr auto WAIT_FOR_VALID_TIMESTAMP_NOT_SUPPORTED_ERROR = -209833;
+constexpr auto INVALID_ATTRIBUTE_VALUE_ERROR = -200077;
+constexpr auto RETRIEVING_NETWORK_DEVICE_PROPERTIES_ERROR = -201401;
+constexpr auto TEDS_SENSOR_NOT_DETECTED_ERROR = -200709;
+constexpr auto INVALID_TERM_ROUTING_ERROR = -89129;
+constexpr auto DEVICE_DOES_NOT_SUPPORT_CDAQ_SYNC_CONNECTIONS_ERROR = -201450;
 
 // Creates a static TResponse instance that can be used as a default/in-line value (because it's not a temporary).
 template <typename TResponse>
@@ -705,8 +705,8 @@ class NiDAQmxDriverApiTests : public Test {
   template <typename TResponse>
   void EXPECT_SUCCESS(const TResponse& response)
   {
-    EXPECT_EQ(DAQmxSuccess, response.status());
-    if (response.status() != DAQmxSuccess) {
+    EXPECT_EQ(DAQMX_SUCCESS, response.status());
+    if (response.status() != DAQMX_SUCCESS) {
       auto error_response = client::get_error_string(stub(), response.status());
       EXPECT_EQ("", error_response.error_string());
     }
@@ -1005,7 +1005,7 @@ TEST_F(NiDAQmxDriverApiTests, GetScaledUnitsAsDouble_Fails)
       SCALE_NAME,
       (ScaleDoubleAttribute)ScaleStringAttribute::SCALE_ATTRIBUTE_SCALED_UNITS);
 
-  EXPECT_DAQ_ERROR(DAQmxErrorSpecifiedAttrNotValid, response);
+  EXPECT_DAQ_ERROR(SPECIFIED_ATTRIBUTE_NOT_VALID_ERROR, response);
 }
 
 TEST_F(NiDAQmxDriverApiTests, SetScaledUnits_GetScaledUnits_ReturnsAttribute)
@@ -1081,7 +1081,7 @@ TEST_F(NiDAQmxDriverApiTests, AOVoltageChannel_WriteAODataWithOutOfRangeValue_Re
   write_analog_f64(write_data, write_response);
   stop_task();
 
-  EXPECT_EQ(DAQmxErrorInvalidAODataWrite, write_response.status());
+  EXPECT_EQ(INVALID_AO_DATA_WRITE_ERROR, write_response.status());
 }
 
 TEST_F(NiDAQmxDriverApiTests, TaskWithAOChannel_GetNthTaskDevice_ReturnsDeviceForChannel)
@@ -1121,7 +1121,7 @@ TEST_F(NiDAQmxDriverApiTests, CreateCIFreqChannel_Succeeds)
 TEST_F(NiDAQmxDriverApiTests, GetErrorString_ReturnsErrorMessage)
 {
   GetErrorStringResponse response;
-  auto status = get_error_string(DAQmxErrorInvalidAttributeValue, response);
+  auto status = get_error_string(INVALID_ATTRIBUTE_VALUE_ERROR, response);
 
   EXPECT_SUCCESS(status, response);
   const auto& error_string = response.error_string();
@@ -1250,7 +1250,7 @@ TEST_F(NiDAQmxDriverApiTests, ChannelWithDoneEventRegistered_RunCompleteFiniteAc
 
   RegisterDoneEventResponse response;
   reader->Read(&response);
-  EXPECT_EQ(DAQmxSuccess, response.status());
+  EXPECT_EQ(DAQMX_SUCCESS, response.status());
 }
 
 TEST_F(NiDAQmxDriverApiTests, ChannelWithEveryNSamplesEventRegistered_WaitForSamplesMultipleTimes_Succeeds)
@@ -1271,7 +1271,7 @@ TEST_F(NiDAQmxDriverApiTests, ChannelWithEveryNSamplesEventRegistered_WaitForSam
     read_analog_f64(N_SAMPLES, N_SAMPLES);
 
     EXPECT_EQ(N_SAMPLES, response.n_samples());
-    EXPECT_EQ(DAQmxSuccess, response.status());
+    EXPECT_EQ(DAQMX_SUCCESS, response.status());
   }
 }
 
@@ -1295,9 +1295,9 @@ TEST_F(NiDAQmxDriverApiTests, ChannelWithDoneEventRegisteredTwice_RunCompleteFin
 
   RegisterDoneEventResponse response;
   reader->Read(&response);
-  EXPECT_EQ(DAQmxSuccess, response.status());
+  EXPECT_EQ(DAQMX_SUCCESS, response.status());
   second_reader->Read(&response);
-  EXPECT_EQ(DAQmxErrorDoneEventAlreadyRegistered, response.status());
+  EXPECT_EQ(DONE_EVENT_ALREADY_REGISTERED_ERROR, response.status());
 }
 
 TEST_F(NiDAQmxDriverApiTests, AIVoltageChannel_ConfigureInputBuffer_Succeeds)
@@ -1368,7 +1368,7 @@ TEST_F(NiDAQmxDriverApiTests, AIVoltageChannel_WaitForValidTimestamp_ReturnsErro
   auto response = WaitForValidTimestampResponse{};
   auto status = wait_for_valid_timestamp(response);
 
-  EXPECT_DAQ_ERROR(DAQmxErrorWaitForValidTimestampNotSupported, status, response);
+  EXPECT_DAQ_ERROR(WAIT_FOR_VALID_TIMESTAMP_NOT_SUPPORTED_ERROR, status, response);
 }
 
 TEST_F(NiDAQmxDriverApiTests, AIVoltageChannel_CfgTimeStartTrig_ReturnsError)
@@ -1378,7 +1378,7 @@ TEST_F(NiDAQmxDriverApiTests, AIVoltageChannel_CfgTimeStartTrig_ReturnsError)
   auto response = CfgTimeStartTrigResponse{};
   auto status = cfg_time_start_trig(response);
 
-  EXPECT_DAQ_ERROR(DAQmxErrorInvalidAttributeValue, status, response);
+  EXPECT_DAQ_ERROR(INVALID_ATTRIBUTE_VALUE_ERROR, status, response);
 }
 
 TEST_F(NiDAQmxDriverApiTests, LoadedVoltageTask_ReadAIData_ReturnsDataInExpectedRange)
@@ -1415,14 +1415,14 @@ TEST_F(NiDAQmxDriverApiTests, AddNetworkDeviceWithInvalidIP_ErrorRetrievingNetwo
   auto response = AddNetworkDeviceResponse{};
   auto status = add_network_device("0.0.0.0", response);
 
-  EXPECT_DAQ_ERROR(DAQmxErrorRetrievingNetworkDeviceProperties, status, response);
+  EXPECT_DAQ_ERROR(RETRIEVING_NETWORK_DEVICE_PROPERTIES_ERROR, status, response);
 }
 
 TEST_F(NiDAQmxDriverApiTests, ConfigureTEDSOnNonTEDSChannel_ErrorTEDSSensorNotDetected)
 {
   auto response = client::configure_teds(stub(), AI_CHANNEL, "");
 
-  EXPECT_DAQ_ERROR(DAQmxErrorTEDSSensorNotDetected, response);
+  EXPECT_DAQ_ERROR(TEDS_SENSOR_NOT_DETECTED_ERROR, response);
 }
 
 TEST_F(NiDAQmxDriverApiTests, HardwareTimedTask_WaitForNextSampleClock_Succeeds)
@@ -1451,7 +1451,7 @@ TEST_F(NiDAQmxDriverApiTests, ConnectBogusTerms_FailsWithInvalidRoutingError)
   auto response = ConnectTermsResponse{};
   auto status = connect_terms("ABC", "123", response);
 
-  EXPECT_DAQ_ERROR(DAQmxErrorInvalidTerm_Routing, status, response);
+  EXPECT_DAQ_ERROR(INVALID_TERM_ROUTING_ERROR, status, response);
 }
 
 TEST_F(NiDAQmxDriverApiTests, DOWatchdogTask_StartTaskAndWatchdogTask_Succeeds)
@@ -1481,7 +1481,7 @@ TEST_F(NiDAQmxDriverApiTests, AutoConfigureCDAQSyncConnections_ReturnsNotSupport
 {
   auto response = client::auto_configure_cdaq_sync_connections(stub(), DEVICE_NAME, 1.0);
 
-  EXPECT_DAQ_ERROR(DAQmxErrorDeviceDoesNotSupportCDAQSyncConnections, response);
+  EXPECT_DAQ_ERROR(DEVICE_DOES_NOT_SUPPORT_CDAQ_SYNC_CONNECTIONS_ERROR, response);
 }
 
 TEST_F(NiDAQmxDriverApiTests, DIChannel_GetSetResetInputBufferSize_UpdatesBufferSize)
@@ -1700,14 +1700,14 @@ TEST_F(NiDAQmxDriverApiTests, SetWrongCategoryAttribute_ReturnsNotValidError)
 {
   auto response = client::get_device_attribute_bool(stub(), DEVICE_NAME, ScaleDoubleAttribute::SCALE_ATTRIBUTE_LIN_SLOPE);
 
-  EXPECT_DAQ_ERROR(DAQmxErrorSpecifiedAttrNotValid, response);
+  EXPECT_DAQ_ERROR(SPECIFIED_ATTRIBUTE_NOT_VALID_ERROR, response);
 }
 
 TEST_F(NiDAQmxDriverApiTests, SetWrongDataTypeAttribute_ReturnsNotValidError)
 {
   auto response = client::get_device_attribute_bool(stub(), DEVICE_NAME, DeviceStringAttribute::DEVICE_ATTRIBUTE_AO_PHYSICAL_CHANS);
 
-  EXPECT_DAQ_ERROR(DAQmxErrorSpecifiedAttrNotValid, response);
+  EXPECT_DAQ_ERROR(SPECIFIED_ATTRIBUTE_NOT_VALID_ERROR, response);
 }
 
 }  // namespace

--- a/source/tests/system/nidaqmx_session_tests.cpp
+++ b/source/tests/system/nidaqmx_session_tests.cpp
@@ -1,13 +1,16 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "nidaqmx/nidaqmx_service.h"
+#include "nidaqmx/nidaqmx_client.h"
 
 using namespace nidaqmx_grpc;
 
 namespace ni {
 namespace tests {
 namespace system {
+
+constexpr auto DAQMX_SUCCESS = 0;
+
 class NiDAQmxSessionTests : public ::testing::Test {
  protected:
   NiDAQmxSessionTests()
@@ -56,8 +59,8 @@ TEST_F(NiDAQmxSessionTests, CreateTask_ClearTask_Succeeds)
 
   EXPECT_TRUE(create_status.ok());
   EXPECT_TRUE(clear_status.ok());
-  EXPECT_EQ(DAQmxSuccess, create_response.status());
-  EXPECT_EQ(DAQmxSuccess, clear_response.status());
+  EXPECT_EQ(DAQMX_SUCCESS, create_response.status());
+  EXPECT_EQ(DAQMX_SUCCESS, clear_response.status());
   EXPECT_NE(0, create_response.task().id());
 }
 }  // namespace system

--- a/source/tests/system/nidcpower_driver_api_tests.cpp
+++ b/source/tests/system/nidcpower_driver_api_tests.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "ivi.h"
 #include "nidcpower/nidcpower_client.h"
 
 namespace ni {
@@ -10,6 +9,12 @@ namespace system {
 
 namespace dcpower = nidcpower_grpc;
 namespace client = nidcpower_grpc::experimental::client;
+namespace pb = ::google::protobuf;
+
+typedef pb::int32 int32;
+typedef pb::int64 int64;
+typedef pb::uint32 uint32;
+typedef pb::uint16 uint16;
 
 const int kdcpowerDriverApiSuccess = 0;
 
@@ -115,7 +120,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
     EXPECT_TRUE(status.ok());
   }
 
-  ViBoolean get_bool_attribute(const char* channel_list, dcpower::NiDCPowerAttribute attribute_id)
+  bool get_bool_attribute(const char* channel_list, dcpower::NiDCPowerAttribute attribute_id)
   {
     ::grpc::ClientContext context;
     dcpower::GetAttributeViBooleanRequest request;
@@ -131,7 +136,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
     return response.attribute_value();
   }
 
-  ViInt32 get_int32_attribute(const char* channel_list, dcpower::NiDCPowerAttribute attribute_id)
+  int32 get_int32_attribute(const char* channel_list, dcpower::NiDCPowerAttribute attribute_id)
   {
     ::grpc::ClientContext context;
     dcpower::GetAttributeViInt32Request request;
@@ -147,7 +152,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
     return response.attribute_value();
   }
 
-  ViInt64 get_int64_attribute(const char* channel_list, dcpower::NiDCPowerAttribute attribute_id)
+  int64 get_int64_attribute(const char* channel_list, dcpower::NiDCPowerAttribute attribute_id)
   {
     ::grpc::ClientContext context;
     dcpower::GetAttributeViInt64Request request;
@@ -163,7 +168,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
     return response.attribute_value();
   }
 
-  ViReal64 get_real64_attribute(const char* channel_list, dcpower::NiDCPowerAttribute attribute_id)
+  double get_real64_attribute(const char* channel_list, dcpower::NiDCPowerAttribute attribute_id)
   {
     ::grpc::ClientContext context;
     dcpower::GetAttributeViReal64Request request;
@@ -227,7 +232,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
     EXPECT_EQ(kdcpowerDriverApiSuccess, response.status());
   }
 
-  void configure_voltage_level(const char* channel_name, ViReal64 level)
+  void configure_voltage_level(const char* channel_name, double level)
   {
     ::grpc::ClientContext context;
     dcpower::ConfigureVoltageLevelRequest request;
@@ -242,7 +247,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
     EXPECT_EQ(kdcpowerDriverApiSuccess, response.status());
   }
 
-  void configure_current_level(const char* channel_name, ViReal64 level)
+  void configure_current_level(const char* channel_name, double level)
   {
     ::grpc::ClientContext context;
     dcpower::ConfigureCurrentLevelRequest request;
@@ -369,7 +374,7 @@ TEST_F(NiDCPowerDriverApiTest, SetAttributeViInt32_GetAttributeViInt32ReturnsSam
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kdcpowerDriverApiSuccess, response.status());
-  ViInt32 get_attribute_value = get_int32_attribute(channel_name, attribute_to_set);
+  int32 get_attribute_value = get_int32_attribute(channel_name, attribute_to_set);
   EXPECT_EQ(expected_value, get_attribute_value);
 }
 
@@ -384,7 +389,7 @@ TEST_F(NiDCPowerDriverApiTest, SetAttributeViReal64_GetAttributeViReal64ReturnsS
       dcpower::NiDCPowerAttribute::NIDCPOWER_ATTRIBUTE_MEASURE_WHEN,
       dcpower::NiDCPowerInt32AttributeValues::NIDCPOWER_INT32_MEASURE_WHEN_VAL_AUTOMATICALLY_AFTER_SOURCE_COMPLETE);
   const dcpower::NiDCPowerAttribute attribute_to_set = dcpower::NiDCPowerAttribute::NIDCPOWER_ATTRIBUTE_SOURCE_DELAY;
-  const ViReal64 expected_value = 2.516;
+  const double expected_value = 2.516;
   ::grpc::ClientContext context;
   dcpower::SetAttributeViReal64Request request;
   request.mutable_vi()->set_id(GetSessionId());
@@ -396,7 +401,7 @@ TEST_F(NiDCPowerDriverApiTest, SetAttributeViReal64_GetAttributeViReal64ReturnsS
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kdcpowerDriverApiSuccess, response.status());
-  ViReal64 get_attribute_value_sourcedelay = get_real64_attribute(channel_name, attribute_to_set);
+  double get_attribute_value_sourcedelay = get_real64_attribute(channel_name, attribute_to_set);
   EXPECT_EQ(expected_value, get_attribute_value_sourcedelay);
 }
 
@@ -411,7 +416,7 @@ TEST_F(NiDCPowerDriverApiTest, SetAttributeViBoolean_GetAttributeViBooleanReturn
       dcpower::NiDCPowerAttribute::NIDCPOWER_ATTRIBUTE_MEASURE_WHEN,
       dcpower::NiDCPowerInt32AttributeValues::NIDCPOWER_INT32_MEASURE_WHEN_VAL_AUTOMATICALLY_AFTER_SOURCE_COMPLETE);
   const dcpower::NiDCPowerAttribute attribute_to_set = dcpower::NiDCPowerAttribute::NIDCPOWER_ATTRIBUTE_MEASURE_RECORD_LENGTH_IS_FINITE;
-  const ViBoolean expected_value = true;
+  const bool expected_value = true;
   ::grpc::ClientContext context;
   dcpower::SetAttributeViBooleanRequest request;
   request.mutable_vi()->set_id(GetSessionId());
@@ -423,7 +428,7 @@ TEST_F(NiDCPowerDriverApiTest, SetAttributeViBoolean_GetAttributeViBooleanReturn
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kdcpowerDriverApiSuccess, response.status());
-  ViBoolean get_attribute_value = get_bool_attribute(channel_name, attribute_to_set);
+  bool get_attribute_value = get_bool_attribute(channel_name, attribute_to_set);
   EXPECT_EQ(expected_value, get_attribute_value);
 }
 
@@ -452,7 +457,7 @@ TEST_F(NiDCPowerDriverApiTest, SetAttributeViInt64_GetAttributeViInt64ReturnsSam
 {
   const char* channel_name = "";
   const dcpower::NiDCPowerAttribute attribute_to_set = dcpower::NiDCPowerAttribute::NIDCPOWER_ATTRIBUTE_ACTIVE_ADVANCED_SEQUENCE_STEP;
-  const ViInt64 expected_value = 1;
+  const int64 expected_value = 1;
   ::grpc::ClientContext context;
   dcpower::SetAttributeViInt64Request request;
   request.mutable_vi()->set_id(GetSessionId());
@@ -464,20 +469,20 @@ TEST_F(NiDCPowerDriverApiTest, SetAttributeViInt64_GetAttributeViInt64ReturnsSam
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kdcpowerDriverApiSuccess, response.status());
-  ViInt64 get_attribute_value = get_int64_attribute(channel_name, attribute_to_set);
+  int64 get_attribute_value = get_int64_attribute(channel_name, attribute_to_set);
   EXPECT_EQ(expected_value, get_attribute_value);
 }
 
 TEST_F(NiDCPowerDriverApiTest, ConfigureOutputFunctionAndVoltageLevel_ConfiguresSuccessfully)
 {
   const char* channel_name = "0";
-  ViReal64 expected_voltage_level = 3.0;
+  double expected_voltage_level = 3.0;
   auto expected_output_function_value = dcpower::OutputFunction::OUTPUT_FUNCTION_NIDCPOWER_VAL_DC_VOLTAGE;
   configure_output_function(channel_name, expected_output_function_value);
   configure_voltage_level(channel_name, expected_voltage_level);
 
-  ViReal64 actual_voltage_level = get_real64_attribute(channel_name, dcpower::NiDCPowerAttribute::NIDCPOWER_ATTRIBUTE_VOLTAGE_LEVEL);
-  ViInt32 actual_output_function_value = get_int32_attribute(channel_name, dcpower::NiDCPowerAttribute::NIDCPOWER_ATTRIBUTE_OUTPUT_FUNCTION);
+  double actual_voltage_level = get_real64_attribute(channel_name, dcpower::NiDCPowerAttribute::NIDCPOWER_ATTRIBUTE_VOLTAGE_LEVEL);
+  int32 actual_output_function_value = get_int32_attribute(channel_name, dcpower::NiDCPowerAttribute::NIDCPOWER_ATTRIBUTE_OUTPUT_FUNCTION);
   EXPECT_EQ(expected_voltage_level, actual_voltage_level);
   EXPECT_EQ(expected_output_function_value, actual_output_function_value);
 }
@@ -485,13 +490,13 @@ TEST_F(NiDCPowerDriverApiTest, ConfigureOutputFunctionAndVoltageLevel_Configures
 TEST_F(NiDCPowerDriverApiTest, ConfigureOutputFunctionAndCurrentLevel_ConfiguresSuccessfully)
 {
   const char* channel_name = "0";
-  ViReal64 expected_current_level = 3.0;
+  double expected_current_level = 3.0;
   auto expected_output_function_value = dcpower::OutputFunction::OUTPUT_FUNCTION_NIDCPOWER_VAL_DC_CURRENT;
   configure_output_function(channel_name, expected_output_function_value);
   configure_current_level(channel_name, expected_current_level);
 
-  ViReal64 actual_current_level = get_real64_attribute(channel_name, dcpower::NiDCPowerAttribute::NIDCPOWER_ATTRIBUTE_CURRENT_LEVEL);
-  ViInt32 actual_output_function_value = get_int32_attribute(channel_name, dcpower::NiDCPowerAttribute::NIDCPOWER_ATTRIBUTE_OUTPUT_FUNCTION);
+  double actual_current_level = get_real64_attribute(channel_name, dcpower::NiDCPowerAttribute::NIDCPOWER_ATTRIBUTE_CURRENT_LEVEL);
+  int32 actual_output_function_value = get_int32_attribute(channel_name, dcpower::NiDCPowerAttribute::NIDCPOWER_ATTRIBUTE_OUTPUT_FUNCTION);
   EXPECT_EQ(expected_current_level, actual_current_level);
   EXPECT_EQ(expected_output_function_value, actual_output_function_value);
 }

--- a/source/tests/system/nidcpower_driver_api_tests.cpp
+++ b/source/tests/system/nidcpower_driver_api_tests.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
+#include "ivi.h"
 #include "nidcpower/nidcpower_client.h"
-#include "nidcpower/nidcpower_service.h"
 
 namespace ni {
 namespace tests {

--- a/source/tests/system/nidcpower_session_tests.cpp
+++ b/source/tests/system/nidcpower_session_tests.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "nidcpower/nidcpower_service.h"
+#include "nidcpower/nidcpower_client.h"
 
 namespace ni {
 namespace tests {
@@ -11,7 +11,7 @@ namespace dcpower = nidcpower_grpc;
 
 const int kInvalidRsrc = -1074118656;
 const int kInvalidDCPowerSession = -1074130544;
-const char* kViErrorResourceNotFoundMessage = "Device was not recognized.  The device is not supported with this driver or version.";
+const char* kViErrorResourceNotFoundMessage = "Device was not recognized. The device is not supported with this driver or version.";
 const char* kInvalidDCPowerSessionMessage = "IVI: (Hex 0xBFFA1190) The session handle is not valid.";
 const char* kTestRsrc = "FakeDevice";
 const char* kOptionsString = "Simulate=1, DriverSetup=Model:4147; BoardType:PXIe";

--- a/source/tests/system/nidigital_driver_api_tests.cpp
+++ b/source/tests/system/nidigital_driver_api_tests.cpp
@@ -1,7 +1,8 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "nidigitalpattern/nidigitalpattern_service.h"
+#include "ivi.h"
+#include "nidigitalpattern/nidigitalpattern_client.h"
 
 namespace ni {
 namespace tests {
@@ -98,7 +99,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     return response.error_message();
   }
 
-  void set_bool_attribute(const char* channel_name, digital::NiDigitalAttribute attribute, ViBoolean value)
+  void set_bool_attribute(const char* channel_name, digital::NiDigitalAttribute attribute, bool value)
   {
     ::grpc::ClientContext context;
     digital::SetAttributeViBooleanRequest request;
@@ -155,7 +156,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     request.set_attribute(attribute);
     request.set_value_raw(value);
     digital::SetAttributeViStringResponse response;
-    
+
     ::grpc::Status status = GetStub()->SetAttributeViString(&context, request, &response);
 
     EXPECT_TRUE(status.ok());
@@ -236,7 +237,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     digital::FrequencyCounterConfigureMeasurementTimeResponse response;
 
     ::grpc::Status status = GetStub()->FrequencyCounterConfigureMeasurementTime(&context, request, &response);
-    
+
     EXPECT_TRUE(status.ok());
     expect_api_success(response.status());
   }
@@ -250,7 +251,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     request.set_function(function_type);
     digital::SelectFunctionResponse response;
 
-    ::grpc::Status status = GetStub()->SelectFunction(&context, request, &response);    
+    ::grpc::Status status = GetStub()->SelectFunction(&context, request, &response);
 
     EXPECT_TRUE(status.ok());
     expect_api_success(response.status());
@@ -274,7 +275,7 @@ TEST_F(NiDigitalDriverApiTest, PerformReadStatic_CompletesSuccessfully)
   ::grpc::Status status = GetStub()->ReadStatic(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  expect_api_success(response.status()); 
+  expect_api_success(response.status());
 }
 
 TEST_F(NiDigitalDriverApiTest, PerformWriteStatic_CompletesSuccessfully)
@@ -307,7 +308,7 @@ TEST_F(NiDigitalDriverApiTest, PerformFrequencyCounterMeasureFrequency_Completes
   ::grpc::Status status = GetStub()->FrequencyCounterMeasureFrequency(&context, request, &response);
 
   EXPECT_TRUE(status.ok());
-  expect_api_success(response.status()); 
+  expect_api_success(response.status());
 }
 
 TEST_F(NiDigitalDriverApiTest, SelfTest_SelfTestCompletesSuccessfully)

--- a/source/tests/system/nidigital_driver_api_tests.cpp
+++ b/source/tests/system/nidigital_driver_api_tests.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "ivi.h"
 #include "nidigitalpattern/nidigitalpattern_client.h"
 
 namespace ni {
@@ -9,6 +8,10 @@ namespace tests {
 namespace system {
 
 namespace digital = nidigitalpattern_grpc;
+namespace pb = ::google::protobuf;
+
+typedef pb::int32 int32;
+typedef pb::int64 int64;
 
 const int kDigitalDriverApiSuccess = 0;
 
@@ -131,7 +134,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     expect_api_success(response.status());
   }
 
-  void set_int64_attribute(const char* channel_name, digital::NiDigitalAttribute attribute, ViInt64 value)
+  void set_int64_attribute(const char* channel_name, digital::NiDigitalAttribute attribute, int64 value)
   {
     ::grpc::ClientContext context;
     digital::SetAttributeViInt64Request request;
@@ -147,7 +150,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     expect_api_success(response.status());
   }
 
-  void set_string_attribute(const char* channel_name, digital::NiDigitalAttribute attribute, ViString value)
+  void set_string_attribute(const char* channel_name, digital::NiDigitalAttribute attribute, const std::string& value)
   {
     ::grpc::ClientContext context;
     digital::SetAttributeViStringRequest request;
@@ -163,7 +166,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     expect_api_success(response.status());
   }
 
-  ViBoolean get_bool_attribute(const char* channel_name, digital::NiDigitalAttribute attribute)
+  bool get_bool_attribute(const char* channel_name, digital::NiDigitalAttribute attribute)
   {
     ::grpc::ClientContext context;
     digital::GetAttributeViBooleanRequest request;
@@ -179,7 +182,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     return response.value();
   }
 
-  ViInt32 get_int32_attribute(const char* channel_name, digital::NiDigitalAttribute attribute)
+  int32 get_int32_attribute(const char* channel_name, digital::NiDigitalAttribute attribute)
   {
     ::grpc::ClientContext context;
     digital::GetAttributeViInt32Request request;
@@ -195,7 +198,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     return response.value();
   }
 
-  ViInt64 get_int64_attribute(const char* channel_name, digital::NiDigitalAttribute attribute)
+  int64 get_int64_attribute(const char* channel_name, digital::NiDigitalAttribute attribute)
   {
     ::grpc::ClientContext context;
     digital::GetAttributeViInt64Request request;
@@ -227,7 +230,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     return response.value();
   }
 
-  void configure_frequency_counter_measurement_time(const char* channel_list, ViReal64 value)
+  void configure_frequency_counter_measurement_time(const char* channel_list, double value)
   {
     ::grpc::ClientContext context;
     digital::FrequencyCounterConfigureMeasurementTimeRequest request;
@@ -297,7 +300,7 @@ TEST_F(NiDigitalDriverApiTest, PerformWriteStatic_CompletesSuccessfully)
 TEST_F(NiDigitalDriverApiTest, PerformFrequencyCounterMeasureFrequency_CompletesSuccessfully)
 {
   const char* channel_name = "";
-  ViReal64 measurement_time = 5.0;
+  double measurement_time = 5.0;
   ::grpc::ClientContext context;
   select_function(channel_name, digital::SelectedFunction::SELECTED_FUNCTION_NIDIGITAL_VAL_DIGITAL);
   configure_frequency_counter_measurement_time(channel_name, measurement_time);
@@ -344,7 +347,7 @@ TEST_F(NiDigitalDriverApiTest, SetViInt32Attribute_GetViInt32Attribute_ValueMatc
   auto expected_value = digital::NiDigitalInt32AttributeValues::NIDIGITAL_INT32_SELECTED_FUNCTION_VAL_PPMU;
   set_int32_attribute(channel_name, attribute_to_set, expected_value);
 
-  ViInt32 get_attribute_value = get_int32_attribute(channel_name, attribute_to_set);
+  int32 get_attribute_value = get_int32_attribute(channel_name, attribute_to_set);
 
   EXPECT_EQ(expected_value, get_attribute_value);
 }
@@ -353,10 +356,10 @@ TEST_F(NiDigitalDriverApiTest, SetViInt64Attribute_GetViInt64Attribute_ValueMatc
 {
   const char* channel_name = "";
   const digital::NiDigitalAttribute attribute_to_set = digital::NiDigitalAttribute::NIDIGITAL_ATTRIBUTE_CYCLE_NUMBER_HISTORY_RAM_TRIGGER_CYCLE_NUMBER;
-  const ViInt64 expected_value = 4;
+  const int64 expected_value = 4;
   set_int64_attribute(channel_name, attribute_to_set, expected_value);
 
-  ViInt64 get_attribute_value = get_int64_attribute(channel_name, attribute_to_set);
+  int64 get_attribute_value = get_int64_attribute(channel_name, attribute_to_set);
 
   EXPECT_EQ(expected_value, get_attribute_value);
 }
@@ -365,22 +368,22 @@ TEST_F(NiDigitalDriverApiTest, SetViStringAttribute_GetViStringAttribute_ValueMa
 {
   const char* channel_name = "";
   const digital::NiDigitalAttribute attribute_to_set = digital::NiDigitalAttribute::NIDIGITAL_ATTRIBUTE_DIGITAL_EDGE_START_TRIGGER_SOURCE;
-  const ViString expected_value = "Hello world!";
+  const std::string expected_value = "Hello world!";
   set_string_attribute(channel_name, attribute_to_set, expected_value);
 
   std::string get_attribute_value = get_string_attribute(channel_name, attribute_to_set);
 
-  EXPECT_STREQ(expected_value, get_attribute_value.c_str());
+  EXPECT_STREQ(expected_value.c_str(), get_attribute_value.c_str());
 }
 
 TEST_F(NiDigitalDriverApiTest, SetBoolAttribute_GetBoolAttribute_ValueMatchesSetValue)
 {
   const char* channel_name = "";
   const digital::NiDigitalAttribute attribute_to_set = digital::NiDigitalAttribute::NIDIGITAL_ATTRIBUTE_CACHE;
-  const ViBoolean expected_value = true;
+  const bool expected_value = true;
   set_bool_attribute(channel_name, attribute_to_set, expected_value);
 
-  ViBoolean get_attribute_value = get_bool_attribute(channel_name, attribute_to_set);
+  bool get_attribute_value = get_bool_attribute(channel_name, attribute_to_set);
 
   EXPECT_EQ(expected_value, get_attribute_value);
 }

--- a/source/tests/system/nidigital_session_tests.cpp
+++ b/source/tests/system/nidigital_session_tests.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "nidigitalpattern/nidigitalpattern_service.h"
+#include "nidigitalpattern/nidigitalpattern_client.h"
 
 namespace ni {
 namespace tests {

--- a/source/tests/system/nifgen_driver_api_tests.cpp
+++ b/source/tests/system/nifgen_driver_api_tests.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "ivi.h"
 #include "nifgen/nifgen_client.h"
 #include "waveform_helpers.h"
 
@@ -10,6 +9,13 @@ namespace tests {
 namespace system {
 
 namespace fgen = nifgen_grpc;
+namespace pb = ::google::protobuf;
+
+typedef pb::int16 int16;
+typedef pb::int32 int32;
+typedef pb::int64 int64;
+typedef pb::uint32 uint32;
+typedef pb::uint16 uint16;
 
 const int kFgenDriverApiSuccess = 0;
 
@@ -114,7 +120,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
     return response.error_message();
   }
 
-  ViBoolean get_bool_attribute(const char* channel_list, fgen::NiFgenAttribute attribute_id)
+  bool get_bool_attribute(const char* channel_list, fgen::NiFgenAttribute attribute_id)
   {
     ::grpc::ClientContext context;
     fgen::GetAttributeViBooleanRequest request;
@@ -130,7 +136,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
     return response.attribute_value();
   }
 
-  ViInt32 get_int32_attribute(const char* channel_list, fgen::NiFgenAttribute attribute_id)
+  int32 get_int32_attribute(const char* channel_list, fgen::NiFgenAttribute attribute_id)
   {
     ::grpc::ClientContext context;
     fgen::GetAttributeViInt32Request request;
@@ -146,7 +152,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
     return response.attribute_value();
   }
 
-  ViInt64 get_int64_attribute(const char* channel_list, fgen::NiFgenAttribute attribute_id)
+  int64 get_int64_attribute(const char* channel_list, fgen::NiFgenAttribute attribute_id)
   {
     ::grpc::ClientContext context;
     fgen::GetAttributeViInt64Request request;
@@ -162,7 +168,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
     return response.attribute_value();
   }
 
-  ViReal64 get_real64_attribute(const char* channel_list, fgen::NiFgenAttribute attribute_id)
+  double get_real64_attribute(const char* channel_list, fgen::NiFgenAttribute attribute_id)
   {
     ::grpc::ClientContext context;
     fgen::GetAttributeViReal64Request request;
@@ -210,7 +216,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
     expect_api_success(response.status());
   }
 
-  void set_bool_attribute(const char* channel_name, fgen::NiFgenAttribute attribute, ViBoolean value)
+  void set_bool_attribute(const char* channel_name, fgen::NiFgenAttribute attribute, bool value)
   {
     ::grpc::ClientContext context;
     fgen::SetAttributeViBooleanRequest request;
@@ -297,14 +303,14 @@ class NiFgenDriverApiTest : public ::testing::Test {
     expect_api_success(response.status());
   }
 
-  ViInt32 create_arb_waveform(const char* channel_name)
+  int32 create_arb_waveform(const char* channel_name)
   {
     ::grpc::ClientContext context;
     fgen::CreateWaveformF64Request request;
-    const ViReal64 waveform_data_array[] = {1, 0, 0, 1};
+    const double waveform_data_array[] = {1, 0, 0, 1};
     request.mutable_vi()->set_id(GetSessionId());
     request.set_channel_name(channel_name);
-    for (ViReal64 waveform_data : waveform_data_array) {
+    for (double waveform_data : waveform_data_array) {
       request.add_waveform_data_array(waveform_data);
     }
     fgen::CreateWaveformF64Response response;
@@ -316,7 +322,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
     return response.waveform_handle();
   }
 
-  int create_advanced_arb_sequence(ViInt32 sequence_length, ViInt32* waveform_handles_array, ViInt32* loop_counts_array, ViInt32* marker_location_array)
+  int create_advanced_arb_sequence(int32 sequence_length, int32* waveform_handles_array, int32* loop_counts_array, int32* marker_location_array)
   {
     ::grpc::ClientContext context;
     fgen::CreateAdvancedArbSequenceRequest request;
@@ -348,7 +354,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
     expect_api_success(response.status());
   }
 
-  ViStatus write_named_waveform_f64(std::string channel_name, std::string waveform_name, int waveform_size, double waveform[])
+  int32 write_named_waveform_f64(std::string channel_name, std::string waveform_name, int waveform_size, double waveform[])
   {
     ::grpc::ClientContext context;
     fgen::WriteNamedWaveformF64Request request;
@@ -364,7 +370,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
     return response.status();
   }
 
-  ViInt32 allocate_waveform(std::string channel_name, int waveform_size)
+  int32 allocate_waveform(std::string channel_name, int waveform_size)
   {
     ::grpc::ClientContext context;
     fgen::AllocateWaveformRequest request;
@@ -380,7 +386,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
     return response.waveform_handle();
   }
 
-  ViStatus write_waveform_complexf64(std::string channel_name, int waveform_size, int waveform_handle, std::vector<nidevice_grpc::NIComplexNumber> waveform)
+  int32 write_waveform_complexf64(std::string channel_name, int waveform_size, int waveform_handle, std::vector<nidevice_grpc::NIComplexNumber> waveform)
   {
     ::grpc::ClientContext context;
     fgen::WriteWaveformComplexF64Request request;
@@ -455,7 +461,7 @@ TEST_F(NiFgenDriverApiTest, SetAttributeViInt32_GetAttributeViInt32_ValueMatches
   EXPECT_TRUE(status.ok());
   expect_api_success(response.status());
 
-  ViInt32 get_attribute_value = get_int32_attribute(channel_name, attribute_to_set);
+  int32 get_attribute_value = get_int32_attribute(channel_name, attribute_to_set);
 
   EXPECT_EQ(expected_value, get_attribute_value);
 }
@@ -464,7 +470,7 @@ TEST_F(NiFgenDriverApiTest, SetAttributeViReal64_GetAttributeViReal64_ValueMatch
 {
   const char* channel_name = "";
   const fgen::NiFgenAttribute attribute_to_set = fgen::NiFgenAttribute::NIFGEN_ATTRIBUTE_DIGITAL_GAIN;
-  const ViReal64 expected_value = -1.0;
+  const double expected_value = -1.0;
   ::grpc::ClientContext context;
   fgen::SetAttributeViReal64Request request;
   request.mutable_vi()->set_id(GetSessionId());
@@ -476,7 +482,7 @@ TEST_F(NiFgenDriverApiTest, SetAttributeViReal64_GetAttributeViReal64_ValueMatch
   EXPECT_TRUE(status.ok());
   expect_api_success(response.status());
 
-  ViReal64 get_attribute_value_sourcedelay = get_real64_attribute(channel_name, attribute_to_set);
+  double get_attribute_value_sourcedelay = get_real64_attribute(channel_name, attribute_to_set);
 
   EXPECT_EQ(expected_value, get_attribute_value_sourcedelay);
 }
@@ -485,10 +491,10 @@ TEST_F(NiFgenDriverApiTest, SetAttributeViBoolean_GetAttributeViBoolean_ValueMat
 {
   const char* channel_name = "0";
   const fgen::NiFgenAttribute attribute_to_set = fgen::NiFgenAttribute::NIFGEN_ATTRIBUTE_OUTPUT_ENABLED;
-  const ViBoolean expected_value = true;
+  const bool expected_value = true;
   set_bool_attribute(channel_name, attribute_to_set, expected_value);
 
-  ViBoolean get_attribute_value = get_bool_attribute(channel_name, attribute_to_set);
+  bool get_attribute_value = get_bool_attribute(channel_name, attribute_to_set);
 
   EXPECT_EQ(expected_value, get_attribute_value);
 }
@@ -497,7 +503,7 @@ TEST_F(NiFgenDriverApiTest, SetAttributeViString_GetAttributeViString_ValueMatch
 {
   const char* channel_name = "";
   const fgen::NiFgenAttribute attribute_to_set = fgen::NiFgenAttribute::NIFGEN_ATTRIBUTE_MARKER_EVENT_OUTPUT_TERMINAL;
-  const ViString expected_value = "sample";
+  const std::string expected_value = "sample";
   ::grpc::ClientContext context;
   fgen::SetAttributeViStringRequest request;
   request.mutable_vi()->set_id(GetSessionId());
@@ -511,23 +517,23 @@ TEST_F(NiFgenDriverApiTest, SetAttributeViString_GetAttributeViString_ValueMatch
 
   std::string get_attribute_value = get_string_attribute(channel_name, attribute_to_set);
 
-  EXPECT_STREQ(expected_value, get_attribute_value.c_str());
+  EXPECT_STREQ(expected_value.c_str(), get_attribute_value.c_str());
 }
 
 TEST_F(NiFgenDriverApiTest, ConfigureTriggerMode_ConfiguresSuccessfully)
 {
   const char* channel_name = "0";
-  ViInt32 expected_value = 2;  // NIFGEN_VAL_CONTINUOUS
+  int32 expected_value = 2;  // NIFGEN_VAL_CONTINUOUS
   configure_trigger_mode(channel_name, fgen::TriggerMode::TRIGGER_MODE_NIFGEN_VAL_CONTINUOUS);
 
-  ViInt32 actual_trigger_mode = get_int32_attribute(channel_name, fgen::NiFgenAttribute::NIFGEN_ATTRIBUTE_TRIGGER_MODE);
+  int32 actual_trigger_mode = get_int32_attribute(channel_name, fgen::NiFgenAttribute::NIFGEN_ATTRIBUTE_TRIGGER_MODE);
   EXPECT_EQ(expected_value, actual_trigger_mode);
 }
 
 TEST_F(NiFgenDriverApiTest, ResetInterchangeCheck_ResetsSuccessfully)
 {
   const char* channel_name = "0";
-  ViReal64 expected_current_level = 3.0;
+  double expected_current_level = 3.0;
   ::grpc::ClientContext context;
   fgen::ResetInterchangeCheckRequest request;
   request.mutable_vi()->set_id(GetSessionId());
@@ -561,7 +567,7 @@ TEST_F(NiFgenDriverApiTest, AllocateNamedWaveform_WriteNamedWaveformF64_Waveform
   allocate_named_waveform(channel_name, waveform_name, waveform_size);
 
   double waveform[] = {1.55, 40.4, 21.6, 0.7, 15.89};
-  ViStatus status = write_named_waveform_f64(channel_name, waveform_name, waveform_size, waveform);
+  int32 status = write_named_waveform_f64(channel_name, waveform_name, waveform_size, waveform);
 
   expect_api_success(status);
 }
@@ -569,7 +575,7 @@ TEST_F(NiFgenDriverApiTest, AllocateNamedWaveform_WriteNamedWaveformF64_Waveform
 TEST_F(NiFgenDriverApiTest, ExportTriggerMode_ResetAndImportConfiguration_TriggerModeConfigurationIsImported)
 {
   const char* channel_name = "0";
-  ViInt32 expected_trigger_mode = 1;  // NIFGEN_VAL_SINGLE
+  int32 expected_trigger_mode = 1;  // NIFGEN_VAL_SINGLE
   configure_trigger_mode(channel_name, fgen::TriggerMode::TRIGGER_MODE_NIFGEN_VAL_SINGLE);
   auto exported_configuration_response = export_attribute_configuration_buffer();
 
@@ -589,7 +595,7 @@ TEST_F(NiFgenDriverApiTest, AllocateWaveform_WriteWaveformComplexF64_WaveformWri
 
   set_bool_attribute(channel_name.c_str(), fgen::NiFgenAttribute::NIFGEN_ATTRIBUTE_OSP_ENABLED, true);
   set_int32_attribute(channel_name.c_str(), fgen::NiFgenAttribute::NIFGEN_ATTRIBUTE_OSP_DATA_PROCESSING_MODE, fgen::NiFgenInt32AttributeValues::NIFGEN_INT32_DATA_PROCESSING_MODE_VAL_OSP_COMPLEX);
-  ViStatus status = write_waveform_complexf64(channel_name, waveform_size, waveform_handle, complex_number_array({1.55, 40.4, 21.6, 0.7, 15.89}, {2.3, -20.4, 112.4, -100.3, 0.0}));
+  int32 status = write_waveform_complexf64(channel_name, waveform_size, waveform_handle, complex_number_array({1.55, 40.4, 21.6, 0.7, 15.89}, {2.3, -20.4, 112.4, -100.3, 0.0}));
 
   expect_api_success(status);
 }
@@ -597,10 +603,10 @@ TEST_F(NiFgenDriverApiTest, AllocateWaveform_WriteWaveformComplexF64_WaveformWri
 TEST_F(NiFgenDriverApiTest, OutputModeConfiguredToSeq_CreateAdvancedArbSequenceForArbitraryWaveform_CreatesSuccessfully)
 {
   const char* channel_name = "0";
-  ViInt32 sequence_length = 1;
-  ViInt32 waveform_handles_array[1];
-  ViInt32 loop_counts_array[] = {1};
-  ViInt32 marker_location_array[] = {-1};
+  int32 sequence_length = 1;
+  int32 waveform_handles_array[1];
+  int32 loop_counts_array[] = {1};
+  int32 marker_location_array[] = {-1};
   configure_output_mode(channel_name, fgen::OutputMode::OUTPUT_MODE_NIFGEN_VAL_OUTPUT_SEQ);
 
   waveform_handles_array[0] = create_arb_waveform(channel_name);
@@ -612,7 +618,7 @@ TEST_F(NiFgenDriverApiTest, OutputModeConfiguredToSeq_CreateAdvancedArbSequenceF
 TEST_F(NiFgenDriverApiTest, OutputModeConfiguredToArb_CreateWaveformI16_CreatesSuccessfully)
 {
   const char* channel_name = "0";
-  const ViInt16 waveform_data_array[] = {0, 1, 0, 1};
+  const int16 waveform_data_array[] = {0, 1, 0, 1};
   configure_output_mode(channel_name, fgen::OutputMode::OUTPUT_MODE_NIFGEN_VAL_OUTPUT_ARB);
 
   ::grpc::ClientContext context;

--- a/source/tests/system/nifgen_session_tests.cpp
+++ b/source/tests/system/nifgen_session_tests.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "nifgen/nifgen_service.h"
+#include "nifgen/nifgen_client.h"
 
 namespace ni {
 namespace tests {

--- a/source/tests/system/nirfmxbluetooth_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxbluetooth_driver_api_tests.cpp
@@ -3,7 +3,6 @@
 
 #include "device_server.h"
 #include "nirfmxbluetooth/nirfmxbluetooth_client.h"
-#include "nirfmxbluetooth/nirfmxbluetooth_service.h"
 #include "nirfsa/nirfsa_client.h"
 #include "rfmx_macros.h"
 #include "waveform_helpers.h"

--- a/source/tests/system/nirfmxbluetooth_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxbluetooth_driver_api_tests.cpp
@@ -2,21 +2,20 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "niRFmxBT.h"
 #include "nirfmxbluetooth/nirfmxbluetooth_client.h"
 #include "nirfmxbluetooth/nirfmxbluetooth_service.h"
 #include "nirfsa/nirfsa_client.h"
 #include "rfmx_macros.h"
 #include "waveform_helpers.h"
 
-namespace pb = google::protobuf;
 using namespace ::testing;
 using namespace nirfmxbluetooth_grpc;
 namespace client = nirfmxbluetooth_grpc::experimental::client;
 namespace nirfsa_client = nirfsa_grpc::experimental::client;
+namespace pb = ::google::protobuf;
 
 namespace nidevice_grpc {
-// Needs to be in the nirfmxbluetooth_grpc namespace for googletest to find this
+// Needs to be in the nidevice_grpc namespace for googletest to find this
 // because of argument-dependent lookup - see
 // https://stackoverflow.com/questions/33371088/how-to-get-a-custom-operator-to-work-with-google-test
 bool operator==(const NIComplexNumberF32& first, const NIComplexNumber& second)

--- a/source/tests/system/nirfmxbluetooth_session_tests.cpp
+++ b/source/tests/system/nirfmxbluetooth_session_tests.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "nirfmxbluetooth/nirfmxbluetooth_service.h"
+#include "nirfmxbluetooth/nirfmxbluetooth_client.h"
 
 namespace ni {
 namespace tests {

--- a/source/tests/system/nirfmxinstr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxinstr_driver_api_tests.cpp
@@ -2,7 +2,6 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "niRFmxInstr.h"
 #include "nirfmxinstr/nirfmxinstr_client.h"
 #include "nirfmxspecan/nirfmxspecan_client.h"
 #include "nirfsa/nirfsa_client.h"
@@ -12,8 +11,8 @@ using namespace ::testing;
 using namespace nirfmxinstr_grpc;
 namespace client = nirfmxinstr_grpc::experimental::client;
 namespace nirfsa_client = nirfsa_grpc::experimental::client;
+namespace pb = ::google::protobuf;
 namespace specan_client = nirfmxspecan_grpc::experimental::client;
-namespace pb = google::protobuf;
 
 namespace ni {
 namespace tests {

--- a/source/tests/system/nirfmxlte_session_tests.cpp
+++ b/source/tests/system/nirfmxlte_session_tests.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "nirfmxlte/nirfmxlte_service.h"
+#include "nirfmxlte/nirfmxlte_client.h"
 
 namespace ni {
 namespace tests {

--- a/source/tests/system/nirfmxnr_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxnr_driver_api_tests.cpp
@@ -2,7 +2,6 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "niRFmxNR.h"
 #include "nirfmxinstr/nirfmxinstr_client.h"
 #include "nirfmxnr/nirfmxnr_client.h"
 #include "nirfsa/nirfsa_client.h"
@@ -14,12 +13,16 @@ using namespace nirfmxnr_grpc;
 namespace client = nirfmxnr_grpc::experimental::client;
 namespace instr_client = nirfmxinstr_grpc::experimental::client;
 namespace nirfsa_client = nirfsa_grpc::experimental::client;
-namespace pb = google::protobuf;
+namespace pb = ::google::protobuf;
 
 namespace ni {
 namespace tests {
 namespace system {
 namespace {
+
+typedef pb::int32 int32;
+typedef pb::int64 int64;
+typedef double float64;
 
 constexpr auto PXI_5663E = "5663E";
 constexpr auto NR_SYNC_FAILURE_WARNING = 684300;
@@ -423,11 +426,11 @@ TEST_F(NiRFmxNRDriverApiTests, SemContiguousMultiCarrierFromExample_FetchData_Da
   std::vector<float64> componentCarrierRatedOutputPower{0.0, 0.0};
   std::vector<float64> offsetStartFrequency{15.0e3, 1.5e6, 5.5e6, 40.3e6};
   std::vector<float64> offsetStopFrequency{985.0e3, 4.5e6, 39.3e6, 44.3e6};
-  std::vector<int> offsetSideband{RFMXNR_VAL_SEM_OFFSET_SIDEBAND_BOTH, RFMXNR_VAL_SEM_OFFSET_SIDEBAND_BOTH, RFMXNR_VAL_SEM_OFFSET_SIDEBAND_BOTH, RFMXNR_VAL_SEM_OFFSET_SIDEBAND_BOTH};
+  std::vector<int> offsetSideband{SEM_OFFSET_SIDEBAND_BOTH, SEM_OFFSET_SIDEBAND_BOTH, SEM_OFFSET_SIDEBAND_BOTH, SEM_OFFSET_SIDEBAND_BOTH};
   std::vector<float64> offsetRBW{10.0e3, 250.0e3, 1.0e6, 1.0e6};
-  std::vector<int> offsetRBWFilterType{RFMXNR_VAL_SEM_OFFSET_RBW_FILTER_TYPE_GAUSSIAN, RFMXNR_VAL_SEM_OFFSET_RBW_FILTER_TYPE_GAUSSIAN, RFMXNR_VAL_SEM_OFFSET_RBW_FILTER_TYPE_GAUSSIAN, RFMXNR_VAL_SEM_OFFSET_RBW_FILTER_TYPE_GAUSSIAN};
+  std::vector<int> offsetRBWFilterType{SEM_OFFSET_RBW_FILTER_TYPE_GAUSSIAN, SEM_OFFSET_RBW_FILTER_TYPE_GAUSSIAN, SEM_OFFSET_RBW_FILTER_TYPE_GAUSSIAN, SEM_OFFSET_RBW_FILTER_TYPE_GAUSSIAN};
   std::vector<int> bandwidthIntegral{3, 4, 1, 1};
-  std::vector<int> limitFailMask{RFMXNR_VAL_SEM_OFFSET_LIMIT_FAIL_MASK_ABSOLUTE, RFMXNR_VAL_SEM_OFFSET_LIMIT_FAIL_MASK_ABSOLUTE, RFMXNR_VAL_SEM_OFFSET_LIMIT_FAIL_MASK_ABSOLUTE, RFMXNR_VAL_SEM_OFFSET_LIMIT_FAIL_MASK_ABSOLUTE};
+  std::vector<int> limitFailMask{SEM_OFFSET_LIMIT_FAIL_MASK_ABSOLUTE, SEM_OFFSET_LIMIT_FAIL_MASK_ABSOLUTE, SEM_OFFSET_LIMIT_FAIL_MASK_ABSOLUTE, SEM_OFFSET_LIMIT_FAIL_MASK_ABSOLUTE};
   std::vector<float64> absoluteLimitStart{-22.5, -8.5, -11.5, -23.5};
   std::vector<float64> absoluteLimitStop{-22.5, -8.5, -11.5, -23.5};
   std::vector<float64> relativeLimitStart{-53.0, -53.0, -53.0, -53.0};

--- a/source/tests/system/nirfmxnr_session_tests.cpp
+++ b/source/tests/system/nirfmxnr_session_tests.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "nirfmxnr/nirfmxnr_service.h"
+#include "nirfmxnr/nirfmxnr_client.h"
 
 namespace ni {
 namespace tests {

--- a/source/tests/system/nirfmxspecan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxspecan_driver_api_tests.cpp
@@ -7,7 +7,6 @@
 #include "device_server.h"
 #include "nirfmxinstr/nirfmxinstr_client.h"
 #include "nirfmxspecan/nirfmxspecan_client.h"
-#include "nirfmxspecan/nirfmxspecan_service.h"
 #include "rfmx_macros.h"
 #include "waveform_helpers.h"
 

--- a/source/tests/system/nirfmxspecan_session_tests.cpp
+++ b/source/tests/system/nirfmxspecan_session_tests.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "nirfmxspecan/nirfmxspecan_service.h"
+#include "nirfmxspecan/nirfmxspecan_client.h"
 
 namespace ni {
 namespace tests {

--- a/source/tests/system/nirfmxwlan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxwlan_driver_api_tests.cpp
@@ -2,24 +2,27 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "niRFmxWLAN.h"
 #include "nirfmxinstr/nirfmxinstr_client.h"
 #include "nirfmxwlan/nirfmxwlan_client.h"
 #include "nirfsa/nirfsa_client.h"
 #include "rfmx_macros.h"
 #include "waveform_helpers.h"
 
-namespace pb = google::protobuf;
 using namespace ::testing;
 using namespace nirfmxwlan_grpc;
 namespace client = nirfmxwlan_grpc::experimental::client;
 namespace instr_client = nirfmxinstr_grpc::experimental::client;
 namespace nirfsa_client = nirfsa_grpc::experimental::client;
+namespace pb = ::google::protobuf;
 
 namespace ni {
 namespace tests {
 namespace system {
 namespace {
+
+typedef pb::int32 int32;
+typedef pb::int64 int64;
+typedef double float64;
 
 constexpr auto PXI_5663E = "5663E";
 constexpr auto RISING_EDGE_DETECTION_FAILED_WARNING = 379206;
@@ -260,7 +263,7 @@ TEST_F(NiRFmxWLANDriverApiTests, SEMCustomMaskFromExample_FetchData_DataLooksRea
   const auto NUMBER_OF_OFFSETS = 3;
   std::vector<float64> offset_start_frequency{9e06, 11e06, 20e06};
   std::vector<float64> offset_stop_frequency{11e06, 20e06, 40e06};
-  std::vector<int> offset_sideband{RFMXWLAN_VAL_SEM_OFFSET_SIDEBAND_BOTH, RFMXWLAN_VAL_SEM_OFFSET_SIDEBAND_BOTH, RFMXWLAN_VAL_SEM_OFFSET_SIDEBAND_BOTH};
+  std::vector<int> offset_sideband{SEM_OFFSET_SIDEBAND_BOTH, SEM_OFFSET_SIDEBAND_BOTH, SEM_OFFSET_SIDEBAND_BOTH};
   std::vector<float64> relative_limit_start{0.0, -20.0, -28.0};
   std::vector<float64> relative_limit_stop{-20.0, -28.0, -40.0};
   auto session = init_session(stub(), PXI_5663E);

--- a/source/tests/system/nirfmxwlan_session_tests.cpp
+++ b/source/tests/system/nirfmxwlan_session_tests.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "nirfmxwlan/nirfmxwlan_service.h"
+#include "nirfmxwlan/nirfmxwlan_client.h"
 
 namespace ni {
 namespace tests {

--- a/source/tests/system/nirfsa_driver_api_tests.cpp
+++ b/source/tests/system/nirfsa_driver_api_tests.cpp
@@ -24,6 +24,7 @@ namespace {
 const auto PXI_5663E = "5663E";
 const auto PXI_5603 = "5603";
 const auto IVI_ATTRIBUTE_NOT_SUPPORTED_ERROR = 0xBFFA0012;
+const auto REF_OUT_STR = "RefOut";
 
 template <typename TResponse>
 void EXPECT_SUCCESS(const TResponse& response)
@@ -307,7 +308,7 @@ TEST_F(NiRFSADriverApiTests, ReconfigureExportedRefClockOutTerminal_UpdatesRefCl
   EXPECT_SUCCESS(session, set_response);
   EXPECT_SUCCESS(session, get_response);
   EXPECT_NE(initial_response.value(), get_response.value());
-  EXPECT_EQ("RefOut", get_response.value());
+  EXPECT_EQ(REF_OUT_STR, get_response.value());
 }
 
 TEST_F(NiRFSADriverApiTests, ReconfigureFFTWindowType_UpdatesFFTWindowSuccessfully)

--- a/source/tests/system/nirfsa_driver_api_tests.cpp
+++ b/source/tests/system/nirfsa_driver_api_tests.cpp
@@ -572,7 +572,7 @@ TEST_F(NiRFSADriverApiTests, IsSelfCalValid)
 
   EXPECT_SUCCESS(session, response);
   EXPECT_THAT(response.valid_steps_array(), ElementsAre(SELF_CALIBRATE_STEPS_DIGITIZER_SELF_CAL));
-  EXPECT_EQ(8, response.valid_steps_raw());
+  EXPECT_EQ(SELF_CALIBRATE_STEPS_DIGITIZER_SELF_CAL, response.valid_steps_raw());
 }
 
 TEST_F(NiRFSADriverApiTests, SelfTest_Succeeds)

--- a/source/tests/system/nirfsa_driver_api_tests.cpp
+++ b/source/tests/system/nirfsa_driver_api_tests.cpp
@@ -4,7 +4,6 @@
 #include <algorithm>
 
 #include "device_server.h"
-#include "ivi.h"  // VI_SUCCESS
 #include "niRFSAErrors.h"
 #include "nirfsa/nirfsa_client.h"
 #include "niscope/niscope_client.h"
@@ -24,11 +23,12 @@ namespace {
 
 const auto PXI_5663E = "5663E";
 const auto PXI_5603 = "5603";
+const auto IVI_ATTRIBUTE_NOT_SUPPORTED_ERROR = 0xBFFA0012;
 
 template <typename TResponse>
 void EXPECT_SUCCESS(const TResponse& response)
 {
-  EXPECT_EQ(VI_SUCCESS, response.status());
+  EXPECT_EQ(0, response.status());
 }
 
 template <typename TResponse>
@@ -496,7 +496,7 @@ TEST_F(NiRFSADriverApiTests, CreateConfigurationListWithInvalidAttribute_Reports
       {NiRFSAAttribute::NIRFSA_ATTRIBUTE_EXTERNAL_GAIN, NiRFSAAttribute::NIRFSA_ATTRIBUTE_NOTCH_FILTER_ENABLED},
       true);
 
-  EXPECT_RFSA_ERROR(IVI_ERROR_ATTRIBUTE_NOT_SUPPORTED, "Attribute or property not supported.", session, response);
+  EXPECT_RFSA_ERROR(IVI_ATTRIBUTE_NOT_SUPPORTED_ERROR, "Attribute or property not supported.", session, response);
 }
 
 TEST_F(NiRFSADriverApiTests, GetScalingCoefficients_ReturnsCoefficients)
@@ -587,7 +587,7 @@ TEST_F(NiRFSADriverApiTests, SelfTest_Succeeds)
 TEST_F(NiRFSADriverApiTests, ErrorMessage_ReturnsErrorMessage)
 {
   auto session = init_session(stub(), PXI_5663E);
-  const auto response = client::error_message(stub(), session, IVI_ERROR_ATTRIBUTE_NOT_SUPPORTED);
+  const auto response = client::error_message(stub(), session, IVI_ATTRIBUTE_NOT_SUPPORTED_ERROR);
 
   EXPECT_SUCCESS(session, response);
   EXPECT_EQ(

--- a/source/tests/system/nirfsa_driver_api_tests.cpp
+++ b/source/tests/system/nirfsa_driver_api_tests.cpp
@@ -5,7 +5,6 @@
 
 #include "device_server.h"
 #include "ivi.h"  // VI_SUCCESS
-#include "niRFSA.h"
 #include "niRFSAErrors.h"
 #include "nirfsa/nirfsa_client.h"
 #include "niscope/niscope_client.h"
@@ -308,7 +307,7 @@ TEST_F(NiRFSADriverApiTests, ReconfigureExportedRefClockOutTerminal_UpdatesRefCl
   EXPECT_SUCCESS(session, set_response);
   EXPECT_SUCCESS(session, get_response);
   EXPECT_NE(initial_response.value(), get_response.value());
-  EXPECT_EQ(NIRFSA_VAL_REF_OUT_STR, get_response.value());
+  EXPECT_EQ("RefOut", get_response.value());
 }
 
 TEST_F(NiRFSADriverApiTests, ReconfigureFFTWindowType_UpdatesFFTWindowSuccessfully)
@@ -573,7 +572,7 @@ TEST_F(NiRFSADriverApiTests, IsSelfCalValid)
 
   EXPECT_SUCCESS(session, response);
   EXPECT_THAT(response.valid_steps_array(), ElementsAre(SELF_CALIBRATE_STEPS_DIGITIZER_SELF_CAL));
-  EXPECT_EQ(NIRFSA_VAL_SELF_CAL_DIGITIZER_SELF_CAL, response.valid_steps_raw());
+  EXPECT_EQ(8, response.valid_steps_raw());
 }
 
 TEST_F(NiRFSADriverApiTests, SelfTest_Succeeds)

--- a/source/tests/system/nirfsg_driver_api_tests.cpp
+++ b/source/tests/system/nirfsg_driver_api_tests.cpp
@@ -3,8 +3,8 @@
 #include <thread>
 
 #include "device_server.h"
+#include "ivi.h"
 #include "nirfsg/nirfsg_client.h"
-#include "nirfsg/nirfsg_service.h"
 #include "nitclk/nitclk_client.h"
 
 using namespace nirfsg_grpc;
@@ -14,7 +14,7 @@ namespace pb = google::protobuf;
 using namespace ::testing;
 
 namespace nidevice_grpc {
-// Needs to be in the nirfsg_grpc namespace for googletest to find this
+// Needs to be in the nidevice_grpc namespace for googletest to find this
 // because of argument-dependent lookup - see
 // https://stackoverflow.com/questions/33371088/how-to-get-a-custom-operator-to-work-with-google-test
 bool operator==(const NIComplexNumber& first, const NIComplexNumber& second)
@@ -221,7 +221,7 @@ TEST_F(NiRFSGDriverApiTests, ReconfigureExportedRefClockOutTerminal_UpdatesRefCl
   EXPECT_SUCCESS(session, set_response);
   EXPECT_SUCCESS(session, get_response);
   EXPECT_NE(initial_response.value(), get_response.value());
-  EXPECT_EQ(NIRFSG_VAL_REF_OUT_STR, get_response.value());
+  EXPECT_EQ("RefOut", get_response.value());
 }
 
 TEST_F(NiRFSGDriverApiTests, SetAutomaticThermalCorrection_UpdatesSuccessfully)

--- a/source/tests/system/nirfsg_driver_api_tests.cpp
+++ b/source/tests/system/nirfsg_driver_api_tests.cpp
@@ -3,7 +3,6 @@
 #include <thread>
 
 #include "device_server.h"
-#include "ivi.h"
 #include "nirfsg/nirfsg_client.h"
 #include "nitclk/nitclk_client.h"
 
@@ -30,6 +29,7 @@ namespace system {
 const auto PXI_5652 = "5652";
 const auto PXI_5820 = "5820";
 const auto PXI_5841 = "5841";
+const auto IVI_ATTRIBUTE_NOT_SUPPORTED_ERROR = 0xBFFA0012;
 
 const int krfsgDriverApiSuccess = 0;
 
@@ -519,7 +519,7 @@ TEST_F(NiRFSGDriverApiTests, TwoSessions_SetupTclkSyncPulseSenderSynchronization
 TEST_F(NiRFSGDriverApiTests, ErrorMessage_ReturnsErrorMessage)
 {
   auto session = init_session(stub(), PXI_5652);
-  const auto response = client::error_message(stub(), session, IVI_ERROR_ATTRIBUTE_NOT_SUPPORTED);
+  const auto response = client::error_message(stub(), session, IVI_ATTRIBUTE_NOT_SUPPORTED_ERROR);
 
   EXPECT_SUCCESS(session, response);
   EXPECT_EQ(

--- a/source/tests/system/nirfsg_session_tests.cpp
+++ b/source/tests/system/nirfsg_session_tests.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "nirfsg/nirfsg_service.h"
+#include "nirfsg/nirfsg_client.h"
 
 namespace ni {
 namespace tests {

--- a/source/tests/system/niscope_driver_api_tests.cpp
+++ b/source/tests/system/niscope_driver_api_tests.cpp
@@ -1,7 +1,8 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "niscope/niscope_service.h"
+#include "ivi.h"
+#include "niscope/niscope_client.h"
 
 namespace ni {
 namespace tests {

--- a/source/tests/system/niscope_driver_api_tests.cpp
+++ b/source/tests/system/niscope_driver_api_tests.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "ivi.h"
 #include "niscope/niscope_client.h"
 
 namespace ni {
@@ -9,6 +8,13 @@ namespace tests {
 namespace system {
 
 namespace scope = niscope_grpc;
+namespace pb = ::google::protobuf;
+
+typedef pb::int16 int16;
+typedef pb::int32 int32;
+typedef pb::int64 int64;
+typedef pb::uint32 uint32;
+typedef pb::uint16 uint16;
 
 const int kScopeDriverApiSuccess = 0;
 
@@ -143,7 +149,7 @@ class NiScopeDriverApiTest : public ::testing::Test {
     expect_api_success(response.status());
   }
 
-  ViBoolean get_bool_attribute(const char* channel_list, scope::NiScopeAttribute attribute_id)
+  bool get_bool_attribute(const char* channel_list, scope::NiScopeAttribute attribute_id)
   {
     ::grpc::ClientContext context;
     scope::GetAttributeViBooleanRequest request;
@@ -157,7 +163,7 @@ class NiScopeDriverApiTest : public ::testing::Test {
     return response.value();
   }
 
-  ViInt32 get_int32_attribute(const char* channel_list, scope::NiScopeAttribute attribute_id)
+  int32 get_int32_attribute(const char* channel_list, scope::NiScopeAttribute attribute_id)
   {
     ::grpc::ClientContext context;
     scope::GetAttributeViInt32Request request;
@@ -171,7 +177,7 @@ class NiScopeDriverApiTest : public ::testing::Test {
     return response.value();
   }
 
-  ViInt64 get_int64_attribute(const char* channel_list, scope::NiScopeAttribute attribute_id)
+  int64 get_int64_attribute(const char* channel_list, scope::NiScopeAttribute attribute_id)
   {
     ::grpc::ClientContext context;
     scope::GetAttributeViInt64Request request;
@@ -185,7 +191,7 @@ class NiScopeDriverApiTest : public ::testing::Test {
     return response.value();
   }
 
-  ViReal64 get_real64_attribute(const char* channel_list, scope::NiScopeAttribute attribute_id)
+  double get_real64_attribute(const char* channel_list, scope::NiScopeAttribute attribute_id)
   {
     ::grpc::ClientContext context;
     scope::GetAttributeViReal64Request request;
@@ -249,9 +255,9 @@ TEST_F(NiScopeDriverApiTest, NiScopeReset_SendRequest_ResetCompletesSuccessfully
 
 TEST_F(NiScopeDriverApiTest, NiScopeRead_SendRequest_ReadCompletesWithCorrectSizes)
 {
-  const ViInt32 expected_num_samples = 100000;
+  const int32 expected_num_samples = 100000;
   const char* channel_list = "0";
-  const ViInt32 expected_num_waveforms = get_actual_num_wfms(channel_list);
+  const int32 expected_num_waveforms = get_actual_num_wfms(channel_list);
   ::grpc::ClientContext context;
   scope::ReadRequest request;
   request.mutable_vi()->set_id(GetSessionId());
@@ -272,11 +278,11 @@ TEST_F(NiScopeDriverApiTest, NiScopeFetchArrayMeasurement_SendRequest_FetchCompl
 {
   auto_setup();
   initiate_acquisition();
-  const ViInt32 expected_num_samples = 100000;
+  const int32 expected_num_samples = 100000;
   const char* channel_list = "0";
-  const ViInt32 expected_num_waveforms = get_actual_num_wfms(channel_list);
+  const int32 expected_num_waveforms = get_actual_num_wfms(channel_list);
   const niscope_grpc::ArrayMeasurement measurement_func = niscope_grpc::ArrayMeasurement::ARRAY_MEASUREMENT_NISCOPE_VAL_INVERSE;
-  const ViInt32 expected_waveform_size = get_actual_measurement_waveform_size(measurement_func);
+  const int32 expected_waveform_size = get_actual_measurement_waveform_size(measurement_func);
   ::grpc::ClientContext context;
   scope::FetchArrayMeasurementRequest request;
   request.mutable_vi()->set_id(GetSessionId());
@@ -297,9 +303,9 @@ TEST_F(NiScopeDriverApiTest, NiScopeFetchBinary16_SendRequest_FetchCompletesWith
 {
   auto_setup();
   initiate_acquisition();
-  const ViInt32 expected_num_samples = 100000;
+  const int32 expected_num_samples = 100000;
   const char* channel_list = "0";
-  const ViInt32 expected_num_waveforms = get_actual_num_wfms(channel_list);
+  const int32 expected_num_waveforms = get_actual_num_wfms(channel_list);
   ::grpc::ClientContext context;
   scope::FetchBinary16Request request;
   request.mutable_vi()->set_id(GetSessionId());
@@ -320,9 +326,9 @@ TEST_F(NiScopeDriverApiTest, NiScopeFetchBinary8_SendRequest_FetchCompletesWithC
 {
   auto_setup();
   initiate_acquisition();
-  const ViInt32 expected_num_samples = 100000;
+  const int32 expected_num_samples = 100000;
   const char* channel_list = "0";
-  const ViInt32 expected_num_waveforms = get_actual_num_wfms(channel_list);
+  const int32 expected_num_waveforms = get_actual_num_wfms(channel_list);
   ::grpc::ClientContext context;
   scope::FetchBinary8Request request;
   request.mutable_vi()->set_id(GetSessionId());
@@ -343,7 +349,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeSetViInt32Attribute_SendRequest_GetViInt32At
 {
   const char* channel_list = "";
   const scope::NiScopeAttribute attribute_to_set = scope::NiScopeAttribute::NISCOPE_ATTRIBUTE_HORZ_NUM_RECORDS;
-  const ViInt32 expected_value = 4;
+  const int32 expected_value = 4;
   ::grpc::ClientContext context;
   scope::SetAttributeViInt32Request request;
   request.mutable_vi()->set_id(GetSessionId());
@@ -356,17 +362,17 @@ TEST_F(NiScopeDriverApiTest, NiScopeSetViInt32Attribute_SendRequest_GetViInt32At
   EXPECT_TRUE(status.ok());
   expect_api_success(response.status());
 
-  ViInt32 get_attribute_value = get_int32_attribute(channel_list, attribute_to_set);
+  int32 get_attribute_value = get_int32_attribute(channel_list, attribute_to_set);
   EXPECT_EQ(expected_value, get_attribute_value);
 }
 
 TEST_F(NiScopeDriverApiTest, NiScopeSetViInt64Attribute_SendRequest_GetViInt64AttributeMatches)
 {
   const char* channel_list = "";
-  // The ViInt64 attributes in niScope.h (p2p ones) can't be used on a simulated device. So
-  // we'll just set a ViInt32 attribute to still exercise the get and set ViInt64 methods.
+  // The int64 attributes in niScope.h (p2p ones) can't be used on a simulated device. So
+  // we'll just set a int32 attribute to still exercise the get and set int64 methods.
   const scope::NiScopeAttribute attribute_to_set = scope::NiScopeAttribute::NISCOPE_ATTRIBUTE_FETCH_NUM_RECORDS;
-  const ViInt64 expected_value = 4;
+  const int64 expected_value = 4;
   ::grpc::ClientContext context;
   scope::SetAttributeViInt64Request request;
   request.mutable_vi()->set_id(GetSessionId());
@@ -379,7 +385,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeSetViInt64Attribute_SendRequest_GetViInt64At
   EXPECT_TRUE(status.ok());
   expect_api_success(response.status());
 
-  ViInt64 get_attribute_value = get_int64_attribute(channel_list, attribute_to_set);
+  int64 get_attribute_value = get_int64_attribute(channel_list, attribute_to_set);
   EXPECT_EQ(expected_value, get_attribute_value);
 }
 
@@ -387,7 +393,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeSetViReal64Attribute_SendRequest_GetViReal64
 {
   const char* channel_list = "";
   const scope::NiScopeAttribute attribute_to_set = scope::NiScopeAttribute::NISCOPE_ATTRIBUTE_REF_CLK_RATE;
-  const ViReal64 expected_value = 42.24;
+  const double expected_value = 42.24;
   ::grpc::ClientContext context;
   scope::SetAttributeViReal64Request request;
   request.mutable_vi()->set_id(GetSessionId());
@@ -400,7 +406,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeSetViReal64Attribute_SendRequest_GetViReal64
   EXPECT_TRUE(status.ok());
   expect_api_success(response.status());
 
-  ViReal64 get_attribute_value = get_real64_attribute(channel_list, attribute_to_set);
+  double get_attribute_value = get_real64_attribute(channel_list, attribute_to_set);
   EXPECT_EQ(expected_value, get_attribute_value);
 }
 
@@ -408,7 +414,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeSetViStringAttribute_SendRequest_GetViString
 {
   const char* channel_list = "";
   const scope::NiScopeAttribute attribute_to_set = scope::NiScopeAttribute::NISCOPE_ATTRIBUTE_TRIGGER_SOURCE;
-  const ViString expected_value = "Hello world!";
+  const std::string expected_value = "Hello world!";
   ::grpc::ClientContext context;
   scope::SetAttributeViStringRequest request;
   request.mutable_vi()->set_id(GetSessionId());
@@ -422,14 +428,14 @@ TEST_F(NiScopeDriverApiTest, NiScopeSetViStringAttribute_SendRequest_GetViString
   expect_api_success(response.status());
 
   std::string get_attribute_value = get_string_attribute(channel_list, attribute_to_set);
-  EXPECT_STREQ(expected_value, get_attribute_value.c_str());
+  EXPECT_STREQ(expected_value.c_str(), get_attribute_value.c_str());
 }
 
 TEST_F(NiScopeDriverApiTest, NiScopeSetBoolAttribute_SendRequest_GetBoolAttributeMatches)
 {
   const char* channel_list = "0";
   const scope::NiScopeAttribute attribute_to_set = scope::NiScopeAttribute::NISCOPE_ATTRIBUTE_CHANNEL_ENABLED;
-  const ViBoolean expected_value = true;
+  const bool expected_value = true;
   ::grpc::ClientContext context;
   scope::SetAttributeViBooleanRequest request;
   request.mutable_vi()->set_id(GetSessionId());
@@ -442,7 +448,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeSetBoolAttribute_SendRequest_GetBoolAttribut
   EXPECT_TRUE(status.ok());
   expect_api_success(response.status());
 
-  ViBoolean get_attribute_value = get_bool_attribute(channel_list, attribute_to_set);
+  bool get_attribute_value = get_bool_attribute(channel_list, attribute_to_set);
   EXPECT_EQ(expected_value, get_attribute_value);
 }
 

--- a/source/tests/system/niscope_session_tests.cpp
+++ b/source/tests/system/niscope_session_tests.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "niscope/niscope_service.h"
+#include "niscope/niscope_client.h"
 
 namespace ni {
 namespace tests {

--- a/source/tests/system/niswitch_driver_api_tests.cpp
+++ b/source/tests/system/niswitch_driver_api_tests.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "ivi.h"
 #include "niswitch/niswitch_client.h"
 
 namespace ni {
@@ -9,6 +8,11 @@ namespace tests {
 namespace system {
 
 namespace niswitch = niswitch_grpc;
+namespace pb = ::google::protobuf;
+
+typedef pb::int32 int32;
+typedef pb::uint32 uint32;
+typedef pb::uint16 uint16;
 
 const int kSwitchDriverApiSuccess = 0;
 const int kWaitForDebounceMaxTime = 5000;
@@ -173,7 +177,7 @@ class NiSwitchDriverApiTest : public ::testing::Test {
     return response.relay_position();
   }
 
-  ViReal64 get_real64_attribute(const char* channel_name, niswitch::NiSwitchAttribute attribute_id)
+  double get_real64_attribute(const char* channel_name, niswitch::NiSwitchAttribute attribute_id)
   {
     ::grpc::ClientContext context;
     niswitch::GetAttributeViReal64Request request;
@@ -243,7 +247,7 @@ TEST_F(NiSwitchDriverApiTest, NiSwitchSetViReal64Attribute_SendRequest_GetViReal
 {
   const char* channel_name = "";
   const niswitch::NiSwitchAttribute attribute_to_set = niswitch::NiSwitchAttribute::NISWITCH_ATTRIBUTE_SCAN_DELAY;
-  const ViReal64 expected_value = 402.24;
+  const double expected_value = 402.24;
   ::grpc::ClientContext context;
   niswitch::SetAttributeViReal64Request request;
   request.mutable_vi()->set_id(GetSessionId());
@@ -256,7 +260,7 @@ TEST_F(NiSwitchDriverApiTest, NiSwitchSetViReal64Attribute_SendRequest_GetViReal
 
   EXPECT_TRUE(status.ok());
   expect_api_success(response.status());
-  ViReal64 get_attribute_value = get_real64_attribute(channel_name, attribute_to_set);
+  double get_attribute_value = get_real64_attribute(channel_name, attribute_to_set);
   EXPECT_EQ(expected_value, get_attribute_value);
 }
 
@@ -264,7 +268,7 @@ TEST_F(NiSwitchDriverApiTest, NiSwitchSetViStringAttribute_SendRequest_GetViStri
 {
   const char* channel_name = "";
   const niswitch::NiSwitchAttribute attribute_to_set = niswitch::NiSwitchAttribute::NISWITCH_ATTRIBUTE_SCAN_LIST;
-  const ViString expected_value = "b0r1->b0c1;b0r1->b0c2;b0r2->b0c3";
+  const std::string expected_value = "b0r1->b0c1;b0r1->b0c2;b0r2->b0c3";
   ::grpc::ClientContext context;
   niswitch::SetAttributeViStringRequest request;
   request.mutable_vi()->set_id(GetSessionId());
@@ -278,7 +282,7 @@ TEST_F(NiSwitchDriverApiTest, NiSwitchSetViStringAttribute_SendRequest_GetViStri
   EXPECT_TRUE(status.ok());
   expect_api_success(response.status());
   std::string get_attribute_value = get_string_attribute(channel_name, attribute_to_set);
-  EXPECT_STREQ(expected_value, get_attribute_value.c_str());
+  EXPECT_STREQ(expected_value.c_str(), get_attribute_value.c_str());
 }
 
 TEST_F(NiSwitchDriverApiTest, NiSwitchRelayControl_SendRequest_RelayPositionMatches)

--- a/source/tests/system/niswitch_driver_api_tests.cpp
+++ b/source/tests/system/niswitch_driver_api_tests.cpp
@@ -1,7 +1,8 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "niswitch/niswitch_service.h"
+#include "ivi.h"
+#include "niswitch/niswitch_client.h"
 
 namespace ni {
 namespace tests {

--- a/source/tests/system/niswitch_session_tests.cpp
+++ b/source/tests/system/niswitch_session_tests.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "niswitch/niswitch_service.h"
+#include "niswitch/niswitch_client.h"
 
 namespace ni {
 namespace tests {

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -2,7 +2,6 @@
 
 #include "device_server.h"
 #include "enumerate_devices.h"
-#include "ivi.h"
 #include "nisync/nisync_client.h"
 
 namespace ni {
@@ -10,6 +9,11 @@ namespace tests {
 namespace system {
 
 namespace nisync = nisync_grpc;
+namespace pb = ::google::protobuf;
+
+typedef pb::int32 int32;
+typedef pb::uint32 uint32;
+typedef pb::uint16 uint16;
 
 constexpr auto INVALID_SOURCE_TERMINAL = 0xBFFA4032;
 constexpr auto SESSION_NAME = "TestSession";
@@ -38,6 +42,7 @@ constexpr auto NISYNC_ERROR_DRIVER_TIMEOUT = 0xBFFA400B;
 constexpr auto NISYNC_VAL_LEVEL_LOW = 0;
 constexpr auto NISYNC_VAL_LEVEL_HIGH = 1;
 constexpr auto NISYNC_ERROR_FEATURE_NOT_SUPPORTED = 0xBFFA4003;
+constexpr auto VI_SUCCESS = 0;
 
 class NiSyncDriverApiTest : public ::testing::Test {
  protected:
@@ -111,7 +116,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     EXPECT_EQ(VI_SUCCESS, response.status());
   }
 
-  ::grpc::Status call_RevisionQuery(std::string* driverRevision, std::string* firmwareRevision, ViStatus* viStatusOut)
+  ::grpc::Status call_RevisionQuery(std::string* driverRevision, std::string* firmwareRevision, int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::RevisionQueryRequest request;
@@ -124,7 +129,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_SendSoftwareTrigger(ViConstString srcTerminal, ViStatus* viStatusOut)
+  ::grpc::Status call_SendSoftwareTrigger(const std::string& srcTerminal, int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::SendSoftwareTriggerRequest request;
@@ -136,7 +141,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_ConnectClkTerminals(ViConstString srcTerminal, ViConstString destTerminal, ViStatus* viStatusOut)
+  ::grpc::Status call_ConnectClkTerminals(const std::string& srcTerminal, const std::string& destTerminal, int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::ConnectClkTerminalsRequest request;
@@ -149,7 +154,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_DisconnectClkTerminals(ViConstString srcTerminal, ViConstString destTerminal, ViStatus* viStatusOut)
+  ::grpc::Status call_DisconnectClkTerminals(const std::string& srcTerminal, const std::string& destTerminal, int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::DisconnectClkTerminalsRequest request;
@@ -163,13 +168,13 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_ConnectSWTrigToTerminal(
-      ViConstString srcTerminal,
-      ViConstString destTerminal,
-      ViConstString syncClock,
-      ViInt32 invert,
-      ViInt32 updateEdge,
-      ViReal64 delay,
-      ViStatus* viStatusOut)
+      const std::string& srcTerminal,
+      const std::string& destTerminal,
+      const std::string& syncClock,
+      int32 invert,
+      int32 updateEdge,
+      double delay,
+      int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::ConnectSWTrigToTerminalRequest request;
@@ -186,7 +191,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_DisconnectSWTrigFromTerminal(ViConstString srcTerminal, ViConstString destTerminal, ViStatus* viStatusOut)
+  ::grpc::Status call_DisconnectSWTrigFromTerminal(const std::string& srcTerminal, const std::string& destTerminal, int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::DisconnectSWTrigFromTerminalRequest request;
@@ -200,12 +205,12 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_ConnectTrigTerminals(
-      ViConstString srcTerminal,
-      ViConstString destTerminal,
-      ViConstString syncClock,
-      ViInt32 invert,
-      ViInt32 updateEdge,
-      ViStatus* viStatusOut)
+      const std::string& srcTerminal,
+      const std::string& destTerminal,
+      const std::string& syncClock,
+      int32 invert,
+      int32 updateEdge,
+      int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::ConnectTrigTerminalsRequest request;
@@ -221,7 +226,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_DisconnectTrigTerminals(ViConstString srcTerminal, ViConstString destTerminal, ViStatus* viStatusOut)
+  ::grpc::Status call_DisconnectTrigTerminals(const std::string& srcTerminal, const std::string& destTerminal, int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::DisconnectTrigTerminalsRequest request;
@@ -234,7 +239,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_SetAttributeViInt32(ViConstString activeItem, ViAttr attribute, ViInt32 value, ViStatus* viStatusOut)
+  ::grpc::Status call_SetAttributeViInt32(const std::string& activeItem, uint32 attribute, int32 value, int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::SetAttributeViInt32Request request;
@@ -248,7 +253,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_GetAttributeViInt32(ViConstString activeItem, ViAttr attribute, ViInt32* valueOut, ViStatus* viStatusOut)
+  ::grpc::Status call_GetAttributeViInt32(const std::string& activeItem, uint32 attribute, int32* valueOut, int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::GetAttributeViInt32Request request;
@@ -262,7 +267,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_SetAttributeViString(ViConstString activeItem, ViAttr attribute, ViConstString value, ViStatus* viStatusOut)
+  ::grpc::Status call_SetAttributeViString(const std::string& activeItem, uint32 attribute, const std::string& value, int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::SetAttributeViStringRequest request;
@@ -276,7 +281,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_GetAttributeViString(ViConstString activeItem, ViAttr attribute, std::string* valueOut, ViStatus* viStatusOut)
+  ::grpc::Status call_GetAttributeViString(const std::string& activeItem, uint32 attribute, std::string* valueOut, int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::GetAttributeViStringRequest request;
@@ -290,7 +295,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_SetAttributeViBoolean(ViConstString activeItem, ViAttr attribute, ViBoolean value, ViStatus* viStatusOut)
+  ::grpc::Status call_SetAttributeViBoolean(const std::string& activeItem, uint32 attribute, bool value, int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::SetAttributeViBooleanRequest request;
@@ -304,7 +309,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_GetAttributeViBoolean(ViConstString activeItem, ViAttr attribute, ViBoolean* valueOut, ViStatus* viStatusOut)
+  ::grpc::Status call_GetAttributeViBoolean(const std::string& activeItem, uint32 attribute, bool* valueOut, int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::GetAttributeViBooleanRequest request;
@@ -318,7 +323,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_SetAttributeViReal64(ViConstString activeItem, ViAttr attribute, ViReal64 value, ViStatus* viStatusOut)
+  ::grpc::Status call_SetAttributeViReal64(const std::string& activeItem, uint32 attribute, double value, int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::SetAttributeViReal64Request request;
@@ -332,7 +337,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_GetAttributeViReal64(ViConstString activeItem, ViAttr attribute, ViReal64* valueOut, ViStatus* viStatusOut)
+  ::grpc::Status call_GetAttributeViReal64(const std::string& activeItem, uint32 attribute, double* valueOut, int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::GetAttributeViReal64Request request;
@@ -347,13 +352,13 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_MeasureFrequencyEx(
-      ViConstString srcTerminal,
-      ViReal64 duration,
-      ViUInt32 decimationCount,
-      ViReal64* actualDurationOut,
-      ViReal64* frequencyOut,
-      ViReal64* frequencyErrorOut,
-      ViStatus* viStatusOut)
+      const std::string& srcTerminal,
+      double duration,
+      uint32 decimationCount,
+      double* actualDurationOut,
+      double* frequencyOut,
+      double* frequencyErrorOut,
+      int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::MeasureFrequencyExRequest request;
@@ -371,10 +376,10 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_GetTime(
-      ViUInt32* timeSeconds,
-      ViUInt32* timeNanoseconds,
-      ViUInt16* timeFractionalNanoseconds,
-      ViStatus* viStatusOut)
+      uint32* timeSeconds,
+      uint32* timeNanoseconds,
+      uint16* timeFractionalNanoseconds,
+      int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::GetTimeRequest request;
@@ -388,7 +393,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_SetTimeReferenceFreeRunning(ViStatus* viStatusOut)
+  ::grpc::Status call_SetTimeReferenceFreeRunning(int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::SetTimeReferenceFreeRunningRequest request;
@@ -399,7 +404,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_SetTimeReferenceGPS(ViStatus* viStatusOut)
+  ::grpc::Status call_SetTimeReferenceGPS(int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::SetTimeReferenceGPSRequest request;
@@ -411,9 +416,9 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_SetTimeReferenceIRIG(
-      ViInt32 irigType,
-      ViConstString terminalName,
-      ViStatus* viStatusOut)
+      int32 irigType,
+      const std::string& terminalName,
+      int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::SetTimeReferenceIRIGRequest request;
@@ -427,12 +432,12 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_SetTimeReferencePPS(
-      ViConstString terminalName,
-      ViBoolean useManualTime,
-      ViUInt32 initialTimeSeconds,
-      ViUInt32 initialTimeNanoseconds,
-      ViUInt16 initialTimeFractionalNanoseconds,
-      ViStatus* viStatusOut)
+      const std::string& terminalName,
+      bool useManualTime,
+      uint32 initialTimeSeconds,
+      uint32 initialTimeNanoseconds,
+      uint16 initialTimeFractionalNanoseconds,
+      int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::SetTimeReferencePPSRequest request;
@@ -448,7 +453,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_SetTimeReference1588OrdinaryClock(ViStatus* viStatusOut)
+  ::grpc::Status call_SetTimeReference1588OrdinaryClock(int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::SetTimeReference1588OrdinaryClockRequest request;
@@ -459,7 +464,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ::grpc::Status call_SetTimeReference8021AS(ViStatus* viStatusOut)
+  ::grpc::Status call_SetTimeReference8021AS(int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::SetTimeReference8021ASRequest request;
@@ -471,12 +476,12 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_CreateFutureTimeEvent(
-      ViConstString terminal,
-      ViInt32 outputLevel,
-      ViUInt32 timeSeconds,
-      ViUInt32 timeNanoseconds,
-      ViUInt16 timeFractionalNanoseconds,
-      ViStatus* viStatusOut)
+      const std::string& terminal,
+      int32 outputLevel,
+      uint32 timeSeconds,
+      uint32 timeNanoseconds,
+      uint16 timeFractionalNanoseconds,
+      int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::CreateFutureTimeEventRequest request;
@@ -493,13 +498,13 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   void CreateFutureTimeEvent(
-      ViConstString terminal,
-      ViInt32 outputLevel,
-      ViUInt32 timeSeconds,
-      ViUInt32 timeNanoseconds,
-      ViUInt16 timeFractionalNanoseconds)
+      const std::string& terminal,
+      int32 outputLevel,
+      uint32 timeSeconds,
+      uint32 timeNanoseconds,
+      uint16 timeFractionalNanoseconds)
   {
-    ViStatus viStatus;
+    int32 viStatus;
     auto grpcStatus = call_CreateFutureTimeEvent(
         terminal,
         outputLevel,
@@ -512,8 +517,8 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_ClearFutureTimeEvents(
-      ViConstString terminal,
-      ViStatus* viStatusOut)
+      const std::string& terminal,
+      int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::ClearFutureTimeEventsRequest request;
@@ -526,16 +531,16 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_CreateClock(
-      ViConstString terminal,
-      ViUInt32 highTicks,
-      ViUInt32 lowTicks,
-      ViUInt32 startTimeSeconds,
-      ViUInt32 startTimeNanoseconds,
-      ViUInt16 startTimeFractionalNanoseconds,
-      ViUInt32 stopTimeSeconds,
-      ViUInt32 stopTimeNanoseconds,
-      ViUInt16 stopTimeFractionalNanoseconds,
-      ViStatus* viStatusOut)
+      const std::string& terminal,
+      uint32 highTicks,
+      uint32 lowTicks,
+      uint32 startTimeSeconds,
+      uint32 startTimeNanoseconds,
+      uint16 startTimeFractionalNanoseconds,
+      uint32 stopTimeSeconds,
+      uint32 stopTimeNanoseconds,
+      uint16 stopTimeFractionalNanoseconds,
+      int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::CreateClockRequest request;
@@ -556,8 +561,8 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_ClearClock(
-      ViConstString terminal,
-      ViStatus* viStatusOut)
+      const std::string& terminal,
+      int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::ClearClockRequest request;
@@ -571,7 +576,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
 
   ::grpc::Status call_GetTimeReferenceNames(
       std::string* valueOut,
-      ViStatus* viStatusOut)
+      int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::GetTimeReferenceNamesRequest request;
@@ -584,9 +589,9 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_EnableTimeStampTrigger(
-      ViConstString terminal,
-      ViInt32 activeEdge,
-      ViStatus* viStatusOut)
+      const std::string& terminal,
+      int32 activeEdge,
+      int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::EnableTimeStampTriggerRequest request;
@@ -600,23 +605,23 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   void EnableTimeStampTrigger(
-      ViConstString terminal,
-      ViInt32 activeEdge)
+      const std::string& terminal,
+      int32 activeEdge)
   {
-    ViStatus viStatus;
+    int32 viStatus;
     auto grpcStatus = call_EnableTimeStampTrigger(terminal, activeEdge, &viStatus);
     ASSERT_TRUE(grpcStatus.ok());
     ASSERT_EQ(VI_SUCCESS, viStatus);
   }
 
   ::grpc::Status call_ReadTriggerTimeStamp(
-      ViConstString terminal,
-      ViReal64 timeout,
-      ViUInt32* timeSeconds,
-      ViUInt32* timeNanoseconds,
-      ViUInt16* timeFractionalNanoseconds,
-      ViInt32* detectedEdge,
-      ViStatus* viStatusOut)
+      const std::string& terminal,
+      double timeout,
+      uint32* timeSeconds,
+      uint32* timeNanoseconds,
+      uint16* timeFractionalNanoseconds,
+      int32* detectedEdge,
+      int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::ReadTriggerTimeStampRequest request;
@@ -634,15 +639,15 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_ReadMultipleTriggerTimeStamp(
-      ViConstString terminal,
-      ViReal64 timeout,
-      ViUInt32 timestampsToRead,
-      ViUInt32* timeSecondsBuffer,
-      ViUInt32* timeNanosecondsBuffer,
-      ViUInt16* timeFractionalNanosecondsBuffer,
-      ViInt32* detectedEdgeBuffer,
-      ViUInt32* timestampsRead,
-      ViStatus* viStatusOut)
+      const std::string& terminal,
+      double timeout,
+      uint32 timestampsToRead,
+      uint32* timeSecondsBuffer,
+      uint32* timeNanosecondsBuffer,
+      uint16* timeFractionalNanosecondsBuffer,
+      int32* detectedEdgeBuffer,
+      uint32* timestampsRead,
+      int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::ReadMultipleTriggerTimeStampRequest request;
@@ -662,8 +667,8 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_DisableTimeStampTrigger(
-      ViConstString terminal,
-      ViStatus* viStatusOut)
+      const std::string& terminal,
+      int32* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::DisableTimeStampTriggerRequest request;
@@ -675,11 +680,11 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-  ViUInt32 GetCurrentBoardTimeSeconds()
+  uint32 GetCurrentBoardTimeSeconds()
   {
-    ViStatus viStatus;
-    ViUInt32 timeSeconds = 0, timeNanoseconds;
-    ViUInt16 timeFractionalNanoseconds;
+    int32 viStatus;
+    uint32 timeSeconds = 0, timeNanoseconds;
+    uint16 timeFractionalNanoseconds;
     auto grpcStatus = call_GetTime(
         &timeSeconds,
         &timeNanoseconds,            // ignored
@@ -710,7 +715,7 @@ class NiSyncDriver6683Test : public NiSyncDriverApiTest {
 
 TEST_F(NiSyncDriver6674Test, RevisionQuery_ReturnsNonEmptyRevisions)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   std::string driverRevision, firmwareRevision;
   auto grpcStatus = call_RevisionQuery(&driverRevision, &firmwareRevision, &viStatus);
 
@@ -721,7 +726,7 @@ TEST_F(NiSyncDriver6674Test, RevisionQuery_ReturnsNonEmptyRevisions)
 
 TEST_F(NiSyncDriver6674Test, ConnectClkTerminals_ReturnsSuccess)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto srcTerminal = NISYNC_VAL_OSCILLATOR, destTerminal = NISYNC_VAL_CLKOUT;
   auto grpcStatus = call_ConnectClkTerminals(srcTerminal, destTerminal, &viStatus);
 
@@ -732,7 +737,7 @@ TEST_F(NiSyncDriver6674Test, ConnectClkTerminals_ReturnsSuccess)
 
 TEST_F(NiSyncDriver6674Test, ConnectInvalidClkTerminals_ReturnsInvalidSrcTerminal)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto srcTerminal = INVALID_TERMINAL, destTerminal = NISYNC_VAL_CLKOUT;
   auto grpcStatus = call_ConnectClkTerminals(srcTerminal, destTerminal, &viStatus);
 
@@ -742,7 +747,7 @@ TEST_F(NiSyncDriver6674Test, ConnectInvalidClkTerminals_ReturnsInvalidSrcTermina
 
 TEST_F(NiSyncDriver6674Test, ConnectedClkTerminals_DisconnectClkTerminals_ReturnsSuccess)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto srcTerminal = NISYNC_VAL_OSCILLATOR, destTerminal = NISYNC_VAL_CLKOUT;
   auto grpcStatus = call_ConnectClkTerminals(srcTerminal, destTerminal, &viStatus);
   EXPECT_TRUE(grpcStatus.ok());
@@ -756,7 +761,7 @@ TEST_F(NiSyncDriver6674Test, ConnectedClkTerminals_DisconnectClkTerminals_Return
 
 TEST_F(NiSyncDriver6674Test, ConnectedClkTerminals_DisconnectNotConnectedClkTerminals_ReturnsSuccess)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto srcTerminal = NISYNC_VAL_OSCILLATOR, destTerminal = NISYNC_VAL_CLKOUT;
   auto grpcStatus = call_ConnectClkTerminals(srcTerminal, destTerminal, &viStatus);
   EXPECT_TRUE(grpcStatus.ok());
@@ -772,11 +777,11 @@ TEST_F(NiSyncDriver6674Test, ConnectedClkTerminals_DisconnectNotConnectedClkTerm
 
 TEST_F(NiSyncDriver6674Test, ConnectSWTrigToTerminal_ReturnsSuccess)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto srcTerminal = NISYNC_VAL_SWTRIG_GLOBAL, destTerminal = NISYNC_VAL_PXIEDSTARC;
   auto syncClock = NISYNC_VAL_SYNC_CLK_FULLSPEED;
-  ViInt32 invert = VI_TRUE, updateEdge = VI_FALSE;
-  ViReal64 delay = 0;
+  int32 invert = true, updateEdge = false;
+  double delay = 0;
   auto grpcStatus = call_ConnectSWTrigToTerminal(
       srcTerminal,
       destTerminal,
@@ -793,11 +798,11 @@ TEST_F(NiSyncDriver6674Test, ConnectSWTrigToTerminal_ReturnsSuccess)
 
 TEST_F(NiSyncDriver6674Test, ConnectInvalidSWTrigToTerminal_ReturnsInvalidSrcTerminal)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto srcTerminal = INVALID_TERMINAL, destTerminal = NISYNC_VAL_PXIEDSTARC;
   auto syncClock = NISYNC_VAL_SYNC_CLK_FULLSPEED;
-  ViInt32 invert = VI_TRUE, updateEdge = VI_FALSE;
-  ViReal64 delay = 0;
+  int32 invert = true, updateEdge = false;
+  double delay = 0;
   auto grpcStatus = call_ConnectSWTrigToTerminal(
       srcTerminal,
       destTerminal,
@@ -813,11 +818,11 @@ TEST_F(NiSyncDriver6674Test, ConnectInvalidSWTrigToTerminal_ReturnsInvalidSrcTer
 
 TEST_F(NiSyncDriver6674Test, ConnectedSWTrigToTerminal_DisconnectSWTrigFromTerminal_ReturnsSuccess)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto srcTerminal = NISYNC_VAL_SWTRIG_GLOBAL, destTerminal = NISYNC_VAL_PXIEDSTARC;
   auto syncClock = NISYNC_VAL_SYNC_CLK_FULLSPEED;
-  ViInt32 invert = VI_TRUE, updateEdge = VI_FALSE;
-  ViReal64 delay = 0;
+  int32 invert = true, updateEdge = false;
+  double delay = 0;
   auto grpcStatus = call_ConnectSWTrigToTerminal(
       srcTerminal,
       destTerminal,
@@ -837,11 +842,11 @@ TEST_F(NiSyncDriver6674Test, ConnectedSWTrigToTerminal_DisconnectSWTrigFromTermi
 
 TEST_F(NiSyncDriver6674Test, SWTrigConnectedToTerminal_DisconnectSWTrigFromNotConnectedTerminal_ReturnsSuccess)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto srcTerminal = NISYNC_VAL_SWTRIG_GLOBAL, destTerminal = NISYNC_VAL_PXIEDSTARC;
   auto syncClock = NISYNC_VAL_SYNC_CLK_FULLSPEED;
-  ViInt32 invert = VI_TRUE, updateEdge = VI_FALSE;
-  ViReal64 delay = 0;
+  int32 invert = true, updateEdge = false;
+  double delay = 0;
   auto grpcStatus = call_ConnectSWTrigToTerminal(
       srcTerminal,
       destTerminal,
@@ -863,7 +868,7 @@ TEST_F(NiSyncDriver6674Test, SWTrigConnectedToTerminal_DisconnectSWTrigFromNotCo
 
 TEST_F(NiSyncDriver6674Test, SendSoftwareTrigger_ReturnsSuccess)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto srcTerminal = NISYNC_VAL_SWTRIG_GLOBAL;
   auto grpcStatus = call_SendSoftwareTrigger(srcTerminal, &viStatus);
 
@@ -873,7 +878,7 @@ TEST_F(NiSyncDriver6674Test, SendSoftwareTrigger_ReturnsSuccess)
 
 TEST_F(NiSyncDriver6674Test, SendSoftwareTriggerOnInvalidTerminal_ReturnsInvalidSrcTerminal)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto srcTerminal = INVALID_TERMINAL;
   auto grpcStatus = call_SendSoftwareTrigger(srcTerminal, &viStatus);
 
@@ -883,10 +888,10 @@ TEST_F(NiSyncDriver6674Test, SendSoftwareTriggerOnInvalidTerminal_ReturnsInvalid
 
 TEST_F(NiSyncDriver6674Test, ConnectTrigTerminals_ReturnsSuccess)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto srcTerminal = NISYNC_VAL_PFI0, destTerminal = NISYNC_VAL_PFI1;
   auto syncClock = NISYNC_VAL_SYNC_CLK_ASYNC;
-  ViInt32 invert = VI_FALSE, updateEdge = VI_FALSE;
+  int32 invert = false, updateEdge = false;
   auto grpcStatus = call_ConnectTrigTerminals(
       srcTerminal,
       destTerminal,
@@ -902,10 +907,10 @@ TEST_F(NiSyncDriver6674Test, ConnectTrigTerminals_ReturnsSuccess)
 
 TEST_F(NiSyncDriver6674Test, ConnectInvalidTrigTerminals_ReturnsInvalidSrcTerminal)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto srcTerminal = INVALID_TERMINAL, destTerminal = NISYNC_VAL_CLKOUT;
   auto syncClock = NISYNC_VAL_SYNC_CLK_ASYNC;
-  ViInt32 invert = VI_FALSE, updateEdge = VI_FALSE;
+  int32 invert = false, updateEdge = false;
   auto grpcStatus = call_ConnectTrigTerminals(
       srcTerminal,
       destTerminal,
@@ -920,10 +925,10 @@ TEST_F(NiSyncDriver6674Test, ConnectInvalidTrigTerminals_ReturnsInvalidSrcTermin
 
 TEST_F(NiSyncDriver6674Test, ConnectedTrigTerminals_DisconnectTrigTerminals_ReturnsSuccess)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto srcTerminal = NISYNC_VAL_PFI0, destTerminal = NISYNC_VAL_PFI1;
   auto syncClock = NISYNC_VAL_SYNC_CLK_ASYNC;
-  ViInt32 invert = VI_FALSE, updateEdge = VI_FALSE;
+  int32 invert = false, updateEdge = false;
   auto grpcStatus = call_ConnectTrigTerminals(
       srcTerminal,
       destTerminal,
@@ -942,10 +947,10 @@ TEST_F(NiSyncDriver6674Test, ConnectedTrigTerminals_DisconnectTrigTerminals_Retu
 
 TEST_F(NiSyncDriver6674Test, NotConnectedTrigTerminals_DisconnectSWTrigFromTerminal_ReturnsSuccess)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto srcTerminal = NISYNC_VAL_PFI0, destTerminal = NISYNC_VAL_PFI1;
   auto syncClock = NISYNC_VAL_SYNC_CLK_ASYNC;
-  ViInt32 invert = VI_FALSE, updateEdge = VI_FALSE;
+  int32 invert = false, updateEdge = false;
   auto grpcStatus = call_ConnectTrigTerminals(
       srcTerminal,
       destTerminal,
@@ -966,15 +971,15 @@ TEST_F(NiSyncDriver6674Test, NotConnectedTrigTerminals_DisconnectSWTrigFromTermi
 
 TEST_F(NiSyncDriver6674Test, AttributeSet_GetAttributeViInt32_ReturnsValue)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto activeItem = "";
-  ViAttr attribute = nisync_grpc::NISYNC_ATTRIBUTE_SYNC_CLK_DIV1;
-  ViInt32 expectedValue = NISYNC_VAL_1588_CLK_ACCURACY_WITHIN_1_USEC;
+  uint32 attribute = nisync_grpc::NISYNC_ATTRIBUTE_SYNC_CLK_DIV1;
+  int32 expectedValue = NISYNC_VAL_1588_CLK_ACCURACY_WITHIN_1_USEC;
   auto grpcStatus = call_SetAttributeViInt32(activeItem, attribute, expectedValue, &viStatus);
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
 
-  ViInt32 value;
+  int32 value;
   grpcStatus = call_GetAttributeViInt32(activeItem, attribute, &value, &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
@@ -984,10 +989,10 @@ TEST_F(NiSyncDriver6674Test, AttributeSet_GetAttributeViInt32_ReturnsValue)
 
 TEST_F(NiSyncDriver6674Test, AttributeSet_GetAttributeViString_ReturnsValue)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto activeItem = "";
-  ViAttr attribute = nisync_grpc::NISYNC_ATTRIBUTE_FRONT_SYNC_CLK_SRC;
-  ViConstString expectedValue = NISYNC_VAL_CLK10;
+  uint32 attribute = nisync_grpc::NISYNC_ATTRIBUTE_FRONT_SYNC_CLK_SRC;
+  const std::string& expectedValue = NISYNC_VAL_CLK10;
   auto grpcStatus = call_SetAttributeViString(activeItem, attribute, expectedValue, &viStatus);
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
@@ -997,20 +1002,20 @@ TEST_F(NiSyncDriver6674Test, AttributeSet_GetAttributeViString_ReturnsValue)
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
-  EXPECT_STREQ(expectedValue, value.c_str());
+  EXPECT_STREQ(expectedValue.c_str(), value.c_str());
 }
 
 TEST_F(NiSyncDriver6674Test, AttributeSet_GetAttributeViBoolean_ReturnsValue)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto activeItem = "";
-  ViAttr attribute = nisync_grpc::NISYNC_ATTRIBUTE_CLKIN_ATTENUATION_DISABLE;
-  ViBoolean expectedValue = VI_TRUE;
+  uint32 attribute = nisync_grpc::NISYNC_ATTRIBUTE_CLKIN_ATTENUATION_DISABLE;
+  bool expectedValue = true;
   auto grpcStatus = call_SetAttributeViBoolean(activeItem, attribute, expectedValue, &viStatus);
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
 
-  ViBoolean value;
+  bool value;
   grpcStatus = call_GetAttributeViBoolean(activeItem, attribute, &value, &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
@@ -1020,15 +1025,15 @@ TEST_F(NiSyncDriver6674Test, AttributeSet_GetAttributeViBoolean_ReturnsValue)
 
 TEST_F(NiSyncDriver6674Test, AttributeSet_GetAttributeViReal64_ReturnsValue)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto activeItem = "";
-  ViAttr attribute = nisync_grpc::NISYNC_ATTRIBUTE_PFI0_THRESHOLD;
-  ViReal64 expectedValue = 2.3;
+  uint32 attribute = nisync_grpc::NISYNC_ATTRIBUTE_PFI0_THRESHOLD;
+  double expectedValue = 2.3;
   auto grpcStatus = call_SetAttributeViReal64(activeItem, attribute, expectedValue, &viStatus);
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
 
-  ViReal64 value;
+  double value;
   grpcStatus = call_GetAttributeViReal64(activeItem, attribute, &value, &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
@@ -1041,11 +1046,11 @@ TEST_F(NiSyncDriver6674Test, AttributeSet_GetAttributeViReal64_ReturnsValue)
 
 TEST_F(NiSyncDriver6674Test, MeasureFrequencyExOnTerminalWithNoFrequency_ReturnsNoFrequency)
 {
-  ViStatus viStatus;
-  ViConstString srcTerminal = NISYNC_VAL_PFI0;
-  ViReal64 duration = 0.1;       // duration is in seconds
-  ViUInt32 decimationCount = 0;  // ignored for 6674
-  ViReal64 actualDuration, frequency, frequencyError;
+  int32 viStatus;
+  const std::string& srcTerminal = NISYNC_VAL_PFI0;
+  double duration = 0.1;       // duration is in seconds
+  uint32 decimationCount = 0;  // ignored for 6674
+  double actualDuration, frequency, frequencyError;
   auto grpcStatus = call_MeasureFrequencyEx(
       srcTerminal,
       duration,
@@ -1063,11 +1068,11 @@ TEST_F(NiSyncDriver6674Test, MeasureFrequencyExOnTerminalWithNoFrequency_Returns
 
 TEST_F(NiSyncDriver6674Test, MeasureFrequencyExOnOscillatorWithFrequency_ReturnsFrequency)
 {
-  ViStatus viStatus;
-  ViConstString srcTerminal = NISYNC_VAL_OSCILLATOR;
-  ViReal64 duration = 0.1;       // duration is in seconds
-  ViUInt32 decimationCount = 0;  // ignored for 6674
-  ViReal64 actualDuration, frequency, frequencyError;
+  int32 viStatus;
+  const std::string& srcTerminal = NISYNC_VAL_OSCILLATOR;
+  double duration = 0.1;       // duration is in seconds
+  uint32 decimationCount = 0;  // ignored for 6674
+  double actualDuration, frequency, frequencyError;
   auto grpcStatus = call_MeasureFrequencyEx(
       srcTerminal,
       duration,
@@ -1085,9 +1090,9 @@ TEST_F(NiSyncDriver6674Test, MeasureFrequencyExOnOscillatorWithFrequency_Returns
 
 TEST_F(NiSyncDriver6683Test, GetTime_ReturnsTime)
 {
-  ViStatus viStatus;
-  ViUInt32 timeSeconds, timeNanoseconds;
-  ViUInt16 timeFractionalNanoseconds;
+  int32 viStatus;
+  uint32 timeSeconds, timeNanoseconds;
+  uint16 timeFractionalNanoseconds;
   auto grpcStatus = call_GetTime(
       &timeSeconds,
       &timeNanoseconds,
@@ -1096,13 +1101,13 @@ TEST_F(NiSyncDriver6683Test, GetTime_ReturnsTime)
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
-  EXPECT_GT(timeSeconds, (ViUInt32)0);
-  EXPECT_GT(timeNanoseconds, (ViUInt32)0);
+  EXPECT_GT(timeSeconds, (uint32)0);
+  EXPECT_GT(timeNanoseconds, (uint32)0);
 }
 
 TEST_F(NiSyncDriver6683Test, SetTimeReferenceFreeRunning_ReturnsSuccess)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto grpcStatus = call_SetTimeReferenceFreeRunning(&viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
@@ -1111,7 +1116,7 @@ TEST_F(NiSyncDriver6683Test, SetTimeReferenceFreeRunning_ReturnsSuccess)
 
 TEST_F(NiSyncDriver6683Test, SetTimeReferenceGPS_ReturnsSuccess)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto grpcStatus = call_SetTimeReferenceGPS(&viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
@@ -1120,7 +1125,7 @@ TEST_F(NiSyncDriver6683Test, SetTimeReferenceGPS_ReturnsSuccess)
 
 TEST_F(NiSyncDriver6683Test, SetTimeReferenceIRIG_ReturnsSuccess)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto grpcStatus = call_SetTimeReferenceIRIG(
       NISYNC_VAL_IRIG_TYPE_IRIGB_DC,  // irigType
       NISYNC_VAL_PFI0,                // terminalName
@@ -1132,7 +1137,7 @@ TEST_F(NiSyncDriver6683Test, SetTimeReferenceIRIG_ReturnsSuccess)
 
 TEST_F(NiSyncDriver6683Test, SetTimeReferenceIRIGWithInvalidTerminal_ReturnsError)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto grpcStatus = call_SetTimeReferenceIRIG(
       NISYNC_VAL_IRIG_TYPE_IRIGB_DC,  // irigType
       NISYNC_VAL_GND,                 // terminalName
@@ -1144,11 +1149,11 @@ TEST_F(NiSyncDriver6683Test, SetTimeReferenceIRIGWithInvalidTerminal_ReturnsErro
 
 TEST_F(NiSyncDriver6683Test, SetTimeReferencePPS_ReturnsSuccess)
 {
-  ViStatus viStatus;
-  ViUInt32 initialTimeSeconds = 30, initialTimeNanoseconds = 500;
+  int32 viStatus;
+  uint32 initialTimeSeconds = 30, initialTimeNanoseconds = 500;
   auto grpcStatus = call_SetTimeReferencePPS(
       NISYNC_VAL_PFI1,  // terminalName
-      VI_TRUE,          // useManualTime
+      true,             // useManualTime
       initialTimeSeconds,
       initialTimeNanoseconds,
       0,  // initialTimeFractionalNanoseconds, ignored
@@ -1167,11 +1172,11 @@ TEST_F(NiSyncDriver6683Test, SetTimeReferencePPS_ReturnsSuccess)
 
 TEST_F(NiSyncDriver6683Test, SetTimeReferencePPSWithInvalidTerminal_ReturnsError)
 {
-  ViStatus viStatus;
-  ViUInt32 initialTimeSeconds = 30, initialTimeNanoseconds = 500;
+  int32 viStatus;
+  uint32 initialTimeSeconds = 30, initialTimeNanoseconds = 500;
   auto grpcStatus = call_SetTimeReferencePPS(
       NISYNC_VAL_GND,  // terminalName
-      VI_TRUE,         // useManualTime
+      true,            // useManualTime
       initialTimeSeconds,
       initialTimeNanoseconds,
       0,  // initialTimeFractionalNanoseconds, ignored
@@ -1183,7 +1188,7 @@ TEST_F(NiSyncDriver6683Test, SetTimeReferencePPSWithInvalidTerminal_ReturnsError
 
 TEST_F(NiSyncDriver6683Test, SetTimeReference1588OrdinaryClock_ReturnsSuccess)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto grpcStatus = call_SetTimeReference1588OrdinaryClock(&viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
@@ -1193,7 +1198,7 @@ TEST_F(NiSyncDriver6683Test, SetTimeReference1588OrdinaryClock_ReturnsSuccess)
 TEST_F(NiSyncDriver6683Test, SetTimeReference8021AS_ReturnsSuccess)
 {
   // SetTimeReference8021AS is only supported in LinuxRT targets.
-  ViStatus viStatus;
+  int32 viStatus;
   auto grpcStatus = call_SetTimeReference8021AS(&viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
@@ -1207,8 +1212,8 @@ TEST_F(NiSyncDriver6683Test, SetTimeReference8021AS_ReturnsSuccess)
 
 TEST_F(NiSyncDriver6683Test, CreateClearFutureTimeEvent_ReturnsSuccess)
 {
-  ViStatus viStatusCreate;
-  ViUInt32 timeSeconds = GetCurrentBoardTimeSeconds() + 30;
+  int32 viStatusCreate;
+  uint32 timeSeconds = GetCurrentBoardTimeSeconds() + 30;
   auto grpcStatusCreate = call_CreateFutureTimeEvent(
       NISYNC_VAL_PFI1,       // terminalName
       NISYNC_VAL_LEVEL_LOW,  // outputLevel
@@ -1219,7 +1224,7 @@ TEST_F(NiSyncDriver6683Test, CreateClearFutureTimeEvent_ReturnsSuccess)
   EXPECT_TRUE(grpcStatusCreate.ok());
   EXPECT_EQ(VI_SUCCESS, viStatusCreate);
 
-  ViStatus viStatusClear;
+  int32 viStatusClear;
   auto grpcStatusClear = call_ClearFutureTimeEvents(
       NISYNC_VAL_PFI1,
       &viStatusClear);
@@ -1229,8 +1234,8 @@ TEST_F(NiSyncDriver6683Test, CreateClearFutureTimeEvent_ReturnsSuccess)
 
 TEST_F(NiSyncDriver6683Test, CreateFutureTimeEventWithInvalidTerminal_ReturnsError)
 {
-  ViStatus viStatus;
-  ViUInt32 timeSeconds = GetCurrentBoardTimeSeconds() + 30;
+  int32 viStatus;
+  uint32 timeSeconds = GetCurrentBoardTimeSeconds() + 30;
   auto grpcStatus = call_CreateFutureTimeEvent(
       NISYNC_VAL_GND,        // terminalName
       NISYNC_VAL_LEVEL_LOW,  // outputLevel
@@ -1250,7 +1255,7 @@ TEST_F(NiSyncDriver6683Test, CreateFutureTimeEventWithInvalidTerminal_ReturnsErr
 
 TEST_F(NiSyncDriver6683Test, ClearFutureTimeEventsNotReserved_ReturnsError)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto grpcStatus = call_ClearFutureTimeEvents(
       NISYNC_VAL_PFI1,  // terminalName
       &viStatus);
@@ -1261,10 +1266,10 @@ TEST_F(NiSyncDriver6683Test, ClearFutureTimeEventsNotReserved_ReturnsError)
 
 TEST_F(NiSyncDriver6683Test, CreateClearClock_ReturnsSuccess)
 {
-  ViStatus viStatusCreate;
-  ViUInt32 highTicks = 50, lowTicks = 50;
-  ViUInt32 startTimeSeconds = GetCurrentBoardTimeSeconds() + 30;
-  ViUInt32 stopTimeSeconds = startTimeSeconds + 30;
+  int32 viStatusCreate;
+  uint32 highTicks = 50, lowTicks = 50;
+  uint32 startTimeSeconds = GetCurrentBoardTimeSeconds() + 30;
+  uint32 stopTimeSeconds = startTimeSeconds + 30;
   auto grpcStatusCreate = call_CreateClock(
       NISYNC_VAL_PFI1,  // terminalName
       highTicks,
@@ -1279,7 +1284,7 @@ TEST_F(NiSyncDriver6683Test, CreateClearClock_ReturnsSuccess)
   EXPECT_TRUE(grpcStatusCreate.ok());
   EXPECT_EQ(VI_SUCCESS, viStatusCreate);
 
-  ViStatus viStatusClear;
+  int32 viStatusClear;
   auto grpcStatusClear = call_ClearClock(
       NISYNC_VAL_PFI1,
       &viStatusClear);
@@ -1289,10 +1294,10 @@ TEST_F(NiSyncDriver6683Test, CreateClearClock_ReturnsSuccess)
 
 TEST_F(NiSyncDriver6683Test, CreateClockWithInvalidTerminal_ReturnsError)
 {
-  ViStatus viStatus;
-  ViUInt32 highTicks = 50, lowTicks = 50;
-  ViUInt32 startTimeSeconds = GetCurrentBoardTimeSeconds() + 30;
-  ViUInt32 stopTimeSeconds = startTimeSeconds + 30;
+  int32 viStatus;
+  uint32 highTicks = 50, lowTicks = 50;
+  uint32 startTimeSeconds = GetCurrentBoardTimeSeconds() + 30;
+  uint32 stopTimeSeconds = startTimeSeconds + 30;
   auto grpcStatus = call_CreateClock(
       NISYNC_VAL_GND,  // terminalName
       highTicks,
@@ -1316,7 +1321,7 @@ TEST_F(NiSyncDriver6683Test, CreateClockWithInvalidTerminal_ReturnsError)
 
 TEST_F(NiSyncDriver6683Test, ClearClockNotReserved_ReturnsError)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto grpcStatus = call_ClearClock(
       NISYNC_VAL_PFI1,  // terminalName
       &viStatus);
@@ -1327,7 +1332,7 @@ TEST_F(NiSyncDriver6683Test, ClearClockNotReserved_ReturnsError)
 
 TEST_F(NiSyncDriver6683Test, GetTimeReferenceNames_ReturnsSuccess)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   std::string timeReferenceNames;
   auto grpcStatus = call_GetTimeReferenceNames(
       &timeReferenceNames,
@@ -1340,7 +1345,7 @@ TEST_F(NiSyncDriver6683Test, GetTimeReferenceNames_ReturnsSuccess)
 
 TEST_F(NiSyncDriver6683Test, EnableTimeStampTrigger_ReturnsSuccess)
 {
-  ViStatus viStatusEnable;
+  int32 viStatusEnable;
   auto grpcStatusEnable = call_EnableTimeStampTrigger(
       NISYNC_VAL_PFI1,         // terminalName
       NISYNC_VAL_EDGE_RISING,  // activeEdge
@@ -1348,7 +1353,7 @@ TEST_F(NiSyncDriver6683Test, EnableTimeStampTrigger_ReturnsSuccess)
   EXPECT_TRUE(grpcStatusEnable.ok());
   EXPECT_EQ(VI_SUCCESS, viStatusEnable);
 
-  ViStatus viStatusDisable;
+  int32 viStatusDisable;
   auto grpcStatusDisable = call_DisableTimeStampTrigger(
       NISYNC_VAL_PFI1,
       &viStatusDisable);
@@ -1358,7 +1363,7 @@ TEST_F(NiSyncDriver6683Test, EnableTimeStampTrigger_ReturnsSuccess)
 
 TEST_F(NiSyncDriver6683Test, EnableTimeStampTriggerWithInvalidTerminal_ReturnsError)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto grpcStatus = call_EnableTimeStampTrigger(
       NISYNC_VAL_GND,          // terminalName
       NISYNC_VAL_EDGE_RISING,  // activeEdge
@@ -1370,7 +1375,7 @@ TEST_F(NiSyncDriver6683Test, EnableTimeStampTriggerWithInvalidTerminal_ReturnsEr
 
 TEST_F(NiSyncDriver6683Test, DisableTimeStampTriggerNotReserved_ReturnsError)
 {
-  ViStatus viStatus;
+  int32 viStatus;
   auto grpcStatus = call_DisableTimeStampTrigger(
       NISYNC_VAL_PFI1,  // terminalName
       &viStatus);
@@ -1384,11 +1389,11 @@ TEST_F(NiSyncDriver6683Test, GivenNoTrigger_ReadTriggerTimeStamp_ReturnsTimeoutE
   auto terminal = NISYNC_VAL_PFI1;
   EnableTimeStampTrigger(terminal, NISYNC_VAL_EDGE_RISING);
 
-  ViStatus viStatusRead;
-  ViReal64 timeout = 0.1;
-  ViUInt32 timeSeconds, timeNanoseconds;
-  ViUInt16 timeFractionalNanoseconds;
-  ViInt32 detectedEdge;
+  int32 viStatusRead;
+  double timeout = 0.1;
+  uint32 timeSeconds, timeNanoseconds;
+  uint16 timeFractionalNanoseconds;
+  int32 detectedEdge;
   auto grpcStatusRead = call_ReadTriggerTimeStamp(
       terminal,
       timeout,
@@ -1407,13 +1412,13 @@ TEST_F(NiSyncDriver6683Test, GivenNoTrigger_ReadMultipleTriggerTimeStamp_Returns
   auto terminal = NISYNC_VAL_PFI1;
   EnableTimeStampTrigger(terminal, NISYNC_VAL_EDGE_RISING);
 
-  ViStatus viStatusRead;
-  ViReal64 timeout = 0.1;
-  ViUInt32 timestampsToRead = 1;
-  ViUInt32 timeSeconds, timeNanoseconds;
-  ViUInt16 timeFractionalNanoseconds;
-  ViInt32 detectedEdge;
-  ViUInt32 timestampsRead;
+  int32 viStatusRead;
+  double timeout = 0.1;
+  uint32 timestampsToRead = 1;
+  uint32 timeSeconds, timeNanoseconds;
+  uint16 timeFractionalNanoseconds;
+  int32 detectedEdge;
+  uint32 timestampsRead;
   auto grpcStatusRead = call_ReadMultipleTriggerTimeStamp(
       terminal,
       timeout,
@@ -1438,13 +1443,13 @@ TEST_F(NiSyncDriver6683Test, GivenOneTrigger_ReadMultipleTriggerTimeStamp_Return
   CreateFutureTimeEvent(terminal, NISYNC_VAL_LEVEL_HIGH, 0, 0, 0);
   CreateFutureTimeEvent(terminal, NISYNC_VAL_LEVEL_LOW, 0, 0, 0);
 
-  ViStatus viStatusRead;
-  ViReal64 timeout = 1.0;
-  const ViUInt32 timestampsToRead = 5;
-  ViUInt32 timeSeconds[timestampsToRead] = {}, timeNanoseconds[timestampsToRead] = {};
-  ViUInt16 timeFractionalNanoseconds[timestampsToRead] = {};
-  ViInt32 detectedEdge[timestampsToRead] = {};
-  ViUInt32 timestampsRead = 0;
+  int32 viStatusRead;
+  double timeout = 1.0;
+  const uint32 timestampsToRead = 5;
+  uint32 timeSeconds[timestampsToRead] = {}, timeNanoseconds[timestampsToRead] = {};
+  uint16 timeFractionalNanoseconds[timestampsToRead] = {};
+  int32 detectedEdge[timestampsToRead] = {};
+  uint32 timestampsRead = 0;
   auto grpcStatusRead = call_ReadMultipleTriggerTimeStamp(
       terminal,
       timeout,
@@ -1456,7 +1461,7 @@ TEST_F(NiSyncDriver6683Test, GivenOneTrigger_ReadMultipleTriggerTimeStamp_Return
       &timestampsRead,
       &viStatusRead);
 
-  const ViUInt32 expectedTimestampsRead = 1;
+  const uint32 expectedTimestampsRead = 1;
   EXPECT_TRUE(grpcStatusRead.ok());
   EXPECT_EQ(NISYNC_ERROR_DRIVER_TIMEOUT, viStatusRead);
   EXPECT_EQ(expectedTimestampsRead, timestampsRead);
@@ -1471,20 +1476,20 @@ TEST_F(NiSyncDriver6683Test, GivenFiveTriggers_ReadMultipleTriggerTimeStamp_Retu
   CreateFutureTimeEvent(terminal, NISYNC_VAL_LEVEL_LOW, 0, 0, 0);
   EnableTimeStampTrigger(terminal, NISYNC_VAL_EDGE_RISING);
   // Create 5 pulses
-  ViInt32 level = NISYNC_VAL_LEVEL_HIGH;
+  int32 level = NISYNC_VAL_LEVEL_HIGH;
   for (int i = 0; i < 10; ++i) {
     SCOPED_TRACE(::testing::Message("i=") << i);
     CreateFutureTimeEvent(terminal, level, 0, 0, 0);
     level = (level == NISYNC_VAL_LEVEL_LOW) ? NISYNC_VAL_LEVEL_HIGH : NISYNC_VAL_LEVEL_LOW;
   }
 
-  ViStatus viStatusRead;
-  ViReal64 timeout = 1.0;
-  const ViUInt32 timestampsToRead = 5;
-  ViUInt32 timeSeconds[timestampsToRead] = {}, timeNanoseconds[timestampsToRead] = {};
-  ViUInt16 timeFractionalNanoseconds[timestampsToRead] = {};
-  ViInt32 detectedEdge[timestampsToRead] = {};
-  ViUInt32 timestampsRead = 0;
+  int32 viStatusRead;
+  double timeout = 1.0;
+  const uint32 timestampsToRead = 5;
+  uint32 timeSeconds[timestampsToRead] = {}, timeNanoseconds[timestampsToRead] = {};
+  uint16 timeFractionalNanoseconds[timestampsToRead] = {};
+  int32 detectedEdge[timestampsToRead] = {};
+  uint32 timestampsRead = 0;
   auto grpcStatusRead = call_ReadMultipleTriggerTimeStamp(
       terminal,
       timeout,
@@ -1499,7 +1504,7 @@ TEST_F(NiSyncDriver6683Test, GivenFiveTriggers_ReadMultipleTriggerTimeStamp_Retu
   EXPECT_TRUE(grpcStatusRead.ok());
   EXPECT_EQ(VI_SUCCESS, viStatusRead);
   EXPECT_EQ(timestampsToRead, timestampsRead);
-  for (ViUInt32 i = 0; i < timestampsRead; ++i) {
+  for (uint32 i = 0; i < timestampsRead; ++i) {
     SCOPED_TRACE(::testing::Message("i=") << i);
     EXPECT_NE(0, timeSeconds[i]);
     EXPECT_EQ(NISYNC_VAL_EDGE_RISING, detectedEdge[i]);

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -42,6 +42,7 @@ constexpr auto NISYNC_ERROR_DRIVER_TIMEOUT = 0xBFFA400B;
 constexpr auto NISYNC_VAL_LEVEL_LOW = 0;
 constexpr auto NISYNC_VAL_LEVEL_HIGH = 1;
 constexpr auto NISYNC_ERROR_FEATURE_NOT_SUPPORTED = 0xBFFA4003;
+constexpr auto NISYNC_ERROR_DEST_TERMINAL_INVALID = 0xBFFA4033;
 constexpr auto VI_SUCCESS = 0;
 
 class NiSyncDriverApiTest : public ::testing::Test {

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -11,11 +11,11 @@ namespace system {
 
 namespace nisync = nisync_grpc;
 
-constexpr auto kSyncInvalidSrcTerminal = 0xBFFA4032;
-constexpr auto kTestSessionName = "TestSession";
-constexpr auto kEmptySessionName = "";
-constexpr auto kInvalidRsrcName = "InvalidName";
-constexpr auto kInvalidTerminal = "Invalid";
+constexpr auto INVALID_SOURCE_TERMINAL = 0xBFFA4032;
+constexpr auto SESSION_NAME = "TestSession";
+constexpr auto EMPTY_SESSION_NAME = "";
+constexpr auto INVALID_RESOURCE_NAME = "InvalidName";
+constexpr auto INVALID_TERMINAL = "Invalid";
 constexpr auto NISYNC_VAL_OSCILLATOR = "Oscillator";
 constexpr auto NISYNC_VAL_CLKOUT = "ClkOut";
 constexpr auto NISYNC_ERROR_SRC_TERMINAL_INVALID = 0xBFFA4032;
@@ -86,7 +86,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     nisync::InitRequest request;
     nisync::InitResponse response;
     request.set_resource_name(test_resource_name);
-    request.set_session_name(kTestSessionName);
+    request.set_session_name(SESSION_NAME);
     request.set_reset_device(false);
 
     ::grpc::Status status = GetStub()->Init(&context, request, &response);
@@ -733,7 +733,7 @@ TEST_F(NiSyncDriver6674Test, ConnectClkTerminals_ReturnsSuccess)
 TEST_F(NiSyncDriver6674Test, ConnectInvalidClkTerminals_ReturnsInvalidSrcTerminal)
 {
   ViStatus viStatus;
-  auto srcTerminal = kInvalidTerminal, destTerminal = NISYNC_VAL_CLKOUT;
+  auto srcTerminal = INVALID_TERMINAL, destTerminal = NISYNC_VAL_CLKOUT;
   auto grpcStatus = call_ConnectClkTerminals(srcTerminal, destTerminal, &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
@@ -794,7 +794,7 @@ TEST_F(NiSyncDriver6674Test, ConnectSWTrigToTerminal_ReturnsSuccess)
 TEST_F(NiSyncDriver6674Test, ConnectInvalidSWTrigToTerminal_ReturnsInvalidSrcTerminal)
 {
   ViStatus viStatus;
-  auto srcTerminal = kInvalidTerminal, destTerminal = NISYNC_VAL_PXIEDSTARC;
+  auto srcTerminal = INVALID_TERMINAL, destTerminal = NISYNC_VAL_PXIEDSTARC;
   auto syncClock = NISYNC_VAL_SYNC_CLK_FULLSPEED;
   ViInt32 invert = VI_TRUE, updateEdge = VI_FALSE;
   ViReal64 delay = 0;
@@ -808,7 +808,7 @@ TEST_F(NiSyncDriver6674Test, ConnectInvalidSWTrigToTerminal_ReturnsInvalidSrcTer
       &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
-  EXPECT_EQ(kSyncInvalidSrcTerminal, viStatus);
+  EXPECT_EQ(INVALID_SOURCE_TERMINAL, viStatus);
 }
 
 TEST_F(NiSyncDriver6674Test, ConnectedSWTrigToTerminal_DisconnectSWTrigFromTerminal_ReturnsSuccess)
@@ -874,7 +874,7 @@ TEST_F(NiSyncDriver6674Test, SendSoftwareTrigger_ReturnsSuccess)
 TEST_F(NiSyncDriver6674Test, SendSoftwareTriggerOnInvalidTerminal_ReturnsInvalidSrcTerminal)
 {
   ViStatus viStatus;
-  auto srcTerminal = kInvalidTerminal;
+  auto srcTerminal = INVALID_TERMINAL;
   auto grpcStatus = call_SendSoftwareTrigger(srcTerminal, &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
@@ -903,7 +903,7 @@ TEST_F(NiSyncDriver6674Test, ConnectTrigTerminals_ReturnsSuccess)
 TEST_F(NiSyncDriver6674Test, ConnectInvalidTrigTerminals_ReturnsInvalidSrcTerminal)
 {
   ViStatus viStatus;
-  auto srcTerminal = kInvalidTerminal, destTerminal = NISYNC_VAL_CLKOUT;
+  auto srcTerminal = INVALID_TERMINAL, destTerminal = NISYNC_VAL_CLKOUT;
   auto syncClock = NISYNC_VAL_SYNC_CLK_ASYNC;
   ViInt32 invert = VI_FALSE, updateEdge = VI_FALSE;
   auto grpcStatus = call_ConnectTrigTerminals(
@@ -915,7 +915,7 @@ TEST_F(NiSyncDriver6674Test, ConnectInvalidTrigTerminals_ReturnsInvalidSrcTermin
       &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
-  EXPECT_EQ(kSyncInvalidSrcTerminal, viStatus);
+  EXPECT_EQ(INVALID_SOURCE_TERMINAL, viStatus);
 }
 
 TEST_F(NiSyncDriver6674Test, ConnectedTrigTerminals_DisconnectTrigTerminals_ReturnsSuccess)

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -1,8 +1,9 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "nisync/nisync_service.h"
 #include "enumerate_devices.h"
+#include "ivi.h"
+#include "nisync/nisync_client.h"
 
 namespace ni {
 namespace tests {
@@ -10,11 +11,33 @@ namespace system {
 
 namespace nisync = nisync_grpc;
 
-static const ViStatus kSyncInvalidSrcTerminal = 0xBFFA4032;
-static const char* kTestSessionName = "TestSession";
-static const char* kEmptySessionName = "";
-static const char* kInvalidRsrcName = "InvalidName";
-static const char* kInvalidTerminal = "Invalid";
+constexpr auto kSyncInvalidSrcTerminal = 0xBFFA4032;
+constexpr auto kTestSessionName = "TestSession";
+constexpr auto kEmptySessionName = "";
+constexpr auto kInvalidRsrcName = "InvalidName";
+constexpr auto kInvalidTerminal = "Invalid";
+constexpr auto NISYNC_VAL_OSCILLATOR = "Oscillator";
+constexpr auto NISYNC_VAL_CLKOUT = "ClkOut";
+constexpr auto NISYNC_ERROR_SRC_TERMINAL_INVALID = 0xBFFA4032;
+constexpr auto NISYNC_VAL_CLKIN = "ClkIn";
+constexpr auto NISYNC_VAL_SWTRIG_GLOBAL = "GlobalSorftwareTrigger";
+constexpr auto NISYNC_VAL_PXIEDSTARC = "PXIe_DStarC";
+constexpr auto NISYNC_VAL_SYNC_CLK_FULLSPEED = "SyncClkFullSpeed";
+constexpr auto NISYNC_VAL_CLK100 = "PXIe_Clk100";
+constexpr auto NISYNC_VAL_PFI0 = "PFI0";
+constexpr auto NISYNC_VAL_PFI1 = "PFI1";
+constexpr auto NISYNC_VAL_SYNC_CLK_ASYNC = "SyncClkAsync";
+constexpr auto NISYNC_VAL_1588_CLK_ACCURACY_WITHIN_1_USEC = 4;
+constexpr auto NISYNC_VAL_CLK10 = "PXI_Clk10";
+constexpr auto NISYNC_VAL_IRIG_TYPE_IRIGB_DC = 0;
+constexpr auto NISYNC_VAL_GND = "Ground";
+constexpr auto NISYNC_ERROR_TERMINAL_INVALID = 0xBFFA4036;
+constexpr auto NISYNC_ERROR_RSRC_NOT_RESERVED = 0xBFFA4048;
+constexpr auto NISYNC_VAL_EDGE_RISING = 0;
+constexpr auto NISYNC_ERROR_DRIVER_TIMEOUT = 0xBFFA400B;
+constexpr auto NISYNC_VAL_LEVEL_LOW = 0;
+constexpr auto NISYNC_VAL_LEVEL_HIGH = 1;
+constexpr auto NISYNC_ERROR_FEATURE_NOT_SUPPORTED = 0xBFFA4003;
 
 class NiSyncDriverApiTest : public ::testing::Test {
  protected:
@@ -33,7 +56,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
 
   void SetUp() override
   {
-    for(const auto& device : EnumerateDevices()) {
+    for (const auto& device : EnumerateDevices()) {
       if (device.model() == get_model_name()) {
         test_resource_name = device.name();
         break;
@@ -101,7 +124,6 @@ class NiSyncDriverApiTest : public ::testing::Test {
     return grpcStatus;
   }
 
-
   ::grpc::Status call_SendSoftwareTrigger(ViConstString srcTerminal, ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
@@ -141,13 +163,13 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_ConnectSWTrigToTerminal(
-    ViConstString srcTerminal,
-    ViConstString destTerminal,
-    ViConstString syncClock,
-    ViInt32 invert,
-    ViInt32 updateEdge,
-    ViReal64 delay,
-    ViStatus* viStatusOut)
+      ViConstString srcTerminal,
+      ViConstString destTerminal,
+      ViConstString syncClock,
+      ViInt32 invert,
+      ViInt32 updateEdge,
+      ViReal64 delay,
+      ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::ConnectSWTrigToTerminalRequest request;
@@ -178,12 +200,12 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_ConnectTrigTerminals(
-    ViConstString srcTerminal,
-    ViConstString destTerminal,
-    ViConstString syncClock,
-    ViInt32 invert,
-    ViInt32 updateEdge,
-    ViStatus* viStatusOut)
+      ViConstString srcTerminal,
+      ViConstString destTerminal,
+      ViConstString syncClock,
+      ViInt32 invert,
+      ViInt32 updateEdge,
+      ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::ConnectTrigTerminalsRequest request;
@@ -325,13 +347,13 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_MeasureFrequencyEx(
-     ViConstString srcTerminal,
-     ViReal64 duration,
-     ViUInt32 decimationCount,
-     ViReal64* actualDurationOut,
-     ViReal64* frequencyOut,
-     ViReal64* frequencyErrorOut,
-     ViStatus* viStatusOut)
+      ViConstString srcTerminal,
+      ViReal64 duration,
+      ViUInt32 decimationCount,
+      ViReal64* actualDurationOut,
+      ViReal64* frequencyOut,
+      ViReal64* frequencyErrorOut,
+      ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::MeasureFrequencyExRequest request;
@@ -349,10 +371,10 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_GetTime(
-     ViUInt32* timeSeconds,
-     ViUInt32* timeNanoseconds,
-     ViUInt16* timeFractionalNanoseconds,
-     ViStatus* viStatusOut)
+      ViUInt32* timeSeconds,
+      ViUInt32* timeNanoseconds,
+      ViUInt16* timeFractionalNanoseconds,
+      ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::GetTimeRequest request;
@@ -389,9 +411,9 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_SetTimeReferenceIRIG(
-     ViInt32 irigType,
-     ViConstString terminalName,
-     ViStatus* viStatusOut)
+      ViInt32 irigType,
+      ViConstString terminalName,
+      ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::SetTimeReferenceIRIGRequest request;
@@ -405,12 +427,12 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_SetTimeReferencePPS(
-     ViConstString terminalName,
-     ViBoolean useManualTime,
-     ViUInt32 initialTimeSeconds,
-     ViUInt32 initialTimeNanoseconds,
-     ViUInt16 initialTimeFractionalNanoseconds,
-     ViStatus* viStatusOut)
+      ViConstString terminalName,
+      ViBoolean useManualTime,
+      ViUInt32 initialTimeSeconds,
+      ViUInt32 initialTimeNanoseconds,
+      ViUInt16 initialTimeFractionalNanoseconds,
+      ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::SetTimeReferencePPSRequest request;
@@ -449,12 +471,12 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_CreateFutureTimeEvent(
-     ViConstString terminal,
-     ViInt32 outputLevel,
-     ViUInt32 timeSeconds,
-     ViUInt32 timeNanoseconds,
-     ViUInt16 timeFractionalNanoseconds,
-     ViStatus* viStatusOut)
+      ViConstString terminal,
+      ViInt32 outputLevel,
+      ViUInt32 timeSeconds,
+      ViUInt32 timeNanoseconds,
+      ViUInt16 timeFractionalNanoseconds,
+      ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::CreateFutureTimeEventRequest request;
@@ -471,27 +493,27 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   void CreateFutureTimeEvent(
-     ViConstString terminal,
-     ViInt32 outputLevel,
-     ViUInt32 timeSeconds,
-     ViUInt32 timeNanoseconds,
-     ViUInt16 timeFractionalNanoseconds)
+      ViConstString terminal,
+      ViInt32 outputLevel,
+      ViUInt32 timeSeconds,
+      ViUInt32 timeNanoseconds,
+      ViUInt16 timeFractionalNanoseconds)
   {
     ViStatus viStatus;
     auto grpcStatus = call_CreateFutureTimeEvent(
-      terminal,
-      outputLevel,
-      timeSeconds,
-      timeNanoseconds,
-      timeFractionalNanoseconds,
-      &viStatus);
+        terminal,
+        outputLevel,
+        timeSeconds,
+        timeNanoseconds,
+        timeFractionalNanoseconds,
+        &viStatus);
     ASSERT_TRUE(grpcStatus.ok());
     ASSERT_EQ(VI_SUCCESS, viStatus);
   }
 
   ::grpc::Status call_ClearFutureTimeEvents(
-     ViConstString terminal,
-     ViStatus* viStatusOut)
+      ViConstString terminal,
+      ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::ClearFutureTimeEventsRequest request;
@@ -504,16 +526,16 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_CreateClock(
-     ViConstString terminal,
-     ViUInt32 highTicks,
-     ViUInt32 lowTicks,
-     ViUInt32 startTimeSeconds,
-     ViUInt32 startTimeNanoseconds,
-     ViUInt16 startTimeFractionalNanoseconds,
-     ViUInt32 stopTimeSeconds,
-     ViUInt32 stopTimeNanoseconds,
-     ViUInt16 stopTimeFractionalNanoseconds,
-     ViStatus* viStatusOut)
+      ViConstString terminal,
+      ViUInt32 highTicks,
+      ViUInt32 lowTicks,
+      ViUInt32 startTimeSeconds,
+      ViUInt32 startTimeNanoseconds,
+      ViUInt16 startTimeFractionalNanoseconds,
+      ViUInt32 stopTimeSeconds,
+      ViUInt32 stopTimeNanoseconds,
+      ViUInt16 stopTimeFractionalNanoseconds,
+      ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::CreateClockRequest request;
@@ -534,8 +556,8 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_ClearClock(
-     ViConstString terminal,
-     ViStatus* viStatusOut)
+      ViConstString terminal,
+      ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::ClearClockRequest request;
@@ -548,8 +570,8 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_GetTimeReferenceNames(
-     std::string* valueOut,
-     ViStatus* viStatusOut)
+      std::string* valueOut,
+      ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::GetTimeReferenceNamesRequest request;
@@ -562,9 +584,9 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_EnableTimeStampTrigger(
-     ViConstString terminal,
-     ViInt32 activeEdge,
-     ViStatus* viStatusOut)
+      ViConstString terminal,
+      ViInt32 activeEdge,
+      ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::EnableTimeStampTriggerRequest request;
@@ -578,8 +600,8 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   void EnableTimeStampTrigger(
-     ViConstString terminal,
-     ViInt32 activeEdge)
+      ViConstString terminal,
+      ViInt32 activeEdge)
   {
     ViStatus viStatus;
     auto grpcStatus = call_EnableTimeStampTrigger(terminal, activeEdge, &viStatus);
@@ -588,13 +610,13 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_ReadTriggerTimeStamp(
-     ViConstString terminal,
-     ViReal64 timeout,
-     ViUInt32* timeSeconds,
-     ViUInt32* timeNanoseconds,
-     ViUInt16* timeFractionalNanoseconds,
-     ViInt32* detectedEdge,
-     ViStatus* viStatusOut)
+      ViConstString terminal,
+      ViReal64 timeout,
+      ViUInt32* timeSeconds,
+      ViUInt32* timeNanoseconds,
+      ViUInt16* timeFractionalNanoseconds,
+      ViInt32* detectedEdge,
+      ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::ReadTriggerTimeStampRequest request;
@@ -612,15 +634,15 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_ReadMultipleTriggerTimeStamp(
-     ViConstString terminal,
-     ViReal64 timeout,
-     ViUInt32 timestampsToRead,
-     ViUInt32* timeSecondsBuffer,
-     ViUInt32* timeNanosecondsBuffer,
-     ViUInt16* timeFractionalNanosecondsBuffer,
-     ViInt32* detectedEdgeBuffer,
-     ViUInt32* timestampsRead,
-     ViStatus* viStatusOut)
+      ViConstString terminal,
+      ViReal64 timeout,
+      ViUInt32 timestampsToRead,
+      ViUInt32* timeSecondsBuffer,
+      ViUInt32* timeNanosecondsBuffer,
+      ViUInt16* timeFractionalNanosecondsBuffer,
+      ViInt32* detectedEdgeBuffer,
+      ViUInt32* timestampsRead,
+      ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::ReadMultipleTriggerTimeStampRequest request;
@@ -640,8 +662,8 @@ class NiSyncDriverApiTest : public ::testing::Test {
   }
 
   ::grpc::Status call_DisableTimeStampTrigger(
-     ViConstString terminal,
-     ViStatus* viStatusOut)
+      ViConstString terminal,
+      ViStatus* viStatusOut)
   {
     ::grpc::ClientContext clientContext;
     nisync::DisableTimeStampTriggerRequest request;
@@ -659,31 +681,29 @@ class NiSyncDriverApiTest : public ::testing::Test {
     ViUInt32 timeSeconds = 0, timeNanoseconds;
     ViUInt16 timeFractionalNanoseconds;
     auto grpcStatus = call_GetTime(
-      &timeSeconds,
-      &timeNanoseconds, // ignored
-      &timeFractionalNanoseconds, // ignored
-      &viStatus);
+        &timeSeconds,
+        &timeNanoseconds,            // ignored
+        &timeFractionalNanoseconds,  // ignored
+        &viStatus);
     EXPECT_TRUE(grpcStatus.ok());
     EXPECT_EQ(VI_SUCCESS, viStatus);
     return timeSeconds;
   }
 
-private:
+ private:
   DeviceServerInterface* device_server_;
   std::unique_ptr<::nidevice_grpc::Session> driver_session_;
   std::unique_ptr<nisync::NiSync::Stub> nisync_stub_;
 };
 
-class NiSyncDriver6674Test : public NiSyncDriverApiTest
-{
-public:
+class NiSyncDriver6674Test : public NiSyncDriverApiTest {
+ public:
   NiSyncDriver6674Test() : NiSyncDriverApiTest() {}
   const char* get_model_name() const override { return "NI PXIe-6674T"; }
 };
 
-class NiSyncDriver6683Test : public NiSyncDriverApiTest
-{
-public:
+class NiSyncDriver6683Test : public NiSyncDriverApiTest {
+ public:
   NiSyncDriver6683Test() : NiSyncDriverApiTest() {}
   const char* get_model_name() const override { return "NI PXI-6683H"; }
 };
@@ -758,13 +778,13 @@ TEST_F(NiSyncDriver6674Test, ConnectSWTrigToTerminal_ReturnsSuccess)
   ViInt32 invert = VI_TRUE, updateEdge = VI_FALSE;
   ViReal64 delay = 0;
   auto grpcStatus = call_ConnectSWTrigToTerminal(
-    srcTerminal,
-    destTerminal,
-    syncClock,
-    invert,
-    updateEdge,
-    delay,
-    &viStatus);
+      srcTerminal,
+      destTerminal,
+      syncClock,
+      invert,
+      updateEdge,
+      delay,
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
@@ -779,13 +799,13 @@ TEST_F(NiSyncDriver6674Test, ConnectInvalidSWTrigToTerminal_ReturnsInvalidSrcTer
   ViInt32 invert = VI_TRUE, updateEdge = VI_FALSE;
   ViReal64 delay = 0;
   auto grpcStatus = call_ConnectSWTrigToTerminal(
-    srcTerminal,
-    destTerminal,
-    syncClock,
-    invert,
-    updateEdge,
-    delay,
-    &viStatus);
+      srcTerminal,
+      destTerminal,
+      syncClock,
+      invert,
+      updateEdge,
+      delay,
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(kSyncInvalidSrcTerminal, viStatus);
@@ -799,13 +819,13 @@ TEST_F(NiSyncDriver6674Test, ConnectedSWTrigToTerminal_DisconnectSWTrigFromTermi
   ViInt32 invert = VI_TRUE, updateEdge = VI_FALSE;
   ViReal64 delay = 0;
   auto grpcStatus = call_ConnectSWTrigToTerminal(
-    srcTerminal,
-    destTerminal,
-    syncClock,
-    invert,
-    updateEdge,
-    delay,
-    &viStatus);
+      srcTerminal,
+      destTerminal,
+      syncClock,
+      invert,
+      updateEdge,
+      delay,
+      &viStatus);
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
 
@@ -823,13 +843,13 @@ TEST_F(NiSyncDriver6674Test, SWTrigConnectedToTerminal_DisconnectSWTrigFromNotCo
   ViInt32 invert = VI_TRUE, updateEdge = VI_FALSE;
   ViReal64 delay = 0;
   auto grpcStatus = call_ConnectSWTrigToTerminal(
-    srcTerminal,
-    destTerminal,
-    syncClock,
-    invert,
-    updateEdge,
-    delay,
-    &viStatus);
+      srcTerminal,
+      destTerminal,
+      syncClock,
+      invert,
+      updateEdge,
+      delay,
+      &viStatus);
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
 
@@ -868,12 +888,12 @@ TEST_F(NiSyncDriver6674Test, ConnectTrigTerminals_ReturnsSuccess)
   auto syncClock = NISYNC_VAL_SYNC_CLK_ASYNC;
   ViInt32 invert = VI_FALSE, updateEdge = VI_FALSE;
   auto grpcStatus = call_ConnectTrigTerminals(
-    srcTerminal,
-    destTerminal,
-    syncClock,
-    invert,
-    updateEdge,
-    &viStatus);
+      srcTerminal,
+      destTerminal,
+      syncClock,
+      invert,
+      updateEdge,
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
@@ -887,12 +907,12 @@ TEST_F(NiSyncDriver6674Test, ConnectInvalidTrigTerminals_ReturnsInvalidSrcTermin
   auto syncClock = NISYNC_VAL_SYNC_CLK_ASYNC;
   ViInt32 invert = VI_FALSE, updateEdge = VI_FALSE;
   auto grpcStatus = call_ConnectTrigTerminals(
-    srcTerminal,
-    destTerminal,
-    syncClock,
-    invert,
-    updateEdge,
-    &viStatus);
+      srcTerminal,
+      destTerminal,
+      syncClock,
+      invert,
+      updateEdge,
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(kSyncInvalidSrcTerminal, viStatus);
@@ -905,12 +925,12 @@ TEST_F(NiSyncDriver6674Test, ConnectedTrigTerminals_DisconnectTrigTerminals_Retu
   auto syncClock = NISYNC_VAL_SYNC_CLK_ASYNC;
   ViInt32 invert = VI_FALSE, updateEdge = VI_FALSE;
   auto grpcStatus = call_ConnectTrigTerminals(
-    srcTerminal,
-    destTerminal,
-    syncClock,
-    invert,
-    updateEdge,
-    &viStatus);
+      srcTerminal,
+      destTerminal,
+      syncClock,
+      invert,
+      updateEdge,
+      &viStatus);
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
 
@@ -927,12 +947,12 @@ TEST_F(NiSyncDriver6674Test, NotConnectedTrigTerminals_DisconnectSWTrigFromTermi
   auto syncClock = NISYNC_VAL_SYNC_CLK_ASYNC;
   ViInt32 invert = VI_FALSE, updateEdge = VI_FALSE;
   auto grpcStatus = call_ConnectTrigTerminals(
-    srcTerminal,
-    destTerminal,
-    syncClock,
-    invert,
-    updateEdge,
-    &viStatus);
+      srcTerminal,
+      destTerminal,
+      syncClock,
+      invert,
+      updateEdge,
+      &viStatus);
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
 
@@ -948,7 +968,7 @@ TEST_F(NiSyncDriver6674Test, AttributeSet_GetAttributeViInt32_ReturnsValue)
 {
   ViStatus viStatus;
   auto activeItem = "";
-  ViAttr attribute = NISYNC_ATTR_SYNC_CLK_DIV1;
+  ViAttr attribute = nisync_grpc::NISYNC_ATTRIBUTE_SYNC_CLK_DIV1;
   ViInt32 expectedValue = NISYNC_VAL_1588_CLK_ACCURACY_WITHIN_1_USEC;
   auto grpcStatus = call_SetAttributeViInt32(activeItem, attribute, expectedValue, &viStatus);
   EXPECT_TRUE(grpcStatus.ok());
@@ -966,7 +986,7 @@ TEST_F(NiSyncDriver6674Test, AttributeSet_GetAttributeViString_ReturnsValue)
 {
   ViStatus viStatus;
   auto activeItem = "";
-  ViAttr attribute = NISYNC_ATTR_FRONT_SYNC_CLK_SRC;
+  ViAttr attribute = nisync_grpc::NISYNC_ATTRIBUTE_FRONT_SYNC_CLK_SRC;
   ViConstString expectedValue = NISYNC_VAL_CLK10;
   auto grpcStatus = call_SetAttributeViString(activeItem, attribute, expectedValue, &viStatus);
   EXPECT_TRUE(grpcStatus.ok());
@@ -984,7 +1004,7 @@ TEST_F(NiSyncDriver6674Test, AttributeSet_GetAttributeViBoolean_ReturnsValue)
 {
   ViStatus viStatus;
   auto activeItem = "";
-  ViAttr attribute = NISYNC_ATTR_CLKIN_ATTENUATION_DISABLE;
+  ViAttr attribute = nisync_grpc::NISYNC_ATTRIBUTE_CLKIN_ATTENUATION_DISABLE;
   ViBoolean expectedValue = VI_TRUE;
   auto grpcStatus = call_SetAttributeViBoolean(activeItem, attribute, expectedValue, &viStatus);
   EXPECT_TRUE(grpcStatus.ok());
@@ -1002,7 +1022,7 @@ TEST_F(NiSyncDriver6674Test, AttributeSet_GetAttributeViReal64_ReturnsValue)
 {
   ViStatus viStatus;
   auto activeItem = "";
-  ViAttr attribute = NISYNC_ATTR_PFI0_THRESHOLD;
+  ViAttr attribute = nisync_grpc::NISYNC_ATTRIBUTE_PFI0_THRESHOLD;
   ViReal64 expectedValue = 2.3;
   auto grpcStatus = call_SetAttributeViReal64(activeItem, attribute, expectedValue, &viStatus);
   EXPECT_TRUE(grpcStatus.ok());
@@ -1023,17 +1043,17 @@ TEST_F(NiSyncDriver6674Test, MeasureFrequencyExOnTerminalWithNoFrequency_Returns
 {
   ViStatus viStatus;
   ViConstString srcTerminal = NISYNC_VAL_PFI0;
-  ViReal64 duration = 0.1; // duration is in seconds
-  ViUInt32 decimationCount = 0; // ignored for 6674
+  ViReal64 duration = 0.1;       // duration is in seconds
+  ViUInt32 decimationCount = 0;  // ignored for 6674
   ViReal64 actualDuration, frequency, frequencyError;
   auto grpcStatus = call_MeasureFrequencyEx(
-     srcTerminal,
-     duration,
-     decimationCount,
-     &actualDuration,
-     &frequency,
-     &frequencyError,
-     &viStatus);
+      srcTerminal,
+      duration,
+      decimationCount,
+      &actualDuration,
+      &frequency,
+      &frequencyError,
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
@@ -1045,21 +1065,21 @@ TEST_F(NiSyncDriver6674Test, MeasureFrequencyExOnOscillatorWithFrequency_Returns
 {
   ViStatus viStatus;
   ViConstString srcTerminal = NISYNC_VAL_OSCILLATOR;
-  ViReal64 duration = 0.1; // duration is in seconds
-  ViUInt32 decimationCount = 0; // ignored for 6674
+  ViReal64 duration = 0.1;       // duration is in seconds
+  ViUInt32 decimationCount = 0;  // ignored for 6674
   ViReal64 actualDuration, frequency, frequencyError;
   auto grpcStatus = call_MeasureFrequencyEx(
-     srcTerminal,
-     duration,
-     decimationCount,
-     &actualDuration,
-     &frequency,
-     &frequencyError,
-     &viStatus);
+      srcTerminal,
+      duration,
+      decimationCount,
+      &actualDuration,
+      &frequency,
+      &frequencyError,
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
-  EXPECT_GT(actualDuration, 0);  
+  EXPECT_GT(actualDuration, 0);
   EXPECT_GT(frequency, 0);
 }
 
@@ -1069,14 +1089,14 @@ TEST_F(NiSyncDriver6683Test, GetTime_ReturnsTime)
   ViUInt32 timeSeconds, timeNanoseconds;
   ViUInt16 timeFractionalNanoseconds;
   auto grpcStatus = call_GetTime(
-     &timeSeconds, 
-     &timeNanoseconds, 
-     &timeFractionalNanoseconds, // ignored
-     &viStatus);
+      &timeSeconds,
+      &timeNanoseconds,
+      &timeFractionalNanoseconds,  // ignored
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
-  EXPECT_GT(timeSeconds, (ViUInt32)0);  
+  EXPECT_GT(timeSeconds, (ViUInt32)0);
   EXPECT_GT(timeNanoseconds, (ViUInt32)0);
 }
 
@@ -1102,9 +1122,9 @@ TEST_F(NiSyncDriver6683Test, SetTimeReferenceIRIG_ReturnsSuccess)
 {
   ViStatus viStatus;
   auto grpcStatus = call_SetTimeReferenceIRIG(
-     NISYNC_VAL_IRIG_TYPE_IRIGB_DC, // irigType
-     NISYNC_VAL_PFI0, // terminalName
-     &viStatus);
+      NISYNC_VAL_IRIG_TYPE_IRIGB_DC,  // irigType
+      NISYNC_VAL_PFI0,                // terminalName
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
@@ -1114,9 +1134,9 @@ TEST_F(NiSyncDriver6683Test, SetTimeReferenceIRIGWithInvalidTerminal_ReturnsErro
 {
   ViStatus viStatus;
   auto grpcStatus = call_SetTimeReferenceIRIG(
-     NISYNC_VAL_IRIG_TYPE_IRIGB_DC, // irigType
-     NISYNC_VAL_GND, // terminalName
-     &viStatus);
+      NISYNC_VAL_IRIG_TYPE_IRIGB_DC,  // irigType
+      NISYNC_VAL_GND,                 // terminalName
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(NISYNC_ERROR_TERMINAL_INVALID, viStatus);
@@ -1127,12 +1147,12 @@ TEST_F(NiSyncDriver6683Test, SetTimeReferencePPS_ReturnsSuccess)
   ViStatus viStatus;
   ViUInt32 initialTimeSeconds = 30, initialTimeNanoseconds = 500;
   auto grpcStatus = call_SetTimeReferencePPS(
-     NISYNC_VAL_PFI1, // terminalName
-     VI_TRUE, // useManualTime
-     initialTimeSeconds,
-     initialTimeNanoseconds,
-     0, // initialTimeFractionalNanoseconds, ignored
-     &viStatus);
+      NISYNC_VAL_PFI1,  // terminalName
+      VI_TRUE,          // useManualTime
+      initialTimeSeconds,
+      initialTimeNanoseconds,
+      0,  // initialTimeFractionalNanoseconds, ignored
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(VI_SUCCESS, viStatus);
@@ -1150,12 +1170,12 @@ TEST_F(NiSyncDriver6683Test, SetTimeReferencePPSWithInvalidTerminal_ReturnsError
   ViStatus viStatus;
   ViUInt32 initialTimeSeconds = 30, initialTimeNanoseconds = 500;
   auto grpcStatus = call_SetTimeReferencePPS(
-     NISYNC_VAL_GND, // terminalName
-     VI_TRUE, // useManualTime
-     initialTimeSeconds,
-     initialTimeNanoseconds,
-     0, // initialTimeFractionalNanoseconds, ignored
-     &viStatus);
+      NISYNC_VAL_GND,  // terminalName
+      VI_TRUE,         // useManualTime
+      initialTimeSeconds,
+      initialTimeNanoseconds,
+      0,  // initialTimeFractionalNanoseconds, ignored
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(NISYNC_ERROR_TERMINAL_INVALID, viStatus);
@@ -1177,12 +1197,12 @@ TEST_F(NiSyncDriver6683Test, SetTimeReference8021AS_ReturnsSuccess)
   auto grpcStatus = call_SetTimeReference8021AS(&viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
-  #if defined(_MSC_VER)
+#if defined(_MSC_VER)
   // SetTimeReference8021AS is only supported on Linux RT targets.
   EXPECT_EQ(NISYNC_ERROR_FEATURE_NOT_SUPPORTED, viStatus);
-  #else
+#else
   EXPECT_EQ(VI_SUCCESS, viStatus);
-  #endif
+#endif
 }
 
 TEST_F(NiSyncDriver6683Test, CreateClearFutureTimeEvent_ReturnsSuccess)
@@ -1190,19 +1210,19 @@ TEST_F(NiSyncDriver6683Test, CreateClearFutureTimeEvent_ReturnsSuccess)
   ViStatus viStatusCreate;
   ViUInt32 timeSeconds = GetCurrentBoardTimeSeconds() + 30;
   auto grpcStatusCreate = call_CreateFutureTimeEvent(
-     NISYNC_VAL_PFI1, // terminalName
-     NISYNC_VAL_LEVEL_LOW, // outputLevel
-     timeSeconds,
-     0, // timeNanoseconds, ignored
-     0, // timeFractionalNanoseconds, ignored
-     &viStatusCreate);
+      NISYNC_VAL_PFI1,       // terminalName
+      NISYNC_VAL_LEVEL_LOW,  // outputLevel
+      timeSeconds,
+      0,  // timeNanoseconds, ignored
+      0,  // timeFractionalNanoseconds, ignored
+      &viStatusCreate);
   EXPECT_TRUE(grpcStatusCreate.ok());
   EXPECT_EQ(VI_SUCCESS, viStatusCreate);
 
   ViStatus viStatusClear;
   auto grpcStatusClear = call_ClearFutureTimeEvents(
-     NISYNC_VAL_PFI1,
-     &viStatusClear);
+      NISYNC_VAL_PFI1,
+      &viStatusClear);
   EXPECT_TRUE(grpcStatusClear.ok());
   EXPECT_EQ(VI_SUCCESS, viStatusClear);
 }
@@ -1212,28 +1232,28 @@ TEST_F(NiSyncDriver6683Test, CreateFutureTimeEventWithInvalidTerminal_ReturnsErr
   ViStatus viStatus;
   ViUInt32 timeSeconds = GetCurrentBoardTimeSeconds() + 30;
   auto grpcStatus = call_CreateFutureTimeEvent(
-     NISYNC_VAL_GND, // terminalName
-     NISYNC_VAL_LEVEL_LOW, // outputLevel
-     timeSeconds,
-     0, // timeNanoseconds, ignored
-     0, // timeFractionalNanoseconds, ignored
-     &viStatus);
+      NISYNC_VAL_GND,        // terminalName
+      NISYNC_VAL_LEVEL_LOW,  // outputLevel
+      timeSeconds,
+      0,  // timeNanoseconds, ignored
+      0,  // timeFractionalNanoseconds, ignored
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
-  // Bug 1462752: 6683 CreateFutureTimeEvent has different error behavior on Linux RT
-  #if defined(_MSC_VER)
+// Bug 1462752: 6683 CreateFutureTimeEvent has different error behavior on Linux RT
+#if defined(_MSC_VER)
   EXPECT_EQ(NISYNC_ERROR_TERMINAL_INVALID, viStatus);
-  #else
+#else
   EXPECT_EQ(NISYNC_ERROR_DEST_TERMINAL_INVALID, viStatus);
-  #endif
+#endif
 }
 
 TEST_F(NiSyncDriver6683Test, ClearFutureTimeEventsNotReserved_ReturnsError)
 {
   ViStatus viStatus;
   auto grpcStatus = call_ClearFutureTimeEvents(
-     NISYNC_VAL_PFI1, // terminalName
-     &viStatus);
+      NISYNC_VAL_PFI1,  // terminalName
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(NISYNC_ERROR_RSRC_NOT_RESERVED, viStatus);
@@ -1246,26 +1266,25 @@ TEST_F(NiSyncDriver6683Test, CreateClearClock_ReturnsSuccess)
   ViUInt32 startTimeSeconds = GetCurrentBoardTimeSeconds() + 30;
   ViUInt32 stopTimeSeconds = startTimeSeconds + 30;
   auto grpcStatusCreate = call_CreateClock(
-     NISYNC_VAL_PFI1, // terminalName
-     highTicks,
-     lowTicks,
-     startTimeSeconds,
-     0, // startTimeNanoseconds, ignored
-     0, // startTimeFractionalNanoseconds, ignored
-     stopTimeSeconds,
-     0, // stopTimeNanoseconds, ignored
-     0, // stopTimeFractionalNanoseconds, ignored
-     &viStatusCreate);
+      NISYNC_VAL_PFI1,  // terminalName
+      highTicks,
+      lowTicks,
+      startTimeSeconds,
+      0,  // startTimeNanoseconds, ignored
+      0,  // startTimeFractionalNanoseconds, ignored
+      stopTimeSeconds,
+      0,  // stopTimeNanoseconds, ignored
+      0,  // stopTimeFractionalNanoseconds, ignored
+      &viStatusCreate);
   EXPECT_TRUE(grpcStatusCreate.ok());
   EXPECT_EQ(VI_SUCCESS, viStatusCreate);
 
   ViStatus viStatusClear;
   auto grpcStatusClear = call_ClearClock(
-     NISYNC_VAL_PFI1,
-     &viStatusClear);
+      NISYNC_VAL_PFI1,
+      &viStatusClear);
   EXPECT_TRUE(grpcStatusClear.ok());
   EXPECT_EQ(VI_SUCCESS, viStatusClear);
-
 }
 
 TEST_F(NiSyncDriver6683Test, CreateClockWithInvalidTerminal_ReturnsError)
@@ -1275,32 +1294,32 @@ TEST_F(NiSyncDriver6683Test, CreateClockWithInvalidTerminal_ReturnsError)
   ViUInt32 startTimeSeconds = GetCurrentBoardTimeSeconds() + 30;
   ViUInt32 stopTimeSeconds = startTimeSeconds + 30;
   auto grpcStatus = call_CreateClock(
-     NISYNC_VAL_GND, // terminalName
-     highTicks,
-     lowTicks,
-     startTimeSeconds,
-     0, // startTimeNanoseconds, ignored
-     0, // startTimeFractionalNanoseconds, ignored
-     stopTimeSeconds,
-     0, // stopTimeNanoseconds, ignored
-     0, // stopTimeFractionalNanoseconds, ignored
-     &viStatus);
+      NISYNC_VAL_GND,  // terminalName
+      highTicks,
+      lowTicks,
+      startTimeSeconds,
+      0,  // startTimeNanoseconds, ignored
+      0,  // startTimeFractionalNanoseconds, ignored
+      stopTimeSeconds,
+      0,  // stopTimeNanoseconds, ignored
+      0,  // stopTimeFractionalNanoseconds, ignored
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
-  // Bug 1462754: 6683 CreateClock has different error behavior on Linux RT
-  #if defined(_MSC_VER)
+// Bug 1462754: 6683 CreateClock has different error behavior on Linux RT
+#if defined(_MSC_VER)
   EXPECT_EQ(NISYNC_ERROR_TERMINAL_INVALID, viStatus);
-  #else
+#else
   EXPECT_EQ(NISYNC_ERROR_DEST_TERMINAL_INVALID, viStatus);
-  #endif
+#endif
 }
 
 TEST_F(NiSyncDriver6683Test, ClearClockNotReserved_ReturnsError)
 {
   ViStatus viStatus;
   auto grpcStatus = call_ClearClock(
-     NISYNC_VAL_PFI1, // terminalName
-     &viStatus);
+      NISYNC_VAL_PFI1,  // terminalName
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(NISYNC_ERROR_RSRC_NOT_RESERVED, viStatus);
@@ -1311,8 +1330,8 @@ TEST_F(NiSyncDriver6683Test, GetTimeReferenceNames_ReturnsSuccess)
   ViStatus viStatus;
   std::string timeReferenceNames;
   auto grpcStatus = call_GetTimeReferenceNames(
-     &timeReferenceNames,
-     &viStatus);
+      &timeReferenceNames,
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_GT(timeReferenceNames.length(), 0);
@@ -1323,16 +1342,16 @@ TEST_F(NiSyncDriver6683Test, EnableTimeStampTrigger_ReturnsSuccess)
 {
   ViStatus viStatusEnable;
   auto grpcStatusEnable = call_EnableTimeStampTrigger(
-     NISYNC_VAL_PFI1, // terminalName
-     NISYNC_VAL_EDGE_RISING, // activeEdge
-     &viStatusEnable);
+      NISYNC_VAL_PFI1,         // terminalName
+      NISYNC_VAL_EDGE_RISING,  // activeEdge
+      &viStatusEnable);
   EXPECT_TRUE(grpcStatusEnable.ok());
   EXPECT_EQ(VI_SUCCESS, viStatusEnable);
 
   ViStatus viStatusDisable;
   auto grpcStatusDisable = call_DisableTimeStampTrigger(
-     NISYNC_VAL_PFI1,
-     &viStatusDisable);
+      NISYNC_VAL_PFI1,
+      &viStatusDisable);
   EXPECT_TRUE(grpcStatusDisable.ok());
   EXPECT_EQ(VI_SUCCESS, viStatusDisable);
 }
@@ -1341,9 +1360,9 @@ TEST_F(NiSyncDriver6683Test, EnableTimeStampTriggerWithInvalidTerminal_ReturnsEr
 {
   ViStatus viStatus;
   auto grpcStatus = call_EnableTimeStampTrigger(
-     NISYNC_VAL_GND, // terminalName
-     NISYNC_VAL_EDGE_RISING, // activeEdge
-     &viStatus);
+      NISYNC_VAL_GND,          // terminalName
+      NISYNC_VAL_EDGE_RISING,  // activeEdge
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(NISYNC_ERROR_TERMINAL_INVALID, viStatus);
@@ -1353,8 +1372,8 @@ TEST_F(NiSyncDriver6683Test, DisableTimeStampTriggerNotReserved_ReturnsError)
 {
   ViStatus viStatus;
   auto grpcStatus = call_DisableTimeStampTrigger(
-     NISYNC_VAL_PFI1, // terminalName
-     &viStatus);
+      NISYNC_VAL_PFI1,  // terminalName
+      &viStatus);
 
   EXPECT_TRUE(grpcStatus.ok());
   EXPECT_EQ(NISYNC_ERROR_RSRC_NOT_RESERVED, viStatus);
@@ -1371,13 +1390,13 @@ TEST_F(NiSyncDriver6683Test, GivenNoTrigger_ReadTriggerTimeStamp_ReturnsTimeoutE
   ViUInt16 timeFractionalNanoseconds;
   ViInt32 detectedEdge;
   auto grpcStatusRead = call_ReadTriggerTimeStamp(
-     terminal,
-     timeout,
-     &timeSeconds,
-     &timeNanoseconds,
-     &timeFractionalNanoseconds,
-     &detectedEdge,
-     &viStatusRead);
+      terminal,
+      timeout,
+      &timeSeconds,
+      &timeNanoseconds,
+      &timeFractionalNanoseconds,
+      &detectedEdge,
+      &viStatusRead);
 
   EXPECT_TRUE(grpcStatusRead.ok());
   EXPECT_EQ(NISYNC_ERROR_DRIVER_TIMEOUT, viStatusRead);
@@ -1396,15 +1415,15 @@ TEST_F(NiSyncDriver6683Test, GivenNoTrigger_ReadMultipleTriggerTimeStamp_Returns
   ViInt32 detectedEdge;
   ViUInt32 timestampsRead;
   auto grpcStatusRead = call_ReadMultipleTriggerTimeStamp(
-     terminal,
-     timeout,
-     timestampsToRead,
-     &timeSeconds,
-     &timeNanoseconds,
-     &timeFractionalNanoseconds,
-     &detectedEdge,
-     &timestampsRead,
-     &viStatusRead);
+      terminal,
+      timeout,
+      timestampsToRead,
+      &timeSeconds,
+      &timeNanoseconds,
+      &timeFractionalNanoseconds,
+      &detectedEdge,
+      &timestampsRead,
+      &viStatusRead);
 
   EXPECT_TRUE(grpcStatusRead.ok());
   EXPECT_EQ(NISYNC_ERROR_DRIVER_TIMEOUT, viStatusRead);
@@ -1427,15 +1446,15 @@ TEST_F(NiSyncDriver6683Test, GivenOneTrigger_ReadMultipleTriggerTimeStamp_Return
   ViInt32 detectedEdge[timestampsToRead] = {};
   ViUInt32 timestampsRead = 0;
   auto grpcStatusRead = call_ReadMultipleTriggerTimeStamp(
-     terminal,
-     timeout,
-     timestampsToRead,
-     timeSeconds,
-     timeNanoseconds,
-     timeFractionalNanoseconds,
-     detectedEdge,
-     &timestampsRead,
-     &viStatusRead);
+      terminal,
+      timeout,
+      timestampsToRead,
+      timeSeconds,
+      timeNanoseconds,
+      timeFractionalNanoseconds,
+      detectedEdge,
+      &timestampsRead,
+      &viStatusRead);
 
   const ViUInt32 expectedTimestampsRead = 1;
   EXPECT_TRUE(grpcStatusRead.ok());
@@ -1467,15 +1486,15 @@ TEST_F(NiSyncDriver6683Test, GivenFiveTriggers_ReadMultipleTriggerTimeStamp_Retu
   ViInt32 detectedEdge[timestampsToRead] = {};
   ViUInt32 timestampsRead = 0;
   auto grpcStatusRead = call_ReadMultipleTriggerTimeStamp(
-     terminal,
-     timeout,
-     timestampsToRead,
-     timeSeconds,
-     timeNanoseconds,
-     timeFractionalNanoseconds,
-     detectedEdge,
-     &timestampsRead,
-     &viStatusRead);
+      terminal,
+      timeout,
+      timestampsToRead,
+      timeSeconds,
+      timeNanoseconds,
+      timeFractionalNanoseconds,
+      detectedEdge,
+      &timestampsRead,
+      &viStatusRead);
 
   EXPECT_TRUE(grpcStatusRead.ok());
   EXPECT_EQ(VI_SUCCESS, viStatusRead);

--- a/source/tests/system/nisync_session_tests.cpp
+++ b/source/tests/system/nisync_session_tests.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "nisync/nisync_service.h"
 #include "enumerate_devices.h"
+#include "nisync/nisync_client.h"
 
 namespace ni {
 namespace tests {
@@ -28,7 +28,7 @@ class NiSyncSessionTest : public ::testing::Test {
 
   void SetUp() override
   {
-    for(const auto& device : EnumerateDevices()) {
+    for (const auto& device : EnumerateDevices()) {
       if ((device.model() == "NI PXI-6683H") || (device.model() == "NI PXIe-6674T")) {
         test_resource_name = device.name();
         break;

--- a/source/tests/system/nitclk_driver_api_tests.cpp
+++ b/source/tests/system/nitclk_driver_api_tests.cpp
@@ -1,7 +1,6 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "ivi.h"
 #include "niscope/niscope_client.h"
 #include "nitclk/nitclk_client.h"
 
@@ -11,6 +10,11 @@ namespace system {
 
 namespace scope = niscope_grpc;
 namespace tclk = nitclk_grpc;
+namespace pb = ::google::protobuf;
+
+typedef pb::int32 int32;
+typedef pb::uint32 uint32;
+typedef pb::uint16 uint16;
 
 const int kScopeDriverApiSuccess = 0;
 const int kTClkDriverApiSuccess = 0;
@@ -83,7 +87,7 @@ class NiTClkDriverApiTest : public ::testing::Test {
     EXPECT_EQ(kScopeDriverApiSuccess, response.status());
   }
 
-  ViReal64 get_real64_attribute(const char* channel_name, tclk::NiTClkAttribute attribute_id)
+  double get_real64_attribute(const char* channel_name, tclk::NiTClkAttribute attribute_id)
   {
     ::grpc::ClientContext context;
     tclk::GetAttributeViReal64Request request;
@@ -131,7 +135,7 @@ class NiTClkDriverApiTest : public ::testing::Test {
     return response.value();
   }
 
-  void set_real64_attribute(const char* channel_name, tclk::NiTClkAttribute attribute_id, const ViReal64 attribute_value)
+  void set_real64_attribute(const char* channel_name, tclk::NiTClkAttribute attribute_id, const double attribute_value)
   {
     ::grpc::ClientContext context;
     tclk::SetAttributeViReal64Request request;
@@ -163,7 +167,7 @@ class NiTClkDriverApiTest : public ::testing::Test {
     EXPECT_EQ(kTClkDriverApiSuccess, response.status());
   }
 
-  void set_string_attribute(const char* channel_name, tclk::NiTClkAttribute attribute_id, const ViString attribute_value)
+  void set_string_attribute(const char* channel_name, tclk::NiTClkAttribute attribute_id, const std::string attribute_value)
   {
     ::grpc::ClientContext context;
     tclk::SetAttributeViStringRequest request;
@@ -214,10 +218,10 @@ TEST_F(NiTClkDriverApiTest, SetAttributeViReal64_CallGetAttributeViReal64_Values
 {
   const char* channel_name = "";
   const tclk::NiTClkAttribute attribute_to_set = tclk::NiTClkAttribute::NITCLK_ATTRIBUTE_SAMPLE_CLOCK_DELAY;
-  const ViReal64 expected_value = 4.24;
+  const double expected_value = 4.24;
   set_real64_attribute(channel_name, attribute_to_set, expected_value);
 
-  ViReal64 get_attribute_value = get_real64_attribute(channel_name, attribute_to_set);
+  double get_attribute_value = get_real64_attribute(channel_name, attribute_to_set);
 
   EXPECT_EQ(expected_value, get_attribute_value);
 }
@@ -238,12 +242,12 @@ TEST_F(NiTClkDriverApiTest, SetAttributeViString_CallGetAttributeViString_Values
 {
   const char* channel_name = "";
   const tclk::NiTClkAttribute attribute_to_set = tclk::NiTClkAttribute::NITCLK_ATTRIBUTE_SYNC_PULSE_SOURCE;
-  const ViString expected_value = "Hello world!";
+  const std::string expected_value = "Hello world!";
   set_string_attribute(channel_name, attribute_to_set, expected_value);
 
   std::string get_attribute_value = get_string_attribute(channel_name, attribute_to_set);
 
-  EXPECT_STREQ(expected_value, get_attribute_value.c_str());
+  EXPECT_STREQ(expected_value.c_str(), get_attribute_value.c_str());
 }
 
 }  // namespace system

--- a/source/tests/system/nitclk_driver_api_tests.cpp
+++ b/source/tests/system/nitclk_driver_api_tests.cpp
@@ -1,8 +1,9 @@
 #include <gtest/gtest.h>
 
 #include "device_server.h"
-#include "niscope/niscope_service.h"
-#include "nitclk/nitclk_service.h"
+#include "ivi.h"
+#include "niscope/niscope_client.h"
+#include "nitclk/nitclk_client.h"
 
 namespace ni {
 namespace tests {
@@ -17,9 +18,9 @@ const int kTClkDriverApiSuccess = 0;
 class NiTClkDriverApiTest : public ::testing::Test {
  protected:
   NiTClkDriverApiTest()
-    : device_server_(DeviceServerInterface::Singleton()),
-      nitclk_stub_(tclk::NiTClk::NewStub(device_server_->InProcessChannel())),
-      niscope_stub_(scope::NiScope::NewStub(device_server_->InProcessChannel()))
+      : device_server_(DeviceServerInterface::Singleton()),
+        nitclk_stub_(tclk::NiTClk::NewStub(device_server_->InProcessChannel())),
+        niscope_stub_(scope::NiScope::NewStub(device_server_->InProcessChannel()))
   {
     device_server_->ResetServer();
   }
@@ -43,7 +44,7 @@ class NiTClkDriverApiTest : public ::testing::Test {
 
   std::unique_ptr<tclk::NiTClk::Stub>& GetTClkStub()
   {
-      return nitclk_stub_;
+    return nitclk_stub_;
   }
 
   int GetScopeSessionId()

--- a/source/tests/system/session_utilities_service_tests.cpp
+++ b/source/tests/system/session_utilities_service_tests.cpp
@@ -1,7 +1,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include "device_server.h"
 #include <server/session_utilities_service.h>
+
+#include "device_server.h"
 
 namespace ni {
 namespace tests {


### PR DESCRIPTION
### What does this Pull Request accomplish?

Stops including driver and service headers in system-level tests.
Instead relies on proto defined enum values where possible like the client will.

### Why should this Pull Request be merged?

Fixes [AB#1858248](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1858248)

### What testing has been done?

System level tests pass locally (except two that were failing without changes).