### PR TITLE
Add get and set sockopt methods for xnetsocket service.

### DIFF
--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -64,7 +64,7 @@ message SockAddr {
 }
 
 message SockOptData {
-  int32 opt = 1;
+  SocketOptions opt = 1;
   oneof data {
     int32 data_int32 = 2;
     bool data_bool = 3;

--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -21,6 +21,7 @@ service NiXnetSocket {
   rpc Close(CloseRequest) returns (CloseResponse);
   rpc GetLastErrorNum(GetLastErrorNumRequest) returns (GetLastErrorNumResponse);
   rpc GetLastErrorStr(GetLastErrorStrRequest) returns (GetLastErrorStrResponse);
+  rpc GetSocketOption(GetSocketOptionRequest) returns (GetSocketOptionResponse);
   rpc IsSet(IsSetRequest) returns (IsSetResponse);
   rpc Select(SelectRequest) returns (SelectResponse);
   rpc SetSocketOption(SetSocketOptionRequest) returns (SetSocketOptionResponse);
@@ -29,6 +30,18 @@ service NiXnetSocket {
 
 enum NiXnetSocketAttribute {
   NIXNETSOCKET_ATTRIBUTE_UNSPECIFIED = 0;
+}
+
+enum SocketOptions {
+  SOCKET_OPTIONS_UNSPECIFIED = 0;
+  SOCKET_OPTIONS_RX_DATA = 257;
+  SOCKET_OPTIONS_RCV_BUF = 258;
+  SOCKET_OPTIONS_SND_BUF = 259;
+  SOCKET_OPTIONS_NON_BLOCK = 260;
+  SOCKET_OPTIONS_BIND_TO_DEVICE = 261;
+  SOCKET_OPTIONS_ERROR = 262;
+  SOCKET_OPTIONS_LINGER = 263;
+  SOCKET_OPTIONS_REUSE_ADDR = 264;
 }
 
 message SockAddrIPv4 {
@@ -51,7 +64,7 @@ message SockAddr {
 }
 
 message SockOptData {
-  int32 opt = 1;
+  SocketOptions opt = 1;
   oneof data {
     int32 data_int32 = 2;
     bool data_bool = 3;
@@ -90,6 +103,20 @@ message GetLastErrorStrRequest {
 message GetLastErrorStrResponse {
   int32 status = 1;
   string error = 2;
+}
+
+message GetSocketOptionRequest {
+  nidevice_grpc.Session socket = 1;
+  int32 level = 2;
+  oneof opt_name_enum {
+    SocketOptions opt_name = 3;
+    int32 opt_name_raw = 4;
+  }
+}
+
+message GetSocketOptionResponse {
+  int32 status = 1;
+  SockOptData optval = 2;
 }
 
 message IsSetRequest {

--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -64,7 +64,7 @@ message SockAddr {
 }
 
 message SockOptData {
-  SocketOptions opt = 1;
+  int32 opt = 1;
   oneof data {
     int32 data_int32 = 2;
     bool data_bool = 3;

--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -23,6 +23,7 @@ service NiXnetSocket {
   rpc GetLastErrorStr(GetLastErrorStrRequest) returns (GetLastErrorStrResponse);
   rpc IsSet(IsSetRequest) returns (IsSetResponse);
   rpc Select(SelectRequest) returns (SelectResponse);
+  rpc SetSocketOption(SetSocketOptionRequest) returns (SetSocketOptionResponse);
   rpc Socket(SocketRequest) returns (SocketResponse);
 }
 
@@ -46,6 +47,15 @@ message SockAddr {
   oneof addr {
     SockAddrIPv4 ipv4 = 1;
     SockAddrIPv6 ipv6 = 2;
+  }
+}
+
+message SockOptData {
+  int32 opt = 1;
+  oneof data {
+    int32 data_int32 = 2;
+    bool data_bool = 3;
+    string data_string = 4;
   }
 }
 
@@ -100,6 +110,16 @@ message SelectRequest {
 }
 
 message SelectResponse {
+  int32 status = 1;
+}
+
+message SetSocketOptionRequest {
+  nidevice_grpc.Session socket = 1;
+  int32 level = 2;
+  SockOptData opt_data = 3;
+}
+
+message SetSocketOptionResponse {
   int32 status = 1;
 }
 

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -81,6 +81,31 @@ get_last_error_str(const StubPtr& stub, const pb::uint64& buf_len)
   return response;
 }
 
+GetSocketOptionResponse
+get_socket_option(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& level, const simple_variant<SocketOptions, pb::int32>& opt_name)
+{
+  ::grpc::ClientContext context;
+
+  auto request = GetSocketOptionRequest{};
+  request.mutable_socket()->CopyFrom(socket);
+  request.set_level(level);
+  const auto opt_name_ptr = opt_name.get_if<SocketOptions>();
+  const auto opt_name_raw_ptr = opt_name.get_if<pb::int32>();
+  if (opt_name_ptr) {
+    request.set_opt_name(*opt_name_ptr);
+  }
+  else if (opt_name_raw_ptr) {
+    request.set_opt_name_raw(*opt_name_raw_ptr);
+  }
+
+  auto response = GetSocketOptionResponse{};
+
+  raise_if_error(
+      stub->GetSocketOption(&context, request, &response));
+
+  return response;
+}
+
 IsSetResponse
 is_set(const StubPtr& stub, const nidevice_grpc::Session& fd, const std::vector<nidevice_grpc::Session>& set)
 {

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -117,6 +117,24 @@ select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& read_fds,
   return response;
 }
 
+SetSocketOptionResponse
+set_socket_option(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& level, const SockOptData& opt_data)
+{
+  ::grpc::ClientContext context;
+
+  auto request = SetSocketOptionRequest{};
+  request.mutable_socket()->CopyFrom(socket);
+  request.set_level(level);
+  request.mutable_opt_data()->CopyFrom(opt_data);
+
+  auto response = SetSocketOptionResponse{};
+
+  raise_if_error(
+      stub->SetSocketOption(&context, request, &response));
+
+  return response;
+}
+
 SocketResponse
 socket(const StubPtr& stub, const pb::int32& domain, const pb::int32& type, const pb::int32& prototcol)
 {

--- a/generated/nixnetsocket/nixnetsocket_client.h
+++ b/generated/nixnetsocket/nixnetsocket_client.h
@@ -28,6 +28,7 @@ GetLastErrorNumResponse get_last_error_num(const StubPtr& stub);
 GetLastErrorStrResponse get_last_error_str(const StubPtr& stub, const pb::uint64& buf_len);
 IsSetResponse is_set(const StubPtr& stub, const nidevice_grpc::Session& fd, const std::vector<nidevice_grpc::Session>& set);
 SelectResponse select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& read_fds, const std::vector<nidevice_grpc::Session>& write_fds, const std::vector<nidevice_grpc::Session>& except_fds, const google::protobuf::Duration& timeout);
+SetSocketOptionResponse set_socket_option(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& level, const SockOptData& opt_data);
 SocketResponse socket(const StubPtr& stub, const pb::int32& domain, const pb::int32& type, const pb::int32& prototcol);
 
 } // namespace nixnetsocket_grpc::experimental::client

--- a/generated/nixnetsocket/nixnetsocket_client.h
+++ b/generated/nixnetsocket/nixnetsocket_client.h
@@ -26,6 +26,7 @@ BindResponse bind(const StubPtr& stub, const nidevice_grpc::Session& socket, con
 CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& socket);
 GetLastErrorNumResponse get_last_error_num(const StubPtr& stub);
 GetLastErrorStrResponse get_last_error_str(const StubPtr& stub, const pb::uint64& buf_len);
+GetSocketOptionResponse get_socket_option(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& level, const simple_variant<SocketOptions, pb::int32>& opt_name);
 IsSetResponse is_set(const StubPtr& stub, const nidevice_grpc::Session& fd, const std::vector<nidevice_grpc::Session>& set);
 SelectResponse select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& read_fds, const std::vector<nidevice_grpc::Session>& write_fds, const std::vector<nidevice_grpc::Session>& except_fds, const google::protobuf::Duration& timeout);
 SetSocketOptionResponse set_socket_option(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& level, const SockOptData& opt_data);

--- a/generated/nixnetsocket/nixnetsocket_library.cpp
+++ b/generated/nixnetsocket/nixnetsocket_library.cpp
@@ -25,6 +25,7 @@ NiXnetSocketLibrary::NiXnetSocketLibrary() : shared_library_(kLibraryName)
   function_pointers_.Close = reinterpret_cast<ClosePtr>(shared_library_.get_function_pointer("nxclose"));
   function_pointers_.GetLastErrorNum = reinterpret_cast<GetLastErrorNumPtr>(shared_library_.get_function_pointer("nxgetlasterrornum"));
   function_pointers_.GetLastErrorStr = reinterpret_cast<GetLastErrorStrPtr>(shared_library_.get_function_pointer("nxgetlasterrorstr"));
+  function_pointers_.GetSocketOption = reinterpret_cast<GetSocketOptionPtr>(shared_library_.get_function_pointer("nxgetsockopt"));
   function_pointers_.IsSet = reinterpret_cast<IsSetPtr>(shared_library_.get_function_pointer("nxfd_isset"));
   function_pointers_.Select = reinterpret_cast<SelectPtr>(shared_library_.get_function_pointer("nxselect"));
   function_pointers_.SetSocketOption = reinterpret_cast<SetSocketOptionPtr>(shared_library_.get_function_pointer("nxsetsockopt"));
@@ -87,6 +88,18 @@ char* NiXnetSocketLibrary::GetLastErrorStr(char buf[], size_t bufLen)
   return nxgetlasterrorstr(buf, bufLen);
 #else
   return function_pointers_.GetLastErrorStr(buf, bufLen);
+#endif
+}
+
+int32_t NiXnetSocketLibrary::GetSocketOption(nxSOCKET socket, int32_t level, int32_t opt_name, void* optval, nxsocklen_t* optlen)
+{
+  if (!function_pointers_.GetSocketOption) {
+    throw nidevice_grpc::LibraryLoadException("Could not find nxgetsockopt.");
+  }
+#if defined(_MSC_VER)
+  return nxgetsockopt(socket, level, opt_name, optval, optlen);
+#else
+  return function_pointers_.GetSocketOption(socket, level, opt_name, optval, optlen);
 #endif
 }
 

--- a/generated/nixnetsocket/nixnetsocket_library.cpp
+++ b/generated/nixnetsocket/nixnetsocket_library.cpp
@@ -27,6 +27,7 @@ NiXnetSocketLibrary::NiXnetSocketLibrary() : shared_library_(kLibraryName)
   function_pointers_.GetLastErrorStr = reinterpret_cast<GetLastErrorStrPtr>(shared_library_.get_function_pointer("nxgetlasterrorstr"));
   function_pointers_.IsSet = reinterpret_cast<IsSetPtr>(shared_library_.get_function_pointer("nxfd_isset"));
   function_pointers_.Select = reinterpret_cast<SelectPtr>(shared_library_.get_function_pointer("nxselect"));
+  function_pointers_.SetSocketOption = reinterpret_cast<SetSocketOptionPtr>(shared_library_.get_function_pointer("nxsetsockopt"));
   function_pointers_.Socket = reinterpret_cast<SocketPtr>(shared_library_.get_function_pointer("nxsocket"));
 }
 
@@ -110,6 +111,18 @@ int32_t NiXnetSocketLibrary::Select(int32_t nfds, nxfd_set* read_fds, nxfd_set* 
   return nxselect(nfds, read_fds, write_fds, except_fds, timeout);
 #else
   return function_pointers_.Select(nfds, read_fds, write_fds, except_fds, timeout);
+#endif
+}
+
+int32_t NiXnetSocketLibrary::SetSocketOption(nxSOCKET socket, int32_t level, int32_t optname, void* optval, nxsocklen_t optlen)
+{
+  if (!function_pointers_.SetSocketOption) {
+    throw nidevice_grpc::LibraryLoadException("Could not find nxsetsockopt.");
+  }
+#if defined(_MSC_VER)
+  return nxsetsockopt(socket, level, optname, optval, optlen);
+#else
+  return function_pointers_.SetSocketOption(socket, level, optname, optval, optlen);
 #endif
 }
 

--- a/generated/nixnetsocket/nixnetsocket_library.h
+++ b/generated/nixnetsocket/nixnetsocket_library.h
@@ -22,6 +22,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   int32_t Close(nxSOCKET socket);
   int32_t GetLastErrorNum();
   char* GetLastErrorStr(char buf[], size_t bufLen);
+  int32_t GetSocketOption(nxSOCKET socket, int32_t level, int32_t opt_name, void* optval, nxsocklen_t* optlen);
   int32_t IsSet(nxSOCKET fd, nxfd_set* set);
   int32_t Select(int32_t nfds, nxfd_set* read_fds, nxfd_set* write_fds, nxfd_set* except_fds, nxtimeval* timeout);
   int32_t SetSocketOption(nxSOCKET socket, int32_t level, int32_t optname, void* optval, nxsocklen_t optlen);
@@ -32,6 +33,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   using ClosePtr = decltype(&nxclose);
   using GetLastErrorNumPtr = decltype(&nxgetlasterrornum);
   using GetLastErrorStrPtr = decltype(&nxgetlasterrorstr);
+  using GetSocketOptionPtr = decltype(&nxgetsockopt);
   using IsSetPtr = decltype(&nxfd_isset);
   using SelectPtr = decltype(&nxselect);
   using SetSocketOptionPtr = decltype(&nxsetsockopt);
@@ -42,6 +44,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
     ClosePtr Close;
     GetLastErrorNumPtr GetLastErrorNum;
     GetLastErrorStrPtr GetLastErrorStr;
+    GetSocketOptionPtr GetSocketOption;
     IsSetPtr IsSet;
     SelectPtr Select;
     SetSocketOptionPtr SetSocketOption;

--- a/generated/nixnetsocket/nixnetsocket_library.h
+++ b/generated/nixnetsocket/nixnetsocket_library.h
@@ -24,6 +24,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   char* GetLastErrorStr(char buf[], size_t bufLen);
   int32_t IsSet(nxSOCKET fd, nxfd_set* set);
   int32_t Select(int32_t nfds, nxfd_set* read_fds, nxfd_set* write_fds, nxfd_set* except_fds, nxtimeval* timeout);
+  int32_t SetSocketOption(nxSOCKET socket, int32_t level, int32_t optname, void* optval, nxsocklen_t optlen);
   nxSOCKET Socket(nxIpStackRef_t stack_ref, int32_t domain, int32_t type, int32_t prototcol);
 
  private:
@@ -33,6 +34,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   using GetLastErrorStrPtr = decltype(&nxgetlasterrorstr);
   using IsSetPtr = decltype(&nxfd_isset);
   using SelectPtr = decltype(&nxselect);
+  using SetSocketOptionPtr = decltype(&nxsetsockopt);
   using SocketPtr = decltype(&nxsocket);
 
   typedef struct FunctionPointers {
@@ -42,6 +44,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
     GetLastErrorStrPtr GetLastErrorStr;
     IsSetPtr IsSet;
     SelectPtr Select;
+    SetSocketOptionPtr SetSocketOption;
     SocketPtr Socket;
   } FunctionLoadStatus;
 

--- a/generated/nixnetsocket/nixnetsocket_library_interface.h
+++ b/generated/nixnetsocket/nixnetsocket_library_interface.h
@@ -21,6 +21,7 @@ class NiXnetSocketLibraryInterface {
   virtual char* GetLastErrorStr(char buf[], size_t bufLen) = 0;
   virtual int32_t IsSet(nxSOCKET fd, nxfd_set* set) = 0;
   virtual int32_t Select(int32_t nfds, nxfd_set* read_fds, nxfd_set* write_fds, nxfd_set* except_fds, nxtimeval* timeout) = 0;
+  virtual int32_t SetSocketOption(nxSOCKET socket, int32_t level, int32_t optname, void* optval, nxsocklen_t optlen) = 0;
   virtual nxSOCKET Socket(nxIpStackRef_t stack_ref, int32_t domain, int32_t type, int32_t prototcol) = 0;
 };
 

--- a/generated/nixnetsocket/nixnetsocket_library_interface.h
+++ b/generated/nixnetsocket/nixnetsocket_library_interface.h
@@ -19,6 +19,7 @@ class NiXnetSocketLibraryInterface {
   virtual int32_t Close(nxSOCKET socket) = 0;
   virtual int32_t GetLastErrorNum() = 0;
   virtual char* GetLastErrorStr(char buf[], size_t bufLen) = 0;
+  virtual int32_t GetSocketOption(nxSOCKET socket, int32_t level, int32_t opt_name, void* optval, nxsocklen_t* optlen) = 0;
   virtual int32_t IsSet(nxSOCKET fd, nxfd_set* set) = 0;
   virtual int32_t Select(int32_t nfds, nxfd_set* read_fds, nxfd_set* write_fds, nxfd_set* except_fds, nxtimeval* timeout) = 0;
   virtual int32_t SetSocketOption(nxSOCKET socket, int32_t level, int32_t optname, void* optval, nxsocklen_t optlen) = 0;

--- a/generated/nixnetsocket/nixnetsocket_mock_library.h
+++ b/generated/nixnetsocket/nixnetsocket_mock_library.h
@@ -23,6 +23,7 @@ class NiXnetSocketMockLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInt
   MOCK_METHOD(char*, GetLastErrorStr, (char buf[], size_t bufLen), (override));
   MOCK_METHOD(int32_t, IsSet, (nxSOCKET fd, nxfd_set* set), (override));
   MOCK_METHOD(int32_t, Select, (int32_t nfds, nxfd_set* read_fds, nxfd_set* write_fds, nxfd_set* except_fds, nxtimeval* timeout), (override));
+  MOCK_METHOD(int32_t, SetSocketOption, (nxSOCKET socket, int32_t level, int32_t optname, void* optval, nxsocklen_t optlen), (override));
   MOCK_METHOD(nxSOCKET, Socket, (nxIpStackRef_t stack_ref, int32_t domain, int32_t type, int32_t prototcol), (override));
 };
 

--- a/generated/nixnetsocket/nixnetsocket_mock_library.h
+++ b/generated/nixnetsocket/nixnetsocket_mock_library.h
@@ -21,6 +21,7 @@ class NiXnetSocketMockLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInt
   MOCK_METHOD(int32_t, Close, (nxSOCKET socket), (override));
   MOCK_METHOD(int32_t, GetLastErrorNum, (), (override));
   MOCK_METHOD(char*, GetLastErrorStr, (char buf[], size_t bufLen), (override));
+  MOCK_METHOD(int32_t, GetSocketOption, (nxSOCKET socket, int32_t level, int32_t opt_name, void* optval, nxsocklen_t* optlen), (override));
   MOCK_METHOD(int32_t, IsSet, (nxSOCKET fd, nxfd_set* set), (override));
   MOCK_METHOD(int32_t, Select, (int32_t nfds, nxfd_set* read_fds, nxfd_set* write_fds, nxfd_set* except_fds, nxtimeval* timeout), (override));
   MOCK_METHOD(int32_t, SetSocketOption, (nxSOCKET socket, int32_t level, int32_t optname, void* optval, nxsocklen_t optlen), (override));

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -174,6 +174,30 @@ namespace nixnetsocket_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiXnetSocketService::SetSocketOption(::grpc::ServerContext* context, const SetSocketOptionRequest* request, SetSocketOptionResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto socket_grpc_session = request->socket();
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      int32_t level = request->level();
+      auto opt_data = convert_from_grpc<SockOptDataHolder>(request->opt_data());
+      auto optname = opt_data.name();
+      auto optval = opt_data.data();
+      auto optlen = opt_data.size();
+      auto status = library_->SetSocketOption(socket, level, optname, optval, optlen);
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiXnetSocketService::Socket(::grpc::ServerContext* context, const SocketRequest* request, SocketResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -128,47 +128,6 @@ namespace nixnetsocket_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiXnetSocketService::GetSocketOption(::grpc::ServerContext* context, const GetSocketOptionRequest* request, GetSocketOptionResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto socket_grpc_session = request->socket();
-      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
-      int32_t level = request->level();
-      int32_t opt_name;
-      switch (request->opt_name_enum_case()) {
-        case nixnetsocket_grpc::GetSocketOptionRequest::OptNameEnumCase::kOptName: {
-          opt_name = static_cast<int32_t>(request->opt_name());
-          break;
-        }
-        case nixnetsocket_grpc::GetSocketOptionRequest::OptNameEnumCase::kOptNameRaw: {
-          opt_name = static_cast<int32_t>(request->opt_name_raw());
-          break;
-        }
-        case nixnetsocket_grpc::GetSocketOptionRequest::OptNameEnumCase::OPT_NAME_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for opt_name was not specified or out of range");
-          break;
-        }
-      }
-
-      void* optval;
-      nxsocklen_t optlen {};
-      auto status = library_->GetSocketOption(socket, level, opt_name, &optval, &optlen);
-      response->set_status(status);
-      if (status_ok(status)) {
-        convert_to_grpc(optval, response->mutable_optval(), request->opt_name(), optlen);
-      }
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiXnetSocketService::IsSet(::grpc::ServerContext* context, const IsSetRequest* request, IsSetResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -128,6 +128,47 @@ namespace nixnetsocket_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiXnetSocketService::GetSocketOption(::grpc::ServerContext* context, const GetSocketOptionRequest* request, GetSocketOptionResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto socket_grpc_session = request->socket();
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      int32_t level = request->level();
+      int32_t opt_name;
+      switch (request->opt_name_enum_case()) {
+        case nixnetsocket_grpc::GetSocketOptionRequest::OptNameEnumCase::kOptName: {
+          opt_name = static_cast<int32_t>(request->opt_name());
+          break;
+        }
+        case nixnetsocket_grpc::GetSocketOptionRequest::OptNameEnumCase::kOptNameRaw: {
+          opt_name = static_cast<int32_t>(request->opt_name_raw());
+          break;
+        }
+        case nixnetsocket_grpc::GetSocketOptionRequest::OptNameEnumCase::OPT_NAME_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for opt_name was not specified or out of range");
+          break;
+        }
+      }
+
+      void* optval;
+      nxsocklen_t optlen {};
+      auto status = library_->GetSocketOption(socket, level, opt_name, &optval, &optlen);
+      response->set_status(status);
+      if (status_ok(status)) {
+        convert_to_grpc(optval, response->mutable_optval(), request->opt_name(), optlen);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiXnetSocketService::IsSet(::grpc::ServerContext* context, const IsSetRequest* request, IsSetResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nixnetsocket/nixnetsocket_service.h
+++ b/generated/nixnetsocket/nixnetsocket_service.h
@@ -45,6 +45,7 @@ public:
   ::grpc::Status Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response) override;
   ::grpc::Status GetLastErrorNum(::grpc::ServerContext* context, const GetLastErrorNumRequest* request, GetLastErrorNumResponse* response) override;
   ::grpc::Status GetLastErrorStr(::grpc::ServerContext* context, const GetLastErrorStrRequest* request, GetLastErrorStrResponse* response) override;
+  ::grpc::Status GetSocketOption(::grpc::ServerContext* context, const GetSocketOptionRequest* request, GetSocketOptionResponse* response) override;
   ::grpc::Status IsSet(::grpc::ServerContext* context, const IsSetRequest* request, IsSetResponse* response) override;
   ::grpc::Status Select(::grpc::ServerContext* context, const SelectRequest* request, SelectResponse* response) override;
   ::grpc::Status SetSocketOption(::grpc::ServerContext* context, const SetSocketOptionRequest* request, SetSocketOptionResponse* response) override;

--- a/generated/nixnetsocket/nixnetsocket_service.h
+++ b/generated/nixnetsocket/nixnetsocket_service.h
@@ -47,6 +47,7 @@ public:
   ::grpc::Status GetLastErrorStr(::grpc::ServerContext* context, const GetLastErrorStrRequest* request, GetLastErrorStrResponse* response) override;
   ::grpc::Status IsSet(::grpc::ServerContext* context, const IsSetRequest* request, IsSetResponse* response) override;
   ::grpc::Status Select(::grpc::ServerContext* context, const SelectRequest* request, SelectResponse* response) override;
+  ::grpc::Status SetSocketOption(::grpc::ServerContext* context, const SetSocketOptionRequest* request, SetSocketOptionResponse* response) override;
   ::grpc::Status Socket(::grpc::ServerContext* context, const SocketRequest* request, SocketResponse* response) override;
 private:
   NiXnetSocketLibraryInterface* library_;

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -46,6 +46,14 @@ def is_repeated_varargs_parameter(parameter: dict):
     """
     return parameter.get("repeated_var_args", False)
 
+def is_meta_parameter(parameter: dict):
+    """Whether the parameter is a meta parameter only included in proto.
+
+    This means the parameter is an extra paramater included in the proto but not
+    in the API.
+    """
+    return parameter.get("meta_param", False)
+
 
 def is_repeating_parameter(parameter: dict):
     """Whether the parameter is a repeating parameter.
@@ -1076,5 +1084,6 @@ def get_driver_api_params(parameters: List[dict]) -> List[dict]:
     Excludes:
     * Return values.
     * Outputs that are calculated/populated after the API call.
+    * Meta params (proto only)
     """
-    return [p for p in parameters if not (is_return_value(p) or is_get_last_error_output_param(p))]
+    return [p for p in parameters if not (is_return_value(p) or is_get_last_error_output_param(p) or is_meta_parameter(p))]

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -37,9 +37,10 @@ def is_pointer_parameter(parameter):
     """Whether the parameter is a pointer parameter."""
     return is_output_parameter(parameter) or parameter.get("pointer", False)
 
+
 def is_void(parameter):
     """Whether the parameter is a void type."""
-    return parameter['type'] in ["void"]
+    return parameter["type"] in ["void"]
 
 
 def is_repeated_varargs_parameter(parameter: dict):
@@ -49,6 +50,7 @@ def is_repeated_varargs_parameter(parameter: dict):
     arbitrary repetition of fixed arguments.
     """
     return parameter.get("repeated_var_args", False)
+
 
 def is_meta_parameter(parameter: dict):
     """Whether the parameter is a meta parameter only included in proto.
@@ -1090,4 +1092,8 @@ def get_driver_api_params(parameters: List[dict]) -> List[dict]:
     * Outputs that are calculated/populated after the API call.
     * Meta params (proto only)
     """
-    return [p for p in parameters if not (is_return_value(p) or is_get_last_error_output_param(p) or is_meta_parameter(p))]
+    return [
+        p
+        for p in parameters
+        if not (is_return_value(p) or is_get_last_error_output_param(p) or is_meta_parameter(p))
+    ]

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -37,6 +37,10 @@ def is_pointer_parameter(parameter):
     """Whether the parameter is a pointer parameter."""
     return is_output_parameter(parameter) or parameter.get("pointer", False)
 
+def is_void(parameter):
+    """Whether the parameter is a void type."""
+    return parameter['type'] in ["void"]
+
 
 def is_repeated_varargs_parameter(parameter: dict):
     """Whether the parameter is a repeated varargs parameter.

--- a/source/codegen/metadata/nixnetsocket/custom_proto.mako
+++ b/source/codegen/metadata/nixnetsocket/custom_proto.mako
@@ -18,7 +18,7 @@ message SockAddr {
 }
 
 message SockOptData {
-  SocketOptions opt = 1;
+  int32 opt = 1;
   oneof data {
     int32 data_int32 = 2;
     bool data_bool = 3;

--- a/source/codegen/metadata/nixnetsocket/custom_proto.mako
+++ b/source/codegen/metadata/nixnetsocket/custom_proto.mako
@@ -18,7 +18,7 @@ message SockAddr {
 }
 
 message SockOptData {
-  int32 opt = 1;
+  SocketOptions opt = 1;
   oneof data {
     int32 data_int32 = 2;
     bool data_bool = 3;

--- a/source/codegen/metadata/nixnetsocket/custom_proto.mako
+++ b/source/codegen/metadata/nixnetsocket/custom_proto.mako
@@ -16,3 +16,12 @@ message SockAddr {
     SockAddrIPv6 ipv6 = 2;
   }
 }
+
+message SockOptData {
+  int32 opt = 1;
+  oneof data {
+    int32 data_int32 = 2;
+    bool data_bool = 3;
+    string data_string = 4;
+  }
+}

--- a/source/codegen/metadata/nixnetsocket/enums.py
+++ b/source/codegen/metadata/nixnetsocket/enums.py
@@ -1,1 +1,38 @@
-enums = {}
+enums = {
+  'SocketOptions': {
+        'values': [
+            {
+                'name': 'RX_DATA',
+                'value': 257
+            },
+            {
+                'name': 'RCV_BUF',
+                'value': 258
+            },
+            {
+                'name': 'SND_BUF',
+                'value': 259
+            },
+            {
+                'name': 'NON_BLOCK',
+                'value': 260
+            },
+            {
+                'name': 'BIND_TO_DEVICE',
+                'value': 261
+            },
+            {
+                'name': 'ERROR',
+                'value': 262
+            },
+            {
+                'name': 'LINGER',
+                'value': 263
+            },
+            {
+                'name': 'REUSE_ADDR',
+                'value': 264
+            }
+        ]
+    },
+}

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -138,8 +138,52 @@ functions = {
             },
         ],
         'returns': 'int32_t'
-
-
+    },
+    'SetSocketOption': {
+        'cname': 'nxsetsockopt',
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'socket',
+                'type': 'nxSOCKET'
+            },
+            {
+                'direction': 'in',
+                'name': 'level',
+                'type': 'int32_t'
+            },
+            {
+                'direction': 'in',
+                'name': 'opt_data',
+                'grpc_type': 'SockOptData',
+                'supports_standard_copy_convert': True,
+                'meta_param': True,
+                'type': 'SockOptDataHolder'
+            },
+            {
+                'direction': 'in',
+                'name': 'optname',
+                'hardcoded_value': 'opt_data.name()',
+                'include_in_proto': False,
+                'type': 'int32_t'
+            },
+            {
+                'direction': 'in',
+                'name': 'optval',
+                'hardcoded_value': 'opt_data.data()',
+                'include_in_proto': False,
+                'pointer': True,
+                'type': 'void'
+            },
+            {
+                'direction': 'in',
+                'name': 'optlen',
+                'hardcoded_value': 'opt_data.size()',
+                'include_in_proto': False,
+                'type': 'nxsocklen_t'
+            }
+        ],
+        'returns': 'int32_t'
     },
     'Socket': {
         'cname': 'nxsocket',

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -71,6 +71,7 @@ functions = {
     },
     'GetSocketOption': {
         'cname': 'nxgetsockopt',
+        "codegen_method": "CustomCode",
         'parameters': [
             {
                 'direction': 'in',

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -69,6 +69,43 @@ functions = {
         ],
         'returns': 'char*'
     },
+    'GetSocketOption': {
+        'cname': 'nxgetsockopt',
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'socket',
+                'type': 'nxSOCKET'
+            },
+            {
+                'direction': 'in',
+                'name': 'level',
+                'type': 'int32_t'
+            },
+            {
+                'direction': 'in',
+                'name': 'opt_name',
+                'type': 'int32_t',
+                'enum': 'SocketOptions'
+            },
+            {
+                'direction': 'out',
+                'name': 'optval',
+                'grpc_type': 'SockOptData',
+                'supports_standard_copy_convert': True,
+                'additional_arguments_to_copy_convert': ['request->opt_name()', 'optlen'],
+                'pointer': True,
+                'type': 'void'
+            },
+            {
+                'direction': 'out',
+                'name': 'optlen',
+                'include_in_proto': False,
+                'type': 'nxsocklen_t'
+            }
+        ],
+        'returns': 'int32_t'
+    },
     'IsSet': {
         'cname': 'nxfd_isset',
         'status_expression': '0',

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -200,7 +200,9 @@ def _validate_function(function_name: str, metadata: dict):
                 if "type" not in parameter:
                     if "grpc_type" not in parameter:
                         raise Exception(f"parameter {parameter['name']} has no type or grpc_type!")
-                    if not parameter.get("repeated_var_args", False) and not parameter.get("meta_param", False):
+                    if not parameter.get("repeated_var_args", False) and not parameter.get(
+                        "meta_param", False
+                    ):
                         raise Exception(
                             f"parameter {parameter['name']} has no type and repeated_var_args or meta_param is not set!"
                         )

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -79,6 +79,7 @@ PARAM_SCHEMA = Schema(
         Optional("supports_standard_copy_convert"): bool,
         Optional("get_last_error"): bool,
         Optional("additional_arguments_to_copy_convert"): [str],
+        Optional("meta_param"): bool,
     }
 )
 
@@ -199,9 +200,9 @@ def _validate_function(function_name: str, metadata: dict):
                 if "type" not in parameter:
                     if "grpc_type" not in parameter:
                         raise Exception(f"parameter {parameter['name']} has no type or grpc_type!")
-                    if not parameter.get("repeated_var_args", False):
+                    if not parameter.get("repeated_var_args", False) and not parameter.get("meta_param", False):
                         raise Exception(
-                            f"parameter {parameter['name']} has no type and repeated_var_args is not set!"
+                            f"parameter {parameter['name']} has no type and repeated_var_args or meta_param is not set!"
                         )
                 if "enum" in parameter:
                     if parameter["enum"] not in metadata["enums"]:

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -679,6 +679,8 @@ ${initialize_standard_input_param(function_name, parameter)}
       response->mutable_${parameter_name}()->Resize(${size}, 0);
       ${underlying_param_type}* ${parameter_name} = response->mutable_${parameter_name}()->mutable_data();
 %     endif
+%   elif common_helpers.is_void(parameter):
+      ${underlying_param_type}* ${parameter_name};
 %   else:
       ${underlying_param_type} ${parameter_name} {};
 %   endif
@@ -800,7 +802,7 @@ ${copy_to_response_with_transform(source_buffer=raw_response_field, parameter_na
 ${initialize_response_buffer(parameter_name=parameter_name, parameter=parameter)}\
 ${copy_to_response_with_transform(source_buffer=parameter_name, parameter_name=parameter_name, transform_x="x", size=common_helpers.get_size_expression(parameter))}\
 %   elif common_helpers.supports_standard_copy_conversion_routines(parameter):
-        convert_to_grpc(${parameter_name}, response->mutable_${parameter_name}());
+        convert_to_grpc(${parameter_name}, ${str.join(", ", [f"response->mutable_{parameter_name}()"] + parameter.get("additional_arguments_to_copy_convert", []))});
 %   elif common_helpers.is_string_arg(parameter):
         response->set_${parameter_name}(${parameter_name});
 %   elif parameter['grpc_type'] == 'nidevice_grpc.Session':

--- a/source/custom/nixnetsocket_service.custom.cpp
+++ b/source/custom/nixnetsocket_service.custom.cpp
@@ -1,2 +1,93 @@
+#include <nixnetsocket/nixnetsocket_service.h>
+
+#include <atomic>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+#include "xnetsocket_converters.h"
+
 namespace nixnetsocket_grpc {
+
+// Returns true if it's safe to use outputs of a method with the given status.
+inline bool status_ok(int32 status)
+{
+  return status >= 0;
+}
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+::grpc::Status NiXnetSocketService::GetSocketOption(::grpc::ServerContext* context, const GetSocketOptionRequest* request, GetSocketOptionResponse* response)
+{
+  if (context->IsCancelled()) {
+    return ::grpc::Status::CANCELLED;
+  }
+  try {
+    auto socket_grpc_session = request->socket();
+    nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+    int32_t level = request->level();
+    int32_t opt_name;
+    switch (request->opt_name_enum_case()) {
+      case nixnetsocket_grpc::GetSocketOptionRequest::OptNameEnumCase::kOptName: {
+        opt_name = static_cast<int32_t>(request->opt_name());
+        break;
+      }
+      case nixnetsocket_grpc::GetSocketOptionRequest::OptNameEnumCase::kOptNameRaw: {
+        opt_name = static_cast<int32_t>(request->opt_name_raw());
+        break;
+      }
+      case nixnetsocket_grpc::GetSocketOptionRequest::OptNameEnumCase::OPT_NAME_ENUM_NOT_SET: {
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for opt_name was not specified or out of range");
+        break;
+      }
+    }
+
+    response->mutable_optval()->set_opt(request->opt_name_raw());
+    nxsocklen_t optlen{};
+    int32_t status;
+    switch (request->opt_name_raw()) {
+      case SocketOptions::SOCKET_OPTIONS_RX_DATA:
+      case SocketOptions::SOCKET_OPTIONS_RCV_BUF:
+      case SocketOptions::SOCKET_OPTIONS_SND_BUF: {
+        int32_t data = 0;
+        status = library_->GetSocketOption(socket, level, opt_name, &data, &optlen);
+        response->set_status(status);
+        if (status_ok(status)) {
+          response->mutable_optval()->set_data_int32(data);
+        }
+        break;
+      }
+      case SocketOptions::SOCKET_OPTIONS_NON_BLOCK:
+      case SocketOptions::SOCKET_OPTIONS_LINGER:
+      case SocketOptions::SOCKET_OPTIONS_REUSE_ADDR: {
+        bool data_bool = false;
+        status = library_->GetSocketOption(socket, level, opt_name, &data_bool, &optlen);
+        response->set_status(status);
+        if (status_ok(status)) {
+          response->mutable_optval()->set_data_bool(data_bool);
+        }
+        break;
+      }
+      case SocketOptions::SOCKET_OPTIONS_BIND_TO_DEVICE:
+      case SocketOptions::SOCKET_OPTIONS_ERROR: {
+        std::string data_string(256 - 1, '\0');  // Guessing here that max is 256... don't know how to figure out actual max size for string options.
+        status = library_->GetSocketOption(socket, level, opt_name, (char*)(data_string.data()), &optlen);
+        response->set_status(status);
+        if (status_ok(status)) {
+          response->mutable_optval()->set_data_string(data_string);
+          nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_optval()->mutable_data_string()));
+        }
+        break;
+      }
+      default:
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for opt_name was not recognized.");
+    }
+    return ::grpc::Status::OK;
+  }
+  catch (nidevice_grpc::LibraryLoadException& ex) {
+    return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+  }
+}
+
 }  // namespace nixnetsocket_grpc

--- a/source/custom/nixnetsocket_service.custom.cpp
+++ b/source/custom/nixnetsocket_service.custom.cpp
@@ -43,14 +43,15 @@ inline bool status_ok(int32 status)
       }
     }
 
-    response->mutable_optval()->set_opt(request->opt_name_raw());
+    response->mutable_optval()->set_opt(request->opt_name());
     nxsocklen_t optlen{};
     int32_t status;
-    switch (request->opt_name_raw()) {
+    switch (request->opt_name()) {
       case SocketOptions::SOCKET_OPTIONS_RX_DATA:
       case SocketOptions::SOCKET_OPTIONS_RCV_BUF:
       case SocketOptions::SOCKET_OPTIONS_SND_BUF: {
         int32_t data = 0;
+        optlen = static_cast<nxsocklen_t>(sizeof(data));
         status = library_->GetSocketOption(socket, level, opt_name, &data, &optlen);
         response->set_status(status);
         if (status_ok(status)) {

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -216,31 +216,5 @@ inline SockOptDataHolder convert_from_grpc(const SockOptData& input)
   return SockOptDataHolder(input);
 }
 
-inline void convert_to_grpc(void* optval, SockOptData* data, SocketOptions option, nxsocklen_t optlen)
-{
-  switch (option) {
-    case SocketOptions::SOCKET_OPTIONS_RX_DATA:
-    case SocketOptions::SOCKET_OPTIONS_RCV_BUF:
-    case SocketOptions::SOCKET_OPTIONS_SND_BUF: {
-      int32_t data_int = *(int32_t*)(optval);
-      data->set_data_int32(data_int);
-      break;
-    }
-    case SocketOptions::SOCKET_OPTIONS_NON_BLOCK:
-    case SocketOptions::SOCKET_OPTIONS_LINGER:
-    case SocketOptions::SOCKET_OPTIONS_REUSE_ADDR: {
-      bool data_bool = *(bool*)(optval);
-      data->set_data_bool(data_bool);
-      break;
-    }
-    case SocketOptions::SOCKET_OPTIONS_BIND_TO_DEVICE:
-    case SocketOptions::SOCKET_OPTIONS_ERROR: {
-      const char* string = (char*)(optval);
-      data->set_data_string(string);
-      break;
-    }
-  }
-}
-
 }  // namespace nixnetsocket_grpc
 #endif /* NIDEVICE_GRPC_DEVICE_XNET_SOCKET_CONVERTERS_H */

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -216,5 +216,31 @@ inline SockOptDataHolder convert_from_grpc(const SockOptData& input)
   return SockOptDataHolder(input);
 }
 
+inline void convert_to_grpc(void* optval, SockOptData* data, SocketOptions option, nxsocklen_t optlen)
+{
+  switch (option) {
+    case SocketOptions::SOCKET_OPTIONS_RX_DATA:
+    case SocketOptions::SOCKET_OPTIONS_RCV_BUF:
+    case SocketOptions::SOCKET_OPTIONS_SND_BUF: {
+      int32_t data_int = *(int32_t*)(optval);
+      data->set_data_int32(data_int);
+      break;
+    }
+    case SocketOptions::SOCKET_OPTIONS_NON_BLOCK:
+    case SocketOptions::SOCKET_OPTIONS_LINGER:
+    case SocketOptions::SOCKET_OPTIONS_REUSE_ADDR: {
+      bool data_bool = *(bool*)(optval);
+      data->set_data_bool(data_bool);
+      break;
+    }
+    case SocketOptions::SOCKET_OPTIONS_BIND_TO_DEVICE:
+    case SocketOptions::SOCKET_OPTIONS_ERROR: {
+      const char* string = (char*)(optval);
+      data->set_data_string(string);
+      break;
+    }
+  }
+}
+
 }  // namespace nixnetsocket_grpc
 #endif /* NIDEVICE_GRPC_DEVICE_XNET_SOCKET_CONVERTERS_H */

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -149,5 +149,72 @@ inline TimeValHolder convert_from_grpc(const pb_::Duration& input)
 {
   return TimeValHolder(input);
 }
+
+// This class allows us to have something allocated on the stack that can be used as an
+// nxsockaddr* and initialized from a grpc SockAddr using standard codegen and copy convert routines.
+struct SockOptDataHolder {
+  SockOptData opt_data;
+  int32_t data_int;
+  bool data_bool;
+  std::string data_string;
+
+  SockOptDataHolder(const SockOptData& input) : opt_data(input)
+  {
+    data_int = opt_data.data_int32();
+    data_bool = opt_data.data_bool();
+    data_string = std::string(opt_data.data_string());
+  }
+
+  int32_t name() const
+  {
+    return opt_data.opt();
+  }
+
+  void* data()
+  {
+    void* dummy_pointer;
+    switch (opt_data.data_case()) {
+      case SockOptData::DataCase::kDataInt32:
+        dummy_pointer = &data_int;
+        break;
+      case SockOptData::DataCase::kDataString:
+        dummy_pointer = &data_string;
+        break;
+      case SockOptData::DataCase::kDataBool:
+        dummy_pointer = &data_bool;
+        break;
+      default:
+        // pass dummy_pointer
+        break;
+    }
+    return dummy_pointer;
+  }
+
+  // size() method is used to simplify codegen calculating the size of the
+  // selected data.
+  nxsocklen_t size() const
+  {
+    switch (opt_data.data_case()) {
+      case SockOptData::DataCase::kDataInt32:
+        return sizeof(int32_t);
+        break;
+      case SockOptData::DataCase::kDataString:
+        return opt_data.data_string().size();
+        break;
+      case SockOptData::DataCase::kDataBool:
+        return sizeof(bool);
+      default:
+        return 0;
+        break;
+    }
+  }
+};
+
+template <typename TSockOptData>
+inline SockOptDataHolder convert_from_grpc(const SockOptData& input)
+{
+  return SockOptDataHolder(input);
+}
+
 }  // namespace nixnetsocket_grpc
 #endif /* NIDEVICE_GRPC_DEVICE_XNET_SOCKET_CONVERTERS_H */

--- a/source/tests/system/nixnetsocket_driver_api_tests.cpp
+++ b/source/tests/system/nixnetsocket_driver_api_tests.cpp
@@ -136,6 +136,27 @@ TEST_F(NiXnetDriverApiTests, InvalidSocket_Select_ReturnsAndSetsExpectedErrors)
   EXPECT_XNET_ERROR(SOCKET_COULD_NOT_BE_FOUND_ERROR, select_last_error);
   EXPECT_THAT(SOCKET_COULD_NOT_BE_FOUND_MESSAGE, select_last_error_str.error());
 }
+
+TEST_F(NiXnetDriverApiTests, Socket_GetSocketOptionMulticastTTL_ResponseIsReasonable)
+{
+  auto socket_response = socket(stub());
+  auto get_socket_option_response = client::get_socket_option(stub(), socket_response.socket(), 13 /* nxSOL_SOCKET */, SocketOptions::SOCKET_OPTIONS_SND_BUF);
+
+  EXPECT_SUCCESS(get_socket_option_response);
+  EXPECT_EQ(get_socket_option_response.optval().data_int32(), 1);
+}
+
+TEST_F(NiXnetDriverApiTests, Socket_SetSocketOptionMulticastTTL_ResponseIsReasonable)
+{
+  auto socket_response = socket(stub());
+  SockOptData sock_opt_data;
+  sock_opt_data.set_opt(SocketOptions::SOCKET_OPTIONS_SND_BUF);
+  sock_opt_data.set_data_int32(1000);
+  auto set_socket_option_response = client::set_socket_option(stub(), socket_response.socket(), 13 /* nxSOL_SOCKET */, sock_opt_data);
+
+  EXPECT_SUCCESS(set_socket_option_response);
+}
+
 }  // namespace
 }  // namespace system
 }  // namespace tests


### PR DESCRIPTION
### What does this Pull Request accomplish?

Includes the getsockopt and setsockopt methods to the xnetsocket gRPC service.

### Why should this Pull Request be merged?

Fixes [AB#1872848](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1872848).

### What testing has been done?

TODO: Still figuring out how to get system tests running.
