### PR TITLE
Add get_last_error support for RFmx init methods

### DIFF
--- a/generated/nifake_non_ivi/nifake_non_ivi.proto
+++ b/generated/nifake_non_ivi/nifake_non_ivi.proto
@@ -19,6 +19,7 @@ import "google/protobuf/timestamp.proto";
 service NiFakeNonIvi {
   rpc Close(CloseRequest) returns (CloseResponse);
   rpc GetCrossDriverSession(GetCrossDriverSessionRequest) returns (GetCrossDriverSessionResponse);
+  rpc GetLatestErrorMessage(GetLatestErrorMessageRequest) returns (GetLatestErrorMessageResponse);
   rpc GetStringAsReturnedValue(GetStringAsReturnedValueRequest) returns (GetStringAsReturnedValueResponse);
   rpc GetMarbleAttributeDouble(GetMarbleAttributeDoubleRequest) returns (GetMarbleAttributeDoubleResponse);
   rpc GetMarbleAttributeInt32(GetMarbleAttributeInt32Request) returns (GetMarbleAttributeInt32Response);
@@ -126,6 +127,14 @@ message GetCrossDriverSessionResponse {
   nidevice_grpc.Session cross_driver_session = 2;
 }
 
+message GetLatestErrorMessageRequest {
+}
+
+message GetLatestErrorMessageResponse {
+  int32 status = 1;
+  string message = 2;
+}
+
 message GetStringAsReturnedValueRequest {
 }
 
@@ -182,6 +191,7 @@ message InitRequest {
 message InitResponse {
   int32 status = 1;
   nidevice_grpc.Session handle = 2;
+  string error_message = 3;
 }
 
 message InitFromCrossDriverSessionRequest {

--- a/generated/nifake_non_ivi/nifake_non_ivi_client.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_client.cpp
@@ -49,6 +49,21 @@ get_cross_driver_session(const StubPtr& stub, const nidevice_grpc::Session& hand
   return response;
 }
 
+GetLatestErrorMessageResponse
+get_latest_error_message(const StubPtr& stub)
+{
+  ::grpc::ClientContext context;
+
+  auto request = GetLatestErrorMessageRequest{};
+
+  auto response = GetLatestErrorMessageResponse{};
+
+  raise_if_error(
+      stub->GetLatestErrorMessage(&context, request, &response));
+
+  return response;
+}
+
 GetStringAsReturnedValueResponse
 get_string_as_returned_value(const StubPtr& stub)
 {

--- a/generated/nifake_non_ivi/nifake_non_ivi_client.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_client.h
@@ -24,6 +24,7 @@ using namespace nidevice_grpc::experimental::client;
 
 CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& handle);
 GetCrossDriverSessionResponse get_cross_driver_session(const StubPtr& stub, const nidevice_grpc::Session& handle);
+GetLatestErrorMessageResponse get_latest_error_message(const StubPtr& stub);
 GetStringAsReturnedValueResponse get_string_as_returned_value(const StubPtr& stub);
 GetMarbleAttributeDoubleResponse get_marble_attribute_double(const StubPtr& stub, const nidevice_grpc::Session& handle, const simple_variant<MarbleDoubleAttribute, pb::int32>& attribute);
 GetMarbleAttributeInt32Response get_marble_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session& handle, const simple_variant<MarbleInt32Attribute, pb::int32>& attribute);

--- a/generated/nifake_non_ivi/nifake_non_ivi_library.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_library.cpp
@@ -23,6 +23,7 @@ NiFakeNonIviLibrary::NiFakeNonIviLibrary() : shared_library_(kLibraryName)
   }
   function_pointers_.Close = reinterpret_cast<ClosePtr>(shared_library_.get_function_pointer("niFakeNonIvi_Close"));
   function_pointers_.GetCrossDriverSession = reinterpret_cast<GetCrossDriverSessionPtr>(shared_library_.get_function_pointer("niFakeNonIvi_GetCrossDriverSession"));
+  function_pointers_.GetLatestErrorMessage = reinterpret_cast<GetLatestErrorMessagePtr>(shared_library_.get_function_pointer("niFakeNonIvi_GetLatestErrorMessage"));
   function_pointers_.GetStringAsReturnedValue = reinterpret_cast<GetStringAsReturnedValuePtr>(shared_library_.get_function_pointer("niFakeNonIvi_GetStringAsReturnedValue"));
   function_pointers_.GetMarbleAttributeDouble = reinterpret_cast<GetMarbleAttributeDoublePtr>(shared_library_.get_function_pointer("niFakeNonIvi_GetMarbleAttributeDouble"));
   function_pointers_.GetMarbleAttributeInt32 = reinterpret_cast<GetMarbleAttributeInt32Ptr>(shared_library_.get_function_pointer("niFakeNonIvi_GetMarbleAttributeInt32"));
@@ -87,6 +88,18 @@ int32 NiFakeNonIviLibrary::GetCrossDriverSession(FakeHandle handle, int32* cross
   return niFakeNonIvi_GetCrossDriverSession(handle, crossDriverSession);
 #else
   return function_pointers_.GetCrossDriverSession(handle, crossDriverSession);
+#endif
+}
+
+int32 NiFakeNonIviLibrary::GetLatestErrorMessage(char message[], uInt32 size)
+{
+  if (!function_pointers_.GetLatestErrorMessage) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFakeNonIvi_GetLatestErrorMessage.");
+  }
+#if defined(_MSC_VER)
+  return niFakeNonIvi_GetLatestErrorMessage(message, size);
+#else
+  return function_pointers_.GetLatestErrorMessage(message, size);
 #endif
 }
 

--- a/generated/nifake_non_ivi/nifake_non_ivi_library.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_library.h
@@ -20,6 +20,7 @@ class NiFakeNonIviLibrary : public nifake_non_ivi_grpc::NiFakeNonIviLibraryInter
   ::grpc::Status check_function_exists(std::string functionName);
   int32 Close(FakeHandle handle);
   int32 GetCrossDriverSession(FakeHandle handle, int32* crossDriverSession);
+  int32 GetLatestErrorMessage(char message[], uInt32 size);
   const char* GetStringAsReturnedValue(char buf[512]);
   int32 GetMarbleAttributeDouble(FakeHandle handle, int32 attribute, double* value);
   int32 GetMarbleAttributeInt32(FakeHandle handle, int32 attribute, int32* value);
