### PR TITLE
Add support for IPStackRef_t to xnet socket service

### DIFF
--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -21,6 +21,8 @@ service NiXnetSocket {
   rpc Close(CloseRequest) returns (CloseResponse);
   rpc GetLastErrorNum(GetLastErrorNumRequest) returns (GetLastErrorNumResponse);
   rpc GetLastErrorStr(GetLastErrorStrRequest) returns (GetLastErrorStrResponse);
+  rpc IpStackClear(IpStackClearRequest) returns (IpStackClearResponse);
+  rpc IpStackCreate(IpStackCreateRequest) returns (IpStackCreateResponse);
   rpc IsSet(IsSetRequest) returns (IsSetResponse);
   rpc Select(SelectRequest) returns (SelectResponse);
   rpc Socket(SocketRequest) returns (SocketResponse);
@@ -82,6 +84,25 @@ message GetLastErrorStrResponse {
   string error = 2;
 }
 
+message IpStackClearRequest {
+  nidevice_grpc.Session stack_ref = 1;
+}
+
+message IpStackClearResponse {
+  int32 status = 1;
+}
+
+message IpStackCreateRequest {
+  string session_name = 1;
+  string stack_name = 2;
+  string config = 3;
+}
+
+message IpStackCreateResponse {
+  int32 status = 1;
+  nidevice_grpc.Session stack_ref = 2;
+}
+
 message IsSetRequest {
   nidevice_grpc.Session fd = 1;
   repeated nidevice_grpc.Session set = 2;
@@ -105,9 +126,10 @@ message SelectResponse {
 
 message SocketRequest {
   string session_name = 1;
-  int32 domain = 2;
-  int32 type = 3;
-  int32 prototcol = 4;
+  nidevice_grpc.Session stack_ref = 2;
+  int32 domain = 3;
+  int32 type = 4;
+  int32 prototcol = 5;
 }
 
 message SocketResponse {

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -81,6 +81,39 @@ get_last_error_str(const StubPtr& stub, const pb::uint64& buf_len)
   return response;
 }
 
+IpStackClearResponse
+ip_stack_clear(const StubPtr& stub, const nidevice_grpc::Session& stack_ref)
+{
+  ::grpc::ClientContext context;
+
+  auto request = IpStackClearRequest{};
+  request.mutable_stack_ref()->CopyFrom(stack_ref);
+
+  auto response = IpStackClearResponse{};
+
+  raise_if_error(
+      stub->IpStackClear(&context, request, &response));
+
+  return response;
+}
+
+IpStackCreateResponse
+ip_stack_create(const StubPtr& stub, const pb::string& stack_name, const pb::string& config)
+{
+  ::grpc::ClientContext context;
+
+  auto request = IpStackCreateRequest{};
+  request.set_stack_name(stack_name);
+  request.set_config(config);
+
+  auto response = IpStackCreateResponse{};
+
+  raise_if_error(
+      stub->IpStackCreate(&context, request, &response));
+
+  return response;
+}
+
 IsSetResponse
 is_set(const StubPtr& stub, const nidevice_grpc::Session& fd, const std::vector<nidevice_grpc::Session>& set)
 {
@@ -118,11 +151,12 @@ select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& read_fds,
 }
 
 SocketResponse
-socket(const StubPtr& stub, const pb::int32& domain, const pb::int32& type, const pb::int32& prototcol)
+socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const pb::int32& domain, const pb::int32& type, const pb::int32& prototcol)
 {
   ::grpc::ClientContext context;
 
   auto request = SocketRequest{};
+  request.mutable_stack_ref()->CopyFrom(stack_ref);
   request.set_domain(domain);
   request.set_type(type);
   request.set_prototcol(prototcol);

--- a/generated/nixnetsocket/nixnetsocket_client.h
+++ b/generated/nixnetsocket/nixnetsocket_client.h
@@ -26,9 +26,11 @@ BindResponse bind(const StubPtr& stub, const nidevice_grpc::Session& socket, con
 CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& socket);
 GetLastErrorNumResponse get_last_error_num(const StubPtr& stub);
 GetLastErrorStrResponse get_last_error_str(const StubPtr& stub, const pb::uint64& buf_len);
+IpStackClearResponse ip_stack_clear(const StubPtr& stub, const nidevice_grpc::Session& stack_ref);
+IpStackCreateResponse ip_stack_create(const StubPtr& stub, const pb::string& stack_name, const pb::string& config);
 IsSetResponse is_set(const StubPtr& stub, const nidevice_grpc::Session& fd, const std::vector<nidevice_grpc::Session>& set);
 SelectResponse select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& read_fds, const std::vector<nidevice_grpc::Session>& write_fds, const std::vector<nidevice_grpc::Session>& except_fds, const google::protobuf::Duration& timeout);
-SocketResponse socket(const StubPtr& stub, const pb::int32& domain, const pb::int32& type, const pb::int32& prototcol);
+SocketResponse socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const pb::int32& domain, const pb::int32& type, const pb::int32& prototcol);
 
 } // namespace nixnetsocket_grpc::experimental::client
 

