### PR TITLE
Add Enums for nxSocket

### DIFF
--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -44,11 +44,45 @@ enum NiXnetSocketAttribute {
   NIXNETSOCKET_ATTRIBUTE_UNSPECIFIED = 0;
 }
 
+enum AddressFamily {
+  ADDRESS_FAMILY_UNSPECIFIED = 0;
+  ADDRESS_FAMILY_INET = 2;
+  ADDRESS_FAMILY_INET6 = 10;
+}
+
+enum IPProtocol {
+  IP_PROTOCOL_IP = 0;
+  IP_PROTOCOL_TCP = 6;
+  IP_PROTOCOL_UDP = 8;
+  IP_PROTOCOL_IPV6 = 12;
+}
+
+enum SocketProtocolType {
+  SOCKET_PROTOCOL_TYPE_UNSPECIFIED = 0;
+  SOCKET_PROTOCOL_TYPE_STREAM = 1;
+  SOCKET_PROTOCOL_TYPE_DGRAM = 2;
+}
+
+enum SocketOptionLevel {
+  SOCKET_OPTION_LEVEL_UNSPECIFIED = 0;
+  SOCKET_OPTION_LEVEL_SOCKET = 13;
+}
+
 enum OptName {
+  option allow_alias = true;
   OPT_NAME_UNSPECIFIED = 0;
   OPT_NAME_TCP_NODELAY = 1;
-  OPT_NAME_IP_MULTICAST_TTL  = 6;
+  OPT_NAME_IP_ADD_MEMBERSHIP = 3;
+  OPT_NAME_IP_DROP_MEMBERSHIP = 4;
+  OPT_NAME_IP_MULTICAST_IF = 5;
+  OPT_NAME_IP_MULTICAST_TTL = 6;
+  OPT_NAME_IPV6_JOIN_GROUP = 12;
+  OPT_NAME_IPV6_LEAVE_GROUP = 13;
+  OPT_NAME_IPV6_ADD_MEMBERSHIP = 12;
+  OPT_NAME_IPV6_DROP_MEMBERSHIP = 13;
+  OPT_NAME_IPV6_MULTICAST_IF = 14;
   OPT_NAME_IPV6_MULTICAST_HOPS = 15;
+  OPT_NAME_IPV6_V6ONLY = 16;
   OPT_NAME_SO_RX_DATA = 257;
   OPT_NAME_SO_RCV_BUF = 258;
   OPT_NAME_SO_SND_BUF = 259;
@@ -57,6 +91,12 @@ enum OptName {
   OPT_NAME_SO_ERROR = 262;
   OPT_NAME_SO_LINGER = 263;
   OPT_NAME_SO_REUSE_ADDR = 264;
+}
+
+enum Shutdown {
+  SHUTDOWN_RD = 0;
+  SHUTDOWN_WR = 1;
+  SHUTDOWN_RDWR = 2;
 }
 
 message IPAddress {
@@ -236,7 +276,10 @@ message GetPeerNameResponse {
 
 message ShutdownRequest {
   nidevice_grpc.Session socket = 1;
-  int32 how = 2;
+  oneof how_enum {
+    Shutdown how = 2;
+    int32 how_raw = 3;
+  }
 }
 
 message ShutdownResponse {
@@ -257,10 +300,13 @@ message CloseResponse {
 
 message GetSockOptRequest {
   nidevice_grpc.Session socket = 1;
-  int32 level = 2;
+  oneof level_enum {
+    SocketOptionLevel level = 2;
+    int32 level_raw = 3;
+  }
   oneof optname_enum {
-    OptName optname = 3;
-    int32 optname_raw = 4;
+    OptName optname = 4;
+    int32 optname_raw = 5;
   }
 }
 
@@ -344,12 +390,15 @@ message SelectResponse {
 
 message SetSockOptRequest {
   nidevice_grpc.Session socket = 1;
-  int32 level = 2;
-  oneof optname_enum {
-    OptName optname = 3;
-    int32 optname_raw = 4;
+  oneof level_enum {
+    SocketOptionLevel level = 2;
+    int32 level_raw = 3;
   }
-  SockOptData opt_data = 5;
+  oneof optname_enum {
+    OptName optname = 4;
+    int32 optname_raw = 5;
+  }
+  SockOptData opt_data = 6;
 }
 
 message SetSockOptResponse {
@@ -361,9 +410,18 @@ message SetSockOptResponse {
 message SocketRequest {
   string session_name = 1;
   nidevice_grpc.Session stack_ref = 2;
-  int32 domain = 3;
-  int32 type = 4;
-  int32 prototcol = 5;
+  oneof domain_enum {
+    AddressFamily domain = 3;
+    int32 domain_raw = 4;
+  }
+  oneof type_enum {
+    SocketProtocolType type = 5;
+    int32 type_raw = 6;
+  }
+  oneof prototcol_enum {
+    IPProtocol prototcol = 7;
+    int32 prototcol_raw = 8;
+  }
 }
 
 message SocketResponse {

--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -42,11 +42,42 @@ enum NiXnetSocketAttribute {
   NIXNETSOCKET_ATTRIBUTE_UNSPECIFIED = 0;
 }
 
+enum AddressFamilies {
+  ADDRESS_FAMILIES_AF_UNSPEC = 0;
+  ADDRESS_FAMILIES_AF_INET = 2;
+  ADDRESS_FAMILIES_AF_INET6 = 10;
+}
+
+enum IPProtocols {
+  IP_PROTOCOLS_IPPROTO_IP = 0;
+  IP_PROTOCOLS_IPPROTO_TCP = 6;
+  IP_PROTOCOLS_IPPROTO_UDP = 8;
+  IP_PROTOCOLS_IPPROTO_IPV6 = 12;
+}
+
+enum SocketProtocolTypes {
+  SOCKET_PROTOCOL_TYPES_UNSPECIFIED = 0;
+  SOCKET_PROTOCOL_TYPES_SOCK_STREAM = 1;
+  SOCKET_PROTOCOL_TYPES_SOCK_DGRAM = 2;
+}
+
+enum SocketOptionLevel {
+  SOCKET_OPTION_LEVEL_UNSPECIFIED = 0;
+  SOCKET_OPTION_LEVEL_SOL_SOCKET = 13;
+}
+
 enum OptName {
   OPT_NAME_UNSPECIFIED = 0;
   OPT_NAME_TCP_NODELAY = 1;
-  OPT_NAME_IP_MULTICAST_TTL  = 6;
+  OPT_NAME_IP_ADD_MEMBERSHIP = 3;
+  OPT_NAME_IP_DROP_MEMBERSHIP = 4;
+  OPT_NAME_IP_MULTICAST_IF = 5;
+  OPT_NAME_IP_MULTICAST_TTL = 6;
+  OPT_NAME_IPV6_JOIN_GROUP = 12;
+  OPT_NAME_IPV6_LEAVE_GROUP = 13;
+  OPT_NAME_IPV6_MULTICAST_IF = 14;
   OPT_NAME_IPV6_MULTICAST_HOPS = 15;
+  OPT_NAME_IPV6_V6ONLY = 16;
   OPT_NAME_SO_RX_DATA = 257;
   OPT_NAME_SO_RCV_BUF = 258;
   OPT_NAME_SO_SND_BUF = 259;
@@ -55,6 +86,12 @@ enum OptName {
   OPT_NAME_SO_ERROR = 262;
   OPT_NAME_SO_LINGER = 263;
   OPT_NAME_SO_REUSE_ADDR = 264;
+}
+
+enum Shutdown {
+  SHUTDOWN_SHUT_RD = 0;
+  SHUTDOWN_SHUT_WR = 1;
+  SHUTDOWN_SHUT_RDWR = 2;
 }
 
 message SockAddrIPv4 {
@@ -202,7 +239,10 @@ message GetPeerNameResponse {
 
 message ShutdownRequest {
   nidevice_grpc.Session socket = 1;
-  int32 how = 2;
+  oneof how_enum {
+    Shutdown how = 2;
+    int32 how_raw = 3;
+  }
 }
 
 message ShutdownResponse {
@@ -223,10 +263,13 @@ message CloseResponse {
 
 message GetSockOptRequest {
   nidevice_grpc.Session socket = 1;
-  int32 level = 2;
+  oneof level_enum {
+    SocketOptionLevel level = 2;
+    int32 level_raw = 3;
+  }
   oneof optname_enum {
-    OptName optname = 3;
-    int32 optname_raw = 4;
+    OptName optname = 4;
+    int32 optname_raw = 5;
   }
 }
 
@@ -287,12 +330,15 @@ message SelectResponse {
 
 message SetSockOptRequest {
   nidevice_grpc.Session socket = 1;
-  int32 level = 2;
-  oneof optname_enum {
-    OptName optname = 3;
-    int32 optname_raw = 4;
+  oneof level_enum {
+    SocketOptionLevel level = 2;
+    int32 level_raw = 3;
   }
-  SockOptData opt_data = 5;
+  oneof optname_enum {
+    OptName optname = 4;
+    int32 optname_raw = 5;
+  }
+  SockOptData opt_data = 6;
 }
 
 message SetSockOptResponse {
@@ -304,9 +350,18 @@ message SetSockOptResponse {
 message SocketRequest {
   string session_name = 1;
   nidevice_grpc.Session stack_ref = 2;
-  int32 domain = 3;
-  int32 type = 4;
-  int32 prototcol = 5;
+  oneof domain_enum {
+    AddressFamilies domain = 3;
+    int32 domain_raw = 4;
+  }
+  oneof type_enum {
+    SocketProtocolTypes type = 5;
+    int32 type_raw = 6;
+  }
+  oneof prototcol_enum {
+    IPProtocols prototcol = 7;
+    int32 prototcol_raw = 8;
+  }
 }
 
 message SocketResponse {

--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -42,31 +42,32 @@ enum NiXnetSocketAttribute {
   NIXNETSOCKET_ATTRIBUTE_UNSPECIFIED = 0;
 }
 
-enum AddressFamilies {
-  ADDRESS_FAMILIES_AF_UNSPEC = 0;
-  ADDRESS_FAMILIES_AF_INET = 2;
-  ADDRESS_FAMILIES_AF_INET6 = 10;
+enum AddressFamily {
+  ADDRESS_FAMILY_UNSPECIFIED = 0;
+  ADDRESS_FAMILY_INET = 2;
+  ADDRESS_FAMILY_INET6 = 10;
 }
 
-enum IPProtocols {
-  IP_PROTOCOLS_IPPROTO_IP = 0;
-  IP_PROTOCOLS_IPPROTO_TCP = 6;
-  IP_PROTOCOLS_IPPROTO_UDP = 8;
-  IP_PROTOCOLS_IPPROTO_IPV6 = 12;
+enum IPProtocol {
+  IP_PROTOCOL_IP = 0;
+  IP_PROTOCOL_TCP = 6;
+  IP_PROTOCOL_UDP = 8;
+  IP_PROTOCOL_IPV6 = 12;
 }
 
-enum SocketProtocolTypes {
-  SOCKET_PROTOCOL_TYPES_UNSPECIFIED = 0;
-  SOCKET_PROTOCOL_TYPES_SOCK_STREAM = 1;
-  SOCKET_PROTOCOL_TYPES_SOCK_DGRAM = 2;
+enum SocketProtocolType {
+  SOCKET_PROTOCOL_TYPE_UNSPECIFIED = 0;
+  SOCKET_PROTOCOL_TYPE_STREAM = 1;
+  SOCKET_PROTOCOL_TYPE_DGRAM = 2;
 }
 
 enum SocketOptionLevel {
   SOCKET_OPTION_LEVEL_UNSPECIFIED = 0;
-  SOCKET_OPTION_LEVEL_SOL_SOCKET = 13;
+  SOCKET_OPTION_LEVEL_SOCKET = 13;
 }
 
 enum OptName {
+  option allow_alias = true;
   OPT_NAME_UNSPECIFIED = 0;
   OPT_NAME_TCP_NODELAY = 1;
   OPT_NAME_IP_ADD_MEMBERSHIP = 3;
@@ -75,6 +76,8 @@ enum OptName {
   OPT_NAME_IP_MULTICAST_TTL = 6;
   OPT_NAME_IPV6_JOIN_GROUP = 12;
   OPT_NAME_IPV6_LEAVE_GROUP = 13;
+  OPT_NAME_IPV6_ADD_MEMBERSHIP = 12;
+  OPT_NAME_IPV6_DROP_MEMBERSHIP = 13;
   OPT_NAME_IPV6_MULTICAST_IF = 14;
   OPT_NAME_IPV6_MULTICAST_HOPS = 15;
   OPT_NAME_IPV6_V6ONLY = 16;
@@ -89,9 +92,9 @@ enum OptName {
 }
 
 enum Shutdown {
-  SHUTDOWN_SHUT_RD = 0;
-  SHUTDOWN_SHUT_WR = 1;
-  SHUTDOWN_SHUT_RDWR = 2;
+  SHUTDOWN_RD = 0;
+  SHUTDOWN_WR = 1;
+  SHUTDOWN_RDWR = 2;
 }
 
 message SockAddrIPv4 {
@@ -351,15 +354,15 @@ message SocketRequest {
   string session_name = 1;
   nidevice_grpc.Session stack_ref = 2;
   oneof domain_enum {
-    AddressFamilies domain = 3;
+    AddressFamily domain = 3;
     int32 domain_raw = 4;
   }
   oneof type_enum {
-    SocketProtocolTypes type = 5;
+    SocketProtocolType type = 5;
     int32 type_raw = 6;
   }
   oneof prototcol_enum {
-    IPProtocols prototcol = 7;
+    IPProtocol prototcol = 7;
     int32 prototcol_raw = 8;
   }
 }

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -190,13 +190,20 @@ get_peer_name(const StubPtr& stub, const nidevice_grpc::Session& socket)
 }
 
 ShutdownResponse
-shutdown(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& how)
+shutdown(const StubPtr& stub, const nidevice_grpc::Session& socket, const simple_variant<Shutdown, pb::int32>& how)
 {
   ::grpc::ClientContext context;
 
   auto request = ShutdownRequest{};
   request.mutable_socket()->CopyFrom(socket);
-  request.set_how(how);
+  const auto how_ptr = how.get_if<Shutdown>();
+  const auto how_raw_ptr = how.get_if<pb::int32>();
+  if (how_ptr) {
+    request.set_how(*how_ptr);
+  }
+  else if (how_raw_ptr) {
+    request.set_how_raw(*how_raw_ptr);
+  }
 
   auto response = ShutdownResponse{};
 
@@ -223,13 +230,20 @@ close(const StubPtr& stub, const nidevice_grpc::Session& socket)
 }
 
 GetSockOptResponse
-get_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& level, const simple_variant<OptName, pb::int32>& optname)
+get_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const simple_variant<SocketOptionLevel, pb::int32>& level, const simple_variant<OptName, pb::int32>& optname)
 {
   ::grpc::ClientContext context;
 
   auto request = GetSockOptRequest{};
   request.mutable_socket()->CopyFrom(socket);
-  request.set_level(level);
+  const auto level_ptr = level.get_if<SocketOptionLevel>();
+  const auto level_raw_ptr = level.get_if<pb::int32>();
+  if (level_ptr) {
+    request.set_level(*level_ptr);
+  }
+  else if (level_raw_ptr) {
+    request.set_level_raw(*level_raw_ptr);
+  }
   const auto optname_ptr = optname.get_if<OptName>();
   const auto optname_raw_ptr = optname.get_if<pb::int32>();
   if (optname_ptr) {
@@ -317,13 +331,20 @@ select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& read_fds,
 }
 
 SetSockOptResponse
-set_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& level, const simple_variant<OptName, pb::int32>& optname, const SockOptData& opt_data)
+set_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const simple_variant<SocketOptionLevel, pb::int32>& level, const simple_variant<OptName, pb::int32>& optname, const SockOptData& opt_data)
 {
   ::grpc::ClientContext context;
 
   auto request = SetSockOptRequest{};
   request.mutable_socket()->CopyFrom(socket);
-  request.set_level(level);
+  const auto level_ptr = level.get_if<SocketOptionLevel>();
+  const auto level_raw_ptr = level.get_if<pb::int32>();
+  if (level_ptr) {
+    request.set_level(*level_ptr);
+  }
+  else if (level_raw_ptr) {
+    request.set_level_raw(*level_raw_ptr);
+  }
   const auto optname_ptr = optname.get_if<OptName>();
   const auto optname_raw_ptr = optname.get_if<pb::int32>();
   if (optname_ptr) {
@@ -343,15 +364,36 @@ set_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb
 }
 
 SocketResponse
-socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const pb::int32& domain, const pb::int32& type, const pb::int32& prototcol)
+socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const simple_variant<AddressFamilies, pb::int32>& domain, const simple_variant<SocketProtocolTypes, pb::int32>& type, const simple_variant<IPProtocols, pb::int32>& prototcol)
 {
   ::grpc::ClientContext context;
 
   auto request = SocketRequest{};
   request.mutable_stack_ref()->CopyFrom(stack_ref);
-  request.set_domain(domain);
-  request.set_type(type);
-  request.set_prototcol(prototcol);
+  const auto domain_ptr = domain.get_if<AddressFamilies>();
+  const auto domain_raw_ptr = domain.get_if<pb::int32>();
+  if (domain_ptr) {
+    request.set_domain(*domain_ptr);
+  }
+  else if (domain_raw_ptr) {
+    request.set_domain_raw(*domain_raw_ptr);
+  }
+  const auto type_ptr = type.get_if<SocketProtocolTypes>();
+  const auto type_raw_ptr = type.get_if<pb::int32>();
+  if (type_ptr) {
+    request.set_type(*type_ptr);
+  }
+  else if (type_raw_ptr) {
+    request.set_type_raw(*type_raw_ptr);
+  }
+  const auto prototcol_ptr = prototcol.get_if<IPProtocols>();
+  const auto prototcol_raw_ptr = prototcol.get_if<pb::int32>();
+  if (prototcol_ptr) {
+    request.set_prototcol(*prototcol_ptr);
+  }
+  else if (prototcol_raw_ptr) {
+    request.set_prototcol_raw(*prototcol_raw_ptr);
+  }
 
   auto response = SocketResponse{};
 

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -364,13 +364,13 @@ set_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const si
 }
 
 SocketResponse
-socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const simple_variant<AddressFamilies, pb::int32>& domain, const simple_variant<SocketProtocolTypes, pb::int32>& type, const simple_variant<IPProtocols, pb::int32>& prototcol)
+socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const simple_variant<AddressFamily, pb::int32>& domain, const simple_variant<SocketProtocolType, pb::int32>& type, const simple_variant<IPProtocol, pb::int32>& prototcol)
 {
   ::grpc::ClientContext context;
 
   auto request = SocketRequest{};
   request.mutable_stack_ref()->CopyFrom(stack_ref);
-  const auto domain_ptr = domain.get_if<AddressFamilies>();
+  const auto domain_ptr = domain.get_if<AddressFamily>();
   const auto domain_raw_ptr = domain.get_if<pb::int32>();
   if (domain_ptr) {
     request.set_domain(*domain_ptr);
@@ -378,7 +378,7 @@ socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const simpl
   else if (domain_raw_ptr) {
     request.set_domain_raw(*domain_raw_ptr);
   }
-  const auto type_ptr = type.get_if<SocketProtocolTypes>();
+  const auto type_ptr = type.get_if<SocketProtocolType>();
   const auto type_raw_ptr = type.get_if<pb::int32>();
   if (type_ptr) {
     request.set_type(*type_ptr);
@@ -386,7 +386,7 @@ socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const simpl
   else if (type_raw_ptr) {
     request.set_type_raw(*type_raw_ptr);
   }
-  const auto prototcol_ptr = prototcol.get_if<IPProtocols>();
+  const auto prototcol_ptr = prototcol.get_if<IPProtocol>();
   const auto prototcol_raw_ptr = prototcol.get_if<pb::int32>();
   if (prototcol_ptr) {
     request.set_prototcol(*prototcol_ptr);

--- a/generated/nixnetsocket/nixnetsocket_client.h
+++ b/generated/nixnetsocket/nixnetsocket_client.h
@@ -32,15 +32,15 @@ RecvFromResponse recv_from(const StubPtr& stub, const nidevice_grpc::Session& so
 RecvResponse recv(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& mem, const pb::int32& flags);
 GetSockNameResponse get_sock_name(const StubPtr& stub, const nidevice_grpc::Session& socket);
 GetPeerNameResponse get_peer_name(const StubPtr& stub, const nidevice_grpc::Session& socket);
-ShutdownResponse shutdown(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& how);
+ShutdownResponse shutdown(const StubPtr& stub, const nidevice_grpc::Session& socket, const simple_variant<Shutdown, pb::int32>& how);
 CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& socket);
-GetSockOptResponse get_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& level, const simple_variant<OptName, pb::int32>& optname);
+GetSockOptResponse get_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const simple_variant<SocketOptionLevel, pb::int32>& level, const simple_variant<OptName, pb::int32>& optname);
 IpStackClearResponse ip_stack_clear(const StubPtr& stub, const nidevice_grpc::Session& stack_ref);
 IpStackCreateResponse ip_stack_create(const StubPtr& stub, const pb::string& stack_name, const pb::string& config);
 IsSetResponse is_set(const StubPtr& stub, const nidevice_grpc::Session& fd, const std::vector<nidevice_grpc::Session>& set);
 SelectResponse select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& read_fds, const std::vector<nidevice_grpc::Session>& write_fds, const std::vector<nidevice_grpc::Session>& except_fds, const google::protobuf::Duration& timeout);
-SetSockOptResponse set_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& level, const simple_variant<OptName, pb::int32>& optname, const SockOptData& opt_data);
-SocketResponse socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const pb::int32& domain, const pb::int32& type, const pb::int32& prototcol);
+SetSockOptResponse set_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const simple_variant<SocketOptionLevel, pb::int32>& level, const simple_variant<OptName, pb::int32>& optname, const SockOptData& opt_data);
+SocketResponse socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const simple_variant<AddressFamilies, pb::int32>& domain, const simple_variant<SocketProtocolTypes, pb::int32>& type, const simple_variant<IPProtocols, pb::int32>& prototcol);
 
 } // namespace nixnetsocket_grpc::experimental::client
 

--- a/generated/nixnetsocket/nixnetsocket_client.h
+++ b/generated/nixnetsocket/nixnetsocket_client.h
@@ -40,7 +40,7 @@ IpStackCreateResponse ip_stack_create(const StubPtr& stub, const pb::string& sta
 IsSetResponse is_set(const StubPtr& stub, const nidevice_grpc::Session& fd, const std::vector<nidevice_grpc::Session>& set);
 SelectResponse select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& read_fds, const std::vector<nidevice_grpc::Session>& write_fds, const std::vector<nidevice_grpc::Session>& except_fds, const google::protobuf::Duration& timeout);
 SetSockOptResponse set_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const simple_variant<SocketOptionLevel, pb::int32>& level, const simple_variant<OptName, pb::int32>& optname, const SockOptData& opt_data);
-SocketResponse socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const simple_variant<AddressFamilies, pb::int32>& domain, const simple_variant<SocketProtocolTypes, pb::int32>& type, const simple_variant<IPProtocols, pb::int32>& prototcol);
+SocketResponse socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const simple_variant<AddressFamily, pb::int32>& domain, const simple_variant<SocketProtocolType, pb::int32>& type, const simple_variant<IPProtocol, pb::int32>& prototcol);
 
 } // namespace nixnetsocket_grpc::experimental::client
 

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -356,7 +356,22 @@ namespace nixnetsocket_grpc {
     try {
       auto socket_grpc_session = request->socket();
       nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
-      int32_t how = request->how();
+      int32_t how;
+      switch (request->how_enum_case()) {
+        case nixnetsocket_grpc::ShutdownRequest::HowEnumCase::kHow: {
+          how = static_cast<int32_t>(request->how());
+          break;
+        }
+        case nixnetsocket_grpc::ShutdownRequest::HowEnumCase::kHowRaw: {
+          how = static_cast<int32_t>(request->how_raw());
+          break;
+        }
+        case nixnetsocket_grpc::ShutdownRequest::HowEnumCase::HOW_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for how was not specified or out of range");
+          break;
+        }
+      }
+
       auto status = library_->Shutdown(socket, how);
       response->set_status(status);
       if (status_ok(status)) {
@@ -412,7 +427,22 @@ namespace nixnetsocket_grpc {
     try {
       auto socket_grpc_session = request->socket();
       nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
-      int32_t level = request->level();
+      int32_t level;
+      switch (request->level_enum_case()) {
+        case nixnetsocket_grpc::GetSockOptRequest::LevelEnumCase::kLevel: {
+          level = static_cast<int32_t>(request->level());
+          break;
+        }
+        case nixnetsocket_grpc::GetSockOptRequest::LevelEnumCase::kLevelRaw: {
+          level = static_cast<int32_t>(request->level_raw());
+          break;
+        }
+        case nixnetsocket_grpc::GetSockOptRequest::LevelEnumCase::LEVEL_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for level was not specified or out of range");
+          break;
+        }
+      }
+
       int32_t optname;
       switch (request->optname_enum_case()) {
         case nixnetsocket_grpc::GetSockOptRequest::OptnameEnumCase::kOptname: {
@@ -584,7 +614,22 @@ namespace nixnetsocket_grpc {
     try {
       auto socket_grpc_session = request->socket();
       nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
-      int32_t level = request->level();
+      int32_t level;
+      switch (request->level_enum_case()) {
+        case nixnetsocket_grpc::SetSockOptRequest::LevelEnumCase::kLevel: {
+          level = static_cast<int32_t>(request->level());
+          break;
+        }
+        case nixnetsocket_grpc::SetSockOptRequest::LevelEnumCase::kLevelRaw: {
+          level = static_cast<int32_t>(request->level_raw());
+          break;
+        }
+        case nixnetsocket_grpc::SetSockOptRequest::LevelEnumCase::LEVEL_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for level was not specified or out of range");
+          break;
+        }
+      }
+
       int32_t optname;
       switch (request->optname_enum_case()) {
         case nixnetsocket_grpc::SetSockOptRequest::OptnameEnumCase::kOptname: {
@@ -631,9 +676,54 @@ namespace nixnetsocket_grpc {
     try {
       auto stack_ref_grpc_session = request->stack_ref();
       nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
-      int32_t domain = request->domain();
-      int32_t type = request->type();
-      int32_t prototcol = request->prototcol();
+      int32_t domain;
+      switch (request->domain_enum_case()) {
+        case nixnetsocket_grpc::SocketRequest::DomainEnumCase::kDomain: {
+          domain = static_cast<int32_t>(request->domain());
+          break;
+        }
+        case nixnetsocket_grpc::SocketRequest::DomainEnumCase::kDomainRaw: {
+          domain = static_cast<int32_t>(request->domain_raw());
+          break;
+        }
+        case nixnetsocket_grpc::SocketRequest::DomainEnumCase::DOMAIN_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for domain was not specified or out of range");
+          break;
+        }
+      }
+
+      int32_t type;
+      switch (request->type_enum_case()) {
+        case nixnetsocket_grpc::SocketRequest::TypeEnumCase::kType: {
+          type = static_cast<int32_t>(request->type());
+          break;
+        }
+        case nixnetsocket_grpc::SocketRequest::TypeEnumCase::kTypeRaw: {
+          type = static_cast<int32_t>(request->type_raw());
+          break;
+        }
+        case nixnetsocket_grpc::SocketRequest::TypeEnumCase::TYPE_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for type was not specified or out of range");
+          break;
+        }
+      }
+
+      int32_t prototcol;
+      switch (request->prototcol_enum_case()) {
+        case nixnetsocket_grpc::SocketRequest::PrototcolEnumCase::kPrototcol: {
+          prototcol = static_cast<int32_t>(request->prototcol());
+          break;
+        }
+        case nixnetsocket_grpc::SocketRequest::PrototcolEnumCase::kPrototcolRaw: {
+          prototcol = static_cast<int32_t>(request->prototcol_raw());
+          break;
+        }
+        case nixnetsocket_grpc::SocketRequest::PrototcolEnumCase::PROTOTCOL_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for prototcol was not specified or out of range");
+          break;
+        }
+      }
+
 
       auto init_lambda = [&] () {
         auto socket = library_->Socket(stack_ref, domain, type, prototcol);

--- a/source/codegen/metadata/nixnetsocket/__init__.py
+++ b/source/codegen/metadata/nixnetsocket/__init__.py
@@ -1,6 +1,7 @@
 from .functions import functions
 from .functions_addon import functions_validation_suppressions
 from .attributes import attributes
+from .enums_addon import enums_validation_suppressions
 from .enums import enums
 from .config import config
 
@@ -9,5 +10,6 @@ metadata = {
     "functions_validation_suppressions": functions_validation_suppressions,
     "attributes": attributes,
     "enums": enums,
+    "enums_validation_suppressions": enums_validation_suppressions,
     "config": config,
 }

--- a/source/codegen/metadata/nixnetsocket/enums.py
+++ b/source/codegen/metadata/nixnetsocket/enums.py
@@ -1,17 +1,143 @@
 enums = {
-  'OptName': {
+  'OperationalStatus': {
+      'enum-value-prefix': 'OPERATIONAL_STATUS',
+        'values': [
+            {
+                'name': 'DOWN',
+                'value': 0
+            },
+            {
+                'name': 'UP',
+                'value': 1
+            }
+        ]
+    },
+     'IPStackInffoStringFormat': {
+        'enum-value-prefix': 'IPSTACK_INFO_STR_FORMAT',
+        'values': [
+            {
+                'name': 'JSON',
+                'value': 0
+            },
+            {
+                'name': 'TEXT',
+                'value': 1
+            }
+        ]
+    },
+    'AddressFamilies': {
+        'values': [
+            {
+                'name': 'AF_UNSPEC',
+                'value': 0
+            },
+            {
+                'name': 'AF_INET',
+                'value': 2
+            },
+            {
+                'name': 'AF_INET6',
+                'value': 10
+            }
+        ]
+    },
+    'ProtocolFamilies': {
+        'values': [
+            {
+                'name': 'PF_UNSPEC',
+                'value': 0
+            },
+            {
+                'name': 'PF_INET',
+                'value': 2
+            },
+            {
+                'name': 'PF_INET6',
+                'value': 10
+            }
+        ]
+    },
+    'IPProtocols': {
+        'values': [
+            {
+                'name': 'IPPROTO_IP',
+                'value': 0
+            },
+            {
+                'name': 'IPPROTO_TCP',
+                'value': 6
+            },
+            {
+                'name': 'IPPROTO_UDP',
+                'value': 8
+            },
+            {
+                'name': 'IPPROTO_IPV6',
+                'value': 12
+            }
+        ]
+    },
+    'SocketProtocolTypes': {
+        'values': [
+            {
+                'name': 'SOCK_STREAM',
+                'value': 1
+            },
+            {
+                'name': 'SOCK_DGRAM',
+                'value': 2
+            }
+        ]
+    },
+    'SocketOptionLevel': {
+        'values': [
+            {
+                'name': 'SOL_SOCKET',
+                'value': 13
+            }
+        ]
+    },
+    'OptName': {
         'values': [
             {
                 'name': 'TCP_NODELAY',
                 'value': 1
             },
             {
-                'name': 'IP_MULTICAST_TTL ',
+                'name': 'IP_ADD_MEMBERSHIP',
+                'value': 3
+            },
+            {
+                'name': 'IP_DROP_MEMBERSHIP',
+                'value': 4
+            },
+            {
+                'name': 'IP_MULTICAST_IF',
+                'value': 5
+            },
+            {
+                'name': 'IP_MULTICAST_TTL',
                 'value': 6
+            },
+            {
+                'name': 'IPV6_JOIN_GROUP',
+                'value': 12
+            },
+            {
+                'name': 'IPV6_LEAVE_GROUP',
+                'value': 13
+            },
+            {
+                'name': 'IPV6_MULTICAST_IF',
+                'value': 14
             },
             {
                 'name': 'IPV6_MULTICAST_HOPS',
                 'value': 15
+            },
+            {
+                'name': 'IPV6_V6ONLY',
+                'value': 16
             },
             {
                 'name': 'SO_RX_DATA',
@@ -45,6 +171,98 @@ enums = {
                 'name': 'SO_REUSE_ADDR',
                 'value': 264
             },
+        ]
+    },
+    'Shutdown': {
+        'values': [
+            {
+                'name': 'SHUT_RD',
+                'value': 0
+            },
+            {
+                'name': 'SHUT_WR',
+                'value': 1
+            },
+            {
+                'name': 'SHUT_RDWR',
+                'value': 2
+            }
+        ]
+    },
+    'GetAddrInfoFlags': {
+        'values': [
+            {
+                'name': 'AI_PASSIVE',
+                'value': 1
+            },
+            {
+                'name': 'AI_CANONNAME',
+                'value': 2
+            },
+            {
+                'name': 'AI_NUMERICHOST',
+                'value': 4
+            },
+            {
+                'name': 'AI_NUMERICSERV',
+                'value': 8
+            },
+            {
+                'name': 'AI_V4MAPPED',
+                'value': 16
+            },
+            {
+                'name': 'AI_ALL',
+                'value': 32
+            },
+            {
+                'name': 'AI_ADDRCONFIG',
+                'value': 64
+            },
+            {
+                'name': 'AI_LOCALQUERY',
+                'value': 128
+            },
+            {
+                'name': 'AI_PREFER_V4',
+                'value': 256
+            },
+            {
+                'name': 'AI_UNICAST_REPLY',
+                'value': 512
+            },
+            {
+                'name': 'AI_SHARED_RESET',
+                'value': 1024
+            },
+            {
+                'name': 'AI_BYPASS_CACHE',
+                'value': 2048
+            }
+        ]
+    },
+    'GetNameInfoFlags': {
+        'values': [
+            {
+                'name': 'NI_NOFQDN',
+                'value': 1
+            },
+            {
+                'name': 'NI_NUMERICHOST',
+                'value': 2
+            },
+            {
+                'name': 'NI_NAMEREQD',
+                'value': 4
+            },
+            {
+                'name': 'NI_NUMERICSERV',
+                'value': 8
+            },
+            {
+                'name': 'NI_DGRAM',
+                'value': 16
+            }
         ]
     },
 }

--- a/source/codegen/metadata/nixnetsocket/enums.py
+++ b/source/codegen/metadata/nixnetsocket/enums.py
@@ -192,51 +192,51 @@ enums = {
     'GetAddrInfoFlags': {
         'values': [
             {
-                'name': 'AI_PASSIVE',
+                'name': 'PASSIVE',
                 'value': 1
             },
             {
-                'name': 'AI_CANONNAME',
+                'name': 'CANONNAME',
                 'value': 2
             },
             {
-                'name': 'AI_NUMERICHOST',
+                'name': 'NUMERICHOST',
                 'value': 4
             },
             {
-                'name': 'AI_NUMERICSERV',
+                'name': 'NUMERICSERV',
                 'value': 8
             },
             {
-                'name': 'AI_V4MAPPED',
+                'name': 'V4MAPPED',
                 'value': 16
             },
             {
-                'name': 'AI_ALL',
+                'name': 'ALL',
                 'value': 32
             },
             {
-                'name': 'AI_ADDRCONFIG',
+                'name': 'ADDRCONFIG',
                 'value': 64
             },
             {
-                'name': 'AI_LOCALQUERY',
+                'name': 'LOCALQUERY',
                 'value': 128
             },
             {
-                'name': 'AI_PREFER_V4',
+                'name': 'PREFER_V4',
                 'value': 256
             },
             {
-                'name': 'AI_UNICAST_REPLY',
+                'name': 'UNICAST_REPLY',
                 'value': 512
             },
             {
-                'name': 'AI_SHARED_RESET',
+                'name': 'SHARED_RESET',
                 'value': 1024
             },
             {
-                'name': 'AI_BYPASS_CACHE',
+                'name': 'BYPASS_CACHE',
                 'value': 2048
             }
         ]
@@ -244,23 +244,23 @@ enums = {
     'GetNameInfoFlags': {
         'values': [
             {
-                'name': 'NI_NOFQDN',
+                'name': 'NOFQDN',
                 'value': 1
             },
             {
-                'name': 'NI_NUMERICHOST',
+                'name': 'NUMERICHOST',
                 'value': 2
             },
             {
-                'name': 'NI_NAMEREQD',
+                'name': 'NAMEREQD',
                 'value': 4
             },
             {
-                'name': 'NI_NUMERICSERV',
+                'name': 'NUMERICSERV',
                 'value': 8
             },
             {
-                'name': 'NI_DGRAM',
+                'name': 'DGRAM',
                 'value': 16
             }
         ]

--- a/source/codegen/metadata/nixnetsocket/enums.py
+++ b/source/codegen/metadata/nixnetsocket/enums.py
@@ -12,7 +12,7 @@ enums = {
             }
         ]
     },
-     'IPStackInffoStringFormat': {
+     'IPStackInfoStringFormat': {
         'enum-value-prefix': 'IPSTACK_INFO_STR_FORMAT',
         'values': [
             {
@@ -25,66 +25,58 @@ enums = {
             }
         ]
     },
-    'AddressFamilies': {
+    'AddressFamily': {
         'values': [
             {
-                'name': 'AF_UNSPEC',
-                'value': 0
-            },
-            {
-                'name': 'AF_INET',
+                'name': 'INET',
                 'value': 2
             },
             {
-                'name': 'AF_INET6',
+                'name': 'INET6',
                 'value': 10
             }
         ]
     },
-    'ProtocolFamilies': {
+    'ProtocolFamily': {
         'values': [
             {
-                'name': 'PF_UNSPEC',
-                'value': 0
-            },
-            {
-                'name': 'PF_INET',
+                'name': 'INET',
                 'value': 2
             },
             {
-                'name': 'PF_INET6',
+                'name': 'INET6',
                 'value': 10
             }
         ]
     },
-    'IPProtocols': {
+    'IPProtocol': {
         'values': [
             {
-                'name': 'IPPROTO_IP',
+                'name': 'IP',
                 'value': 0
             },
             {
-                'name': 'IPPROTO_TCP',
+                'name': 'TCP',
                 'value': 6
             },
             {
-                'name': 'IPPROTO_UDP',
+                'name': 'UDP',
                 'value': 8
             },
             {
-                'name': 'IPPROTO_IPV6',
+                'name': 'IPV6',
                 'value': 12
             }
         ]
     },
-    'SocketProtocolTypes': {
+    'SocketProtocolType': {
         'values': [
             {
-                'name': 'SOCK_STREAM',
+                'name': 'STREAM',
                 'value': 1
             },
             {
-                'name': 'SOCK_DGRAM',
+                'name': 'DGRAM',
                 'value': 2
             }
         ]
@@ -92,7 +84,7 @@ enums = {
     'SocketOptionLevel': {
         'values': [
             {
-                'name': 'SOL_SOCKET',
+                'name': 'SOCKET',
                 'value': 13
             }
         ]
@@ -125,6 +117,14 @@ enums = {
             },
             {
                 'name': 'IPV6_LEAVE_GROUP',
+                'value': 13
+            },
+            {
+                'name': 'IPV6_ADD_MEMBERSHIP',
+                'value': 12
+            },
+            {
+                'name': 'IPV6_DROP_MEMBERSHIP',
                 'value': 13
             },
             {
@@ -176,15 +176,15 @@ enums = {
     'Shutdown': {
         'values': [
             {
-                'name': 'SHUT_RD',
+                'name': 'RD',
                 'value': 0
             },
             {
-                'name': 'SHUT_WR',
+                'name': 'WR',
                 'value': 1
             },
             {
-                'name': 'SHUT_RDWR',
+                'name': 'RDWR',
                 'value': 2
             }
         ]

--- a/source/codegen/metadata/nixnetsocket/enums_addon.py
+++ b/source/codegen/metadata/nixnetsocket/enums_addon.py
@@ -4,3 +4,7 @@
 enums_override_metadata = {
 }
 
+enums_validation_suppressions = {
+    "OptName": ["ENUMS_SHOULD_NOT_HAVE_DUPLICATE_VALUES"]
+}
+

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -312,7 +312,8 @@ functions = {
              {
                 'direction': 'in',
                 'name': 'how',
-                'type': 'int32_t'
+                'type': 'int32_t',
+                'enum': 'Shutdown'
             },
         ],
         'returns': 'int32_t'
@@ -374,7 +375,8 @@ functions = {
             {
                 'direction': 'in',
                 'name': 'level',
-                'type': 'int32_t'
+                'type': 'int32_t',
+                'enum': 'SocketOptionLevel'
             },
             {
                 'direction': 'in',
@@ -515,7 +517,8 @@ functions = {
             {
                 'direction': 'in',
                 'name': 'level',
-                'type': 'int32_t'
+                'type': 'int32_t',
+                'enum': 'SocketOptionLevel'
             },
             {
                 'direction': 'in',
@@ -562,17 +565,20 @@ functions = {
             {
                 'direction': 'in',
                 'name': 'domain',
-                'type': 'int32_t'
+                'type': 'int32_t',
+                'enum': 'AddressFamilies'
             },
             {
                 'direction': 'in',
                 'name': 'type',
-                'type': 'int32_t'
+                'type': 'int32_t',
+                'enum': 'SocketProtocolTypes'
             },
             {
                 'direction': 'in',
                 'name': 'prototcol',
-                'type': 'int32_t'
+                'type': 'int32_t',
+                'enum': 'IPProtocols'
             },
             {
                 'direction': 'out',

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -566,19 +566,19 @@ functions = {
                 'direction': 'in',
                 'name': 'domain',
                 'type': 'int32_t',
-                'enum': 'AddressFamilies'
+                'enum': 'AddressFamily'
             },
             {
                 'direction': 'in',
                 'name': 'type',
                 'type': 'int32_t',
-                'enum': 'SocketProtocolTypes'
+                'enum': 'SocketProtocolType'
             },
             {
                 'direction': 'in',
                 'name': 'prototcol',
                 'type': 'int32_t',
-                'enum': 'IPProtocols'
+                'enum': 'IPProtocol'
             },
             {
                 'direction': 'out',

--- a/source/tests/system/nixnetsocket_driver_api_tests.cpp
+++ b/source/tests/system/nixnetsocket_driver_api_tests.cpp
@@ -140,7 +140,7 @@ class NiXnetSocketNoHardwareTests : public NiXnetSocketDriverApiTests {
 SocketResponse
 socket(client::StubPtr& stub, const nidevice_grpc::Session& stack)
 {
-  return client::socket(stub, stack, ADDRESS_FAMILIES_AF_INET, SOCKET_PROTOCOL_TYPES_SOCK_STREAM, IP_PROTOCOLS_IPPROTO_TCP);
+  return client::socket(stub, stack, ADDRESS_FAMILY_INET, SOCKET_PROTOCOL_TYPE_STREAM, IP_PROTOCOL_TCP);
 }
 
 SocketResponse socket(client::StubPtr& stub)

--- a/source/tests/system/nixnetsocket_driver_api_tests.cpp
+++ b/source/tests/system/nixnetsocket_driver_api_tests.cpp
@@ -140,7 +140,7 @@ class NiXnetSocketNoHardwareTests : public NiXnetSocketDriverApiTests {
 SocketResponse
 socket(client::StubPtr& stub, const nidevice_grpc::Session& stack)
 {
-  return client::socket(stub, stack, 2 /* nxAF_INET */, 1 /* STREAM */, 6 /* TCP */);
+  return client::socket(stub, stack, ADDRESS_FAMILIES_AF_INET, SOCKET_PROTOCOL_TYPES_SOCK_STREAM, IP_PROTOCOLS_IPPROTO_TCP);
 }
 
 SocketResponse socket(client::StubPtr& stub)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds defined enums from nxSocket for use.

### Why should this Pull Request be merged?

Adding enums helps to complete the XNET use case for socket functions and helps make usage of several functions easier. 

### What testing has been done?

Builds passed, updated test class to use some of the enums for the socket methods and all ran tests passed. 