@@ -54,6 +55,7 @@ class NiFakeNonIviLibrary : public nifake_non_ivi_grpc::NiFakeNonIviLibraryInter
  private:
   using ClosePtr = decltype(&niFakeNonIvi_Close);
   using GetCrossDriverSessionPtr = decltype(&niFakeNonIvi_GetCrossDriverSession);
+  using GetLatestErrorMessagePtr = decltype(&niFakeNonIvi_GetLatestErrorMessage);
   using GetStringAsReturnedValuePtr = decltype(&niFakeNonIvi_GetStringAsReturnedValue);
   using GetMarbleAttributeDoublePtr = decltype(&niFakeNonIvi_GetMarbleAttributeDouble);
   using GetMarbleAttributeInt32Ptr = decltype(&niFakeNonIvi_GetMarbleAttributeInt32);
@@ -88,6 +90,7 @@ class NiFakeNonIviLibrary : public nifake_non_ivi_grpc::NiFakeNonIviLibraryInter
   typedef struct FunctionPointers {
     ClosePtr Close;
     GetCrossDriverSessionPtr GetCrossDriverSession;
+    GetLatestErrorMessagePtr GetLatestErrorMessage;
     GetStringAsReturnedValuePtr GetStringAsReturnedValue;
     GetMarbleAttributeDoublePtr GetMarbleAttributeDouble;
     GetMarbleAttributeInt32Ptr GetMarbleAttributeInt32;

--- a/generated/nifake_non_ivi/nifake_non_ivi_library_interface.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_library_interface.h
@@ -17,6 +17,7 @@ class NiFakeNonIviLibraryInterface {
 
   virtual int32 Close(FakeHandle handle) = 0;
   virtual int32 GetCrossDriverSession(FakeHandle handle, int32* crossDriverSession) = 0;
+  virtual int32 GetLatestErrorMessage(char message[], uInt32 size) = 0;
   virtual const char* GetStringAsReturnedValue(char buf[512]) = 0;
   virtual int32 GetMarbleAttributeDouble(FakeHandle handle, int32 attribute, double* value) = 0;
   virtual int32 GetMarbleAttributeInt32(FakeHandle handle, int32 attribute, int32* value) = 0;

--- a/generated/nifake_non_ivi/nifake_non_ivi_mock_library.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_mock_library.h
@@ -19,6 +19,7 @@ class NiFakeNonIviMockLibrary : public nifake_non_ivi_grpc::NiFakeNonIviLibraryI
  public:
   MOCK_METHOD(int32, Close, (FakeHandle handle), (override));
   MOCK_METHOD(int32, GetCrossDriverSession, (FakeHandle handle, int32* crossDriverSession), (override));
+  MOCK_METHOD(int32, GetLatestErrorMessage, (char message[], uInt32 size), (override));
   MOCK_METHOD(const char*, GetStringAsReturnedValue, (char buf[512]), (override));
   MOCK_METHOD(int32, GetMarbleAttributeDouble, (FakeHandle handle, int32 attribute, double* value), (override));
   MOCK_METHOD(int32, GetMarbleAttributeInt32, (FakeHandle handle, int32 attribute, int32* value), (override));

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include "custom/nifake_non_ivi_errors.h"
 #include <server/converters.h>
 #include <server/callback_router.h>
 #include <server/server_reactor.h>
@@ -21,6 +22,9 @@ namespace nifake_non_ivi_grpc {
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;
   using nidevice_grpc::converters::MatchState;
+
+  const auto kErrorReadBufferTooSmall = -200229;
+  const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;
 
   NiFakeNonIviService::NiFakeNonIviService(
       NiFakeNonIviLibraryInterface* library,
@@ -89,6 +93,45 @@ namespace nifake_non_ivi_grpc {
         response->mutable_cross_driver_session()->set_id(session_id);
       }
       return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFakeNonIviService::GetLatestErrorMessage(::grpc::ServerContext* context, const GetLatestErrorMessageRequest* request, GetLatestErrorMessageResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+
+      while (true) {
+        auto status = library_->GetLatestErrorMessage(nullptr, 0);
+        if (status < 0) {
+          response->set_status(status);
+          return ::grpc::Status::OK;
+        }
+        uInt32 size = status;
+
+        std::string message;
+        if (size > 0) {
+            message.resize(size - 1);
+        }
+        status = library_->GetLatestErrorMessage((char*)message.data(), size);
+        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(size)) {
+          // buffer is now too small, try again
+          continue;
+        }
+        response->set_status(status);
+        if (status_ok(status)) {
+          response->set_message(message);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_message()));
+        }
+        return ::grpc::Status::OK;
+      }
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
@@ -286,6 +329,10 @@ namespace nifake_non_ivi_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_handle()->set_id(session_id);
+      }
+      else {
+        const auto last_error_buffer = get_last_error(library_);
+        response->set_error_message(last_error_buffer.data());
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.h
@@ -46,6 +46,7 @@ public:
   
   ::grpc::Status Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response) override;
   ::grpc::Status GetCrossDriverSession(::grpc::ServerContext* context, const GetCrossDriverSessionRequest* request, GetCrossDriverSessionResponse* response) override;
+  ::grpc::Status GetLatestErrorMessage(::grpc::ServerContext* context, const GetLatestErrorMessageRequest* request, GetLatestErrorMessageResponse* response) override;
   ::grpc::Status GetStringAsReturnedValue(::grpc::ServerContext* context, const GetStringAsReturnedValueRequest* request, GetStringAsReturnedValueResponse* response) override;
   ::grpc::Status GetMarbleAttributeDouble(::grpc::ServerContext* context, const GetMarbleAttributeDoubleRequest* request, GetMarbleAttributeDoubleResponse* response) override;
   ::grpc::Status GetMarbleAttributeInt32(::grpc::ServerContext* context, const GetMarbleAttributeInt32Request* request, GetMarbleAttributeInt32Response* response) override;

--- a/generated/nirfmxbluetooth/nirfmxbluetooth.proto
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth.proto
@@ -1373,6 +1373,7 @@ message InitializeResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
   int32 is_new_session = 3;
+  string error_message = 4;
 }
 
 message InitializeFromNIRFSASessionRequest {
@@ -1383,6 +1384,7 @@ message InitializeFromNIRFSASessionRequest {
 message InitializeFromNIRFSASessionResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
+  string error_message = 3;
 }
 
 message InitiateRequest {

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include "custom/nirfmx_errors.h"
 #include <server/converters.h>
 
 namespace nirfmxbluetooth_grpc {
@@ -2404,6 +2405,11 @@ namespace nirfmxbluetooth_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
+        response->set_is_new_session(is_new_session);
+      }
+      else {
+        const auto last_error_buffer = get_last_error(library_);
+        response->set_error_message(last_error_buffer.data());
       }
       return ::grpc::Status::OK;
     }
@@ -2435,6 +2441,10 @@ namespace nirfmxbluetooth_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
+      }
+      else {
+        const auto last_error_buffer = get_last_error(library_);
+        response->set_error_message(last_error_buffer.data());
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nirfmxinstr/nirfmxinstr.proto
+++ b/generated/nirfmxinstr/nirfmxinstr.proto
@@ -1054,6 +1054,7 @@ message InitializeResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
   int32 is_new_session = 3;
+  string error_message = 4;
 }
 
 message InitializeFromNIRFSASessionRequest {
@@ -1064,6 +1065,7 @@ message InitializeFromNIRFSASessionRequest {
 message InitializeFromNIRFSASessionResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
+  string error_message = 3;
 }
 
 message InitializeFromNIRFSASessionArrayRequest {
@@ -1074,6 +1076,7 @@ message InitializeFromNIRFSASessionArrayRequest {
 message InitializeFromNIRFSASessionArrayResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
+  string error_message = 3;
 }
 
 message IsSelfCalibrateValidRequest {

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include "custom/nirfmx_errors.h"
 #include <server/converters.h>
 
 namespace nirfmxinstr_grpc {
@@ -1885,6 +1886,11 @@ namespace nirfmxinstr_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
+        response->set_is_new_session(is_new_session);
+      }
+      else {
+        const auto last_error_buffer = get_last_error(library_);
+        response->set_error_message(last_error_buffer.data());
       }
       return ::grpc::Status::OK;
     }
@@ -1916,6 +1922,10 @@ namespace nirfmxinstr_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
+      }
+      else {
+        const auto last_error_buffer = get_last_error(library_);
+        response->set_error_message(last_error_buffer.data());
       }
       return ::grpc::Status::OK;
     }
