### PR TITLE
Add support for SockAddr outputs and allocate_output_storage

### DIFF
--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -18,6 +18,7 @@
 
 namespace nidaqmx_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -15,6 +15,7 @@
 
 namespace nidcpower_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -15,6 +15,7 @@
 
 namespace nidigitalpattern_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -15,6 +15,7 @@
 
 namespace nidmm_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -16,6 +16,7 @@
 
 namespace nifake_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nifake_extension/nifake_extension_service.cpp
+++ b/generated/nifake_extension/nifake_extension_service.cpp
@@ -15,6 +15,7 @@
 
 namespace nifake_extension_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -18,6 +18,7 @@
 
 namespace nifake_non_ivi_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -15,6 +15,7 @@
 
 namespace nifgen_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
@@ -16,6 +16,7 @@
 
 namespace nirfmxbluetooth_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -16,6 +16,7 @@
 
 namespace nirfmxinstr_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nirfmxlte/nirfmxlte_service.cpp
+++ b/generated/nirfmxlte/nirfmxlte_service.cpp
@@ -16,6 +16,7 @@
 
 namespace nirfmxlte_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nirfmxnr/nirfmxnr_service.cpp
+++ b/generated/nirfmxnr/nirfmxnr_service.cpp
@@ -16,6 +16,7 @@
 
 namespace nirfmxnr_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nirfmxspecan/nirfmxspecan_service.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_service.cpp
@@ -16,6 +16,7 @@
 
 namespace nirfmxspecan_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nirfmxwlan/nirfmxwlan_service.cpp
+++ b/generated/nirfmxwlan/nirfmxwlan_service.cpp
@@ -17,6 +17,7 @@
 
 namespace nirfmxwlan_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -16,6 +16,7 @@
 
 namespace nirfsa_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nirfsg/nirfsg_service.cpp
+++ b/generated/nirfsg/nirfsg_service.cpp
@@ -15,6 +15,7 @@
 
 namespace nirfsg_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -15,6 +15,7 @@
 
 namespace niscope_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -15,6 +15,7 @@
 
 namespace niswitch_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -15,6 +15,7 @@
 
 namespace nisync_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -15,6 +15,7 @@
 
 namespace nitclk_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nixnet/nixnet_service.cpp
