### PR TITLE
Add LTE examples

### DIFF
--- a/examples/nirfmxlte/acp-single-carrier.py
+++ b/examples/nirfmxlte/acp-single-carrier.py
@@ -1,0 +1,335 @@
+# Steps:
+# 1. Open a new RFmx Session.
+# 2. Configure Frequency Reference.
+# 3. Configure basic signal properties(Center Frequency, RF Attenuation and External Attenuation).
+# 4. Configure Trigger Type and Trigger Parameters.
+# 5. Configure Carrier Bandwidth.
+# 6. Configure Reference Level.
+# 7. Configure Duplex Mode.
+# 8. Configure Link Direction.
+# 9. Select ACP measurement and enable Traces.
+# 10. Configure Measurement Method.
+# 11. Configure Averaging Parameters for ACP measurement.
+# 12. Configure Sweep Time Parameters.
+# 13. Configure Noise Compensation Parameter.
+# 14. Initiate the Measurement.
+# 15. Fetch ACP Measurements and Traces.
+# 16. Close RFmx Session.
+#
+# The gRPC API is built from the C API. RFmx LTE documentation is installed with the driver at:
+# C:\Program Files (x86)\National Instruments\RFmx\LTE\Documentation\ltecvi.chm
+#
+# Getting Started:
+#
+# To run this example, install "RFmx LTE" on the server machine.
+# Link: https://www.ni.com/en-us/support/downloads/software-products/download.rfmx-lte.html
+#
+# For instructions on how to use protoc to generate gRPC client interfaces, see our "Creating a gRPC Client" wiki page.
+# Link: https://github.com/ni/grpc-device/wiki/Creating-a-gRPC-Client
+#
+# Refer to the NI-RFmxLTE gRPC Wiki for the latest C Function Reference:
+# Link: https://github.com/ni/grpc-device/wiki/NI-RFmxLTE-C-Function-Reference
+#
+# Running from command line:
+#
+# Server machine's IP address, port number, and physical channel name can be passed as separate command line arguments.
+#   > python acp-single-carrier.py <server_address> <port_number> <physical_channel_name>
+# If they are not passed in as command line arguments, then by default the server address will be "localhost:31763", with "SimulatedDevice" as the resource name
+
+
+import sys
+from typing import List, Tuple
+
+import grpc
+import nirfmxlte_pb2 as nirfmxlte_types
+import nirfmxlte_pb2_grpc as grpc_nirfmxlte
+
+server_address = "localhost"
+server_port = "31763"
+session_name = "RFmxLTESession"
+
+# Resource name and options for a simulated 5663 client.
+resource = "SimulatedDevice"
+options = "Simulate=1,DriverSetup=Model:5663"
+
+# Read in cmd args
+if len(sys.argv) >= 2:
+    server_address = sys.argv[1]
+if len(sys.argv) >= 3:
+    server_port = sys.argv[2]
+if len(sys.argv) >= 4:
+    resource = sys.argv[3]
+    options = ""
+
+# Create a gRPC channel + client.
+channel = grpc.insecure_channel(f"{server_address}:{server_port}")
+client = grpc_nirfmxlte.NiRFmxLTEStub(channel)
+instr = None
+
+
+NUMBER_OF_OFFSETS = 3
+
+# Raise an exception if an error was returned
+def raise_if_error(response):
+    if response.status != 0:
+        error_response = client.GetError(
+            nirfmxlte_types.GetErrorRequest(
+                instrument=instr,
+            )
+        )
+        if response.status < 0:
+            raise RuntimeError(f"Error: {error_response.error_description or response.status}")
+        else:
+            sys.stderr.write(f"Warning: {error_response.error_description or response.status}\n")
+
+    return response
+
+
+try:
+    auto_level = True
+
+    initialize_response = raise_if_error(
+        client.Initialize(
+            nirfmxlte_types.InitializeRequest(
+                session_name=session_name, resource_name=resource, option_string=options
+            )
+        )
+    )
+    instr = initialize_response.instrument
+    raise_if_error(
+        client.CfgFrequencyReference(
+            nirfmxlte_types.CfgFrequencyReferenceRequest(
+                instrument=instr,
+                channel_name="",
+                frequency_reference_source_mapped=nirfmxlte_types.FREQUENCY_REFERENCE_SOURCE_ONBOARD_CLOCK,
+                frequency_reference_frequency=10e6,
+            )
+        )
+    )
+    raise_if_error(
+        client.CfgFrequency(
+            nirfmxlte_types.CfgFrequencyRequest(
+                instrument=instr, selector_string="", center_frequency=1.95e9
+            )
+        )
+    )
+    raise_if_error(
+        client.CfgExternalAttenuation(
+            nirfmxlte_types.CfgExternalAttenuationRequest(
+                instrument=instr, selector_string="", external_attenuation=0.0
+            )
+        )
+    )
+    raise_if_error(
+        client.CfgRFAttenuation(
+            nirfmxlte_types.CfgRFAttenuationRequest(
+                instrument=instr,
+                channel_name="",
+                rf_attenuation_auto=nirfmxlte_types.RF_ATTENUATION_AUTO_TRUE,
+                rf_attenuation_value=10.0,
+            )
+        )
+    )
+    raise_if_error(
+        client.CfgDigitalEdgeTrigger(
+            nirfmxlte_types.CfgDigitalEdgeTriggerRequest(
+                instrument=instr,
+                selector_string="",
+                digital_edge_source_mapped=nirfmxlte_types.DIGITAL_EDGE_TRIGGER_SOURCE_PFI0,
+                digital_edge=nirfmxlte_types.DIGITAL_EDGE_TRIGGER_EDGE_RISING,
+                trigger_delay=0.0,
+                enable_trigger=False,
+            )
+        )
+    )
+
+    raise_if_error(
+        client.CfgComponentCarrier(
+            nirfmxlte_types.CfgComponentCarrierRequest(
+                instrument=instr,
+                selector_string="",
+                component_carrier_bandwidth=10e6,
+                component_carrier_frequency=0.0,
+                cell_id=0,
+            )
+        )
+    )
+    if auto_level:
+        auto_level_response = raise_if_error(
+            client.AutoLevel(
+                nirfmxlte_types.AutoLevelRequest(
+                    instrument=instr, selector_string="", measurement_interval=0.01
+                )
+            )
+        )
+        reference_level = auto_level_response.reference_level
+        print(f"Reference level (dBm)        : {reference_level}")
+    else:
+        raise_if_error(
+            client.CfgReferenceLevel(
+                nirfmxlte_types.CfgReferenceLevelRequest(
+                    instrument=instr, selector_string="", reference_level=0.0
+                )
+            )
+        )
+    raise_if_error(
+        client.CfgDuplexScheme(
+            nirfmxlte_types.CfgDuplexSchemeRequest(
+                instrument=instr,
+                selector_string="",
+                duplex_scheme=nirfmxlte_types.DUPLEX_SCHEME_FDD,
+                uplink_downlink_configuration=nirfmxlte_types.UPLINK_DOWNLINK_CONFIGURATION_0,
+            )
+        )
+    )
+    raise_if_error(
+        client.CfgLinkDirection(
+            nirfmxlte_types.CfgLinkDirectionRequest(
+                instrument=instr,
+                selector_string="",
+                link_direction=nirfmxlte_types.LINK_DIRECTION_UPLINK,
+            )
+        )
+    )
+    raise_if_error(
+        client.SelectMeasurements(
+            nirfmxlte_types.SelectMeasurementsRequest(
+                instrument=instr,
+                selector_string="",
+                measurements=nirfmxlte_types.MEASUREMENT_TYPES_ACP,
+                enable_all_traces=True,
+            )
+        )
+    )
+    raise_if_error(
+        client.ACPCfgMeasurementMethod(
+            nirfmxlte_types.ACPCfgMeasurementMethodRequest(
+                instrument=instr,
+                selector_string="",
+                measurement_method=nirfmxlte_types.ACP_MEASUREMENT_METHOD_NORMAL,
+            )
+        )
+    )
+    raise_if_error(
+        client.ACPCfgAveraging(
+            nirfmxlte_types.ACPCfgAveragingRequest(
+                instrument=instr,
+                selector_string="",
+                averaging_enabled=nirfmxlte_types.ACP_AVERAGING_ENABLED_FALSE,
+                averaging_count=10,
+                averaging_type=nirfmxlte_types.ACP_AVERAGING_TYPE_RMS,
+            )
+        )
+    )
+    raise_if_error(
+        client.ACPCfgSweepTime(
+            nirfmxlte_types.ACPCfgSweepTimeRequest(
+                instrument=instr,
+                selector_string="",
+                sweep_time_auto=nirfmxlte_types.ACP_SWEEP_TIME_AUTO_TRUE,
+                sweep_time_interval=0.001,
+            )
+        )
+    )
+    raise_if_error(
+        client.ACPCfgNoiseCompensationEnabled(
+            nirfmxlte_types.ACPCfgNoiseCompensationEnabledRequest(
+                instrument=instr,
+                selector_string="",
+                noise_compensation_enabled=nirfmxlte_types.ACP_NOISE_COMPENSATION_ENABLED_FALSE,
+            )
+        )
+    )
+    raise_if_error(
+        client.Initiate(
+            nirfmxlte_types.InitiateRequest(instrument=instr, selector_string="", result_name="")
+        )
+    )
+
+    ### Fetch results ###
+
+    acp_fetch_offset_measurement_array_response = raise_if_error(
+        client.ACPFetchOffsetMeasurementArray(
+            nirfmxlte_types.ACPFetchOffsetMeasurementArrayRequest(
+                instrument=instr, selector_string="", timeout=10.0
+            )
+        )
+    )
+    lower_relative_power = acp_fetch_offset_measurement_array_response.lower_relative_power
+    upper_relative_power = acp_fetch_offset_measurement_array_response.upper_relative_power
+    lower_absolute_power = acp_fetch_offset_measurement_array_response.lower_absolute_power
+    upper_absolute_power = acp_fetch_offset_measurement_array_response.upper_absolute_power
+
+    assert len(lower_relative_power) == NUMBER_OF_OFFSETS, len(lower_relative_power)
+    assert len(upper_relative_power) == NUMBER_OF_OFFSETS, len(upper_relative_power)
+    assert len(lower_absolute_power) == NUMBER_OF_OFFSETS, len(lower_absolute_power)
+    assert len(upper_absolute_power) == NUMBER_OF_OFFSETS, len(upper_absolute_power)
+
+    acp_fetch_component_carrier_measurement_response = raise_if_error(
+        client.ACPFetchComponentCarrierMeasurement(
+            nirfmxlte_types.ACPFetchComponentCarrierMeasurementRequest(
+                instrument=instr, selector_string="", timeout=10.0
+            )
+        )
+    )
+    absolute_power = acp_fetch_component_carrier_measurement_response.absolute_power
+    relative_power = acp_fetch_component_carrier_measurement_response.relative_power
+
+    absolute_powers_trace_results = []  # type: List[Tuple[float, float, float]]
+    for i in range(NUMBER_OF_OFFSETS):
+        acp_fetch_absolute_powers_trace_response = raise_if_error(
+            client.ACPFetchAbsolutePowersTrace(
+                nirfmxlte_types.ACPFetchAbsolutePowersTraceRequest(
+                    instrument=instr, selector_string="", timeout=10.0, trace_index=i
+                )
+            )
+        )
+        absolute_powers_trace_results.append(
+            (
+                acp_fetch_absolute_powers_trace_response.x0,
+                acp_fetch_absolute_powers_trace_response.dx,
+                acp_fetch_absolute_powers_trace_response.absolute_powers_trace,
+            )
+        )
+
+    relative_powers_trace_results = []  # type: List[Tuple[float, float, float]]
+    for i in range(NUMBER_OF_OFFSETS):
+        acp_fetch_relative_powers_trace_response = raise_if_error(
+            client.ACPFetchRelativePowersTrace(
+                nirfmxlte_types.ACPFetchRelativePowersTraceRequest(
+                    instrument=instr, selector_string="", timeout=10.0, trace_index=i
+                )
+            )
+        )
+        relative_powers_trace_results.append(
+            (
+                acp_fetch_relative_powers_trace_response.x0,
+                acp_fetch_relative_powers_trace_response.dx,
+                acp_fetch_relative_powers_trace_response.relative_powers_trace,
+            )
+        )
+
+    acp_fetch_spectrum_response = raise_if_error(
+        client.ACPFetchSpectrum(
+            nirfmxlte_types.ACPFetchSpectrumRequest(
+                instrument=instr, selector_string="", timeout=10.0
+            )
+        )
+    )
+    x0 = acp_fetch_spectrum_response.x0
+    dx = acp_fetch_spectrum_response.dx
+    spectrum = acp_fetch_spectrum_response.spectrum
+
+    print(f"\nCarrier Absolute Power (dBm) : {absolute_power}")
+
+    print("\n-----------Offset Channel Measurements----------- ")
+    for i in range(NUMBER_OF_OFFSETS):
+        print(f"Offset : {i}")
+        print(f"Lower Relative Power (dB)    : {lower_relative_power[i]}")
+        print(f"Upper Relative Power (dB)    : {upper_relative_power[i]}")
+        print(f"Lower Absolute Power (dBm)   : {lower_absolute_power[i]}")
+        print(f"Upper Absolute Power (dBm)   : {upper_absolute_power[i]}")
+        print("------------------------------------------")
+finally:
+    if instr:
+        client.Close(nirfmxlte_types.CloseRequest(instrument=instr, force_destroy=False))

