### PR TITLE
add remaining nxsocket functions with output sockaddr

### DIFF
--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -23,7 +23,10 @@ service NiXnetSocket {
   rpc Listen(ListenRequest) returns (ListenResponse);
   rpc SendTo(SendToRequest) returns (SendToResponse);
   rpc Send(SendRequest) returns (SendResponse);
+  rpc RecVFrom(RecVFromRequest) returns (RecVFromResponse);
   rpc Recv(RecvRequest) returns (RecvResponse);
+  rpc GetSockName(GetSockNameRequest) returns (GetSockNameResponse);
+  rpc GetPeerName(GetPeerNameRequest) returns (GetPeerNameResponse);
   rpc Shutdown(ShutdownRequest) returns (ShutdownResponse);
   rpc Close(CloseRequest) returns (CloseResponse);
   rpc IpStackClear(IpStackClearRequest) returns (IpStackClearResponse);
@@ -125,6 +128,19 @@ message SendResponse {
   int32 error_num = 3;
 }
 
+message RecVFromRequest {
+  nidevice_grpc.Session socket = 1;
+  bytes mem = 2;
+  int32 flags = 3;
+}
+
+message RecVFromResponse {
+  int32 status = 1;
+  SockAddr from = 2;
+  string error_message = 3;
+  int32 error_num = 4;
+}
+
 message RecvRequest {
   nidevice_grpc.Session socket = 1;
   bytes mem = 2;
@@ -135,6 +151,28 @@ message RecvResponse {
   int32 status = 1;
   string error_message = 2;
   int32 error_num = 3;
+}
+
+message GetSockNameRequest {
+  nidevice_grpc.Session socket = 1;
+}
+
+message GetSockNameResponse {
+  int32 status = 1;
+  SockAddr addr = 2;
+  string error_message = 3;
+  int32 error_num = 4;
+}
+
+message GetPeerNameRequest {
+  nidevice_grpc.Session socket = 1;
+}
+
+message GetPeerNameResponse {
+  int32 status = 1;
+  SockAddr addr = 2;
+  string error_message = 3;
+  int32 error_num = 4;
 }
 
 message ShutdownRequest {

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -121,6 +121,24 @@ send(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string
   return response;
 }
 
+RecVFromResponse
+rec_v_from(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& mem, const pb::int32& flags)
+{
+  ::grpc::ClientContext context;
+
+  auto request = RecVFromRequest{};
+  request.mutable_socket()->CopyFrom(socket);
+  request.set_mem(mem);
+  request.set_flags(flags);
+
+  auto response = RecVFromResponse{};
+
+  raise_if_error(
+      stub->RecVFrom(&context, request, &response));
+
+  return response;
+}
+
 RecvResponse
 recv(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& mem, const pb::int32& flags)
 {
@@ -135,6 +153,38 @@ recv(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string
 
   raise_if_error(
       stub->Recv(&context, request, &response));
+
+  return response;
+}
+
+GetSockNameResponse
+get_sock_name(const StubPtr& stub, const nidevice_grpc::Session& socket)
+{
+  ::grpc::ClientContext context;
+
+  auto request = GetSockNameRequest{};
+  request.mutable_socket()->CopyFrom(socket);
+
+  auto response = GetSockNameResponse{};
+
+  raise_if_error(
+      stub->GetSockName(&context, request, &response));
+
+  return response;
+}
+
+GetPeerNameResponse
+get_peer_name(const StubPtr& stub, const nidevice_grpc::Session& socket)
+{
+  ::grpc::ClientContext context;
+
+  auto request = GetPeerNameRequest{};
+  request.mutable_socket()->CopyFrom(socket);
+
+  auto response = GetPeerNameResponse{};
+
+  raise_if_error(
+      stub->GetPeerName(&context, request, &response));
 
   return response;
 }

--- a/generated/nixnetsocket/nixnetsocket_client.h
+++ b/generated/nixnetsocket/nixnetsocket_client.h
@@ -28,7 +28,10 @@ ConnectResponse connect(const StubPtr& stub, const nidevice_grpc::Session& socke
 ListenResponse listen(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& backlog);
 SendToResponse send_to(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags, const SockAddr& to);
 SendResponse send(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags);
+RecVFromResponse rec_v_from(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& mem, const pb::int32& flags);
 RecvResponse recv(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& mem, const pb::int32& flags);
+GetSockNameResponse get_sock_name(const StubPtr& stub, const nidevice_grpc::Session& socket);
+GetPeerNameResponse get_peer_name(const StubPtr& stub, const nidevice_grpc::Session& socket);
 ShutdownResponse shutdown(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& how);
 CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& socket);
 IpStackClearResponse ip_stack_clear(const StubPtr& stub, const nidevice_grpc::Session& stack_ref);

--- a/generated/nixnetsocket/nixnetsocket_library.cpp
+++ b/generated/nixnetsocket/nixnetsocket_library.cpp
@@ -27,7 +27,10 @@ NiXnetSocketLibrary::NiXnetSocketLibrary() : shared_library_(kLibraryName)
   function_pointers_.Listen = reinterpret_cast<ListenPtr>(shared_library_.get_function_pointer("nxlisten"));
   function_pointers_.SendTo = reinterpret_cast<SendToPtr>(shared_library_.get_function_pointer("nxsendto"));
   function_pointers_.Send = reinterpret_cast<SendPtr>(shared_library_.get_function_pointer("nxsend"));
+  function_pointers_.RecVFrom = reinterpret_cast<RecVFromPtr>(shared_library_.get_function_pointer("nxrecvfrom"));
   function_pointers_.Recv = reinterpret_cast<RecvPtr>(shared_library_.get_function_pointer("nxrecv"));
+  function_pointers_.GetSockName = reinterpret_cast<GetSockNamePtr>(shared_library_.get_function_pointer("nxgetsockname"));
+  function_pointers_.GetPeerName = reinterpret_cast<GetPeerNamePtr>(shared_library_.get_function_pointer("nxgetpeername"));
   function_pointers_.Shutdown = reinterpret_cast<ShutdownPtr>(shared_library_.get_function_pointer("nxshutdown"));
   function_pointers_.Close = reinterpret_cast<ClosePtr>(shared_library_.get_function_pointer("nxclose"));
   function_pointers_.GetLastErrorNum = reinterpret_cast<GetLastErrorNumPtr>(shared_library_.get_function_pointer("nxgetlasterrornum"));
@@ -122,6 +125,18 @@ int32_t NiXnetSocketLibrary::Send(nxSOCKET socket, char dataptr[], int32_t size,
 #endif
 }
 
+int32_t NiXnetSocketLibrary::RecVFrom(nxSOCKET socket, char mem[], int32_t size, int32_t flags, nxsockaddr* from, nxsocklen_t* fromlen)
+{
+  if (!function_pointers_.RecVFrom) {
+    throw nidevice_grpc::LibraryLoadException("Could not find nxrecvfrom.");
+  }
+#if defined(_MSC_VER)
+  return nxrecvfrom(socket, mem, size, flags, from, fromlen);
+#else
+  return function_pointers_.RecVFrom(socket, mem, size, flags, from, fromlen);
+#endif
+}
+
 int32_t NiXnetSocketLibrary::Recv(nxSOCKET socket, char mem[], int32_t size, int32_t flags)
 {
   if (!function_pointers_.Recv) {
@@ -131,6 +146,30 @@ int32_t NiXnetSocketLibrary::Recv(nxSOCKET socket, char mem[], int32_t size, int
   return nxrecv(socket, mem, size, flags);
 #else
   return function_pointers_.Recv(socket, mem, size, flags);
+#endif
+}
+
+int32_t NiXnetSocketLibrary::GetSockName(nxSOCKET socket, nxsockaddr* addr, nxsocklen_t* addrlen)
+{
+  if (!function_pointers_.GetSockName) {
+    throw nidevice_grpc::LibraryLoadException("Could not find nxgetsockname.");
+  }
+#if defined(_MSC_VER)
+  return nxgetsockname(socket, addr, addrlen);
+#else
+  return function_pointers_.GetSockName(socket, addr, addrlen);
+#endif
+}
+
+int32_t NiXnetSocketLibrary::GetPeerName(nxSOCKET socket, nxsockaddr* addr, nxsocklen_t* addrlen)
+{
+  if (!function_pointers_.GetPeerName) {
+    throw nidevice_grpc::LibraryLoadException("Could not find nxgetpeername.");
+  }
+#if defined(_MSC_VER)
+  return nxgetpeername(socket, addr, addrlen);
+#else
+  return function_pointers_.GetPeerName(socket, addr, addrlen);
 #endif
 }
 

--- a/generated/nixnetsocket/nixnetsocket_library.h
+++ b/generated/nixnetsocket/nixnetsocket_library.h
@@ -24,7 +24,10 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   int32_t Listen(nxSOCKET socket, int32_t backlog);
   int32_t SendTo(nxSOCKET socket, char dataptr[], int32_t size, int32_t flags, nxsockaddr* to, nxsocklen_t tolen);
   int32_t Send(nxSOCKET socket, char dataptr[], int32_t size, int32_t flags);
+  int32_t RecVFrom(nxSOCKET socket, char mem[], int32_t size, int32_t flags, nxsockaddr* from, nxsocklen_t* fromlen);
   int32_t Recv(nxSOCKET socket, char mem[], int32_t size, int32_t flags);
+  int32_t GetSockName(nxSOCKET socket, nxsockaddr* addr, nxsocklen_t* addrlen);
+  int32_t GetPeerName(nxSOCKET socket, nxsockaddr* addr, nxsocklen_t* addrlen);
   int32_t Shutdown(nxSOCKET socket, int32_t how);
   int32_t Close(nxSOCKET socket);
   int32_t GetLastErrorNum();
@@ -42,7 +45,10 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   using ListenPtr = decltype(&nxlisten);
   using SendToPtr = decltype(&nxsendto);
   using SendPtr = decltype(&nxsend);
+  using RecVFromPtr = decltype(&nxrecvfrom);
   using RecvPtr = decltype(&nxrecv);
+  using GetSockNamePtr = decltype(&nxgetsockname);
+  using GetPeerNamePtr = decltype(&nxgetpeername);
   using ShutdownPtr = decltype(&nxshutdown);
   using ClosePtr = decltype(&nxclose);
   using GetLastErrorNumPtr = int32_t (*)();
@@ -60,7 +66,10 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
     ListenPtr Listen;
     SendToPtr SendTo;
     SendPtr Send;
+    RecVFromPtr RecVFrom;
     RecvPtr Recv;
+    GetSockNamePtr GetSockName;
+    GetPeerNamePtr GetPeerName;
     ShutdownPtr Shutdown;
     ClosePtr Close;
     GetLastErrorNumPtr GetLastErrorNum;

--- a/generated/nixnetsocket/nixnetsocket_library_interface.h
+++ b/generated/nixnetsocket/nixnetsocket_library_interface.h
@@ -21,7 +21,10 @@ class NiXnetSocketLibraryInterface {
   virtual int32_t Listen(nxSOCKET socket, int32_t backlog) = 0;
   virtual int32_t SendTo(nxSOCKET socket, char dataptr[], int32_t size, int32_t flags, nxsockaddr* to, nxsocklen_t tolen) = 0;
   virtual int32_t Send(nxSOCKET socket, char dataptr[], int32_t size, int32_t flags) = 0;
+  virtual int32_t RecVFrom(nxSOCKET socket, char mem[], int32_t size, int32_t flags, nxsockaddr* from, nxsocklen_t* fromlen) = 0;
   virtual int32_t Recv(nxSOCKET socket, char mem[], int32_t size, int32_t flags) = 0;
+  virtual int32_t GetSockName(nxSOCKET socket, nxsockaddr* addr, nxsocklen_t* addrlen) = 0;
+  virtual int32_t GetPeerName(nxSOCKET socket, nxsockaddr* addr, nxsocklen_t* addrlen) = 0;
   virtual int32_t Shutdown(nxSOCKET socket, int32_t how) = 0;
   virtual int32_t Close(nxSOCKET socket) = 0;
   virtual int32_t GetLastErrorNum() = 0;

--- a/generated/nixnetsocket/nixnetsocket_mock_library.h
+++ b/generated/nixnetsocket/nixnetsocket_mock_library.h
@@ -23,7 +23,10 @@ class NiXnetSocketMockLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInt
   MOCK_METHOD(int32_t, Listen, (nxSOCKET socket, int32_t backlog), (override));
   MOCK_METHOD(int32_t, SendTo, (nxSOCKET socket, char dataptr[], int32_t size, int32_t flags, nxsockaddr* to, nxsocklen_t tolen), (override));
   MOCK_METHOD(int32_t, Send, (nxSOCKET socket, char dataptr[], int32_t size, int32_t flags), (override));
+  MOCK_METHOD(int32_t, RecVFrom, (nxSOCKET socket, char mem[], int32_t size, int32_t flags, nxsockaddr* from, nxsocklen_t* fromlen), (override));
   MOCK_METHOD(int32_t, Recv, (nxSOCKET socket, char mem[], int32_t size, int32_t flags), (override));
+  MOCK_METHOD(int32_t, GetSockName, (nxSOCKET socket, nxsockaddr* addr, nxsocklen_t* addrlen), (override));
+  MOCK_METHOD(int32_t, GetPeerName, (nxSOCKET socket, nxsockaddr* addr, nxsocklen_t* addrlen), (override));
   MOCK_METHOD(int32_t, Shutdown, (nxSOCKET socket, int32_t how), (override));
   MOCK_METHOD(int32_t, Close, (nxSOCKET socket), (override));
   MOCK_METHOD(int32_t, GetLastErrorNum, (), (override));

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -225,6 +225,39 @@ namespace nixnetsocket_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiXnetSocketService::RecVFrom(::grpc::ServerContext* context, const RecVFromRequest* request, RecVFromResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto socket_grpc_session = request->socket();
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      char* mem = (char*)request->mem().c_str();
+      int32_t size = static_cast<int32_t>(request->mem().size());
+      int32_t flags = request->flags();
+      auto from = allocate_output_storage<nxsockaddr, SockAddr>();
+      nxsocklen_t fromlen {};
+      auto status = library_->RecVFrom(socket, mem, size, flags, &from, &fromlen);
+      response->set_status(status);
+      if (status_ok(status)) {
+        convert_to_grpc(from, response->mutable_from());
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+        const auto error_num = get_last_error_num(library_);
+        response->set_error_num(error_num);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiXnetSocketService::Recv(::grpc::ServerContext* context, const RecvRequest* request, RecvResponse* response)
   {
     if (context->IsCancelled()) {
@@ -239,6 +272,66 @@ namespace nixnetsocket_grpc {
       auto status = library_->Recv(socket, mem, size, flags);
       response->set_status(status);
       if (status_ok(status)) {
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+        const auto error_num = get_last_error_num(library_);
+        response->set_error_num(error_num);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiXnetSocketService::GetSockName(::grpc::ServerContext* context, const GetSockNameRequest* request, GetSockNameResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto socket_grpc_session = request->socket();
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      auto addr = allocate_output_storage<nxsockaddr, SockAddr>();
+      nxsocklen_t addrlen {};
+      auto status = library_->GetSockName(socket, &addr, &addrlen);
+      response->set_status(status);
+      if (status_ok(status)) {
+        convert_to_grpc(addr, response->mutable_addr());
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+        const auto error_num = get_last_error_num(library_);
+        response->set_error_num(error_num);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiXnetSocketService::GetPeerName(::grpc::ServerContext* context, const GetPeerNameRequest* request, GetPeerNameResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto socket_grpc_session = request->socket();
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      auto addr = allocate_output_storage<nxsockaddr, SockAddr>();
+      nxsocklen_t addrlen {};
+      auto status = library_->GetPeerName(socket, &addr, &addrlen);
+      response->set_status(status);
+      if (status_ok(status)) {
+        convert_to_grpc(addr, response->mutable_addr());
       }
       else {
         const auto error_message = get_last_error_message(library_);

--- a/generated/nixnetsocket/nixnetsocket_service.h
+++ b/generated/nixnetsocket/nixnetsocket_service.h
@@ -49,7 +49,10 @@ public:
   ::grpc::Status Listen(::grpc::ServerContext* context, const ListenRequest* request, ListenResponse* response) override;
   ::grpc::Status SendTo(::grpc::ServerContext* context, const SendToRequest* request, SendToResponse* response) override;
   ::grpc::Status Send(::grpc::ServerContext* context, const SendRequest* request, SendResponse* response) override;
+  ::grpc::Status RecVFrom(::grpc::ServerContext* context, const RecVFromRequest* request, RecVFromResponse* response) override;
   ::grpc::Status Recv(::grpc::ServerContext* context, const RecvRequest* request, RecvResponse* response) override;
+  ::grpc::Status GetSockName(::grpc::ServerContext* context, const GetSockNameRequest* request, GetSockNameResponse* response) override;
+  ::grpc::Status GetPeerName(::grpc::ServerContext* context, const GetPeerNameRequest* request, GetPeerNameResponse* response) override;
   ::grpc::Status Shutdown(::grpc::ServerContext* context, const ShutdownRequest* request, ShutdownResponse* response) override;
   ::grpc::Status Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response) override;
   ::grpc::Status IpStackClear(::grpc::ServerContext* context, const IpStackClearRequest* request, IpStackClearResponse* response) override;

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -173,6 +173,52 @@ functions = {
         ],
         'returns': 'int32_t'
     },
+    'RecVFrom': {
+        'cname': 'nxrecvfrom',
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'socket',
+                'type': 'nxSOCKET'
+            },
+            {
+                'direction': 'in',
+                'name': 'mem',
+                'size': {
+                    'mechanism': 'len',
+                    'value': 'size'
+                },
+                'pointer': True,
+                'grpc_type': 'bytes',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'size',
+                'type': 'int32_t'
+            },
+            {
+                'direction': 'in',
+                'name': 'flags',
+                'type': 'int32_t'
+            },
+            {
+                'direction': 'out',
+                'grpc_type': 'SockAddr',
+                'name': 'from',
+                'supports_standard_output_allocation': True,
+                'supports_standard_copy_convert': True,
+                'type': 'nxsockaddr'
+            },
+            {
+                'direction': 'out',
+                'name': 'fromlen',
+                'include_in_proto': False,
+                'type': 'nxsocklen_t'
+            },
+        ],
+        'returns': 'int32_t'
+    },
     'Recv': {
         'cname': 'nxrecv',
         'parameters': [
@@ -201,6 +247,56 @@ functions = {
                 'direction': 'in',
                 'name': 'flags',
                 'type': 'int32_t'
+            },
+        ],
+        'returns': 'int32_t'
+    },
+    'GetSockName': {
+        'cname': 'nxgetsockname',
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'socket',
+                'type': 'nxSOCKET'
+            },
+            {
+                'direction': 'out',
+                'grpc_type': 'SockAddr',
+                'name': 'addr',
+                'supports_standard_output_allocation': True,
+                'supports_standard_copy_convert': True,
+                'type': 'nxsockaddr'
+            },
+            {
+                'direction': 'out',
+                'name': 'addrlen',
+                'include_in_proto': False,
+                'type': 'nxsocklen_t'
+            },
+        ],
+        'returns': 'int32_t'
+    },
+    'GetPeerName': {
+        'cname': 'nxgetpeername',
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'socket',
+                'type': 'nxSOCKET'
+            },
+            {
+                'direction': 'out',
+                'grpc_type': 'SockAddr',
+                'name': 'addr',
+                'supports_standard_output_allocation': True,
+                'supports_standard_copy_convert': True,
+                'type': 'nxsockaddr'
+            },
+            {
+                'direction': 'out',
+                'name': 'addrlen',
+                'include_in_proto': False,
+                'type': 'nxsocklen_t'
             },
         ],
         'returns': 'int32_t'


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds remaining output metadata for SockAddr output nxSocket methods.

### Why should this Pull Request be merged?

Works to increase XNET Socket functionality by adding missing methods. 

### What testing has been done?

All Xnet and conversion tests passing. 
