### PR TITLE
Fix several python linter issues in source/codegen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [tool.black]
 line-length = 100
 exclude = "source/codegen/metadata/"
+
+[tool.mypy]
+mypy_path = "$MYPY_CONFIG_FILE_DIR/source/codegen/"

--- a/python_build_requirements.txt
+++ b/python_build_requirements.txt
@@ -4,3 +4,5 @@ MarkupSafe==2.0.1
 schema==0.7.4
 black>=21.10b0
 mypy>=0.910
+ni-python-styleguide~=0.1
+pycodestyle==2.7.*

--- a/source/codegen/client_helpers.py
+++ b/source/codegen/client_helpers.py
@@ -3,7 +3,7 @@ from collections import namedtuple
 from enum import Enum
 from typing import List, Tuple
 
-from . import common_helpers
+import common_helpers
 
 
 class ParamMechanism(Enum):
@@ -18,7 +18,6 @@ ClientParam = namedtuple("ClientParam", ["name", "type", "mechanism"])
 
 
 def to_parameter_list(client_params: List[ClientParam]) -> List[str]:
-
     param_list = [f"{p.type} {p.name}" for p in client_params]
 
     return param_list

--- a/source/codegen/client_helpers.py
+++ b/source/codegen/client_helpers.py
@@ -1,9 +1,9 @@
-from typing import List, Tuple
-import common_helpers
 import re
 from collections import namedtuple
-from copy import deepcopy
 from enum import Enum
+from typing import List, Tuple
+
+from . import common_helpers
 
 
 class ParamMechanism(Enum):
@@ -151,6 +151,7 @@ def get_client_parameters(func: dict, enums: dict) -> List[ClientParam]:
 
 def split_types_from_variant(variant_type: str) -> Tuple[str, str]:
     match = re.match(r".*simple_variant<([^,]+), ([^>]+)>", variant_type)
+    assert match
     return (match[1], match[2])
 
 

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -899,12 +899,18 @@ def get_enum_value_cpp_type(enum: dict) -> str:
 
 
 def is_regular_string_arg(parameter: dict) -> bool:
-    """Exclude byte arrays."""
+    """Return whether the parameter is a "regular" string.
+
+    This excludes byte arrays.
+    """
     return is_string_arg(parameter) and not parameter["grpc_type"] == "bytes"
 
 
 def is_regular_byte_array_arg(parameter: dict) -> bool:
-    """Exclude strings and byte arrays that are mapped to enums."""
+    """Return whether the parameter is a "regular" byte array.
+
+    This excludes byte arrays that are mapped to enums.
+    """
     return parameter["grpc_type"] == "bytes" and not is_enum(parameter)
 
 

--- a/source/codegen/generate_service.py
+++ b/source/codegen/generate_service.py
@@ -1,11 +1,11 @@
-import os
 import argparse
-import metadata_mutation
-import metadata_validation
-from mako.lookup import TemplateLookup
+import os
 
-import common_helpers
-from template_helpers import instantiate_mako_template, load_metadata, write_if_changed
+from mako.lookup import TemplateLookup  # type: ignore
+
+from . import metadata_mutation
+from . import metadata_validation
+from .template_helpers import instantiate_mako_template, load_metadata, write_if_changed
 
 
 def generate_service_file(metadata, template_file_name, generated_file_suffix, gen_dir):

--- a/source/codegen/generate_service.py
+++ b/source/codegen/generate_service.py
@@ -1,11 +1,10 @@
 import argparse
 import os
 
+import metadata_mutation
+import metadata_validation
 from mako.lookup import TemplateLookup  # type: ignore
-
-from . import metadata_mutation
-from . import metadata_validation
-from .template_helpers import instantiate_mako_template, load_metadata, write_if_changed
+from template_helpers import instantiate_mako_template, load_metadata, write_if_changed
 
 
 def generate_service_file(metadata, template_file_name, generated_file_suffix, gen_dir):

--- a/source/codegen/generate_shared_service_files.py
+++ b/source/codegen/generate_shared_service_files.py
@@ -1,14 +1,14 @@
 from argparse import ArgumentParser
 from pathlib import Path
 
-from template_helpers import instantiate_mako_template, write_if_changed, load_metadata
+from .template_helpers import instantiate_mako_template, write_if_changed, load_metadata
 
 
 def generate_register_all_services(metadata_dir: Path, output_dir: Path) -> None:
     driver_modules = [
         load_metadata(p)
         for p in sorted(metadata_dir.iterdir())
-        if p.is_dir() and not "fake" in p.name
+        if p.is_dir() and "fake" not in p.name
     ]
 
     template = instantiate_mako_template("register_all_services.h.mako")

