### PR TITLE
Ensure absolute path for staging_dir in validate_examples.py

### DIFF
--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -40,6 +40,7 @@ def _create_stage_dir(staging_dir):
 
 def validate_examples(driver_glob_expression: str, ip_address: str, device_name: str) -> None:
     staging_dir = Path(__file__).parent.parent.parent / "build" / "validate_examples"
+    staging_dir = staging_dir.resolve()
 
     print(f"Validating examples using staging_dir: {staging_dir}")
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Call `resolve` on the `staging_dir` `Path` to ensure that it's absolute.

### Why should this Pull Request be merged?

The subsequent code changes the working directory. On my ubuntu setup, this ran with a relative path and staged the client files to a subdirectory.

### What testing has been done?

Tested with above-mentioned ubuntu setup and on local windows.