--- a/examples/nirfmxlte/ul-modacc-single-carrier.py
+++ b/examples/nirfmxlte/ul-modacc-single-carrier.py
@@ -1,0 +1,289 @@
+# Steps:
+# 1. Open a new RFmx Session.
+# 2. Configure Frequency Reference.
+# 3. Configure basic signal properties (Center Frequency, Reference Level and External Attenuation).
+# 4. Configure Trigger Type and Trigger Parameters.
+# 5. Configure Carrier Bandwidth.
+# 6. Configure operating Band.
+# 7. Configure Duplex Mode.
+# 8. Configure Auto DMRS Detection Enabled.
+# 9. Select ModAcc measurement and enable Traces.
+# 10. Configure Synchronization Mode and Measurement Interval.
+# 11. Configure EVM Unit.
+# 12. Configure In-Band Emission Mask Type.
+# 13. Configure Averaging Parameters for ModAcc measurement.
+# 14. Initiate the Measurement.
+# 15. Fetch ModAcc Measurements and Traces.
+# 16. Close RFmx Session.
+#
+# The gRPC API is built from the C API. RFmx LTE documentation is installed with the driver at:
+# C:\Program Files (x86)\National Instruments\RFmx\LTE\Documentation\ltecvi.chm
+#
+# Getting Started:
+#
+# To run this example, install "RFmx LTE" on the server machine.
+# Link: https://www.ni.com/en-us/support/downloads/software-products/download.rfmx-lte.html
+#
+# For instructions on how to use protoc to generate gRPC client interfaces, see our "Creating a gRPC Client" wiki page.
+# Link: https://github.com/ni/grpc-device/wiki/Creating-a-gRPC-Client
+#
+# Refer to the NI-RFmxLTE gRPC Wiki for the latest C Function Reference:
+# Link: https://github.com/ni/grpc-device/wiki/NI-RFmxLTE-C-Function-Reference
+#
+# Running from command line:
+#
+# Server machine's IP address, port number, and physical channel name can be passed as separate command line arguments.
+#   > python ul-modacc-single-carrier.py <server_address> <port_number> <physical_channel_name>
+# If they are not passed in as command line arguments, then by default the server address will be "localhost:31763", with "SimulatedDevice" as the resource name
+
+
+import sys
+
+import grpc
+import nirfmxlte_pb2 as nirfmxlte_types
+import nirfmxlte_pb2_grpc as grpc_nirfmxlte
+
+server_address = "localhost"
+server_port = "31763"
+session_name = "RFmxLTESession"
+
+# Resource name and options for a simulated 5663 client.
+resource = "SimulatedDevice"
+options = "Simulate=1,DriverSetup=Model:5663"
+
+# Read in cmd args
+if len(sys.argv) >= 2:
+    server_address = sys.argv[1]
+if len(sys.argv) >= 3:
+    server_port = sys.argv[2]
+if len(sys.argv) >= 4:
+    resource = sys.argv[3]
+    options = ""
+
+# Create a gRPC channel + client.
+channel = grpc.insecure_channel(f"{server_address}:{server_port}")
+client = grpc_nirfmxlte.NiRFmxLTEStub(channel)
+instr = None
+
+
+# Raise an exception if an error was returned
+def raise_if_error(response):
+    if response.status != 0:
+        error_response = client.GetError(
+            nirfmxlte_types.GetErrorRequest(
+                instrument=instr,
+            )
+        )
+        if response.status < 0:
+            raise RuntimeError(f"Error: {error_response.error_description or response.status}")
+        else:
+            sys.stderr.write(f"Warning: {error_response.error_description or response.status}\n")
+
+    return response
+
+
+try:
+    initialize_response = raise_if_error(
+        client.Initialize(
+            nirfmxlte_types.InitializeRequest(
+                session_name=session_name, resource_name=resource, option_string=options
+            )
+        )
+    )
+    instr = initialize_response.instrument
+    raise_if_error(
+        client.CfgFrequencyReference(
+            nirfmxlte_types.CfgFrequencyReferenceRequest(
+                instrument=instr,
+                channel_name="",
+                frequency_reference_source_mapped=nirfmxlte_types.FREQUENCY_REFERENCE_SOURCE_ONBOARD_CLOCK,
+                frequency_reference_frequency=10e6,
+            )
+        )
+    )
+    raise_if_error(
+        client.CfgRF(
+            nirfmxlte_types.CfgRFRequest(
+                instrument=instr,
+                selector_string="",
+                center_frequency=1.95e9,
+                reference_level=0.0,
+                external_attenuation=0.0,
+            )
+        )
+    )
+    raise_if_error(
+        client.CfgDigitalEdgeTrigger(
+            nirfmxlte_types.CfgDigitalEdgeTriggerRequest(
+                instrument=instr,
+                selector_string="",
+                digital_edge_source_mapped=nirfmxlte_types.DIGITAL_EDGE_TRIGGER_SOURCE_PFI0,
+                digital_edge=nirfmxlte_types.DIGITAL_EDGE_TRIGGER_EDGE_RISING,
+                trigger_delay=0.0,
+                enable_trigger=False,
+            )
+        )
+    )
+    raise_if_error(
+        client.CfgComponentCarrier(
+            nirfmxlte_types.CfgComponentCarrierRequest(
+                instrument=instr,
+                selector_string="",
+                component_carrier_bandwidth=10e6,
+                component_carrier_frequency=0.0,
+                cell_id=0,
+            )
+        )
+    )
+    raise_if_error(
+        client.CfgBand(nirfmxlte_types.CfgBandRequest(instrument=instr, selector_string="", band=1))
+    )
+    raise_if_error(
+        client.CfgDuplexScheme(
+            nirfmxlte_types.CfgDuplexSchemeRequest(
+                instrument=instr,
+                selector_string="",
+                duplex_scheme=nirfmxlte_types.DUPLEX_SCHEME_FDD,
+                uplink_downlink_configuration=nirfmxlte_types.UPLINK_DOWNLINK_CONFIGURATION_0,
+            )
+        )
+    )
+    raise_if_error(
+        client.CfgAutoDMRSDetectionEnabled(
+            nirfmxlte_types.CfgAutoDMRSDetectionEnabledRequest(
+                instrument=instr,
+                selector_string="",
+                auto_dmrs_detection_enabled=nirfmxlte_types.AUTO_DMRS_DETECTION_ENABLED_TRUE,
+            )
+        )
+    )
+    raise_if_error(
+        client.SelectMeasurements(
+            nirfmxlte_types.SelectMeasurementsRequest(
+                instrument=instr,
+                selector_string="",
+                measurements=nirfmxlte_types.MEASUREMENT_TYPES_MODACC,
+                enable_all_traces=True,
+            )
+        )
+    )
+    raise_if_error(
+        client.ModAccCfgSynchronizationModeAndInterval(
+            nirfmxlte_types.ModAccCfgSynchronizationModeAndIntervalRequest(
+                instrument=instr,
+                selector_string="",
+                synchronization_mode=nirfmxlte_types.MODACC_SYNCHRONIZATION_MODE_SLOT,
+                measurement_offset=0,
+                measurement_length=1,
+            )
+        )
+    )
+    raise_if_error(
+        client.ModAccCfgEVMUnit(
+            nirfmxlte_types.ModAccCfgEVMUnitRequest(
+                instrument=instr,
+                selector_string="",
+                evm_unit=nirfmxlte_types.MODACC_EVM_UNIT_PERCENTAGE,
+            )
+        )
+    )
+    raise_if_error(
+        client.ModAccCfgInBandEmissionMaskType(
+            nirfmxlte_types.ModAccCfgInBandEmissionMaskTypeRequest(
+                instrument=instr,
+                selector_string="",
+                in_band_emission_mask_type=nirfmxlte_types.MODACC_IN_BAND_EMISSION_MASK_TYPE_RELEASE_11_ONWARDS,
+            )
+        )
+    )
+    raise_if_error(
+        client.ModAccCfgAveraging(
+            nirfmxlte_types.ModAccCfgAveragingRequest(
+                instrument=instr,
+                selector_string="",
+                averaging_enabled=nirfmxlte_types.MODACC_AVERAGING_ENABLED_FALSE,
+                averaging_count=10,
+            )
+        )
+    )
+    raise_if_error(
+        client.Initiate(
+            nirfmxlte_types.InitiateRequest(instrument=instr, selector_string="", result_name="")
+        )
+    )
+
+    mod_acc_fetch_composite_evm_response = raise_if_error(
+        client.ModAccFetchCompositeEVM(
+            nirfmxlte_types.ModAccFetchCompositeEVMRequest(
+                instrument=instr, selector_string="", timeout=10.000000
+            )
+        )
+    )
+    mean_rms_composite_evm = mod_acc_fetch_composite_evm_response.mean_rms_composite_evm
+    max_peak_composite_evm = mod_acc_fetch_composite_evm_response.maximum_peak_composite_evm
+    mean_frequency_error = mod_acc_fetch_composite_evm_response.mean_frequency_error
+    peak_composite_evm_symbol_index = (
+        mod_acc_fetch_composite_evm_response.peak_composite_evm_symbol_index
+    )
+    peak_composite_evm_subcarrier_index = (
+        mod_acc_fetch_composite_evm_response.peak_composite_evm_subcarrier_index
+    )
+    peak_composite_evm_slot_index = (
+        mod_acc_fetch_composite_evm_response.peak_composite_evm_slot_index
+    )
+    mod_acc_fetch_iq_impairments_response = raise_if_error(
+        client.ModAccFetchIQImpairments(
+            nirfmxlte_types.ModAccFetchIQImpairmentsRequest(
+                instrument=instr, selector_string="", timeout=10.000000
+            )
+        )
+    )
+    mean_iq_origin_offset = mod_acc_fetch_iq_impairments_response.mean_iq_origin_offset
+    mean_iq_gain_imbalance = mod_acc_fetch_iq_impairments_response.mean_iq_gain_imbalance
+    mean_iq_quadrature_error = mod_acc_fetch_iq_impairments_response.mean_iq_quadrature_error
+    mod_acc_fetch_in_band_emission_margin_response = raise_if_error(
+        client.ModAccFetchInBandEmissionMargin(
+            nirfmxlte_types.ModAccFetchInBandEmissionMarginRequest(
+                instrument=instr, selector_string="", timeout=10.000000
+            )
+        )
+    )
+    in_band_emission_margin = mod_acc_fetch_in_band_emission_margin_response.in_band_emission_margin
+
+    mod_acc_fetch_pusch_constellation_trace_response = raise_if_error(
+        client.ModAccFetchPUSCHConstellationTrace(
+            nirfmxlte_types.ModAccFetchPUSCHConstellationTraceRequest(
+                instrument=instr, selector_string="", timeout=10.000000
+            )
+        )
+    )
+    data_constellation = mod_acc_fetch_pusch_constellation_trace_response.data_constellation
+    dmrs_constellation = mod_acc_fetch_pusch_constellation_trace_response.dmrs_constellation
+
+    mod_acc_fetch_evm_per_subcarrier_trace_response = raise_if_error(
+        client.ModAccFetchEVMPerSubcarrierTrace(
+            nirfmxlte_types.ModAccFetchEVMPerSubcarrierTraceRequest(
+                instrument=instr, selector_string="", timeout=10.000000
+            )
+        )
+    )
+    x0 = mod_acc_fetch_evm_per_subcarrier_trace_response.x0
+    dx = mod_acc_fetch_evm_per_subcarrier_trace_response.dx
+    mean_rmsevm_per_subcarrier = (
+        mod_acc_fetch_evm_per_subcarrier_trace_response.mean_rms_evm_per_subcarrier
+    )
+
+    print("------------------Measurement------------------")
+    print(f"Mean RMS Composite EVM (% or dB)     : {mean_rms_composite_evm}")
+    print(f"Max Peak Composite EVM (% or dB)     : {max_peak_composite_evm}")
+    print(f"Peak Composite EVM Slot Index        : {peak_composite_evm_slot_index}")
+    print(f"Peak Composite EVM Symbol Index      : {peak_composite_evm_symbol_index}")
+    print(f"Peak Composite EVM Subcarrier Index  : {peak_composite_evm_subcarrier_index}")
+    print(f"Mean Frequency Error (Hz)            : {mean_frequency_error}")
+    print(f"Mean IQ Origin Offset (dBc)          : {mean_iq_origin_offset}")
+    print(f"Mean IQ Gain Imbalance (dB)          : {mean_iq_gain_imbalance}")
+    print(f"Mean IQ Quadrature Error (deg)       : {mean_iq_quadrature_error}")
+    print(f"In Band Emission Margin (dB)         : {in_band_emission_margin}")
+finally:
+    if instr:
+        client.Close(nirfmxlte_types.CloseRequest(instrument=instr, force_destroy=False))

