### PR TITLE
Add get_last_error mechanism to IVI init methods.

### DIFF
--- a/examples/nidcpower/measure-record.py
+++ b/examples/nidcpower/measure-record.py
@@ -68,6 +68,14 @@ def check_for_error(vi, status):
         raise Exception(error_message_response.error_message)
 
 
+def check_for_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+
+
 # Create the communication channel for the remote host and create connections to the NI-DCPower and
 # session services.
 channel = grpc.insecure_channel(f"{SERVER_ADDRESS}:{SERVER_PORT}")
@@ -85,7 +93,7 @@ try:
         )
     )
     vi = initialize_with_channels_response.vi
-    check_for_error(vi, initialize_with_channels_response.status)
+    check_for_initialization_error(initialize_with_channels_response)
 
     # Specify when the measure unit should acquire measurements.
     configure_measure_when = client.SetAttributeViInt32(

--- a/examples/nidigitalpattern/configure-voltage-levels-and-termination-voltage.py
+++ b/examples/nidigitalpattern/configure-voltage-levels-and-termination-voltage.py
@@ -107,6 +107,14 @@ def check_for_error(vi, status):
         raise Exception(error_message_response.error_message)
 
 
+def check_for_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+
+
 try:
     # Open session to NI-Digital Pattern Driver with options
     init_with_options_response = nidigital_client.InitWithOptions(
@@ -119,7 +127,7 @@ try:
         )
     )
     vi = init_with_options_response.vi
