### PR TITLE
Add nxaddrinfo functions for xnet socket service.

### DIFF
--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -20,6 +20,7 @@ service NiXnetSocket {
   rpc Accept(AcceptRequest) returns (AcceptResponse);
   rpc Bind(BindRequest) returns (BindResponse);
   rpc Connect(ConnectRequest) returns (ConnectResponse);
+  rpc GetAddrInfo(GetAddrInfoRequest) returns (GetAddrInfoResponse);
   rpc Listen(ListenRequest) returns (ListenResponse);
   rpc SendTo(SendToRequest) returns (SendToResponse);
   rpc Send(SendRequest) returns (SendResponse);
@@ -164,6 +165,22 @@ message SockOptData {
   }
 }
 
+message AddrInfo {
+  int32 flags = 1;
+  int32 family = 2;
+  int32 sock_type = 3;
+  int32 protocol = 4;
+  SockAddr addr = 5;
+  string canon_name = 6;
+}
+
+message AddrInfoHint {
+  int32 flags = 1;
+  int32 family = 2;
+  int32 sock_type = 3;
+  int32 protocol = 4;
+}
+
 message AcceptRequest {
   nidevice_grpc.Session socket = 1;
 }
@@ -195,6 +212,20 @@ message ConnectResponse {
   int32 status = 1;
   string error_message = 2;
   int32 error_num = 3;
+}
+
+message GetAddrInfoRequest {
+  nidevice_grpc.Session stack_ref = 1;
+  string node = 2;
+  string service = 3;
+  AddrInfoHint hints = 4;
+}
+
+message GetAddrInfoResponse {
+  int32 status = 1;
+  repeated AddrInfo res = 2;
+  string error_message = 3;
+  int32 error_num = 4;
 }
 
 message ListenRequest {

--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -100,6 +100,22 @@ enum Shutdown {
   SHUTDOWN_RDWR = 2;
 }
 
+enum GetAddrInfoFlags {
+  GET_ADDR_INFO_FLAGS_UNSPECIFIED = 0;
+  GET_ADDR_INFO_FLAGS_PASSIVE = 1;
+  GET_ADDR_INFO_FLAGS_CANONNAME = 2;
+  GET_ADDR_INFO_FLAGS_NUMERICHOST = 4;
+  GET_ADDR_INFO_FLAGS_NUMERICSERV = 8;
+  GET_ADDR_INFO_FLAGS_V4MAPPED = 16;
+  GET_ADDR_INFO_FLAGS_ALL = 32;
+  GET_ADDR_INFO_FLAGS_ADDRCONFIG = 64;
+  GET_ADDR_INFO_FLAGS_LOCALQUERY = 128;
+  GET_ADDR_INFO_FLAGS_PREFER_V4 = 256;
+  GET_ADDR_INFO_FLAGS_UNICAST_REPLY = 512;
+  GET_ADDR_INFO_FLAGS_SHARED_RESET = 1024;
+  GET_ADDR_INFO_FLAGS_BYPASS_CACHE = 2048;
+}
+
 message IPAddress {
   uint32 family = 1;
   string address = 2;
@@ -143,19 +159,19 @@ message SockAddr {
 }
 
 message AddrInfo {
-  int32 flags = 1;
-  int32 family = 2;
-  int32 sock_type = 3;
-  int32 protocol = 4;
+  GetAddrInfoFlags flags = 1;
+  AddressFamily family = 2;
+  SocketProtocolType sock_type = 3;
+  IPProtocol protocol = 4;
   SockAddr addr = 5;
   string canon_name = 6;
 }
 
 message AddrInfoHint {
-  int32 flags = 1;
-  int32 family = 2;
-  int32 sock_type = 3;
-  int32 protocol = 4;
+  GetAddrInfoFlags flags = 1;
+  AddressFamily family = 2;
+  SocketProtocolType sock_type = 3;
+  IPProtocol protocol = 4;
 }
 
 message Linger {

--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -21,6 +21,7 @@ service NiXnetSocket {
   rpc Bind(BindRequest) returns (BindResponse);
   rpc Connect(ConnectRequest) returns (ConnectResponse);
   rpc GetAddrInfo(GetAddrInfoRequest) returns (GetAddrInfoResponse);
+  rpc GetNameInfo(GetNameInfoRequest) returns (GetNameInfoResponse);
   rpc Listen(ListenRequest) returns (ListenResponse);
   rpc SendTo(SendToRequest) returns (SendToResponse);
   rpc Send(SendRequest) returns (SendResponse);
@@ -233,6 +234,22 @@ message GetAddrInfoResponse {
   repeated AddrInfo res = 2;
   string error_message = 3;
   int32 error_num = 4;
+}
+
+message GetNameInfoRequest {
+  nidevice_grpc.Session stack_ref = 1;
+  SockAddr addr = 2;
+  int32 host_len = 3;
+  int32 serv_len = 4;
+  int32 flags = 5;
+}
+
+message GetNameInfoResponse {
+  int32 status = 1;
+  string host = 2;
+  string serv = 3;
+  string error_message = 4;
+  int32 error_num = 5;
 }
 
 message ListenRequest {

--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -151,6 +151,13 @@ message AddrInfo {
   string canon_name = 6;
 }
 
+message AddrInfoHint {
+  int32 flags = 1;
+  int32 family = 2;
+  int32 sock_type = 3;
+  int32 protocol = 4;
+}
+
 message Linger {
   int32 l_onoff = 1;
   int32 l_linger = 2;
@@ -163,22 +170,6 @@ message SockOptData {
     string data_string = 3;
     Linger data_linger = 4;
   }
-}
-
-message AddrInfo {
-  int32 flags = 1;
-  int32 family = 2;
-  int32 sock_type = 3;
-  int32 protocol = 4;
-  SockAddr addr = 5;
-  string canon_name = 6;
-}
-
-message AddrInfoHint {
-  int32 flags = 1;
-  int32 family = 2;
-  int32 sock_type = 3;
-  int32 protocol = 4;
 }
 
 message AcceptRequest {

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -86,6 +86,26 @@ get_addr_info(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, cons
   return response;
 }
 
+GetNameInfoResponse
+get_name_info(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const SockAddr& addr, const pb::int32& host_len, const pb::int32& serv_len, const pb::int32& flags)
+{
+  ::grpc::ClientContext context;
+
+  auto request = GetNameInfoRequest{};
+  request.mutable_stack_ref()->CopyFrom(stack_ref);
+  request.mutable_addr()->CopyFrom(addr);
+  request.set_host_len(host_len);
+  request.set_serv_len(serv_len);
+  request.set_flags(flags);
+
+  auto response = GetNameInfoResponse{};
+
+  raise_if_error(
+      stub->GetNameInfo(&context, request, &response));
+
+  return response;
+}
+
 ListenResponse
 listen(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& backlog)
 {

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -67,6 +67,25 @@ connect(const StubPtr& stub, const nidevice_grpc::Session& socket, const SockAdd
   return response;
 }
 
+GetAddrInfoResponse
+get_addr_info(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const pb::string& node, const pb::string& service, const AddrInfoHint& hints)
+{
+  ::grpc::ClientContext context;
+
+  auto request = GetAddrInfoRequest{};
+  request.mutable_stack_ref()->CopyFrom(stack_ref);
+  request.set_node(node);
+  request.set_service(service);
+  request.mutable_hints()->CopyFrom(hints);
+
+  auto response = GetAddrInfoResponse{};
+
+  raise_if_error(
+      stub->GetAddrInfo(&context, request, &response));
+
+  return response;
+}
+
 ListenResponse
 listen(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& backlog)
 {

--- a/generated/nixnetsocket/nixnetsocket_client.h
+++ b/generated/nixnetsocket/nixnetsocket_client.h
@@ -25,6 +25,7 @@ using namespace nidevice_grpc::experimental::client;
 AcceptResponse accept(const StubPtr& stub, const nidevice_grpc::Session& socket);
 BindResponse bind(const StubPtr& stub, const nidevice_grpc::Session& socket, const SockAddr& name);
 ConnectResponse connect(const StubPtr& stub, const nidevice_grpc::Session& socket, const SockAddr& name);
+GetAddrInfoResponse get_addr_info(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const pb::string& node, const pb::string& service, const AddrInfoHint& hints);
 ListenResponse listen(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& backlog);
 SendToResponse send_to(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags, const SockAddr& to);
 SendResponse send(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags);

--- a/generated/nixnetsocket/nixnetsocket_client.h
+++ b/generated/nixnetsocket/nixnetsocket_client.h
@@ -26,6 +26,7 @@ AcceptResponse accept(const StubPtr& stub, const nidevice_grpc::Session& socket)
 BindResponse bind(const StubPtr& stub, const nidevice_grpc::Session& socket, const SockAddr& name);
 ConnectResponse connect(const StubPtr& stub, const nidevice_grpc::Session& socket, const SockAddr& name);
 GetAddrInfoResponse get_addr_info(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const pb::string& node, const pb::string& service, const AddrInfoHint& hints);
+GetNameInfoResponse get_name_info(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const SockAddr& addr, const pb::int32& host_len, const pb::int32& serv_len, const pb::int32& flags);
 ListenResponse listen(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& backlog);
 SendToResponse send_to(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags, const SockAddr& to);
 SendResponse send(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags);

--- a/generated/nixnetsocket/nixnetsocket_library.cpp
+++ b/generated/nixnetsocket/nixnetsocket_library.cpp
@@ -24,6 +24,7 @@ NiXnetSocketLibrary::NiXnetSocketLibrary() : shared_library_(kLibraryName)
   function_pointers_.Accept = reinterpret_cast<AcceptPtr>(shared_library_.get_function_pointer("nxaccept"));
   function_pointers_.Bind = reinterpret_cast<BindPtr>(shared_library_.get_function_pointer("nxbind"));
   function_pointers_.Connect = reinterpret_cast<ConnectPtr>(shared_library_.get_function_pointer("nxconnect"));
+  function_pointers_.GetAddrInfo = reinterpret_cast<GetAddrInfoPtr>(shared_library_.get_function_pointer("nxgetaddrinfo"));
   function_pointers_.Listen = reinterpret_cast<ListenPtr>(shared_library_.get_function_pointer("nxlisten"));
   function_pointers_.SendTo = reinterpret_cast<SendToPtr>(shared_library_.get_function_pointer("nxsendto"));
   function_pointers_.Send = reinterpret_cast<SendPtr>(shared_library_.get_function_pointer("nxsend"));
@@ -91,6 +92,18 @@ int32_t NiXnetSocketLibrary::Connect(nxSOCKET socket, nxsockaddr* name, nxsockle
   return nxconnect(socket, name, namelen);
 #else
   return function_pointers_.Connect(socket, name, namelen);
+#endif
+}
+
+int32_t NiXnetSocketLibrary::GetAddrInfo(nxIpStackRef_t stack_ref, const char node[], const char service[], nxaddrinfo* hints, nxaddrinfo** res)
+{
+  if (!function_pointers_.GetAddrInfo) {
+    throw nidevice_grpc::LibraryLoadException("Could not find nxgetaddrinfo.");
+  }
+#if defined(_MSC_VER)
+  return nxgetaddrinfo(stack_ref, node, service, hints, res);
+#else
+  return function_pointers_.GetAddrInfo(stack_ref, node, service, hints, res);
 #endif
 }
 

--- a/generated/nixnetsocket/nixnetsocket_library.cpp
+++ b/generated/nixnetsocket/nixnetsocket_library.cpp
@@ -26,6 +26,7 @@ NiXnetSocketLibrary::NiXnetSocketLibrary() : shared_library_(kLibraryName)
   function_pointers_.Connect = reinterpret_cast<ConnectPtr>(shared_library_.get_function_pointer("nxconnect"));
   function_pointers_.FreeAddrInfo = reinterpret_cast<FreeAddrInfoPtr>(shared_library_.get_function_pointer("nxfreeaddrinfo"));
   function_pointers_.GetAddrInfo = reinterpret_cast<GetAddrInfoPtr>(shared_library_.get_function_pointer("nxgetaddrinfo"));
+  function_pointers_.GetNameInfo = reinterpret_cast<GetNameInfoPtr>(shared_library_.get_function_pointer("nxgetnameinfo"));
   function_pointers_.Listen = reinterpret_cast<ListenPtr>(shared_library_.get_function_pointer("nxlisten"));
   function_pointers_.SendTo = reinterpret_cast<SendToPtr>(shared_library_.get_function_pointer("nxsendto"));
   function_pointers_.Send = reinterpret_cast<SendPtr>(shared_library_.get_function_pointer("nxsend"));
@@ -113,6 +114,18 @@ int32_t NiXnetSocketLibrary::GetAddrInfo(nxIpStackRef_t stack_ref, const char no
   return nxgetaddrinfo(stack_ref, node, service, hints, res);
 #else
   return function_pointers_.GetAddrInfo(stack_ref, node, service, hints, res);
+#endif
+}
+
+int32_t NiXnetSocketLibrary::GetNameInfo(nxIpStackRef_t stack_ref, nxsockaddr* addr, nxsocklen_t addr_len, char host[], nxsocklen_t host_len, char serv[], nxsocklen_t serv_len, int32_t flags)
+{
+  if (!function_pointers_.GetNameInfo) {
+    throw nidevice_grpc::LibraryLoadException("Could not find nxgetnameinfo.");
+  }
+#if defined(_MSC_VER)
+  return nxgetnameinfo(stack_ref, addr, addr_len, host, host_len, serv, serv_len, flags);
+#else
+  return function_pointers_.GetNameInfo(stack_ref, addr, addr_len, host, host_len, serv, serv_len, flags);
 #endif
 }
 

--- a/generated/nixnetsocket/nixnetsocket_library.cpp
+++ b/generated/nixnetsocket/nixnetsocket_library.cpp
@@ -24,6 +24,7 @@ NiXnetSocketLibrary::NiXnetSocketLibrary() : shared_library_(kLibraryName)
   function_pointers_.Accept = reinterpret_cast<AcceptPtr>(shared_library_.get_function_pointer("nxaccept"));
   function_pointers_.Bind = reinterpret_cast<BindPtr>(shared_library_.get_function_pointer("nxbind"));
   function_pointers_.Connect = reinterpret_cast<ConnectPtr>(shared_library_.get_function_pointer("nxconnect"));
+  function_pointers_.FreeAddrInfo = reinterpret_cast<FreeAddrInfoPtr>(shared_library_.get_function_pointer("nxfreeaddrinfo"));
   function_pointers_.GetAddrInfo = reinterpret_cast<GetAddrInfoPtr>(shared_library_.get_function_pointer("nxgetaddrinfo"));
   function_pointers_.Listen = reinterpret_cast<ListenPtr>(shared_library_.get_function_pointer("nxlisten"));
   function_pointers_.SendTo = reinterpret_cast<SendToPtr>(shared_library_.get_function_pointer("nxsendto"));
@@ -93,6 +94,14 @@ int32_t NiXnetSocketLibrary::Connect(nxSOCKET socket, nxsockaddr* name, nxsockle
 #else
   return function_pointers_.Connect(socket, name, namelen);
 #endif
+}
+
+int32_t NiXnetSocketLibrary::FreeAddrInfo(nxaddrinfo* res)
+{
+  if (!function_pointers_.FreeAddrInfo) {
+    throw nidevice_grpc::LibraryLoadException("Could not find nxfreeaddrinfo.");
+  }
+  return function_pointers_.FreeAddrInfo(res);
 }
 
 int32_t NiXnetSocketLibrary::GetAddrInfo(nxIpStackRef_t stack_ref, const char node[], const char service[], nxaddrinfo* hints, nxaddrinfo** res)

--- a/generated/nixnetsocket/nixnetsocket_library.h
+++ b/generated/nixnetsocket/nixnetsocket_library.h
@@ -21,6 +21,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   int32_t Accept(nxSOCKET socket, nxsockaddr* addr, nxsocklen_t* addrlen);
   int32_t Bind(nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen);
   int32_t Connect(nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen);
+  int32_t FreeAddrInfo(nxaddrinfo* res);
   int32_t GetAddrInfo(nxIpStackRef_t stack_ref, const char node[], const char service[], nxaddrinfo* hints, nxaddrinfo** res);
   int32_t Listen(nxSOCKET socket, int32_t backlog);
   int32_t SendTo(nxSOCKET socket, char dataptr[], int32_t size, int32_t flags, nxsockaddr* to, nxsocklen_t tolen);
@@ -48,6 +49,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   using AcceptPtr = decltype(&nxaccept);
   using BindPtr = decltype(&nxbind);
   using ConnectPtr = decltype(&nxconnect);
+  using FreeAddrInfoPtr = int32_t (*)(nxaddrinfo* res);
   using GetAddrInfoPtr = decltype(&nxgetaddrinfo);
   using ListenPtr = decltype(&nxlisten);
   using SendToPtr = decltype(&nxsendto);
@@ -75,6 +77,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
     AcceptPtr Accept;
     BindPtr Bind;
     ConnectPtr Connect;
+    FreeAddrInfoPtr FreeAddrInfo;
     GetAddrInfoPtr GetAddrInfo;
     ListenPtr Listen;
     SendToPtr SendTo;

--- a/generated/nixnetsocket/nixnetsocket_library.h
+++ b/generated/nixnetsocket/nixnetsocket_library.h
@@ -21,6 +21,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   int32_t Accept(nxSOCKET socket, nxsockaddr* addr, nxsocklen_t* addrlen);
   int32_t Bind(nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen);
   int32_t Connect(nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen);
+  int32_t GetAddrInfo(nxIpStackRef_t stack_ref, const char node[], const char service[], nxaddrinfo* hints, nxaddrinfo** res);
   int32_t Listen(nxSOCKET socket, int32_t backlog);
   int32_t SendTo(nxSOCKET socket, char dataptr[], int32_t size, int32_t flags, nxsockaddr* to, nxsocklen_t tolen);
   int32_t Send(nxSOCKET socket, char dataptr[], int32_t size, int32_t flags);
@@ -47,6 +48,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   using AcceptPtr = decltype(&nxaccept);
   using BindPtr = decltype(&nxbind);
   using ConnectPtr = decltype(&nxconnect);
+  using GetAddrInfoPtr = decltype(&nxgetaddrinfo);
   using ListenPtr = decltype(&nxlisten);
   using SendToPtr = decltype(&nxsendto);
   using SendPtr = decltype(&nxsend);
@@ -73,6 +75,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
     AcceptPtr Accept;
     BindPtr Bind;
     ConnectPtr Connect;
+    GetAddrInfoPtr GetAddrInfo;
     ListenPtr Listen;
     SendToPtr SendTo;
     SendPtr Send;

--- a/generated/nixnetsocket/nixnetsocket_library.h
+++ b/generated/nixnetsocket/nixnetsocket_library.h
@@ -23,6 +23,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   int32_t Connect(nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen);
   int32_t FreeAddrInfo(nxaddrinfo* res);
   int32_t GetAddrInfo(nxIpStackRef_t stack_ref, const char node[], const char service[], nxaddrinfo* hints, nxaddrinfo** res);
+  int32_t GetNameInfo(nxIpStackRef_t stack_ref, nxsockaddr* addr, nxsocklen_t addr_len, char host[], nxsocklen_t host_len, char serv[], nxsocklen_t serv_len, int32_t flags);
   int32_t Listen(nxSOCKET socket, int32_t backlog);
   int32_t SendTo(nxSOCKET socket, char dataptr[], int32_t size, int32_t flags, nxsockaddr* to, nxsocklen_t tolen);
   int32_t Send(nxSOCKET socket, char dataptr[], int32_t size, int32_t flags);
@@ -51,6 +52,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
   using ConnectPtr = decltype(&nxconnect);
   using FreeAddrInfoPtr = int32_t (*)(nxaddrinfo* res);
   using GetAddrInfoPtr = decltype(&nxgetaddrinfo);
+  using GetNameInfoPtr = decltype(&nxgetnameinfo);
   using ListenPtr = decltype(&nxlisten);
   using SendToPtr = decltype(&nxsendto);
   using SendPtr = decltype(&nxsend);
@@ -79,6 +81,7 @@ class NiXnetSocketLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInterfa
     ConnectPtr Connect;
     FreeAddrInfoPtr FreeAddrInfo;
     GetAddrInfoPtr GetAddrInfo;
+    GetNameInfoPtr GetNameInfo;
     ListenPtr Listen;
     SendToPtr SendTo;
     SendPtr Send;

--- a/generated/nixnetsocket/nixnetsocket_library_interface.h
+++ b/generated/nixnetsocket/nixnetsocket_library_interface.h
@@ -20,6 +20,7 @@ class NiXnetSocketLibraryInterface {
   virtual int32_t Connect(nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen) = 0;
   virtual int32_t FreeAddrInfo(nxaddrinfo* res) = 0;
   virtual int32_t GetAddrInfo(nxIpStackRef_t stack_ref, const char node[], const char service[], nxaddrinfo* hints, nxaddrinfo** res) = 0;
+  virtual int32_t GetNameInfo(nxIpStackRef_t stack_ref, nxsockaddr* addr, nxsocklen_t addr_len, char host[], nxsocklen_t host_len, char serv[], nxsocklen_t serv_len, int32_t flags) = 0;
   virtual int32_t Listen(nxSOCKET socket, int32_t backlog) = 0;
   virtual int32_t SendTo(nxSOCKET socket, char dataptr[], int32_t size, int32_t flags, nxsockaddr* to, nxsocklen_t tolen) = 0;
   virtual int32_t Send(nxSOCKET socket, char dataptr[], int32_t size, int32_t flags) = 0;

--- a/generated/nixnetsocket/nixnetsocket_library_interface.h
+++ b/generated/nixnetsocket/nixnetsocket_library_interface.h
@@ -18,6 +18,7 @@ class NiXnetSocketLibraryInterface {
   virtual int32_t Accept(nxSOCKET socket, nxsockaddr* addr, nxsocklen_t* addrlen) = 0;
   virtual int32_t Bind(nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen) = 0;
   virtual int32_t Connect(nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen) = 0;
+  virtual int32_t FreeAddrInfo(nxaddrinfo* res) = 0;
   virtual int32_t GetAddrInfo(nxIpStackRef_t stack_ref, const char node[], const char service[], nxaddrinfo* hints, nxaddrinfo** res) = 0;
   virtual int32_t Listen(nxSOCKET socket, int32_t backlog) = 0;
   virtual int32_t SendTo(nxSOCKET socket, char dataptr[], int32_t size, int32_t flags, nxsockaddr* to, nxsocklen_t tolen) = 0;

--- a/generated/nixnetsocket/nixnetsocket_library_interface.h
+++ b/generated/nixnetsocket/nixnetsocket_library_interface.h
@@ -18,6 +18,7 @@ class NiXnetSocketLibraryInterface {
   virtual int32_t Accept(nxSOCKET socket, nxsockaddr* addr, nxsocklen_t* addrlen) = 0;
   virtual int32_t Bind(nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen) = 0;
   virtual int32_t Connect(nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen) = 0;
+  virtual int32_t GetAddrInfo(nxIpStackRef_t stack_ref, const char node[], const char service[], nxaddrinfo* hints, nxaddrinfo** res) = 0;
   virtual int32_t Listen(nxSOCKET socket, int32_t backlog) = 0;
   virtual int32_t SendTo(nxSOCKET socket, char dataptr[], int32_t size, int32_t flags, nxsockaddr* to, nxsocklen_t tolen) = 0;
   virtual int32_t Send(nxSOCKET socket, char dataptr[], int32_t size, int32_t flags) = 0;

--- a/generated/nixnetsocket/nixnetsocket_mock_library.h
+++ b/generated/nixnetsocket/nixnetsocket_mock_library.h
@@ -22,6 +22,7 @@ class NiXnetSocketMockLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInt
   MOCK_METHOD(int32_t, Connect, (nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen), (override));
   MOCK_METHOD(int32_t, FreeAddrInfo, (nxaddrinfo* res), (override));
   MOCK_METHOD(int32_t, GetAddrInfo, (nxIpStackRef_t stack_ref, const char node[], const char service[], nxaddrinfo* hints, nxaddrinfo** res), (override));
+  MOCK_METHOD(int32_t, GetNameInfo, (nxIpStackRef_t stack_ref, nxsockaddr* addr, nxsocklen_t addr_len, char host[], nxsocklen_t host_len, char serv[], nxsocklen_t serv_len, int32_t flags), (override));
   MOCK_METHOD(int32_t, Listen, (nxSOCKET socket, int32_t backlog), (override));
   MOCK_METHOD(int32_t, SendTo, (nxSOCKET socket, char dataptr[], int32_t size, int32_t flags, nxsockaddr* to, nxsocklen_t tolen), (override));
   MOCK_METHOD(int32_t, Send, (nxSOCKET socket, char dataptr[], int32_t size, int32_t flags), (override));

--- a/generated/nixnetsocket/nixnetsocket_mock_library.h
+++ b/generated/nixnetsocket/nixnetsocket_mock_library.h
@@ -20,6 +20,7 @@ class NiXnetSocketMockLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInt
   MOCK_METHOD(int32_t, Accept, (nxSOCKET socket, nxsockaddr* addr, nxsocklen_t* addrlen), (override));
   MOCK_METHOD(int32_t, Bind, (nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen), (override));
   MOCK_METHOD(int32_t, Connect, (nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen), (override));
+  MOCK_METHOD(int32_t, GetAddrInfo, (nxIpStackRef_t stack_ref, const char node[], const char service[], nxaddrinfo* hints, nxaddrinfo** res), (override));
   MOCK_METHOD(int32_t, Listen, (nxSOCKET socket, int32_t backlog), (override));
   MOCK_METHOD(int32_t, SendTo, (nxSOCKET socket, char dataptr[], int32_t size, int32_t flags, nxsockaddr* to, nxsocklen_t tolen), (override));
   MOCK_METHOD(int32_t, Send, (nxSOCKET socket, char dataptr[], int32_t size, int32_t flags), (override));

--- a/generated/nixnetsocket/nixnetsocket_mock_library.h
+++ b/generated/nixnetsocket/nixnetsocket_mock_library.h
@@ -20,6 +20,7 @@ class NiXnetSocketMockLibrary : public nixnetsocket_grpc::NiXnetSocketLibraryInt
   MOCK_METHOD(int32_t, Accept, (nxSOCKET socket, nxsockaddr* addr, nxsocklen_t* addrlen), (override));
   MOCK_METHOD(int32_t, Bind, (nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen), (override));
   MOCK_METHOD(int32_t, Connect, (nxSOCKET socket, nxsockaddr* name, nxsocklen_t namelen), (override));
+  MOCK_METHOD(int32_t, FreeAddrInfo, (nxaddrinfo* res), (override));
   MOCK_METHOD(int32_t, GetAddrInfo, (nxIpStackRef_t stack_ref, const char node[], const char service[], nxaddrinfo* hints, nxaddrinfo** res), (override));
   MOCK_METHOD(int32_t, Listen, (nxSOCKET socket, int32_t backlog), (override));
   MOCK_METHOD(int32_t, SendTo, (nxSOCKET socket, char dataptr[], int32_t size, int32_t flags, nxsockaddr* to, nxsocklen_t tolen), (override));

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -167,6 +167,50 @@ namespace nixnetsocket_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiXnetSocketService::GetNameInfo(::grpc::ServerContext* context, const GetNameInfoRequest* request, GetNameInfoResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto stack_ref_grpc_session = request->stack_ref();
+      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
+      auto addr = convert_from_grpc<nxsockaddr>(request->addr());
+      auto addr_len = addr.size();
+      nxsocklen_t host_len = request->host_len();
+      nxsocklen_t serv_len = request->serv_len();
+      int32_t flags = request->flags();
+      std::string host;
+      if (host_len > 0) {
+          host.resize(host_len - 1);
+      }
+      std::string serv;
+      if (serv_len > 0) {
+          serv.resize(serv_len - 1);
+      }
+      auto status = library_->GetNameInfo(stack_ref, addr, addr_len, (char*)host.data(), host_len, (char*)serv.data(), serv_len, flags);
+      response->set_status(status);
+      if (status_ok(status)) {
+        response->set_host(host);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_host()));
+        response->set_serv(serv);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_serv()));
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+        const auto error_num = get_last_error_num(library_);
+        response->set_error_num(error_num);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiXnetSocketService::Listen(::grpc::ServerContext* context, const ListenRequest* request, ListenResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -146,7 +146,7 @@ namespace nixnetsocket_grpc {
       auto node = request->node().c_str();
       auto service = request->service().c_str();
       auto hints = convert_from_grpc<nxaddrinfo>(request->hints());
-      auto res = allocate_output_storage<nxaddrinfo, google::protobuf::RepeatedPtrField<AddrInfo>>();
+      auto res = allocate_output_storage<nxaddrinfo, google::protobuf::RepeatedPtrField<AddrInfo>>(library_);
       auto status = library_->GetAddrInfo(stack_ref, node, service, hints, &res);
       response->set_status(status);
       if (status_ok(status)) {

--- a/generated/nixnetsocket/nixnetsocket_service.h
+++ b/generated/nixnetsocket/nixnetsocket_service.h
@@ -47,6 +47,7 @@ public:
   ::grpc::Status Bind(::grpc::ServerContext* context, const BindRequest* request, BindResponse* response) override;
   ::grpc::Status Connect(::grpc::ServerContext* context, const ConnectRequest* request, ConnectResponse* response) override;
   ::grpc::Status GetAddrInfo(::grpc::ServerContext* context, const GetAddrInfoRequest* request, GetAddrInfoResponse* response) override;
+  ::grpc::Status GetNameInfo(::grpc::ServerContext* context, const GetNameInfoRequest* request, GetNameInfoResponse* response) override;
   ::grpc::Status Listen(::grpc::ServerContext* context, const ListenRequest* request, ListenResponse* response) override;
   ::grpc::Status SendTo(::grpc::ServerContext* context, const SendToRequest* request, SendToResponse* response) override;
   ::grpc::Status Send(::grpc::ServerContext* context, const SendRequest* request, SendResponse* response) override;

--- a/generated/nixnetsocket/nixnetsocket_service.h
+++ b/generated/nixnetsocket/nixnetsocket_service.h
@@ -46,6 +46,7 @@ public:
   ::grpc::Status Accept(::grpc::ServerContext* context, const AcceptRequest* request, AcceptResponse* response) override;
   ::grpc::Status Bind(::grpc::ServerContext* context, const BindRequest* request, BindResponse* response) override;
   ::grpc::Status Connect(::grpc::ServerContext* context, const ConnectRequest* request, ConnectResponse* response) override;
+  ::grpc::Status GetAddrInfo(::grpc::ServerContext* context, const GetAddrInfoRequest* request, GetAddrInfoResponse* response) override;
   ::grpc::Status Listen(::grpc::ServerContext* context, const ListenRequest* request, ListenResponse* response) override;
   ::grpc::Status SendTo(::grpc::ServerContext* context, const SendToRequest* request, SendToResponse* response) override;
   ::grpc::Status Send(::grpc::ServerContext* context, const SendRequest* request, SendResponse* response) override;

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -462,7 +462,7 @@ def get_attribute_enums_by_type(attributes):
     return attribute_enums_by_type
 
 
-def get_function_enums(functions):
+def get_function_enums(functions, enums: List[dict]):
     """Get a list of the enums used by functions."""
     function_enums = set()
     for function in functions:
@@ -473,7 +473,16 @@ def get_function_enums(functions):
                 function_enums.add(parameter["mapped-enum"])
             if "bitfield_as_enum_array" in parameter:
                 function_enums.add(parameter["bitfield_as_enum_array"])
+    function_enums.update(_get_force_include_enums(enums))
     return sorted(function_enums)
+
+
+def _get_force_include_enums(enums: List[dict]):
+    force_include_enums = set()
+    for enum in enums:
+        if enums[enum].get("force-include", False):
+            force_include_enums.add(enum)
+    return force_include_enums
 
 
 def has_viboolean_array_param(functions):

--- a/source/codegen/metadata/nixnetsocket/config.py
+++ b/source/codegen/metadata/nixnetsocket/config.py
@@ -36,6 +36,7 @@ config = {
         'uint32_t': 'uint32',
         'uint16_t': 'uint16',
         'int64_t': 'int64',
+        'nxaddrinfo': 'repeated AddrInfo',
         'nxlinger': 'Linger',
         'nxsockaddr': 'SockAddr',
         'nxtimeval': 'google.protobuf.Duration',

--- a/source/codegen/metadata/nixnetsocket/custom_proto.mako
+++ b/source/codegen/metadata/nixnetsocket/custom_proto.mako
@@ -49,6 +49,13 @@ message AddrInfo {
   string canon_name = 6;
 }
 
+message AddrInfoHint {
+  int32 flags = 1;
+  int32 family = 2;
+  int32 sock_type = 3;
+  int32 protocol = 4;
+}
+
 message Linger {
   int32 l_onoff = 1;
   int32 l_linger = 2;
@@ -61,20 +68,4 @@ message SockOptData {
     string data_string = 3;
     Linger data_linger = 4;
   }
-}
-
-message AddrInfo {
-  int32 flags = 1;
-  int32 family = 2;
-  int32 sock_type = 3;
-  int32 protocol = 4;
-  SockAddr addr = 5;
-  string canon_name = 6;
-}
-
-message AddrInfoHint {
-  int32 flags = 1;
-  int32 family = 2;
-  int32 sock_type = 3;
-  int32 protocol = 4;
 }

--- a/source/codegen/metadata/nixnetsocket/custom_proto.mako
+++ b/source/codegen/metadata/nixnetsocket/custom_proto.mako
@@ -62,3 +62,19 @@ message SockOptData {
     Linger data_linger = 4;
   }
 }
+
+message AddrInfo {
+  int32 flags = 1;
+  int32 family = 2;
+  int32 sock_type = 3;
+  int32 protocol = 4;
+  SockAddr addr = 5;
+  string canon_name = 6;
+}
+
+message AddrInfoHint {
+  int32 flags = 1;
+  int32 family = 2;
+  int32 sock_type = 3;
+  int32 protocol = 4;
+}

--- a/source/codegen/metadata/nixnetsocket/custom_proto.mako
+++ b/source/codegen/metadata/nixnetsocket/custom_proto.mako
@@ -41,19 +41,19 @@ message SockAddr {
 }
 
 message AddrInfo {
-  int32 flags = 1;
-  int32 family = 2;
-  int32 sock_type = 3;
-  int32 protocol = 4;
+  GetAddrInfoFlags flags = 1;
+  AddressFamily family = 2;
+  SocketProtocolType sock_type = 3;
+  IPProtocol protocol = 4;
   SockAddr addr = 5;
   string canon_name = 6;
 }
 
 message AddrInfoHint {
-  int32 flags = 1;
-  int32 family = 2;
-  int32 sock_type = 3;
-  int32 protocol = 4;
+  GetAddrInfoFlags flags = 1;
+  AddressFamily family = 2;
+  SocketProtocolType sock_type = 3;
+  IPProtocol protocol = 4;
 }
 
 message Linger {

--- a/source/codegen/metadata/nixnetsocket/enums.py
+++ b/source/codegen/metadata/nixnetsocket/enums.py
@@ -190,6 +190,7 @@ enums = {
         ]
     },
     'GetAddrInfoFlags': {
+        'force-include': True,
         'values': [
             {
                 'name': 'PASSIVE',

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -76,6 +76,43 @@ functions = {
         ],
         'returns': 'int32_t'
     },
+    'GetAddrInfo': {
+        'cname': 'nxgetaddrinfo',
+        'parameters': [
+            {
+                'direction': 'in', 
+                'name': 'stack_ref', 
+                'type': 'nxIpStackRef_t'
+            },
+            {
+                'direction': 'in',
+                'name': 'node',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'service',
+                'type': 'const char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'hints',
+                'supports_standard_copy_convert': True,
+                'grpc_type': 'AddrInfoHint',
+                'pointer': True,
+                'type': 'nxaddrinfo'
+            },
+            {
+                'direction': 'out',
+                'name': 'res',
+                'supports_standard_copy_convert': True,
+                'supports_standard_output_allocation': True,
+                'pointer': True,
+                'type': 'nxaddrinfo'
+            }
+        ],
+        'returns': 'int32_t'
+    },
     'Listen': {
         'cname': 'nxlisten',
         'parameters': [

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -127,6 +127,65 @@ functions = {
         ],
         'returns': 'int32_t'
     },
+    'GetNameInfo': {
+        'cname': 'nxgetnameinfo',
+        'parameters': [
+            {
+                'direction': 'in', 
+                'name': 'stack_ref', 
+                'type': 'nxIpStackRef_t'
+            },
+            {
+                'direction': 'in',
+                'grpc_type': 'SockAddr',
+                'name': 'addr',
+                'pointer': True,
+                'supports_standard_copy_convert': True,
+                'type': 'nxsockaddr'
+            },
+            {
+                'direction': 'in',
+                'name': 'addr_len',
+                'hardcoded_value': 'addr.size()',
+                'include_in_proto': False,
+                'type': 'nxsocklen_t'
+            },
+            {
+                'direction': 'out',
+                'name': 'host',
+                'type': 'char[]',
+                'size': {
+                    'mechanism': 'passed-in',
+                    'value': 'host_len'
+                }
+            },
+            {
+                'direction': 'in',
+                'name': 'host_len',
+                'type': 'nxsocklen_t'
+            },
+            {
+                'direction': 'out',
+                'name': 'serv',
+                'type': 'char[]',
+                'size': {
+                    'mechanism': 'passed-in',
+                    'value': 'serv_len'
+                }
+            },
+            {
+                'direction': 'in',
+                'name': 'serv_len',
+                'type': 'nxsocklen_t'
+            },
+            {
+                'direction': 'in',
+                'name': 'flags',
+                'type': 'int32_t'
+            },
+        ],
+        'returns': 'int32_t'
+    },
     'Listen': {
         'cname': 'nxlisten',
         'parameters': [

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -76,6 +76,19 @@ functions = {
         ],
         'returns': 'int32_t'
     },
+    'FreeAddrInfo': {
+        'codegen_method': 'private',
+        'cname': 'nxfreeaddrinfo',
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'res',
+                'type': 'nxaddrinfo',
+                'pointer': True
+            }
+        ],
+        'returns': 'int32_t'
+    },
     'GetAddrInfo': {
         'cname': 'nxgetaddrinfo',
         'parameters': [
@@ -107,6 +120,7 @@ functions = {
                 'name': 'res',
                 'supports_standard_copy_convert': True,
                 'supports_standard_output_allocation': True,
+                'additional_arguments_to_output_allocation': ['library_'],
                 'pointer': True,
                 'type': 'nxaddrinfo'
             }

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -160,6 +160,7 @@ ENUM_SCHEMA = Schema(
         Optional("generate-mappings"): bool,
         Optional("enum-value-prefix"): str,
         Optional("generate-mapping-type"): bool,
+        Optional("force-include"): bool,
     }
 )
 

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -436,7 +436,7 @@ def get_enums_to_map(functions: dict, enums: dict) -> List[str]:
         enum = get_enum_or_default(enum_name)
         return enum.get("generate-mappings", False)
 
-    function_enums = common_helpers.get_function_enums(functions)
+    function_enums = common_helpers.get_function_enums(functions, enums)
     return [e for e in function_enums if should_generate_mappings(e)]
 
 

--- a/source/codegen/templates/proto.mako
+++ b/source/codegen/templates/proto.mako
@@ -7,7 +7,7 @@ enums = data["enums"]
 functions = data["functions"]
 
 service_class_prefix = config["service_class_prefix"]
-function_enums = common_helpers.get_function_enums(functions)
+function_enums = common_helpers.get_function_enums(functions, enums)
 external_proto_deps = common_helpers.list_external_proto_dependencies(functions)
 %>\
 <%namespace name="mako_helper" file="/proto_helpers.mako"/>\

--- a/source/codegen/templates/service.h.mako
+++ b/source/codegen/templates/service.h.mako
@@ -6,7 +6,6 @@ enums = data['enums']
 config = data['config']
 functions = data['functions']
 
-function_enums = common_helpers.get_function_enums(functions)
 enums_to_map = service_helpers.get_enums_to_map(functions, enums)
 enums_mapped_to_type = service_helpers.generate_mapping_enums_to_type(enums)
 type_from_enum = service_helpers.get_distinct_types_from_enums(enums)

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -431,7 +431,7 @@ inline void convert_to_grpc(const SockOptDataOutputConverter& storage, SockOptDa
     addr_info.ai_socktype = input.sock_type();
     addr_info.ai_protocol = input.protocol();
 
-    // Other addr_info fields for the hint should be left unset.
+    // Other addr_info fields for the hint should be left unset (0 initialized).
   }
 
   operator nxaddrinfo*()

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -136,7 +136,7 @@ struct SockAddrOutputConverter {
 
   // Overriding the address_of operator is like a implicit conversion for output
   // params. This works with our default output param passing codegen that passes
-  // this as nxaccepr(sock, &addr, &addrlen);
+  // this as nxaccept(sock, &addr, &addrlen);
   nxsockaddr* operator&()
   {
     return storage_cast<nxsockaddr>();

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -433,9 +433,9 @@ inline void convert_to_grpc(const SockOptDataOutputConverter& storage, SockOptDa
 
     // Other addr_info fields for the hint should be 0 or null
     addr_info.ai_addrlen = 0;
-    addr_info.ai_addr = NULL;
-    addr_info.ai_canonname = NULL;
-    addr_info.ai_next = NULL;
+    addr_info.ai_addr = nullptr;
+    addr_info.ai_canonname = nullptr;
+    addr_info.ai_next = nullptr;
   }
 
   operator nxaddrinfo*()

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -459,7 +459,7 @@ inline AddrInfoHintInputConverter convert_from_grpc(const AddrInfoHint& input)
 }
 
 struct AddrInfoOutputConverter {
-  AddrInfoOutputConverter() : addr_info_ptr(nullptr)
+  AddrInfoOutputConverter(NiXnetSocketLibraryInterface* library) : addr_info_ptr(nullptr), library(library)
   {
   }
 
@@ -509,11 +509,12 @@ struct AddrInfoOutputConverter {
       }
     }
     // Free the address info after we've read it.
-    nxfreeaddrinfo(addr_info_ptr);
+    library->FreeAddrInfo(addr_info_ptr);
     addr_info_ptr = nullptr;
   }
 
   nxaddrinfo* addr_info_ptr;
+  NiXnetSocketLibraryInterface* library;
 };
 
 inline void convert_to_grpc(AddrInfoOutputConverter& storage, pb_::RepeatedPtrField<AddrInfo>* output)

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -475,10 +475,10 @@ struct AddrInfoOutputConverter {
         curr_addr_info_ptr != nullptr;
         curr_addr_info_ptr = curr_addr_info_ptr->ai_next) {
       auto curr_grpc_addr_info = output.Add();
-      curr_grpc_addr_info->set_flags(curr_addr_info_ptr->ai_flags);
-      curr_grpc_addr_info->set_family(curr_addr_info_ptr->ai_family);
-      curr_grpc_addr_info->set_sock_type(curr_addr_info_ptr->ai_socktype);
-      curr_grpc_addr_info->set_protocol(curr_addr_info_ptr->ai_protocol);
+      curr_grpc_addr_info->set_flags((GetAddrInfoFlags)curr_addr_info_ptr->ai_flags);
+      curr_grpc_addr_info->set_family((AddressFamily)curr_addr_info_ptr->ai_family);
+      curr_grpc_addr_info->set_sock_type((SocketProtocolType)curr_addr_info_ptr->ai_socktype);
+      curr_grpc_addr_info->set_protocol((IPProtocol)curr_addr_info_ptr->ai_protocol);
       curr_grpc_addr_info->set_canon_name(curr_addr_info_ptr->ai_canonname);
 
       // Copy out the SockAddr.

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -423,7 +423,12 @@ struct SockOptDataOutputConverter {
   nxlinger data_linger;
 };
 
-inline void convert_to_grpc(const SockOptDataOutputConverter& storage, SockOptData* output) struct AddrInfoHintInputConverter {
+inline void convert_to_grpc(const SockOptDataOutputConverter& storage, SockOptData* output)
+{
+  storage.to_grpc(*output);
+}
+
+struct AddrInfoHintInputConverter {
   AddrInfoHintInputConverter(const AddrInfoHint& input)
   {
     addr_info.ai_flags = input.flags();
@@ -532,7 +537,6 @@ template <>
 struct TypeToStorageType<nxVirtualInterface_t, google::protobuf::RepeatedPtrField<nixnetsocket_grpc::VirtualInterface>> {
   using StorageType = nixnetsocket_grpc::VirtualInterfaceOutputConverter;
 };
-
 // Specialization of TypeToStorageType so that allocate_storage_type will
 // allocate SockOptDataOutputConverters for void* output params.
 template <>

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -431,11 +431,7 @@ inline void convert_to_grpc(const SockOptDataOutputConverter& storage, SockOptDa
     addr_info.ai_socktype = input.sock_type();
     addr_info.ai_protocol = input.protocol();
 
-    // Other addr_info fields for the hint should be 0 or null
-    addr_info.ai_addrlen = 0;
-    addr_info.ai_addr = nullptr;
-    addr_info.ai_canonname = nullptr;
-    addr_info.ai_next = nullptr;
+    // Other addr_info fields for the hint should be left unset.
   }
 
   operator nxaddrinfo*()
@@ -448,7 +444,7 @@ inline void convert_to_grpc(const SockOptDataOutputConverter& storage, SockOptDa
     return &addr_info;
   }
 
-  nxaddrinfo addr_info;
+  nxaddrinfo addr_info{};
 };
 
 template <typename TAddrInfoHint>

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -465,7 +465,6 @@ struct AddrInfoOutputConverter {
 
   void to_grpc(pb_::RepeatedPtrField<AddrInfo>& output)
   {
-    auto curr_addr_info_ptr = addr_info_ptr;
     for (
         auto curr_addr_info_ptr = addr_info_ptr;
         curr_addr_info_ptr != nullptr;
@@ -505,8 +504,8 @@ struct AddrInfoOutputConverter {
       }
     }
     // Free the address info after we've read it.
-    nxfreeaddrinfo(curr_addr_info_ptr);
-    curr_addr_info_ptr = nullptr;
+    nxfreeaddrinfo(addr_info_ptr);
+    addr_info_ptr = nullptr;
   }
 
   nxaddrinfo* addr_info_ptr;


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Adds nxaddrinfo functions to the xnet socket service (GetAddrInfo and GetNameInfo).
- Added a tag for Enums called 'force-include'. This makes it so even if the enum isn't referenced  in functions.py it is still included in generation. This was to pull in an Enum that was only referenced in a custom_proto message type.

Follows a similar pattern as what is done for nxVirtualInterface_t in #607 


### Why should this Pull Request be merged?

Fixes [AB#1876325](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1876325)

### What testing has been done?

Manual inspection. Going to add tests in [AB#1895026](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1895026) to get these functions in early.