### PR TITLE
Add support for passing --artifacts to validate_examples

### DIFF
--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -4,9 +4,9 @@ from argparse import ArgumentParser
 from contextlib import contextmanager
 from os import getcwd, chdir, system as _system_core
 from pathlib import Path
-from shutil import rmtree
+from shutil import rmtree, copytree
 from sys import exit
-from typing import List, NamedTuple
+from typing import List, NamedTuple, Optional
 
 from stage_client_files import stage_client_files
 
@@ -38,7 +38,16 @@ def _create_stage_dir(staging_dir):
         chdir(initial_dir)
 
 
-def _validate_examples(driver_glob_expression: str, ip_address: str, device_name: str) -> None:
+def _stage_client_files(artifact_location: Optional[str], staging_dir: Path) -> None:
+    if artifact_location:
+        copytree(artifact_location, staging_dir, dirs_exist_ok=True)
+    else:
+        stage_client_files(staging_dir, True)
+
+
+def _validate_examples(
+    driver_glob_expression: str, ip_address: str, device_name: str, artifact_location: Optional[str]
+) -> None:
     staging_dir = Path(__file__).parent.parent.parent / "build" / "validate_examples"
     staging_dir = staging_dir.resolve()
 
@@ -53,9 +62,10 @@ def _validate_examples(driver_glob_expression: str, ip_address: str, device_name
         _system('poetry add --dev --python ">=3.6.2" black')
         _system("poetry install")
 
-        stage_client_files(staging_dir, True)
+        _stage_client_files(artifact_location, staging_dir)
         examples_dir = staging_dir / "examples"
         proto_dir = staging_dir / "proto"
+
         proto_files_str = str.join(" ", [file.name for file in proto_dir.glob("*.proto")])
 
         _system(
@@ -99,9 +109,16 @@ if __name__ == "__main__":
         default="",
     )
 
+    parser.add_argument(
+        "-a",
+        "--artifacts",
+        help="Pre-existing client artifact directory. If set, these files will be used. Otherwise, artifacts will be staged from source.",
+        default=None,
+    )
+
     args = parser.parse_args()
 
-    _validate_examples(args.pattern, args.server, args.device)
+    _validate_examples(args.pattern, args.server, args.device, args.artifacts)
 
     if any(_FAILED_COMMANDS):
         for code, command in _FAILED_COMMANDS:


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add support for passing `--artifacts` to `validate_examples.py` to use a pre-existing artifacts directory (i.e., from a release or workflow result).

### Why should this Pull Request be merged?

Makes it easier to test releases.

### What testing has been done?

Ran a bunch of examples with `validate_examples.py`: ensured that they worked and used the correct files.