### PR TITLE
Fix typo in two-dimension Invalid Argument message.

### DIFF
--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -518,7 +518,7 @@ namespace nifake_grpc {
       auto total_length = std::accumulate(request->array_lengths().cbegin(), request->array_lengths().cend(), 0);
 
       if (total_length != request->array_size()) {
-        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The total size of the two-dimensional array array does not match the exected size from the sum of array_lengths");
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The total size of the two-dimensional array array does not match the expected size from the sum of array_lengths");
       }
 
       auto array_lengths = const_cast<ViInt32*>(reinterpret_cast<const ViInt32*>(request->array_lengths().data()));

--- a/generated/nirfmxwlan/nirfmxwlan_service.cpp
+++ b/generated/nirfmxwlan/nirfmxwlan_service.cpp
@@ -111,7 +111,7 @@ namespace nirfmxwlan_grpc {
       auto total_length = std::accumulate(request->iq_sizes().cbegin(), request->iq_sizes().cend(), 0);
 
       if (total_length != request->iq_size()) {
-        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The total size of the two-dimensional array iq does not match the exected size from the sum of iq_sizes");
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The total size of the two-dimensional array iq does not match the expected size from the sum of iq_sizes");
       }
 
       auto iq_sizes = const_cast<int32*>(reinterpret_cast<const int32*>(request->iq_sizes().data()));
@@ -156,7 +156,7 @@ namespace nirfmxwlan_grpc {
       auto total_length = std::accumulate(request->spectrum_sizes().cbegin(), request->spectrum_sizes().cend(), 0);
 
       if (total_length != request->spectrum_size()) {
-        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The total size of the two-dimensional array spectrum does not match the exected size from the sum of spectrum_sizes");
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The total size of the two-dimensional array spectrum does not match the expected size from the sum of spectrum_sizes");
       }
 
       auto spectrum_sizes = const_cast<int32*>(reinterpret_cast<const int32*>(request->spectrum_sizes().data()));
@@ -3062,7 +3062,7 @@ namespace nirfmxwlan_grpc {
       auto total_length = std::accumulate(request->reference_waveform_sizes().cbegin(), request->reference_waveform_sizes().cend(), 0);
 
       if (total_length != request->reference_waveform_size()) {
-        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The total size of the two-dimensional array reference_waveform does not match the exected size from the sum of reference_waveform_sizes");
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The total size of the two-dimensional array reference_waveform does not match the expected size from the sum of reference_waveform_sizes");
       }
 
       auto reference_waveform_sizes = const_cast<int32*>(reinterpret_cast<const int32*>(request->reference_waveform_sizes().data()));

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -428,7 +428,7 @@ ${initialize_standard_input_param(function_name, parameter)}
 % else:
           ${parameter_name} = static_cast<${parameter['type']}>(${raw_request_snippet});
 % endif
-% if validate_attribute_enum: # raw validation can be overriden with a toggle.
+% if validate_attribute_enum: # raw validation can be overridden with a toggle.
           auto ${parameter_name}_is_valid = ${check_enum_is_valid} || feature_toggles_.is_allow_undefined_attributes_enabled;
           ${parameter_name} = ${parameter_name}_is_valid ? ${parameter_name} : 0;
 % endif
@@ -496,7 +496,7 @@ ${initialize_standard_input_param(function_name, parameter)}
       auto total_length = std::accumulate(request->${size_field_name}().cbegin(), request->${size_field_name}().cend(), 0);
 
       if (total_length != request->${parameter_name}_size()) {
-        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The total size of the two-dimensional array ${parameter_name} does not match the exected size from the sum of ${size_field_name}");
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The total size of the two-dimensional array ${parameter_name} does not match the expected size from the sum of ${size_field_name}");
       }
 </%def>
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes typo of "exected" with "expected". This shows up in the two-dimension array size handling in the services when we return an Invalid Argument status.

### Why should this Pull Request be merged?

Typos are typically frowned upon.

### What testing has been done?

Build / Visual inspection.
