### PR TITLE
Add support for nxfd_set and nxtimeval for select

### DIFF
--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -174,14 +174,7 @@ namespace nifake_grpc {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 number_of_elements = request->number_of_elements();
-      auto an_array_request = request->an_array();
-      std::vector<ViBoolean> an_array;
-      std::transform(
-        an_array_request.begin(),
-        an_array_request.end(),
-        std::back_inserter(an_array),
-        [](auto x) { return x ? VI_TRUE : VI_FALSE; });
-
+      auto an_array = convert_from_grpc<ViBoolean>(request->an_array());
       auto status = library_->BoolArrayInputFunction(vi, number_of_elements, an_array.data());
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -14,12 +14,15 @@ option csharp_namespace = "NationalInstruments.Grpc.NiXnetSocket";
 package nixnetsocket_grpc;
 
 import "session.proto";
+import "google/protobuf/duration.proto";
 
 service NiXnetSocket {
   rpc Bind(BindRequest) returns (BindResponse);
   rpc Close(CloseRequest) returns (CloseResponse);
   rpc GetLastErrorNum(GetLastErrorNumRequest) returns (GetLastErrorNumResponse);
   rpc GetLastErrorStr(GetLastErrorStrRequest) returns (GetLastErrorStrResponse);
+  rpc IsSet(IsSetRequest) returns (IsSetResponse);
+  rpc Select(SelectRequest) returns (SelectResponse);
   rpc Socket(SocketRequest) returns (SocketResponse);
 }
 
@@ -77,6 +80,27 @@ message GetLastErrorStrRequest {
 message GetLastErrorStrResponse {
   int32 status = 1;
   string error = 2;
+}
+
+message IsSetRequest {
+  nidevice_grpc.Session fd = 1;
+  repeated nidevice_grpc.Session set = 2;
+}
+
+message IsSetResponse {
+  int32 status = 1;
+  int32 is_set = 2;
+}
+
+message SelectRequest {
+  repeated nidevice_grpc.Session read_fds = 1;
+  repeated nidevice_grpc.Session write_fds = 2;
+  repeated nidevice_grpc.Session except_fds = 3;
+  google.protobuf.Duration timeout = 4;
+}
+
+message SelectResponse {
+  int32 status = 1;
 }
 
 message SocketRequest {

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -81,6 +81,42 @@ get_last_error_str(const StubPtr& stub, const pb::uint64& buf_len)
   return response;
 }
 
+IsSetResponse
+is_set(const StubPtr& stub, const nidevice_grpc::Session& fd, const std::vector<nidevice_grpc::Session>& set)
+{
+  ::grpc::ClientContext context;
+
+  auto request = IsSetRequest{};
+  request.mutable_fd()->CopyFrom(fd);
+  copy_array(set, request.mutable_set());
+
+  auto response = IsSetResponse{};
+
+  raise_if_error(
+      stub->IsSet(&context, request, &response));
+
+  return response;
+}
+
+SelectResponse
+select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& read_fds, const std::vector<nidevice_grpc::Session>& write_fds, const std::vector<nidevice_grpc::Session>& except_fds, const google::protobuf::Duration& timeout)
+{
+  ::grpc::ClientContext context;
+
+  auto request = SelectRequest{};
+  copy_array(read_fds, request.mutable_read_fds());
+  copy_array(write_fds, request.mutable_write_fds());
+  copy_array(except_fds, request.mutable_except_fds());
+  request.mutable_timeout()->CopyFrom(timeout);
+
+  auto response = SelectResponse{};
+
+  raise_if_error(
+      stub->Select(&context, request, &response));
+
+  return response;
+}
+
 SocketResponse
 socket(const StubPtr& stub, const pb::int32& domain, const pb::int32& type, const pb::int32& prototcol)
 {

--- a/generated/nixnetsocket/nixnetsocket_client.h
+++ b/generated/nixnetsocket/nixnetsocket_client.h
@@ -26,6 +26,8 @@ BindResponse bind(const StubPtr& stub, const nidevice_grpc::Session& socket, con
 CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& socket);
 GetLastErrorNumResponse get_last_error_num(const StubPtr& stub);
 GetLastErrorStrResponse get_last_error_str(const StubPtr& stub, const pb::uint64& buf_len);
+IsSetResponse is_set(const StubPtr& stub, const nidevice_grpc::Session& fd, const std::vector<nidevice_grpc::Session>& set);
+SelectResponse select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& read_fds, const std::vector<nidevice_grpc::Session>& write_fds, const std::vector<nidevice_grpc::Session>& except_fds, const google::protobuf::Duration& timeout);
 SocketResponse socket(const StubPtr& stub, const pb::int32& domain, const pb::int32& type, const pb::int32& prototcol);
 
 } // namespace nixnetsocket_grpc::experimental::client