--- a/examples/nirfmxlte/ul-modacc-single-carrier.py
+++ b/examples/nirfmxlte/ul-modacc-single-carrier.py
@@ -212,65 +212,65 @@ try:
         )
     )
 
-    mod_acc_fetch_composite_evm_response = raise_if_error(
+    modacc_fetch_composite_evm_response = raise_if_error(
         client.ModAccFetchCompositeEVM(
             nirfmxlte_types.ModAccFetchCompositeEVMRequest(
-                instrument=instr, selector_string="", timeout=10.000000
+                instrument=instr, selector_string="", timeout=10.0
             )
         )
     )
-    mean_rms_composite_evm = mod_acc_fetch_composite_evm_response.mean_rms_composite_evm
-    max_peak_composite_evm = mod_acc_fetch_composite_evm_response.maximum_peak_composite_evm
-    mean_frequency_error = mod_acc_fetch_composite_evm_response.mean_frequency_error
+    mean_rms_composite_evm = modacc_fetch_composite_evm_response.mean_rms_composite_evm
+    max_peak_composite_evm = modacc_fetch_composite_evm_response.maximum_peak_composite_evm
+    mean_frequency_error = modacc_fetch_composite_evm_response.mean_frequency_error
     peak_composite_evm_symbol_index = (
-        mod_acc_fetch_composite_evm_response.peak_composite_evm_symbol_index
+        modacc_fetch_composite_evm_response.peak_composite_evm_symbol_index
     )
     peak_composite_evm_subcarrier_index = (
-        mod_acc_fetch_composite_evm_response.peak_composite_evm_subcarrier_index
+        modacc_fetch_composite_evm_response.peak_composite_evm_subcarrier_index
     )
     peak_composite_evm_slot_index = (
-        mod_acc_fetch_composite_evm_response.peak_composite_evm_slot_index
+        modacc_fetch_composite_evm_response.peak_composite_evm_slot_index
     )
-    mod_acc_fetch_iq_impairments_response = raise_if_error(
+    modacc_fetch_iq_impairments_response = raise_if_error(
         client.ModAccFetchIQImpairments(
             nirfmxlte_types.ModAccFetchIQImpairmentsRequest(
-                instrument=instr, selector_string="", timeout=10.000000
+                instrument=instr, selector_string="", timeout=10.0
             )
         )
     )
-    mean_iq_origin_offset = mod_acc_fetch_iq_impairments_response.mean_iq_origin_offset
-    mean_iq_gain_imbalance = mod_acc_fetch_iq_impairments_response.mean_iq_gain_imbalance
-    mean_iq_quadrature_error = mod_acc_fetch_iq_impairments_response.mean_iq_quadrature_error
-    mod_acc_fetch_in_band_emission_margin_response = raise_if_error(
+    mean_iq_origin_offset = modacc_fetch_iq_impairments_response.mean_iq_origin_offset
+    mean_iq_gain_imbalance = modacc_fetch_iq_impairments_response.mean_iq_gain_imbalance
+    mean_iq_quadrature_error = modacc_fetch_iq_impairments_response.mean_iq_quadrature_error
+    modacc_fetch_in_band_emission_margin_response = raise_if_error(
         client.ModAccFetchInBandEmissionMargin(
             nirfmxlte_types.ModAccFetchInBandEmissionMarginRequest(
-                instrument=instr, selector_string="", timeout=10.000000
+                instrument=instr, selector_string="", timeout=10.0
             )
         )
     )
-    in_band_emission_margin = mod_acc_fetch_in_band_emission_margin_response.in_band_emission_margin
+    in_band_emission_margin = modacc_fetch_in_band_emission_margin_response.in_band_emission_margin
 
-    mod_acc_fetch_pusch_constellation_trace_response = raise_if_error(
+    modacc_fetch_pusch_constellation_trace_response = raise_if_error(
         client.ModAccFetchPUSCHConstellationTrace(
             nirfmxlte_types.ModAccFetchPUSCHConstellationTraceRequest(
-                instrument=instr, selector_string="", timeout=10.000000
+                instrument=instr, selector_string="", timeout=10.0
             )
         )
     )
-    data_constellation = mod_acc_fetch_pusch_constellation_trace_response.data_constellation
-    dmrs_constellation = mod_acc_fetch_pusch_constellation_trace_response.dmrs_constellation
+    data_constellation = modacc_fetch_pusch_constellation_trace_response.data_constellation
+    dmrs_constellation = modacc_fetch_pusch_constellation_trace_response.dmrs_constellation
 
-    mod_acc_fetch_evm_per_subcarrier_trace_response = raise_if_error(
+    modacc_fetch_evm_per_subcarrier_trace_response = raise_if_error(
         client.ModAccFetchEVMPerSubcarrierTrace(
             nirfmxlte_types.ModAccFetchEVMPerSubcarrierTraceRequest(
-                instrument=instr, selector_string="", timeout=10.000000
+                instrument=instr, selector_string="", timeout=10.0
             )
         )
     )
-    x0 = mod_acc_fetch_evm_per_subcarrier_trace_response.x0
-    dx = mod_acc_fetch_evm_per_subcarrier_trace_response.dx
+    x0 = modacc_fetch_evm_per_subcarrier_trace_response.x0
+    dx = modacc_fetch_evm_per_subcarrier_trace_response.dx
     mean_rmsevm_per_subcarrier = (
-        mod_acc_fetch_evm_per_subcarrier_trace_response.mean_rms_evm_per_subcarrier
+        modacc_fetch_evm_per_subcarrier_trace_response.mean_rms_evm_per_subcarrier
     )
 
     print("------------------Measurement------------------")


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds python examples for LTE

### Why should this Pull Request be merged?

[AB#1858415](https://ni.visualstudio.com/DevCentral/_workitems/edit/1858415)
[AB#1858416](https://ni.visualstudio.com/DevCentral/_workitems/edit/1858416)

### What testing has been done?

```
(.venv) Z:\dev\grpc-device\examples\nirfmxlte>python acp-single-carrier.py
Reference level (dBm)        : 22.5

Carrier Absolute Power (dBm) : 18.58660888671875

-----------Offset Channel Measurements-----------
Offset : 0
Lower Relative Power (dB)    : -39.762245178222656
Upper Relative Power (dB)    : -39.762245178222656
Lower Absolute Power (dBm)   : -21.175636291503906
Upper Absolute Power (dBm)   : -21.175636291503906
------------------------------------------
Offset : 1
Lower Relative Power (dB)    : -39.50843048095703
Upper Relative Power (dB)    : -39.50843048095703
Lower Absolute Power (dBm)   : -20.92182159423828
Upper Absolute Power (dBm)   : -20.92182159423828
------------------------------------------
Offset : 2
Lower Relative Power (dB)    : -35.93755340576172
Upper Relative Power (dB)    : -35.93755340576172
Lower Absolute Power (dBm)   : -17.35094451904297
Upper Absolute Power (dBm)   : -17.35094451904297
------------------------------------------

(.venv) Z:\dev\grpc-device\examples\nirfmxlte>python ul-modacc-single-carrier.py
------------------Measurement------------------
Mean RMS Composite EVM (% or dB)     : 24.47988128392011
Max Peak Composite EVM (% or dB)     : 59.352272748947144
Peak Composite EVM Slot Index        : 0
Peak Composite EVM Symbol Index      : 6
Peak Composite EVM Subcarrier Index  : 310
Mean Frequency Error (Hz)            : 147.35012817382812
Mean IQ Origin Offset (dBc)          : -5.3845953941345215
Mean IQ Gain Imbalance (dB)          : 1.833428144454956
Mean IQ Quadrature Error (deg)       : 1.153283715248108
In Band Emission Margin (dB)         : -6.15078726092953
```