@@ -1953,6 +1963,10 @@ namespace nirfmxinstr_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
+      }
+      else {
+        const auto last_error_buffer = get_last_error(library_);
+        response->set_error_message(last_error_buffer.data());
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nirfmxlte/nirfmxlte.proto
+++ b/generated/nirfmxlte/nirfmxlte.proto
@@ -3033,6 +3033,7 @@ message InitializeResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
   int32 is_new_session = 3;
+  string error_message = 4;
 }
 
 message InitializeFromNIRFSASessionRequest {
@@ -3043,6 +3044,7 @@ message InitializeFromNIRFSASessionRequest {
 message InitializeFromNIRFSASessionResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
+  string error_message = 3;
 }
 
 message InitiateRequest {

--- a/generated/nirfmxlte/nirfmxlte_service.cpp
+++ b/generated/nirfmxlte/nirfmxlte_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include "custom/nirfmx_errors.h"
 #include <server/converters.h>
 
 namespace nirfmxlte_grpc {
@@ -4249,6 +4250,11 @@ namespace nirfmxlte_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
+        response->set_is_new_session(is_new_session);
+      }
+      else {
+        const auto last_error_buffer = get_last_error(library_);
+        response->set_error_message(last_error_buffer.data());
       }
       return ::grpc::Status::OK;
     }
@@ -4280,6 +4286,10 @@ namespace nirfmxlte_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
+      }
+      else {
+        const auto last_error_buffer = get_last_error(library_);
+        response->set_error_message(last_error_buffer.data());
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nirfmxnr/nirfmxnr.proto
+++ b/generated/nirfmxnr/nirfmxnr.proto
@@ -2519,6 +2519,7 @@ message InitializeResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
   int32 is_new_session = 3;
+  string error_message = 4;
 }
 
 message InitializeFromNIRFSASessionRequest {
@@ -2529,6 +2530,7 @@ message InitializeFromNIRFSASessionRequest {
 message InitializeFromNIRFSASessionResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
+  string error_message = 3;
 }
 
 message InitiateRequest {

--- a/generated/nirfmxnr/nirfmxnr_service.cpp
+++ b/generated/nirfmxnr/nirfmxnr_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include "custom/nirfmx_errors.h"
 #include <server/converters.h>
 
 namespace nirfmxnr_grpc {
@@ -3311,6 +3312,11 @@ namespace nirfmxnr_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
+        response->set_is_new_session(is_new_session);
+      }
+      else {
+        const auto last_error_buffer = get_last_error(library_);
+        response->set_error_message(last_error_buffer.data());
       }
       return ::grpc::Status::OK;
     }
@@ -3342,6 +3348,10 @@ namespace nirfmxnr_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
+      }
+      else {
+        const auto last_error_buffer = get_last_error(library_);
+        response->set_error_message(last_error_buffer.data());
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nirfmxspecan/nirfmxspecan.proto
+++ b/generated/nirfmxspecan/nirfmxspecan.proto
@@ -5457,6 +5457,7 @@ message InitializeResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
   int32 is_new_session = 3;
+  string error_message = 4;
 }
 
 message InitializeFromNIRFSASessionRequest {
@@ -5467,6 +5468,7 @@ message InitializeFromNIRFSASessionRequest {
 message InitializeFromNIRFSASessionResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
+  string error_message = 3;
 }
 
 message InitiateRequest {

--- a/generated/nirfmxspecan/nirfmxspecan_service.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include "custom/nirfmx_errors.h"
 #include <server/converters.h>
 
 namespace nirfmxspecan_grpc {
@@ -7714,6 +7715,11 @@ namespace nirfmxspecan_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
+        response->set_is_new_session(is_new_session);
+      }
+      else {
+        const auto last_error_buffer = get_last_error(library_);
+        response->set_error_message(last_error_buffer.data());
       }
       return ::grpc::Status::OK;
     }
@@ -7745,6 +7751,10 @@ namespace nirfmxspecan_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
+      }
+      else {
+        const auto last_error_buffer = get_last_error(library_);
+        response->set_error_message(last_error_buffer.data());
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nirfmxwlan/nirfmxwlan.proto
+++ b/generated/nirfmxwlan/nirfmxwlan.proto
@@ -2044,6 +2044,7 @@ message InitializeResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
   int32 is_new_session = 3;
+  string error_message = 4;
 }
 
 message InitializeFromNIRFSASessionRequest {
@@ -2054,6 +2055,7 @@ message InitializeFromNIRFSASessionRequest {
 message InitializeFromNIRFSASessionResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
+  string error_message = 3;
 }
 
 message InitiateRequest {

--- a/generated/nirfmxwlan/nirfmxwlan_service.cpp
+++ b/generated/nirfmxwlan/nirfmxwlan_service.cpp
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <vector>
 #include <numeric>
+#include "custom/nirfmx_errors.h"
 #include <server/converters.h>
 
 namespace nirfmxwlan_grpc {
@@ -2628,6 +2629,11 @@ namespace nirfmxwlan_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
+        response->set_is_new_session(is_new_session);
+      }
+      else {
+        const auto last_error_buffer = get_last_error(library_);
+        response->set_error_message(last_error_buffer.data());
       }
       return ::grpc::Status::OK;
     }
@@ -2659,6 +2665,10 @@ namespace nirfmxwlan_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_instrument()->set_id(session_id);
+      }
+      else {
+        const auto last_error_buffer = get_last_error(library_);
+        response->set_error_message(last_error_buffer.data());
       }
       return ::grpc::Status::OK;
     }

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -1055,7 +1055,7 @@ def is_get_last_error_output_param(parameter: dict) -> bool:
     return "get_last_error" in parameter
 
 