+++ b/generated/nixnet/nixnet_service.cpp
@@ -15,6 +15,7 @@
 
 namespace nixnet_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -63,6 +63,8 @@ message AcceptRequest {
 message AcceptResponse {
   int32 status = 1;
   SockAddr addr = 2;
+  string error_message = 3;
+  int32 error_num = 4;
 }
 
 message BindRequest {

--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -17,6 +17,7 @@ import "session.proto";
 import "google/protobuf/duration.proto";
 
 service NiXnetSocket {
+  rpc Accept(AcceptRequest) returns (AcceptResponse);
   rpc Bind(BindRequest) returns (BindResponse);
   rpc Close(CloseRequest) returns (CloseResponse);
   rpc GetLastErrorNum(GetLastErrorNumRequest) returns (GetLastErrorNumResponse);
@@ -47,6 +48,15 @@ message SockAddr {
     SockAddrIPv4 ipv4 = 1;
     SockAddrIPv6 ipv6 = 2;
   }
+}
+
+message AcceptRequest {
+  nidevice_grpc.Session socket = 1;
+}
+
+message AcceptResponse {
+  int32 status = 1;
+  SockAddr addr = 2;
 }
 
 message BindRequest {

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -17,6 +17,22 @@
 
 namespace nixnetsocket_grpc::experimental::client {
 
+AcceptResponse
+accept(const StubPtr& stub, const nidevice_grpc::Session& socket)
+{
+  ::grpc::ClientContext context;
+
+  auto request = AcceptRequest{};
+  request.mutable_socket()->CopyFrom(socket);
+
+  auto response = AcceptResponse{};
+
+  raise_if_error(
+      stub->Accept(&context, request, &response));
+
+  return response;
+}
+
 BindResponse
 bind(const StubPtr& stub, const nidevice_grpc::Session& socket, const SockAddr& name)
 {

--- a/generated/nixnetsocket/nixnetsocket_client.h
+++ b/generated/nixnetsocket/nixnetsocket_client.h
@@ -22,6 +22,7 @@ using StubPtr = std::unique_ptr<NiXnetSocket::Stub>;
 using namespace nidevice_grpc::experimental::client;
 
 
+AcceptResponse accept(const StubPtr& stub, const nidevice_grpc::Session& socket);
 BindResponse bind(const StubPtr& stub, const nidevice_grpc::Session& socket, const SockAddr& name);
 CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& socket);
 GetLastErrorNumResponse get_last_error_num(const StubPtr& stub);

--- a/generated/nixnetsocket/nixnetsocket_library.h
+++ b/generated/nixnetsocket/nixnetsocket_library.h
@@ -18,6 +18,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   virtual ~NiXnetSocketLibrary();
 
   ::grpc::Status check_function_exists(std::string functionName);
+  int32_t Accept(nxSOCKET socket, nxsockaddr* addr, nxsocklen_t* addrlen);
   int32_t Bind(nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen);
   int32_t Close(nxSOCKET socket);
   int32_t GetLastErrorNum();
@@ -27,6 +28,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   nxSOCKET Socket(nxIpStackRef_t stack_ref, int32_t domain, int32_t type, int32_t prototcol);
 
  private:
+  using AcceptPtr = decltype(&nxaccept);
   using BindPtr = decltype(&nxbind);
   using ClosePtr = decltype(&nxclose);
   using GetLastErrorNumPtr = decltype(&nxgetlasterrornum);
@@ -36,6 +38,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   using SocketPtr = decltype(&nxsocket);
 
   typedef struct FunctionPointers {
+    AcceptPtr Accept;
     BindPtr Bind;
     ClosePtr Close;
     GetLastErrorNumPtr GetLastErrorNum;

--- a/generated/nixnetsocket/nixnetsocket_library_interface.h
+++ b/generated/nixnetsocket/nixnetsocket_library_interface.h
@@ -15,6 +15,7 @@ class NiXnetSocketLibraryInterface {
  public:
   virtual ~NiXnetSocketLibraryInterface() {}
 
+  virtual int32_t Accept(nxSOCKET socket, nxsockaddr* addr, nxsocklen_t* addrlen) = 0;
   virtual int32_t Bind(nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen) = 0;
   virtual int32_t Close(nxSOCKET socket) = 0;
   virtual int32_t GetLastErrorNum() = 0;

--- a/generated/nixnetsocket/nixnetsocket_mock_library.h
+++ b/generated/nixnetsocket/nixnetsocket_mock_library.h
@@ -17,6 +17,7 @@ namespace unit {
 
 class NiXnetSocketMockLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterface {
  public:
+  MOCK_METHOD(int32_t, Accept, (nxSOCKET socket, nxsockaddr* addr, nxsocklen_t* addrlen), (override));
   MOCK_METHOD(int32_t, Bind, (nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen), (override));
   MOCK_METHOD(int32_t, Close, (nxSOCKET socket), (override));
   MOCK_METHOD(int32_t, GetLastErrorNum, (), (override));

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -62,6 +62,12 @@ namespace nixnetsocket_grpc {
       if (status_ok(status)) {
         convert_to_grpc(addr, response->mutable_addr());
       }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+        const auto error_num = get_last_error_num(library_);
+        response->set_error_num(error_num);
+      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {

--- a/generated/nixnetsocket/nixnetsocket_service.h
+++ b/generated/nixnetsocket/nixnetsocket_service.h
@@ -41,6 +41,7 @@ public:
     const NiXnetSocketFeatureToggles& feature_toggles = {});
   virtual ~NiXnetSocketService();
   
+  ::grpc::Status Accept(::grpc::ServerContext* context, const AcceptRequest* request, AcceptResponse* response) override;
   ::grpc::Status Bind(::grpc::ServerContext* context, const BindRequest* request, BindResponse* response) override;
   ::grpc::Status Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response) override;
   ::grpc::Status GetLastErrorNum(::grpc::ServerContext* context, const GetLastErrorNumRequest* request, GetLastErrorNumResponse* response) override;

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -135,6 +135,11 @@ def supports_standard_copy_conversion_routines(parameter: dict) -> bool:
     )
 
 
+def supports_standard_output_allocation_routines(parameter: dict) -> bool:
+    """Whether the parameter can be allocated as an output param with allocate_output_storage."""
+    return parameter.get("supports_standard_output_allocation", False)
+
+
 def _any_function_uses_grpc_type(functions, type_name):
     return any(p["grpc_type"] == type_name for f in functions for p in functions[f]["parameters"])
 

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -1,4 +1,29 @@
 functions = {
+    'Accept': {
+        'cname': 'nxaccept',
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'socket',
+                'type': 'nxSOCKET'
+            },
+            {
+                'direction': 'out',
+                'grpc_type': 'SockAddr',
+                'name': 'addr',
+                'supports_standard_output_allocation': True,
+                'supports_standard_copy_convert': True,
+                'type': 'nxsockaddr'
+            },
+            {
+                'direction': 'out',
+                'name': 'addrlen',
+                'include_in_proto': False,
+                'type': 'nxsocklen_t'
+            },
+        ],
+        'returns': 'int32_t'
+    },
     'Bind': {
         'cname': 'nxbind',
         'parameters': [

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -77,6 +77,7 @@ PARAM_SCHEMA = Schema(
         Optional("grpc_name"): str,
         Optional("return_value"): bool,
         Optional("supports_standard_copy_convert"): bool,
+        Optional("supports_standard_output_allocation"): bool,
         Optional("get_last_error"): bool,
         Optional("additional_arguments_to_copy_convert"): [str],
     }

--- a/source/codegen/templates/service.cpp.mako
+++ b/source/codegen/templates/service.cpp.mako
@@ -54,6 +54,7 @@ resource_repository_deps = service_helpers.get_driver_shared_resource_repository
 
 namespace ${config["namespace_component"]}_grpc {
 
+  using nidevice_grpc::converters::allocate_output_storage;
   using nidevice_grpc::converters::calculate_linked_array_size;
   using nidevice_grpc::converters::convert_from_grpc;
   using nidevice_grpc::converters::convert_to_grpc;

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -11,6 +11,7 @@
 #include <cstring>
 #include <memory>
 
+// Helper classes and overrides of standard conversion routines go in nixnetsocket_grpc.
 namespace nixnetsocket_grpc {
 
 // Add underscore to usings so they don't conflict with including files in the same namespace.
@@ -19,8 +20,8 @@ using ResourceRepositorySharedPtr_ = std::shared_ptr<nidevice_grpc::SessionResou
 
 // This class allows us to have something allocated on the stack that can be used as an
 // nxsockaddr* and initialized from a grpc SockAddr using standard codegen and copy convert routines.
-struct SockAddrHolder {
-  SockAddrHolder(const SockAddr& input)
+struct SockAddrInputConverter {
+  SockAddrInputConverter(const SockAddr& input)
   {
     // memset zero ensures:
     // (a) any unset bytes in the ipv6 addr are zero.
@@ -46,7 +47,7 @@ struct SockAddrHolder {
         addr.ipv6.sin6_scope_id = input.ipv6().scope_id();
         break;
       default:
-        // pass. Use zero'd out SockAddrHolder.
+        // pass. Use zero'd out SockAddrInputConverter.
         break;
     }
   }
@@ -85,8 +86,68 @@ struct SockAddrHolder {
   } addr;
 };
 
-struct SetHolder {
-  SetHolder(
+// This class allows us to have something allocated on the stack that provides backing
+// storage for an nxsockaddr output param and converts it to the SockAddr grpc-type.
+struct SockAddrOutputConverter {
+  SockAddrOutputConverter()
+  {
+    std::memset(&storage, 0, sizeof(storage));
+  }
+
+  template <typename TAddr>
+  const TAddr* storage_cast() const
+  {
+    return reinterpret_cast<const TAddr*>(&storage);
+  }
+
+  template <typename TAddr>
+  TAddr* storage_cast()
+  {
+    return reinterpret_cast<TAddr*>(&storage);
+  }
+
+  // Overriding the address_of operator is like a implicit conversion for output
+  // params. This works with our default output param passing codegen that passes
+  // this as nxaccepr(sock, &addr, &addrlen);
+  nxsockaddr* operator&()
+  {
+    return storage_cast<nxsockaddr>();
+  }
+
+  void to_grpc(SockAddr& output) const
+  {
+    switch (storage.ss_family) {
+      case nxAF_INET: {
+        auto ipv4_input = storage_cast<const nxsockaddr_in>();
+        auto ipv4_output = output.mutable_ipv4();
+        ipv4_output->set_port(ipv4_input->sin_port);
+        ipv4_output->set_addr(ipv4_input->sin_addr.addr);
+      } break;
+      case nxAF_INET6: {
+        const auto ipv6_input = storage_cast<const nxsockaddr_in6>();
+        auto ipv6_output = output.mutable_ipv6();
+        ipv6_output->set_port(ipv6_input->sin6_port);
+        ipv6_output->set_flow_info(ipv6_input->sin6_flowinfo);
+        // Reinterpret unsigned char to char.
+        auto addr_out = reinterpret_cast<const char*>(ipv6_input->sin6_addr.addr);
+        auto addr_size = sizeof(ipv6_input->sin6_addr.addr);
+        ipv6_output->set_addr(
+            {&addr_out[0],
+             &addr_out[addr_size]});
+        ipv6_output->set_scope_id(ipv6_input->sin6_scope_id);
+      } break;
+      default:
+        break;
+    }
+  }
+
+  // nxsockaddr_storage is a type specifically designed to be large enough to hold
+  // any of the nxsockaddr types.
+  nxsockaddr_storage storage;
+};
+
+struct SetInputConverter {
+  SetInputConverter(
       const pb_::RepeatedPtrField<nidevice_grpc::Session>& input,
       const ResourceRepositorySharedPtr_& resource_repository)
   {
@@ -110,8 +171,8 @@ struct SetHolder {
   nxfd_set set;
 };
 
-struct TimeValHolder {
-  TimeValHolder(const pb_::Duration& input)
+struct TimeValInputConverter {
+  TimeValInputConverter(const pb_::Duration& input)
   {
     time_val.tv_sec = input.seconds();
     time_val.tv_usec = input.nanos() / 1000;
@@ -131,23 +192,41 @@ struct TimeValHolder {
 };
 
 template <typename TSockAddr>
-inline SockAddrHolder convert_from_grpc(const SockAddr& input)
+inline SockAddrInputConverter convert_from_grpc(const SockAddr& input)
 {
-  return SockAddrHolder(input);
+  return SockAddrInputConverter(input);
 }
 
-template <typename TSet>
-inline SetHolder convert_from_grpc(
+inline void convert_to_grpc(const SockAddrOutputConverter& input, SockAddr* output)
+{
+  input.to_grpc(*output);
+}
+
+template <typename TTimeVal>
+inline SetInputConverter convert_from_grpc(
     const pb_::RepeatedPtrField<nidevice_grpc::Session>& input,
     const ResourceRepositorySharedPtr_& resource_repository)
 {
-  return SetHolder(input, resource_repository);
+  return SetInputConverter(input, resource_repository);
 }
 
-template <typename TSet>
-inline TimeValHolder convert_from_grpc(const pb_::Duration& input)
+template <typename TTimeVal>
+inline TimeValInputConverter convert_from_grpc(const pb_::Duration& input)
 {
-  return TimeValHolder(input);
+  return TimeValInputConverter(input);
 }
 }  // namespace nixnetsocket_grpc
+
+// Template specializations go in nidevice_grpc::converters.
+namespace nidevice_grpc {
+namespace converters {
+// Specialization of TypeToStorageType so that allocate_storage_type will
+// allocate SockAddrOutputConverters for nxsockaddr output params.
+template <>
+struct TypeToStorageType<nxsockaddr, nixnetsocket_grpc::SockAddr> {
+  using StorageType = nixnetsocket_grpc::SockAddrOutputConverter;
+};
+}  // namespace converters
+}  // namespace nidevice_grpc
+
 #endif /* NIDEVICE_GRPC_DEVICE_XNET_SOCKET_CONVERTERS_H */

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -197,9 +197,9 @@ inline SockAddrInputConverter convert_from_grpc(const SockAddr& input)
   return SockAddrInputConverter(input);
 }
 
-inline void convert_to_grpc(const SockAddrOutputConverter& input, SockAddr* output)
+inline void convert_to_grpc(const SockAddrOutputConverter& storage, SockAddr* output)
 {
-  input.to_grpc(*output);
+  storage.to_grpc(*output);
 }
 
 template <typename TTimeVal>

--- a/source/server/converters.h
+++ b/source/server/converters.h
@@ -288,6 +288,22 @@ inline CVIAbsoluteTime convert_from_grpc(const google::protobuf::Timestamp& valu
   return cviTime;
 }
 
+// TypeToStorageType should be specialized to define a (TDriverType, TGrpcType)->StorageType mapping, which
+// will be used by allocate_output_storage.
+template <typename TDriverType, typename TGrpcType>
+struct TypeToStorageType {
+  using StorageType = TDriverType;
+};
+
+// Constructs a default implementation of TypeToStorageType<TDriverType>::StorageType to use as an output_param.
+// This should be customized by specializing the TypeToStorageType struct.
+template <typename TDriverType, typename TGrpcType>
+typename TypeToStorageType<TDriverType, TGrpcType>::StorageType allocate_output_storage()
+{
+  using StorageType = typename TypeToStorageType<TDriverType, TGrpcType>::StorageType;
+  return StorageType{};
+}
+
 }  // namespace converters
 }  // namespace nidevice_grpc
 

--- a/source/tests/unit/xnet_converters_tests.cpp
+++ b/source/tests/unit/xnet_converters_tests.cpp
@@ -7,6 +7,9 @@
 using namespace nixnetsocket_grpc;
 using namespace ::testing;
 namespace pb = ::google::protobuf;
+using nidevice_grpc::converters::allocate_output_storage;
+using nidevice_grpc::converters::convert_from_grpc;
+using nidevice_grpc::converters::convert_to_grpc;
 
 namespace ni {
 namespace tests {
@@ -43,7 +46,7 @@ SockAddr create_addr_ipv6(pb::uint32 port, pb::uint32 flow_info, const std::vect
 }
 
 void EXPECT_IPV6_ADDR(
-    const SockAddrHolder& converted_addr,
+    const SockAddrInputConverter& converted_addr,
     pb::uint32 port,
     pb::uint32 flow_info,
     const std::vector<char>& address,
@@ -231,6 +234,65 @@ TEST(XnetConvertersTests, DurationWithSubMicroSecondResolution_ConvertFromGrpc_C
 
   EXPECT_EQ(SECONDS, timeval_ptr->tv_sec);
   EXPECT_EQ(MICROS, timeval_ptr->tv_usec);
+}
+
+TEST(XnetConvertersTests, IPv4Address_ConvertToGrpc_ConvertsToIPv4Address)
+{
+  constexpr auto PORT = 100;
+  constexpr auto ADDR = 1234567;
+  auto storage = allocate_output_storage<nxsockaddr, SockAddr>();
+  auto ptr_to_storage = reinterpret_cast<nxsockaddr_in*>(&storage);
+  ptr_to_storage->sin_family = nxAF_INET;
+  ptr_to_storage->sin_port = PORT;
+  ptr_to_storage->sin_addr.addr = ADDR;
+
+  auto grpc_data = SockAddr{};
+  convert_to_grpc(storage, &grpc_data);
+
+  EXPECT_EQ(SockAddr::AddrCase::kIpv4, grpc_data.addr_case());
+  EXPECT_EQ(PORT, grpc_data.ipv4().port());
+  EXPECT_EQ(ADDR, grpc_data.ipv4().addr());
+}
+
+TEST(XnetConvertersTests, IPv6Address_ConvertToGrpc_ConvertsToIPv6Address)
+{
+  constexpr auto PORT = 100;
+  constexpr auto FLOW_INFO = 999;
+  const auto ADDRESS = std::vector<char>{0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xA, 0xB, 0xC, 0xD, 0xE, 0xF};
+  constexpr auto SCOPE_ID = 777;
+  auto storage = allocate_output_storage<nxsockaddr, SockAddr>();
+  auto ptr_to_storage = reinterpret_cast<nxsockaddr_in6*>(&storage);
+  ptr_to_storage->sin6_family = nxAF_INET6;
+  ptr_to_storage->sin6_port = PORT;
+  std::memcpy(
+      ptr_to_storage->sin6_addr.addr,
+      ADDRESS.data(),
+      sizeof(ptr_to_storage->sin6_addr.addr));
+  ptr_to_storage->sin6_flowinfo = FLOW_INFO;
+  ptr_to_storage->sin6_scope_id = SCOPE_ID;
+
+  auto grpc_data = SockAddr{};
+  convert_to_grpc(storage, &grpc_data);
+
+  EXPECT_EQ(SockAddr::AddrCase::kIpv6, grpc_data.addr_case());
+  EXPECT_EQ(PORT, grpc_data.ipv6().port());
+  EXPECT_EQ(FLOW_INFO, grpc_data.ipv6().flow_info());
+  EXPECT_THAT(
+      grpc_data.ipv6().addr(),
+      ElementsAreArray(ADDRESS.data(), ADDRESS.size()));
+  EXPECT_EQ(SCOPE_ID, grpc_data.ipv6().scope_id());
+}
+
+TEST(XnetConvertersTests, UnknownAddress_ConvertToGrpc_ConvertsToUnsetAddress)
+{
+  auto storage = allocate_output_storage<nxsockaddr, SockAddr>();
+  auto ptr_to_storage = &storage;
+  ptr_to_storage->sa_family = nxAF_UNSPEC;
+
+  auto grpc_data = SockAddr{};
+  convert_to_grpc(storage, &grpc_data);
+
+  EXPECT_EQ(SockAddr::AddrCase::ADDR_NOT_SET, grpc_data.addr_case());
 }
 }  // namespace
 }  // namespace unit


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add support for `SockAddr` outputs and `allocate_output_storage`.

### Why should this Pull Request be merged?

Fixes [AB#1881846](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1881846).

Provides a generic mechanism for handling structs that require custom conversion and non-default backing storage for output params.

Required for basic workflow testing in xnet socket service.

### What testing has been done?

Ran and passed all converters tests and all Xnet tests.