### PR TITLE
Add GetSockOpt to xnetsocket service.

### DIFF
--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -26,6 +26,7 @@ service NiXnetSocket {
   rpc Recv(RecvRequest) returns (RecvResponse);
   rpc Shutdown(ShutdownRequest) returns (ShutdownResponse);
   rpc Close(CloseRequest) returns (CloseResponse);
+  rpc GetSockOpt(GetSockOptRequest) returns (GetSockOptResponse);
   rpc IpStackClear(IpStackClearRequest) returns (IpStackClearResponse);
   rpc IpStackCreate(IpStackCreateRequest) returns (IpStackCreateResponse);
   rpc IsSet(IsSetRequest) returns (IsSetResponse);
@@ -180,6 +181,22 @@ message CloseResponse {
   int32 status = 1;
   string error_message = 2;
   int32 error_num = 3;
+}
+
+message GetSockOptRequest {
+  nidevice_grpc.Session socket = 1;
+  int32 level = 2;
+  oneof optname_enum {
+    OptName optname = 3;
+    int32 optname_raw = 4;
+  }
+}
+
+message GetSockOptResponse {
+  int32 status = 1;
+  SockOptData optval = 2;
+  string error_message = 3;
+  int32 error_num = 4;
 }
 
 message IpStackClearRequest {

--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -233,11 +233,11 @@ message SelectResponse {
 message SetSockOptRequest {
   nidevice_grpc.Session socket = 1;
   int32 level = 2;
-  SockOptData opt_data = 3;
   oneof optname_enum {
-    OptName optname = 4;
-    int32 optname_raw = 5;
+    OptName optname = 3;
+    int32 optname_raw = 4;
   }
+  SockOptData opt_data = 5;
 }
 
 message SetSockOptResponse {

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -172,6 +172,31 @@ close(const StubPtr& stub, const nidevice_grpc::Session& socket)
   return response;
 }
 
+GetSockOptResponse
+get_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& level, const simple_variant<OptName, pb::int32>& optname)
+{
+  ::grpc::ClientContext context;
+
+  auto request = GetSockOptRequest{};
+  request.mutable_socket()->CopyFrom(socket);
+  request.set_level(level);
+  const auto optname_ptr = optname.get_if<OptName>();
+  const auto optname_raw_ptr = optname.get_if<pb::int32>();
+  if (optname_ptr) {
+    request.set_optname(*optname_ptr);
+  }
+  else if (optname_raw_ptr) {
+    request.set_optname_raw(*optname_raw_ptr);
+  }
+
+  auto response = GetSockOptResponse{};
+
+  raise_if_error(
+      stub->GetSockOpt(&context, request, &response));
+
+  return response;
+}
+
 IpStackClearResponse
 ip_stack_clear(const StubPtr& stub, const nidevice_grpc::Session& stack_ref)
 {

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -242,14 +242,13 @@ select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& read_fds,
 }
 
 SetSockOptResponse
-set_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& level, const SockOptData& opt_data, const simple_variant<OptName, pb::int32>& optname)
+set_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& level, const simple_variant<OptName, pb::int32>& optname, const SockOptData& opt_data)
 {
   ::grpc::ClientContext context;
 
   auto request = SetSockOptRequest{};
   request.mutable_socket()->CopyFrom(socket);
   request.set_level(level);
-  request.mutable_opt_data()->CopyFrom(opt_data);
   const auto optname_ptr = optname.get_if<OptName>();
   const auto optname_raw_ptr = optname.get_if<pb::int32>();
   if (optname_ptr) {
@@ -258,6 +257,7 @@ set_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb
   else if (optname_raw_ptr) {
     request.set_optname_raw(*optname_raw_ptr);
   }
+  request.mutable_opt_data()->CopyFrom(opt_data);
 
   auto response = SetSockOptResponse{};
 

--- a/generated/nixnetsocket/nixnetsocket_client.h
+++ b/generated/nixnetsocket/nixnetsocket_client.h
@@ -35,7 +35,7 @@ IpStackClearResponse ip_stack_clear(const StubPtr& stub, const nidevice_grpc::Se
 IpStackCreateResponse ip_stack_create(const StubPtr& stub, const pb::string& stack_name, const pb::string& config);
 IsSetResponse is_set(const StubPtr& stub, const nidevice_grpc::Session& fd, const std::vector<nidevice_grpc::Session>& set);
 SelectResponse select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& read_fds, const std::vector<nidevice_grpc::Session>& write_fds, const std::vector<nidevice_grpc::Session>& except_fds, const google::protobuf::Duration& timeout);
-SetSockOptResponse set_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& level, const SockOptData& opt_data, const simple_variant<OptName, pb::int32>& optname);
+SetSockOptResponse set_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& level, const simple_variant<OptName, pb::int32>& optname, const SockOptData& opt_data);
 SocketResponse socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const pb::int32& domain, const pb::int32& type, const pb::int32& prototcol);
 
 } // namespace nixnetsocket_grpc::experimental::client

--- a/generated/nixnetsocket/nixnetsocket_client.h
+++ b/generated/nixnetsocket/nixnetsocket_client.h
@@ -31,6 +31,7 @@ SendResponse send(const StubPtr& stub, const nidevice_grpc::Session& socket, con
 RecvResponse recv(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& mem, const pb::int32& flags);
 ShutdownResponse shutdown(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& how);
 CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& socket);
+GetSockOptResponse get_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& level, const simple_variant<OptName, pb::int32>& optname);
 IpStackClearResponse ip_stack_clear(const StubPtr& stub, const nidevice_grpc::Session& stack_ref);
 IpStackCreateResponse ip_stack_create(const StubPtr& stub, const pb::string& stack_name, const pb::string& config);
 IsSetResponse is_set(const StubPtr& stub, const nidevice_grpc::Session& fd, const std::vector<nidevice_grpc::Session>& set);

--- a/generated/nixnetsocket/nixnetsocket_library.cpp
+++ b/generated/nixnetsocket/nixnetsocket_library.cpp
@@ -32,6 +32,7 @@ NiXnetSocketLibrary::NiXnetSocketLibrary() : shared_library_(kLibraryName)
   function_pointers_.Close = reinterpret_cast<ClosePtr>(shared_library_.get_function_pointer("nxclose"));
   function_pointers_.GetLastErrorNum = reinterpret_cast<GetLastErrorNumPtr>(shared_library_.get_function_pointer("nxgetlasterrornum"));
   function_pointers_.GetLastErrorStr = reinterpret_cast<GetLastErrorStrPtr>(shared_library_.get_function_pointer("nxgetlasterrorstr"));
