### PR TITLE
Change interface to interface_name in xnet CreateSession API

### DIFF
--- a/examples/nixnet/can-signal-single-point-output.py
+++ b/examples/nixnet/can-signal-single-point-output.py
@@ -79,7 +79,7 @@ try:
             database_name=DATABASE,
             cluster_name=CLUSTER,
             list=SIGNAL_LIST,
-            interface=INTERFACE,
+            interface_name=INTERFACE,
             mode=nixnet_types.CREATE_SESSION_MODE_SIGNAL_OUT_SINGLE_POINT,
         )
     )

--- a/examples/nixnet/ethernet-frame-stream-input-reader.py
+++ b/examples/nixnet/ethernet-frame-stream-input-reader.py
@@ -102,7 +102,7 @@ try:
             database_name="",
             cluster_name="",
             list="",
-            interface=INTERFACE,
+            interface_name=INTERFACE,
             mode=nixnet_types.CREATE_SESSION_MODE_FRAME_IN_STREAM,
         )
     )

--- a/examples/nixnet/flexray-signal-single-point-input.py
+++ b/examples/nixnet/flexray-signal-single-point-input.py
@@ -81,7 +81,7 @@ try:
             database_name=DATABASE,
             cluster_name=CLUSTER,
             list=SIGNAL_LIST,
-            interface=INTERFACE,
+            interface_name=INTERFACE,
             mode=nixnet_types.CREATE_SESSION_MODE_SIGNAL_IN_SINGLE_POINT,
         )
     )

--- a/examples/nixnet/lin-signal-single-point-output.py
+++ b/examples/nixnet/lin-signal-single-point-output.py
@@ -93,7 +93,7 @@ try:
             database_name=DATABASE,
             cluster_name=CLUSTER,
             list=SIGNAL_LIST,
-            interface=INTERFACE,
+            interface_name=INTERFACE,
             mode=nixnet_types.CREATE_SESSION_MODE_SIGNAL_OUT_SINGLE_POINT,
         )
     )