--- a/generated/nixnetsocket/nixnetsocket_library.cpp
+++ b/generated/nixnetsocket/nixnetsocket_library.cpp
@@ -25,6 +25,8 @@ NiXnetSocketLibrary::NiXnetSocketLibrary() : shared_library_(kLibraryName)
   function_pointers_.Close = reinterpret_cast<ClosePtr>(shared_library_.get_function_pointer("nxclose"));
   function_pointers_.GetLastErrorNum = reinterpret_cast<GetLastErrorNumPtr>(shared_library_.get_function_pointer("nxgetlasterrornum"));
   function_pointers_.GetLastErrorStr = reinterpret_cast<GetLastErrorStrPtr>(shared_library_.get_function_pointer("nxgetlasterrorstr"));
+  function_pointers_.IsSet = reinterpret_cast<IsSetPtr>(shared_library_.get_function_pointer("nxfd_isset"));
+  function_pointers_.Select = reinterpret_cast<SelectPtr>(shared_library_.get_function_pointer("nxselect"));
   function_pointers_.Socket = reinterpret_cast<SocketPtr>(shared_library_.get_function_pointer("nxsocket"));
 }
 
@@ -84,6 +86,30 @@ char* NiXnetSocketLibrary::GetLastErrorStr(char buf[], size_t bufLen)
   return nxgetlasterrorstr(buf, bufLen);
 #else
   return function_pointers_.GetLastErrorStr(buf, bufLen);
+#endif
+}
+
+int32_t NiXnetSocketLibrary::IsSet(nxSOCKET fd, nxfd_set* set)
+{
+  if (!function_pointers_.IsSet) {
+    throw nidevice_grpc::LibraryLoadException("Could not find nxfd_isset.");
+  }
+#if defined(_MSC_VER)
+  return nxfd_isset(fd, set);
+#else
+  return function_pointers_.IsSet(fd, set);
+#endif
+}
+
+int32_t NiXnetSocketLibrary::Select(int32_t nfds, nxfd_set* read_fds, nxfd_set* write_fds, nxfd_set* except_fds, nxtimeval* timeout)
+{
+  if (!function_pointers_.Select) {
+    throw nidevice_grpc::LibraryLoadException("Could not find nxselect.");
+  }
+#if defined(_MSC_VER)
+  return nxselect(nfds, read_fds, write_fds, except_fds, timeout);
+#else
+  return function_pointers_.Select(nfds, read_fds, write_fds, except_fds, timeout);
 #endif
 }
 

--- a/generated/nixnetsocket/nixnetsocket_library.h
+++ b/generated/nixnetsocket/nixnetsocket_library.h
@@ -22,6 +22,8 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   int32_t Close(nxSOCKET socket);
   int32_t GetLastErrorNum();
   char* GetLastErrorStr(char buf[], size_t bufLen);
+  int32_t IsSet(nxSOCKET fd, nxfd_set* set);
+  int32_t Select(int32_t nfds, nxfd_set* read_fds, nxfd_set* write_fds, nxfd_set* except_fds, nxtimeval* timeout);
   nxSOCKET Socket(nxIpStackRef_t stack_ref, int32_t domain, int32_t type, int32_t prototcol);
 
  private:
@@ -29,6 +31,8 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   using ClosePtr = decltype(&nxclose);
   using GetLastErrorNumPtr = decltype(&nxgetlasterrornum);
   using GetLastErrorStrPtr = decltype(&nxgetlasterrorstr);