--- a/source/codegen/generate_shared_service_files.py
+++ b/source/codegen/generate_shared_service_files.py
@@ -1,7 +1,7 @@
 from argparse import ArgumentParser
 from pathlib import Path
 
-from .template_helpers import instantiate_mako_template, write_if_changed, load_metadata
+from template_helpers import instantiate_mako_template, write_if_changed, load_metadata
 
 
 def generate_register_all_services(metadata_dir: Path, output_dir: Path) -> None:

--- a/source/codegen/metadata_mutation.py
+++ b/source/codegen/metadata_mutation.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 from typing import Optional
 
-from . import common_helpers
+import common_helpers
 
 RESERVED_WORDS = [
     "abstract",

--- a/source/codegen/metadata_mutation.py
+++ b/source/codegen/metadata_mutation.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
 from typing import Optional
-import common_helpers
+
+from . import common_helpers
 
 RESERVED_WORDS = [
     "abstract",
@@ -84,7 +85,10 @@ RESERVED_WORDS = [
 
 
 def sanitize_names(parameters):
-    """Sanitizes name fields on a list of parameter objects and populates the cppname field with the sanitized value."""
+    """Sanitize name fields on a list of parameter objects.
+
+    Also, populate the cppname field with the sanitized value.
+    """
     for parameter in parameters:
         if "callback_params" in parameter:
             sanitize_names(parameter["callback_params"])
@@ -94,14 +98,14 @@ def sanitize_names(parameters):
 
 
 def set_var_args_types(parameters, config):
-    """Sets information about varargs parameters in the metadata."""
+    """Set information about varargs parameters in the metadata."""
     for parameter in parameters:
         if common_helpers.is_repeated_varargs_parameter(parameter):
             parameter["type"] = "..."
 
 
 def mark_size_params(parameters):
-    """Marks the size parameters in the metadata."""
+    """Mark the size parameters in the metadata."""
     for param in parameters:
         mechanism = common_helpers.get_size_mechanism(param)
         if mechanism in {
@@ -133,7 +137,9 @@ def mark_coerced_narrow_numeric_parameters(parameters: dict) -> None:
 
 def mark_non_proto_params(parameters):
     """Mark the parameters that shouldn't be included in the proto request message.
-    Their values should be derived from other sources in the service handlers."""
+
+    Their values should be derived from other sources in the service handlers.
+    """
     for param in parameters:
         mechanism = common_helpers.get_size_mechanism(param)
         if mechanism in {"len", "ivi-dance", "ivi-dance-with-a-twist"}:
@@ -205,7 +211,8 @@ def add_attribute_values_enums(enums, attribute_enums_by_type, group_name):
             enum = enums[enum_name]
             is_mapped_enum = enum.get("generate-mappings", False)
             for value in enum["values"]:
-                # Remove the leading group name (if any) because it will be redundant in the aggregate enum.
+                # Remove the leading group name (if any) because it will be redundant in the
+                # aggregate enum.
                 value_name = remove_leading_group_name(value["name"], group_name)
                 # Add a leading enum to differentiate sub-enums within the aggregate values enum.
                 value_name = add_leading_enum_name(value_name, enum_name, enum)
@@ -228,8 +235,7 @@ AttributeReferencingParameter = namedtuple(
 
 
 class AttributeAccessorExpander:
-    """
-    Wraps an _attribute_type_map of:
+    """Wraps an _attribute_type_map of:
 
     group -> type -> attributes
 
@@ -311,7 +317,7 @@ class AttributeAccessorExpander:
 def expand_attribute_function_value_param(
     function, enums, attribute_enums_by_type, service_class_prefix
 ):
-    """For SetAttribute and CheckAttribute APIs, update function metadata to mark value parameter as enum."""
+    """For SetAttribute and CheckAttribute, update function metadata to mark value param as enum."""
     value_param = get_attribute_function_value_param(function)
     if not value_param:
         return
@@ -372,7 +378,8 @@ def add_enum(enum_name, enum_values, enums, enum_value_prefix, is_mapped=False):
 
 
 def move_zero_enums_to_front(enums: dict) -> None:
-    """
+    """Put the enum value with value 0 _first_ if there is one, or else add UNSPECIFIED enum value.
+
     protobuf requires that the first enum value be zero. For enums missing a zero value,
     we will add an UNSPECIFIED enum value to the front (this is the best practice). But if
     there already is a zero enum, make sure that pre-existing zero value is at the front.

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -1,7 +1,9 @@
-from typing import Any, Dict, Iterable, List, Set
-from schema import Schema, And, Optional, Or, Use
-import common_helpers
-import service_helpers
+from typing import Any, Dict, List, Set
+
+from schema import And, Optional, Or, Schema, Use  # type: ignore
+
+from . import common_helpers
+from . import service_helpers
 
 
 # Rules that can be suppressed
@@ -209,7 +211,7 @@ def validate_function(function_name: str, metadata: dict):
                     for callback_param in parameter["callback_params"]:
                         try:
                             PARAM_SCHEMA.validate(callback_param)
-                        except Exception as e:
+                        except Exception:
                             raise Exception(
                                 f"Failed to validate callback_param with name {callback_param['name']}"
                             )

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -1,9 +1,8 @@
 from typing import Any, Dict, List, Set
 
+import common_helpers
+import service_helpers
 from schema import And, Optional, Or, Schema, Use  # type: ignore
-
-from . import common_helpers
-from . import service_helpers
 
 
 # Rules that can be suppressed

--- a/source/codegen/proto_helpers.py
+++ b/source/codegen/proto_helpers.py
@@ -1,5 +1,6 @@
 from typing import List
-import common_helpers
+
+from . import common_helpers
 
 
 def _is_attribute_values(enum_name):
@@ -7,8 +8,7 @@ def _is_attribute_values(enum_name):
 
 
 def _should_add_unspecified_enum_value(enum_name, enum_values_metadata):
-    """
-    Returns True if an UNSPECIFIED zero-value enum should be added to enum_values_metadata.
+    """Return whether an UNSPECIFIED zero-value enum should be added to enum_values_metadata.
 
     UNSPECIFIED zero-values are a best practice in protobuf. BUT they're not helpful if there
     is some other zero-value. In that case they introduce an unnecessary alias and don't serve
@@ -30,7 +30,9 @@ def should_allow_alias(enum_values_metadata):
 
 def generate_parameter_field_number(parameter, used_indexes, field_name_suffix=""):
     """Get unique field number for field corresponding to this parameter in proto file.
-    If field number is not stored in metadata of parameter, get the next unused integer value."""
+
+    If field number is not stored in metadata of parameter, get the next unused integer value.
+    """
     field_name_key = f"grpc{field_name_suffix}_field_number"
     if field_name_key in parameter:
         field_number = parameter[field_name_key]
@@ -80,11 +82,12 @@ def is_array_input(parameter: dict):
 
 
 def is_decomposable_enum(parameter: dict):
-    """
+    """Return whether the parameter is a decomposable enum.
+
     Enums are typically decomposed from a single param into an enum param and an _raw param.
     The exception is array_inputs which are left as single enum param.
-    This is because protobuf does not support oneof on repeated types, so the standard
-    input decomposition does not work for arrays.
+    This is because protobuf does not support oneof on repeated types, so the standard input
+    decomposition does not work for arrays.
     """
     return common_helpers.is_enum(parameter) and not (
         is_array_input(parameter) and parameter["grpc_type"] != "string"
@@ -234,8 +237,8 @@ def get_parameters(function):
 
 
 def get_callback_output_params(function):
-    """
-    Looks for a parameter that specifies callback_params and returns those params
+    """Look for a parameter that specifies callback_params and return those params.
+
     These will be used as the outputs of a streaming response.
     """
     params = [p for p in function["parameters"] if "callback_params" in p]

--- a/source/codegen/proto_helpers.py
+++ b/source/codegen/proto_helpers.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from . import common_helpers
+import common_helpers
 
 
 def _is_attribute_values(enum_name):

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, NamedTuple, Optional
 
-from . import common_helpers
+import common_helpers
 
 
 def get_include_guard_name(config, suffix):

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, NamedTuple, Optional
-import common_helpers
+
+from . import common_helpers
 
 
 def get_include_guard_name(config, suffix):
@@ -67,10 +68,7 @@ def create_args_for_callback(parameters):
 
 
 def _is_array_that_requires_conversion(parameter):
-    """
-    Returns True for any array parameter where the protobuf representation is not the same
-    as the C API representation.
-    """
+    """Return whether the protobuf representation is not the same as the C API representation."""
     is_array = common_helpers.is_array(parameter["type"])
 
     if is_array:
@@ -271,7 +269,7 @@ def get_output_lookup_values(enum_data):
 
 
 def filter_api_functions(functions, only_mockable_functions=True):
-    """Returns function metadata only for those functions to include for generating the function types to the API library"""
+    """Return function metadata only for functions to include for generating the function types to the API library."""
 
     def filter_function(function):
         if function.get("codegen_method", "") == "no":
@@ -284,7 +282,7 @@ def filter_api_functions(functions, only_mockable_functions=True):
 
 
 def filter_proto_rpc_functions_to_generate(functions):
-    """Returns function metadata only for those functions to include for generating proto rpc methods"""
+    """Return function metadata only for functions to include for generating proto rpc methods."""
     functions_for_code_gen = {"public"}
     return [
         name
@@ -439,16 +437,14 @@ def get_cross_driver_session_type(parameter: dict) -> Optional[str]:
 
 
 def get_cross_driver_session_dependencies(
-    functions: List[dict],
+    functions: dict,
 ) -> List[CrossDriverSessionDependency]:
     return sorted(
         set(
-            [
-                _create_cross_driver_session_dependency(get_cross_driver_session_type(p))
-                for f in functions.values()
-                for p in f["parameters"]
-                if get_cross_driver_session_type(p)
-            ]
+            _create_cross_driver_session_dependency(get_cross_driver_session_type(p))
+            for f in functions.values()
+            for p in f["parameters"]
+            if get_cross_driver_session_type(p)
         )
     )
 
@@ -472,7 +468,7 @@ SessionRepositoryHandleTypeMap = Dict[str, Dict[str, Any]]
 def list_session_repository_handle_types(
     driver_configs: List[dict],
 ) -> SessionRepositoryHandleTypeMap:
-    session_repository_handle_type_map = {}
+    session_repository_handle_type_map = {}  # type: Dict[str, Dict[str, Any]]
     for config in driver_configs:
         handle_type = get_resource_handle_type(config)
         if handle_type in session_repository_handle_type_map:

--- a/source/codegen/stage_client_files.py
+++ b/source/codegen/stage_client_files.py
@@ -4,8 +4,8 @@ from shutil import copy2, copytree
 from tempfile import TemporaryDirectory
 from typing import Dict, Iterable, List
 
-from .common_helpers import get_driver_readiness
-from .template_helpers import load_metadata
+from common_helpers import get_driver_readiness
+from template_helpers import load_metadata
 
 
 class _ArtifactReadiness:

--- a/source/codegen/stage_client_files.py
+++ b/source/codegen/stage_client_files.py
@@ -4,21 +4,18 @@ from shutil import copy2, copytree
 from tempfile import TemporaryDirectory
 from typing import Dict, Iterable, List
 
-from common_helpers import get_driver_readiness
-from template_helpers import load_metadata
+from .common_helpers import get_driver_readiness
+from .template_helpers import load_metadata
 
 
 class _ArtifactReadiness:
-    """
-    Helper class to determine whether a Path with a module-named artifact directory
-    is release-ready.
-    """
+    """Class to determine whether a Path with a module-named artifact directory is release-ready."""
 
-    _module_to_readiness = Dict[str, str]
+    _module_to_readiness = {}  # type: Dict[str, str]
 
     def __init__(self, metadata_dir: Path, include_prerelease: bool):
         modules = [
-            load_metadata(p) for p in metadata_dir.iterdir() if p.is_dir() and not "fake" in p.name
+            load_metadata(p) for p in metadata_dir.iterdir() if p.is_dir() and "fake" not in p.name
         ]
 
         self._module_to_readiness = {
@@ -28,9 +25,10 @@ class _ArtifactReadiness:
         self.include_prerelease = include_prerelease
 
     def is_release_ready(self, module_path: Path) -> bool:
-        """
-        Determine release-readiness by checking the name of the module_path directory
-        against code_readiness for the module_name in config.py.
+        """Determine release-readiness.
+
+        Do so by checking the name of the module_path directory against code_readiness for the
+        module_name in config.py.
         """
         module_name = module_path.name
         if "fake" in module_name:
@@ -39,15 +37,13 @@ class _ArtifactReadiness:
         if "session" == module_name:
             return True
 
-        if not module_name in self._module_to_readiness:
+        if module_name not in self._module_to_readiness:
             raise KeyError(f"No module config.py metadata for module_name: {module_path}")
 
         return self._module_to_readiness[module_name] == "Release"
 
     def get_release_ready_subdirs(self, directory: Path) -> Iterable[Path]:
-        """
-        Return all subdirectories of directory for which is_release_ready is True.
-        """
+        """Return all subdirectories of directory for which is_release_ready is True."""
         return (
             d
             for d in directory.iterdir()
@@ -88,8 +84,7 @@ def _get_release_proto_files(
 
 def _get_release_example_directories(
     artifact_locations: ArtifactLocations, readiness: _ArtifactReadiness
-) -> List[Path]:
-
+) -> Iterable[Path]:
     return readiness.get_release_ready_subdirs(artifact_locations.examples)
 
 

--- a/source/codegen/template_helpers.py
+++ b/source/codegen/template_helpers.py
@@ -1,8 +1,9 @@
 from importlib import import_module
 from pathlib import Path
+from typing import Union
 
-from mako.lookup import TemplateLookup
-from mako.template import Template, Template
+from mako.lookup import TemplateLookup  # type: ignore
+from mako.template import Template  # type: ignore
 
 
 def instantiate_mako_template(template_file_name: str) -> Template:
@@ -13,12 +14,10 @@ def instantiate_mako_template(template_file_name: str) -> Template:
     return Template(filename=str(template_file_path), lookup=template_lookup)
 
 
-def write_if_changed(output_file_path: str, new_contents: str) -> None:
-    """Write new_contents to output_file_path if new_contents != the contents
-    of output_file_path.
+def write_if_changed(output_file_path: Union[Path, str], new_contents: str) -> None:
+    """Write new_contents to output_file_path if new_contents != the contents of output_file_path.
 
-    This prevents downstream recompiles when codegen runs but does not change
-    a given file.
+    This prevents downstream recompiles when codegen runs but does not change a given file.
     """
     old_contents = _read_file_contents(output_file_path)
     if old_contents != new_contents:
@@ -26,16 +25,16 @@ def write_if_changed(output_file_path: str, new_contents: str) -> None:
             f.write(new_contents)
 
 
-def load_metadata(metadata_dir: str) -> dict:
+def load_metadata(metadata_dir: Union[Path, str]) -> dict:
     metadata_path = Path(metadata_dir)
     module = import_module("metadata." + metadata_path.name)
 
     return module.metadata
 
 
-def _read_file_contents(output_file_path: str) -> str:
+def _read_file_contents(output_file_path: Union[Path, str]) -> str:
     try:
-        with open(output_file_path, "r", newline="") as f:
+        with Path(output_file_path).open("r", newline="") as f:
             return f.read()
     except FileNotFoundError:
         return ""

--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -6,7 +6,7 @@ from shutil import rmtree
 from sys import exit
 from typing import List, NamedTuple
 
-from .stage_client_files import stage_client_files
+from stage_client_files import stage_client_files
 
 
 class _CommandRecord(NamedTuple):

--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -6,7 +6,7 @@ from shutil import rmtree
 from sys import exit
 from typing import List, NamedTuple
 
-from stage_client_files import stage_client_files
+from .stage_client_files import stage_client_files
 
 
 class _CommandRecord(NamedTuple):
@@ -18,9 +18,7 @@ _FAILED_COMMANDS: List[_CommandRecord] = []
 
 
 def _system(command):
-    """
-    Capture the result of any failed system calls in _FAILED_COMMANDS.
-    """
+    """Capture the result of any failed system calls in _FAILED_COMMANDS."""
     exit_code = _system_core(command)
     if exit_code:
         _FAILED_COMMANDS.append(_CommandRecord(exit_code, command))
@@ -71,8 +69,8 @@ def validate_examples(driver_glob_expression: str, ip_address: str, device_name:
             if ip_address:
                 for file in dir.glob("*.py"):
                     print(f" -> Running example: {file.name}")
-                    PORT = 31763
-                    _system(rf"poetry run python {file} {ip_address} {PORT} {device_name}")
+                    port = 31763
+                    _system(rf"poetry run python {file} {ip_address} {port} {device_name}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes issues reported by the ni-python-styleguide tool, except for adding missing docstrings and non-trivial fixes to existing docstrings.

### Why should this Pull Request be merged?

Stepping toward using the ni-python-styleguide

### What testing has been done?

```
> ni-python-styleguide lint source\codegen\*.py | grep -v "Missing docstring\|doc line too long"
source\codegen\metadata_mutation.py:238:1: D415 First line should end with a period, question mark, or exclamation point
source\codegen\metadata_mutation.py:275:1: D205 1 blank line required between summary line and description
source\codegen\metadata_mutation.py:275:1: D212 Multi-line docstring summary should start at the first line
source\codegen\metadata_mutation.py:275:1: D415 First line should end with a period, question mark, or exclamation point
```