### PR TITLE
Add support for service-wide get_last_error parameters for nxsocket

### DIFF
--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -353,8 +353,8 @@ namespace nifake_non_ivi_grpc {
         response->mutable_handle()->set_id(session_id);
       }
       else {
-        const auto last_error_buffer = get_last_error(library_);
-        response->set_error_message(last_error_buffer.data());
+        const auto error_message = get_last_error(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
@@ -2408,8 +2408,8 @@ namespace nirfmxbluetooth_grpc {
         response->set_is_new_session(is_new_session);
       }
       else {
-        const auto last_error_buffer = get_last_error(library_);
-        response->set_error_message(last_error_buffer.data());
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }
@@ -2443,8 +2443,8 @@ namespace nirfmxbluetooth_grpc {
         response->mutable_instrument()->set_id(session_id);
       }
       else {
-        const auto last_error_buffer = get_last_error(library_);
-        response->set_error_message(last_error_buffer.data());
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -1889,8 +1889,8 @@ namespace nirfmxinstr_grpc {
         response->set_is_new_session(is_new_session);
       }
       else {
-        const auto last_error_buffer = get_last_error(library_);
-        response->set_error_message(last_error_buffer.data());
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }
@@ -1924,8 +1924,8 @@ namespace nirfmxinstr_grpc {
         response->mutable_instrument()->set_id(session_id);
       }
       else {
-        const auto last_error_buffer = get_last_error(library_);
-        response->set_error_message(last_error_buffer.data());
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }
@@ -1965,8 +1965,8 @@ namespace nirfmxinstr_grpc {
         response->mutable_instrument()->set_id(session_id);
       }
       else {
-        const auto last_error_buffer = get_last_error(library_);
-        response->set_error_message(last_error_buffer.data());
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nirfmxlte/nirfmxlte_service.cpp
+++ b/generated/nirfmxlte/nirfmxlte_service.cpp
@@ -4232,8 +4232,8 @@ namespace nirfmxlte_grpc {
         response->set_is_new_session(is_new_session);
       }
       else {
-        const auto last_error_buffer = get_last_error(library_);
-        response->set_error_message(last_error_buffer.data());
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }
@@ -4267,8 +4267,8 @@ namespace nirfmxlte_grpc {
         response->mutable_instrument()->set_id(session_id);
       }
       else {
-        const auto last_error_buffer = get_last_error(library_);
-        response->set_error_message(last_error_buffer.data());
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nirfmxnr/nirfmxnr_service.cpp
+++ b/generated/nirfmxnr/nirfmxnr_service.cpp
@@ -3315,8 +3315,8 @@ namespace nirfmxnr_grpc {
         response->set_is_new_session(is_new_session);
       }
       else {
-        const auto last_error_buffer = get_last_error(library_);
-        response->set_error_message(last_error_buffer.data());
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }
@@ -3350,8 +3350,8 @@ namespace nirfmxnr_grpc {
         response->mutable_instrument()->set_id(session_id);
       }
       else {
-        const auto last_error_buffer = get_last_error(library_);
-        response->set_error_message(last_error_buffer.data());
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nirfmxspecan/nirfmxspecan_service.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_service.cpp
@@ -7718,8 +7718,8 @@ namespace nirfmxspecan_grpc {
         response->set_is_new_session(is_new_session);
       }
       else {
-        const auto last_error_buffer = get_last_error(library_);
-        response->set_error_message(last_error_buffer.data());
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }
@@ -7753,8 +7753,8 @@ namespace nirfmxspecan_grpc {
         response->mutable_instrument()->set_id(session_id);
       }
       else {
-        const auto last_error_buffer = get_last_error(library_);
-        response->set_error_message(last_error_buffer.data());
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nirfmxwlan/nirfmxwlan_service.cpp
+++ b/generated/nirfmxwlan/nirfmxwlan_service.cpp
@@ -2632,8 +2632,8 @@ namespace nirfmxwlan_grpc {
         response->set_is_new_session(is_new_session);
       }
       else {
-        const auto last_error_buffer = get_last_error(library_);
-        response->set_error_message(last_error_buffer.data());
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }
@@ -2667,8 +2667,8 @@ namespace nirfmxwlan_grpc {
         response->mutable_instrument()->set_id(session_id);
       }
       else {
-        const auto last_error_buffer = get_last_error(library_);
-        response->set_error_message(last_error_buffer.data());
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -19,8 +19,6 @@ import "google/protobuf/duration.proto";
 service NiXnetSocket {
   rpc Bind(BindRequest) returns (BindResponse);
   rpc Close(CloseRequest) returns (CloseResponse);
-  rpc GetLastErrorNum(GetLastErrorNumRequest) returns (GetLastErrorNumResponse);
-  rpc GetLastErrorStr(GetLastErrorStrRequest) returns (GetLastErrorStrResponse);
   rpc IsSet(IsSetRequest) returns (IsSetResponse);
   rpc Select(SelectRequest) returns (SelectResponse);
   rpc Socket(SocketRequest) returns (SocketResponse);
@@ -56,6 +54,8 @@ message BindRequest {
 
 message BindResponse {
   int32 status = 1;
+  string error_message = 2;
+  int32 error_num = 3;
 }
 
 message CloseRequest {
@@ -64,22 +64,8 @@ message CloseRequest {
 
 message CloseResponse {
   int32 status = 1;
-}
-
-message GetLastErrorNumRequest {
-}
-
-message GetLastErrorNumResponse {
-  int32 status = 1;
-}
-
-message GetLastErrorStrRequest {
-  uint64 buf_len = 1;
-}
-
-message GetLastErrorStrResponse {
-  int32 status = 1;
-  string error = 2;
+  string error_message = 2;
+  int32 error_num = 3;
 }
 
 message IsSetRequest {
@@ -90,6 +76,8 @@ message IsSetRequest {
 message IsSetResponse {
   int32 status = 1;
   int32 is_set = 2;
+  string error_message = 3;
+  int32 error_num = 4;
 }
 
 message SelectRequest {
@@ -101,6 +89,8 @@ message SelectRequest {
 
 message SelectResponse {
   int32 status = 1;
+  string error_message = 2;
+  int32 error_num = 3;
 }
 
 message SocketRequest {
@@ -113,5 +103,7 @@ message SocketRequest {
 message SocketResponse {
   int32 status = 1;
   nidevice_grpc.Session socket = 2;
+  string error_message = 3;
+  int32 error_num = 4;
 }
 

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -50,37 +50,6 @@ close(const StubPtr& stub, const nidevice_grpc::Session& socket)
   return response;
 }
 
-GetLastErrorNumResponse
-get_last_error_num(const StubPtr& stub)
-{
-  ::grpc::ClientContext context;
-
-  auto request = GetLastErrorNumRequest{};
-
-  auto response = GetLastErrorNumResponse{};
-
-  raise_if_error(
-      stub->GetLastErrorNum(&context, request, &response));
-
-  return response;
-}
-
-GetLastErrorStrResponse
-get_last_error_str(const StubPtr& stub, const pb::uint64& buf_len)
-{
-  ::grpc::ClientContext context;
-
-  auto request = GetLastErrorStrRequest{};
-  request.set_buf_len(buf_len);
-
-  auto response = GetLastErrorStrResponse{};
-
-  raise_if_error(
-      stub->GetLastErrorStr(&context, request, &response));
-
-  return response;
-}
-
 IsSetResponse
 is_set(const StubPtr& stub, const nidevice_grpc::Session& fd, const std::vector<nidevice_grpc::Session>& set)
 {

--- a/generated/nixnetsocket/nixnetsocket_client.h
+++ b/generated/nixnetsocket/nixnetsocket_client.h
@@ -24,8 +24,6 @@ using namespace nidevice_grpc::experimental::client;
 
 BindResponse bind(const StubPtr& stub, const nidevice_grpc::Session& socket, const SockAddr& name);
 CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& socket);
-GetLastErrorNumResponse get_last_error_num(const StubPtr& stub);
-GetLastErrorStrResponse get_last_error_str(const StubPtr& stub, const pb::uint64& buf_len);
 IsSetResponse is_set(const StubPtr& stub, const nidevice_grpc::Session& fd, const std::vector<nidevice_grpc::Session>& set);
 SelectResponse select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& read_fds, const std::vector<nidevice_grpc::Session>& write_fds, const std::vector<nidevice_grpc::Session>& except_fds, const google::protobuf::Duration& timeout);
 SocketResponse socket(const StubPtr& stub, const pb::int32& domain, const pb::int32& type, const pb::int32& prototcol);

--- a/generated/nixnetsocket/nixnetsocket_library.cpp
+++ b/generated/nixnetsocket/nixnetsocket_library.cpp
@@ -70,11 +70,7 @@ int32_t NiXnetSocketLibrary::GetLastErrorNum()
   if (!function_pointers_.GetLastErrorNum) {
     throw nidevice_grpc::LibraryLoadException("Could not find nxgetlasterrornum.");
   }
-#if defined(_MSC_VER)
-  return nxgetlasterrornum();
-#else
   return function_pointers_.GetLastErrorNum();
-#endif
 }
 
 char* NiXnetSocketLibrary::GetLastErrorStr(char buf[], size_t bufLen)
@@ -82,11 +78,7 @@ char* NiXnetSocketLibrary::GetLastErrorStr(char buf[], size_t bufLen)
   if (!function_pointers_.GetLastErrorStr) {
     throw nidevice_grpc::LibraryLoadException("Could not find nxgetlasterrorstr.");
   }
-#if defined(_MSC_VER)
-  return nxgetlasterrorstr(buf, bufLen);
-#else
   return function_pointers_.GetLastErrorStr(buf, bufLen);
-#endif
 }
 
 int32_t NiXnetSocketLibrary::IsSet(nxSOCKET fd, nxfd_set* set)

--- a/generated/nixnetsocket/nixnetsocket_library.h
+++ b/generated/nixnetsocket/nixnetsocket_library.h
@@ -29,8 +29,8 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
  private:
   using BindPtr = decltype(&nxbind);
   using ClosePtr = decltype(&nxclose);
-  using GetLastErrorNumPtr = decltype(&nxgetlasterrornum);
-  using GetLastErrorStrPtr = decltype(&nxgetlasterrorstr);
+  using GetLastErrorNumPtr = int32_t (*)();
+  using GetLastErrorStrPtr = char* (*)(char buf[], size_t bufLen);
   using IsSetPtr = decltype(&nxfd_isset);
   using SelectPtr = decltype(&nxselect);
   using SocketPtr = decltype(&nxsocket);

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <vector>
 #include "custom/xnetsocket_converters.h"
+#include "custom/xnetsocket_errors.h"
 #include <server/converters.h>
 
 namespace nixnetsocket_grpc {
@@ -55,6 +56,14 @@ namespace nixnetsocket_grpc {
       auto namelen = name.size();
       auto status = library_->Bind(socket, name, namelen);
       response->set_status(status);
+      if (status_ok(status)) {
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+        const auto error_num = get_last_error_num(library_);
+        response->set_error_num(error_num);
+      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
@@ -75,49 +84,13 @@ namespace nixnetsocket_grpc {
       session_repository_->remove_session(socket_grpc_session.id(), socket_grpc_session.name());
       auto status = library_->Close(socket);
       response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiXnetSocketService::GetLastErrorNum(::grpc::ServerContext* context, const GetLastErrorNumRequest* request, GetLastErrorNumResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto status = library_->GetLastErrorNum();
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiXnetSocketService::GetLastErrorStr(::grpc::ServerContext* context, const GetLastErrorStrRequest* request, GetLastErrorStrResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      size_t buf_len = request->buf_len();
-      std::string buf;
-      if (buf_len > 0) {
-          buf.resize(buf_len - 1);
-      }
-      auto error = library_->GetLastErrorStr((char*)buf.data(), buf_len);
-      auto status = error ? 0 : -1;
-      response->set_status(status);
       if (status_ok(status)) {
-        response->set_error(error);
-        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error()));
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+        const auto error_num = get_last_error_num(library_);
+        response->set_error_num(error_num);
       }
       return ::grpc::Status::OK;
     }
@@ -143,6 +116,12 @@ namespace nixnetsocket_grpc {
       if (status_ok(status)) {
         response->set_is_set(is_set);
       }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+        const auto error_num = get_last_error_num(library_);
+        response->set_error_num(error_num);
+      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
@@ -165,6 +144,14 @@ namespace nixnetsocket_grpc {
       auto timeout = convert_from_grpc<nxtimeval>(request->timeout());
       auto status = library_->Select(nfds, read_fds, write_fds, except_fds, timeout);
       response->set_status(status);
+      if (status_ok(status)) {
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+        const auto error_num = get_last_error_num(library_);
+        response->set_error_num(error_num);
+      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
@@ -197,6 +184,12 @@ namespace nixnetsocket_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_socket()->set_id(session_id);
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+        const auto error_num = get_last_error_num(library_);
+        response->set_error_num(error_num);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nixnetsocket/nixnetsocket_service.h
+++ b/generated/nixnetsocket/nixnetsocket_service.h
@@ -43,8 +43,6 @@ public:
   
   ::grpc::Status Bind(::grpc::ServerContext* context, const BindRequest* request, BindResponse* response) override;
   ::grpc::Status Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response) override;
-  ::grpc::Status GetLastErrorNum(::grpc::ServerContext* context, const GetLastErrorNumRequest* request, GetLastErrorNumResponse* response) override;
-  ::grpc::Status GetLastErrorStr(::grpc::ServerContext* context, const GetLastErrorStrRequest* request, GetLastErrorStrResponse* response) override;
   ::grpc::Status IsSet(::grpc::ServerContext* context, const IsSetRequest* request, IsSetResponse* response) override;
   ::grpc::Status Select(::grpc::ServerContext* context, const SelectRequest* request, SelectResponse* response) override;
   ::grpc::Status Socket(::grpc::ServerContext* context, const SocketRequest* request, SocketResponse* response) override;

--- a/source/codegen/generate_service.py
+++ b/source/codegen/generate_service.py
@@ -29,6 +29,7 @@ def _mutate_metadata(metadata: dict):
     for function_name in metadata["functions"]:
         function = metadata["functions"][function_name]
         parameters = function["parameters"]
+        metadata_mutation.add_get_last_error_params_if_needed(parameters, config)
         metadata_mutation.sanitize_names(parameters)
         metadata_mutation.set_var_args_types(parameters, config)
         metadata_mutation.mark_size_params(parameters)

--- a/source/codegen/metadata/nifake_non_ivi/functions.py
+++ b/source/codegen/metadata/nifake_non_ivi/functions.py
@@ -164,7 +164,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'get_last_error': True,
+                'get_last_error': 'get_last_error',
                 'name': 'errorMessage',
                 'type': 'char[]'
             }

--- a/source/codegen/metadata/nirfmxbluetooth/functions.py
+++ b/source/codegen/metadata/nirfmxbluetooth/functions.py
@@ -2242,7 +2242,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'get_last_error': True,
+                'get_last_error': 'get_last_error_message',
                 'name': 'errorMessage',
                 'type': 'char[]'
             }
@@ -2268,7 +2268,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'get_last_error': True,
+                'get_last_error': 'get_last_error_message',
                 'name': 'errorMessage',
                 'type': 'char[]'
             }

--- a/source/codegen/metadata/nirfmxinstr/functions.py
+++ b/source/codegen/metadata/nirfmxinstr/functions.py
@@ -1686,7 +1686,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'get_last_error': True,
+                'get_last_error': 'get_last_error_message',
                 'name': 'errorMessage',
                 'type': 'char[]'
             }
@@ -1712,7 +1712,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'get_last_error': True,
+                'get_last_error': 'get_last_error_message',
                 'name': 'errorMessage',
                 'type': 'char[]'
             }
@@ -1747,7 +1747,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'get_last_error': True,
+                'get_last_error': 'get_last_error_message',
                 'name': 'errorMessage',
                 'type': 'char[]'
             }

--- a/source/codegen/metadata/nirfmxlte/functions.py
+++ b/source/codegen/metadata/nirfmxlte/functions.py
@@ -3738,7 +3738,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'get_last_error': True,
+                'get_last_error': 'get_last_error_message',
                 'name': 'errorMessage',
                 'type': 'char[]'
             }
@@ -3764,7 +3764,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'get_last_error': True,
+                'get_last_error': 'get_last_error_message',
                 'name': 'errorMessage',
                 'type': 'char[]'
             }

--- a/source/codegen/metadata/nirfmxnr/functions.py
+++ b/source/codegen/metadata/nirfmxnr/functions.py
@@ -2952,7 +2952,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'get_last_error': True,
+                'get_last_error': 'get_last_error_message',
                 'name': 'errorMessage',
                 'type': 'char[]'
             }
@@ -2978,7 +2978,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'get_last_error': True,
+                'get_last_error': 'get_last_error_message',
                 'name': 'errorMessage',
                 'type': 'char[]'
             }

--- a/source/codegen/metadata/nirfmxspecan/functions.py
+++ b/source/codegen/metadata/nirfmxspecan/functions.py
@@ -7281,7 +7281,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'get_last_error': True,
+                'get_last_error': 'get_last_error_message',
                 'name': 'errorMessage',
                 'type': 'char[]'
             }
@@ -7307,7 +7307,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'get_last_error': True,
+                'get_last_error': 'get_last_error_message',
                 'name': 'errorMessage',
                 'type': 'char[]'
             }

--- a/source/codegen/metadata/nirfmxwlan/functions.py
+++ b/source/codegen/metadata/nirfmxwlan/functions.py
@@ -2528,7 +2528,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'get_last_error': True,
+                'get_last_error': 'get_last_error_message',
                 'name': 'errorMessage',
                 'type': 'char[]'
             }
@@ -2554,7 +2554,7 @@ functions = {
             },
             {
                 'direction': 'out',
-                'get_last_error': True,
+                'get_last_error': 'get_last_error_message',
                 'name': 'errorMessage',
                 'type': 'char[]'
             }

--- a/source/codegen/metadata/nixnetsocket/config.py
+++ b/source/codegen/metadata/nixnetsocket/config.py
@@ -9,7 +9,20 @@ config = {
     'namespace_component': 'nixnetsocket',
     'close_function': 'Close',
     'custom_types': [],
-    'additional_headers': { "custom/xnetsocket_converters.h": ["service.cpp"] },
+    'additional_headers': { 
+        "custom/xnetsocket_converters.h": ["service.cpp"],
+        "custom/xnetsocket_errors.h": ["service.cpp"] 
+    },
+    'get_last_error': [
+        {
+            'name': 'error_message',
+            'type': 'char[]'
+        }, 
+        {
+            'name': 'error_num', 
+            'type': 'int32_t'
+        }
+    ],
     'type_to_grpc_type': {
         'nxSOCKET': 'nidevice_grpc.Session',
         'nxfd_set': 'repeated nidevice_grpc.Session',

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -37,11 +37,13 @@ functions = {
         'returns': 'int32_t'
     },
     'GetLastErrorNum': {
+        'codegen_method': 'private',
         'cname': 'nxgetlasterrornum',
         'parameters': [],
         'returns': 'int32_t'
     },
     'GetLastErrorStr': {
+        'codegen_method': 'private',
         'cname': 'nxgetlasterrorstr',
         'status_expression': 'error ? 0 : -1',
         'parameters': [

--- a/source/codegen/metadata_mutation.py
+++ b/source/codegen/metadata_mutation.py
@@ -1,7 +1,7 @@
 """Metadata mutation."""
 
 from collections import namedtuple
-from typing import Optional
+from typing import List, Optional
 
 import common_helpers
 
@@ -403,3 +403,16 @@ def move_zero_enums_to_front(enums: dict) -> None:
             values.insert(0, values.pop(i))
         except StopIteration:
             pass
+
+
+def add_get_last_error_params_if_needed(parameters: List[dict], config: dict) -> None:
+    """Add get_last_error parameters to the list if any are specified in config."""
+    for get_last_error_field in config.get("get_last_error", []):
+        parameters.append(
+            {
+                "direction": "out",
+                "get_last_error": f"get_last_{get_last_error_field['name']}",
+                "name": get_last_error_field["name"],
+                "type": get_last_error_field["type"],
+            }
+        )

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -77,7 +77,7 @@ PARAM_SCHEMA = Schema(
         Optional("grpc_name"): str,
         Optional("return_value"): bool,
         Optional("supports_standard_copy_convert"): bool,
-        Optional("get_last_error"): bool,
+        Optional("get_last_error"): str,
         Optional("additional_arguments_to_copy_convert"): [str],
     }
 )

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -625,10 +625,9 @@ def is_size_param_passed_by_ptr(parameter: dict) -> bool:
     return parameter.get("is_size_param") and parameter.get("pointer")
 
 
-def get_last_error_output_param(parameters: List[dict]) -> Optional[dict]:
-    """Get the get_last_error parameter if any (or None)."""
+def get_last_error_output_params(parameters: List[dict]) -> List[dict]:
+    """Return list of get_last_error parameters."""
     get_last_error_outputs = [
         p for p in parameters if common_helpers.is_get_last_error_output_param(p)
     ]
-    assert len(get_last_error_outputs) <= 1, "Only one get_last_error output is supported"
-    return get_last_error_outputs[0] if get_last_error_outputs else None
+    return get_last_error_outputs

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -689,8 +689,8 @@ ${initialize_standard_input_param(function_name, parameter)}
 ## Handles populating the response message after calling the driver API.
 <%def name="populate_response(output_parameters, indent_level=0, init_method=False)">\
 <%
-  get_last_error_output = service_helpers.get_last_error_output_param(output_parameters)
-  normal_outputs = [p for p in output_parameters if p is not get_last_error_output]
+  get_last_error_outputs = service_helpers.get_last_error_output_params(output_parameters)
+  normal_outputs = [p for p in output_parameters if not p in get_last_error_outputs]
 %>\
 <%block filter="common_helpers.indent(indent_level)">\
       response->set_status(status);
@@ -698,13 +698,16 @@ ${initialize_standard_input_param(function_name, parameter)}
       if (status_ok(status)) {
 ${set_response_values(normal_outputs, init_method)}\
       }
-%   if get_last_error_output:
+%   if any(get_last_error_outputs):
+      else {
+%     for get_last_error_output in get_last_error_outputs:
 <%
   get_last_error_output_name = common_helpers.get_grpc_field_name(get_last_error_output)
+  get_last_error_method_name = get_last_error_output["get_last_error"]
 %>\
-      else {
-        const auto last_error_buffer = get_last_error(library_);
-        response->set_${get_last_error_output_name}(last_error_buffer.data());
+        const auto ${get_last_error_output_name} = ${get_last_error_method_name}(library_);
+        response->set_${get_last_error_output_name}(${get_last_error_output_name});
+%     endfor
       }
 %   endif
 %endif

--- a/source/custom/nifake_non_ivi_errors.h
+++ b/source/custom/nifake_non_ivi_errors.h
@@ -4,14 +4,14 @@
 #include <vector>
 
 template <typename TLibraryPtr>
-std::vector<char> get_last_error(TLibraryPtr& library)
+std::string get_last_error(TLibraryPtr& library)
 {
   std::vector<char> error_message;
   const auto buffer_size = library->GetLatestErrorMessage(nullptr, 0);
   error_message.resize(buffer_size);
   library->GetLatestErrorMessage(error_message.data(), buffer_size);
 
-  return error_message;
+  return std::string(error_message.data());
 }
 
 #endif  // NIDEVICE_GRPC_DEVICE_NIFAKE_NON_IVI_ERRORS_H

--- a/source/custom/nirfmx_errors.h
+++ b/source/custom/nirfmx_errors.h
@@ -5,7 +5,7 @@
 #include <vector>
 
 template <typename TLibraryPtr>
-std::vector<char> get_last_error(TLibraryPtr& library)
+std::string get_last_error_message(TLibraryPtr& library)
 {
   std::vector<char> error_message;
   int32 error_code;
@@ -16,7 +16,7 @@ std::vector<char> get_last_error(TLibraryPtr& library)
   error_message.resize(buffer_size);
   library->GetError(NO_INSTR_HANDLE, &error_code, buffer_size, error_message.data());
 
-  return error_message;
+  return std::string(error_message.data());
 }
 
 #endif  // NIDEVICE_GRPC_DEVICE_NIRFMX_ERRORS_H

--- a/source/custom/xnetsocket_errors.h
+++ b/source/custom/xnetsocket_errors.h
@@ -1,0 +1,26 @@
+#ifndef NIDEVICE_GRPC_DEVICE_XNET_SOCKET_ERRORS_H
+#define NIDEVICE_GRPC_DEVICE_XNET_SOCKET_ERRORS_H
+
+#include <nixnetsocket.pb.h>
+#include <nixnetsocket/nixnetsocket_library_interface.h>
+#include <nxsocket.h>
+#include <server/converters.h>
+
+#include <algorithm>
+#include <cstring>
+
+namespace nixnetsocket_grpc {
+constexpr auto ERROR_BUFFER_SIZE = 4096;
+std::string get_last_error_message(NiXnetSocketLibraryInterface* library)
+{
+  auto buffer = std::vector<char>(ERROR_BUFFER_SIZE);
+  library->GetLastErrorStr(buffer.data(), ERROR_BUFFER_SIZE);
+  return std::string(buffer.data());
+}
+
+int32_t get_last_error_num(NiXnetSocketLibraryInterface* library)
+{
+  return library->GetLastErrorNum();
+}
+}  // namespace nixnetsocket_grpc
+#endif /* NIDEVICE_GRPC_DEVICE_XNET_SOCKET_ERRORS_H */


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add support for service-wide `get_last_error` parameters for `nxsocket`.

Add support for multiple `get_last_error` parameters on a single method.

Make `GetLastError` methods in `xnetsocket` `private` so they cannot be accessed through the `grpc-device` API.

### Why should this Pull Request be merged?

The `nxsocket` API uses a thread-local `get_last_error` implementation as they're primary mechanism for error reporting.  Even the error code must be retrieved with `nxgetlasterrornum`. This does not work when split into multiple service calls.

Fixes [AB#1877861](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1877861).

### What testing has been done?

Ran and passed all `Xnet` tests, `RFmxSpecAn` tests, and unit tests.