### PR TITLE
Enable toggle for nirfmxspecan service

### DIFF
--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -2918,7 +2918,7 @@ namespace nirfmxinstr_grpc {
   NiRFmxInstrFeatureToggles::NiRFmxInstrFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("nirfmxinstr", CodeReadiness::kNextRelease))
+        feature_toggles.is_feature_enabled("nirfmxinstr", CodeReadiness::kRelease))
   {
   }
 } // namespace nirfmxinstr_grpc

--- a/generated/nirfmxspecan/nirfmxspecan_service.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_service.cpp
@@ -14658,7 +14658,7 @@ namespace nirfmxspecan_grpc {
   NiRFmxSpecAnFeatureToggles::NiRFmxSpecAnFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("nirfmxspecan", CodeReadiness::kNextRelease))
+        feature_toggles.is_feature_enabled("nirfmxspecan", CodeReadiness::kRelease))
   {
   }
 } // namespace nirfmxspecan_grpc

--- a/source/codegen/metadata/nirfmxinstr/config.py
+++ b/source/codegen/metadata/nirfmxinstr/config.py
@@ -28,7 +28,7 @@ config = {
         "NIComplexDouble": "nidevice_grpc.NIComplexNumber",
         "CVIAbsoluteTime": "google.protobuf.Timestamp",
     },
-    'code_readiness': 'NextRelease',
+    'code_readiness': 'Release',
     'feature_toggles': {},
     'driver_name': 'NI-RFMXINSTR',
     'extra_errors_used': [

--- a/source/codegen/metadata/nirfmxspecan/config.py
+++ b/source/codegen/metadata/nirfmxspecan/config.py
@@ -27,7 +27,7 @@ config = {
         "NIComplexSingle": "nidevice_grpc.NIComplexNumberF32",
         "NIComplexDouble": "nidevice_grpc.NIComplexNumber",
     },
-    'code_readiness': 'NextRelease',
+    'code_readiness': 'Release',
     'feature_toggles': {},
     'driver_name': 'NI-RFMXSPECAN',
     'extra_errors_used': [


### PR DESCRIPTION
### What does this Pull Request accomplish?

Enables the `nirfmxspecan` and `nirfmxinstr` services in `grpc-device`.

### Why should this Pull Request be merged?

Planned dev work for `nirfmxspecan` is complete: prepare to release.

### What testing has been done?

Ran and passed `validate_examples.py` targeting server with default configuration.