### PR TITLE
Add raise_if_initialization_error to rfmx examples

### DIFF
--- a/examples/nirfmxbluetooth/acp-basic.py
+++ b/examples/nirfmxbluetooth/acp-basic.py
@@ -69,6 +69,15 @@ client = grpc_nirfmxbluetooth.NiRFmxBluetoothStub(channel)
 instr = None
 
 
+def raise_if_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+    return response
+
+
 def raise_if_error(response):
     """Raise an exception if an error was returned."""
     if response.status != 0:
@@ -88,7 +97,7 @@ def raise_if_error(response):
 try:
     offset_channel_mode = nirfmxbluetooth_types.ACP_OFFSET_CHANNEL_MODE_SYMMETRIC
 
-    initialize_response = raise_if_error(
+    initialize_response = raise_if_initialization_error(
         client.Initialize(
             nirfmxbluetooth_types.InitializeRequest(
                 session_name=SESSION_NAME, resource_name=RESOURCE, option_string=OPTIONS

--- a/examples/nirfmxbluetooth/txp-basic.py
+++ b/examples/nirfmxbluetooth/txp-basic.py
@@ -70,6 +70,15 @@ client = grpc_nirfmxbluetooth.NiRFmxBluetoothStub(channel)
 instr = None
 
 
+def raise_if_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+    return response
+
+
 def raise_if_error(response):
     """Raise an exception if an error was returned."""
     if response.status != 0:
@@ -90,7 +99,7 @@ try:
     auto_level = True
     basic_rate_packets = True
 
-    initialize_response = raise_if_error(
+    initialize_response = raise_if_initialization_error(
         client.Initialize(
             nirfmxbluetooth_types.InitializeRequest(
                 session_name=SESSION_NAME, resource_name=RESOURCE, option_string=OPTIONS

--- a/examples/nirfmxlte/acp-single-carrier.py
+++ b/examples/nirfmxlte/acp-single-carrier.py
@@ -74,6 +74,15 @@ client = grpc_nirfmxlte.NiRFmxLTEStub(channel)
 instr = None
 
 
+def raise_if_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+    return response
+
+
 def raise_if_error(response):
     """Raise an exception if an error was returned."""
     if response.status != 0:
@@ -93,7 +102,7 @@ def raise_if_error(response):
 try:
     auto_level = True
 
-    initialize_response = raise_if_error(
+    initialize_response = raise_if_initialization_error(
         client.Initialize(
             nirfmxlte_types.InitializeRequest(
                 session_name=SESSION_NAME, resource_name=RESOURCE, option_string=OPTIONS

--- a/examples/nirfmxlte/ul-modacc-single-carrier.py
+++ b/examples/nirfmxlte/ul-modacc-single-carrier.py
@@ -71,6 +71,15 @@ client = grpc_nirfmxlte.NiRFmxLTEStub(channel)
 instr = None
 
 
+def raise_if_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+    return response
+
+
 def raise_if_error(response):
     """Raise an exception if an error was returned."""
     if response.status != 0:
@@ -88,7 +97,7 @@ def raise_if_error(response):
 
 
 try:
-    initialize_response = raise_if_error(
+    initialize_response = raise_if_initialization_error(
         client.Initialize(
             nirfmxlte_types.InitializeRequest(
                 session_name=SESSION_NAME, resource_name=RESOURCE, option_string=OPTIONS

--- a/examples/nirfmxnr/acp-single-carrier.py
+++ b/examples/nirfmxnr/acp-single-carrier.py
@@ -70,6 +70,15 @@ client = grpc_nirfmxnr.NiRFmxNRStub(channel)
 instr = None
 
 
+def raise_if_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+    return response
+
+
 def raise_if_error(response):
     """Raise an exception if an error was returned."""
     if response.status != 0:
@@ -89,7 +98,7 @@ def raise_if_error(response):
 try:
     auto_level = True
 
-    initialize_response = raise_if_error(
+    initialize_response = raise_if_initialization_error(
         client.Initialize(
             nirfmxnr_types.InitializeRequest(
                 session_name=SESSION_NAME, resource_name=RESOURCE, option_string=OPTIONS

--- a/examples/nirfmxnr/txp-single-carrier.py
+++ b/examples/nirfmxnr/txp-single-carrier.py
@@ -67,6 +67,15 @@ client = grpc_nirfmxnr.NiRFmxNRStub(channel)
 instr = None
 
 
+def raise_if_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+    return response
+
+
 def raise_if_error(response):
     """Raise an exception if an error was returned."""
     if response.status != 0:
@@ -84,7 +93,7 @@ def raise_if_error(response):
 
 
 try:
-    initialize_response = raise_if_error(
+    initialize_response = raise_if_initialization_error(
         client.Initialize(
             nirfmxnr_types.InitializeRequest(
                 session_name=SESSION_NAME, resource_name=RESOURCE, option_string=OPTIONS

--- a/examples/nirfmxspecan/acp-basic.py
+++ b/examples/nirfmxspecan/acp-basic.py
@@ -67,6 +67,15 @@ client = grpc_nirfmxspecan.NiRFmxSpecAnStub(channel)
 instr = None
 
 
+def raise_if_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+    return response
+
+
 def raise_if_error(response):
     """Raise an exception if an error was returned."""
     if response.status != 0:
@@ -84,7 +93,7 @@ def raise_if_error(response):
 
 
 try:
-    initialize_response = raise_if_error(
+    initialize_response = raise_if_initialization_error(
         client.Initialize(
             nirfmxspecan_types.InitializeRequest(
                 session_name=SESSION_NAME, resource_name=RESOURCE, option_string=OPTIONS

--- a/examples/nirfmxspecan/spectrum-basic.py
+++ b/examples/nirfmxspecan/spectrum-basic.py
@@ -74,6 +74,15 @@ def _format_frequency(f):
     return f"{f:.3f} G{suffix}"
 
 
+def raise_if_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+    return response
+
+
 def raise_if_error(response):
     """Raise an exception if an error was returned."""
     if response.status != 0:

--- a/examples/nirfmxspecan/txp-basic.py
+++ b/examples/nirfmxspecan/txp-basic.py
@@ -64,6 +64,15 @@ client = grpc_nirfmxspecan.NiRFmxSpecAnStub(channel)
 instr = None
 
 
+def raise_if_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+    return response
+
+
 def raise_if_error(response):
     """Raise an exception if an error was returned."""
     if response.status != 0:
@@ -81,7 +90,7 @@ def raise_if_error(response):
 
 
 try:
-    initialize_response = raise_if_error(
+    initialize_response = raise_if_initialization_error(
         client.Initialize(
             nirfmxspecan_types.InitializeRequest(
                 session_name=SESSION_NAME, resource_name=RESOURCE, option_string=OPTIONS

--- a/examples/nirfmxwlan/ofdm-modacc.py
+++ b/examples/nirfmxwlan/ofdm-modacc.py
@@ -76,6 +76,15 @@ instr_client = grpc_nirfmxinstr.NiRFmxInstrStub(channel)
 instr = None
 
 
+def raise_if_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+    return response
+
+
 def raise_if_error(response):
     """Raise an exception if an error was returned."""
     if response.status != 0:
@@ -93,7 +102,7 @@ def raise_if_error(response):
 
 
 try:
-    initialize_response = raise_if_error(
+    initialize_response = raise_if_initialization_error(
         instr_client.Initialize(
             nirfmxinstr_types.InitializeRequest(
                 session_name=SESSION_NAME, resource_name=RESOURCE, option_string=OPTIONS

--- a/examples/nirfmxwlan/txp-basic.py
+++ b/examples/nirfmxwlan/txp-basic.py
@@ -68,6 +68,15 @@ client = grpc_nirfmxwlan.NiRFmxWLANStub(channel)
 instr = None
 
 
+def raise_if_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+    return response
+
+
 def raise_if_error(response):
     """Raise an exception if an error was returned."""
     if response.status != 0:
@@ -87,7 +96,7 @@ def raise_if_error(response):
 try:
     auto_level = True
 
-    initialize_response = raise_if_error(
+    initialize_response = raise_if_initialization_error(
         client.Initialize(
             nirfmxwlan_types.InitializeRequest(
                 session_name=SESSION_NAME, resource_name=RESOURCE, option_string=OPTIONS


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update `rfmx` examples to `raise_if_initialization_error` to correctly handle error messages by using the init response.

### Why should this Pull Request be merged?

#583 added this feature. The normal `raise_if_error` implementation does not work for `Initialize`.

### What testing has been done?

Ran and passed all examples with `validate_examples`. Tested that an error from `Initialize` was reported correctly.