-    check_for_error(vi, init_with_options_response.status)
+    check_for_initialization_error(init_with_options_response)
 
     load_pin_map_response = nidigital_client.LoadPinMap(
         nidigital_types.LoadPinMapRequest(

--- a/examples/nidmm/continuous-acquire-graph-multiple-points.py
+++ b/examples/nidmm/continuous-acquire-graph-multiple-points.py
@@ -72,6 +72,14 @@ def check_for_error(vi, status):
         raise Exception(error_message_response.error_message)
 
 
+def check_for_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+
+
 try:
     # Open session to NI-DMM with options
     init_with_options_response = nidmm_client.InitWithOptions(
@@ -80,7 +88,7 @@ try:
         )
     )
     vi = init_with_options_response.vi
-    check_for_error(vi, init_with_options_response.status)
+    check_for_initialization_error(init_with_options_response)
 
     # Configure measurement
     config_measurement_response = nidmm_client.ConfigureMeasurementDigits(

--- a/examples/nifgen/basic-arbitrary-waveform.py
+++ b/examples/nifgen/basic-arbitrary-waveform.py
@@ -71,6 +71,14 @@ def check_for_error(vi, status):
         raise Exception(error_message_response.error_message)
 
 
+def check_for_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+
+
 try:
     # Initalize NI-FGEN session
     init_with_options_resp = nifgen_client.InitWithOptions(
@@ -79,7 +87,7 @@ try:
         )
     )
     vi = init_with_options_resp.vi
-    check_for_error(vi, init_with_options_resp.status)
+    check_for_initialization_error(init_with_options_resp)
 
     # Configure channels
     config_channels_resp = nifgen_client.ConfigureChannels(

--- a/examples/nirfsa/getting-started-iq.py
+++ b/examples/nirfsa/getting-started-iq.py
@@ -71,8 +71,17 @@ def raise_if_error(response):
     return response
 
 
+def raise_if_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+    return response
+
+
 try:
-    init_response = raise_if_error(
+    init_response = raise_if_initialization_error(
         client.InitWithOptions(
             nirfsa_types.InitWithOptionsRequest(
                 session_name=SESSION_NAME, resource_name=RESOURCE, option_string=OPTIONS

--- a/examples/nirfsa/getting-started-spectrum.py
+++ b/examples/nirfsa/getting-started-spectrum.py
@@ -75,8 +75,17 @@ def raise_if_error(response):
     return response
 
 
+def raise_if_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+    return response
+
+
 try:
-    init_response = raise_if_error(
+    init_response = raise_if_initialization_error(
         client.InitWithOptions(
             nirfsa_types.InitWithOptionsRequest(
                 session_name=SESSION_NAME, resource_name=RESOURCE, option_string=OPTIONS

--- a/examples/nirfsg/getting-started-single-tone-generation.py
+++ b/examples/nirfsg/getting-started-single-tone-generation.py
@@ -63,13 +63,22 @@ def raise_if_error(response):
         raise Exception(f"Error: {response.error_string}")
 
 
+def raise_if_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+    return response
+
+
 try:
     response = client.InitWithOptions(
         nirfsg_types.InitWithOptionsRequest(
             session_name=SESSION_NAME, resource_name=RESOURCE, option_string=OPTIONS
         )
     )
-    raise_if_error(response)
+    raise_if_initialization_error(response)
     vi = response.vi
     raise_if_error(
         client.ConfigureRF(nirfsg_types.ConfigureRFRequest(vi=vi, frequency=1e9, power_level=-5))

--- a/examples/nirfsg/reference-clock.py
+++ b/examples/nirfsg/reference-clock.py
@@ -61,13 +61,22 @@ def raise_if_error(response):
         raise Exception(f"Error: {response.error_string}")
 
 
+def raise_if_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+    return response
+
+
 try:
     response = client.InitWithOptions(
         nirfsg_types.InitWithOptionsRequest(
             session_name=SESSION_NAME, resource_name=RESOURCE, option_string=OPTIONS
         )
     )
-    raise_if_error(response)
+    raise_if_initialization_error(response)
     vi = response.vi
     raise_if_error(
         client.ConfigureRF(nirfsg_types.ConfigureRFRequest(vi=vi, frequency=1e9, power_level=-5))

--- a/examples/niscope/fetch-continuous.py
+++ b/examples/niscope/fetch-continuous.py
@@ -71,6 +71,14 @@ def check_for_error(vi, status):
         raise Exception(error_message_response.error_message)
 
 
+def check_for_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+
+
 try:
     # Open session to NI-SCOPE module with options.
     init_with_options_response = client.InitWithOptions(
@@ -79,7 +87,7 @@ try:
         )
     )
     vi = init_with_options_response.vi
-    check_for_error(vi, init_with_options_response.status)
+    check_for_initialization_error(init_with_options_response)
 
     # Configure vertical.
     voltage = 10.0

--- a/examples/niscope/fetch.py
+++ b/examples/niscope/fetch.py
@@ -68,6 +68,14 @@ def check_for_error(vi, status):
         raise Exception(error_message_response.error_message)
 
 
+def check_for_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+
+
 try:
     # Open session to NI-SCOPE module with options.
     init_with_options_response = client.InitWithOptions(
@@ -76,7 +84,7 @@ try:
         )
     )
     vi = init_with_options_response.vi
-    check_for_error(vi, init_with_options_response.status)
+    check_for_initialization_error(init_with_options_response)
 
     # Configure vertical.
     voltage = 10.0

--- a/examples/niscope/graph-measurement.py
+++ b/examples/niscope/graph-measurement.py
@@ -67,6 +67,14 @@ def check_for_error(vi, status):
         raise Exception(error_message_response.error_message)
 
 
+def check_for_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+
+
 # Create the communication channel for the remote host (in this case we are connecting to a local
 # server) and create a connection to the NI-SCOPE service
 channel = grpc.insecure_channel(f"{SERVER_ADDRESS}:{SERVER_PORT}")
@@ -80,7 +88,7 @@ try:
         )
     )
     vi = init_result.vi
-    check_for_error(vi, init_result.status)
+    check_for_initialization_error(init_result)
 
     # Configure Vertical
     vertical_result = niscope_client.ConfigureVertical(

--- a/examples/niscope/plot-read-waveform.py
+++ b/examples/niscope/plot-read-waveform.py
@@ -63,6 +63,14 @@ def check_for_error(vi, status):
         raise Exception(error_message_response.error_message)
 
 
+def check_for_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+
+
 # Create the communcation channel for the remote host (in this case we are connecting to a local
 # server) and create a connection to the niScope service
 channel = grpc.insecure_channel(f"{SERVER_ADDRESS}:{SERVER_PORT}")
@@ -76,7 +84,7 @@ try:
         )
     )
     vi = init_result.vi
-    check_for_error(vi, init_result.status)
+    check_for_initialization_error(init_result)
 
     # Configure horizontal timing
     config_result = niscope_client.ConfigureHorizontalTiming(

--- a/examples/niswitch/controlling-an-individual-relay.py
+++ b/examples/niswitch/controlling-an-individual-relay.py
@@ -70,6 +70,14 @@ def check_for_error(vi, status):
         raise Exception(error_message_response.error_message)
 
 
+def check_for_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+
+
 try:
     # Open session to NI-SWITCH and set topology.
     init_with_topology_response = niswitch_client.InitWithTopology(
@@ -82,7 +90,7 @@ try:
         )
     )
     vi = init_with_topology_response.vi
-    check_for_error(vi, init_with_topology_response.status)
+    check_for_initialization_error(init_with_topology_response)
     print("Topology set to : ", TOPOLOGY_STRING)
 
     # Close the relay. Use values that are valid for the model being used.

--- a/examples/niswitch/software-scanning.py
+++ b/examples/niswitch/software-scanning.py
@@ -71,6 +71,14 @@ def check_for_error(vi, status):
         raise Exception(error_message_response.error_message)
 
 
+def check_for_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+
+
 try:
     # Open session to NI-SWITCH and set topology.
     init_with_topology_response = niswitch_client.InitWithTopology(
@@ -83,7 +91,7 @@ try:
         )
     )
     vi = init_with_topology_response.vi
-    check_for_error(vi, init_with_topology_response.status)
+    check_for_initialization_error(init_with_topology_response)
     print("Topology set to : ", TOPOLOGY_STRING)
 
     # Configure the scan list.

--- a/generated/nidcpower/nidcpower.proto
+++ b/generated/nidcpower/nidcpower.proto
@@ -771,6 +771,7 @@ message InitializeWithIndependentChannelsRequest {
 message InitializeWithIndependentChannelsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  string error_message = 3;
 }
 
 message InitiateWithChannelsRequest {
@@ -1592,6 +1593,7 @@ message InitializeWithChannelsRequest {
 message InitializeWithChannelsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  string error_message = 3;
 }
 
 message InitiateRequest {

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include "custom/ivi_errors.h"
 #include <server/converters.h>
 
 namespace nidcpower_grpc {
@@ -780,6 +781,10 @@ namespace nidcpower_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }
@@ -2865,6 +2870,10 @@ namespace nidcpower_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nidigitalpattern/nidigitalpattern.proto
+++ b/generated/nidigitalpattern/nidigitalpattern.proto
@@ -1324,6 +1324,7 @@ message InitRequest {
 message InitResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  string error_message = 3;
 }
 
 message InitWithOptionsRequest {
@@ -1337,6 +1338,7 @@ message InitWithOptionsRequest {
 message InitWithOptionsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  string error_message = 3;
 }
 
 message InitiateRequest {

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -2469,6 +2469,10 @@ namespace nidigitalpattern_grpc {
       if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
@@ -2501,6 +2505,10 @@ namespace nidigitalpattern_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include "custom/ivi_errors.h"
 #include <server/converters.h>
 
 namespace nidigitalpattern_grpc {

--- a/generated/nidmm/nidmm.proto
+++ b/generated/nidmm/nidmm.proto
@@ -1237,6 +1237,7 @@ message InitRequest {
 message InitResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  string error_message = 3;
 }
 
 message InitWithOptionsRequest {
@@ -1250,6 +1251,7 @@ message InitWithOptionsRequest {
 message InitWithOptionsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  string error_message = 3;
 }
 
 message InitiateRequest {

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include "custom/ivi_errors.h"
 #include <server/converters.h>
 
 namespace nidmm_grpc {

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -1996,6 +1996,10 @@ namespace nidmm_grpc {
       if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
@@ -2028,6 +2032,10 @@ namespace nidmm_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nifgen/nifgen.proto
+++ b/generated/nifgen/nifgen.proto
@@ -1645,6 +1645,7 @@ message InitRequest {
 message InitResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  string error_message = 3;
 }
 
 message InitWithOptionsRequest {
@@ -1658,6 +1659,7 @@ message InitWithOptionsRequest {
 message InitWithOptionsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  string error_message = 3;
 }
 
 message InitializeWithChannelsRequest {
@@ -1671,6 +1673,7 @@ message InitializeWithChannelsRequest {
 message InitializeWithChannelsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  string error_message = 3;
 }
 
 message InitiateGenerationRequest {

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -2423,6 +2423,10 @@ namespace nifgen_grpc {
       if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
@@ -2456,6 +2460,10 @@ namespace nifgen_grpc {
       if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
@@ -2488,6 +2496,10 @@ namespace nifgen_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include "custom/ivi_errors.h"
 #include <server/converters.h>
 
 namespace nifgen_grpc {

--- a/generated/nirfsa/nirfsa.proto
+++ b/generated/nirfsa/nirfsa.proto
@@ -1603,6 +1603,7 @@ message InitRequest {
 message InitResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  string error_message = 3;
 }
 
 message InitWithOptionsRequest {
@@ -1616,6 +1617,7 @@ message InitWithOptionsRequest {
 message InitWithOptionsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  string error_message = 3;
 }
 
 message InitiateRequest {

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -2274,6 +2274,10 @@ namespace nirfsa_grpc {
       if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
@@ -2306,6 +2310,10 @@ namespace nirfsa_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -12,6 +12,7 @@
 #include <atomic>
 #include <vector>
 #include "custom/nirfsa_aliases.h"
+#include "custom/ivi_errors.h"
 #include <server/converters.h>
 
 namespace nirfsa_grpc {

--- a/generated/nirfsg/nirfsg.proto
+++ b/generated/nirfsg/nirfsg.proto
@@ -1556,6 +1556,7 @@ message InitRequest {
 message InitResponse {
   int32 status = 1;
   nidevice_grpc.Session new_vi = 2;
+  string error_message = 3;
 }
 
 message InitWithOptionsRequest {
@@ -1569,6 +1570,7 @@ message InitWithOptionsRequest {
 message InitWithOptionsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  string error_message = 3;
 }
 
 message InitiateRequest {

--- a/generated/nirfsg/nirfsg_service.cpp
+++ b/generated/nirfsg/nirfsg_service.cpp
@@ -2271,6 +2271,10 @@ namespace nirfsg_grpc {
       if (status_ok(status)) {
         response->mutable_new_vi()->set_id(session_id);
       }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
@@ -2303,6 +2307,10 @@ namespace nirfsg_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nirfsg/nirfsg_service.cpp
+++ b/generated/nirfsg/nirfsg_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include "custom/ivi_errors.h"
 #include <server/converters.h>
 
 namespace nirfsg_grpc {

--- a/generated/niscope/niscope.proto
+++ b/generated/niscope/niscope.proto
@@ -1616,6 +1616,7 @@ message InitRequest {
 message InitResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  string error_message = 3;
 }
 
 message InitWithOptionsRequest {
@@ -1629,6 +1630,7 @@ message InitWithOptionsRequest {
 message InitWithOptionsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  string error_message = 3;
 }
 
 message InitiateAcquisitionRequest {

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -1904,6 +1904,10 @@ namespace niscope_grpc {
       if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
@@ -1936,6 +1940,10 @@ namespace niscope_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include "custom/ivi_errors.h"
 #include <server/converters.h>
 
 namespace niscope_grpc {

--- a/generated/niswitch/niswitch.proto
+++ b/generated/niswitch/niswitch.proto
@@ -705,6 +705,7 @@ message InitRequest {
 message InitResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  string error_message = 3;
 }
 
 message InitWithOptionsRequest {
@@ -718,6 +719,7 @@ message InitWithOptionsRequest {
 message InitWithOptionsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  string error_message = 3;
 }
 
 message InitWithTopologyRequest {
@@ -731,6 +733,7 @@ message InitWithTopologyRequest {
 message InitWithTopologyResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  string error_message = 3;
 }
 
 message InitiateScanRequest {

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include "custom/ivi_errors.h"
 #include <server/converters.h>
 
 namespace niswitch_grpc {

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -1022,6 +1022,10 @@ namespace niswitch_grpc {
       if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
@@ -1055,6 +1059,10 @@ namespace niswitch_grpc {
       if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
       }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
+      }
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
@@ -1087,6 +1095,10 @@ namespace niswitch_grpc {
       response->set_status(status);
       if (status_ok(status)) {
         response->mutable_vi()->set_id(session_id);
+      }
+      else {
+        const auto error_message = get_last_error_message(library_);
+        response->set_error_message(error_message);
       }
       return ::grpc::Status::OK;
     }

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include "custom/ivi_errors.h"
 #include <server/converters.h>
 
 namespace nisync_grpc {

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -11,7 +11,6 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-#include "custom/ivi_errors.h"
 #include <server/converters.h>
 
 namespace nisync_grpc {

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
+#include "custom/ivi_errors.h"
 #include <server/converters.h>
 
 namespace nitclk_grpc {

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -11,7 +11,6 @@
 #include <iostream>
 #include <atomic>
 #include <vector>
-#include "custom/ivi_errors.h"
 #include <server/converters.h>
 
 namespace nitclk_grpc {

--- a/source/codegen/metadata/nidcpower/config.py
+++ b/source/codegen/metadata/nidcpower/config.py
@@ -16,6 +16,7 @@ config = {
     },
     'custom_types': [
     ],
+    'additional_headers': {'custom/ivi_errors.h': ['service.cpp']},
     'driver_name': 'NI-DCPower',
     'extra_errors_used': [
         'InvalidRepeatedCapabilityError',

--- a/source/codegen/metadata/nidcpower/functions.py
+++ b/source/codegen/metadata/nidcpower/functions.py
@@ -608,6 +608,12 @@ functions = {
         'name': 'vi',
         'direction': 'out',
         'type': 'ViSession'
+      },
+      {
+          'direction': 'out',
+          'get_last_error': 'get_last_error_message',
+          'name': 'errorMessage',
+          'type': 'ViChar[]'
       }
     ],
     'returns': 'ViStatus'
@@ -2189,6 +2195,12 @@ functions = {
         'name': 'vi',
         'direction': 'out',
         'type': 'ViSession'
+      },
+      {
+          'direction': 'out',
+          'get_last_error': 'get_last_error_message',
+          'name': 'errorMessage',
+          'type': 'ViChar[]'
       }
     ],
     'returns': 'ViStatus'

--- a/source/codegen/metadata/nidigitalpattern/config.py
+++ b/source/codegen/metadata/nidigitalpattern/config.py
@@ -16,6 +16,7 @@ config = {
     },
     'custom_types': [
     ],
+    'additional_headers': {'custom/ivi_errors.h': ['service.cpp']},
     'driver_name': 'NI-Digital Pattern Driver',
     'enum_whitelist_suffix': [
     ],

--- a/source/codegen/metadata/nidigitalpattern/functions.py
+++ b/source/codegen/metadata/nidigitalpattern/functions.py
@@ -2219,6 +2219,12 @@ functions = {
                 "name": "vi",
                 "direction": "out",
                 "type": "ViSession"
+            },
+            {
+                'direction': 'out',
+                'get_last_error': 'get_last_error_message',
+                'name': 'errorMessage',
+                'type': 'ViChar[]'
             }
         ],
         "returns": "ViStatus"
@@ -2251,6 +2257,12 @@ functions = {
                 "direction": "out",
                 "name": "vi",
                 "type": "ViSession"
+            },
+            {
+                'direction': 'out',
+                'get_last_error': 'get_last_error_message',
+                'name': 'errorMessage',
+                'type': 'ViChar[]'
             }
         ],
         "returns": "ViStatus",

--- a/source/codegen/metadata/nidmm/config.py
+++ b/source/codegen/metadata/nidmm/config.py
@@ -16,6 +16,7 @@ config = {
     },
     'custom_types': [
     ],
+    'additional_headers': {'custom/ivi_errors.h': ['service.cpp']},
     'driver_name': 'NI-DMM',
     'extra_errors_used': [
         'InvalidRepeatedCapabilityError',

--- a/source/codegen/metadata/nidmm/functions.py
+++ b/source/codegen/metadata/nidmm/functions.py
@@ -1364,6 +1364,12 @@ functions = {
                 'name':'vi',
                 'direction':'out',
                 'type':'ViSession'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': 'get_last_error_message',
+                'name': 'errorMessage',
+                'type': 'ViChar[]'
             }
         ],
         'returns':'ViStatus'
@@ -1398,6 +1404,12 @@ functions = {
                 'direction': 'out',
                 'name': 'vi',
                 'type': 'ViSession'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': 'get_last_error_message',
+                'name': 'errorMessage',
+                'type': 'ViChar[]'
             }
         ],
         'returns': 'ViStatus',

--- a/source/codegen/metadata/nifgen/config.py
+++ b/source/codegen/metadata/nifgen/config.py
@@ -15,6 +15,7 @@ config = {
         'task': 'generation'
     },
     'custom_types': [],
+    'additional_headers': {'custom/ivi_errors.h': ['service.cpp']},
     'driver_name': 'NI-FGEN',
     'extra_errors_used': [
         'InvalidRepeatedCapabilityError',

--- a/source/codegen/metadata/nifgen/functions.py
+++ b/source/codegen/metadata/nifgen/functions.py
@@ -2066,6 +2066,12 @@ functions = {
                 'direction': 'out',
                 'name': 'vi',
                 'type': 'ViSession'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': 'get_last_error_message',
+                'name': 'errorMessage',
+                'type': 'ViChar[]'
             }
         ],
         'returns': 'ViStatus',
@@ -2097,6 +2103,12 @@ functions = {
                 'name':'vi',
                 'direction':'out',
                 'type':'ViSession'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': 'get_last_error_message',
+                'name': 'errorMessage',
+                'type': 'ViChar[]'
             }
         ],
         'returns':'ViStatus'
@@ -2128,6 +2140,12 @@ functions = {
                 'name':'vi',
                 'direction':'out',
                 'type':'ViSession'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': 'get_last_error_message',
+                'name': 'errorMessage',
+                'type': 'ViChar[]'
             }
         ],
         'returns':'ViStatus'

--- a/source/codegen/metadata/nirfsa/config.py
+++ b/source/codegen/metadata/nirfsa/config.py
@@ -118,7 +118,7 @@ config = {
             ]
         }
     ],
-    'additional_headers': { 'custom/nirfsa_aliases.h': ['service.cpp', 'library_interface.h'] },
+    'additional_headers': { 'custom/nirfsa_aliases.h': ['service.cpp', 'library_interface.h'], 'custom/ivi_errors.h': ['service.cpp'] },
     'driver_name': 'NI-RFSA',
     'init_function': 'InitWithOptions',
     'status_ok': 'status >= 0',

--- a/source/codegen/metadata/nirfsa/functions.py
+++ b/source/codegen/metadata/nirfsa/functions.py
@@ -1936,6 +1936,12 @@ functions = {
                 'direction': 'out',
                 'name': 'vi',
                 'type': 'ViSession'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': 'get_last_error_message',
+                'name': 'errorMessage',
+                'type': 'ViChar[]'
             }
         ],
         'returns': 'ViStatus'
@@ -1967,6 +1973,12 @@ functions = {
                 'direction': 'out',
                 'name': 'vi',
                 'type': 'ViSession'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': 'get_last_error_message',
+                'name': 'errorMessage',
+                'type': 'ViChar[]'
             }
         ],
         'returns': 'ViStatus'

--- a/source/codegen/metadata/nirfsg/config.py
+++ b/source/codegen/metadata/nirfsg/config.py
@@ -14,6 +14,7 @@ config = {
         'task': 'generation'
     },
     'custom_types': [],
+    'additional_headers': {'custom/ivi_errors.h': ['service.cpp']},
     'code_readiness': 'Release',
     'driver_name': 'NI-RFSG',
     'extra_errors_used': [

--- a/source/codegen/metadata/nirfsg/functions.py
+++ b/source/codegen/metadata/nirfsg/functions.py
@@ -1590,6 +1590,12 @@ functions = {
                 'direction': 'out',
                 'name': 'newVi',
                 'type': 'ViSession'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': 'get_last_error_message',
+                'name': 'errorMessage',
+                'type': 'ViChar[]'
             }
         ],
         'returns': 'ViStatus'
@@ -1621,6 +1627,12 @@ functions = {
                 'direction': 'out',
                 'name': 'vi',
                 'type': 'ViSession'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': 'get_last_error_message',
+                'name': 'errorMessage',
+                'type': 'ViChar[]'
             }
         ],
         'returns': 'ViStatus'

--- a/source/codegen/metadata/niscope/config.py
+++ b/source/codegen/metadata/niscope/config.py
@@ -88,6 +88,7 @@ config = {
             ]
         },
     ],
+    'additional_headers': {'custom/ivi_errors.h': ['service.cpp']},
     'driver_name': 'NI-SCOPE',
     'extra_errors_used': [
         'InvalidRepeatedCapabilityError',

--- a/source/codegen/metadata/niscope/functions.py
+++ b/source/codegen/metadata/niscope/functions.py
@@ -2146,6 +2146,12 @@ functions = {
                 'name':'vi',
                 'direction':'out',
                 'type':'ViSession'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': 'get_last_error_message',
+                'name': 'errorMessage',
+                'type': 'ViChar[]'
             }
         ],
         'returns':'ViStatus'
@@ -2177,6 +2183,12 @@ functions = {
                 'direction': 'out',
                 'name': 'vi',
                 'type': 'ViSession'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': 'get_last_error_message',
+                'name': 'errorMessage',
+                'type': 'ViChar[]'
             }
         ],
         'returns': 'ViStatus',

--- a/source/codegen/metadata/niswitch/config.py
+++ b/source/codegen/metadata/niswitch/config.py
@@ -16,6 +16,7 @@ config = {
     },
     'custom_types': [
     ],
+    'additional_headers': {'custom/ivi_errors.h': ['service.cpp']},
     'driver_name': 'NI-SWITCH',
     'extra_errors_used': [
         'InvalidRepeatedCapabilityError',

--- a/source/codegen/metadata/niswitch/functions.py
+++ b/source/codegen/metadata/niswitch/functions.py
@@ -761,6 +761,12 @@ functions = {
                 'direction': 'out',
                 'name': 'vi',
                 'type': 'ViSession'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': 'get_last_error_message',
+                'name': 'errorMessage',
+                'type': 'ViChar[]'
             }
         ],
         'returns': 'ViStatus',
@@ -792,6 +798,12 @@ functions = {
                 'direction': 'out',
                 'name': 'vi',
                 'type': 'ViSession'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': 'get_last_error_message',
+                'name': 'errorMessage',
+                'type': 'ViChar[]'
             }
         ],
         'returns': 'ViStatus',
@@ -823,6 +835,12 @@ functions = {
                 'direction': 'out',
                 'name': 'vi',
                 'type': 'ViSession'
+            },
+            {
+                'direction': 'out',
+                'get_last_error': 'get_last_error_message',
+                'name': 'errorMessage',
+                'type': 'ViChar[]'
             }
         ],
         'returns': 'ViStatus',

--- a/source/codegen/metadata/nisync/config.py
+++ b/source/codegen/metadata/nisync/config.py
@@ -14,6 +14,7 @@ config = {
         "task": "acquisition",
     },
     "custom_types": [],
+    'additional_headers': {'custom/ivi_errors.h': ['service.cpp']},
     "driver_name": "NI-SYNC",
     "init_function": "init",
     'status_ok': 'status >= 0',

--- a/source/codegen/metadata/nisync/config.py
+++ b/source/codegen/metadata/nisync/config.py
@@ -14,10 +14,9 @@ config = {
         "task": "acquisition",
     },
     "custom_types": [],
-    'additional_headers': {'custom/ivi_errors.h': ['service.cpp']},
     "driver_name": "NI-SYNC",
     "init_function": "init",
-    'status_ok': 'status >= 0',
+    "status_ok": "status >= 0",
     "library_info": {
         "Linux": {"64bit": {"name": "nisync", "type": "cdll"}},
         "Windows": {

--- a/source/codegen/metadata/nisync/functions.py
+++ b/source/codegen/metadata/nisync/functions.py
@@ -23,7 +23,7 @@ functions = {
                 "direction": "out",
                 "name": "vi",
                 "type": "ViSession",
-            },
+            }
         ],
         "returns": "ViStatus",
     },
@@ -1470,7 +1470,7 @@ functions = {
                 "direction": "out",
                 "name": "vi",
                 "type": "ViSession",
-            },
+            }
         ],
         "returns": "ViStatus",
     },

--- a/source/codegen/metadata/nitclk/config.py
+++ b/source/codegen/metadata/nitclk/config.py
@@ -11,6 +11,7 @@ config = {
     'close_function': None,
     'custom_types': [
     ],
+    'additional_headers': {'custom/ivi_errors.h': ['service.cpp']},
     'driver_name': 'NI-TClk',
     'extra_errors_used': [],
     'status_ok': 'status >= 0',

--- a/source/codegen/metadata/nitclk/config.py
+++ b/source/codegen/metadata/nitclk/config.py
@@ -11,7 +11,6 @@ config = {
     'close_function': None,
     'custom_types': [
     ],
-    'additional_headers': {'custom/ivi_errors.h': ['service.cpp']},
     'driver_name': 'NI-TClk',
     'extra_errors_used': [],
     'status_ok': 'status >= 0',

--- a/source/custom/ivi_errors.h
+++ b/source/custom/ivi_errors.h
@@ -1,0 +1,22 @@
+#ifndef NIDEVICE_GRPC_DEVICE_IVI_ERRORS_H
+#define NIDEVICE_GRPC_DEVICE_IVI_ERRORS_H
+#include <vector>
+
+#include "IviVisaType.h"
+
+template <typename TLibraryPtr>
+std::string get_last_error_message(TLibraryPtr& library)
+{
+  std::vector<char> error_message;
+  ViStatus error_code;
+  // Calling with no ViSession gives us thread-local errors instead of session
+  // scoped errors. This method should only be used in cases where that is correct.
+  constexpr auto INVALID_SESSION = static_cast<ViSession>(0UL);
+  const auto buffer_size = library->GetError(INVALID_SESSION, &error_code, 0, nullptr);
+  error_message.resize(buffer_size);
+  library->GetError(INVALID_SESSION, &error_code, buffer_size, error_message.data());
+
+  return std::string(error_message.data());
+}
+
+#endif  // NIDEVICE_GRPC_DEVICE_IVI_ERRORS_H

--- a/source/tests/system/nidcpower_session_tests.cpp
+++ b/source/tests/system/nidcpower_session_tests.cpp
@@ -11,7 +11,7 @@ namespace dcpower = nidcpower_grpc;
 
 const int kInvalidRsrc = -1074118656;
 const int kInvalidDCPowerSession = -1074130544;
-const char* kViErrorResourceNotFoundMessage = "Device was not recognized. The device is not supported with this driver or version.";
+const char* kViErrorResourceNotFoundMessage = "Device was not recognized. The device is not supported with this driver or version.\n\nInvalid Identifier: ";
 const char* kInvalidDCPowerSessionMessage = "IVI: (Hex 0xBFFA1190) The session handle is not valid.";
 const char* kTestRsrc = "FakeDevice";
 const char* kOptionsString = "Simulate=1, DriverSetup=Model:4147; BoardType:PXIe";
@@ -156,22 +156,13 @@ TEST_F(NiDCPowerSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionEr
   EXPECT_STREQ(kInvalidDCPowerSessionMessage, error_message.c_str());
 }
 
-TEST_F(NiDCPowerSessionTest, ErrorFromDriver_ErrorMessage_ReturnsUserErrorMessage)
+TEST_F(NiDCPowerSessionTest, InitWithErrorFromDriver_ReturnsUserErrorMessage)
 {
   dcpower::InitializeWithChannelsResponse initialize_response;
   call_initialize_with_channels(kTestInvalidRsrc, "", "", &initialize_response);
+
   EXPECT_EQ(kInvalidRsrc, initialize_response.status());
-
-  nidevice_grpc::Session session = initialize_response.vi();
-  ::grpc::ClientContext context;
-  dcpower::ErrorMessageRequest error_request;
-  error_request.mutable_vi()->set_id(session.id());
-  error_request.set_error_code(kInvalidRsrc);
-  dcpower::ErrorMessageResponse error_response;
-  ::grpc::Status status = GetStub()->ErrorMessage(&context, error_request, &error_response);
-
-  EXPECT_TRUE(status.ok());
-  EXPECT_STREQ(kViErrorResourceNotFoundMessage, error_response.error_message().c_str());
+  EXPECT_STREQ(kViErrorResourceNotFoundMessage, initialize_response.error_message().c_str());
 }
 
 }  // namespace system

--- a/source/tests/system/nidcpower_session_tests.cpp
+++ b/source/tests/system/nidcpower_session_tests.cpp
@@ -98,6 +98,7 @@ TEST_F(NiDCPowerSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDr
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
   EXPECT_NE(0, response.vi().id());
+  EXPECT_EQ("", response.error_message());
 }
 
 TEST_F(NiDCPowerSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesDriverSession)
@@ -109,6 +110,7 @@ TEST_F(NiDCPowerSessionTest, InitializeSessionWithDeviceAndNoSessionName_Creates
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
   EXPECT_NE(0, response.vi().id());
+  EXPECT_EQ("", response.error_message());
 }
 
 TEST_F(NiDCPowerSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
@@ -119,6 +121,7 @@ TEST_F(NiDCPowerSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kInvalidRsrc, response.status());
   EXPECT_EQ(0, response.vi().id());
+  EXPECT_NE("", response.error_message());
 }
 
 TEST_F(NiDCPowerSessionTest, InitializedSession_CloseSession_ClosesDriverSession)

--- a/source/tests/system/nidigital_session_tests.cpp
+++ b/source/tests/system/nidigital_session_tests.cpp
@@ -66,6 +66,7 @@ TEST_F(NiDigitalSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDr
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
   EXPECT_NE(0, response.vi().id());
+  EXPECT_EQ("", response.error_message());
 }
 
 TEST_F(NiDigitalSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesDriverSession)
@@ -76,6 +77,7 @@ TEST_F(NiDigitalSessionTest, InitializeSessionWithDeviceAndNoSessionName_Creates
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
   EXPECT_NE(0, response.vi().id());
+  EXPECT_EQ("", response.error_message());
 }
 
 TEST_F(NiDigitalSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
@@ -86,6 +88,7 @@ TEST_F(NiDigitalSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kDigitalRsrcNotFound, response.status());
   EXPECT_EQ(0, response.vi().id());
+  EXPECT_NE("", response.error_message());
 }
 
 TEST_F(NiDigitalSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
@@ -104,22 +107,13 @@ TEST_F(NiDigitalSessionTest, InitializedSession_CloseSession_ClosesDriverSession
   EXPECT_EQ(0, close_response.status());
 }
 
-TEST_F(NiDigitalSessionTest, ErrorFromDriver_GetErrorMessage_ReturnsUserErrorMessage)
+TEST_F(NiDigitalSessionTest, InitWithErrorFromDriver_ReturnsUserErrorMessage)
 {
   digital::InitWithOptionsResponse init_response;
   call_init_with_options(kDigitalInvalidResourceName, "", "", &init_response);
+
   EXPECT_EQ(kDigitalRsrcNotFound, init_response.status());
-
-  nidevice_grpc::Session session = init_response.vi();
-  ::grpc::ClientContext context;
-  digital::ErrorMessageRequest error_request;
-  error_request.mutable_vi()->set_id(session.id());
-  error_request.set_error_code(kDigitalRsrcNotFound);
-  digital::ErrorMessageResponse error_response;
-  ::grpc::Status status = GetStub()->ErrorMessage(&context, error_request, &error_response);
-
-  EXPECT_TRUE(status.ok());
-  EXPECT_STREQ(kDigitalRsrcNotFoundMessage, error_response.error_message().c_str());
+  EXPECT_STREQ(kDigitalRsrcNotFoundMessage, init_response.error_message().c_str());
 }
 
 }  // namespace system

--- a/source/tests/system/nirfsa_driver_api_tests.cpp
+++ b/source/tests/system/nirfsa_driver_api_tests.cpp
@@ -126,6 +126,14 @@ TEST_F(NiRFSADriverApiTests, Init_Close_Succeeds)
   EXPECT_SUCCESS(session, close_response);
 }
 
+TEST_F(NiRFSADriverApiTests, InitWithErrorFromDriver_ReturnsUserErrorMessage)
+{
+  auto initialize_response = client::init_with_options(stub(), "", false, false, "");
+
+  EXPECT_EQ(-200220, initialize_response.status());
+  EXPECT_STREQ("Device identifier is invalid.", initialize_response.error_message().c_str());
+}
+
 MATCHER(IsNonDefaultComplexArray, "")
 {
   return std::all_of(

--- a/source/tests/system/nirfsg_session_tests.cpp
+++ b/source/tests/system/nirfsg_session_tests.cpp
@@ -72,6 +72,7 @@ TEST_F(NiRFSGSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDrive
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
   EXPECT_NE(0, response.vi().id());
+  EXPECT_EQ("", response.error_message());
 }
 
 TEST_F(NiRFSGSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesDriverSession)
@@ -82,6 +83,7 @@ TEST_F(NiRFSGSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesDri
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
   EXPECT_NE(0, response.vi().id());
+  EXPECT_EQ("", response.error_message());
 }
 
 TEST_F(NiRFSGSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
@@ -92,6 +94,7 @@ TEST_F(NiRFSGSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kInvalidRsrc, response.status());
   EXPECT_EQ(0, response.vi().id());
+  EXPECT_NE("", response.error_message());
 }
 
 TEST_F(NiRFSGSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
@@ -110,14 +113,13 @@ TEST_F(NiRFSGSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
   EXPECT_EQ(0, close_response.status());
 }
 
-TEST_F(NiRFSGSessionTest, ErrorFromDriver_GetErrorMessage_ReturnsUserErrorMessage)
+TEST_F(NiRFSGSessionTest, InitWithErrorFromDriver_ReturnsUserErrorMessage)
 {
   rfsg::InitWithOptionsResponse init_response;
   call_init_with_options(kRFSGTestInvalidRsrc, "", "", &init_response);
-  EXPECT_EQ(kInvalidRsrc, init_response.status());
 
-  nidevice_grpc::Session session = init_response.vi();
-  expect_error_string(session, init_response.status(), kRFSGErrorResourceNotFoundMessage);
+  EXPECT_EQ(kInvalidRsrc, init_response.status());
+  EXPECT_STREQ(kRFSGErrorResourceNotFoundMessage, init_response.error_message().c_str());
 }
 
 TEST_F(NiRFSGSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Updates IVI based drivers to have an error_message field appended to initialization response messages. It's populated using the same `get_last_error` codegen pattern used for RFmx.

### Why should this Pull Request be merged?

Fixes [AB#1873996](https://ni.visualstudio.com/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1873996)
When an initialization method fails, we should tack on the error message to the response. We did this with RFmx to avoid some problems with the previous pattern of getting the error message after the initialization response was returned.

### What testing has been done?

Ran all *SessionTest* tests and they all pass.
Ran all updated examples and they still pass. Also, for each one I updated the initialization to fail (invalid resource) and it printed out the failure as expected.

## Breaking Change

Marking this as a breaking change. It's not API breaking as the client can continue to use their pre-existing code unaware of the new field on the end of initialization responses. It is breaking in the behavioral sense, though, since there is a new pattern to detect errors for initialization calls as outlined in the updated examples.