--- a/generated/nixnet/nixnet.proto
+++ b/generated/nixnet/nixnet.proto
@@ -1335,7 +1335,7 @@ message CreateSessionRequest {
   string database_name = 2;
   string cluster_name = 3;
   string list = 4;
-  string interface = 5;
+  string interface_name = 5;
   oneof mode_enum {
     CreateSessionMode mode = 6;
     uint32 mode_raw = 7;
@@ -1350,7 +1350,7 @@ message CreateSessionResponse {
 message CreateSessionByRefRequest {
   string session_name = 1;
   repeated nidevice_grpc.Session array_of_database_ref = 2;
-  string interface = 3;
+  string interface_name = 3;
   oneof mode_enum {
     CreateSessionMode mode = 4;
     uint32 mode_raw = 5;

--- a/generated/nixnet/nixnet_client.cpp
+++ b/generated/nixnet/nixnet_client.cpp
@@ -212,7 +212,7 @@ convert_timestamp1ns_to100ns(const StubPtr& stub, const pb::uint64& from_timesta
 }
 
 CreateSessionResponse
-create_session(const StubPtr& stub, const pb::string& database_name, const pb::string& cluster_name, const pb::string& list, const pb::string& interface_parameter, const simple_variant<CreateSessionMode, pb::uint32>& mode)
+create_session(const StubPtr& stub, const pb::string& database_name, const pb::string& cluster_name, const pb::string& list, const pb::string& interface_name, const simple_variant<CreateSessionMode, pb::uint32>& mode)
 {
   ::grpc::ClientContext context;
 
@@ -220,7 +220,7 @@ create_session(const StubPtr& stub, const pb::string& database_name, const pb::s
   request.set_database_name(database_name);
   request.set_cluster_name(cluster_name);
   request.set_list(list);
-  request.set_interface(interface_parameter);
+  request.set_interface_name(interface_name);
   const auto mode_ptr = mode.get_if<CreateSessionMode>();
   const auto mode_raw_ptr = mode.get_if<pb::uint32>();
   if (mode_ptr) {
@@ -239,13 +239,13 @@ create_session(const StubPtr& stub, const pb::string& database_name, const pb::s
 }
 
 CreateSessionByRefResponse
-create_session_by_ref(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& array_of_database_ref, const pb::string& interface_parameter, const simple_variant<CreateSessionMode, pb::uint32>& mode)
+create_session_by_ref(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& array_of_database_ref, const pb::string& interface_name, const simple_variant<CreateSessionMode, pb::uint32>& mode)
 {
   ::grpc::ClientContext context;
 
   auto request = CreateSessionByRefRequest{};
   copy_array(array_of_database_ref, request.mutable_array_of_database_ref());
-  request.set_interface(interface_parameter);
+  request.set_interface_name(interface_name);
   const auto mode_ptr = mode.get_if<CreateSessionMode>();
   const auto mode_raw_ptr = mode.get_if<pb::uint32>();
   if (mode_ptr) {

--- a/generated/nixnet/nixnet_client.h
+++ b/generated/nixnet/nixnet_client.h
@@ -31,8 +31,8 @@ ConvertFramesToSignalsSinglePointResponse convert_frames_to_signals_single_point
 ConvertSignalsToFramesSinglePointResponse convert_signals_to_frames_single_point(const StubPtr& stub, const nidevice_grpc::Session& session, const std::vector<double>& value_buffer, const pb::uint32& number_of_frames, const pb::uint32& max_payload_per_frame, const simple_variant<Protocol, pb::uint32>& protocol);
 ConvertTimestamp100nsTo1nsResponse convert_timestamp100ns_to1ns(const StubPtr& stub, const pb::uint64& from_timestamp_100ns);
 ConvertTimestamp1nsTo100nsResponse convert_timestamp1ns_to100ns(const StubPtr& stub, const pb::uint64& from_timestamp_1ns);
-CreateSessionResponse create_session(const StubPtr& stub, const pb::string& database_name, const pb::string& cluster_name, const pb::string& list, const pb::string& interface_parameter, const simple_variant<CreateSessionMode, pb::uint32>& mode);
-CreateSessionByRefResponse create_session_by_ref(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& array_of_database_ref, const pb::string& interface_parameter, const simple_variant<CreateSessionMode, pb::uint32>& mode);
+CreateSessionResponse create_session(const StubPtr& stub, const pb::string& database_name, const pb::string& cluster_name, const pb::string& list, const pb::string& interface_name, const simple_variant<CreateSessionMode, pb::uint32>& mode);
+CreateSessionByRefResponse create_session_by_ref(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& array_of_database_ref, const pb::string& interface_name, const simple_variant<CreateSessionMode, pb::uint32>& mode);
 DbAddAliasResponse db_add_alias(const StubPtr& stub, const pb::string& database_alias, const pb::string& database_filepath, const pb::uint32& default_baud_rate);
 DbAddAlias64Response db_add_alias64(const StubPtr& stub, const pb::string& database_alias, const pb::string& database_filepath, const pb::uint64& default_baud_rate);
 DbCloseDatabaseResponse db_close_database(const StubPtr& stub, const nidevice_grpc::Session& database, const pb::uint32& close_all_refs);

--- a/generated/nixnet/nixnet_service.cpp
+++ b/generated/nixnet/nixnet_service.cpp
@@ -359,7 +359,7 @@ namespace nixnet_grpc {
       auto database_name = request->database_name().c_str();
       auto cluster_name = request->cluster_name().c_str();
       auto list = request->list().c_str();
-      auto interface_parameter = request->interface().c_str();
+      auto interface_name = request->interface_name().c_str();
       u32 mode;
       switch (request->mode_enum_case()) {
         case nixnet_grpc::CreateSessionRequest::ModeEnumCase::kMode: {
@@ -379,7 +379,7 @@ namespace nixnet_grpc {
 
       auto init_lambda = [&] () {
         nxSessionRef_t session;
-        auto status = library_->CreateSession(database_name, cluster_name, list, interface_parameter, mode, &session);
+        auto status = library_->CreateSession(database_name, cluster_name, list, interface_name, mode, &session);
         return std::make_tuple(status, session);
       };
       uint32_t session_id = 0;
@@ -413,7 +413,7 @@ namespace nixnet_grpc {
         array_of_database_ref_request.end(),
         std::back_inserter(array_of_database_ref),
         [&](auto session) { return nx_database_ref_t_resource_repository_->access_session(session.id(), session.name()); }); 
-      auto interface_parameter = request->interface().c_str();
+      auto interface_name = request->interface_name().c_str();
       u32 mode;
       switch (request->mode_enum_case()) {
         case nixnet_grpc::CreateSessionByRefRequest::ModeEnumCase::kMode: {
@@ -433,7 +433,7 @@ namespace nixnet_grpc {
 
       auto init_lambda = [&] () {
         nxSessionRef_t session;
-        auto status = library_->CreateSessionByRef(number_of_database_ref, array_of_database_ref.data(), interface_parameter, mode, &session);
+        auto status = library_->CreateSessionByRef(number_of_database_ref, array_of_database_ref.data(), interface_name, mode, &session);
         return std::make_tuple(status, session);
       };
       uint32_t session_id = 0;

--- a/source/codegen/metadata/nixnet/functions.py
+++ b/source/codegen/metadata/nixnet/functions.py
@@ -337,6 +337,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'grpc_name': 'interface_name',
                 'name': 'interface',
                 'type': 'const char[]'
             },
@@ -373,6 +374,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'grpc_name': 'interface_name',
                 'name': 'interface',
                 'type': 'const char[]'
             },


### PR DESCRIPTION
### What does this Pull Request accomplish?

Change `interface` to `interface_name` in xnet CreateSession API.

### Why should this Pull Request be merged?

`interface` is a non-standard reserved keyword in MSVC (not C/C++). This can cause failures in some msvc setups when windows.h is included.

### What testing has been done?

Ran and passed static type checking with `python .\source\codegen\validate_examples.py -p *xnet*`.