+  function_pointers_.GetSockOpt = reinterpret_cast<GetSockOptPtr>(shared_library_.get_function_pointer("nxgetsockopt"));
   function_pointers_.IpStackClear = reinterpret_cast<IpStackClearPtr>(shared_library_.get_function_pointer("nxIpStackClear"));
   function_pointers_.IpStackCreate = reinterpret_cast<IpStackCreatePtr>(shared_library_.get_function_pointer("nxIpStackCreate"));
   function_pointers_.IsSet = reinterpret_cast<IsSetPtr>(shared_library_.get_function_pointer("nxfd_isset"));
@@ -173,6 +174,18 @@ char* NiXnetSocketLibrary::GetLastErrorStr(char buf[], size_t bufLen)
     throw nidevice_grpc::LibraryLoadException("Could not find nxgetlasterrorstr.");
   }
   return function_pointers_.GetLastErrorStr(buf, bufLen);
+}
+
+int32_t NiXnetSocketLibrary::GetSockOpt(nxSOCKET socket, int32_t level, int32_t optname, void* optval, nxsocklen_t* optlen)
+{
+  if (!function_pointers_.GetSockOpt) {
+    throw nidevice_grpc::LibraryLoadException("Could not find nxgetsockopt.");
+  }
+#if defined(_MSC_VER)
+  return nxgetsockopt(socket, level, optname, optval, optlen);
+#else
+  return function_pointers_.GetSockOpt(socket, level, optname, optval, optlen);
+#endif
 }
 
 int32_t NiXnetSocketLibrary::IpStackClear(nxIpStackRef_t stack_ref)

--- a/generated/nixnetsocket/nixnetsocket_library.h
+++ b/generated/nixnetsocket/nixnetsocket_library.h
@@ -29,6 +29,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   int32_t Close(nxSOCKET socket);
   int32_t GetLastErrorNum();
   char* GetLastErrorStr(char buf[], size_t bufLen);
+  int32_t GetSockOpt(nxSOCKET socket, int32_t level, int32_t optname, void* optval, nxsocklen_t* optlen);
   int32_t IpStackClear(nxIpStackRef_t stack_ref);
   int32_t IpStackCreate(char stack_name[], char config[], nxIpStackRef_t* stack_ref);
   int32_t IsSet(nxSOCKET fd, nxfd_set* set);
@@ -48,6 +49,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   using ClosePtr = decltype(&nxclose);
   using GetLastErrorNumPtr = int32_t (*)();
   using GetLastErrorStrPtr = char* (*)(char buf[], size_t bufLen);
+  using GetSockOptPtr = decltype(&nxgetsockopt);
   using IpStackClearPtr = decltype(&nxIpStackClear);
   using IpStackCreatePtr = decltype(&nxIpStackCreate);
   using IsSetPtr = decltype(&nxfd_isset);
@@ -67,6 +69,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
     ClosePtr Close;
     GetLastErrorNumPtr GetLastErrorNum;
     GetLastErrorStrPtr GetLastErrorStr;
+    GetSockOptPtr GetSockOpt;
     IpStackClearPtr IpStackClear;
     IpStackCreatePtr IpStackCreate;
     IsSetPtr IsSet;

--- a/generated/nixnetsocket/nixnetsocket_library_interface.h
+++ b/generated/nixnetsocket/nixnetsocket_library_interface.h
@@ -26,6 +26,7 @@ class NiXnetSocketLibraryInterface {
   virtual int32_t Close(nxSOCKET socket) = 0;
   virtual int32_t GetLastErrorNum() = 0;
   virtual char* GetLastErrorStr(char buf[], size_t bufLen) = 0;
+  virtual int32_t GetSockOpt(nxSOCKET socket, int32_t level, int32_t optname, void* optval, nxsocklen_t* optlen) = 0;
   virtual int32_t IpStackClear(nxIpStackRef_t stack_ref) = 0;
   virtual int32_t IpStackCreate(char stack_name[], char config[], nxIpStackRef_t* stack_ref) = 0;
   virtual int32_t IsSet(nxSOCKET fd, nxfd_set* set) = 0;

--- a/generated/nixnetsocket/nixnetsocket_mock_library.h
+++ b/generated/nixnetsocket/nixnetsocket_mock_library.h
@@ -28,6 +28,7 @@ class NiXnetSocketMockLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInt
   MOCK_METHOD(int32_t, Close, (nxSOCKET socket), (override));
   MOCK_METHOD(int32_t, GetLastErrorNum, (), (override));
   MOCK_METHOD(char*, GetLastErrorStr, (char buf[], size_t bufLen), (override));
+  MOCK_METHOD(int32_t, GetSockOpt, (nxSOCKET socket, int32_t level, int32_t optname, void* optval, nxsocklen_t* optlen), (override));
   MOCK_METHOD(int32_t, IpStackClear, (nxIpStackRef_t stack_ref), (override));
   MOCK_METHOD(int32_t, IpStackCreate, (char stack_name[], char config[], nxIpStackRef_t* stack_ref), (override));
   MOCK_METHOD(int32_t, IsSet, (nxSOCKET fd, nxfd_set* set), (override));

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -336,7 +336,7 @@ namespace nixnetsocket_grpc {
         }
       }
 
