### PR TITLE
Set CodeReadiness to Release for nirfmxbluetooth.

### DIFF
--- a/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
@@ -4272,7 +4272,7 @@ namespace nirfmxbluetooth_grpc {
   NiRFmxBluetoothFeatureToggles::NiRFmxBluetoothFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("nirfmxbluetooth", CodeReadiness::kNextRelease))
+        feature_toggles.is_feature_enabled("nirfmxbluetooth", CodeReadiness::kRelease))
   {
   }
 } // namespace nirfmxbluetooth_grpc

--- a/source/codegen/metadata/nirfmxbluetooth/config.py
+++ b/source/codegen/metadata/nirfmxbluetooth/config.py
@@ -27,7 +27,7 @@ config = {
         "NIComplexSingle": "nidevice_grpc.NIComplexNumberF32",
         "NIComplexDouble": "nidevice_grpc.NIComplexNumber",
     },
-    'code_readiness': 'NextRelease',
+    'code_readiness': 'Release',
     'feature_toggles': {},
     'driver_name': 'NI-RFMXBLUETOOTH',
     'extra_errors_used': [


### PR DESCRIPTION
### What does this Pull Request accomplish?

This pull request enables nirfmxbluetooth so that a build of grpc-device produces a gRPC server supporting remote device calls for NI-RFmx Bluetooth.
Fixes [AB#1873829](https://ni.visualstudio.com/DevCentral/_workitems/edit/1873829).

### Why should this Pull Request be merged?

This pull request should be merged because development is finished and signed off on for nirfmxbluetooth. The Bluetooth service is ready for use by customers.

### What testing has been done?

Built grpc-device locally and copied `ni_grpc_device_server.exe` and `server_config.json` to a system with NI-RFSA and NI-RFmx (all personalities) installed. Observed that the Bluetooth python examples are runnable, but that running python examples of various other personalities (e.g. NR, WLAN) returns not implemented/supported errors.
