### PR TITLE
XNET Socket API cleanup: C-specific memory oriented names

### DIFF
--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -417,7 +417,7 @@ message InetNToAResponse {
 
 message InetNToPRequest {
   nidevice_grpc.Session stack_ref = 1;
-  Addr src = 2;
+  Addr addr = 2;
 }
 
 message InetNToPResponse {
@@ -433,12 +433,12 @@ message InetPToNRequest {
     AddressFamily af = 2;
     int32 af_raw = 3;
   }
-  string src = 4;
+  string address = 4;
 }
 
 message InetPToNResponse {
   int32 status = 1;
-  Addr dst = 2;
+  Addr addr = 2;
   string error_message = 3;
   int32 error_num = 4;
 }
@@ -535,7 +535,7 @@ message RecvRequest {
 
 message RecvResponse {
   int32 status = 1;
-  bytes mem = 2;
+  bytes data = 2;
   string error_message = 3;
   int32 error_num = 4;
 }
@@ -549,7 +549,7 @@ message RecvFromRequest {
 
 message RecvFromResponse {
   int32 status = 1;
-  bytes mem = 2;
+  bytes data = 2;
   SockAddr from_addr = 3;
   string error_message = 4;
   int32 error_num = 5;
@@ -570,7 +570,7 @@ message SelectResponse {
 
 message SendRequest {
   nidevice_grpc.Session socket = 1;
-  bytes dataptr = 2;
+  bytes data = 2;
   int32 flags_raw = 3;
 }
 
@@ -582,7 +582,7 @@ message SendResponse {
 
 message SendToRequest {
   nidevice_grpc.Session socket = 1;
-  bytes dataptr = 2;
+  bytes data = 2;
   int32 flags_raw = 3;
   SockAddr to = 4;
 }

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -255,13 +255,13 @@ inet_n_to_a(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const 
 }
 
 InetNToPResponse
-inet_n_to_p(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const Addr& src)
+inet_n_to_p(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const Addr& addr)
 {
   ::grpc::ClientContext context;
 
   auto request = InetNToPRequest{};
   request.mutable_stack_ref()->CopyFrom(stack_ref);
-  request.mutable_src()->CopyFrom(src);
+  request.mutable_addr()->CopyFrom(addr);
 
   auto response = InetNToPResponse{};
 
@@ -272,7 +272,7 @@ inet_n_to_p(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const 
 }
 
 InetPToNResponse
-inet_p_to_n(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const simple_variant<AddressFamily, pb::int32>& af, const pb::string& src)
+inet_p_to_n(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const simple_variant<AddressFamily, pb::int32>& af, const pb::string& address)
 {
   ::grpc::ClientContext context;
 
@@ -286,7 +286,7 @@ inet_p_to_n(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const 
   else if (af_raw_ptr) {
     request.set_af_raw(*af_raw_ptr);
   }
-  request.set_src(src);
+  request.set_address(address);
 
   auto response = InetPToNResponse{};
 
@@ -475,13 +475,13 @@ select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& readfds, 
 }
 
 SendResponse
-send(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags_raw)
+send(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& data, const pb::int32& flags_raw)
 {
   ::grpc::ClientContext context;
 
   auto request = SendRequest{};
   request.mutable_socket()->CopyFrom(socket);
-  request.set_dataptr(dataptr);
+  request.set_data(data);
   request.set_flags_raw(flags_raw);
 
   auto response = SendResponse{};
@@ -493,13 +493,13 @@ send(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string
 }
 
 SendToResponse
-send_to(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags_raw, const SockAddr& to)
+send_to(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& data, const pb::int32& flags_raw, const SockAddr& to)
 {
   ::grpc::ClientContext context;
 
   auto request = SendToRequest{};
   request.mutable_socket()->CopyFrom(socket);
-  request.set_dataptr(dataptr);
+  request.set_data(data);
   request.set_flags_raw(flags_raw);
   request.mutable_to()->CopyFrom(to);
 

--- a/generated/nixnetsocket/nixnetsocket_client.h
+++ b/generated/nixnetsocket/nixnetsocket_client.h
@@ -35,8 +35,8 @@ GetSockOptResponse get_sock_opt(const StubPtr& stub, const nidevice_grpc::Sessio
 InetAddrResponse inet_addr(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const pb::string& cp);
 InetAToNResponse inet_a_to_n(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const pb::string& cp);
 InetNToAResponse inet_n_to_a(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const InAddr& in_addr);
-InetNToPResponse inet_n_to_p(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const Addr& src);
-InetPToNResponse inet_p_to_n(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const simple_variant<AddressFamily, pb::int32>& af, const pb::string& src);
+InetNToPResponse inet_n_to_p(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const Addr& addr);
+InetPToNResponse inet_p_to_n(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const simple_variant<AddressFamily, pb::int32>& af, const pb::string& address);
 IpStackClearResponse ip_stack_clear(const StubPtr& stub, const nidevice_grpc::Session& stack_ref);
 IpStackCreateResponse ip_stack_create(const StubPtr& stub, const pb::string& stack_name, const pb::string& config);
 IpStackGetAllStacksInfoStrResponse ip_stack_get_all_stacks_info_str(const StubPtr& stub, const simple_variant<IPStackInfoStringFormat, pb::uint32>& format);
@@ -47,8 +47,8 @@ ListenResponse listen(const StubPtr& stub, const nidevice_grpc::Session& socket,
 RecvResponse recv(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& size, const simple_variant<std::vector<RecvFlags>, std::int32_t>& flags);
 RecvFromResponse recv_from(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32& size, const simple_variant<std::vector<RecvFlags>, std::int32_t>& flags);
 SelectResponse select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& readfds, const std::vector<nidevice_grpc::Session>& writefds, const std::vector<nidevice_grpc::Session>& exceptfds, const google::protobuf::Duration& timeout);
-SendResponse send(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags_raw);
-SendToResponse send_to(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& dataptr, const pb::int32& flags_raw, const SockAddr& to);
+SendResponse send(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& data, const pb::int32& flags_raw);
+SendToResponse send_to(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string& data, const pb::int32& flags_raw, const SockAddr& to);
 SetSockOptResponse set_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const simple_variant<SocketOptionLevel, pb::int32>& level, const simple_variant<OptName, pb::int32>& optname, const SockOptData& opt_data);
 ShutdownResponse shutdown(const StubPtr& stub, const nidevice_grpc::Session& socket, const simple_variant<Shutdown, pb::int32>& how);
 SocketResponse socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const simple_variant<AddressFamily, pb::int32>& domain, const simple_variant<SocketProtocolType, pb::int32>& type, const simple_variant<IPProtocol, pb::int32>& protocol);

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -505,11 +505,11 @@ namespace nixnetsocket_grpc {
     try {
       auto stack_ref_grpc_session = request->stack_ref();
       nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
-      auto af = get_address_family(request->src().addr_case());
-      auto src = convert_from_grpc<void>(request->src());
+      auto af = get_address_family(request->addr().addr_case());
+      auto addr = convert_from_grpc<void>(request->addr());
       auto size = nxINET6_ADDRSTRLEN;
       std::string dst(nxINET6_ADDRSTRLEN - 1, '\0');
-      auto address = library_->InetNToP(stack_ref, af, src, (char*)dst.data(), size);
+      auto address = library_->InetNToP(stack_ref, af, addr, (char*)dst.data(), size);
       auto status = address ? 0 : -1;
       response->set_status(status);
       if (status_ok(status)) {
@@ -555,12 +555,12 @@ namespace nixnetsocket_grpc {
         }
       }
 
-      auto src = request->src().c_str();
-      auto dst = allocate_output_storage<void, Addr>(af);
-      auto status = library_->InetPToN(stack_ref, af, src, &dst);
+      auto address = request->address().c_str();
+      auto addr = allocate_output_storage<void, Addr>(af);
+      auto status = library_->InetPToN(stack_ref, af, address, &addr);
       response->set_status(status);
       if (status_ok(status)) {
-        convert_to_grpc(dst, response->mutable_dst());
+        convert_to_grpc(addr, response->mutable_addr());
       }
       else {
         const auto error_message = get_last_error_message(library_);
@@ -822,11 +822,11 @@ namespace nixnetsocket_grpc {
         request->flags_array(),
         request->flags_raw());
 
-      std::string mem(size, '\0');
-      auto status = library_->Recv(socket, (char*)mem.data(), size, flags);
+      std::string data(size, '\0');
+      auto status = library_->Recv(socket, (char*)data.data(), size, flags);
       response->set_status(status);
       if (status_ok(status)) {
-        response->set_mem(mem);
+        response->set_data(data);
       }
       else {
         const auto error_message = get_last_error_message(library_);
@@ -856,13 +856,13 @@ namespace nixnetsocket_grpc {
         request->flags_array(),
         request->flags_raw());
 
-      std::string mem(size, '\0');
+      std::string data(size, '\0');
       auto from_addr = allocate_output_storage<nxsockaddr, SockAddr>();
       nxsocklen_t fromlen {};
-      auto status = library_->RecvFrom(socket, (char*)mem.data(), size, flags, &from_addr, &fromlen);
+      auto status = library_->RecvFrom(socket, (char*)data.data(), size, flags, &from_addr, &fromlen);
       response->set_status(status);
       if (status_ok(status)) {
-        response->set_mem(mem);
+        response->set_data(data);
         convert_to_grpc(from_addr, response->mutable_from_addr());
       }
       else {
@@ -918,10 +918,10 @@ namespace nixnetsocket_grpc {
     try {
       auto socket_grpc_session = request->socket();
       nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
-      char* dataptr = (char*)request->dataptr().c_str();
-      int32_t size = static_cast<int32_t>(request->dataptr().size());
+      char* data = (char*)request->data().c_str();
+      int32_t size = static_cast<int32_t>(request->data().size());
       int32_t flags_raw = request->flags_raw();
-      auto status = library_->Send(socket, dataptr, size, flags_raw);
+      auto status = library_->Send(socket, data, size, flags_raw);
       response->set_status(status);
       if (status_ok(status)) {
       }
@@ -948,12 +948,12 @@ namespace nixnetsocket_grpc {
     try {
       auto socket_grpc_session = request->socket();
       nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
-      char* dataptr = (char*)request->dataptr().c_str();
-      int32_t size = static_cast<int32_t>(request->dataptr().size());
+      char* data = (char*)request->data().c_str();
+      int32_t size = static_cast<int32_t>(request->data().size());
       int32_t flags_raw = request->flags_raw();
       auto to = convert_from_grpc<nxsockaddr>(request->to());
       auto tolen = to.size();
-      auto status = library_->SendTo(socket, dataptr, size, flags_raw, to, tolen);
+      auto status = library_->SendTo(socket, data, size, flags_raw, to, tolen);
       response->set_status(status);
       if (status_ok(status)) {
       }

--- a/source/codegen/metadata/nixnetsocket/functions.py
+++ b/source/codegen/metadata/nixnetsocket/functions.py
@@ -460,13 +460,14 @@ functions = {
             },
             {
                 'direction': 'in',
-                'hardcoded_value': 'get_address_family(request->src().addr_case())',
+                'hardcoded_value': 'get_address_family(request->addr().addr_case())',
                 'include_in_proto': False,
                 'name': 'af',
                 'type': 'int32_t'
             },
             {
                 'direction': 'in',
+                'grpc_name': 'addr',
                 'name': 'src',
                 'grpc_type': 'Addr',
                 'pointer': True,
@@ -515,11 +516,13 @@ functions = {
             },
             {
                 'direction': 'in',
+                'grpc_name': 'address',
                 'name': 'src',
                 'type': 'const char[]'
             },
             {
                 'direction': 'out',
+                'grpc_name': 'addr',
                 'grpc_type': 'Addr',
                 'name': 'dst',
                 'supports_standard_output_allocation': True,
@@ -694,6 +697,7 @@ functions = {
             },
             {
                 'direction': 'out',
+                'grpc_name': 'data',
                 'name': 'mem',
                 'size': {
                     'mechanism': 'passed-in',
@@ -726,6 +730,7 @@ functions = {
             },
             {
                 'direction': 'out',
+                'grpc_name': 'data',
                 'name': 'mem',
                 'size': {
                     'mechanism': 'passed-in',
@@ -817,6 +822,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'grpc_name': 'data',
                 'name': 'dataptr',
                 'pointer': True,
                 'size': {
@@ -851,6 +857,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'grpc_name': 'data',
                 'name': 'dataptr',
                 'pointer': True,
                 'size': {


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixup names that are too memory-oriented in a way that doesn't make sense for a gRPC API.

### Why should this Pull Request be merged?

This is a speedbump working with a remote client and there's not much upside to preserving names from C APIs (names are just "documentation" in C).

* Fixes [AB#1908078](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1908078)
* Fixes [AB#1908079](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1908079)

### What testing has been done?

Ran and passed all Xnet tests.