### PR TITLE
buffer clearing bug and associated can tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,6 +470,7 @@ set(system_test_runner_sources
   "source/tests/system/nisync_driver_api_tests.cpp"
   "source/tests/system/nisync_session_tests.cpp"
   "source/tests/system/nitclk_driver_api_tests.cpp"
+  "source/tests/system/nixnet_can_driver_api_tests.cpp"
   "source/tests/system/nixnetsocket_driver_api_tests.cpp"
   "source/server/device_enumerator.cpp"
   "source/server/feature_toggles.cpp"

--- a/source/custom/nixnet_converters.h
+++ b/source/custom/nixnet_converters.h
@@ -139,6 +139,10 @@ struct FrameHolder {
   {
     auto payload_length = input.payload().length();
     auto frame_size = nxFrameSize(payload_length);
+    
+    // We need to clear the output buffer since it is being reused for multiple frames.
+    // Not clearing it might result in stale data from the previous frame into this one.
+    output.clear();
     output.resize(frame_size, 0);
     nxFrameVar_t* current_frame = (nxFrameVar_t*)output.data();
     current_frame->Timestamp = input.timestamp();

--- a/source/tests/system/nixnet_can_driver_api_tests.cpp
+++ b/source/tests/system/nixnet_can_driver_api_tests.cpp
@@ -1,0 +1,179 @@
+#include <gmock/gmock.h>
+#include <google/protobuf/util/time_util.h>
+#include <gtest/gtest.h>
+#undef interface
+#include <nixnet/nixnet_client.h>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "device_server.h"
+#include "enumerate_devices.h"
+#include "nixnet_utilities.h"
+
+using namespace nixnet_grpc;
+namespace client = nixnet_grpc::experimental::client;
+namespace pb = google::protobuf;
+using namespace ::testing;
+using namespace ::nixnet_utilities;
+
+namespace ni {
+namespace tests {
+namespace system {
+namespace {
+
+typedef pb::uint8 u8;
+typedef pb::uint16 u16;
+typedef pb::uint32 u32;
+typedef pb::uint64 u64;
+typedef double f64;
+
+class NiXnetCANDriverApiTests : public ::testing::Test {
+ protected:
+  NiXnetCANDriverApiTests()
+      : device_server_(DeviceServerInterface::Singleton()),
+        stub_(NiXnet::NewStub(device_server_->InProcessChannel()))
+  {
+    device_server_->ResetServer();
+  }
+  virtual ~NiXnetCANDriverApiTests() {}
+
+  void TearDown() override
+  {
+    device_server_->ResetServer();
+  }
+
+  template <typename TService>
+  std::unique_ptr<typename TService::Stub> create_stub()
+  {
+    return TService::NewStub(device_server_->InProcessChannel());
+  }
+
+  std::unique_ptr<NiXnet::Stub>& stub()
+  {
+    return stub_;
+  }
+
+  void claim_by_address(::nidevice_grpc::Session session, u64 node_name, u32 in_node_addr, u32* out_node_addr);
+  void NiXnetCANDriverApiTests::assert_can_frames_are_equal(nixnet_grpc::FrameRequest* frame1, nixnet_grpc::FrameResponse* frame2)
+  {
+    int frame1_flags = calculate_bitwise_or_of_flags(frame1->flags());
+    int frame2_flags = calculate_bitwise_or_of_flags(frame2->flags());
+    EXPECT_EQ(frame1_flags, frame2_flags);
+
+    EXPECT_EQ(frame1->type(), frame2->type());
+    EXPECT_EQ(frame1->identifier(), frame2->identifier());
+    EXPECT_EQ(frame1->payload(), frame2->payload());
+  }
+
+  int calculate_bitwise_or_of_flags(google::protobuf::RepeatedField<google::protobuf::int32> flags)
+  {
+    int bitwise_or_of_flags = 0;
+    for(int i = 0; i < flags.size(); i++)
+    {
+      bitwise_or_of_flags = bitwise_or_of_flags | flags[i];
+    }
+    return bitwise_or_of_flags;
+  }
+
+ private:
+  DeviceServerInterface* device_server_;
+  std::unique_ptr<NiXnet::Stub> stub_;
+};
+
+TEST_F(NiXnetCANDriverApiTests, ConvertFramesToFromSignalsFromExample_TwoFrames_InputAndOutFramesAreEquivalent)
+{
+  constexpr auto NUM_FRAMES = 2;
+  constexpr auto NUM_SIGNALS = 2;
+  std::vector<nixnet_grpc::FrameBufferRequest> frames;
+  auto session = EXPECT_SUCCESS(client::create_session(stub(), "NIXNET_example", "CAN_Cluster", "CANEventSignal1,CANEventSignal3", "", CREATE_SESSION_MODE_SIGNAL_CONVERSION_SINGLE_POINT)).session();
+  nixnet_grpc::FrameRequest* frame_in_1 = new nixnet_grpc::FrameRequest();
+  frame_in_1->set_timestamp(0);
+  frame_in_1->add_flags(FrameFlags::FRAME_FLAGS_UNSPECIFIED);
+  frame_in_1->set_identifier(66);
+  frame_in_1->set_type(FRAME_TYPE_CAN_DATA);
+  frame_in_1->set_payload("\2\1\2\3\4\5\6\7");
+  frames.push_back(nixnet_grpc::FrameBufferRequest());
+  frames.back().set_allocated_can(frame_in_1);
+
+  nixnet_grpc::FrameRequest* frame_in_2 = new nixnet_grpc::FrameRequest();
+  frame_in_2->set_timestamp(0);
+  frame_in_2->add_flags(FrameFlags::FRAME_FLAGS_UNSPECIFIED);
+  frame_in_2->set_identifier(67);
+  frame_in_2->set_type(FRAME_TYPE_CAN_DATA);
+  frame_in_2->set_payload("\4\1");
+  frames.push_back(nixnet_grpc::FrameBufferRequest());
+  frames.back().set_allocated_can(frame_in_2);
+
+  auto convert_frames_to_signals_single_point_response = EXPECT_SUCCESS(client::convert_frames_to_signals_single_point(stub(), session, NUM_SIGNALS, frames));
+  std::vector<f64> value_buffer_copy(convert_frames_to_signals_single_point_response.value_buffer().begin(), convert_frames_to_signals_single_point_response.value_buffer().end());
+  auto convert_signals_to_frames_single_point_response = EXPECT_SUCCESS(client::convert_signals_to_frames_single_point(stub(), session, value_buffer_copy, NUM_FRAMES, 8, Protocol::PROTOCOL_CAN));
+
+  EXPECT_EQ(2, convert_frames_to_signals_single_point_response.value_buffer_size());
+  EXPECT_EQ(2, convert_frames_to_signals_single_point_response.value_buffer().size());
+
+  EXPECT_EQ(2, convert_signals_to_frames_single_point_response.buffer_size());
+  EXPECT_EQ(2, convert_signals_to_frames_single_point_response.buffer().size());
+
+  auto frame_out_1 = convert_signals_to_frames_single_point_response.buffer()[0];
+  auto frame_out_2 = convert_signals_to_frames_single_point_response.buffer()[1];
+  auto can_1 = frame_out_1.can();
+  auto can_2 = frame_out_2.can();
+
+  assert_can_frames_are_equal(frame_in_1, &can_1);
+  assert_can_frames_are_equal(frame_in_2, &can_2);
+  EXPECT_SUCCESS(client::clear(stub(), session));
+}
+
+TEST_F(NiXnetCANDriverApiTests, ConvertFramesToFromSignalsFromExample_TwoFrames_SecondFramePayloadDoesNotContainDataFromFirstFramePayload)
+{
+  constexpr auto NUM_FRAMES = 2;
+  constexpr auto NUM_SIGNALS = 2;
+  std::vector<nixnet_grpc::FrameBufferRequest> frames;
+  auto session = EXPECT_SUCCESS(client::create_session(stub(), "NIXNET_example", "CAN_Cluster", "CANEventSignal1,CANEventSignal3", "", CREATE_SESSION_MODE_SIGNAL_CONVERSION_SINGLE_POINT)).session();
+  nixnet_grpc::FrameRequest* frame_in_1 = new nixnet_grpc::FrameRequest();
+  frame_in_1->set_timestamp(0);
+  frame_in_1->add_flags(FrameFlags::FRAME_FLAGS_UNSPECIFIED);
+  frame_in_1->set_identifier(66);
+  frame_in_1->set_type(FRAME_TYPE_CAN_DATA);
+  frame_in_1->set_payload("\2\1\2\3\4\5\6\7");
+  frames.push_back(nixnet_grpc::FrameBufferRequest());
+  frames.back().set_allocated_can(frame_in_1);
+
+  nixnet_grpc::FrameRequest* frame_in_2 = new nixnet_grpc::FrameRequest();
+  frame_in_2->set_timestamp(0);
+  frame_in_2->add_flags(FrameFlags::FRAME_FLAGS_UNSPECIFIED);
+  frame_in_2->set_identifier(67);
+  frame_in_2->set_type(FRAME_TYPE_CAN_DATA);
+  frame_in_2->set_payload("\4");
+  frames.push_back(nixnet_grpc::FrameBufferRequest());
+  frames.back().set_allocated_can(frame_in_2);
+
+  auto convert_frames_to_signals_single_point_response = EXPECT_SUCCESS(client::convert_frames_to_signals_single_point(stub(), session, NUM_SIGNALS, frames));
+  std::vector<f64> value_buffer_copy(convert_frames_to_signals_single_point_response.value_buffer().begin(), convert_frames_to_signals_single_point_response.value_buffer().end());
+  auto convert_signals_to_frames_single_point_response = EXPECT_SUCCESS(client::convert_signals_to_frames_single_point(stub(), session, value_buffer_copy, NUM_FRAMES, 8, Protocol::PROTOCOL_CAN));
+
+  EXPECT_EQ(2, convert_frames_to_signals_single_point_response.value_buffer_size());
+  EXPECT_EQ(2, convert_frames_to_signals_single_point_response.value_buffer().size());
+
+  EXPECT_EQ(2, convert_signals_to_frames_single_point_response.buffer_size());
+  EXPECT_EQ(2, convert_signals_to_frames_single_point_response.buffer().size());
+
+  auto frame_out_1 = convert_signals_to_frames_single_point_response.buffer()[0];
+  auto can_1 = frame_out_1.can();
+  assert_can_frames_are_equal(frame_in_1, &can_1);
+
+  // This assertion is specifically for a bug where payload data from previous frame was being copied over to the next frame.
+  auto frame_out_2 = convert_signals_to_frames_single_point_response.buffer()[1];
+  auto payload_2 = frame_out_2.can().payload();
+  EXPECT_EQ(2, payload_2.length());
+  EXPECT_EQ('\4', payload_2[0]);
+  EXPECT_NE('\1', payload_2[1]);
+  EXPECT_SUCCESS(client::clear(stub(), session));
+}
+
+}  // namespace
+}  // namespace system
+}  // namespace tests
+}  // namespace ni

--- a/source/tests/system/nixnet_utilities.h
+++ b/source/tests/system/nixnet_utilities.h
@@ -1,0 +1,195 @@
+#include <gtest/gtest.h>
+#undef interface
+#include <nixnet/nixnet_client.h>
+
+#include <string>
+#include <vector>
+
+#define EXPECT_SUCCESS(response_)    \
+  ([](auto& response) {              \
+    EXPECT_EQ(0, response.status()); \
+    return response;                 \
+  })(response_)
+
+#define EXPECT_XNET_ERROR(error, response) \
+  if (1) {                                 \
+    EXPECT_EQ(error, (response).status()); \
+  }
+
+namespace nixnet_utilities {
+namespace {
+
+namespace client = nixnet_grpc::experimental::client;
+namespace pb = google::protobuf;
+using namespace nixnet_grpc;
+
+typedef pb::uint32 u32;
+
+GetPropertyResponse get_property(const client::StubPtr& stub, const nidevice_grpc::Session& session_ref, const client::simple_variant<nixnet_grpc::Property, pb::uint32>& property_id)
+{
+  ::grpc::ClientContext context;
+
+  auto request = GetPropertyRequest{};
+  request.mutable_session()->CopyFrom(session_ref);
+  const auto property_id_ptr = property_id.get_if<nixnet_grpc::Property>();
+  const auto property_id_raw_ptr = property_id.get_if<pb::uint32>();
+  if (property_id_ptr) {
+    request.set_property_id(*property_id_ptr);
+  }
+  else if (property_id_raw_ptr) {
+    request.set_property_id_raw(*property_id_raw_ptr);
+  }
+
+  auto response = GetPropertyResponse{};
+
+  client::raise_if_error(
+      stub->GetProperty(&context, request, &response));
+
+  return response;
+}
+
+void _set_property_value(SetPropertyRequest& request, const pb::uint32& value)
+{
+  request.set_u32_scalar(value);
+}
+
+void _set_property_value(SetPropertyRequest& request, const bool& value)
+{
+  request.set_bool_scalar(value);
+}
+
+void _set_property_value(SetPropertyRequest& request, const std::string& value)
+{
+  request.set_str(value);
+}
+
+void _set_property_value(SetPropertyRequest& request, const pb::uint64& value)
+{
+  request.set_u64_scalar(value);
+}
+
+void _set_property_value(SetPropertyRequest& request, const pb::int32& value)
+{
+  request.set_i32_scalar(value);
+}
+
+void _set_property_value(SetPropertyRequest& request, const double& value)
+{
+  request.set_f64_scalar(value);
+}
+
+void _set_property_value(SetPropertyRequest& request, const std::vector<std::string>& value)
+{
+  // TODO: set_string_array expects a single string?!?
+  request.set_string_array(value[0]);
+}
+
+void _set_property_value(SetPropertyRequest& request, const std::vector<pb::uint32>& value)
+{
+  request.mutable_u32_array()->clear_u32_array();
+  request.mutable_u32_array()->mutable_u32_array()->Add(value.begin(), value.end());
+}
+
+void _set_property_value(SetPropertyRequest& request, const nidevice_grpc::Session& value)
+{
+  request.mutable_db_ref()->CopyFrom(value);
+}
+
+void _set_property_value(SetPropertyRequest& request, const std::vector<nidevice_grpc::Session>& value)
+{
+  request.mutable_db_ref_array()->clear_db_ref();
+  request.mutable_db_ref_array()->mutable_db_ref()->Reserve(static_cast<int>(value.size()));
+  for (int i = 0; i < value.size(); ++i) {
+    request.mutable_db_ref_array()->mutable_db_ref()->at(i) = value[i];
+  }
+}
+
+/* TODO
+void _set_property_value(SetPropertyRequest& request, const std::vector<EptRxFilter>& value)
+{
+  request.mutable_ept_rx_filter_array()->clear_ept_rx_filter();
+  request.mutable_ept_rx_filter_array()->mutable_ept_rx_filter()->Reserve(static_cast<int>(value.size()));
+  for (int i = 0; i < value.size(); ++i) {
+    request.mutable_ept_rx_filter_array()->mutable_ept_rx_filter()->at(i) = value[i];
+  }
+}
+*/
+
+template <typename T>
+SetPropertyResponse set_property(
+    const client::StubPtr& stub,
+    const nidevice_grpc::Session& session,
+    const client::simple_variant<nixnet_grpc::Property, pb::uint32>& property_id,
+    const T& value)
+{
+  ::grpc::ClientContext context;
+
+  auto request = SetPropertyRequest{};
+  request.mutable_session()->CopyFrom(session);
+  const auto property_id_ptr = property_id.get_if<nixnet_grpc::Property>();
+  const auto property_id_raw_ptr = property_id.get_if<pb::uint32>();
+  if (property_id_ptr) {
+    request.set_property_id(*property_id_ptr);
+  }
+  else if (property_id_raw_ptr) {
+    request.set_property_id_raw(*property_id_raw_ptr);
+  }
+  _set_property_value(request, value);
+
+  auto response = SetPropertyResponse{};
+
+  client::raise_if_error(
+      stub->SetProperty(&context, request, &response));
+
+  return response;
+}
+
+DbGetPropertyResponse db_get_property(const client::StubPtr& stub, const nidevice_grpc::Session& dbobject_ref, const client::simple_variant<nixnet_grpc::DBProperty, pb::uint32>& property_id)
+{
+  ::grpc::ClientContext context;
+
+  auto request = DbGetPropertyRequest{};
+  request.mutable_dbobject()->CopyFrom(dbobject_ref);
+  const auto property_id_ptr = property_id.get_if<nixnet_grpc::DBProperty>();
+  const auto property_id_raw_ptr = property_id.get_if<pb::uint32>();
+  if (property_id_ptr) {
+    request.set_property_id(*property_id_ptr);
+  }
+  else if (property_id_raw_ptr) {
+    request.set_property_id_raw(*property_id_raw_ptr);
+  }
+
+  auto response = DbGetPropertyResponse{};
+
+  client::raise_if_error(
+      stub->DbGetProperty(&context, request, &response));
+
+  return response;
+}
+
+std::vector<u32> get_property_u32_vtr(const client::StubPtr& stub, const nidevice_grpc::Session& session_ref, const client::simple_variant<nixnet_grpc::Property, pb::uint32>& property_id)
+{
+  auto array = EXPECT_SUCCESS(get_property(stub, session_ref, property_id)).u32_array().u32_array();
+  return std::vector<u32>(array.begin(), array.end());
+}
+
+std::vector<nidevice_grpc::Session> get_property_db_ref_vtr(const client::StubPtr& stub, const nidevice_grpc::Session& session_ref, const client::simple_variant<nixnet_grpc::Property, pb::uint32>& property_id)
+{
+  auto array = EXPECT_SUCCESS(get_property(stub, session_ref, property_id)).db_ref_array().db_ref();
+  return std::vector<nidevice_grpc::Session>(array.begin(), array.end());
+}
+
+std::vector<u32> db_get_property_u32_vtr(const client::StubPtr& stub, const nidevice_grpc::Session& database_ref, const client::simple_variant<nixnet_grpc::DBProperty, pb::uint32>& property_id)
+{
+  auto array = EXPECT_SUCCESS(db_get_property(stub, database_ref, property_id)).u32_array().u32_array();
+  return std::vector<u32>(array.begin(), array.end());
+}
+
+std::vector<nidevice_grpc::Session> db_get_property_db_ref_vtr(const client::StubPtr& stub, const nidevice_grpc::Session& database_ref, const client::simple_variant<nixnet_grpc::DBProperty, pb::uint32>& property_id)
+{
+  auto array = EXPECT_SUCCESS(db_get_property(stub, database_ref, property_id)).db_ref_array().db_ref();
+  return std::vector<nidevice_grpc::Session>(array.begin(), array.end());
+}
+
+}  // namespace
+}  // namespace nixnet_utilities


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR fixes a bug that was causing frame payload data to contain stale payload data from the previous frame.
Add tests to verify ConvertFramesToSignals and back work correctly.
Add tests to verify the above bug.

### Why should this Pull Request be merged?

More test coverage and bug fix

### What testing has been done?

Written automated tests to verify the changes work
