### PR TITLE
Add a python version restriction for the black dependency

### DIFF
--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -45,7 +45,10 @@ def validate_examples(driver_glob_expression: str, ip_address: str, device_name:
     with _create_stage_dir(staging_dir):
         _system("poetry new .")
         _system("poetry add grpcio")
-        _system("poetry add --dev grpcio-tools black mypy mypy-protobuf types-protobuf grpc-stubs")
+        _system("poetry add --dev grpcio-tools mypy mypy-protobuf types-protobuf grpc-stubs")
+        # black requires python >=3.6.2, so only ask it to be installed for python >=3.6.2, or else
+        # poetry can give a SolverProblemError and fail the "install" step
+        _system('poetry add --dev --python ">=3.6.2" black')
         _system("poetry install")
 
         stage_client_files(staging_dir, True)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds a python version restriction for the black dependency.

### Why should this Pull Request be merged?

black requires python >=3.6.2, so only ask it to be installed for python >=3.6.2, or else poetry can give a SolverProblemError and fail the "install" step.

### What testing has been done?

Local runs of validate_examples.py, which failed for me before I added this change.
