### PR TITLE
Set code_readiness to Release for XNET and Socket services

### DIFF
--- a/generated/nixnet/nixnet_service.cpp
+++ b/generated/nixnet/nixnet_service.cpp
@@ -1580,7 +1580,7 @@ namespace nixnet_grpc {
   NiXnetFeatureToggles::NiXnetFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("nixnet", CodeReadiness::kNextRelease))
+        feature_toggles.is_feature_enabled("nixnet", CodeReadiness::kRelease))
   {
   }
 } // namespace nixnet_grpc

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -1192,7 +1192,7 @@ namespace nixnetsocket_grpc {
   NiXnetSocketFeatureToggles::NiXnetSocketFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("nixnetsocket", CodeReadiness::kNextRelease))
+        feature_toggles.is_feature_enabled("nixnetsocket", CodeReadiness::kRelease))
   {
   }
 } // namespace nixnetsocket_grpc

--- a/source/codegen/metadata/nixnet/config.py
+++ b/source/codegen/metadata/nixnet/config.py
@@ -8,7 +8,7 @@ config = {
     'csharp_namespace': 'NationalInstruments.Grpc.NiXnet',
     'namespace_component': 'nixnet',
     'close_function': 'Clear',
-    'code_readiness': 'NextRelease',
+    'code_readiness': 'Release',
     'driver_name': 'NI-XNET',
     'status_ok': 'status >= 0',
     'additional_headers': { 'custom/nixnet_converters.h': ['service.cpp'] },

--- a/source/codegen/metadata/nixnetsocket/config.py
+++ b/source/codegen/metadata/nixnetsocket/config.py
@@ -44,7 +44,7 @@ config = {
         'nxVirtualInterface_t': 'repeated VirtualInterface',
         'nixnetsocket_grpc::IpStackInfoString': 'string'
     },
-    'code_readiness': 'NextRelease',
+    'code_readiness': 'Release',
     'driver_name': 'NI-XNETSOCKET',
     'extra_errors_used': [
     ],


### PR DESCRIPTION
### What does this Pull Request accomplish?

Enable XNET and XNET Socket APIs in release version of grpc_server.

### Why should this Pull Request be merged?

These features are tested and ready for release.

### What testing has been done?

Invoked one API each from both the services without any configuration in server_config.json and validated it works.
