### PR TITLE
Updated not implemented and missing target messaging for LT examples.

### DIFF
--- a/examples/nirfmxlte/acp-single-carrier.py
+++ b/examples/nirfmxlte/acp-single-carrier.py
@@ -330,6 +330,15 @@ try:
         print(f"Lower Absolute Power (dBm)   : {lower_absolute_power[i]}")
         print(f"Upper Absolute Power (dBm)   : {upper_absolute_power[i]}")
         print("------------------------------------------")
+except grpc.RpcError as rpc_error:
+    error_message = rpc_error.details()
+    if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
+        error_message = f"Failed to connect to server on {server_address}:{server_port}"
+    elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
+    sys.stderr.write(f"{error_message}\n")
 finally:
     if instr:
         client.Close(nirfmxlte_types.CloseRequest(instrument=instr, force_destroy=False))

--- a/examples/nirfmxlte/ul-modacc-single-carrier.py
+++ b/examples/nirfmxlte/ul-modacc-single-carrier.py
@@ -284,6 +284,15 @@ try:
     print(f"Mean IQ Gain Imbalance (dB)          : {mean_iq_gain_imbalance}")
     print(f"Mean IQ Quadrature Error (deg)       : {mean_iq_quadrature_error}")
     print(f"In Band Emission Margin (dB)         : {in_band_emission_margin}")
+except grpc.RpcError as rpc_error:
+    error_message = rpc_error.details()
+    if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
+        error_message = f"Failed to connect to server on {server_address}:{server_port}"
+    elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
+    sys.stderr.write(f"{error_message}\n")
 finally:
     if instr:
         client.Close(nirfmxlte_types.CloseRequest(instrument=instr, force_destroy=False))


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds the common exception handling to the LTE examples so it gives reasonable info to the user when either
- The server isn't running / couldn't be found
- A method that was called isn't implemented (service isn't present / toggled on)

### Why should this Pull Request be merged?

Matches other RFmx examples.
Fixes [AB#1869076](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1869076)

### What testing has been done?

Ran validate_examples.py for LTE. Before it had the grpc error statuses bubbling up to the user. Now for both situations it gives our more user friendly messages.