-def get_driver_api_params(parameters: List[dict]) -> bool:
+def get_driver_api_params(parameters: List[dict]) -> List[dict]:
     """Return all parameters that are passed as parameters to the driver API.
 
     Excludes:

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -1048,3 +1048,18 @@ def get_grpc_field_names_for_param_names(params: List[dict], names: List[str]) -
 def is_return_value(parameter: dict) -> bool:
     """Whether the parameter is marked as a return_value."""
     return parameter.get("return_value", False)
+
+
+def is_get_last_error_output_param(parameter: dict) -> bool:
+    """Return True if pararameter is a get_last_error parameter."""
+    return "get_last_error" in parameter
+
+
+def get_driver_api_params(parameters: List[dict]) -> bool:
+    """Return all parameters that are passed as parameters to the driver API.
+
+    Excludes:
+    * Return values.
+    * Outputs that are calculated/populated after the API call.
+    """
+    return [p for p in parameters if not (is_return_value(p) or is_get_last_error_output_param(p))]

--- a/source/codegen/metadata/nifake_non_ivi/config.py
+++ b/source/codegen/metadata/nifake_non_ivi/config.py
@@ -12,6 +12,7 @@ config = {
     'driver_name': 'NI-FAKE-NON-IVI',
     'resource_handle_type': 'FakeHandle',
     'status_ok': 'status >= 0',
+    'additional_headers': { 'custom/nifake_non_ivi_errors.h': ['service.cpp'] },
     'custom_types': [
         {
             'name': 'StringAndEnum',

--- a/source/codegen/metadata/nifake_non_ivi/functions.py
+++ b/source/codegen/metadata/nifake_non_ivi/functions.py
@@ -28,6 +28,25 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'GetLatestErrorMessage': {
+        'parameters': [
+            {
+                'direction': 'out',
+                'name': 'message',
+                'size': {
+                    'mechanism': 'ivi-dance',
+                    'value': 'size'
+                },
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'size',
+                'type': 'uInt32'
+            }
+        ],
+        'returns': 'int32'
+    },
     'GetStringAsReturnedValue': {
         'status_expression': 'string_out ? 0 : -1',
         'parameters': [
@@ -130,6 +149,12 @@ functions = {
                 'direction': 'out',
                 'name': 'handle',
                 'type': 'FakeHandle'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': True,
+                'name': 'errorMessage',
+                'type': 'char[]'
             }
         ],
         'returns': 'int32'

--- a/source/codegen/metadata/nirfmxbluetooth/config.py
+++ b/source/codegen/metadata/nirfmxbluetooth/config.py
@@ -9,7 +9,7 @@ config = {
     'namespace_component': 'nirfmxbluetooth',
     'close_function': 'Close',
     'custom_types': [],
-    'additional_headers': {},
+    'additional_headers': { 'custom/nirfmx_errors.h': ['service.cpp'] },
     'type_to_grpc_type': {
         "char[]": "string",
         "float32": "float",

--- a/source/codegen/metadata/nirfmxbluetooth/functions.py
+++ b/source/codegen/metadata/nirfmxbluetooth/functions.py
@@ -2239,6 +2239,12 @@ functions = {
                 'direction': 'out',
                 'name': 'isNewSession',
                 'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': True,
+                'name': 'errorMessage',
+                'type': 'char[]'
             }
         ],
         'returns': 'int32'
@@ -2259,6 +2265,12 @@ functions = {
                 'grpc_name': 'instrument',
                 'name': 'handleOut',
                 'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': True,
+                'name': 'errorMessage',
+                'type': 'char[]'
             }
         ],
         'returns': 'int32'

--- a/source/codegen/metadata/nirfmxinstr/config.py
+++ b/source/codegen/metadata/nirfmxinstr/config.py
@@ -9,7 +9,7 @@ config = {
     'namespace_component': 'nirfmxinstr',
     'close_function': 'Close',
     'custom_types': [],
-    'additional_headers': { "ivi.h": ["service.h"] },
+    'additional_headers': { 'ivi.h': ['service.h'], 'custom/nirfmx_errors.h': ['service.cpp'] },
     'type_to_grpc_type': {
         "char[]": "string",
         "float32": "float",

--- a/source/codegen/metadata/nirfmxinstr/functions.py
+++ b/source/codegen/metadata/nirfmxinstr/functions.py
@@ -1683,6 +1683,12 @@ functions = {
                 'direction': 'out',
                 'name': 'isNewSession',
                 'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': True,
+                'name': 'errorMessage',
+                'type': 'char[]'
             }
         ],
         'returns': 'int32'
@@ -1703,6 +1709,12 @@ functions = {
                 'grpc_name': 'instrument',
                 'name': 'handleOut',
                 'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': True,
+                'name': 'errorMessage',
+                'type': 'char[]'
             }
         ],
         'returns': 'int32'
@@ -1732,6 +1744,12 @@ functions = {
                 'grpc_name': 'instrument',
                 'name': 'handleOut',
                 'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': True,
+                'name': 'errorMessage',
+                'type': 'char[]'
             }
         ],
         'returns': 'int32'

--- a/source/codegen/metadata/nirfmxlte/config.py
+++ b/source/codegen/metadata/nirfmxlte/config.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 config = {
-    "api_version": "21.0.0",
-    "c_header": "niRFmxLTE.h",
-    "c_function_prefix": "RFmxLTE_",
-    "service_class_prefix": "NiRFmxLTE",
-    "java_package": "com.ni.grpc.nirfmxlte",
-    "csharp_namespace": "NationalInstruments.Grpc.NiRFmxLTE",
-    "namespace_component": "nirfmxlte",
-    "close_function": "Close",
-    "custom_types": [],
-    "additional_headers": {"custom/nirfmx_errors.h": ["service.cpp"]},
-    "type_to_grpc_type": {
+    'api_version': '21.0.0',
+    'c_header': 'niRFmxLTE.h',
+    'c_function_prefix': 'RFmxLTE_',
+    'service_class_prefix': 'NiRFmxLTE',
+    'java_package': 'com.ni.grpc.nirfmxlte',
+    'csharp_namespace': 'NationalInstruments.Grpc.NiRFmxLTE',
+    'namespace_component': 'nirfmxlte',
+    'close_function': 'Close',
+    'custom_types': [],
+    'additional_headers': {'custom/nirfmx_errors.h': ['service.cpp']},
+    'type_to_grpc_type': {
         "char[]": "string",
         "float32": "float",
         "float64": "double",
@@ -27,24 +27,37 @@ config = {
         "NIComplexSingle": "nidevice_grpc.NIComplexNumberF32",
         "NIComplexDouble": "nidevice_grpc.NIComplexNumber",
     },
-    "code_readiness": "NextRelease",
-    "feature_toggles": {},
-    "driver_name": "NI-RFMXLTE",
-    "extra_errors_used": [],
-    "init_function": "Initialize",
-    "resource_handle_type": "niRFmxInstrHandle",
-    "status_ok": "status >= 0",
-    "windows_only": True,
-    "library_info": {
-        "Linux": {"64bit": {"name": "nirfmxlte", "type": "cdll", "abi_version": "1"}},
-        "Windows": {
-            "32bit": {"name": "niRFmxLTE.dll", "type": "windll"},
-            "64bit": {"name": "niRFmxLTE.dll", "type": "cdll"},
+    'code_readiness': 'NextRelease',
+    'feature_toggles': {},
+    'driver_name': 'NI-RFMXLTE',
+    'extra_errors_used': [
+    ],
+    'init_function': 'Initialize',
+    'resource_handle_type': 'niRFmxInstrHandle',
+    'status_ok': 'status >= 0',
+    'windows_only': True,
+    'library_info': {
+        'Linux': {
+            '64bit': {
+                'name': 'nirfmxlte',
+                'type': 'cdll',
+                'abi_version': '1'
+            }
         },
+        'Windows': {
+            '32bit': {
+                'name': 'niRFmxLTE.dll',
+                'type': 'windll'
+            },
+            '64bit': {
+                'name': 'niRFmxLTE.dll',
+                'type': 'cdll'
+            }
+        }
     },
-    "metadata_version": "0.1",
-    "module_name": "nirfmxlte",
-    "session_class_description": "An NI-RFmxLTE instrument handle",
-    "session_handle_parameter_name": "instrumentHandle",
-    "duplicate_resource_handles_allowed": True,
+    'metadata_version': '0.1',
+    'module_name': 'nirfmxlte',
+    'session_class_description': 'An NI-RFmxLTE instrument handle',
+    'session_handle_parameter_name': 'instrumentHandle',
+    'duplicate_resource_handles_allowed': True
 }

--- a/source/codegen/metadata/nirfmxlte/config.py
+++ b/source/codegen/metadata/nirfmxlte/config.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 config = {
-    'api_version': '21.0.0',
-    'c_header': 'niRFmxLTE.h',
-    'c_function_prefix': 'RFmxLTE_',
-    'service_class_prefix': 'NiRFmxLTE',
-    'java_package': 'com.ni.grpc.nirfmxlte',
-    'csharp_namespace': 'NationalInstruments.Grpc.NiRFmxLTE',
-    'namespace_component': 'nirfmxlte',
-    'close_function': 'Close',
-    'custom_types': [],
-    'additional_headers': {},
-    'type_to_grpc_type': {
+    "api_version": "21.0.0",
+    "c_header": "niRFmxLTE.h",
+    "c_function_prefix": "RFmxLTE_",
+    "service_class_prefix": "NiRFmxLTE",
+    "java_package": "com.ni.grpc.nirfmxlte",
+    "csharp_namespace": "NationalInstruments.Grpc.NiRFmxLTE",
+    "namespace_component": "nirfmxlte",
+    "close_function": "Close",
+    "custom_types": [],
+    "additional_headers": {"custom/nirfmx_errors.h": ["service.cpp"]},
+    "type_to_grpc_type": {
         "char[]": "string",
         "float32": "float",
         "float64": "double",
@@ -27,37 +27,24 @@ config = {
         "NIComplexSingle": "nidevice_grpc.NIComplexNumberF32",
         "NIComplexDouble": "nidevice_grpc.NIComplexNumber",
     },
-    'code_readiness': 'NextRelease',
-    'feature_toggles': {},
-    'driver_name': 'NI-RFMXLTE',
-    'extra_errors_used': [
-    ],
-    'init_function': 'Initialize',
-    'resource_handle_type': 'niRFmxInstrHandle',
-    'status_ok': 'status >= 0',
-    'windows_only': True,
-    'library_info': {
-        'Linux': {
-            '64bit': {
-                'name': 'nirfmxlte',
-                'type': 'cdll',
-                'abi_version': '1'
-            }
+    "code_readiness": "NextRelease",
+    "feature_toggles": {},
+    "driver_name": "NI-RFMXLTE",
+    "extra_errors_used": [],
+    "init_function": "Initialize",
+    "resource_handle_type": "niRFmxInstrHandle",
+    "status_ok": "status >= 0",
+    "windows_only": True,
+    "library_info": {
+        "Linux": {"64bit": {"name": "nirfmxlte", "type": "cdll", "abi_version": "1"}},
+        "Windows": {
+            "32bit": {"name": "niRFmxLTE.dll", "type": "windll"},
+            "64bit": {"name": "niRFmxLTE.dll", "type": "cdll"},
         },
-        'Windows': {
-            '32bit': {
-                'name': 'niRFmxLTE.dll',
-                'type': 'windll'
-            },
-            '64bit': {
-                'name': 'niRFmxLTE.dll',
-                'type': 'cdll'
-            }
-        }
     },
-    'metadata_version': '0.1',
-    'module_name': 'nirfmxlte',
-    'session_class_description': 'An NI-RFmxLTE instrument handle',
-    'session_handle_parameter_name': 'instrumentHandle',
-    'duplicate_resource_handles_allowed': True
+    "metadata_version": "0.1",
+    "module_name": "nirfmxlte",
+    "session_class_description": "An NI-RFmxLTE instrument handle",
+    "session_handle_parameter_name": "instrumentHandle",
+    "duplicate_resource_handles_allowed": True,
 }

--- a/source/codegen/metadata/nirfmxlte/functions.py
+++ b/source/codegen/metadata/nirfmxlte/functions.py
@@ -3756,6 +3756,12 @@ functions = {
                 'direction': 'out',
                 'name': 'isNewSession',
                 'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': True,
+                'name': 'errorMessage',
+                'type': 'char[]'
             }
         ],
         'returns': 'int32'
@@ -3776,6 +3782,12 @@ functions = {
                 'grpc_name': 'instrument',
                 'name': 'handleOut',
                 'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': True,
+                'name': 'errorMessage',
+                'type': 'char[]'
             }
         ],
         'returns': 'int32'

--- a/source/codegen/metadata/nirfmxnr/config.py
+++ b/source/codegen/metadata/nirfmxnr/config.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 config = {
-    'api_version': '21.0.0',
-    'c_header': 'niRFmxNR.h',
-    'c_function_prefix': 'RFmxNR_',
-    'service_class_prefix': 'NiRFmxNR',
-    'java_package': 'com.ni.grpc.nirfmxnr',
-    'csharp_namespace': 'NationalInstruments.Grpc.NiRFmxNR',
-    'namespace_component': 'nirfmxnr',
-    'close_function': 'Close',
-    'custom_types': [],
-    'additional_headers': {},
-    'type_to_grpc_type': {
+    "api_version": "21.0.0",
+    "c_header": "niRFmxNR.h",
+    "c_function_prefix": "RFmxNR_",
+    "service_class_prefix": "NiRFmxNR",
+    "java_package": "com.ni.grpc.nirfmxnr",
+    "csharp_namespace": "NationalInstruments.Grpc.NiRFmxNR",
+    "namespace_component": "nirfmxnr",
+    "close_function": "Close",
+    "custom_types": [],
+    "additional_headers": {"custom/nirfmx_errors.h": ["service.cpp"]},
+    "type_to_grpc_type": {
         "char[]": "string",
         "float32": "float",
         "float64": "double",
@@ -27,36 +27,23 @@ config = {
         "NIComplexSingle": "nidevice_grpc.NIComplexNumberF32",
         "NIComplexDouble": "nidevice_grpc.NIComplexNumber",
     },
-    'code_readiness': 'NextRelease',
-    'feature_toggles': {},
-    'driver_name': 'NI-RFMXNR',
-    'extra_errors_used': [
-    ],
-    'init_function': 'Initialize',
-    'resource_handle_type': 'niRFmxInstrHandle',
-    'status_ok': 'status >= 0',
-    'windows_only': True,
-    'library_info': {
-        'Linux': {
-            '64bit': {
-                'name': 'nirfmxnr',
-                'type': 'cdll',
-                'abi_version': '1'
-            }
+    "code_readiness": "NextRelease",
+    "feature_toggles": {},
+    "driver_name": "NI-RFMXNR",
+    "extra_errors_used": [],
+    "init_function": "Initialize",
+    "resource_handle_type": "niRFmxInstrHandle",
+    "status_ok": "status >= 0",
+    "windows_only": True,
+    "library_info": {
+        "Linux": {"64bit": {"name": "nirfmxnr", "type": "cdll", "abi_version": "1"}},
+        "Windows": {
+            "32bit": {"name": "niRFmxNR.dll", "type": "windll"},
+            "64bit": {"name": "niRFmxNR.dll", "type": "cdll"},
         },
-        'Windows': {
-            '32bit': {
-                'name': 'niRFmxNR.dll',
-                'type': 'windll'
-            },
-            '64bit': {
-                'name': 'niRFmxNR.dll',
-                'type': 'cdll'
-            }
-        }
     },
-    'metadata_version': '0.1',
-    'module_name': 'nirfmxnr',
-    'session_class_description': 'An NI-RFmxNR instrument handle',
-    'duplicate_resource_handles_allowed': True
+    "metadata_version": "0.1",
+    "module_name": "nirfmxnr",
+    "session_class_description": "An NI-RFmxNR instrument handle",
+    "duplicate_resource_handles_allowed": True,
 }

--- a/source/codegen/metadata/nirfmxnr/config.py
+++ b/source/codegen/metadata/nirfmxnr/config.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 config = {
-    "api_version": "21.0.0",
-    "c_header": "niRFmxNR.h",
-    "c_function_prefix": "RFmxNR_",
-    "service_class_prefix": "NiRFmxNR",
-    "java_package": "com.ni.grpc.nirfmxnr",
-    "csharp_namespace": "NationalInstruments.Grpc.NiRFmxNR",
-    "namespace_component": "nirfmxnr",
-    "close_function": "Close",
-    "custom_types": [],
-    "additional_headers": {"custom/nirfmx_errors.h": ["service.cpp"]},
-    "type_to_grpc_type": {
+    'api_version': '21.0.0',
+    'c_header': 'niRFmxNR.h',
+    'c_function_prefix': 'RFmxNR_',
+    'service_class_prefix': 'NiRFmxNR',
+    'java_package': 'com.ni.grpc.nirfmxnr',
+    'csharp_namespace': 'NationalInstruments.Grpc.NiRFmxNR',
+    'namespace_component': 'nirfmxnr',
+    'close_function': 'Close',
+    'custom_types': [],
+    'additional_headers': {'custom/nirfmx_errors.h': ['service.cpp']},
+    'type_to_grpc_type': {
         "char[]": "string",
         "float32": "float",
         "float64": "double",
@@ -27,23 +27,37 @@ config = {
         "NIComplexSingle": "nidevice_grpc.NIComplexNumberF32",
         "NIComplexDouble": "nidevice_grpc.NIComplexNumber",
     },
-    "code_readiness": "NextRelease",
-    "feature_toggles": {},
-    "driver_name": "NI-RFMXNR",
-    "extra_errors_used": [],
-    "init_function": "Initialize",
-    "resource_handle_type": "niRFmxInstrHandle",
-    "status_ok": "status >= 0",
-    "windows_only": True,
-    "library_info": {
-        "Linux": {"64bit": {"name": "nirfmxnr", "type": "cdll", "abi_version": "1"}},
-        "Windows": {
-            "32bit": {"name": "niRFmxNR.dll", "type": "windll"},
-            "64bit": {"name": "niRFmxNR.dll", "type": "cdll"},
+    'code_readiness': 'NextRelease',
+    'feature_toggles': {},
+    'driver_name': 'NI-RFMXNR',
+    'extra_errors_used': [
+    ],
+    'init_function': 'Initialize',
+    'resource_handle_type': 'niRFmxInstrHandle',
+    'status_ok': 'status >= 0',
+    'windows_only': True,
+    'library_info': {
+        'Linux': {
+            '64bit': {
+                'name': 'nirfmxnr',
+                'type': 'cdll',
+                'abi_version': '1'
+            }
         },
+        'Windows': {
+            '32bit': {
+                'name': 'niRFmxNR.dll',
+                'type': 'windll'
+            },
+            '64bit': {
+                'name': 'niRFmxNR.dll',
+                'type': 'cdll'
+            }
+        }
     },
-    "metadata_version": "0.1",
-    "module_name": "nirfmxnr",
-    "session_class_description": "An NI-RFmxNR instrument handle",
-    "duplicate_resource_handles_allowed": True,
+    'metadata_version': '0.1',
+    'module_name': 'nirfmxnr',
+    'session_class_description': 'An NI-RFmxNR instrument handle',
+    'duplicate_resource_handles_allowed': True
 }
+

--- a/source/codegen/metadata/nirfmxnr/functions.py
+++ b/source/codegen/metadata/nirfmxnr/functions.py
@@ -2949,6 +2949,12 @@ functions = {
                 'direction': 'out',
                 'name': 'isNewSession',
                 'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': True,
+                'name': 'errorMessage',
+                'type': 'char[]'
             }
         ],
         'returns': 'int32'
@@ -2969,6 +2975,12 @@ functions = {
                 'grpc_name': 'instrument',
                 'name': 'handleOut',
                 'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': True,
+                'name': 'errorMessage',
+                'type': 'char[]'
             }
         ],
         'returns': 'int32'

--- a/source/codegen/metadata/nirfmxspecan/config.py
+++ b/source/codegen/metadata/nirfmxspecan/config.py
@@ -9,7 +9,7 @@ config = {
     'namespace_component': 'nirfmxspecan',
     'close_function': 'Close',
     'custom_types': [],
-    'additional_headers': {},
+    'additional_headers': { 'custom/nirfmx_errors.h': ['service.cpp'] },
     'type_to_grpc_type': {
         "char[]": "string",
         "float32": "float",

--- a/source/codegen/metadata/nirfmxspecan/functions.py
+++ b/source/codegen/metadata/nirfmxspecan/functions.py
@@ -7278,6 +7278,12 @@ functions = {
                 'direction': 'out',
                 'name': 'isNewSession',
                 'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': True,
+                'name': 'errorMessage',
+                'type': 'char[]'
             }
         ],
         'returns': 'int32'
@@ -7298,6 +7304,12 @@ functions = {
                 'grpc_name': 'instrument',
                 'name': 'handleOut',
                 'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': True,
+                'name': 'errorMessage',
+                'type': 'char[]'
             }
         ],
         'returns': 'int32'

--- a/source/codegen/metadata/nirfmxwlan/config.py
+++ b/source/codegen/metadata/nirfmxwlan/config.py
@@ -9,7 +9,7 @@ config = {
     'namespace_component': 'nirfmxwlan',
     'close_function': 'Close',
     'custom_types': [],
-    'additional_headers': {},
+    'additional_headers': { 'custom/nirfmx_errors.h': ['service.cpp'] },
     'type_to_grpc_type': {
         "char[]": "string",
         "float32": "float",

--- a/source/codegen/metadata/nirfmxwlan/functions.py
+++ b/source/codegen/metadata/nirfmxwlan/functions.py
@@ -2525,6 +2525,12 @@ functions = {
                 'direction': 'out',
                 'name': 'isNewSession',
                 'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': True,
+                'name': 'errorMessage',
+                'type': 'char[]'
             }
         ],
         'returns': 'int32'
@@ -2545,6 +2551,12 @@ functions = {
                 'grpc_name': 'instrument',
                 'name': 'handleOut',
                 'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': True,
+                'name': 'errorMessage',
+                'type': 'char[]'
             }
         ],
         'returns': 'int32'

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -76,6 +76,7 @@ PARAM_SCHEMA = Schema(
         Optional("cross_driver_session"): str,
         Optional("grpc_name"): str,
         Optional("return_value"): bool,
+        Optional("get_last_error"): bool,
     }
 )
 

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -120,7 +120,7 @@ def _create_standard_arg(parameter):
 
 def create_args(parameters):
     """Get the args needed to call the library function."""
-    parameters = [p for p in parameters if not common_helpers.is_return_value(p)]
+    parameters = common_helpers.get_driver_api_params(parameters)
     result = ""
     have_expanded_varargs = False
     for parameter in parameters:
@@ -190,7 +190,7 @@ def create_args_for_ivi_dance_with_a_twist(parameters):
 
 def create_params(parameters, expand_varargs=True):
     """Get the params needed for defining the library function."""
-    parameters = [p for p in parameters if not common_helpers.is_return_value(p)]
+    parameters = common_helpers.get_driver_api_params(parameters)
     if not len(parameters):
         return ""
     repeated_parameters = [p for p in parameters if common_helpers.is_repeating_parameter(p)]
@@ -216,7 +216,7 @@ def expand_varargs_parameters(parameters):
     The max_length value comes from the first repeated_var_args parameter. Each repeated parameter
     gets a number (starting at zero) appended to the parameter name.
     """
