### PR TITLE
Enable remaining RFmx feature toggles

### DIFF
--- a/generated/nirfmxlte/nirfmxlte_service.cpp
+++ b/generated/nirfmxlte/nirfmxlte_service.cpp
@@ -10099,7 +10099,7 @@ namespace nirfmxlte_grpc {
   NiRFmxLTEFeatureToggles::NiRFmxLTEFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("nirfmxlte", CodeReadiness::kNextRelease))
+        feature_toggles.is_feature_enabled("nirfmxlte", CodeReadiness::kRelease))
   {
   }
 } // namespace nirfmxlte_grpc

--- a/generated/nirfmxnr/nirfmxnr_service.cpp
+++ b/generated/nirfmxnr/nirfmxnr_service.cpp
@@ -7797,7 +7797,7 @@ namespace nirfmxnr_grpc {
   NiRFmxNRFeatureToggles::NiRFmxNRFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("nirfmxnr", CodeReadiness::kNextRelease))
+        feature_toggles.is_feature_enabled("nirfmxnr", CodeReadiness::kRelease))
   {
   }
 } // namespace nirfmxnr_grpc

--- a/generated/nirfmxwlan/nirfmxwlan_service.cpp
+++ b/generated/nirfmxwlan/nirfmxwlan_service.cpp
@@ -7813,7 +7813,7 @@ namespace nirfmxwlan_grpc {
   NiRFmxWLANFeatureToggles::NiRFmxWLANFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("nirfmxwlan", CodeReadiness::kNextRelease))
+        feature_toggles.is_feature_enabled("nirfmxwlan", CodeReadiness::kRelease))
   {
   }
 } // namespace nirfmxwlan_grpc

--- a/source/codegen/metadata/nirfmxlte/config.py
+++ b/source/codegen/metadata/nirfmxlte/config.py
@@ -27,7 +27,7 @@ config = {
         "NIComplexSingle": "nidevice_grpc.NIComplexNumberF32",
         "NIComplexDouble": "nidevice_grpc.NIComplexNumber",
     },
-    'code_readiness': 'NextRelease',
+    'code_readiness': 'Release',
     'feature_toggles': {},
     'driver_name': 'NI-RFMXLTE',
     'extra_errors_used': [

--- a/source/codegen/metadata/nirfmxnr/config.py
+++ b/source/codegen/metadata/nirfmxnr/config.py
@@ -27,7 +27,7 @@ config = {
         "NIComplexSingle": "nidevice_grpc.NIComplexNumberF32",
         "NIComplexDouble": "nidevice_grpc.NIComplexNumber",
     },
-    'code_readiness': 'NextRelease',
+    'code_readiness': 'Release',
     'feature_toggles': {},
     'driver_name': 'NI-RFMXNR',
     'extra_errors_used': [

--- a/source/codegen/metadata/nirfmxwlan/config.py
+++ b/source/codegen/metadata/nirfmxwlan/config.py
@@ -27,7 +27,7 @@ config = {
         "NIComplexSingle": "nidevice_grpc.NIComplexNumberF32",
         "NIComplexDouble": "nidevice_grpc.NIComplexNumber",
     },
-    'code_readiness': 'NextRelease',
+    'code_readiness': 'Release',
     'feature_toggles': {},
     'driver_name': 'NI-RFMXWLAN',
     'extra_errors_used': [


### PR DESCRIPTION
### What does this Pull Request accomplish?

Enables the `nirfmxlte`, `nirfmxnr`, and `nirfmxwlan` services in `grpc-device`.

### Why should this Pull Request be merged?

Planned dev work for RFmx services is complete: prepare to release.

### What testing has been done?

Ran and passed `validate_examples.py` targeting server with default configuration.