+  using IsSetPtr = decltype(&nxfd_isset);
+  using SelectPtr = decltype(&nxselect);
   using SocketPtr = decltype(&nxsocket);
 
   typedef struct FunctionPointers {
@@ -36,6 +40,8 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
     ClosePtr Close;
     GetLastErrorNumPtr GetLastErrorNum;
     GetLastErrorStrPtr GetLastErrorStr;
+    IsSetPtr IsSet;
+    SelectPtr Select;
     SocketPtr Socket;
   } FunctionLoadStatus;
 

--- a/generated/nixnetsocket/nixnetsocket_library_interface.h
+++ b/generated/nixnetsocket/nixnetsocket_library_interface.h
@@ -19,6 +19,8 @@ class NiXnetSocketLibraryInterface {
   virtual int32_t Close(nxSOCKET socket) = 0;
   virtual int32_t GetLastErrorNum() = 0;
   virtual char* GetLastErrorStr(char buf[], size_t bufLen) = 0;
+  virtual int32_t IsSet(nxSOCKET fd, nxfd_set* set) = 0;
+  virtual int32_t Select(int32_t nfds, nxfd_set* read_fds, nxfd_set* write_fds, nxfd_set* except_fds, nxtimeval* timeout) = 0;
   virtual nxSOCKET Socket(nxIpStackRef_t stack_ref, int32_t domain, int32_t type, int32_t prototcol) = 0;
 };
 

--- a/generated/nixnetsocket/nixnetsocket_mock_library.h
+++ b/generated/nixnetsocket/nixnetsocket_mock_library.h
@@ -21,6 +21,8 @@ class NiXnetSocketMockLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInt
   MOCK_METHOD(int32_t, Close, (nxSOCKET socket), (override));
   MOCK_METHOD(int32_t, GetLastErrorNum, (), (override));
   MOCK_METHOD(char*, GetLastErrorStr, (char buf[], size_t bufLen), (override));
+  MOCK_METHOD(int32_t, IsSet, (nxSOCKET fd, nxfd_set* set), (override));
+  MOCK_METHOD(int32_t, Select, (int32_t nfds, nxfd_set* read_fds, nxfd_set* write_fds, nxfd_set* except_fds, nxtimeval* timeout), (override));
   MOCK_METHOD(nxSOCKET, Socket, (nxIpStackRef_t stack_ref, int32_t domain, int32_t type, int32_t prototcol), (override));
 };
 

--- a/generated/nixnetsocket/nixnetsocket_service.h
+++ b/generated/nixnetsocket/nixnetsocket_service.h
@@ -45,6 +45,8 @@ public:
   ::grpc::Status Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response) override;
   ::grpc::Status GetLastErrorNum(::grpc::ServerContext* context, const GetLastErrorNumRequest* request, GetLastErrorNumResponse* response) override;
   ::grpc::Status GetLastErrorStr(::grpc::ServerContext* context, const GetLastErrorStrRequest* request, GetLastErrorStrResponse* response) override;
+  ::grpc::Status IsSet(::grpc::ServerContext* context, const IsSetRequest* request, IsSetResponse* response) override;
+  ::grpc::Status Select(::grpc::ServerContext* context, const SelectRequest* request, SelectResponse* response) override;
   ::grpc::Status Socket(::grpc::ServerContext* context, const SocketRequest* request, SocketResponse* response) override;
 private:
   NiXnetSocketLibraryInterface* library_;

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -135,14 +135,21 @@ def supports_standard_copy_conversion_routines(parameter: dict) -> bool:
     )
 
 