-    parameters = [p for p in parameters if not common_helpers.is_return_value(p)]
+    parameters = common_helpers.get_driver_api_params(parameters)
     if not common_helpers.has_repeated_varargs_parameter(parameters):
         return parameters
     # omit the varargs parameters that we're going to expand
@@ -578,3 +578,12 @@ def should_copy_to_response(parameter: dict) -> bool:
     # They should execute that map/copy logic even if include_in_proto is False.
     is_mapped_as_repeating_parameter = common_helpers.is_repeating_parameter(parameter)
     return is_included_in_response_proto or is_mapped_as_repeating_parameter
+
+
+def get_last_error_output_param(parameters: List[dict]) -> Optional[dict]:
+    """Get the get_last_error parameter if any (or None)."""
+    get_last_error_outputs = [
+        p for p in parameters if common_helpers.is_get_last_error_output_param(p)
+    ]
+    assert len(get_last_error_outputs) <= 1, "Only one get_last_error output is supported"
+    return get_last_error_outputs[0] if get_last_error_outputs else None

--- a/source/custom/nifake_non_ivi_errors.h
+++ b/source/custom/nifake_non_ivi_errors.h
@@ -1,0 +1,17 @@
+#ifndef NIDEVICE_GRPC_DEVICE_NIFAKE_NON_IVI_ERRORS_H
+#define NIDEVICE_GRPC_DEVICE_NIFAKE_NON_IVI_ERRORS_H
+
+#include <vector>
+
+template <typename TLibraryPtr>
+std::vector<char> get_last_error(TLibraryPtr& library)
+{
+  std::vector<char> error_message;
+  const auto buffer_size = library->GetLatestErrorMessage(nullptr, 0);
+  error_message.resize(buffer_size);
+  library->GetLatestErrorMessage(error_message.data(), buffer_size);
+
+  return error_message;
+}
+
+#endif  // NIDEVICE_GRPC_DEVICE_NIFAKE_NON_IVI_ERRORS_H

