### PR TITLE
Add support for bitfield_as_enum_array inputs

### DIFF
--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -326,10 +326,8 @@ message GetNameInfoRequest {
   SockAddr addr = 2;
   int32 hostlen = 3;
   int32 servlen = 4;
-  oneof flags_enum {
-    GetNameInfoFlags flags = 5;
-    int32 flags_raw = 6;
-  }
+  repeated GetNameInfoFlags flags_array = 5;
+  int32 flags_raw = 6;
 }
 
 message GetNameInfoResponse {

--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -127,6 +127,11 @@ enum OptName {
   OPT_NAME_SO_REUSEADDR = 264;
 }
 
+enum RecvFlags {
+  RECV_FLAGS_UNSPECIFIED = 0;
+  RECV_FLAGS_MSG_PEEK = 1;
+}
+
 enum Shutdown {
   SHUTDOWN_RD = 0;
   SHUTDOWN_WR = 1;
@@ -202,7 +207,7 @@ message SockAddr {
 }
 
 message AddrInfo {
-  repeated GetAddrInfoFlags flags = 1;
+  repeated GetAddrInfoFlags flags_array = 1;
   int32 flags_raw = 2;
   AddressFamily family = 3;
   SocketProtocolType sock_type = 4;
@@ -212,7 +217,7 @@ message AddrInfo {
 }
 
 message AddrInfoHint {
-  repeated GetAddrInfoFlags flags = 1;
+  repeated GetAddrInfoFlags flags_array = 1;
   int32 flags_raw = 2;
   AddressFamily family = 3;
   SocketProtocolType sock_type = 4;
@@ -526,7 +531,8 @@ message ListenResponse {
 message RecvRequest {
   nidevice_grpc.Session socket = 1;
   int32 size = 2;
-  int32 flags = 3;
+  repeated RecvFlags flags_array = 3;
+  int32 flags_raw = 4;
 }
 
 message RecvResponse {
@@ -539,7 +545,8 @@ message RecvResponse {
 message RecvFromRequest {
   nidevice_grpc.Session socket = 1;
   int32 size = 2;
-  int32 flags = 3;
+  repeated RecvFlags flags_array = 3;
+  int32 flags_raw = 4;
 }
 
 message RecvFromResponse {
@@ -566,7 +573,7 @@ message SelectResponse {
 message SendRequest {
   nidevice_grpc.Session socket = 1;
   bytes dataptr = 2;
-  int32 flags = 3;
+  int32 flags_raw = 3;
 }
 
 message SendResponse {
@@ -578,7 +585,7 @@ message SendResponse {
 message SendToRequest {
   nidevice_grpc.Session socket = 1;
   bytes dataptr = 2;
-  int32 flags = 3;
+  int32 flags_raw = 3;
   SockAddr to = 4;
 }
 

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -427,14 +427,14 @@ listen(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int3
 }
 
 RecvResponse
-recv(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& size, const pb::int32& flags)
+recv(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& size, const simple_variant<std::vector<RecvFlags>, std::int32_t>& flags)
 {
   ::grpc::ClientContext context;
 
   auto request = RecvRequest{};
   request.mutable_socket()->CopyFrom(socket);
   request.set_size(size);
-  request.set_flags(flags);
+  request.set_flags_raw(copy_bitfield_as_enum_array(flags));
 
   auto response = RecvResponse{};
 
@@ -445,14 +445,14 @@ recv(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32&
 }
 
 RecvFromResponse
-recv_from(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& size, const pb::int32& flags)
+recv_from(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& size, const simple_variant<std::vector<RecvFlags>, std::int32_t>& flags)
 {
   ::grpc::ClientContext context;
 
   auto request = RecvFromRequest{};
   request.mutable_socket()->CopyFrom(socket);
   request.set_size(size);
-  request.set_flags(flags);
+  request.set_flags_raw(copy_bitfield_as_enum_array(flags));
 
   auto response = RecvFromResponse{};
 
@@ -482,14 +482,14 @@ select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& readfds, 
 }
 
 SendResponse
-send(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags)
+send(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags_raw)
 {
   ::grpc::ClientContext context;
 
   auto request = SendRequest{};
   request.mutable_socket()->CopyFrom(socket);
   request.set_dataptr(dataptr);
-  request.set_flags(flags);
+  request.set_flags_raw(flags_raw);
 
   auto response = SendResponse{};
 
@@ -500,14 +500,14 @@ send(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string
 }
 
 SendToResponse
-send_to(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags, const SockAddr& to)
+send_to(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags_raw, const SockAddr& to)
 {
   ::grpc::ClientContext context;
 
   auto request = SendToRequest{};
   request.mutable_socket()->CopyFrom(socket);
   request.set_dataptr(dataptr);
-  request.set_flags(flags);
+  request.set_flags_raw(flags_raw);
   request.mutable_to()->CopyFrom(to);
 
   auto response = SendToResponse{};

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -120,7 +120,7 @@ get_addr_info(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, cons
 }
 
 GetNameInfoResponse
-get_name_info(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const SockAddr& addr, const pb::int32& hostlen, const pb::int32& servlen, const simple_variant<GetNameInfoFlags, pb::int32>& flags)
+get_name_info(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const SockAddr& addr, const pb::int32& hostlen, const pb::int32& servlen, const simple_variant<std::vector<GetNameInfoFlags>, std::int32_t>& flags)
 {
   ::grpc::ClientContext context;
 
@@ -129,14 +129,7 @@ get_name_info(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, cons
   request.mutable_addr()->CopyFrom(addr);
   request.set_hostlen(hostlen);
   request.set_servlen(servlen);
-  const auto flags_ptr = flags.get_if<GetNameInfoFlags>();
-  const auto flags_raw_ptr = flags.get_if<pb::int32>();
-  if (flags_ptr) {
-    request.set_flags(*flags_ptr);
-  }
-  else if (flags_raw_ptr) {
-    request.set_flags_raw(*flags_raw_ptr);
-  }
+  request.set_flags_raw(copy_bitfield_as_enum_array(flags));
 
   auto response = GetNameInfoResponse{};
 

--- a/generated/nixnetsocket/nixnetsocket_client.h
+++ b/generated/nixnetsocket/nixnetsocket_client.h
@@ -44,11 +44,11 @@ IpStackGetInfoResponse ip_stack_get_info(const StubPtr& stub, const nidevice_grp
 IpStackOpenResponse ip_stack_open(const StubPtr& stub, const pb::string& stack_name);
 IpStackWaitForInterfaceResponse ip_stack_wait_for_interface(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const pb::string& local_interface, const pb::int32& timeout_ms);
 ListenResponse listen(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& backlog);
-RecvResponse recv(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& size, const pb::int32& flags);
-RecvFromResponse recv_from(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& size, const pb::int32& flags);
+RecvResponse recv(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& size, const simple_variant<std::vector<RecvFlags>, std::int32_t>& flags);
+RecvFromResponse recv_from(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& size, const simple_variant<std::vector<RecvFlags>, std::int32_t>& flags);
 SelectResponse select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& readfds, const std::vector<nidevice_grpc::Session>& writefds, const std::vector<nidevice_grpc::Session>& exceptfds, const google::protobuf::Duration& timeout);
-SendResponse send(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags);
-SendToResponse send_to(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags, const SockAddr& to);
+SendResponse send(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags_raw);
+SendToResponse send_to(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags_raw, const SockAddr& to);
 SetSockOptResponse set_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const simple_variant<SocketOptionLevel, pb::int32>& level, const simple_variant<OptName, pb::int32>& optname, const SockOptData& opt_data);
 ShutdownResponse shutdown(const StubPtr& stub, const nidevice_grpc::Session& socket, const simple_variant<Shutdown, pb::int32>& how);
 SocketResponse socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const simple_variant<AddressFamily, pb::int32>& domain, const simple_variant<SocketProtocolType, pb::int32>& type, const simple_variant<IPProtocol, pb::int32>& protocol);

--- a/generated/nixnetsocket/nixnetsocket_client.h
+++ b/generated/nixnetsocket/nixnetsocket_client.h
@@ -28,7 +28,7 @@ CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& socket);
 ConnectResponse connect(const StubPtr& stub, const nidevice_grpc::Session& socket, const SockAddr& name);
 FdIsSetResponse fd_is_set(const StubPtr& stub, const nidevice_grpc::Session& fd, const std::vector<nidevice_grpc::Session>& set);
 GetAddrInfoResponse get_addr_info(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const pb::string& node, const pb::string& service, const AddrInfoHint& hints);
-GetNameInfoResponse get_name_info(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const SockAddr& addr, const pb::int32& hostlen, const pb::int32& servlen, const simple_variant<GetNameInfoFlags, pb::int32>& flags);
+GetNameInfoResponse get_name_info(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const SockAddr& addr, const pb::int32& hostlen, const pb::int32& servlen, const simple_variant<std::vector<GetNameInfoFlags>, std::int32_t>& flags);
 GetPeerNameResponse get_peer_name(const StubPtr& stub, const nidevice_grpc::Session& socket);
 GetSockNameResponse get_sock_name(const StubPtr& stub, const nidevice_grpc::Session& socket);
 GetSockOptResponse get_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const simple_variant<SocketOptionLevel, pb::int32>& level, const simple_variant<OptName, pb::int32>& optname);

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -830,7 +830,10 @@ namespace nixnetsocket_grpc {
       auto socket_grpc_session = request->socket();
       nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
       int32_t size = request->size();
-      int32_t flags = request->flags();
+      const auto flags = nidevice_grpc::converters::convert_bitfield_as_enum_array_input(
+        request->flags_array(),
+        request->flags_raw());
+
       std::string mem(size, '\0');
       auto status = library_->Recv(socket, (char*)mem.data(), size, flags);
       response->set_status(status);
@@ -861,7 +864,10 @@ namespace nixnetsocket_grpc {
       auto socket_grpc_session = request->socket();
       nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
       int32_t size = request->size();
-      int32_t flags = request->flags();
+      const auto flags = nidevice_grpc::converters::convert_bitfield_as_enum_array_input(
+        request->flags_array(),
+        request->flags_raw());
+
       std::string mem(size, '\0');
       auto from_addr = allocate_output_storage<nxsockaddr, SockAddr>();
       nxsocklen_t fromlen {};
@@ -926,8 +932,8 @@ namespace nixnetsocket_grpc {
       nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
       char* dataptr = (char*)request->dataptr().c_str();
       int32_t size = static_cast<int32_t>(request->dataptr().size());
-      int32_t flags = request->flags();
-      auto status = library_->Send(socket, dataptr, size, flags);
+      int32_t flags_raw = request->flags_raw();
+      auto status = library_->Send(socket, dataptr, size, flags_raw);
       response->set_status(status);
       if (status_ok(status)) {
       }
@@ -956,10 +962,10 @@ namespace nixnetsocket_grpc {
       nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
       char* dataptr = (char*)request->dataptr().c_str();
       int32_t size = static_cast<int32_t>(request->dataptr().size());
-      int32_t flags = request->flags();
+      int32_t flags_raw = request->flags_raw();
       auto to = convert_from_grpc<nxsockaddr>(request->to());
       auto tolen = to.size();
-      auto status = library_->SendTo(socket, dataptr, size, flags, to, tolen);
+      auto status = library_->SendTo(socket, dataptr, size, flags_raw, to, tolen);
       response->set_status(status);
       if (status_ok(status)) {
       }

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -249,21 +249,9 @@ namespace nixnetsocket_grpc {
       auto addrlen = addr.size();
       nxsocklen_t hostlen = request->hostlen();
       nxsocklen_t servlen = request->servlen();
-      int32_t flags;
-      switch (request->flags_enum_case()) {
-        case nixnetsocket_grpc::GetNameInfoRequest::FlagsEnumCase::kFlags: {
-          flags = static_cast<int32_t>(request->flags());
-          break;
-        }
-        case nixnetsocket_grpc::GetNameInfoRequest::FlagsEnumCase::kFlagsRaw: {
-          flags = static_cast<int32_t>(request->flags_raw());
-          break;
-        }
-        case nixnetsocket_grpc::GetNameInfoRequest::FlagsEnumCase::FLAGS_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for flags was not specified or out of range");
-          break;
-        }
-      }
+      const auto flags = nidevice_grpc::converters::convert_bitfield_as_enum_array_input(
+        request->flags_array(),
+        request->flags_raw());
 
       std::string host;
       if (hostlen > 0) {

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -66,11 +66,19 @@ def is_array(data_type: str):
     return data_type.endswith("[]") or data_type.endswith("*")
 
 
+def get_bitfield_enum_type(parameter: dict) -> str:
+    """Get the enum type for a bitfield represented as an enum array."""
+    return parameter["bitfield_as_enum_array"]
+
+
+def is_bitfield_as_enum_array(parameter: dict) -> bool:
+    """Whether the parameter is a bitfield represented as an enum array."""
+    return "bitfield_as_enum_array" in parameter
+
+
 def is_enum(parameter: dict):
     """Whether the parameter's type is an enum."""
-    return (
-        "enum" in parameter or "mapped-enum" in parameter or "bitfield_as_enum_array" in parameter
-    )
+    return "enum" in parameter or "mapped-enum" in parameter or is_bitfield_as_enum_array(parameter)
 
 
 def _is_custom_struct(parameter: dict) -> bool:

--- a/source/codegen/metadata/nixnetsocket/custom_proto.mako
+++ b/source/codegen/metadata/nixnetsocket/custom_proto.mako
@@ -56,7 +56,7 @@ message SockAddr {
 }
 
 message AddrInfo {
-  repeated GetAddrInfoFlags flags = 1;
+  repeated GetAddrInfoFlags flags_array = 1;
   int32 flags_raw = 2;
   AddressFamily family = 3;
   SocketProtocolType sock_type = 4;
@@ -66,7 +66,7 @@ message AddrInfo {
 }
 
 message AddrInfoHint {
-  repeated GetAddrInfoFlags flags = 1;
+  repeated GetAddrInfoFlags flags_array = 1;
   int32 flags_raw = 2;
   AddressFamily family = 3;
   SocketProtocolType sock_type = 4;

--- a/source/codegen/metadata/nixnetsocket/enums.py
+++ b/source/codegen/metadata/nixnetsocket/enums.py
@@ -231,6 +231,14 @@ enums = {
             }
         ]
     },
+    'RecvFlags': {
+        'values': [
+            {
+                'name': 'MSG_PEEK',
+                'value': 1
+            }
+        ]
+    },
     'Shutdown': {
         'values': [
             {

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -707,6 +707,7 @@ functions = {
                 'type': 'int32_t'
             },
             {
+                'bitfield_as_enum_array': 'RecvFlags',
                 'direction': 'in',
                 'name': 'flags',
                 'type': 'int32_t'
@@ -738,6 +739,7 @@ functions = {
                 'type': 'int32_t'
             },
             {
+                'bitfield_as_enum_array': 'RecvFlags',
                 'direction': 'in',
                 'name': 'flags',
                 'type': 'int32_t'
@@ -831,6 +833,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'grpc_name': 'flags_raw',
                 'name': 'flags',
                 'type': 'int32_t'
             },
@@ -864,6 +867,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'grpc_name': 'flags_raw',
                 'name': 'flags',
                 'type': 'int32_t'
             },

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -276,10 +276,10 @@ functions = {
                 'type': 'nxsocklen_t'
             },
             {
+                'bitfield_as_enum_array': 'GetNameInfoFlags',
                 'direction': 'in',
                 'name': 'flags',
                 'type': 'int32_t',
-                'enum': 'GetNameInfoFlags'
             },
         ],
         'returns': 'int32_t'

--- a/source/codegen/proto_helpers.py
+++ b/source/codegen/proto_helpers.py
@@ -117,7 +117,7 @@ def get_message_parameter_definitions(parameters):
             enum_parameters = _get_enum_parameters(
                 parameter, parameter_name, parameter_type, is_array, used_indexes
             )
-            if is_request_message:
+            if is_request_message and not common_helpers.is_bitfield_as_enum_array(parameter):
                 # use oneof for enums in request messages
                 parameter_definitions.append(
                     {

--- a/source/codegen/templates/client_helpers.mako
+++ b/source/codegen/templates/client_helpers.mako
@@ -31,6 +31,8 @@ from client_helpers import ParamMechanism
   }
 %     elif param.mechanism == ParamMechanism.COPY:
   request.mutable_${grpc_field_name}()->CopyFrom(${field_name});
+%     elif param.mechanism == ParamMechanism.BITFIELD_AS_ENUM_ARRAY:
+  request.set_${grpc_field_name}_raw(copy_bitfield_as_enum_array(${field_name}));
 %     else:
   request.set_${grpc_field_name}(${field_name});
 %     endif

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -290,6 +290,8 @@ ${initialize_input_param(function_name, parameter, parameters, input_vararg_para
 ${initialize_repeating_param(parameter, input_vararg_parameter)}
 % elif common_helpers.is_repeated_varargs_parameter(parameter):
 ${initialize_repeated_varargs_param(parameter)}
+% elif common_helpers.is_bitfield_as_enum_array(parameter):
+${initialize_bitfield_as_enum_array_param(function_name, parameter)}
 % elif common_helpers.is_enum(parameter) and common_helpers.is_array(parameter['type']) and not common_helpers.is_string_arg(parameter):
 ${initialize_enum_array_input_param(function_name, parameter)}
 % elif common_helpers.is_enum(parameter):
@@ -376,6 +378,19 @@ ${initialize_standard_input_param(function_name, parameter)}
         std::back_inserter(${parameter_name}_vector),
         [](auto x) { return x; });
       auto ${parameter_name} = ${parameter_name}_vector.data();
+</%def>
+
+## Initialize a bitfield as enum array input parameter for an API call.
+<%def name="initialize_bitfield_as_enum_array_param(function_name, parameter)">\
+<%
+  parameter_name = common_helpers.get_cpp_local_name(parameter)
+  field_name = common_helpers.get_grpc_field_name(parameter)
+  enum_type = common_helpers.get_bitfield_enum_type(parameter)
+  bitfield_type = parameter["type"]
+%>\
+      const auto ${parameter_name} = nidevice_grpc::converters::convert_bitfield_as_enum_array_input(
+        request->${field_name}_array(),
+        request->${field_name}_raw());
 </%def>
 
 ## Initialize an enum input parameter for an API call.

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -593,11 +593,9 @@ inline void convert_to_grpc(const SockOptDataOutputConverter& storage, SockOptDa
 struct AddrInfoHintInputConverter {
   AddrInfoHintInputConverter(const AddrInfoHint& input)
   {
-    int32_t flags = input.flags_raw();
-    for (int i = 0; i < input.flags().size(); i++) {
-      flags |= input.flags()[i];
-    }
-    addr_info.ai_flags = flags;
+    addr_info.ai_flags = nidevice_grpc::converters::convert_bitfield_as_enum_array_input(
+        input.flags_array(),
+        input.flags_raw());
     addr_info.ai_family = input.family();
     addr_info.ai_socktype = input.sock_type();
     addr_info.ai_protocol = input.protocol();
@@ -655,7 +653,7 @@ struct AddrInfoOutputConverter {
         curr_addr_info_ptr = curr_addr_info_ptr->ai_next) {
       auto curr_grpc_addr_info = output.Add();
       curr_grpc_addr_info->set_flags_raw(curr_addr_info_ptr->ai_flags);
-      convert_to_addr_info_flags(curr_addr_info_ptr->ai_flags, *(curr_grpc_addr_info->mutable_flags()));
+      convert_to_addr_info_flags(curr_addr_info_ptr->ai_flags, *(curr_grpc_addr_info->mutable_flags_array()));
       curr_grpc_addr_info->set_family((AddressFamily)curr_addr_info_ptr->ai_family);
       curr_grpc_addr_info->set_sock_type((SocketProtocolType)curr_addr_info_ptr->ai_socktype);
       curr_grpc_addr_info->set_protocol((IPProtocol)curr_addr_info_ptr->ai_protocol);

--- a/source/server/converters.h
+++ b/source/server/converters.h
@@ -9,6 +9,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <numeric>
 #include <string>
 #include <vector>
 
@@ -286,6 +287,17 @@ inline CVIAbsoluteTime convert_from_grpc(const google::protobuf::Timestamp& valu
   cviTime.cviTime.msb = static_cast<int64>(unixTime + SecondsFromCVI1904EpochTo1970Epoch);
   cviTime.cviTime.lsb = static_cast<uInt64>((static_cast<double>(value.nanos()) / NanosecondsPerSecond) * TwoToSixtyFour);
   return cviTime;
+}
+
+// Or together input_array and input_raw to implement the "bitfield_as_enum_array" feature for inputs.
+// Note: TEnum is unused because protobuf C++ represents repeated enums as a int32 arrays.
+template <typename TArray, typename TBitfield>
+inline TBitfield convert_bitfield_as_enum_array_input(
+    const TArray& input,
+    TBitfield input_raw)
+{
+  const auto or_delegate = [](google::protobuf::int32 first, google::protobuf::int32 second) { return static_cast<TBitfield>(first | second); };
+  return input_raw | std::accumulate(input.cbegin(), input.cend(), TBitfield{0}, or_delegate);
 }
 
 // TypeToStorageType should be specialized to define a (TDriverType, TGrpcType)->StorageType mapping, which

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -43,7 +43,6 @@ constexpr auto NISYNC_VAL_LEVEL_LOW = 0;
 constexpr auto NISYNC_VAL_LEVEL_HIGH = 1;
 constexpr auto NISYNC_ERROR_FEATURE_NOT_SUPPORTED = 0xBFFA4003;
 constexpr auto NISYNC_ERROR_DEST_TERMINAL_INVALID = 0xBFFA4033;
-constexpr auto VI_SUCCESS = 0;
 
 class NiSyncDriverApiTest : public ::testing::Test {
  protected:

--- a/source/tests/unit/converters_tests.cpp
+++ b/source/tests/unit/converters_tests.cpp
@@ -163,7 +163,7 @@ TEST(ConvertersTests, RawValue_ConvertBitfieldAsEnumArrayInput_ReturnsRawValue)
 TEST(ConvertersTests, ArrayAndRawValue_ConvertBitfieldAsEnumArrayInput_ReturnsOrOfValues)
 {
   constexpr auto INPUT_RAW = 0x8;
-  const auto input_array = std::vector{TestEnum::TWO, TestEnum::FOUR};
+  const auto input_array = std::vector<TestEnum>{TestEnum::TWO, TestEnum::FOUR};
 
   const auto converted = convert_bitfield_as_enum_array_input(input_array, INPUT_RAW);
 

--- a/source/tests/unit/converters_tests.cpp
+++ b/source/tests/unit/converters_tests.cpp
@@ -135,6 +135,41 @@ TEST(ConvertersTests, NullableVectorInitializedWithData_ConditionallyAssignMoved
   const auto data = vec.data();
   EXPECT_THAT(std::vector<int32_t>(data, data + DATA.size()), ElementsAreArray(DATA));
 }
+
+enum TestEnum {
+  ONE = 1,
+  TWO = 2,
+  FOUR = 4
+};
+
+TEST(ConvertersTests, EnumArray_ConvertBitfieldAsEnumArrayInput_ReturnsOrOfValues)
+{
+  const auto input = std::vector<TestEnum>{TestEnum::ONE, TestEnum::FOUR};
+
+  const auto converted = convert_bitfield_as_enum_array_input(input, 0);
+
+  EXPECT_EQ(0x1 | 0x4, converted);
+}
+
+TEST(ConvertersTests, RawValue_ConvertBitfieldAsEnumArrayInput_ReturnsRawValue)
+{
+  constexpr auto INPUT_RAW = 0x7;
+
+  const auto converted = convert_bitfield_as_enum_array_input(std::vector<TestEnum>{}, INPUT_RAW);
+
+  EXPECT_EQ(INPUT_RAW, converted);
+}
+
+TEST(ConvertersTests, ArrayAndRawValue_ConvertBitfieldAsEnumArrayInput_ReturnsOrOfValues)
+{
+  constexpr auto INPUT_RAW = 0x8;
+  const auto input_array = std::vector{TestEnum::TWO, TestEnum::FOUR};
+
+  const auto converted = convert_bitfield_as_enum_array_input(input_array, INPUT_RAW);
+
+  EXPECT_EQ(0x2 | 0x4 | 0x8, converted);
+}
+
 }  // namespace
 }  // namespace unit
 }  // namespace tests

--- a/source/tests/unit/xnet_converters_tests.cpp
+++ b/source/tests/unit/xnet_converters_tests.cpp
@@ -609,8 +609,8 @@ TEST(XnetConvertersTests, AddrInfoHintInputConverter_ConvertFromGrpc_ConvertsToA
   AddrInfoHint hints{};
   constexpr auto EXPECTED_FLAGS = nxAI_PASSIVE | nxAI_V4MAPPED;
   hints.set_family(FAMILY);
-  hints.add_flags(GetAddrInfoFlags::GET_ADDR_INFO_FLAGS_PASSIVE);
-  hints.add_flags(GetAddrInfoFlags::GET_ADDR_INFO_FLAGS_V4MAPPED);
+  hints.add_flags_array(GetAddrInfoFlags::GET_ADDR_INFO_FLAGS_PASSIVE);
+  hints.add_flags_array(GetAddrInfoFlags::GET_ADDR_INFO_FLAGS_V4MAPPED);
   hints.set_protocol(PROTOCOL);
   hints.set_sock_type(SOCKET_TYPE);
 
@@ -640,9 +640,9 @@ void EXPECT_ADDR_INFO(
 {
   int expected_flags_raw = std::accumulate(flags.begin(), flags.end(), 0, std::bit_or<int>());
   EXPECT_EQ(expected_flags_raw, addr_info.flags_raw());
-  EXPECT_EQ(flags.size(), addr_info.flags().size());
-  for (int i = 0; i < std::min<size_t>(flags.size(), addr_info.flags().size()); i++) {
-    EXPECT_EQ(flags.at(i), addr_info.flags(i));
+  EXPECT_EQ(flags.size(), addr_info.flags_array().size());
+  for (int i = 0; i < std::min<size_t>(flags.size(), addr_info.flags_array().size()); i++) {
+    EXPECT_EQ(flags.at(i), addr_info.flags_array(i));
   }
   EXPECT_EQ(family, addr_info.family());
   EXPECT_EQ(sock_type, addr_info.sock_type());
@@ -713,12 +713,12 @@ TEST(XnetConvertersTests, AddrInfoFlagsAsInt_ConvertToRepeatedFlagsEnum_AllFlags
   int32_t flags = nxAI_BYPASS_CACHE | nxAI_V4MAPPED | nxAI_PASSIVE;
 
   AddrInfo grpc_addr_info{};
-  convert_to_addr_info_flags(flags, *(grpc_addr_info.mutable_flags()));
+  convert_to_addr_info_flags(flags, *(grpc_addr_info.mutable_flags_array()));
 
-  EXPECT_EQ(3, grpc_addr_info.flags().size());
-  EXPECT_EQ(GetAddrInfoFlags::GET_ADDR_INFO_FLAGS_BYPASS_CACHE, grpc_addr_info.flags(0));
-  EXPECT_EQ(GetAddrInfoFlags::GET_ADDR_INFO_FLAGS_V4MAPPED, grpc_addr_info.flags(1));
-  EXPECT_EQ(GetAddrInfoFlags::GET_ADDR_INFO_FLAGS_PASSIVE, grpc_addr_info.flags(2));
+  EXPECT_EQ(3, grpc_addr_info.flags_array().size());
+  EXPECT_EQ(GetAddrInfoFlags::GET_ADDR_INFO_FLAGS_BYPASS_CACHE, grpc_addr_info.flags_array(0));
+  EXPECT_EQ(GetAddrInfoFlags::GET_ADDR_INFO_FLAGS_V4MAPPED, grpc_addr_info.flags_array(1));
+  EXPECT_EQ(GetAddrInfoFlags::GET_ADDR_INFO_FLAGS_PASSIVE, grpc_addr_info.flags_array(2));
 }
 
 TEST(XnetConvertersTests, IpStackInfoStringOutputConverter_ConvertToGrpc_ConvertsToAndFreesInfoString)

--- a/source/tests/utilities/client_helpers.h
+++ b/source/tests/utilities/client_helpers.h
@@ -2,6 +2,7 @@
 #define CLIENT_HELPERS
 
 #include <grpcpp/grpcpp.h>
+#include <server/converters.h>
 
 #include <cstdint>
 
@@ -57,6 +58,14 @@ template <typename TSource, typename TDestination>
 inline void copy_array(const TSource& source, TDestination* destination)
 {
   destination->CopyFrom({source.cbegin(), source.cend()});
+}
+
+template <typename TArray, typename TBitfield>
+inline google::protobuf::int32 copy_bitfield_as_enum_array(const simple_variant<TArray, TBitfield>& input)
+{
+  const auto unpacked_array = input.get_if<TArray>() ? *input.get_if<TArray>() : TArray{};
+  const auto unpacked_bitfield = input.get_if<TBitfield>() ? *input.get_if<TBitfield>() : TBitfield{};
+  return nidevice_grpc::converters::convert_bitfield_as_enum_array_input(unpacked_array, unpacked_bitfield);
 }
 
 }  // namespace nidevice_grpc::experimental::client


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add support for `bitfield_as_enum_array` inputs to `grpc-device`.

Add flag support for `xnetsocket` `recv` and `recvfrom` APIs.

Mark `send` and `sendto` `flags` as `flags_raw`. These currently have to publicly supported flags, but we'll match the names on a true `flags` input. See notes in [AB#1901927](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1901927).

Update pseudo-`bitfield_as_enum_array` code in `custom_proto` to match naming and use underlying implementation.

### Why should this Pull Request be merged?

Allows setting flags in a consistent/coherent way.

* Fixes [AB#1901927](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1901927)
* Fixes [AB#1896770](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1896770)


### What testing has been done?

Ran and passed all `Xnet` tests and all `Unit` tests.

Manual testing in debugger.