--- a/generated/nixnetsocket/nixnetsocket_library.cpp
+++ b/generated/nixnetsocket/nixnetsocket_library.cpp
@@ -25,6 +25,8 @@ NiXnetSocketLibrary::NiXnetSocketLibrary() : shared_library_(kLibraryName)
   function_pointers_.Close = reinterpret_cast<ClosePtr>(shared_library_.get_function_pointer("nxclose"));
   function_pointers_.GetLastErrorNum = reinterpret_cast<GetLastErrorNumPtr>(shared_library_.get_function_pointer("nxgetlasterrornum"));
   function_pointers_.GetLastErrorStr = reinterpret_cast<GetLastErrorStrPtr>(shared_library_.get_function_pointer("nxgetlasterrorstr"));
+  function_pointers_.IpStackClear = reinterpret_cast<IpStackClearPtr>(shared_library_.get_function_pointer("nxIpStackClear"));
+  function_pointers_.IpStackCreate = reinterpret_cast<IpStackCreatePtr>(shared_library_.get_function_pointer("nxIpStackCreate"));
   function_pointers_.IsSet = reinterpret_cast<IsSetPtr>(shared_library_.get_function_pointer("nxfd_isset"));
   function_pointers_.Select = reinterpret_cast<SelectPtr>(shared_library_.get_function_pointer("nxselect"));
   function_pointers_.Socket = reinterpret_cast<SocketPtr>(shared_library_.get_function_pointer("nxsocket"));
@@ -86,6 +88,30 @@ char* NiXnetSocketLibrary::GetLastErrorStr(char buf[], size_t bufLen)
   return nxgetlasterrorstr(buf, bufLen);
 #else
   return function_pointers_.GetLastErrorStr(buf, bufLen);
+#endif
+}
+
+int32_t NiXnetSocketLibrary::IpStackClear(nxIpStackRef_t stack_ref)
+{
+  if (!function_pointers_.IpStackClear) {
+    throw nidevice_grpc::LibraryLoadException("Could not find nxIpStackClear.");
+  }
+#if defined(_MSC_VER)
+  return nxIpStackClear(stack_ref);
+#else
+  return function_pointers_.IpStackClear(stack_ref);
+#endif
+}
+
+int32_t NiXnetSocketLibrary::IpStackCreate(char stack_name[], char config[], nxIpStackRef_t* stack_ref)
+{
+  if (!function_pointers_.IpStackCreate) {
+    throw nidevice_grpc::LibraryLoadException("Could not find nxIpStackCreate.");
+  }
+#if defined(_MSC_VER)
+  return nxIpStackCreate(stack_name, config, stack_ref);
+#else
+  return function_pointers_.IpStackCreate(stack_name, config, stack_ref);
 #endif
 }
 

--- a/generated/nixnetsocket/nixnetsocket_library.h
+++ b/generated/nixnetsocket/nixnetsocket_library.h
@@ -22,6 +22,8 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   int32_t Close(nxSOCKET socket);
   int32_t GetLastErrorNum();
   char* GetLastErrorStr(char buf[], size_t bufLen);
+  int32_t IpStackClear(nxIpStackRef_t stack_ref);
+  int32_t IpStackCreate(char stack_name[], char config[], nxIpStackRef_t* stack_ref);
   int32_t IsSet(nxSOCKET fd, nxfd_set* set);
   int32_t Select(int32_t nfds, nxfd_set* read_fds, nxfd_set* write_fds, nxfd_set* except_fds, nxtimeval* timeout);
   nxSOCKET Socket(nxIpStackRef_t stack_ref, int32_t domain, int32_t type, int32_t prototcol);
@@ -31,6 +33,8 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   using ClosePtr = decltype(&nxclose);
   using GetLastErrorNumPtr = decltype(&nxgetlasterrornum);
   using GetLastErrorStrPtr = decltype(&nxgetlasterrorstr);
+  using IpStackClearPtr = decltype(&nxIpStackClear);
+  using IpStackCreatePtr = decltype(&nxIpStackCreate);
   using IsSetPtr = decltype(&nxfd_isset);
   using SelectPtr = decltype(&nxselect);
   using SocketPtr = decltype(&nxsocket);