--- a/source/custom/nirfmx_errors.h
+++ b/source/custom/nirfmx_errors.h
@@ -1,0 +1,22 @@
+#ifndef NIDEVICE_GRPC_DEVICE_NIRFMX_ERRORS_H
+#define NIDEVICE_GRPC_DEVICE_NIRFMX_ERRORS_H
+#include <nirfmxinstr/nirfmxinstr_library_interface.h>  // For niRFmxInstrHandle, int32
+
+#include <vector>
+
+template <typename TLibraryPtr>
+std::vector<char> get_last_error(TLibraryPtr& library)
+{
+  std::vector<char> error_message;
+  int32 error_code;
+  // Calling with no instr handle gives us thread-local errors instead of handle
+  // scoped errors. This method should only be used in cases where that is correct.
+  constexpr auto NO_INSTR_HANDLE = static_cast<niRFmxInstrHandle>(nullptr);
+  const auto buffer_size = library->GetError(NO_INSTR_HANDLE, &error_code, 0, nullptr);
+  error_message.resize(buffer_size);
+  library->GetError(NO_INSTR_HANDLE, &error_code, buffer_size, error_message.data());
+
+  return error_message;
+}
+
+#endif  // NIDEVICE_GRPC_DEVICE_NIRFMX_ERRORS_H