-def any_function_uses_timestamp(functions):
-    """Whether the function has any parameters whose type is a timestamp."""
-    for function in functions:
-        if any(
-            p["grpc_type"] == "google.protobuf.Timestamp" for p in functions[function]["parameters"]
-        ):
-            return True
-    return False
+def _any_function_uses_grpc_type(functions, type_name):
+    return any(p["grpc_type"] == type_name for f in functions for p in functions[f]["parameters"])
+
+
+def list_external_proto_dependencies(functions: dict) -> List[str]:
+    """Return a list of external proto files required by the functions dictionary."""
+    mappings = {
+        "google.protobuf.Timestamp": "google/protobuf/timestamp.proto",
+        "google.protobuf.Duration": "google/protobuf/duration.proto",
+    }
+    return [
+        proto_name
+        for type_name, proto_name in mappings.items()
+        if _any_function_uses_grpc_type(functions, type_name)
+    ]
 
 
 def get_custom_types(config: dict) -> List[Dict[str, Any]]:

--- a/source/codegen/metadata/nixnetsocket/config.py
+++ b/source/codegen/metadata/nixnetsocket/config.py
@@ -12,6 +12,7 @@ config = {
     'additional_headers': { "custom/xnetsocket_converters.h": ["service.cpp"] },
     'type_to_grpc_type': {
         'nxSOCKET': 'nidevice_grpc.Session',
+        'nxfd_set': 'repeated nidevice_grpc.Session',
         'nxIpStackRef_t': 'nidevice_grpc.Session',
         'char[]': 'string',
         'int32_t': 'int32',
@@ -22,7 +23,8 @@ config = {
         'uint32_t': 'uint32',
         'uint16_t': 'uint16',
         'int64_t': 'int64',
-        'nxsockaddr': 'SockAddr'
+        'nxsockaddr': 'SockAddr',
+        'nxtimeval': 'google.protobuf.Duration'
     },
     'code_readiness': 'NextRelease',
     'driver_name': 'NI-XNETSOCKET',

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -69,6 +69,78 @@ functions = {
         ],
         'returns': 'char*'
     },
+    'IsSet': {
+        'cname': 'nxfd_isset',
+        'status_expression': '0',
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'fd',
+                'type': 'nxSOCKET'
+            },
+            {
+                'direction': 'in',
+                'name': 'set',
+                'pointer': True,
+                'supports_standard_copy_convert': True,
+                'additional_arguments_to_copy_convert': ['session_repository_'],
+                'type': 'nxfd_set'
+            },
+            {
+                'direction': 'out',
+                'name': 'is_set',
+                'return_value': True,
+                'type': 'int32_t'
+            }
+        ],
+        'returns': 'int32_t'
+    },
+    'Select': {
+        'cname': 'nxselect',
+        'parameters': [
+            {
+                'direction': 'in',
+                'hardcoded_value': '0',
+                'include_in_proto': False,
+                'name': 'nfds',
+                'type': 'int32_t'
+            },
+            {
+                'direction': 'in',
+                'name': 'read_fds',
+                'pointer': True,
+                'supports_standard_copy_convert': True,
+                'additional_arguments_to_copy_convert': ['session_repository_'],
+                'type': 'nxfd_set'
+            },
+            {
+                'direction': 'in',
+                'name': 'write_fds',
+                'pointer': True,
+                'supports_standard_copy_convert': True,
+                'additional_arguments_to_copy_convert': ['session_repository_'],
+                'type': 'nxfd_set'
+            },
+            {
+                'direction': 'in',
+                'name': 'except_fds',
+                'pointer': True,
+                'supports_standard_copy_convert': True,
+                'additional_arguments_to_copy_convert': ['session_repository_'],
+                'type': 'nxfd_set'
+            },
+            {
+                'direction': 'in',
+                'name': 'timeout',
+                'pointer': True,
+                'supports_standard_copy_convert': True,
+                'type': 'nxtimeval'
+            },
+        ],
+        'returns': 'int32_t'
+
+
+    },
     'Socket': {
         'cname': 'nxsocket',
         'init_method': True,

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -78,6 +78,7 @@ PARAM_SCHEMA = Schema(
         Optional("return_value"): bool,
         Optional("supports_standard_copy_convert"): bool,
         Optional("get_last_error"): bool,
+        Optional("additional_arguments_to_copy_convert"): [str],
     }
 )
 
