### PR TITLE
Fix remaining linter issues in source/codegen/

### DIFF
--- a/.github/workflows/validate_python.yml
+++ b/.github/workflows/validate_python.yml
@@ -20,13 +20,9 @@ jobs:
     - name: Install build dependencies
       run: python -m pip install -r python_build_requirements.txt
 
-    - name: Validate python style with black
-      run: |
-        black source/codegen examples --check
-
     - name: Validate python style with ni-python-styleguide
       run: |
-        ni-python-styleguide lint examples
+        ni-python-styleguide lint source/codegen/*.py examples
 
     - name: Install poetry for validate_examples.py
       uses: abatilo/actions-poetry@v2.0.0

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -104,7 +104,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 device_name_out_buffer_size = status;
-      
+
         std::string device_name_out;
         if (device_name_out_buffer_size > 0) {
             device_name_out.resize(device_name_out_buffer_size - 1);
@@ -7120,7 +7120,7 @@ namespace nidaqmx_grpc {
           response->channel_type_array_raw().begin(),
           response->channel_type_array_raw().begin() + array_size_copy,
           google::protobuf::RepeatedFieldBackInserter(response->mutable_channel_type_array()),
-          [&](auto x) { 
+          [&](auto x) {
               return static_cast<nidaqmx_grpc::PowerUpChannelType>(x);
           });
       }
@@ -7193,7 +7193,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 port_list_size = status;
-      
+
         std::string port_list;
         if (port_list_size > 0) {
             port_list.resize(port_list_size - 1);
@@ -7378,7 +7378,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value;
         if (size > 0) {
             value.resize(size - 1);
@@ -7569,7 +7569,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         response->mutable_value()->Resize(size, 0);
         float64* value = response->mutable_value()->mutable_data();
         status = library_->GetChanAttributeDoubleArray(task, channel, attribute, value, size);
@@ -7676,7 +7676,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value;
         if (size > 0) {
             value.resize(size - 1);
@@ -7863,7 +7863,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         response->mutable_value()->Resize(size, 0);
         float64* value = response->mutable_value()->mutable_data();
         status = library_->GetDeviceAttributeDoubleArray(device_name, attribute, value, size);
@@ -7966,7 +7966,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         response->mutable_value_raw()->Resize(size, 0);
         int32* value = reinterpret_cast<int32*>(response->mutable_value_raw()->mutable_data());
         status = library_->GetDeviceAttributeInt32Array(device_name, attribute, value, size);
@@ -7987,7 +7987,7 @@ namespace nidaqmx_grpc {
             response->value_raw().begin(),
             response->value_raw().begin() + size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_value()),
-            [&](auto x) { 
+            [&](auto x) {
                 return checked_convert_value(x);
             });
         }
@@ -8035,7 +8035,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value;
         if (size > 0) {
             value.resize(size - 1);
@@ -8136,7 +8136,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         response->mutable_value()->Resize(size, 0);
         uInt32* value = reinterpret_cast<uInt32*>(response->mutable_value()->mutable_data());
         status = library_->GetDeviceAttributeUInt32Array(device_name, attribute, value, size);
@@ -8283,7 +8283,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 port_list_size = status;
-      
+
         std::string port_list;
         if (port_list_size > 0) {
             port_list.resize(port_list_size - 1);
@@ -8323,7 +8323,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 buffer_size = status;
-      
+
         std::string error_string;
         if (buffer_size > 0) {
             error_string.resize(buffer_size - 1);
@@ -8518,7 +8518,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value;
         if (size > 0) {
             value.resize(size - 1);
@@ -8600,7 +8600,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 buffer_size = status;
-      
+
         std::string error_string;
         if (buffer_size > 0) {
             error_string.resize(buffer_size - 1);
@@ -8688,7 +8688,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         int32 buffer_size = status;
-      
+
         std::string buffer;
         if (buffer_size > 0) {
             buffer.resize(buffer_size - 1);
@@ -8730,7 +8730,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         int32 buffer_size = status;
-      
+
         std::string buffer;
         if (buffer_size > 0) {
             buffer.resize(buffer_size - 1);
@@ -8772,7 +8772,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         int32 buffer_size = status;
-      
+
         std::string buffer;
         if (buffer_size > 0) {
             buffer.resize(buffer_size - 1);
@@ -8873,7 +8873,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value;
         if (size > 0) {
             value.resize(size - 1);
@@ -8974,7 +8974,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value;
         if (size > 0) {
             value.resize(size - 1);
@@ -9075,7 +9075,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value;
         if (size > 0) {
             value.resize(size - 1);
@@ -9176,7 +9176,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value(size, '\0');
         status = library_->GetPhysicalChanAttributeBytes(physical_channel, attribute, (uInt8*)value.data(), size);
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(size)) {
@@ -9273,7 +9273,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         response->mutable_value()->Resize(size, 0);
         float64* value = response->mutable_value()->mutable_data();
         status = library_->GetPhysicalChanAttributeDoubleArray(physical_channel, attribute, value, size);
@@ -9376,7 +9376,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         response->mutable_value_raw()->Resize(size, 0);
         int32* value = reinterpret_cast<int32*>(response->mutable_value_raw()->mutable_data());
         status = library_->GetPhysicalChanAttributeInt32Array(physical_channel, attribute, value, size);
@@ -9397,7 +9397,7 @@ namespace nidaqmx_grpc {
             response->value_raw().begin(),
             response->value_raw().begin() + size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_value()),
-            [&](auto x) { 
+            [&](auto x) {
                 return checked_convert_value(x);
             });
         }
@@ -9445,7 +9445,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value;
         if (size > 0) {
             value.resize(size - 1);
@@ -9546,7 +9546,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         response->mutable_value()->Resize(size, 0);
         uInt32* value = reinterpret_cast<uInt32*>(response->mutable_value()->mutable_data());
         status = library_->GetPhysicalChanAttributeUInt32Array(physical_channel, attribute, value, size);
@@ -9737,7 +9737,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value;
         if (size > 0) {
             value.resize(size - 1);
@@ -10082,7 +10082,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         response->mutable_value()->Resize(size, 0);
         float64* value = response->mutable_value()->mutable_data();
         status = library_->GetScaleAttributeDoubleArray(scale_name, attribute, value, size);
@@ -10185,7 +10185,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value;
         if (size > 0) {
             value.resize(size - 1);
@@ -10342,7 +10342,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value;
         if (size > 0) {
             value.resize(size - 1);
@@ -10486,7 +10486,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value;
         if (size > 0) {
             value.resize(size - 1);
@@ -10814,7 +10814,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value;
         if (size > 0) {
             value.resize(size - 1);
@@ -11055,7 +11055,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value;
         if (size > 0) {
             value.resize(size - 1);
@@ -11330,7 +11330,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         response->mutable_value()->Resize(size, 0);
         float64* value = response->mutable_value()->mutable_data();
         status = library_->GetTrigAttributeDoubleArray(task, attribute, value, size);
@@ -11435,7 +11435,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         response->mutable_value_raw()->Resize(size, 0);
         int32* value = reinterpret_cast<int32*>(response->mutable_value_raw()->mutable_data());
         status = library_->GetTrigAttributeInt32Array(task, attribute, value, size);
@@ -11456,7 +11456,7 @@ namespace nidaqmx_grpc {
             response->value_raw().begin(),
             response->value_raw().begin() + size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_value()),
-            [&](auto x) { 
+            [&](auto x) {
                 return checked_convert_value(x);
             });
         }
@@ -11505,7 +11505,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value;
         if (size > 0) {
             value.resize(size - 1);
@@ -11790,7 +11790,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value;
         if (size > 0) {
             value.resize(size - 1);
@@ -11985,7 +11985,7 @@ namespace nidaqmx_grpc {
           return ::grpc::Status::OK;
         }
         uInt32 size = status;
-      
+
         std::string value;
         if (size > 0) {
             value.resize(size - 1);
@@ -12258,7 +12258,7 @@ namespace nidaqmx_grpc {
           read_array.begin(),
           read_array.begin() + array_size_in_samps,
           google::protobuf::RepeatedFieldBackInserter(response->mutable_read_array()),
-          [&](auto x) { 
+          [&](auto x) {
               return x;
           });
         response->set_samps_per_chan_read(samps_per_chan_read);
@@ -12356,7 +12356,7 @@ namespace nidaqmx_grpc {
           read_array.begin(),
           read_array.begin() + array_size_in_samps,
           google::protobuf::RepeatedFieldBackInserter(response->mutable_read_array()),
-          [&](auto x) { 
+          [&](auto x) {
               return x;
           });
         response->set_samps_per_chan_read(samps_per_chan_read);
@@ -12946,7 +12946,7 @@ namespace nidaqmx_grpc {
           read_array.begin(),
           read_array.begin() + array_size_in_samps,
           google::protobuf::RepeatedFieldBackInserter(response->mutable_read_array()),
-          [&](auto x) { 
+          [&](auto x) {
               return x;
           });
         response->set_samps_per_chan_read(samps_per_chan_read);
@@ -17105,7 +17105,7 @@ namespace nidaqmx_grpc {
         write_array_raw.begin(),
         write_array_raw.end(),
         std::back_inserter(write_array),
-        [](auto x) { 
+        [](auto x) {
               if (x < std::numeric_limits<int16>::min() || x > std::numeric_limits<int16>::max()) {
                   std::string message("value ");
                   message.append(std::to_string(x));
@@ -17213,7 +17213,7 @@ namespace nidaqmx_grpc {
         write_array_raw.begin(),
         write_array_raw.end(),
         std::back_inserter(write_array),
-        [](auto x) { 
+        [](auto x) {
               if (x < std::numeric_limits<uInt16>::min() || x > std::numeric_limits<uInt16>::max()) {
                   std::string message("value ");
                   message.append(std::to_string(x));
@@ -17595,7 +17595,7 @@ namespace nidaqmx_grpc {
         write_array_raw.begin(),
         write_array_raw.end(),
         std::back_inserter(write_array),
-        [](auto x) { 
+        [](auto x) {
               if (x < std::numeric_limits<uInt16>::min() || x > std::numeric_limits<uInt16>::max()) {
                   std::string message("value ");
                   message.append(std::to_string(x));

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -2181,7 +2181,7 @@ namespace nidcpower_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 size = status;
-      
+
         response->mutable_configuration()->Resize(size, 0);
         ViAddr* configuration = reinterpret_cast<ViAddr*>(response->mutable_configuration()->mutable_data());
         status = library_->ExportAttributeConfigurationBuffer(vi, size, configuration);
@@ -2435,7 +2435,7 @@ namespace nidcpower_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string attribute_value;
         if (buffer_size > 0) {
             attribute_value.resize(buffer_size - 1);
@@ -2477,7 +2477,7 @@ namespace nidcpower_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string channel_name;
         if (buffer_size > 0) {
             channel_name.resize(buffer_size - 1);
@@ -2519,7 +2519,7 @@ namespace nidcpower_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string channel_name;
         if (buffer_size > 0) {
             channel_name.resize(buffer_size - 1);
@@ -2560,7 +2560,7 @@ namespace nidcpower_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         ViStatus code {};
         std::string description;
         if (buffer_size > 0) {
@@ -2680,7 +2680,7 @@ namespace nidcpower_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string coercion_record;
         if (buffer_size > 0) {
             coercion_record.resize(buffer_size - 1);
@@ -2721,7 +2721,7 @@ namespace nidcpower_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string interchange_warning;
         if (buffer_size > 0) {
             interchange_warning.resize(buffer_size - 1);

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -1767,7 +1767,7 @@ namespace nidigitalpattern_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string value;
         if (buffer_size > 0) {
             value.resize(buffer_size - 1);
@@ -1809,7 +1809,7 @@ namespace nidigitalpattern_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 name_buffer_size = status;
-      
+
         std::string name;
         if (name_buffer_size > 0) {
             name.resize(name_buffer_size - 1);
@@ -1851,7 +1851,7 @@ namespace nidigitalpattern_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 name_buffer_size = status;
-      
+
         std::string names;
         if (name_buffer_size > 0) {
             names.resize(name_buffer_size - 1);
@@ -1892,7 +1892,7 @@ namespace nidigitalpattern_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 error_description_buffer_size = status;
-      
+
         ViStatus error_code {};
         std::string error_description;
         if (error_description_buffer_size > 0) {
@@ -2038,7 +2038,7 @@ namespace nidigitalpattern_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 name_buffer_size = status;
-      
+
         std::string name;
         if (name_buffer_size > 0) {
             name.resize(name_buffer_size - 1);
@@ -2080,7 +2080,7 @@ namespace nidigitalpattern_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 pin_list_buffer_size = status;
-      
+
         std::string pin_list;
         if (pin_list_buffer_size > 0) {
             pin_list.resize(pin_list_buffer_size - 1);
@@ -2122,7 +2122,7 @@ namespace nidigitalpattern_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 name_buffer_size = status;
-      
+
         std::string name;
         if (name_buffer_size > 0) {
             name.resize(name_buffer_size - 1);
@@ -2395,7 +2395,7 @@ namespace nidigitalpattern_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 name_buffer_size = status;
-      
+
         std::string name;
         if (name_buffer_size > 0) {
             name.resize(name_buffer_size - 1);

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -1182,7 +1182,7 @@ namespace nidmm_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 size = status;
-      
+
         std::string configuration(size, '\0');
         status = library_->ExportAttributeConfigurationBuffer(vi, size, (ViInt8*)configuration.data());
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(size)) {
@@ -1494,7 +1494,7 @@ namespace nidmm_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string attribute_value;
         if (buffer_size > 0) {
             attribute_value.resize(buffer_size - 1);
@@ -1606,7 +1606,7 @@ namespace nidmm_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string channel_string;
         if (buffer_size > 0) {
             channel_string.resize(buffer_size - 1);
@@ -1671,7 +1671,7 @@ namespace nidmm_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         ViStatus error_code {};
         std::string description;
         if (buffer_size > 0) {
@@ -1715,7 +1715,7 @@ namespace nidmm_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string error_message;
         if (buffer_size > 0) {
             error_message.resize(buffer_size - 1);
@@ -1841,7 +1841,7 @@ namespace nidmm_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string coercion_record;
         if (buffer_size > 0) {
             coercion_record.resize(buffer_size - 1);
@@ -1882,7 +1882,7 @@ namespace nidmm_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string interchange_warning;
         if (buffer_size > 0) {
             interchange_warning.resize(buffer_size - 1);

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -319,7 +319,7 @@ namespace nifake_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 size_in_bytes = status;
-      
+
         std::string configuration(size_in_bytes, '\0');
         status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, (ViInt8*)configuration.data());
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(size_in_bytes)) {
@@ -481,7 +481,7 @@ namespace nifake_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string a_string;
         if (buffer_size > 0) {
             a_string.resize(buffer_size - 1);
@@ -604,7 +604,7 @@ namespace nifake_grpc {
             if (shrunk_size != current_size) {
               response->mutable_array_out()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_size(actual_size);
         }
         return ::grpc::Status::OK;
@@ -808,7 +808,7 @@ namespace nifake_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 array_size = status;
-      
+
         response->mutable_array_out()->Resize(array_size, 0);
         ViReal64* array_out = response->mutable_array_out()->mutable_data();
         status = library_->GetArrayUsingIviDance(vi, array_size, array_out);
@@ -997,7 +997,7 @@ namespace nifake_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string attribute_value;
         if (buffer_size > 0) {
             attribute_value.resize(buffer_size - 1);
@@ -1802,7 +1802,7 @@ namespace nifake_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 string_size = status;
-      
+
         ViBoolean a_boolean {};
         ViInt32 an_int32 {};
         ViInt64 an_int64 {};

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -253,7 +253,7 @@ namespace nifake_non_ivi_grpc {
           response->value_raw().begin(),
           response->value_raw().begin() + 10,
           google::protobuf::RepeatedFieldBackInserter(response->mutable_value()),
-          [&](auto x) { 
+          [&](auto x) {
               return checked_convert_value(x);
           });
       }
@@ -437,7 +437,7 @@ namespace nifake_non_ivi_grpc {
         u16_array_raw.begin(),
         u16_array_raw.end(),
         std::back_inserter(u16_array),
-        [](auto x) { 
+        [](auto x) {
               if (x < std::numeric_limits<myUInt16>::min() || x > std::numeric_limits<myUInt16>::max()) {
                   std::string message("value ");
                   message.append(std::to_string(x));
@@ -455,7 +455,7 @@ namespace nifake_non_ivi_grpc {
         i16_array_raw.begin(),
         i16_array_raw.end(),
         std::back_inserter(i16_array),
-        [](auto x) { 
+        [](auto x) {
               if (x < std::numeric_limits<myInt16>::min() || x > std::numeric_limits<myInt16>::max()) {
                   std::string message("value ");
                   message.append(std::to_string(x));
@@ -473,7 +473,7 @@ namespace nifake_non_ivi_grpc {
         i8_array_raw.begin(),
         i8_array_raw.end(),
         std::back_inserter(i8_array),
-        [](auto x) { 
+        [](auto x) {
               if (x < std::numeric_limits<myInt8>::min() || x > std::numeric_limits<myInt8>::max()) {
                   std::string message("value ");
                   message.append(std::to_string(x));
@@ -542,7 +542,7 @@ namespace nifake_non_ivi_grpc {
           u16_data.begin(),
           u16_data.begin() + number_of_u16_samples,
           google::protobuf::RepeatedFieldBackInserter(response->mutable_u16_data()),
-          [&](auto x) { 
+          [&](auto x) {
               return x;
           });
         response->mutable_i16_data()->Clear();
@@ -551,7 +551,7 @@ namespace nifake_non_ivi_grpc {
           i16_data.begin(),
           i16_data.begin() + number_of_i16_samples,
           google::protobuf::RepeatedFieldBackInserter(response->mutable_i16_data()),
-          [&](auto x) { 
+          [&](auto x) {
               return x;
           });
         response->mutable_i8_data()->Clear();
@@ -560,7 +560,7 @@ namespace nifake_non_ivi_grpc {
           i8_data.begin(),
           i8_data.begin() + number_of_i8_samples,
           google::protobuf::RepeatedFieldBackInserter(response->mutable_i8_data()),
-          [&](auto x) { 
+          [&](auto x) {
               return x;
           });
       }
@@ -633,7 +633,7 @@ namespace nifake_non_ivi_grpc {
           u16_data.begin(),
           u16_data.begin() + array_size_copy,
           google::protobuf::RepeatedFieldBackInserter(response->mutable_u16_data()),
-          [&](auto x) { 
+          [&](auto x) {
               return x;
           });
       }

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -1702,7 +1702,7 @@ namespace nifgen_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 size_in_bytes = status;
-      
+
         response->mutable_configuration()->Resize(size_in_bytes, 0);
         ViAddr* configuration = reinterpret_cast<ViAddr*>(response->mutable_configuration()->mutable_data());
         status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, configuration);
@@ -1924,7 +1924,7 @@ namespace nifgen_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 array_size = status;
-      
+
         std::string attribute_value;
         if (array_size > 0) {
             attribute_value.resize(array_size - 1);
@@ -1966,7 +1966,7 @@ namespace nifgen_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string channel_string;
         if (buffer_size > 0) {
             channel_string.resize(buffer_size - 1);
@@ -2007,7 +2007,7 @@ namespace nifgen_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 error_description_buffer_size = status;
-      
+
         ViStatus error_code {};
         std::string error_description;
         if (error_description_buffer_size > 0) {
@@ -2190,7 +2190,7 @@ namespace nifgen_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string coercion_record;
         if (buffer_size > 0) {
             coercion_record.resize(buffer_size - 1);
@@ -2231,7 +2231,7 @@ namespace nifgen_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string interchange_warning;
         if (buffer_size > 0) {
             interchange_warning.resize(buffer_size - 1);

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
@@ -562,7 +562,7 @@ namespace nirfmxbluetooth_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -603,7 +603,7 @@ namespace nirfmxbluetooth_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_length = status;
-      
+
         std::string selector_string;
         if (selector_string_length > 0) {
             selector_string.resize(selector_string_length - 1);
@@ -644,7 +644,7 @@ namespace nirfmxbluetooth_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -1813,7 +1813,7 @@ namespace nirfmxbluetooth_grpc {
             response->attr_val_raw().begin(),
             response->attr_val_raw().begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_attr_val()),
-            [&](auto x) { 
+            [&](auto x) {
                 return checked_convert_attr_val(x);
             });
           response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -1951,7 +1951,7 @@ namespace nirfmxbluetooth_grpc {
             attr_val.begin(),
             attr_val.begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_attr_val()),
-            [&](auto x) { 
+            [&](auto x) {
                 return x;
             });
           response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -2000,7 +2000,7 @@ namespace nirfmxbluetooth_grpc {
             if (shrunk_size != current_size) {
               response->mutable_attr_val()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -2046,7 +2046,7 @@ namespace nirfmxbluetooth_grpc {
             if (shrunk_size != current_size) {
               response->mutable_attr_val()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -2077,7 +2077,7 @@ namespace nirfmxbluetooth_grpc {
           return ::grpc::Status::OK;
         }
         int32 array_size = status;
-      
+
         std::string attr_val;
         if (array_size > 0) {
             attr_val.resize(array_size - 1);
@@ -2313,7 +2313,7 @@ namespace nirfmxbluetooth_grpc {
           return ::grpc::Status::OK;
         }
         int32 error_description_buffer_size = status;
-      
+
         int32 error_code {};
         std::string error_description;
         if (error_description_buffer_size > 0) {
@@ -2357,7 +2357,7 @@ namespace nirfmxbluetooth_grpc {
           return ::grpc::Status::OK;
         }
         int32 error_description_buffer_size = status;
-      
+
         std::string error_description;
         if (error_description_buffer_size > 0) {
             error_description.resize(error_description_buffer_size - 1);
@@ -2572,7 +2572,7 @@ namespace nirfmxbluetooth_grpc {
             if (shrunk_size != current_size) {
               response->mutable_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -2740,7 +2740,7 @@ namespace nirfmxbluetooth_grpc {
             demodulated_bits.begin(),
             demodulated_bits.begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_demodulated_bits()),
-            [&](auto x) { 
+            [&](auto x) {
                 return x;
             });
           response->mutable_demodulated_bits()->Resize(actual_array_size, 0);
@@ -3583,7 +3583,7 @@ namespace nirfmxbluetooth_grpc {
         attr_val_raw.begin(),
         attr_val_raw.end(),
         std::back_inserter(attr_val),
-        [](auto x) { 
+        [](auto x) {
               if (x < std::numeric_limits<int8>::min() || x > std::numeric_limits<int8>::max()) {
                   std::string message("value ");
                   message.append(std::to_string(x));

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -62,7 +62,7 @@ namespace nirfmxinstr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_length = status;
-      
+
         std::string selector_string;
         if (selector_string_length > 0) {
             selector_string.resize(selector_string_length - 1);
@@ -103,7 +103,7 @@ namespace nirfmxinstr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -144,7 +144,7 @@ namespace nirfmxinstr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -185,7 +185,7 @@ namespace nirfmxinstr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -980,7 +980,7 @@ namespace nirfmxinstr_grpc {
             response->attr_val_raw().begin(),
             response->attr_val_raw().begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_attr_val()),
-            [&](auto x) { 
+            [&](auto x) {
                 return checked_convert_attr_val(x);
             });
           response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -1118,7 +1118,7 @@ namespace nirfmxinstr_grpc {
             attr_val.begin(),
             attr_val.begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_attr_val()),
-            [&](auto x) { 
+            [&](auto x) {
                 return x;
             });
           response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -1167,7 +1167,7 @@ namespace nirfmxinstr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_attr_val()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -1213,7 +1213,7 @@ namespace nirfmxinstr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_attr_val()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -1244,7 +1244,7 @@ namespace nirfmxinstr_grpc {
           return ::grpc::Status::OK;
         }
         int32 array_size = status;
-      
+
         std::string attr_val;
         if (array_size > 0) {
             attr_val.resize(array_size - 1);
@@ -1481,7 +1481,7 @@ namespace nirfmxinstr_grpc {
           return ::grpc::Status::OK;
         }
         int32 array_size = status;
-      
+
         std::string available_ports;
         if (array_size > 0) {
             available_ports.resize(array_size - 1);
@@ -1522,7 +1522,7 @@ namespace nirfmxinstr_grpc {
           return ::grpc::Status::OK;
         }
         int32 error_description_buffer_size = status;
-      
+
         int32 error_code {};
         std::string error_description;
         if (error_description_buffer_size > 0) {
@@ -1566,7 +1566,7 @@ namespace nirfmxinstr_grpc {
           return ::grpc::Status::OK;
         }
         int32 error_description_buffer_size = status;
-      
+
         std::string error_description;
         if (error_description_buffer_size > 0) {
             error_description.resize(error_description_buffer_size - 1);
@@ -1672,7 +1672,7 @@ namespace nirfmxinstr_grpc {
             response->personality_raw().begin(),
             response->personality_raw().begin() + actual_personality_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_personality()),
-            [&](auto x) { 
+            [&](auto x) {
                 return static_cast<nirfmxinstr_grpc::Personality>(x);
             });
           response->mutable_personality()->Resize(actual_personality_array_size, 0);
@@ -2589,7 +2589,7 @@ namespace nirfmxinstr_grpc {
         attr_val_raw.begin(),
         attr_val_raw.end(),
         std::back_inserter(attr_val),
-        [](auto x) { 
+        [](auto x) {
               if (x < std::numeric_limits<int8>::min() || x > std::numeric_limits<int8>::max()) {
                   std::string message("value ");
                   message.append(std::to_string(x));

--- a/generated/nirfmxlte/nirfmxlte_service.cpp
+++ b/generated/nirfmxlte/nirfmxlte_service.cpp
@@ -897,7 +897,7 @@ namespace nirfmxlte_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -938,7 +938,7 @@ namespace nirfmxlte_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -979,7 +979,7 @@ namespace nirfmxlte_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -1020,7 +1020,7 @@ namespace nirfmxlte_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -1061,7 +1061,7 @@ namespace nirfmxlte_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_length = status;
-      
+
         std::string selector_string;
         if (selector_string_length > 0) {
             selector_string.resize(selector_string_length - 1);
@@ -1102,7 +1102,7 @@ namespace nirfmxlte_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -1143,7 +1143,7 @@ namespace nirfmxlte_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -3658,7 +3658,7 @@ namespace nirfmxlte_grpc {
             response->attr_val_raw().begin(),
             response->attr_val_raw().begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_attr_val()),
-            [&](auto x) { 
+            [&](auto x) {
                 return checked_convert_attr_val(x);
             });
           response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -3796,7 +3796,7 @@ namespace nirfmxlte_grpc {
             attr_val.begin(),
             attr_val.begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_attr_val()),
-            [&](auto x) { 
+            [&](auto x) {
                 return x;
             });
           response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -3845,7 +3845,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_attr_val()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -3891,7 +3891,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_attr_val()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -3922,7 +3922,7 @@ namespace nirfmxlte_grpc {
           return ::grpc::Status::OK;
         }
         int32 array_size = status;
-      
+
         std::string attr_val;
         if (array_size > 0) {
             attr_val.resize(array_size - 1);
@@ -4158,7 +4158,7 @@ namespace nirfmxlte_grpc {
           return ::grpc::Status::OK;
         }
         int32 error_description_buffer_size = status;
-      
+
         int32 error_code {};
         std::string error_description;
         if (error_description_buffer_size > 0) {
@@ -4202,7 +4202,7 @@ namespace nirfmxlte_grpc {
           return ::grpc::Status::OK;
         }
         int32 error_description_buffer_size = status;
-      
+
         std::string error_description;
         if (error_description_buffer_size > 0) {
             error_description.resize(error_description_buffer_size - 1);
@@ -4586,7 +4586,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_csrs_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -4932,7 +4932,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_pbch_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -4978,7 +4978,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_pcfich_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -5024,7 +5024,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_pdcch_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -5070,7 +5070,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_phich_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -5820,7 +5820,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_data_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_data_constellation_actual_array_size(data_constellation_actual_array_size);
           convert_to_grpc(dmrs_constellation, response->mutable_dmrs_constellation());
           {
@@ -5829,7 +5829,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_dmrs_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_dmrs_constellation_actual_array_size(dmrs_constellation_actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -5956,7 +5956,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_qam1024_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -6067,7 +6067,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_qam16_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -6113,7 +6113,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_qam256_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -6159,7 +6159,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_qam64_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -6290,7 +6290,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_qpsk_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -6339,7 +6339,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_data_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_data_constellation_actual_array_size(data_constellation_actual_array_size);
           convert_to_grpc(dmrs_constellation, response->mutable_dmrs_constellation());
           {
@@ -6348,7 +6348,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_dmrs_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_dmrs_constellation_actual_array_size(dmrs_constellation_actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -6607,7 +6607,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_data_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_data_constellation_actual_array_size(data_constellation_actual_array_size);
           convert_to_grpc(dmrs_constellation, response->mutable_dmrs_constellation());
           {
@@ -6616,7 +6616,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_dmrs_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_dmrs_constellation_actual_array_size(dmrs_constellation_actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -6801,7 +6801,7 @@ namespace nirfmxlte_grpc {
             bits.begin(),
             bits.begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_bits()),
-            [&](auto x) { 
+            [&](auto x) {
                 return x;
             });
           response->mutable_bits()->Resize(actual_array_size, 0);
@@ -7008,7 +7008,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_srs_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -7355,7 +7355,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_sss_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           convert_to_grpc(pss_constellation, response->mutable_pss_constellation());
           {
             auto shrunk_size = actual_array_size;
@@ -7363,7 +7363,7 @@ namespace nirfmxlte_grpc {
             if (shrunk_size != current_size) {
               response->mutable_pss_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -7850,7 +7850,7 @@ namespace nirfmxlte_grpc {
             response->measurement_status_raw().begin(),
             response->measurement_status_raw().begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_measurement_status()),
-            [&](auto x) { 
+            [&](auto x) {
                 return static_cast<nirfmxlte_grpc::PvtMeasurementStatus>(x);
             });
           response->mutable_measurement_status()->Resize(actual_array_size, 0);
@@ -8734,7 +8734,7 @@ namespace nirfmxlte_grpc {
             response->measurement_status_raw().begin(),
             response->measurement_status_raw().begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_measurement_status()),
-            [&](auto x) { 
+            [&](auto x) {
                 return static_cast<nirfmxlte_grpc::SemLowerOffsetMeasurementStatus>(x);
             });
           response->mutable_measurement_status()->Resize(actual_array_size, 0);
@@ -9041,7 +9041,7 @@ namespace nirfmxlte_grpc {
             response->measurement_status_raw().begin(),
             response->measurement_status_raw().begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_measurement_status()),
-            [&](auto x) { 
+            [&](auto x) {
                 return static_cast<nirfmxlte_grpc::SemUpperOffsetMeasurementStatus>(x);
             });
           response->mutable_measurement_status()->Resize(actual_array_size, 0);
@@ -9490,7 +9490,7 @@ namespace nirfmxlte_grpc {
         attr_val_raw.begin(),
         attr_val_raw.end(),
         std::back_inserter(attr_val),
-        [](auto x) { 
+        [](auto x) {
               if (x < std::numeric_limits<int8>::min() || x > std::numeric_limits<int8>::max()) {
                   std::string message("value ");
                   message.append(std::to_string(x));

--- a/generated/nirfmxnr/nirfmxnr_service.cpp
+++ b/generated/nirfmxnr/nirfmxnr_service.cpp
@@ -860,7 +860,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -901,7 +901,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -942,7 +942,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -983,7 +983,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -1025,7 +1025,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_length = status;
-      
+
         std::string selector_string;
         if (selector_string_length > 0) {
             selector_string.resize(selector_string_length - 1);
@@ -1066,7 +1066,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_length = status;
-      
+
         std::string selector_string;
         if (selector_string_length > 0) {
             selector_string.resize(selector_string_length - 1);
@@ -1107,7 +1107,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -1148,7 +1148,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -1189,7 +1189,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -1230,7 +1230,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -1271,7 +1271,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -1312,7 +1312,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -1353,7 +1353,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_length = status;
-      
+
         std::string selector_string;
         if (selector_string_length > 0) {
             selector_string.resize(selector_string_length - 1);
@@ -1394,7 +1394,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -1435,7 +1435,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -2720,7 +2720,7 @@ namespace nirfmxnr_grpc {
             response->attr_val_raw().begin(),
             response->attr_val_raw().begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_attr_val()),
-            [&](auto x) { 
+            [&](auto x) {
                 return checked_convert_attr_val(x);
             });
           response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -2858,7 +2858,7 @@ namespace nirfmxnr_grpc {
             attr_val.begin(),
             attr_val.begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_attr_val()),
-            [&](auto x) { 
+            [&](auto x) {
                 return x;
             });
           response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -2907,7 +2907,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_attr_val()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -2953,7 +2953,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_attr_val()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -2984,7 +2984,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 array_size = status;
-      
+
         std::string attr_val;
         if (array_size > 0) {
             attr_val.resize(array_size - 1);
@@ -3220,7 +3220,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 error_description_buffer_size = status;
-      
+
         int32 error_code {};
         std::string error_description;
         if (error_description_buffer_size > 0) {
@@ -3264,7 +3264,7 @@ namespace nirfmxnr_grpc {
           return ::grpc::Status::OK;
         }
         int32 error_description_buffer_size = status;
-      
+
         std::string error_description;
         if (error_description_buffer_size > 0) {
             error_description.resize(error_description_buffer_size - 1);
@@ -3729,7 +3729,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_pbch_dmrs_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -3863,7 +3863,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_pbch_data_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -3997,7 +3997,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_qam1024_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -4043,7 +4043,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_qam16_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -4089,7 +4089,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_qam256_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -4135,7 +4135,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_qam64_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -4181,7 +4181,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_psk8_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -4227,7 +4227,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_pdsch_dmrs_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -4273,7 +4273,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_pdsch_data_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -4318,7 +4318,7 @@ namespace nirfmxnr_grpc {
             bits.begin(),
             bits.begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_bits()),
-            [&](auto x) { 
+            [&](auto x) {
                 return x;
             });
           response->mutable_bits()->Resize(actual_array_size, 0);
@@ -4367,7 +4367,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_pdsch_ptrs_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -4413,7 +4413,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_qpsk_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -4459,7 +4459,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_pss_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -4593,7 +4593,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_pusch_dmrs_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -4639,7 +4639,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_pusch_data_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -4684,7 +4684,7 @@ namespace nirfmxnr_grpc {
             bits.begin(),
             bits.begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_bits()),
-            [&](auto x) { 
+            [&](auto x) {
                 return x;
             });
           response->mutable_bits()->Resize(actual_array_size, 0);
@@ -4733,7 +4733,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_pusch_ptrs_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -5131,7 +5131,7 @@ namespace nirfmxnr_grpc {
             if (shrunk_size != current_size) {
               response->mutable_sss_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -5757,7 +5757,7 @@ namespace nirfmxnr_grpc {
             response->measurement_status_raw().begin(),
             response->measurement_status_raw().begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_measurement_status()),
-            [&](auto x) { 
+            [&](auto x) {
                 return static_cast<nirfmxnr_grpc::PvtMeasurementStatus>(x);
             });
           response->mutable_measurement_status()->Resize(actual_array_size, 0);
@@ -6657,7 +6657,7 @@ namespace nirfmxnr_grpc {
             response->measurement_status_raw().begin(),
             response->measurement_status_raw().begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_measurement_status()),
-            [&](auto x) { 
+            [&](auto x) {
                 return static_cast<nirfmxnr_grpc::SemLowerOffsetMeasurementStatus>(x);
             });
           response->mutable_measurement_status()->Resize(actual_array_size, 0);
@@ -6964,7 +6964,7 @@ namespace nirfmxnr_grpc {
             response->measurement_status_raw().begin(),
             response->measurement_status_raw().begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_measurement_status()),
-            [&](auto x) { 
+            [&](auto x) {
                 return static_cast<nirfmxnr_grpc::SemUpperOffsetMeasurementStatus>(x);
             });
           response->mutable_measurement_status()->Resize(actual_array_size, 0);
@@ -7413,7 +7413,7 @@ namespace nirfmxnr_grpc {
         attr_val_raw.begin(),
         attr_val_raw.end(),
         std::back_inserter(attr_val),
-        [](auto x) { 
+        [](auto x) {
               if (x < std::numeric_limits<int8>::min() || x > std::numeric_limits<int8>::max()) {
                   std::string message("value ");
                   message.append(std::to_string(x));

--- a/generated/nirfmxspecan/nirfmxspecan_service.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_service.cpp
@@ -1978,7 +1978,7 @@ namespace nirfmxspecan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_processed_mean_acquired_waveform()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -2028,7 +2028,7 @@ namespace nirfmxspecan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_processed_reference_waveform()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -2245,7 +2245,7 @@ namespace nirfmxspecan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -2286,7 +2286,7 @@ namespace nirfmxspecan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -2327,7 +2327,7 @@ namespace nirfmxspecan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -2369,7 +2369,7 @@ namespace nirfmxspecan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_length = status;
-      
+
         std::string selector_string;
         if (selector_string_length > 0) {
             selector_string.resize(selector_string_length - 1);
@@ -2410,7 +2410,7 @@ namespace nirfmxspecan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_length = status;
-      
+
         std::string selector_string;
         if (selector_string_length > 0) {
             selector_string.resize(selector_string_length - 1);
@@ -2451,7 +2451,7 @@ namespace nirfmxspecan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -2492,7 +2492,7 @@ namespace nirfmxspecan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -2535,7 +2535,7 @@ namespace nirfmxspecan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_length = status;
-      
+
         std::string selector_string;
         if (selector_string_length > 0) {
             selector_string.resize(selector_string_length - 1);
@@ -2576,7 +2576,7 @@ namespace nirfmxspecan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -2617,7 +2617,7 @@ namespace nirfmxspecan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -2658,7 +2658,7 @@ namespace nirfmxspecan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_length = status;
-      
+
         std::string selector_string;
         if (selector_string_length > 0) {
             selector_string.resize(selector_string_length - 1);
@@ -2699,7 +2699,7 @@ namespace nirfmxspecan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -4100,7 +4100,7 @@ namespace nirfmxspecan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_waveform_out()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
           response->set_papr(papr);
           response->set_power_offset(power_offset);
@@ -4172,7 +4172,7 @@ namespace nirfmxspecan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_waveform_out()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
           response->set_papr(papr);
         }
@@ -4972,7 +4972,7 @@ namespace nirfmxspecan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_dpd_polynomial()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -5021,7 +5021,7 @@ namespace nirfmxspecan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_complex_gains()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -5096,7 +5096,7 @@ namespace nirfmxspecan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_processed_mean_acquired_waveform()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -5146,7 +5146,7 @@ namespace nirfmxspecan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_processed_reference_waveform()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -5867,7 +5867,7 @@ namespace nirfmxspecan_grpc {
             response->attr_val_raw().begin(),
             response->attr_val_raw().begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_attr_val()),
-            [&](auto x) { 
+            [&](auto x) {
                 return checked_convert_attr_val(x);
             });
           response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -6005,7 +6005,7 @@ namespace nirfmxspecan_grpc {
             attr_val.begin(),
             attr_val.begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_attr_val()),
-            [&](auto x) { 
+            [&](auto x) {
                 return x;
             });
           response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -6054,7 +6054,7 @@ namespace nirfmxspecan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_attr_val()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -6100,7 +6100,7 @@ namespace nirfmxspecan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_attr_val()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -6131,7 +6131,7 @@ namespace nirfmxspecan_grpc {
           return ::grpc::Status::OK;
         }
         int32 array_size = status;
-      
+
         std::string attr_val;
         if (array_size > 0) {
             attr_val.resize(array_size - 1);
@@ -6367,7 +6367,7 @@ namespace nirfmxspecan_grpc {
           return ::grpc::Status::OK;
         }
         int32 error_description_buffer_size = status;
-      
+
         int32 error_code {};
         std::string error_description;
         if (error_description_buffer_size > 0) {
@@ -6411,7 +6411,7 @@ namespace nirfmxspecan_grpc {
           return ::grpc::Status::OK;
         }
         int32 error_description_buffer_size = status;
-      
+
         std::string error_description;
         if (error_description_buffer_size > 0) {
             error_description.resize(error_description_buffer_size - 1);
@@ -7655,7 +7655,7 @@ namespace nirfmxspecan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_data()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -11601,7 +11601,7 @@ namespace nirfmxspecan_grpc {
             response->measurement_status_raw().begin(),
             response->measurement_status_raw().begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_measurement_status()),
-            [&](auto x) { 
+            [&](auto x) {
                 return static_cast<nirfmxspecan_grpc::SemLowerOffsetMeasurementStatus>(x);
             });
           response->mutable_measurement_status()->Resize(actual_array_size, 0);
@@ -11894,7 +11894,7 @@ namespace nirfmxspecan_grpc {
             response->measurement_status_raw().begin(),
             response->measurement_status_raw().begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_measurement_status()),
-            [&](auto x) { 
+            [&](auto x) {
                 return static_cast<nirfmxspecan_grpc::SemUpperOffsetMeasurementStatus>(x);
             });
           response->mutable_measurement_status()->Resize(actual_array_size, 0);
@@ -12343,7 +12343,7 @@ namespace nirfmxspecan_grpc {
         attr_val_raw.begin(),
         attr_val_raw.end(),
         std::back_inserter(attr_val),
-        [](auto x) { 
+        [](auto x) {
               if (x < std::numeric_limits<int8>::min() || x > std::numeric_limits<int8>::max()) {
                   std::string message("value ");
                   message.append(std::to_string(x));
@@ -14209,7 +14209,7 @@ namespace nirfmxspecan_grpc {
             response->range_status_raw().begin(),
             response->range_status_raw().begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_range_status()),
-            [&](auto x) { 
+            [&](auto x) {
                 return static_cast<nirfmxspecan_grpc::SpurRangeStatus>(x);
             });
           response->mutable_range_status()->Resize(actual_array_size, 0);

--- a/generated/nirfmxwlan/nirfmxwlan_service.cpp
+++ b/generated/nirfmxwlan/nirfmxwlan_service.cpp
@@ -270,7 +270,7 @@ namespace nirfmxwlan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -311,7 +311,7 @@ namespace nirfmxwlan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -352,7 +352,7 @@ namespace nirfmxwlan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -393,7 +393,7 @@ namespace nirfmxwlan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -434,7 +434,7 @@ namespace nirfmxwlan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_length = status;
-      
+
         std::string selector_string;
         if (selector_string_length > 0) {
             selector_string.resize(selector_string_length - 1);
@@ -475,7 +475,7 @@ namespace nirfmxwlan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -516,7 +516,7 @@ namespace nirfmxwlan_grpc {
           return ::grpc::Status::OK;
         }
         int32 selector_string_out_length = status;
-      
+
         std::string selector_string_out;
         if (selector_string_out_length > 0) {
             selector_string_out.resize(selector_string_out_length - 1);
@@ -1413,7 +1413,7 @@ namespace nirfmxwlan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -2037,7 +2037,7 @@ namespace nirfmxwlan_grpc {
             response->attr_val_raw().begin(),
             response->attr_val_raw().begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_attr_val()),
-            [&](auto x) { 
+            [&](auto x) {
                 return checked_convert_attr_val(x);
             });
           response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -2175,7 +2175,7 @@ namespace nirfmxwlan_grpc {
             attr_val.begin(),
             attr_val.begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_attr_val()),
-            [&](auto x) { 
+            [&](auto x) {
                 return x;
             });
           response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -2224,7 +2224,7 @@ namespace nirfmxwlan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_attr_val()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -2270,7 +2270,7 @@ namespace nirfmxwlan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_attr_val()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -2301,7 +2301,7 @@ namespace nirfmxwlan_grpc {
           return ::grpc::Status::OK;
         }
         int32 array_size = status;
-      
+
         std::string attr_val;
         if (array_size > 0) {
             attr_val.resize(array_size - 1);
@@ -2537,7 +2537,7 @@ namespace nirfmxwlan_grpc {
           return ::grpc::Status::OK;
         }
         int32 error_description_buffer_size = status;
-      
+
         int32 error_code {};
         std::string error_description;
         if (error_description_buffer_size > 0) {
@@ -2581,7 +2581,7 @@ namespace nirfmxwlan_grpc {
           return ::grpc::Status::OK;
         }
         int32 error_description_buffer_size = status;
-      
+
         std::string error_description;
         if (error_description_buffer_size > 0) {
             error_description.resize(error_description_buffer_size - 1);
@@ -3708,7 +3708,7 @@ namespace nirfmxwlan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_data_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -4694,7 +4694,7 @@ namespace nirfmxwlan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_pilot_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -5712,7 +5712,7 @@ namespace nirfmxwlan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_user_data_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -5758,7 +5758,7 @@ namespace nirfmxwlan_grpc {
             if (shrunk_size != current_size) {
               response->mutable_user_pilot_constellation()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_actual_array_size(actual_array_size);
         }
         return ::grpc::Status::OK;
@@ -6633,7 +6633,7 @@ namespace nirfmxwlan_grpc {
             response->measurement_status_raw().begin(),
             response->measurement_status_raw().begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_measurement_status()),
-            [&](auto x) { 
+            [&](auto x) {
                 return static_cast<nirfmxwlan_grpc::SemLowerOffsetMeasurementStatus>(x);
             });
           response->mutable_measurement_status()->Resize(actual_array_size, 0);
@@ -6886,7 +6886,7 @@ namespace nirfmxwlan_grpc {
             response->measurement_status_raw().begin(),
             response->measurement_status_raw().begin() + actual_array_size,
             google::protobuf::RepeatedFieldBackInserter(response->mutable_measurement_status()),
-            [&](auto x) { 
+            [&](auto x) {
                 return static_cast<nirfmxwlan_grpc::SemUpperOffsetMeasurementStatus>(x);
             });
           response->mutable_measurement_status()->Resize(actual_array_size, 0);
@@ -7335,7 +7335,7 @@ namespace nirfmxwlan_grpc {
         attr_val_raw.begin(),
         attr_val_raw.end(),
         std::back_inserter(attr_val),
-        [](auto x) { 
+        [](auto x) {
               if (x < std::numeric_limits<int8>::min() || x > std::numeric_limits<int8>::max()) {
                   std::string message("value ");
                   message.append(std::to_string(x));

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -1499,7 +1499,7 @@ namespace nirfsa_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buf_size = status;
-      
+
         std::string value;
         if (buf_size > 0) {
             value.resize(buf_size - 1);
@@ -1603,7 +1603,7 @@ namespace nirfsa_grpc {
             if (shrunk_size != current_size) {
               response->mutable_sparameters()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_number_of_sparameters(number_of_sparameters);
           response->set_number_of_ports(number_of_ports);
         }
@@ -1694,7 +1694,7 @@ namespace nirfsa_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 error_description_buffer_size = status;
-      
+
         ViStatus error_code {};
         std::string error_description;
         if (error_description_buffer_size > 0) {
@@ -1900,7 +1900,7 @@ namespace nirfsa_grpc {
             if (shrunk_size != current_size) {
               response->mutable_coefficient_info()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_number_of_coefficient_sets(number_of_coefficient_sets);
         }
         return ::grpc::Status::OK;
@@ -2049,7 +2049,7 @@ namespace nirfsa_grpc {
             if (shrunk_size != current_size) {
               response->mutable_coefficient_info()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_number_of_coefficient_sets(number_of_coefficient_sets);
         }
         return ::grpc::Status::OK;

--- a/generated/nirfsg/nirfsg_service.cpp
+++ b/generated/nirfsg/nirfsg_service.cpp
@@ -1736,7 +1736,7 @@ namespace nirfsg_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buf_size = status;
-      
+
         std::string value;
         if (buf_size > 0) {
             value.resize(buf_size - 1);
@@ -1778,7 +1778,7 @@ namespace nirfsg_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string name;
         if (buffer_size > 0) {
             name.resize(buffer_size - 1);
@@ -1835,7 +1835,7 @@ namespace nirfsg_grpc {
             if (shrunk_size != current_size) {
               response->mutable_sparameters()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
             }
-          }        
+          }
           response->set_number_of_sparameters(number_of_sparameters);
           response->set_number_of_ports(number_of_ports);
         }
@@ -1865,7 +1865,7 @@ namespace nirfsg_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 error_description_buffer_size = status;
-      
+
         ViStatus error_code {};
         std::string error_description;
         if (error_description_buffer_size > 0) {
@@ -2065,7 +2065,7 @@ namespace nirfsg_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string terminal_name;
         if (buffer_size > 0) {
             terminal_name.resize(buffer_size - 1);

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -1342,7 +1342,7 @@ namespace niscope_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 size_in_bytes = status;
-      
+
         std::string configuration(size_in_bytes, '\0');
         status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, (ViInt8*)configuration.data());
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(size_in_bytes)) {
@@ -1564,7 +1564,7 @@ namespace niscope_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buf_size = status;
-      
+
         std::string value;
         if (buf_size > 0) {
             value.resize(buf_size - 1);
@@ -1606,7 +1606,7 @@ namespace niscope_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string channel_string;
         if (buffer_size > 0) {
             channel_string.resize(buffer_size - 1);
@@ -1648,7 +1648,7 @@ namespace niscope_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string name;
         if (buffer_size > 0) {
             name.resize(buffer_size - 1);
@@ -1714,7 +1714,7 @@ namespace niscope_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         ViStatus error_code {};
         std::string description;
         if (buffer_size > 0) {
@@ -1758,7 +1758,7 @@ namespace niscope_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string error_message;
         if (buffer_size > 0) {
             error_message.resize(buffer_size - 1);

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -645,7 +645,7 @@ namespace niswitch_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 array_size = status;
-      
+
         std::string attribute_value;
         if (array_size > 0) {
             attribute_value.resize(array_size - 1);
@@ -713,7 +713,7 @@ namespace niswitch_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string channel_name_buffer;
         if (buffer_size > 0) {
             channel_name_buffer.resize(buffer_size - 1);
@@ -754,7 +754,7 @@ namespace niswitch_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         ViStatus code {};
         std::string description;
         if (buffer_size > 0) {
@@ -797,7 +797,7 @@ namespace niswitch_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string coercion_record;
         if (buffer_size > 0) {
             coercion_record.resize(buffer_size - 1);
@@ -838,7 +838,7 @@ namespace niswitch_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string interchange_warning;
         if (buffer_size > 0) {
             interchange_warning.resize(buffer_size - 1);
@@ -881,7 +881,7 @@ namespace niswitch_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string path;
         if (buffer_size > 0) {
             path.resize(buffer_size - 1);
@@ -947,7 +947,7 @@ namespace niswitch_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 relay_name_buffer_size = status;
-      
+
         std::string relay_name_buffer;
         if (relay_name_buffer_size > 0) {
             relay_name_buffer.resize(relay_name_buffer_size - 1);

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -1093,7 +1093,7 @@ namespace nisync_grpc {
           return ::grpc::Status::OK;
         }
         ViUInt32 buffer_size = status;
-      
+
         std::string time_reference_names;
         if (buffer_size > 0) {
             time_reference_names.resize(buffer_size - 1);
@@ -1211,7 +1211,7 @@ namespace nisync_grpc {
           return ::grpc::Status::OK;
         }
         ViInt32 buffer_size = status;
-      
+
         std::string value;
         if (buffer_size > 0) {
             value.resize(buffer_size - 1);

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -161,7 +161,7 @@ namespace nitclk_grpc {
           return ::grpc::Status::OK;
         }
         ViUInt32 error_string_size = status;
-      
+
         std::string error_string;
         if (error_string_size > 0) {
             error_string.resize(error_string_size - 1);

--- a/source/codegen/__init__.py
+++ b/source/codegen/__init__.py
@@ -1,0 +1,1 @@
+"""Codegen package."""

--- a/source/codegen/client_helpers.py
+++ b/source/codegen/client_helpers.py
@@ -1,3 +1,5 @@
+"""Helpers for creating client .h/.cpp files."""
+
 import re
 from collections import namedtuple
 from enum import Enum
@@ -6,7 +8,7 @@ from typing import List, Tuple
 import common_helpers
 
 
-class ParamMechanism(Enum):
+class ParamMechanism(Enum):  # noqa: D101
     BASIC = 0
     ARRAY = 1
     ENUM = 2
@@ -17,31 +19,7 @@ class ParamMechanism(Enum):
 ClientParam = namedtuple("ClientParam", ["name", "type", "mechanism"])
 
 
-def to_parameter_list(client_params: List[ClientParam]) -> List[str]:
-    param_list = [f"{p.type} {p.name}" for p in client_params]
-
-    return param_list
-
-
-def stub_param() -> str:
-    return f"const {stub_ptr_alias()}& stub"
-
-
-def create_streaming_params(client_params: List[ClientParam]) -> str:
-    params = to_parameter_list(client_params)
-    client_context_param = "::grpc::ClientContext& context"
-    params = [stub_param()] + [client_context_param] + params
-    return str.join(", ", params)
-
-
-def create_unary_params(client_params: List[ClientParam]) -> str:
-    params = to_parameter_list(client_params)
-    params = [stub_param()] + params
-    return str.join(", ", params)
-
-
 PROTOBUF_PRIM_TYPES = ["bool", "double", "float"]
-
 PROTOBUF_TYPE_TO_CPP_TYPE = {
     "double": "double",
     "float": "float",
@@ -61,7 +39,33 @@ PROTOBUF_TYPE_TO_CPP_TYPE = {
 }
 
 
-def is_basic_type(grpc_type: str) -> bool:
+def _to_parameter_list(client_params: List[ClientParam]) -> List[str]:
+    param_list = [f"{p.type} {p.name}" for p in client_params]
+
+    return param_list
+
+
+def stub_param() -> str:
+    """Get the C++ stub parameter."""
+    return f"const {stub_ptr_alias()}& stub"
+
+
+def create_streaming_params(client_params: List[ClientParam]) -> str:
+    """Build the C++ parameter list for streaming functions."""
+    params = _to_parameter_list(client_params)
+    client_context_param = "::grpc::ClientContext& context"
+    params = [stub_param()] + [client_context_param] + params
+    return str.join(", ", params)
+
+
+def create_unary_params(client_params: List[ClientParam]) -> str:
+    """Build the C++ parameter list for normal functions."""
+    params = _to_parameter_list(client_params)
+    params = [stub_param()] + params
+    return str.join(", ", params)
+
+
+def _is_basic_type(grpc_type: str) -> bool:
     return (
         grpc_type in PROTOBUF_PRIM_TYPES
         or grpc_type in PROTOBUF_TYPE_TO_CPP_TYPE
@@ -71,19 +75,20 @@ def is_basic_type(grpc_type: str) -> bool:
 
 
 def protobuf_namespace_alias() -> str:
+    """Get the protobuf namespace alias."""
     return "pb"
 
 
-def get_cpp_client_param_type(param: dict, enums: dict) -> str:
+def _get_cpp_client_param_type(param: dict, enums: dict) -> str:
     grpc_type = param["grpc_type"]
 
-    if is_grpc_array(param):
+    if _is_grpc_array(param):
         underlying_type = common_helpers.strip_prefix(grpc_type, "repeated ")
-        underlying_type = get_cpp_type_for_protobuf_type(underlying_type)
+        underlying_type = _get_cpp_type_for_protobuf_type(underlying_type)
         return f"std::vector<{underlying_type}>"
 
     if "enum" in param:
-        base_type = get_cpp_type_for_protobuf_type(grpc_type)
+        base_type = _get_cpp_type_for_protobuf_type(grpc_type)
         if base_type:
             return f"simple_variant<{param['enum']}, {base_type}>"
         return param["enum"]
@@ -93,10 +98,10 @@ def get_cpp_client_param_type(param: dict, enums: dict) -> str:
         base_type = common_helpers.get_enum_value_cpp_type(enums[enum])
         return f"simple_variant<{enum}, {base_type}>"
 
-    return get_cpp_type_for_protobuf_type(grpc_type)
+    return _get_cpp_type_for_protobuf_type(grpc_type)
 
 
-def get_cpp_type_for_protobuf_type(protobuf_type: str) -> str:
+def _get_cpp_type_for_protobuf_type(protobuf_type: str) -> str:
     if protobuf_type in PROTOBUF_PRIM_TYPES:
         return protobuf_type
 
@@ -107,62 +112,67 @@ def get_cpp_type_for_protobuf_type(protobuf_type: str) -> str:
     return protobuf_type.replace(".", "::")
 
 
-def const_ref_t(t: str) -> str:
+def _const_ref_t(t: str) -> str:
     return f"const {t}&"
 
 
-def get_param_mechanism(param: dict) -> ParamMechanism:
-    if is_grpc_array(param):
+def _get_param_mechanism(param: dict) -> ParamMechanism:
+    if _is_grpc_array(param):
         return ParamMechanism.ARRAY
     if "enum" in param:
         return ParamMechanism.ENUM
     if "mapped-enum" in param:
         return ParamMechanism.MAPPED_ENUM
-    if is_basic_type(param["grpc_type"]):
+    if _is_basic_type(param["grpc_type"]):
         return ParamMechanism.BASIC
     return ParamMechanism.COPY
 
 
-def create_client_param(param: dict, enums: dict) -> ClientParam:
+def _create_client_param(param: dict, enums: dict) -> ClientParam:
     name = common_helpers.get_grpc_field_name(param)
-    param_type = get_cpp_client_param_type(param, enums)
-    param_type = const_ref_t(param_type)
-    param_mechanism = get_param_mechanism(param)
+    param_type = _get_cpp_client_param_type(param, enums)
+    param_type = _const_ref_t(param_type)
+    param_mechanism = _get_param_mechanism(param)
 
     return ClientParam(name, param_type, param_mechanism)
 
 
-def is_grpc_array(param: dict) -> bool:
+def _is_grpc_array(param: dict) -> bool:
     return param["grpc_type"].startswith("repeated ")
 
 
 def stub_ptr_alias():
+    """Get the stub pointer alias."""
     return "StubPtr"
 
 
 def get_client_parameters(func: dict, enums: dict) -> List[ClientParam]:
+    """Create a list of ClientParam objects for the given function."""
     inputs = [p for p in func["parameters"] if common_helpers.is_input_parameter(p)]
 
     inputs = common_helpers.filter_parameters_for_grpc_fields(inputs)
 
-    return [create_client_param(p, enums) for p in inputs]
+    return [_create_client_param(p, enums) for p in inputs]
 
 
-def split_types_from_variant(variant_type: str) -> Tuple[str, str]:
+def _split_types_from_variant(variant_type: str) -> Tuple[str, str]:
     match = re.match(r".*simple_variant<([^,]+), ([^>]+)>", variant_type)
     assert match
     return (match[1], match[2])
 
 
 def get_enum_value_type(param: ClientParam) -> str:
-    enum, _ = split_types_from_variant(param.type)
+    """Get the enum name of the given enum ClientParam."""
+    enum, _ = _split_types_from_variant(param.type)
     return enum
 
 
 def get_enum_raw_type(param: ClientParam) -> str:
-    _, raw = split_types_from_variant(param.type)
+    """Get the raw C++ value_type of the given enum ClientParam."""
+    _, raw = _split_types_from_variant(param.type)
     return raw
 
 
 def streaming_response_type(response_type: str) -> str:
+    """Wrap the given response type with a reader for streaming functions."""
     return f"std::unique_ptr<grpc::ClientReader<{response_type}>>"

--- a/source/codegen/generate_service.py
+++ b/source/codegen/generate_service.py
@@ -1,3 +1,5 @@
+"""Service generation."""
+
 import argparse
 import os
 
@@ -7,7 +9,7 @@ from mako.lookup import TemplateLookup  # type: ignore
 from template_helpers import instantiate_mako_template, load_metadata, write_if_changed
 
 
-def generate_service_file(metadata, template_file_name, generated_file_suffix, gen_dir):
+def _generate_service_file(metadata, template_file_name, generated_file_suffix, gen_dir):
     module_name = metadata["config"]["module_name"]
     output_dir = os.path.join(gen_dir, module_name)
     file_name = module_name + generated_file_suffix
@@ -18,7 +20,7 @@ def generate_service_file(metadata, template_file_name, generated_file_suffix, g
     write_if_changed(output_file_path, template.render(data=metadata))
 
 
-def mutate_metadata(metadata: dict):
+def _mutate_metadata(metadata: dict):
     config = metadata["config"]
 
     metadata_mutation.move_zero_enums_to_front(metadata["enums"])
@@ -38,7 +40,7 @@ def mutate_metadata(metadata: dict):
         attribute_expander.patch_attribute_enum_type(function_name, function)
 
 
-def generate_all(metadata_dir: str, gen_dir: str, validate_only: bool):
+def _generate_all(metadata_dir: str, gen_dir: str, validate_only: bool):
     metadata = load_metadata(metadata_dir)
     metadata_validation.validate_metadata(metadata)
     if validate_only:
@@ -46,18 +48,20 @@ def generate_all(metadata_dir: str, gen_dir: str, validate_only: bool):
 
     lookup = TemplateLookup(directories=metadata_dir)
     metadata["lookup"] = lookup
-    mutate_metadata(metadata)
-    generate_service_file(metadata, "proto.mako", ".proto", gen_dir)
-    generate_service_file(metadata, "service.h.mako", "_service.h", gen_dir)
-    generate_service_file(metadata, "service.cpp.mako", "_service.cpp", gen_dir)
-    generate_service_file(metadata, "service_registrar.h.mako", "_service_registrar.h", gen_dir)
-    generate_service_file(metadata, "service_registrar.cpp.mako", "_service_registrar.cpp", gen_dir)
-    generate_service_file(metadata, "library_interface.h.mako", "_library_interface.h", gen_dir)
-    generate_service_file(metadata, "library.cpp.mako", "_library.cpp", gen_dir)
-    generate_service_file(metadata, "library.h.mako", "_library.h", gen_dir)
-    generate_service_file(metadata, "mock_library.h.mako", "_mock_library.h", gen_dir)
-    generate_service_file(metadata, "client.h.mako", "_client.h", gen_dir)
-    generate_service_file(metadata, "client.cpp.mako", "_client.cpp", gen_dir)
+    _mutate_metadata(metadata)
+    _generate_service_file(metadata, "proto.mako", ".proto", gen_dir)
+    _generate_service_file(metadata, "service.h.mako", "_service.h", gen_dir)
+    _generate_service_file(metadata, "service.cpp.mako", "_service.cpp", gen_dir)
+    _generate_service_file(metadata, "service_registrar.h.mako", "_service_registrar.h", gen_dir)
+    _generate_service_file(
+        metadata, "service_registrar.cpp.mako", "_service_registrar.cpp", gen_dir
+    )
+    _generate_service_file(metadata, "library_interface.h.mako", "_library_interface.h", gen_dir)
+    _generate_service_file(metadata, "library.cpp.mako", "_library.cpp", gen_dir)
+    _generate_service_file(metadata, "library.h.mako", "_library.h", gen_dir)
+    _generate_service_file(metadata, "mock_library.h.mako", "_mock_library.h", gen_dir)
+    _generate_service_file(metadata, "client.h.mako", "_client.h", gen_dir)
+    _generate_service_file(metadata, "client.cpp.mako", "_client.cpp", gen_dir)
 
 
 if __name__ == "__main__":
@@ -81,4 +85,4 @@ if __name__ == "__main__":
         help="Just validate the metadata and don't generate any files",
     )
     args = parser.parse_args()
-    generate_all(args.metadata, "." if args.output is None else args.output, args.validate)
+    _generate_all(args.metadata, "." if args.output is None else args.output, args.validate)

--- a/source/codegen/generate_shared_service_files.py
+++ b/source/codegen/generate_shared_service_files.py
@@ -1,10 +1,12 @@
+"""Shared service file generation."""
+
 from argparse import ArgumentParser
 from pathlib import Path
 
 from template_helpers import instantiate_mako_template, write_if_changed, load_metadata
 
 
-def generate_register_all_services(metadata_dir: Path, output_dir: Path) -> None:
+def _generate_register_all_services(metadata_dir: Path, output_dir: Path) -> None:
     driver_modules = [
         load_metadata(p)
         for p in sorted(metadata_dir.iterdir())
@@ -35,4 +37,4 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     output_path = "." if args.output is None else args.output
-    generate_register_all_services(Path(args.metadata), Path(output_path))
+    _generate_register_all_services(Path(args.metadata), Path(output_path))

--- a/source/codegen/proto_helpers.py
+++ b/source/codegen/proto_helpers.py
@@ -1,3 +1,5 @@
+"""Helpers for creating .proto files."""
+
 from typing import List
 
 import common_helpers
@@ -21,7 +23,7 @@ def _should_add_unspecified_enum_value(enum_name, enum_values_metadata):
     return _is_attribute_values(enum_name) or 0 not in (v["value"] for v in enum_values_metadata)
 
 
-def should_allow_alias(enum_values_metadata):
+def _should_allow_alias(enum_values_metadata):
     # if enum.get("generate-mappings", False):
     #   return False
     enum_values = [e["value"] for e in enum_values_metadata]
@@ -43,7 +45,10 @@ def generate_parameter_field_number(parameter, used_indexes, field_name_suffix="
 
 
 def get_enum_definitions(enums_to_define, enums):
-    """Get simplified definition for enums and values in it that can be used for defining enums in proto file."""
+    """Get a simplified definition for enums and the values in it.
+
+    This is intended to be used for defining enums in the proto file.
+    """
     enum_definitions = {}
     for enum_name in (e for e in enums if e in enums_to_define):
         enum = enums[enum_name]
@@ -67,7 +72,7 @@ def get_enum_definitions(enums_to_define, enums):
             )
             values.insert(0, {"name": unspecified_value_name, "value": 0})
 
-        allow_alias = should_allow_alias(values)
+        allow_alias = _should_allow_alias(values)
         enum_definition = {"allow_alias": allow_alias, "values": values}
 
         enum_definitions.update({enum_name: enum_definition})
@@ -75,13 +80,13 @@ def get_enum_definitions(enums_to_define, enums):
     return enum_definitions
 
 
-def is_array_input(parameter: dict):
+def _is_array_input(parameter: dict):
     return common_helpers.is_array(parameter["type"]) and common_helpers.is_input_parameter(
         parameter
     )
 
 
-def is_decomposable_enum(parameter: dict):
+def _is_decomposable_enum(parameter: dict):
     """Return whether the parameter is a decomposable enum.
 
     Enums are typically decomposed from a single param into an enum param and an _raw param.
@@ -90,12 +95,15 @@ def is_decomposable_enum(parameter: dict):
     decomposition does not work for arrays.
     """
     return common_helpers.is_enum(parameter) and not (
-        is_array_input(parameter) and parameter["grpc_type"] != "string"
+        _is_array_input(parameter) and parameter["grpc_type"] != "string"
     )
 
 
 def get_message_parameter_definitions(parameters):
-    """Get simplified list of all parameters that can be used for defining request/respones messages in proto file."""
+    """Get a simplified list of all parameters.
+
+    This is intended to be used for defining requests/respones messages in proto file.
+    """
     parameter_definitions = []
     used_indexes = []
     for parameter in parameters:
@@ -103,10 +111,10 @@ def get_message_parameter_definitions(parameters):
             common_helpers.is_array(parameter["type"]) and not parameter["grpc_type"] == "string"
         )
         parameter_name = common_helpers.get_grpc_field_name(parameter)
-        parameter_type = get_parameter_type(parameter)
-        if is_decomposable_enum(parameter):
+        parameter_type = _get_parameter_type(parameter)
+        if _is_decomposable_enum(parameter):
             is_request_message = common_helpers.is_input_parameter(parameter)
-            enum_parameters = get_enum_parameters(
+            enum_parameters = _get_enum_parameters(
                 parameter, parameter_name, parameter_type, is_array, used_indexes
             )
             if is_request_message:
@@ -123,7 +131,8 @@ def get_message_parameter_definitions(parameters):
                 parameter_definitions.extend(enum_parameters)
         else:
             if common_helpers.is_enum(parameter):
-                # For input arrays of enums, don't generate a raw type, but do use the correct enum type.
+                # For input arrays of enums, don't generate a raw type, but do use the correct enum
+                # type.
                 parameter_type = f'repeated {parameter["enum"]}'
             grpc_field_number = generate_parameter_field_number(parameter, used_indexes)
             parameter_definitions.append(
@@ -136,7 +145,7 @@ def get_message_parameter_definitions(parameters):
     return parameter_definitions
 
 
-def get_enum_parameters(parameter, parameter_name, parameter_type, is_array, used_indexes):
+def _get_enum_parameters(parameter, parameter_name, parameter_type, is_array, used_indexes):
     """Get list of mapped/unmapped/raw parameters for enums as applicable."""
     enum_parameters = []
     if parameter.get("enum", None):
@@ -185,13 +194,14 @@ def get_enum_parameters(parameter, parameter_name, parameter_type, is_array, use
     return enum_parameters
 
 
-def get_parameter_type(parameter):
+def _get_parameter_type(parameter):
     if "grpc_type" not in parameter:
         raise KeyError(f"grpc_type not in {parameter['name']} with {parameter['type']}")
     return parameter["grpc_type"]
 
 
 def is_session_name(parameter):
+    """Whether the parameter is a session name parameter."""
     return parameter.get("is_session_name", False)
 
 
@@ -212,6 +222,10 @@ def _prepend_proto_only_session_name_parameter_if_necessary(
 
 
 def get_parameters(function):
+    """Filter the parameters to ones we use in gRPC, and split into input/output parameters.
+
+    Add a default "status" output parameter if there isn't one already.
+    """
     parameter_array = common_helpers.filter_parameters_for_grpc_fields(function["parameters"])
     input_parameters = [p for p in parameter_array if common_helpers.is_input_parameter(p)]
     if common_helpers.is_init_method(function):
@@ -220,7 +234,7 @@ def get_parameters(function):
     default_status_param = {"name": "status", "type": "int32", "grpc_type": "int32"}
     output_parameters = [default_status_param]
 
-    callback_parameters = get_callback_output_params(function)
+    callback_parameters = _get_callback_output_params(function)
 
     if callback_parameters:
         if any((p for p in callback_parameters if p["name"] == "status")):
@@ -236,7 +250,7 @@ def get_parameters(function):
     return (input_parameters, output_parameters)
 
 
-def get_callback_output_params(function):
+def _get_callback_output_params(function):
     """Look for a parameter that specifies callback_params and return those params.
 
     These will be used as the outputs of a streaming response.
@@ -249,4 +263,5 @@ def get_callback_output_params(function):
 
 
 def get_streaming_response_qualifier(function):
+    """Get a qualifier to add to the function's returned response object if it uses streaming."""
     return "stream " if common_helpers.has_streaming_response(function) else ""

--- a/source/codegen/stage_client_files.py
+++ b/source/codegen/stage_client_files.py
@@ -1,3 +1,5 @@
+"""Stage client files."""
+
 from argparse import ArgumentParser
 from pathlib import Path
 from shutil import copy2, copytree
@@ -51,7 +53,7 @@ class _ArtifactReadiness:
         )
 
 
-class ArtifactLocations:
+class _ArtifactLocations:
     repo_root: Path
 
     def __init__(self, repo_root: Path):
@@ -75,7 +77,7 @@ class ArtifactLocations:
 
 
 def _get_release_proto_files(
-    artifact_locations: ArtifactLocations, readiness: _ArtifactReadiness
+    artifact_locations: _ArtifactLocations, readiness: _ArtifactReadiness
 ) -> List[Path]:
 
     release_driver_dirs = readiness.get_release_ready_subdirs(artifact_locations.generated_files)
@@ -83,14 +85,15 @@ def _get_release_proto_files(
 
 
 def _get_release_example_directories(
-    artifact_locations: ArtifactLocations, readiness: _ArtifactReadiness
+    artifact_locations: _ArtifactLocations, readiness: _ArtifactReadiness
 ) -> Iterable[Path]:
     return readiness.get_release_ready_subdirs(artifact_locations.examples)
 
 
 def stage_client_files(output_path: Path, include_prerelease: bool):
+    """Stage the client files into the given output path."""
     repo_root = Path(__file__).parent.parent.parent
-    artifact_locations = ArtifactLocations(repo_root)
+    artifact_locations = _ArtifactLocations(repo_root)
     readiness = _ArtifactReadiness(artifact_locations.metadata_dir, include_prerelease)
 
     proto_path = output_path / "proto"

--- a/source/codegen/template_helpers.py
+++ b/source/codegen/template_helpers.py
@@ -1,3 +1,5 @@
+"""Helpers for mako templates."""
+
 from importlib import import_module
 from pathlib import Path
 from typing import Union
@@ -7,6 +9,7 @@ from mako.template import Template  # type: ignore
 
 
 def instantiate_mako_template(template_file_name: str) -> Template:
+    """Instantiate the mako template in the given file."""
     current_dir = Path(__file__).parent
     template_directory = current_dir / "templates"
     template_file_path = template_directory / template_file_name
@@ -26,6 +29,7 @@ def write_if_changed(output_file_path: Union[Path, str], new_contents: str) -> N
 
 
 def load_metadata(metadata_dir: Union[Path, str]) -> dict:
+    """Load the metadata from the given directory."""
     metadata_path = Path(metadata_dir)
     module = import_module("metadata." + metadata_path.name)
 

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -93,7 +93,7 @@ ${call_library_method(
           return ::grpc::Status::OK;
         }
         ${size_param['type']} ${common_helpers.get_cpp_local_name(size_param)} = status;
-      
+
 <%block filter="common_helpers.indent(1)">\
 ${initialize_output_params(output_parameters)}\
 </%block>\
@@ -178,7 +178,7 @@ ${set_response_values(output_parameters)}\
 
 <%def name="define_async_callback_method_body(function_name, function_data, parameters, config)">\
 <%
-  (input_parameters, callback_parameters) = service_helpers.get_callback_method_parameters(function_data)
+  callback_parameters = service_helpers.get_callback_method_parameters(function_data)
   response_parameters = common_helpers.filter_parameters_for_grpc_fields(callback_parameters)
   request_type = service_helpers.get_request_type(function_name)
   response_type = service_helpers.get_response_type(function_name)
@@ -385,7 +385,7 @@ ${initialize_standard_input_param(function_name, parameter)}
 
 
 ## Initialize an enum array input parameter.
-## This is a straight copy and does not support all of the features of enum parameters 
+## This is a straight copy and does not support all of the features of enum parameters
 ## (i.e. mapped enums, _raw fields, etc.)
 <%def name="initialize_enum_array_input_param(function_name, parameter)">\
 <%
@@ -436,7 +436,7 @@ ${initialize_standard_input_param(function_name, parameter)}
 %   else:
           ${parameter_name} = static_cast<${parameter['type']}>(${enum_request_snippet});
 %   endif
-%   if validate_attribute_enum: 
+%   if validate_attribute_enum:
 ## "raw" attributes always validate non-raw enum values before passing to driver
 ## this can be important if (a) the driver can't handle all validation scenarios
 ## and (b) the caller passes/casts an invalid enum value.
@@ -484,7 +484,7 @@ ${initialize_standard_input_param(function_name, parameter)}
 <%
   parameter_name = common_helpers.get_cpp_local_name(parameter)
   size_sources = common_helpers.get_grpc_field_names_for_param_names(
-    parameters, 
+    parameters,
     parameter["determine_size_from"]
   )
   size_field_name = common_helpers.get_grpc_field_name_from_str(size_sources[-1])
@@ -622,7 +622,7 @@ ${initialize_standard_input_param(function_name, parameter)}
         ${parameter_name}_raw.begin(),
         ${parameter_name}_raw.end(),
         std::back_inserter(${parameter_name}),
-        [](auto x) { 
+        [](auto x) {
               if (x < std::numeric_limits<${c_element_type_that_needs_coercion}>::min() || x > std::numeric_limits<${c_element_type_that_needs_coercion}>::max()) {
                   std::string message("value ");
                   message.append(std::to_string(x));
@@ -834,7 +834,7 @@ ${copy_to_response_with_transform(source_buffer=parameter_name, parameter_name=p
           if (shrunk_size != current_size) {
             response->mutable_${parameter_name}()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
           }
-        }        
+        }
 %     else:
 ## This code doesn't handle all parameter types (i.e., enums), see what initialize_output_params() does for that.
         response->mutable_${parameter_name}()->Resize(${size}, 0);
@@ -855,7 +855,7 @@ ${copy_to_response_with_transform(source_buffer=parameter_name, parameter_name=p
           ${source_buffer}.begin(),
           ${source_buffer}.begin() + ${size},
           google::protobuf::RepeatedFieldBackInserter(response->mutable_${parameter_name}()),
-          [&](auto x) { 
+          [&](auto x) {
               return ${transform_x};
           });
 </%def>

--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -1,3 +1,5 @@
+"""Script for validating the examples."""
+
 from argparse import ArgumentParser
 from contextlib import contextmanager
 from os import getcwd, chdir, system as _system_core
@@ -36,7 +38,7 @@ def _create_stage_dir(staging_dir):
         chdir(initial_dir)
 
 
-def validate_examples(driver_glob_expression: str, ip_address: str, device_name: str) -> None:
+def _validate_examples(driver_glob_expression: str, ip_address: str, device_name: str) -> None:
     staging_dir = Path(__file__).parent.parent.parent / "build" / "validate_examples"
     staging_dir = staging_dir.resolve()
 
@@ -96,7 +98,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    validate_examples(args.pattern, args.server, args.device)
+    _validate_examples(args.pattern, args.server, args.device)
 
     if any(_FAILED_COMMANDS):
         for code, command in _FAILED_COMMANDS:


### PR DESCRIPTION
### What does this Pull Request accomplish?

Mark functions as private if not used outside the module.
Add docstrings to all public functions.
Fix long lines, whether by shortening or splitting.
In PR/CI builds, run the linter on source/codegen/*.py, too.
A couple related improvements, like removing an unused return value, and deleting an unused function or two.
Some minor code cleanups I encountered along the way.

### Why should this Pull Request be merged?

Clean code

### What testing has been done?

Updated PR checks