-      auto optval = allocate_output_storage<void *, SockOptData>();
+      auto optval = allocate_output_storage<void *, SockOptData>(optname);
       nxsocklen_t optlen {};
       auto status = library_->GetSockOpt(socket, level, optname, optval.data(), &optlen);
       response->set_status(status);

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -445,7 +445,6 @@ namespace nixnetsocket_grpc {
       auto socket_grpc_session = request->socket();
       nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
       int32_t level = request->level();
-      auto opt_data = convert_from_grpc<SockOptDataInputConverter>(request->opt_data());
       int32_t optname;
       switch (request->optname_enum_case()) {
         case nixnetsocket_grpc::SetSockOptRequest::OptnameEnumCase::kOptname: {
@@ -462,6 +461,7 @@ namespace nixnetsocket_grpc {
         }
       }
 
+      auto opt_data = convert_from_grpc<SockOptDataInputConverter>(request->opt_data());
       auto optval = opt_data.data();
       auto optlen = opt_data.size();
       auto status = library_->SetSockOpt(socket, level, optname, optval, optlen);

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -311,6 +311,53 @@ namespace nixnetsocket_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiXnetSocketService::GetSockOpt(::grpc::ServerContext* context, const GetSockOptRequest* request, GetSockOptResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto socket_grpc_session = request->socket();
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      int32_t level = request->level();
+      int32_t optname;
+      switch (request->optname_enum_case()) {
+        case nixnetsocket_grpc::GetSockOptRequest::OptnameEnumCase::kOptname: {
+          optname = static_cast<int32_t>(request->optname());
+          break;
+        }
+        case nixnetsocket_grpc::GetSockOptRequest::OptnameEnumCase::kOptnameRaw: {
+          optname = static_cast<int32_t>(request->optname_raw());
+          break;
+        }
+        case nixnetsocket_grpc::GetSockOptRequest::OptnameEnumCase::OPTNAME_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for optname was not specified or out of range");
+          break;
+        }
+      }
+
+      auto optval = allocate_output_storage<void *, SockOptData>();
+      nxsocklen_t optlen {};
+      auto status = library_->GetSockOpt(socket, level, optname, optval.data(), &optlen);
+      response->set_status(status);
+      if (status_ok(status)) {
+        convert_to_grpc(optval, response->mutable_optval());
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+        const auto error_num = get_last_error_num(library_);
+        response->set_error_num(error_num);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiXnetSocketService::IpStackClear(::grpc::ServerContext* context, const IpStackClearRequest* request, IpStackClearResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nixnetsocket/nixnetsocket_service.h
+++ b/generated/nixnetsocket/nixnetsocket_service.h
@@ -52,6 +52,7 @@ public:
   ::grpc::Status Recv(::grpc::ServerContext* context, const RecvRequest* request, RecvResponse* response) override;
   ::grpc::Status Shutdown(::grpc::ServerContext* context, const ShutdownRequest* request, ShutdownResponse* response) override;
   ::grpc::Status Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response) override;
+  ::grpc::Status GetSockOpt(::grpc::ServerContext* context, const GetSockOptRequest* request, GetSockOptResponse* response) override;
   ::grpc::Status IpStackClear(::grpc::ServerContext* context, const IpStackClearRequest* request, IpStackClearResponse* response) override;
   ::grpc::Status IpStackCreate(::grpc::ServerContext* context, const IpStackCreateRequest* request, IpStackCreateResponse* response) override;
   ::grpc::Status IsSet(::grpc::ServerContext* context, const IsSetRequest* request, IsSetResponse* response) override;

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -385,17 +385,17 @@ functions = {
             },
             {
                 'direction': 'in',
+                'name': 'optname',
+                'type': 'int32_t',
+                'enum': 'OptName'
+            },
+            {
+                'direction': 'in',
                 'name': 'opt_data',
                 'grpc_type': 'SockOptData',
                 'supports_standard_copy_convert': True,
                 'proto_only': True,
                 'type': 'SockOptDataInputConverter'
-            },
-            {
-                'direction': 'in',
-                'name': 'optname',
-                'type': 'int32_t',
-                'enum': 'OptName'
             },
             {
                 'direction': 'in',

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -267,6 +267,43 @@ functions = {
         ],
         'returns': 'char*'
     },
+    'GetSockOpt': {
+        'cname': 'nxgetsockopt',
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'socket',
+                'type': 'nxSOCKET'
+            },
+            {
+                'direction': 'in',
+                'name': 'level',
+                'type': 'int32_t'
+            },
+            {
+                'direction': 'in',
+                'name': 'optname',
+                'type': 'int32_t',
+                'enum': 'OptName'
+            },
+            {
+                'direction': 'out',
+                'name': 'optval',
+                'grpc_type': 'SockOptData',
+                'supports_standard_output_allocation': True,
+                'supports_standard_copy_convert': True,
+                'pointer': True,
+                'type': 'void *'
+            },
+            {
+                'direction': 'out',
+                'name': 'optlen',
+                'include_in_proto': False,
+                'type': 'nxsocklen_t'
+            }
+        ],
+        'returns': 'int32_t'
+    },
     'IpStackClear': {
         'custom_close_method': True,
         'parameters': [

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -1,489 +1,327 @@
 functions = {
-    'Accept': {
-        'cname': 'nxaccept',
-        'parameters': [
+    "Accept": {
+        "cname": "nxaccept",
+        "parameters": [
+            {"direction": "in", "name": "socket", "type": "nxSOCKET"},
             {
-                'direction': 'in',
-                'name': 'socket',
-                'type': 'nxSOCKET'
+                "direction": "out",
+                "grpc_type": "SockAddr",
+                "name": "addr",
+                "supports_standard_output_allocation": True,
+                "supports_standard_copy_convert": True,
+                "type": "nxsockaddr",
             },
             {
-                'direction': 'out',
-                'grpc_type': 'SockAddr',
-                'name': 'addr',
-                'supports_standard_output_allocation': True,
-                'supports_standard_copy_convert': True,
-                'type': 'nxsockaddr'
-            },
-            {
-                'direction': 'out',
-                'name': 'addrlen',
-                'include_in_proto': False,
-                'type': 'nxsocklen_t'
+                "direction": "out",
+                "name": "addrlen",
+                "include_in_proto": False,
+                "type": "nxsocklen_t",
             },
         ],
-        'returns': 'int32_t'
+        "returns": "int32_t",
     },
-    'Bind': {
-        'cname': 'nxbind',
-        'parameters': [
+    "Bind": {
+        "cname": "nxbind",
+        "parameters": [
+            {"direction": "in", "name": "socket", "type": "nxSOCKET"},
             {
-                'direction': 'in',
-                'name': 'socket',
-                'type': 'nxSOCKET'
+                "direction": "in",
+                "grpc_type": "SockAddr",
+                "name": "name",
+                "pointer": True,
+                "supports_standard_copy_convert": True,
+                "type": "nxsockaddr",
             },
             {
-                'direction': 'in',
-                'grpc_type': 'SockAddr',
-                'name': 'name',
-                'pointer': True,
-                'supports_standard_copy_convert': True,
-                'type': 'nxsockaddr'
-            },
-            {
-                'direction': 'in',
-                'name': 'namelen',
-                'hardcoded_value': 'name.size()',
-                'include_in_proto': False,
-                'type': 'nxsocklen_t'
+                "direction": "in",
+                "name": "namelen",
+                "hardcoded_value": "name.size()",
+                "include_in_proto": False,
+                "type": "nxsocklen_t",
             },
         ],
-        'returns': 'int32_t'
+        "returns": "int32_t",
     },
-    'Connect': {
-        'cname': 'nxconnect',
-        'parameters': [
+    "Connect": {
+        "cname": "nxconnect",
+        "parameters": [
+            {"direction": "in", "name": "socket", "type": "nxSOCKET"},
             {
-                'direction': 'in',
-                'name': 'socket',
-                'type': 'nxSOCKET'
+                "direction": "in",
+                "grpc_type": "SockAddr",
+                "name": "name",
+                "pointer": True,
+                "supports_standard_copy_convert": True,
+                "type": "nxsockaddr",
             },
             {
-                'direction': 'in',
-                'grpc_type': 'SockAddr',
-                'name': 'name',
-                'pointer': True,
-                'supports_standard_copy_convert': True,
-                'type': 'nxsockaddr'
-            },
-            {
-                'direction': 'in',
-                'name': 'namelen',
-                'hardcoded_value': 'name.size()',
-                'include_in_proto': False,
-                'type': 'nxsocklen_t'
+                "direction": "in",
+                "name": "namelen",
+                "hardcoded_value": "name.size()",
+                "include_in_proto": False,
+                "type": "nxsocklen_t",
             },
         ],
-        'returns': 'int32_t'
+        "returns": "int32_t",
     },
-    'Listen': {
-        'cname': 'nxlisten',
-        'parameters': [
+    "Listen": {
+        "cname": "nxlisten",
+        "parameters": [
+            {"direction": "in", "name": "socket", "type": "nxSOCKET"},
+            {"direction": "in", "name": "backlog", "type": "int32_t"},
+        ],
+        "returns": "int32_t",
+    },
+    "SendTo": {
+        "cname": "nxsendto",
+        "parameters": [
+            {"direction": "in", "name": "socket", "type": "nxSOCKET"},
             {
-                'direction': 'in',
-                'name': 'socket',
-                'type': 'nxSOCKET'
+                "direction": "in",
+                "name": "dataptr",
+                "pointer": True,
+                "size": {"mechanism": "len", "value": "size"},
+                "pointer": True,
+                "grpc_type": "bytes",
+                "type": "char[]",
+            },
+            {"direction": "in", "name": "size", "type": "int32_t"},
+            {"direction": "in", "name": "flags", "type": "int32_t"},
+            {
+                "direction": "in",
+                "grpc_type": "SockAddr",
+                "name": "to",
+                "pointer": True,
+                "supports_standard_copy_convert": True,
+                "type": "nxsockaddr",
             },
             {
-                'direction': 'in',
-                'name': 'backlog',
-                'type': 'int32_t'
+                "direction": "in",
+                "name": "tolen",
+                "hardcoded_value": "to.size()",
+                "include_in_proto": False,
+                "type": "nxsocklen_t",
             },
         ],
-        'returns': 'int32_t'
+        "returns": "int32_t",
     },
-    'SendTo': {
-        'cname': 'nxsendto',
-        'parameters': [
+    "Send": {
+        "cname": "nxsend",
+        "parameters": [
+            {"direction": "in", "name": "socket", "type": "nxSOCKET"},
             {
-                'direction': 'in',
-                'name': 'socket',
-                'type': 'nxSOCKET'
+                "direction": "in",
+                "name": "dataptr",
+                "pointer": True,
+                "size": {"mechanism": "len", "value": "size"},
+                "pointer": True,
+                "grpc_type": "bytes",
+                "type": "char[]",
+            },
+            {"direction": "in", "name": "size", "type": "int32_t"},
+            {"direction": "in", "name": "flags", "type": "int32_t"},
+        ],
+        "returns": "int32_t",
+    },
+    "Recv": {
+        "cname": "nxrecv",
+        "parameters": [
+            {"direction": "in", "name": "socket", "type": "nxSOCKET"},
+            {
+                "direction": "in",
+                "name": "mem",
+                "size": {"mechanism": "len", "value": "size"},
+                "pointer": True,
+                "grpc_type": "bytes",
+                "type": "char[]",
+            },
+            {"direction": "in", "name": "size", "type": "int32_t"},
+            {"direction": "in", "name": "flags", "type": "int32_t"},
+        ],
+        "returns": "int32_t",
+    },
+    "Shutdown": {
+        "cname": "nxshutdown",
+        "parameters": [
+            {"direction": "in", "name": "socket", "type": "nxSOCKET"},
+            {"direction": "in", "name": "how", "type": "int32_t"},
+        ],
+        "returns": "int32_t",
+    },
+    "Close": {
+        "cname": "nxclose",
+        "parameters": [{"direction": "in", "name": "socket", "type": "nxSOCKET"}],
+        "returns": "int32_t",
+    },
+    "GetLastErrorNum": {
+        "codegen_method": "private",
+        "cname": "nxgetlasterrornum",
+        "parameters": [],
+        "returns": "int32_t",
+    },
+    "GetLastErrorStr": {
+        "codegen_method": "private",
+        "cname": "nxgetlasterrorstr",
+        "status_expression": "error ? 0 : -1",
+        "parameters": [
+            {
+                "direction": "out",
+                "include_in_proto": False,
+                "name": "buf",
+                "size": {"mechanism": "passed-in", "value": "bufLen"},
+                "type": "char[]",
+            },
+            {"direction": "in", "name": "bufLen", "type": "size_t"},
+            {"direction": "out", "name": "error", "return_value": True, "type": "char[]"},
+        ],
+        "returns": "char*",
+    },
+    "GetSockOpt": {
+        "cname": "nxgetsockopt",
+        "parameters": [
+            {"direction": "in", "name": "socket", "type": "nxSOCKET"},
+            {"direction": "in", "name": "level", "type": "int32_t"},
+            {"direction": "in", "name": "optname", "type": "int32_t", "enum": "OptName"},
+            {
+                "direction": "out",
+                "name": "optval",
+                "grpc_type": "SockOptData",
+                "supports_standard_output_allocation": True,
+                "additional_arguments_to_output_allocation": ["optname"],
+                "supports_standard_copy_convert": True,
+                "pointer": True,
+                "type": "void *",
             },
             {
-                'direction': 'in',
-                'name': 'dataptr',
-                'pointer': True,
-                'size': {
-                    'mechanism': 'len',
-                    'value': 'size'
-                },
-                'pointer': True,
-                'grpc_type': 'bytes',
-                'type': 'char[]'
-            },
-            {
-                'direction': 'in',
-                'name': 'size',
-                'type': 'int32_t'
-            },
-            {
-                'direction': 'in',
-                'name': 'flags',
-                'type': 'int32_t'
-            },
-            {
-                'direction': 'in',
-                'grpc_type': 'SockAddr',
-                'name': 'to',
-                'pointer': True,
-                'supports_standard_copy_convert': True,
-                'type': 'nxsockaddr'
-            },
-            {
-                'direction': 'in',
-                'name': 'tolen',
-                'hardcoded_value': 'to.size()',
-                'include_in_proto': False,
-                'type': 'nxsocklen_t'
+                "direction": "out",
+                "name": "optlen",
+                "include_in_proto": False,
+                "type": "nxsocklen_t",
             },
         ],
-        'returns': 'int32_t'
+        "returns": "int32_t",
     },
-    'Send': {
-        'cname': 'nxsend',
-        'parameters': [
+    "IpStackClear": {
+        "custom_close_method": True,
+        "parameters": [
+            {"direction": "in", "name": "stack_ref", "type": "nxIpStackRef_t"},
+        ],
+        "returns": "int32_t",
+    },
+    "IpStackCreate": {
+        "custom_close": "IpStackClear(id)",
+        "init_method": True,
+        "parameters": [
+            {"direction": "in", "name": "stack_name", "type": "char[]"},
+            {"direction": "in", "name": "config", "type": "char[]"},
+            {"direction": "out", "name": "stack_ref", "type": "nxIpStackRef_t"},
+        ],
+        "returns": "int32_t",
+    },
+    "IsSet": {
+        "cname": "nxfd_isset",
+        "status_expression": "0",
+        "parameters": [
+            {"direction": "in", "name": "fd", "type": "nxSOCKET"},
             {
-                'direction': 'in',
-                'name': 'socket',
-                'type': 'nxSOCKET'
+                "direction": "in",
+                "name": "set",
+                "pointer": True,
+                "supports_standard_copy_convert": True,
+                "additional_arguments_to_copy_convert": ["session_repository_"],
+                "type": "nxfd_set",
+            },
+            {"direction": "out", "name": "is_set", "return_value": True, "type": "int32_t"},
+        ],
+        "returns": "int32_t",
+    },
+    "Select": {
+        "cname": "nxselect",
+        "parameters": [
+            {
+                "direction": "in",
+                "hardcoded_value": "0",
+                "include_in_proto": False,
+                "name": "nfds",
+                "type": "int32_t",
             },
             {
-                'direction': 'in',
-                'name': 'dataptr',
-                'pointer': True,
-                'size': {
-                    'mechanism': 'len',
-                    'value': 'size'
-                },
-                'pointer': True,
-                'grpc_type': 'bytes',
-                'type': 'char[]'
+                "direction": "in",
+                "name": "read_fds",
+                "pointer": True,
+                "supports_standard_copy_convert": True,
+                "additional_arguments_to_copy_convert": ["session_repository_"],
+                "type": "nxfd_set",
             },
             {
-                'direction': 'in',
-                'name': 'size',
-                'type': 'int32_t'
+                "direction": "in",
+                "name": "write_fds",
+                "pointer": True,
+                "supports_standard_copy_convert": True,
+                "additional_arguments_to_copy_convert": ["session_repository_"],
+                "type": "nxfd_set",
             },
             {
-                'direction': 'in',
-                'name': 'flags',
-                'type': 'int32_t'
+                "direction": "in",
+                "name": "except_fds",
+                "pointer": True,
+                "supports_standard_copy_convert": True,
+                "additional_arguments_to_copy_convert": ["session_repository_"],
+                "type": "nxfd_set",
+            },
+            {
+                "direction": "in",
+                "name": "timeout",
+                "pointer": True,
+                "supports_standard_copy_convert": True,
+                "type": "nxtimeval",
             },
         ],
-        'returns': 'int32_t'
+        "returns": "int32_t",
     },
-    'Recv': {
-        'cname': 'nxrecv',
-        'parameters': [
+    "SetSockOpt": {
+        "cname": "nxsetsockopt",
+        "parameters": [
+            {"direction": "in", "name": "socket", "type": "nxSOCKET"},
+            {"direction": "in", "name": "level", "type": "int32_t"},
+            {"direction": "in", "name": "optname", "type": "int32_t", "enum": "OptName"},
             {
-                'direction': 'in',
-                'name': 'socket',
-                'type': 'nxSOCKET'
+                "direction": "in",
+                "name": "opt_data",
+                "grpc_type": "SockOptData",
+                "supports_standard_copy_convert": True,
+                "proto_only": True,
+                "type": "SockOptDataInputConverter",
             },
             {
-                'direction': 'in',
-                'name': 'mem',
-                'size': {
-                    'mechanism': 'len',
-                    'value': 'size'
-                },
-                'pointer': True,
-                'grpc_type': 'bytes',
-                'type': 'char[]'
+                "direction": "in",
+                "name": "optval",
+                "hardcoded_value": "opt_data.data()",
+                "include_in_proto": False,
+                "pointer": True,
+                "type": "void",
             },
             {
-                'direction': 'in',
-                'name': 'size',
-                'type': 'int32_t'
-            },
-            {
-                'direction': 'in',
-                'name': 'flags',
-                'type': 'int32_t'
+                "direction": "in",
+                "name": "optlen",
+                "hardcoded_value": "opt_data.size()",
+                "include_in_proto": False,
+                "type": "nxsocklen_t",
             },
         ],
-        'returns': 'int32_t'
+        "returns": "int32_t",
     },
-    'Shutdown': {
-        'cname': 'nxshutdown',
-        'parameters': [
-            {
-                'direction': 'in',
-                'name': 'socket',
-                'type': 'nxSOCKET'
-            },
-             {
-                'direction': 'in',
-                'name': 'how',
-                'type': 'int32_t'
-            },
+    "Socket": {
+        "cname": "nxsocket",
+        "init_method": True,
+        "status_expression": "socket == -1 ? -1 : 0",
+        "parameters": [
+            {"direction": "in", "name": "stack_ref", "type": "nxIpStackRef_t"},
+            {"direction": "in", "name": "domain", "type": "int32_t"},
+            {"direction": "in", "name": "type", "type": "int32_t"},
+            {"direction": "in", "name": "prototcol", "type": "int32_t"},
+            {"direction": "out", "name": "socket", "return_value": True, "type": "nxSOCKET"},
         ],
-        'returns': 'int32_t'
-    },
-    'Close': {
-        'cname': 'nxclose',
-        'parameters': [
-            {
-                'direction': 'in',
-                'name': 'socket',
-                'type': 'nxSOCKET'
-            }
-        ],
-        'returns': 'int32_t'
-    },
-    'GetLastErrorNum': {
-        'codegen_method': 'private',
-        'cname': 'nxgetlasterrornum',
-        'parameters': [],
-        'returns': 'int32_t'
-    },
-    'GetLastErrorStr': {
-        'codegen_method': 'private',
-        'cname': 'nxgetlasterrorstr',
-        'status_expression': 'error ? 0 : -1',
-        'parameters': [
-            {
-                'direction': 'out',
-                'include_in_proto': False,
-                'name': 'buf',
-                'size': {
-                    'mechanism': 'passed-in',
-                    'value': 'bufLen'
-                },
-                'type': 'char[]'
-            },
-            {
-                'direction': 'in',
-                'name': 'bufLen',
-                'type': 'size_t'
-            },
-            {
-                'direction': 'out',
-                'name': 'error',
-                'return_value': True,
-                'type': 'char[]'
-            },
-        ],
-        'returns': 'char*'
-    },
-    'GetSockOpt': {
-        'cname': 'nxgetsockopt',
-        'parameters': [
-            {
-                'direction': 'in',
-                'name': 'socket',
-                'type': 'nxSOCKET'
-            },
-            {
-                'direction': 'in',
-                'name': 'level',
-                'type': 'int32_t'
-            },
-            {
-                'direction': 'in',
-                'name': 'optname',
-                'type': 'int32_t',
-                'enum': 'OptName'
-            },
-            {
-                'direction': 'out',
-                'name': 'optval',
-                'grpc_type': 'SockOptData',
-                'supports_standard_output_allocation': True,
-                'supports_standard_copy_convert': True,
-                'pointer': True,
-                'type': 'void *'
-            },
-            {
-                'direction': 'out',
-                'name': 'optlen',
-                'include_in_proto': False,
-                'type': 'nxsocklen_t'
-            }
-        ],
-        'returns': 'int32_t'
-    },
-    'IpStackClear': {
-        'custom_close_method': True,
-        'parameters': [
-            {
-                'direction': 'in',
-                'name': 'stack_ref',
-                'type': 'nxIpStackRef_t'
-            },
-        ],
-        'returns': 'int32_t'
-    },
-    'IpStackCreate': {
-        'custom_close': 'IpStackClear(id)',
-        'init_method': True,
-        'parameters': [
-            {
-                'direction': 'in',
-                'name': 'stack_name',
-                'type': 'char[]'
-            },
-            {
-                'direction': 'in',
-                'name': 'config',
-                'type': 'char[]'
-            },
-            {
-                'direction': 'out',
-                'name': 'stack_ref',
-                'type': 'nxIpStackRef_t'
-            },
-        ],
-        'returns': 'int32_t'
-    },
-    'IsSet': {
-        'cname': 'nxfd_isset',
-        'status_expression': '0',
-        'parameters': [
-            {
-                'direction': 'in',
-                'name': 'fd',
-                'type': 'nxSOCKET'
-            },
-            {
-                'direction': 'in',
-                'name': 'set',
-                'pointer': True,
-                'supports_standard_copy_convert': True,
-                'additional_arguments_to_copy_convert': ['session_repository_'],
-                'type': 'nxfd_set'
-            },
-            {
-                'direction': 'out',
-                'name': 'is_set',
-                'return_value': True,
-                'type': 'int32_t'
-            }
-        ],
-        'returns': 'int32_t'
-    },
-    'Select': {
-        'cname': 'nxselect',
-        'parameters': [
-            {
-                'direction': 'in',
-                'hardcoded_value': '0',
-                'include_in_proto': False,
-                'name': 'nfds',
-                'type': 'int32_t'
-            },
-            {
-                'direction': 'in',
-                'name': 'read_fds',
-                'pointer': True,
-                'supports_standard_copy_convert': True,
-                'additional_arguments_to_copy_convert': ['session_repository_'],
-                'type': 'nxfd_set'
-            },
-            {
-                'direction': 'in',
-                'name': 'write_fds',
-                'pointer': True,
-                'supports_standard_copy_convert': True,
-                'additional_arguments_to_copy_convert': ['session_repository_'],
-                'type': 'nxfd_set'
-            },
-            {
-                'direction': 'in',
-                'name': 'except_fds',
-                'pointer': True,
-                'supports_standard_copy_convert': True,
-                'additional_arguments_to_copy_convert': ['session_repository_'],
-                'type': 'nxfd_set'
-            },
-            {
-                'direction': 'in',
-                'name': 'timeout',
-                'pointer': True,
-                'supports_standard_copy_convert': True,
-                'type': 'nxtimeval'
-            },
-        ],
-        'returns': 'int32_t'
-    },
-    'SetSockOpt': {
-        'cname': 'nxsetsockopt',
-        'parameters': [
-            {
-                'direction': 'in',
-                'name': 'socket',
-                'type': 'nxSOCKET'
-            },
-            {
-                'direction': 'in',
-                'name': 'level',
-                'type': 'int32_t'
-            },
-            {
-                'direction': 'in',
-                'name': 'optname',
-                'type': 'int32_t',
-                'enum': 'OptName'
-            },
-            {
-                'direction': 'in',
-                'name': 'opt_data',
-                'grpc_type': 'SockOptData',
-                'supports_standard_copy_convert': True,
-                'proto_only': True,
-                'type': 'SockOptDataInputConverter'
-            },
-            {
-                'direction': 'in',
-                'name': 'optval',
-                'hardcoded_value': 'opt_data.data()',
-                'include_in_proto': False,
-                'pointer': True,
-                'type': 'void'
-            },
-            {
-                'direction': 'in',
-                'name': 'optlen',
-                'hardcoded_value': 'opt_data.size()',
-                'include_in_proto': False,
-                'type': 'nxsocklen_t'
-            }
-        ],
-        'returns': 'int32_t'
-    },
-    'Socket': {
-        'cname': 'nxsocket',
-        'init_method': True,
-        'status_expression': 'socket == -1 ? -1 : 0',
-        'parameters': [
-            {
-                'direction': 'in',
-                'name': 'stack_ref',
-                'type': 'nxIpStackRef_t'
-            },
-            {
-                'direction': 'in',
-                'name': 'domain',
-                'type': 'int32_t'
-            },
-            {
-                'direction': 'in',
-                'name': 'type',
-                'type': 'int32_t'
-            },
-            {
-                'direction': 'in',
-                'name': 'prototcol',
-                'type': 'int32_t'
-            },
-            {
-                'direction': 'out',
-                'name': 'socket',
-                'return_value': True,
-                'type': 'nxSOCKET'
-            },
-        ],
-        'returns': 'nxSOCKET'
+        "returns": "nxSOCKET",
     },
 }

--- a/source/codegen/metadata/nixnetsocket/functions_addon.py
+++ b/source/codegen/metadata/nixnetsocket/functions_addon.py
@@ -4,3 +4,8 @@ functions_override_metadata = {}
 functions_validation_suppressions = {
     name: {"parameters": {"mem": ["ARRAY_PARAMETER_NEEDS_SIZE"]}} for name in ["Recv", "RecvFrom"]
 }
+
+# Void* param output size is allocated differently.
+functions_validation_suppressions["GetSockOpt"] = {
+    "parameters": {"optval": ["ARRAY_PARAMETER_NEEDS_SIZE"]}
+}

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -80,6 +80,7 @@ PARAM_SCHEMA = Schema(
         Optional("supports_standard_output_allocation"): bool,
         Optional("get_last_error"): str,
         Optional("additional_arguments_to_copy_convert"): [str],
+        Optional("additional_arguments_to_output_allocation"): [str],
         Optional("proto_only"): bool,
     }
 )

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -205,7 +205,7 @@ def _validate_function(function_name: str, metadata: dict):
                         "proto_only", False
                     ):
                         raise Exception(
-                            f"parameter {parameter['name']} has no type and repeated_var_args or meta_param is not set!"
+                            f"parameter {parameter['name']} has no type and repeated_var_args or proto_only is not set!"
                         )
                 if "enum" in parameter:
                     if parameter["enum"] not in metadata["enums"]:

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -245,6 +245,8 @@ def _create_param(parameter, expand_varargs=True, repeated_parameters=None):
         else:
             return "..."
     elif common_helpers.is_array(type):
+        if type == "void *":
+            return f"void* {name}"
         array_size = _get_array_param_size(parameter)
         return f"{type[:-2]} {name}[{array_size}]"
     elif common_helpers.is_pointer_parameter(parameter):

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -640,7 +640,7 @@ ${initialize_standard_input_param(function_name, parameter)}
   grpc_type = parameter["grpc_type"]
 %>\
 %   if common_helpers.supports_standard_output_allocation_routines(parameter):
-      auto ${parameter_name} = allocate_output_storage<${underlying_param_type}, ${grpc_type}>();
+      auto ${parameter_name} = allocate_output_storage<${underlying_param_type}, ${grpc_type}>(${str.join(", ", parameter.get("additional_arguments_to_output_allocation", []))});
 %   elif common_helpers.is_repeating_parameter(parameter):
       auto get_${parameter_name}_if = [](std::vector<${underlying_param_type}>& vector, int n) -> ${underlying_param_type}* {
             if (vector.size() > n) {

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -292,23 +292,24 @@ struct SockOptDataOutputConverter {
   void* data()
   {
     switch (opt_name) {
+      case OptName::OPT_NAME_IP_MULTICAST_TTL:
+      case OptName::OPT_NAME_IPV6_MULTICAST_HOPS:
       case OptName::OPT_NAME_SO_RX_DATA:
       case OptName::OPT_NAME_SO_RCV_BUF:
-      case OptName::OPT_NAME_SO_SND_BUF: {
+      case OptName::OPT_NAME_SO_SND_BUF:
+      case OptName::OPT_NAME_TCP_NODELAY: {
         return &data_int;
         break;
       }
-      case OptName::OPT_NAME_SO_NON_BLOCK:
       case OptName::OPT_NAME_SO_LINGER:
+      case OptName::OPT_NAME_SO_NON_BLOCK:
       case OptName::OPT_NAME_SO_REUSE_ADDR: {
-        // TODO: Bool version
         return &data_bool;
         break;
       }
       case OptName::OPT_NAME_SO_BIND_TO_DEVICE:
       case OptName::OPT_NAME_SO_ERROR: {
-        // TODO: string version
-        data_string = std::string(256 - 1, '\0');  // Guessing here that max is 256... don't know how to figure out actual max size for string options.
+        data_string = std::string(256 - 1, '\0');  // TODO: What's the max string size to allocate for a sock opt?
         return &data_string[0];
         break;
       }
@@ -321,22 +322,23 @@ struct SockOptDataOutputConverter {
   void to_grpc(SockOptData& output) const
   {
     switch (opt_name) {
+      case OptName::OPT_NAME_IP_MULTICAST_TTL:
+      case OptName::OPT_NAME_IPV6_MULTICAST_HOPS:
       case OptName::OPT_NAME_SO_RX_DATA:
       case OptName::OPT_NAME_SO_RCV_BUF:
-      case OptName::OPT_NAME_SO_SND_BUF: {
+      case OptName::OPT_NAME_SO_SND_BUF:
+      case OptName::OPT_NAME_TCP_NODELAY: {
         output.set_data_int32(data_int);
         break;
       }
-      case OptName::OPT_NAME_SO_NON_BLOCK:
       case OptName::OPT_NAME_SO_LINGER:
+      case OptName::OPT_NAME_SO_NON_BLOCK:
       case OptName::OPT_NAME_SO_REUSE_ADDR: {
-        // TODO: Bool version
         output.set_data_bool(data_bool);
         break;
       }
       case OptName::OPT_NAME_SO_BIND_TO_DEVICE:
       case OptName::OPT_NAME_SO_ERROR: {
-        // TODO: string version
         output.set_data_string(data_string);
         nidevice_grpc::converters::trim_trailing_nulls(*(output.mutable_data_string()));
         break;

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -282,6 +282,30 @@ inline SockOptDataInputConverter convert_from_grpc(const SockOptData& input)
   return SockOptDataInputConverter(input);
 }
 
+// This class allows us to have something allocated on the stack that provides backing
+// storage for a void* opt_val output param and converts it to the SockOptData grpc-type.
+struct SockOptDataOutputConverter {
+  SockOptDataOutputConverter()
+  {
+  }
+
+  void* data()
+  {
+    // TODO: Point to backing data field (int, bool, or string)
+    return nullptr;
+  }
+
+  void to_grpc(SockOptData& output) const
+  {
+    output.set_data_bool(true);
+  }
+};
+
+inline void convert_to_grpc(const SockOptDataOutputConverter& storage, SockOptData* output)
+{
+  storage.to_grpc(*output);
+}
+
 }  // namespace nixnetsocket_grpc
 
 // Template specializations go in nidevice_grpc::converters.
@@ -292,6 +316,13 @@ namespace converters {
 template <>
 struct TypeToStorageType<nxsockaddr, nixnetsocket_grpc::SockAddr> {
   using StorageType = nixnetsocket_grpc::SockAddrOutputConverter;
+};
+
+// Specialization of TypeToStorageType so that allocate_storage_type will
+// allocate SockOptDataOutputConverters for void* output params.
+template <>
+struct TypeToStorageType<void*, nixnetsocket_grpc::SockOptData> {
+  using StorageType = nixnetsocket_grpc::SockOptDataOutputConverter;
 };
 }  // namespace converters
 }  // namespace nidevice_grpc

--- a/source/server/converters.h
+++ b/source/server/converters.h
@@ -297,11 +297,11 @@ struct TypeToStorageType {
 
 // Constructs a default implementation of TypeToStorageType<TDriverType>::StorageType to use as an output_param.
 // This should be customized by specializing the TypeToStorageType struct.
-template <typename TDriverType, typename TGrpcType>
-typename TypeToStorageType<TDriverType, TGrpcType>::StorageType allocate_output_storage()
+template <typename TDriverType, typename TGrpcType, typename... TArgs>
+typename TypeToStorageType<TDriverType, TGrpcType>::StorageType allocate_output_storage(TArgs... args)
 {
   using StorageType = typename TypeToStorageType<TDriverType, TGrpcType>::StorageType;
-  return StorageType{};
+  return StorageType{args...};
 }
 
 }  // namespace converters

--- a/source/tests/unit/xnet_converters_tests.cpp
+++ b/source/tests/unit/xnet_converters_tests.cpp
@@ -397,6 +397,19 @@ TEST(XnetConvertersTests, StringSockOptData_ConvertToGrpc_ConvertsToSockOptDataW
   EXPECT_EQ(DEVICE_NAME, grpc_data.data_string());
 }
 
+TEST(XnetConvertersTests, SockOptDataWithUnknownOptName_ConvertToGrpc_ConvertsToUnsetSockOptData)
+{
+  constexpr auto UNKNOWN_OPT_NAME = -1;
+  auto storage = allocate_output_storage<void*, SockOptData>(UNKNOWN_OPT_NAME);
+  void* data_pointer = storage.data();
+  EXPECT_EQ(nullptr, data_pointer);
+
+  auto grpc_data = SockOptData{};
+  convert_to_grpc(storage, &grpc_data);
+
+  EXPECT_EQ(SockOptData::DataCase::DATA_NOT_SET, grpc_data.data_case());
+}
+
 }  // namespace
 }  // namespace unit
 }  // namespace tests

--- a/source/tests/unit/xnet_converters_tests.cpp
+++ b/source/tests/unit/xnet_converters_tests.cpp
@@ -347,6 +347,56 @@ TEST(XnetConvertersTests, SockOptDataWithDataUnset_ConvertFromGrpc_NullPtrDataAn
   EXPECT_EQ(nullptr, opt_data.data());
 }
 
+TEST(XnetConvertersTests, Int32SockOptData_ConvertToGrpc_ConvertsToSockOptDataWithIntValue)
+{
+  constexpr auto RX_DATA = 100;
+  auto storage = allocate_output_storage<void*, SockOptData>(OptName::OPT_NAME_SO_RX_DATA);
+  void* data_pointer = storage.data();
+  EXPECT_EQ(data_pointer, &(storage.data_int));
+  auto int_pointer = reinterpret_cast<int32_t*>(data_pointer);
+  *int_pointer = RX_DATA;
+
+  auto grpc_data = SockOptData{};
+  convert_to_grpc(storage, &grpc_data);
+
+  EXPECT_EQ(SockOptData::DataCase::kDataInt32, grpc_data.data_case());
+  EXPECT_EQ(RX_DATA, grpc_data.data_int32());
+}
+
+TEST(XnetConvertersTests, BoolSockOptData_ConvertToGrpc_ConvertsToSockOptDataWithBoolValue)
+{
+  constexpr auto LINGER = true;
+  auto storage = allocate_output_storage<void*, SockOptData>(OptName::OPT_NAME_SO_LINGER);
+  void* data_pointer = storage.data();
+  EXPECT_EQ(data_pointer, &(storage.data_bool));
+  auto bool_pointer = reinterpret_cast<bool*>(data_pointer);
+  *bool_pointer = LINGER;
+
+  auto grpc_data = SockOptData{};
+  convert_to_grpc(storage, &grpc_data);
+
+  EXPECT_EQ(SockOptData::DataCase::kDataBool, grpc_data.data_case());
+  EXPECT_EQ(LINGER, grpc_data.data_bool());
+}
+
+TEST(XnetConvertersTests, StringSockOptData_ConvertToGrpc_ConvertsToSockOptDataWithStringValue)
+{
+  const std::string DEVICE_NAME = "I'm a Device";
+  constexpr auto MAX_SOCK_OPT_STRING_SIZE = 255;
+  auto storage = allocate_output_storage<void*, SockOptData>(OptName::OPT_NAME_SO_BIND_TO_DEVICE);
+  void* data_pointer = storage.data();
+  EXPECT_EQ(MAX_SOCK_OPT_STRING_SIZE, storage.data_string.size());
+  EXPECT_EQ(data_pointer, &(storage.data_string[0]));
+  auto string_pointer = reinterpret_cast<char*>(data_pointer);
+  strcpy(string_pointer, DEVICE_NAME.c_str());
+
+  auto grpc_data = SockOptData{};
+  convert_to_grpc(storage, &grpc_data);
+
+  EXPECT_EQ(SockOptData::DataCase::kDataString, grpc_data.data_case());
+  EXPECT_EQ(DEVICE_NAME, grpc_data.data_string());
+}
+
 }  // namespace
 }  // namespace unit
 }  // namespace tests


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds GetSockOpt to xnetsocket service.

### Why should this Pull Request be merged?

Fixes AB#1881554

### What testing has been done?

XNET socket converters tests pass including four new ones testing the new SockOptDataOutputConverter and related conversion methods.