### PR TITLE
Add conditional dependency on custom_proto.mako

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,9 @@ foreach(api ${nidrivers})
     "${metadata_dir}/${api}/functions.py"
     "${metadata_dir}/${api}/functions_addon.py"
     "${metadata_dir}/${api}/__init__.py")
+  if (EXISTS "${metadata_dir}/${api}/custom_proto.mako")
+    set(codegen_dependencies ${codegen_dependencies} "${metadata_dir}/${api}/custom_proto.mako")
+  endif()
   set(all_codegen_dependencies
     ${all_codegen_dependencies}
     ${codegen_dependencies}


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update `CMakeLists.txt` to add conditional dependency on `custom_proto.mako` for each driver.

### Why should this Pull Request be merged?

Prior to this change, changes to `custom_proto.mako` do not cause codegen to re-run. This makes it frustrating to change that file.

### What testing has been done?

Tested locally to ensure that codegen re-runs on changes to `custom_proto.mako` for drivers that have one.