@@ -40,6 +44,8 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
     ClosePtr Close;
     GetLastErrorNumPtr GetLastErrorNum;
     GetLastErrorStrPtr GetLastErrorStr;
+    IpStackClearPtr IpStackClear;
+    IpStackCreatePtr IpStackCreate;
     IsSetPtr IsSet;
     SelectPtr Select;
     SocketPtr Socket;

--- a/generated/nixnetsocket/nixnetsocket_library_interface.h
+++ b/generated/nixnetsocket/nixnetsocket_library_interface.h
@@ -19,6 +19,8 @@ class NiXnetSocketLibraryInterface {
   virtual int32_t Close(nxSOCKET socket) = 0;
   virtual int32_t GetLastErrorNum() = 0;
   virtual char* GetLastErrorStr(char buf[], size_t bufLen) = 0;
+  virtual int32_t IpStackClear(nxIpStackRef_t stack_ref) = 0;
+  virtual int32_t IpStackCreate(char stack_name[], char config[], nxIpStackRef_t* stack_ref) = 0;
   virtual int32_t IsSet(nxSOCKET fd, nxfd_set* set) = 0;
   virtual int32_t Select(int32_t nfds, nxfd_set* read_fds, nxfd_set* write_fds, nxfd_set* except_fds, nxtimeval* timeout) = 0;
   virtual nxSOCKET Socket(nxIpStackRef_t stack_ref, int32_t domain, int32_t type, int32_t prototcol) = 0;

--- a/generated/nixnetsocket/nixnetsocket_mock_library.h
+++ b/generated/nixnetsocket/nixnetsocket_mock_library.h
@@ -21,6 +21,8 @@ class NiXnetSocketMockLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInt
   MOCK_METHOD(int32_t, Close, (nxSOCKET socket), (override));
   MOCK_METHOD(int32_t, GetLastErrorNum, (), (override));
   MOCK_METHOD(char*, GetLastErrorStr, (char buf[], size_t bufLen), (override));
+  MOCK_METHOD(int32_t, IpStackClear, (nxIpStackRef_t stack_ref), (override));
+  MOCK_METHOD(int32_t, IpStackCreate, (char stack_name[], char config[], nxIpStackRef_t* stack_ref), (override));
   MOCK_METHOD(int32_t, IsSet, (nxSOCKET fd, nxfd_set* set), (override));
   MOCK_METHOD(int32_t, Select, (int32_t nfds, nxfd_set* read_fds, nxfd_set* write_fds, nxfd_set* except_fds, nxtimeval* timeout), (override));
   MOCK_METHOD(nxSOCKET, Socket, (nxIpStackRef_t stack_ref, int32_t domain, int32_t type, int32_t prototcol), (override));

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -24,9 +24,11 @@ namespace nixnetsocket_grpc {
   NiXnetSocketService::NiXnetSocketService(
       NiXnetSocketLibraryInterface* library,
       ResourceRepositorySharedPtr resource_repository,
+      nxIpStackRef_tResourceRepositorySharedPtr nx_ip_stack_ref_t_resource_repository,
       const NiXnetSocketFeatureToggles& feature_toggles)
       : library_(library),
       session_repository_(resource_repository),
+      nx_ip_stack_ref_t_resource_repository_(nx_ip_stack_ref_t_resource_repository),
       feature_toggles_(feature_toggles)
   {
   }
@@ -128,6 +130,57 @@ namespace nixnetsocket_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiXnetSocketService::IpStackClear(::grpc::ServerContext* context, const IpStackClearRequest* request, IpStackClearResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto stack_ref_grpc_session = request->stack_ref();
+      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
+      nx_ip_stack_ref_t_resource_repository_->remove_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
+      auto status = library_->IpStackClear(stack_ref);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiXnetSocketService::IpStackCreate(::grpc::ServerContext* context, const IpStackCreateRequest* request, IpStackCreateResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      char* stack_name = (char*)request->stack_name().c_str();
+      char* config = (char*)request->config().c_str();
+
+      auto init_lambda = [&] () {
+        nxIpStackRef_t stack_ref;
+        auto status = library_->IpStackCreate(stack_name, config, &stack_ref);
+        return std::make_tuple(status, stack_ref);
+      };
+      uint32_t session_id = 0;
+      const std::string& grpc_device_session_name = request->session_name();
+      auto cleanup_lambda = [&] (nxIpStackRef_t id) { library_->IpStackClear(id); };
+      int status = nx_ip_stack_ref_t_resource_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      response->set_status(status);
+      if (status_ok(status)) {
+        response->mutable_stack_ref()->set_id(session_id);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiXnetSocketService::IsSet(::grpc::ServerContext* context, const IsSetRequest* request, IsSetResponse* response)
   {
     if (context->IsCancelled()) {
@@ -180,7 +233,8 @@ namespace nixnetsocket_grpc {
       return ::grpc::Status::CANCELLED;
     }
     try {
-      auto stack_ref = nullptr;
+      auto stack_ref_grpc_session = request->stack_ref();
+      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
       int32_t domain = request->domain();
       int32_t type = request->type();
       int32_t prototcol = request->prototcol();

--- a/generated/nixnetsocket/nixnetsocket_service.h
+++ b/generated/nixnetsocket/nixnetsocket_service.h
@@ -34,10 +34,12 @@ struct NiXnetSocketFeatureToggles
 class NiXnetSocketService final : public NiXnetSocket::Service {
 public:
   using ResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<nxSOCKET>>;
+  using nxIpStackRef_tResourceRepositorySharedPtr = std::shared_ptr<nidevice_grpc::SessionResourceRepository<nxIpStackRef_t>>;
 
   NiXnetSocketService(
     NiXnetSocketLibraryInterface* library,
     ResourceRepositorySharedPtr resource_repository,
+    nxIpStackRef_tResourceRepositorySharedPtr nx_ip_stack_ref_t_resource_repository,
     const NiXnetSocketFeatureToggles& feature_toggles = {});
   virtual ~NiXnetSocketService();
   
@@ -45,12 +47,15 @@ public:
   ::grpc::Status Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response) override;
   ::grpc::Status GetLastErrorNum(::grpc::ServerContext* context, const GetLastErrorNumRequest* request, GetLastErrorNumResponse* response) override;
   ::grpc::Status GetLastErrorStr(::grpc::ServerContext* context, const GetLastErrorStrRequest* request, GetLastErrorStrResponse* response) override;
+  ::grpc::Status IpStackClear(::grpc::ServerContext* context, const IpStackClearRequest* request, IpStackClearResponse* response) override;
+  ::grpc::Status IpStackCreate(::grpc::ServerContext* context, const IpStackCreateRequest* request, IpStackCreateResponse* response) override;
   ::grpc::Status IsSet(::grpc::ServerContext* context, const IsSetRequest* request, IsSetResponse* response) override;
   ::grpc::Status Select(::grpc::ServerContext* context, const SelectRequest* request, SelectResponse* response) override;
   ::grpc::Status Socket(::grpc::ServerContext* context, const SocketRequest* request, SocketResponse* response) override;
 private:
   NiXnetSocketLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
+  nxIpStackRef_tResourceRepositorySharedPtr nx_ip_stack_ref_t_resource_repository_;
 
   NiXnetSocketFeatureToggles feature_toggles_;
 };

--- a/generated/nixnetsocket/nixnetsocket_service_registrar.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service_registrar.cpp
@@ -17,11 +17,13 @@ namespace {
 struct LibraryAndService {
   LibraryAndService(
     const std::shared_ptr<nidevice_grpc::SessionResourceRepository<nxSOCKET>>& resource_repository,
+    const std::shared_ptr<nidevice_grpc::SessionResourceRepository<nxIpStackRef_t>>& nx_ip_stack_ref_t_resource_repository,
     const NiXnetSocketFeatureToggles& feature_toggles) 
       : library(), 
       service(
         &library, 
         resource_repository,
+        nx_ip_stack_ref_t_resource_repository,
         feature_toggles) {
   }
   NiXnetSocketLibrary library;
@@ -32,6 +34,7 @@ struct LibraryAndService {
 std::shared_ptr<void> register_service(
   grpc::ServerBuilder& builder, 
   const std::shared_ptr<nidevice_grpc::SessionResourceRepository<nxSOCKET>>& resource_repository,
+  const std::shared_ptr<nidevice_grpc::SessionResourceRepository<nxIpStackRef_t>>& nx_ip_stack_ref_t_resource_repository,
   const nidevice_grpc::FeatureToggles& feature_toggles)
 {
   auto toggles = NiXnetSocketFeatureToggles(feature_toggles);
@@ -40,6 +43,7 @@ std::shared_ptr<void> register_service(
   {
     auto library_and_service_ptr = std::make_shared<LibraryAndService>(
       resource_repository,
+      nx_ip_stack_ref_t_resource_repository,
       toggles);
     auto& service = library_and_service_ptr->service;
     builder.RegisterService(&service);

--- a/generated/nixnetsocket/nixnetsocket_service_registrar.h
+++ b/generated/nixnetsocket/nixnetsocket_service_registrar.h
@@ -11,7 +11,7 @@
 
 #include <memory>
 
-#include <nxsocket.h> // for nxSOCKET
+#include <nxsocket.h> // for nxSOCKET, nxIpStackRef_t
 
 namespace grpc {
 class ServerBuilder;
@@ -23,6 +23,7 @@ using CodeReadiness = nidevice_grpc::FeatureToggles::CodeReadiness;
 std::shared_ptr<void> register_service(
   grpc::ServerBuilder& server_builder, 
   const std::shared_ptr<nidevice_grpc::SessionResourceRepository<nxSOCKET>>& resource_repository,
+  const std::shared_ptr<nidevice_grpc::SessionResourceRepository<nxIpStackRef_t>>& nx_ip_stack_ref_t_resource_repository,
   const nidevice_grpc::FeatureToggles& feature_toggles);
 
 } // nixnetsocket_grpc

--- a/generated/register_all_services.cpp
+++ b/generated/register_all_services.cpp
@@ -65,6 +65,7 @@ std::shared_ptr<void> register_all_services(
   auto nx_session_ref_t_repository = std::make_shared<nidevice_grpc::SessionResourceRepository<nxSessionRef_t>>(session_repository.get());
   auto nx_database_ref_t_repository = std::make_shared<nidevice_grpc::SessionResourceRepository<nxDatabaseRef_t>>(session_repository.get());
   auto nx_socket_repository = std::make_shared<nidevice_grpc::SessionResourceRepository<nxSOCKET>>(session_repository.get());
+  auto nx_ip_stack_ref_t_repository = std::make_shared<nidevice_grpc::SessionResourceRepository<nxIpStackRef_t>>(session_repository.get());
 
   service_vector->push_back(
     nidaqmx_grpc::register_service(
@@ -179,6 +180,7 @@ std::shared_ptr<void> register_all_services(
     nixnetsocket_grpc::register_service(
       server_builder, 
       nx_socket_repository,
+      nx_ip_stack_ref_t_repository,
       feature_toggles));
 
   return service_vector;

--- a/source/codegen/metadata/nixnetsocket/config.py
+++ b/source/codegen/metadata/nixnetsocket/config.py
@@ -31,7 +31,7 @@ config = {
     'extra_errors_used': [
     ],
     'init_function': 'Socket',
-    'resource_handle_type': 'nxSOCKET',
+    'resource_handle_type': ['nxSOCKET', 'nxIpStackRef_t'],
     'status_ok': 'status >= 0',
     'library_info': {
         'Linux': {

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -69,6 +69,39 @@ functions = {
         ],
         'returns': 'char*'
     },
+    'IpStackClear': {
+        'custom_close_method': True,
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'stack_ref',
+                'type': 'nxIpStackRef_t'
+            },
+        ],
+        'returns': 'int32_t'
+    },
+    'IpStackCreate': {
+        'custom_close': 'IpStackClear(id)',
+        'init_method': True,
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'stack_name',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'config',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'out',
+                'name': 'stack_ref',
+                'type': 'nxIpStackRef_t'
+            },
+        ],
+        'returns': 'int32_t'
+    },
     'IsSet': {
         'cname': 'nxfd_isset',
         'status_expression': '0',
@@ -138,8 +171,6 @@ functions = {
             },
         ],
         'returns': 'int32_t'
-
-
     },
     'Socket': {
         'cname': 'nxsocket',
@@ -148,8 +179,6 @@ functions = {
         'parameters': [
             {
                 'direction': 'in',
-                'hardcoded_value': 'nullptr',
-                'include_in_proto': False,
                 'name': 'stack_ref',
                 'type': 'nxIpStackRef_t'
             },
@@ -170,7 +199,6 @@ functions = {
             },
             {
                 'direction': 'out',
-                'grpc_type': 'nidevice_grpc.Session',
                 'name': 'socket',
                 'return_value': True,
                 'type': 'nxSOCKET'


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add support for `IPStackRef` to xnet socket service.
* Add secondary session type.
* Add the ability to distinguish HW and NoHW tests for Xnet sockets.
* Add very basic HW tests that create an `IPStackRef`

### Why should this Pull Request be merged?

Incremental progress on Xnet Socket feature.

Enable creation of usable `nxSOCKET` in grpc-device.

Fixes [AB#1863195](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1863195).

### What testing has been done?

Ran and passed all Xnet tests.