@@ -85,7 +86,7 @@ FUNCTION_SCHEMA = Schema(
     {
         "parameters": [PARAM_SCHEMA],
         "returns": str,
-        Optional("cname"): str,
+        Optional("cname"): Or(str, bool),
         Optional("codegen_method"): And(
             str, lambda s: s in ("public", "private", "CustomCode", "no", "python-only")
         ),

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -86,7 +86,7 @@ FUNCTION_SCHEMA = Schema(
     {
         "parameters": [PARAM_SCHEMA],
         "returns": str,
-        Optional("cname"): Or(str, bool),
+        Optional("cname"): str,
         Optional("codegen_method"): And(
             str, lambda s: s in ("public", "private", "CustomCode", "no", "python-only")
         ),

--- a/source/codegen/templates/proto.mako
+++ b/source/codegen/templates/proto.mako
@@ -8,7 +8,7 @@ functions = data["functions"]
 
 service_class_prefix = config["service_class_prefix"]
 function_enums = common_helpers.get_function_enums(functions)
-uses_timestamp = common_helpers.any_function_uses_timestamp(functions)
+external_proto_deps = common_helpers.list_external_proto_dependencies(functions)
 %>\
 <%namespace name="mako_helper" file="/proto_helpers.mako"/>\
 
@@ -30,9 +30,9 @@ package ${config["namespace_component"]}_grpc;
 import "nidevice.proto";
 % endif
 import "session.proto";
-% if uses_timestamp:
-import "google/protobuf/timestamp.proto";
-% endif
+% for proto in external_proto_deps:
+import "${proto}";
+% endfor
 
 service ${service_class_prefix} {
 % for function in common_helpers.filter_proto_rpc_functions(functions):

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -540,6 +540,8 @@ ${initialize_standard_input_param(function_name, parameter)}
       auto ${parameter_name} = ${request_snippet}.c_str();\
 % elif common_helpers.is_string_arg(parameter):
       ${c_type_pointer} ${parameter_name} = (${c_type_pointer})${request_snippet}.c_str();\
+% elif common_helpers.supports_standard_copy_conversion_routines(parameter):
+      auto ${parameter_name} = convert_from_grpc<${c_type_underlying_type}>(${str.join(", ", [request_snippet] + parameter.get("additional_arguments_to_copy_convert", []))});\
 % elif grpc_type == 'repeated nidevice_grpc.Session':
       auto ${parameter_name}_request = ${request_snippet};
       std::vector<${c_type_underlying_type}> ${parameter_name};
@@ -564,8 +566,6 @@ ${initialize_standard_input_param(function_name, parameter)}
         ${parameter_name}_request.end(),
         std::back_inserter(${parameter_name}),
         [](auto x) { return (${c_type_underlying_type})x; }); \
- % elif common_helpers.supports_standard_copy_conversion_routines(parameter):
-      auto ${parameter_name} = convert_from_grpc<${c_type_underlying_type}>(${request_snippet});\
 % elif c_type in ['ViChar', 'ViInt8', 'ViInt16']:
       ${c_type} ${parameter_name} = (${c_type})${request_snippet};\
 % elif grpc_type == 'nidevice_grpc.Session':

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -1,14 +1,20 @@
 #ifndef NIDEVICE_GRPC_DEVICE_XNET_SOCKET_CONVERTERS_H
 #define NIDEVICE_GRPC_DEVICE_XNET_SOCKET_CONVERTERS_H
-
+#include <google/protobuf/repeated_field.h>
+#include <google/protobuf/util/time_util.h>
 #include <nixnetsocket.pb.h>
 #include <nxsocket.h>
 #include <server/converters.h>
+#include <server/session_resource_repository.h>
 
 #include <algorithm>
 #include <cstring>
+#include <memory>
 
 namespace nixnetsocket_grpc {
+
+namespace pb = ::google::protobuf;
+using ResourceRepositorySharedPtr_ = std::shared_ptr<nidevice_grpc::SessionResourceRepository<nxSOCKET>>;
 
 // This class allows us to have something allocated on the stack that can be used as an
 // nxsockaddr* and initialized from a grpc SockAddr using standard codegen and copy convert routines.
@@ -78,10 +84,69 @@ struct SockAddrHolder {
   } addr;
 };
 
+struct SetHolder {
+  SetHolder(
+      const pb::RepeatedPtrField<nidevice_grpc::Session>& input,
+      const ResourceRepositorySharedPtr_& resource_repository)
+  {
+    nxFD_ZERO(&set);
+    for (const auto& session : input) {
+      const auto socket = resource_repository->access_session(session.id(), session.name());
+      nxFD_SET(socket, &set);
+    }
+  }
+
+  operator nxfd_set*()
+  {
+    return &set;
+  }
+
+  operator const nxfd_set*() const
+  {
+    return &set;
+  }
+
+  nxfd_set set;
+};
+
+struct TimeValHolder {
+  TimeValHolder(const pb::Duration& input)
+  {
+    time_val.tv_sec = input.seconds();
+    time_val.tv_usec = input.nanos() / 1000;
+  }
+
+  operator nxtimeval*()
+  {
+    return &time_val;
+  }
+
+  operator const nxtimeval*() const
+  {
+    return &time_val;
+  }
+
+  nxtimeval time_val;
+};
+
 template <typename TSockAddr>
 inline SockAddrHolder convert_from_grpc(const SockAddr& input)
 {
   return SockAddrHolder(input);
+}
+
+template <typename TSet>
+inline SetHolder convert_from_grpc(
+    const pb::RepeatedPtrField<nidevice_grpc::Session>& input,
+    const ResourceRepositorySharedPtr_& resource_repository)
+{
+  return SetHolder(input, resource_repository);
+}
+
+template <typename TSet>
+inline TimeValHolder convert_from_grpc(const pb::Duration& input)
+{
+  return TimeValHolder(input);
 }
 }  // namespace nixnetsocket_grpc
 #endif /* NIDEVICE_GRPC_DEVICE_XNET_SOCKET_CONVERTERS_H */

--- a/source/tests/system/nixnetsocket_driver_api_tests.cpp
+++ b/source/tests/system/nixnetsocket_driver_api_tests.cpp
@@ -16,8 +16,9 @@ namespace system {
 namespace {
 
 constexpr auto INVALID_XNET_SOCKET = -1;
-constexpr auto FAILED_INIT = -1;
+constexpr auto GENERIC_NXSOCKET_ERROR = -1;
 constexpr auto SOCKET_COULD_NOT_BE_FOUND = -13009;
+constexpr auto SOCKET_COULD_NOT_BE_FOUND_MESSAGE = "The specified socket could not be found.";
 
 class NiXnetDriverApiTests : public ::testing::Test {
  protected:
@@ -60,9 +61,14 @@ class NiXnetDriverApiTests : public ::testing::Test {
     EXPECT_EQ(error, (response).status()); \
   }
 
+SocketResponse socket(client::StubPtr& stub)
+{
+  return client::socket(stub, 2 /* nxAF_INET */, 1 /* STREAM */, 6 /* TCP */);
+}
+
 TEST_F(NiXnetDriverApiTests, InitWithInvalidIpStack_Close_ReturnsAndSetsExpectedErrors)
 {
-  auto socket_response = client::socket(stub(), 2 /* nxAF_INET */, 1 /* STREAM */, 6 /* TCP */);
+  auto socket_response = socket(stub());
   auto socket_get_last_error = client::get_last_error_num(stub());
   auto socket_get_last_error_str = client::get_last_error_str(stub(), 512);
 
@@ -70,7 +76,7 @@ TEST_F(NiXnetDriverApiTests, InitWithInvalidIpStack_Close_ReturnsAndSetsExpected
   auto close_get_last_error = client::get_last_error_num(stub());
   auto close_get_last_error_str = client::get_last_error_str(stub(), 512);
 
-  EXPECT_XNET_ERROR(FAILED_INIT, socket_response);
+  EXPECT_XNET_ERROR(GENERIC_NXSOCKET_ERROR, socket_response);
   EXPECT_SUCCESS(socket_get_last_error);
   EXPECT_SUCCESS(socket_get_last_error_str);
   EXPECT_EQ("The specified IP Stack could not be found.", socket_get_last_error_str.error());
@@ -85,29 +91,29 @@ TEST_F(NiXnetDriverApiTests, InitWithInvalidIpStack_Bind_ReturnsAndSetsExpectedE
   auto sock_addr = SockAddr{};
   sock_addr.mutable_ipv4()->set_addr(0x7F000001);
   sock_addr.mutable_ipv4()->set_port(31764);
-  auto socket_response = client::socket(stub(), 2 /* nxAF_INET */, 1 /* STREAM */, 6 /* TCP */);
+  auto socket_response = socket(stub());
   auto bind_response = client::bind(stub(), socket_response.socket(), sock_addr);
   auto bind_get_last_error = client::get_last_error_num(stub());
   auto bind_get_last_error_str = client::get_last_error_str(stub(), 512);
 
-  EXPECT_XNET_ERROR(FAILED_INIT, socket_response);
-  EXPECT_XNET_ERROR(FAILED_INIT, bind_response);
-  EXPECT_XNET_ERROR(-13009, bind_get_last_error);
-  EXPECT_THAT("The specified socket could not be found.", bind_get_last_error_str.error());
+  EXPECT_XNET_ERROR(GENERIC_NXSOCKET_ERROR, socket_response);
+  EXPECT_XNET_ERROR(GENERIC_NXSOCKET_ERROR, bind_response);
+  EXPECT_XNET_ERROR(SOCKET_COULD_NOT_BE_FOUND, bind_get_last_error);
+  EXPECT_THAT(SOCKET_COULD_NOT_BE_FOUND_MESSAGE, bind_get_last_error_str.error());
 }
 
-TEST_F(NiXnetDriverApiTests, IsSet)
+TEST_F(NiXnetDriverApiTests, SocketAndEmptySet_IsSet_ReturnsFalse)
 {
-  auto socket_response = client::socket(stub(), 2 /* nxAF_INET */, 1 /* STREAM */, 6 /* TCP */);
+  auto socket_response = socket(stub());
   auto is_set_response = client::is_set(stub(), socket_response.socket(), {});
 
   EXPECT_SUCCESS(is_set_response);
   EXPECT_EQ(FALSE, is_set_response.is_set());
 }
 
-TEST_F(NiXnetDriverApiTests, IsSet_True)
+TEST_F(NiXnetDriverApiTests, SocketAndSetContainingSocket_IsSet_ReturnsTrue)
 {
-  auto socket_response = client::socket(stub(), 2 /* nxAF_INET */, 1 /* STREAM */, 6 /* TCP */);
+  auto socket_response = socket(stub());
   auto is_set_response = client::is_set(stub(), socket_response.socket(), {socket_response.socket()});
 
   EXPECT_SUCCESS(is_set_response);
@@ -116,7 +122,7 @@ TEST_F(NiXnetDriverApiTests, IsSet_True)
 
 TEST_F(NiXnetDriverApiTests, Select)
 {
-  auto socket_response = client::socket(stub(), 2 /* nxAF_INET */, 1 /* STREAM */, 6 /* TCP */);
+  auto socket_response = socket(stub());
   auto duration = pb::Duration{};
   duration.set_seconds(1);
   duration.set_nanos(500000);
@@ -124,9 +130,9 @@ TEST_F(NiXnetDriverApiTests, Select)
   auto select_last_error = client::get_last_error_num(stub());
   auto select_last_error_str = client::get_last_error_str(stub(), 512);
 
-  EXPECT_SUCCESS(select_response);
-  EXPECT_XNET_ERROR(0, select_last_error);
-  EXPECT_THAT("", select_last_error_str.error());
+  EXPECT_XNET_ERROR(GENERIC_NXSOCKET_ERROR, select_response);
+  EXPECT_XNET_ERROR(SOCKET_COULD_NOT_BE_FOUND, select_last_error);
+  EXPECT_THAT(SOCKET_COULD_NOT_BE_FOUND_MESSAGE, select_last_error_str.error());
 }
 }  // namespace
 }  // namespace system

--- a/source/tests/system/nixnetsocket_driver_api_tests.cpp
+++ b/source/tests/system/nixnetsocket_driver_api_tests.cpp
@@ -1,4 +1,5 @@
 #include <gmock/gmock.h>
+#include <google/protobuf/util/time_util.h>
 #include <gtest/gtest.h>
 #include <nixnetsocket/nixnetsocket_client.h>
 
@@ -14,7 +15,7 @@ namespace tests {
 namespace system {
 namespace {
 
-constexpr auto INVALID_SOCKET = -1;
+constexpr auto INVALID_XNET_SOCKET = -1;
 constexpr auto FAILED_INIT = -1;
 constexpr auto SOCKET_COULD_NOT_BE_FOUND = -13009;
 
@@ -73,7 +74,7 @@ TEST_F(NiXnetDriverApiTests, InitWithInvalidIpStack_Close_ReturnsAndSetsExpected
   EXPECT_SUCCESS(socket_get_last_error);
   EXPECT_SUCCESS(socket_get_last_error_str);
   EXPECT_EQ("The specified IP Stack could not be found.", socket_get_last_error_str.error());
-  EXPECT_XNET_ERROR(INVALID_SOCKET, close_response);
+  EXPECT_XNET_ERROR(INVALID_XNET_SOCKET, close_response);
   EXPECT_XNET_ERROR(-13009, close_get_last_error);
   EXPECT_SUCCESS(close_get_last_error_str);
   EXPECT_THAT("The specified socket could not be found.", close_get_last_error_str.error());
@@ -93,6 +94,39 @@ TEST_F(NiXnetDriverApiTests, InitWithInvalidIpStack_Bind_ReturnsAndSetsExpectedE
   EXPECT_XNET_ERROR(FAILED_INIT, bind_response);
   EXPECT_XNET_ERROR(-13009, bind_get_last_error);
   EXPECT_THAT("The specified socket could not be found.", bind_get_last_error_str.error());
+}
+
+TEST_F(NiXnetDriverApiTests, IsSet)
+{
+  auto socket_response = client::socket(stub(), 2 /* nxAF_INET */, 1 /* STREAM */, 6 /* TCP */);
+  auto is_set_response = client::is_set(stub(), socket_response.socket(), {});
+
+  EXPECT_SUCCESS(is_set_response);
+  EXPECT_EQ(FALSE, is_set_response.is_set());
+}
+
+TEST_F(NiXnetDriverApiTests, IsSet_True)
+{
+  auto socket_response = client::socket(stub(), 2 /* nxAF_INET */, 1 /* STREAM */, 6 /* TCP */);
+  auto is_set_response = client::is_set(stub(), socket_response.socket(), {socket_response.socket()});
+
+  EXPECT_SUCCESS(is_set_response);
+  EXPECT_EQ(TRUE, is_set_response.is_set());
+}
+
+TEST_F(NiXnetDriverApiTests, Select)
+{
+  auto socket_response = client::socket(stub(), 2 /* nxAF_INET */, 1 /* STREAM */, 6 /* TCP */);
+  auto duration = pb::Duration{};
+  duration.set_seconds(1);
+  duration.set_nanos(500000);
+  auto select_response = client::select(stub(), {socket_response.socket()}, {socket_response.socket()}, {}, duration);
+  auto select_last_error = client::get_last_error_num(stub());
+  auto select_last_error_str = client::get_last_error_str(stub(), 512);
+
+  EXPECT_SUCCESS(select_response);
+  EXPECT_XNET_ERROR(0, select_last_error);
+  EXPECT_THAT("", select_last_error_str.error());
 }
 }  // namespace
 }  // namespace system


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add support for `nxfd_set` and `nxtimeval` for select.
* `nxfd_set` is represented as a `repeated Session` where the sessions map to `nxSOCKET` handles.
* `nxtimeval` is represented by the well-known `protobuf` type [Duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration).

Add `additional_arguments_to_copy_convert` tag to allow `nxfd_set` conversion code to access the resource repository to resolve sessions.

Fixes AB#1863225.

### Why should this Pull Request be merged?

Add support for `Select` to the xnet grpc API.

### What testing has been done?

Ran and passed all `Xnet` tests.