--- a/source/tests/system/nirfmxspecan_session_tests.cpp
+++ b/source/tests/system/nirfmxspecan_session_tests.cpp
@@ -112,7 +112,7 @@ TEST_F(NiRFmxSpecAnSessionTest, InitWithErrorFromDriver_ReturnsUserErrorMessage)
   EXPECT_EQ(std::string(kRFmxSpecAnErrorResourceNotFoundMessage), init_response.error_message());
 }
 
-TEST_F(NiRFmxSpecAnSessionTest, InitWithErrorFromDriver_ReInitSuccessfully_ErrorMessageIsEmpty)
+TEST_F(NiRFmxSpecAnSessionTest, InitWithErrorFromDriver_ReinitSuccessfully_ErrorMessageIsEmpty)
 {
   rfmxspecan::InitializeResponse failed_init_response;
   call_initialize(kRFmxSpecAnTestInvalidRsrc, "", "", &failed_init_response);


### PR DESCRIPTION
### What does this Pull Request accomplish?

Change RFmx `init_method`s to `get_last_error` on failed init.

### Why should this Pull Request be merged?

Normally, `GetError` in RFmx gets the last error for the given session. But in the case of failed Init, there is no session to check. The fallback logic uses thread-local storage to get the latest error on the calling thread. This does not work well for `grpc-device` because messages are handled on a thread pool.

Calling `GetError` immediately after a failed init and adding it to the response ensures that we get the correct error message.

Fixes #494 

Fixes [AB#1872435](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1872435)

### Alternatives considered

1. Do Nothing. Reason Rejected: Failed Init can be frustrating to debug without the message.
2. Try to implement a global `get_last_error`. Reason Rejected: This doesn't require API changes but is not easier to implement and can be incorrect with multiple clients.
3. Implement a better error/status reporting strategy like an error service or rich status messages. Reason Rejected: this is feature-level and potentially a major behavior breaking change. The `grpc-device` approach to error messages is not perfect, but it's working OK and we'll stick with the overall approach for now.

### What testing has been done?

Ran and passed all new tests and RFmx tests.