### PR TITLE
Fix failing XNET tests and add GTEST_SKIP for tests with hardware requirements

### DIFF
--- a/source/tests/system/nixnet_can_driver_api_tests.cpp
+++ b/source/tests/system/nixnet_can_driver_api_tests.cpp
@@ -1,7 +1,5 @@
 #include <gmock/gmock.h>
-#include <google/protobuf/util/time_util.h>
 #include <gtest/gtest.h>
-#undef interface
 #include <nixnet/nixnet_client.h>
 
 #include <iostream>
@@ -9,7 +7,6 @@
 #include <vector>
 
 #include "device_server.h"
-#include "enumerate_devices.h"
 #include "nixnet_utilities.h"
 
 using namespace nixnet_grpc;

--- a/source/tests/system/nixnet_lin_driver_api_tests.cpp
+++ b/source/tests/system/nixnet_lin_driver_api_tests.cpp
@@ -86,7 +86,7 @@ class NiXnetLINDriverApiTestsWithHardware : public NiXnetLINDriverApiTests {
   void SetUp() override
   {
     const auto discovered_devices = EnumerateDevices();
-    const auto required_interfaces = {"LIN1", "LIN2"};
+    const auto required_interfaces = {"LIN1,LIN2"};
 
     for (const auto& required_name : required_interfaces) {
       auto found = std::find_if(


### PR DESCRIPTION
### What does this Pull Request accomplish?

This pull requests fixes some of the XNET system tests that were incorrectly written and were failing on hardware.
I have also added GTEST_SKIP for XNET tests that need hardware for execution.

### Why should this Pull Request be merged?

- GTEST_SKIP allows for execution without confusing errors.

### What testing has been done?

Executed all \*LIN\* and \*CAN\* system tests
