### PR TITLE
Fixed payload size issue

### DIFF
--- a/source/custom/nixnet_converters.h
+++ b/source/custom/nixnet_converters.h
@@ -16,6 +16,7 @@ void SetSessionInfoResponse(const u32& input, nixnet_grpc::SessionInfoResponse* 
 }  // namespace converters
 
 constexpr auto ENET_FRAME_HEADER_LENGTH = static_cast<u16>(sizeof(nxFrameEnet_t) - 1);  // last byte in nxFrameEnet_t is u8 FrameData[1]
+constexpr auto ENET_FRAME_FCS_SIZE = 4;
 
 struct FrameHolder {
   FrameHolder(const pb_::RepeatedPtrField<FrameBufferRequest>& input, std::map<std::int32_t, std::int32_t> enetflags_input_map)
@@ -103,7 +104,7 @@ struct FrameHolder {
         throw std::invalid_argument("All FrameBufferRequest instances in repeated field should have same oneof set for the frame");
       }
 
-      size_t frame_size = ENET_FRAME_HEADER_LENGTH + grpc_frame.enet().frame_data().length();
+      size_t frame_size = ENET_FRAME_HEADER_LENGTH + ENET_FRAME_FCS_SIZE + grpc_frame.enet().frame_data().length();
       frame_data.resize(frame_size, 0);
       nxFrameEnet_t* current_frame = (nxFrameEnet_t*)frame_data.data();
       // The Length field in ENET write frame is big-endian. Typecast to u16 before doing the conversion

--- a/source/custom/nixnet_converters.h
+++ b/source/custom/nixnet_converters.h
@@ -18,6 +18,8 @@ void SetSessionInfoResponse(const u32& input, nixnet_grpc::SessionInfoResponse* 
 constexpr auto ENET_FRAME_HEADER_LENGTH = static_cast<u16>(sizeof(nxFrameEnet_t) - 1);  // last byte in nxFrameEnet_t is u8 FrameData[1]
 constexpr auto ENET_FRAME_FCS_SIZE = 4;
 
+u32 get_frame_buffer_size(int32 number_of_frames, u32 max_payload_size, u32 protocol);
+
 struct FrameHolder {
   FrameHolder(const pb_::RepeatedPtrField<FrameBufferRequest>& input, std::map<std::int32_t, std::int32_t> enetflags_input_map)
   {
@@ -104,7 +106,7 @@ struct FrameHolder {
         throw std::invalid_argument("All FrameBufferRequest instances in repeated field should have same oneof set for the frame");
       }
 
-      size_t frame_size = ENET_FRAME_HEADER_LENGTH + ENET_FRAME_FCS_SIZE + grpc_frame.enet().frame_data().length();
+      u32 frame_size = get_frame_buffer_size(1, grpc_frame.enet().frame_data().length(),Protocol::PROTOCOL_ENET);
       frame_data.resize(frame_size, 0);
       nxFrameEnet_t* current_frame = (nxFrameEnet_t*)frame_data.data();
       // The Length field in ENET write frame is big-endian. Typecast to u16 before doing the conversion
@@ -205,8 +207,6 @@ struct FrameHolder {
 void convert_to_grpc(std::vector<u8>& input, google::protobuf::RepeatedPtrField<nixnet_grpc::FrameBufferResponse>* output, u32 number_of_bytes, u32 protocol, std::map<std::int32_t, std::int32_t> enetflags_output_map);
 
 void convert_to_grpc(const void* input, nixnet_grpc::FrameBufferResponse* output, u32 protocol, std::map<std::int32_t, std::int32_t> enetflags_output_map);
-
-u32 get_frame_buffer_size(int32 number_of_frames, u32 max_payload_size, u32 protocol);
 
 template <typename TFrame>
 nixnet_grpc::FrameHolder convert_from_grpc(const pb_::RepeatedPtrField<nixnet_grpc::FrameBufferRequest>& input, std::map<std::int32_t, std::int32_t> enetflags_input_map)

--- a/source/custom/nixnet_service.custom.cpp
+++ b/source/custom/nixnet_service.custom.cpp
@@ -1197,8 +1197,7 @@ void convert_enet_frame_to_grpc(const void* input, nixnet_grpc::FrameBufferRespo
     }
   }
   enet_frame->set_flags_raw(nxEnetFrame->Flags);
-  auto enet_header_length = sizeof(nxFrameEnet_t) - 1;  // last byte in nxFrameEnet_t is u8 FrameData[1]
-  auto frame_data_length = nxEnetFrame->Length - enet_header_length;
+  auto frame_data_length = nxEnetFrame->Length - ENET_FRAME_HEADER_LENGTH - ENET_FRAME_FCS_SIZE;
   enet_frame->mutable_frame_data()->assign((const char*)nxEnetFrame->FrameData, frame_data_length);
 
   output->set_allocated_enet(enet_frame);
@@ -1276,7 +1275,7 @@ void convert_to_grpc(std::vector<f64>& input, google::protobuf::RepeatedField<do
 u32 get_frame_buffer_size(int32 number_of_frames, u32 max_payload_per_frame, u32 protocol)
 {
   if (protocol == Protocol::PROTOCOL_ENET) {
-    return number_of_frames * (ENET_FRAME_HEADER_LENGTH + max_payload_per_frame);
+    return number_of_frames * (ENET_FRAME_HEADER_LENGTH + ENET_FRAME_FCS_SIZE + max_payload_per_frame);
   }
   else {
     return number_of_frames * nxFrameSize(max_payload_per_frame);

--- a/source/tests/unit/xnet_converters_tests.cpp
+++ b/source/tests/unit/xnet_converters_tests.cpp
@@ -30,8 +30,8 @@ void assert_enet_frames_are_equal(nxFrameEnet_t* frame1, nixnet_grpc::EnetFrameR
   EXPECT_EQ(frame1->NetworkTimestamp, frame2.network_timestamp());
   EXPECT_EQ(nixnet_grpc::EnetFlags::ENET_FLAGS_TRANSMIT, frame2.flags_mapped()[0]);
   EXPECT_EQ(frame1->Flags, frame2.flags_raw());
-  EXPECT_EQ(frame1->Length - nixnet_grpc::ENET_FRAME_HEADER_LENGTH, frame2.frame_data().size());
-  ASSERT_THAT(std::vector<u8>(frame1->FrameData, frame1->FrameData + frame1->Length - nixnet_grpc::ENET_FRAME_HEADER_LENGTH), ::testing::ElementsAreArray(frame2.frame_data()));
+  EXPECT_EQ(frame1->Length - nixnet_grpc::ENET_FRAME_HEADER_LENGTH - nixnet_grpc::ENET_FRAME_FCS_SIZE, frame2.frame_data().size());
+  ASSERT_THAT(std::vector<u8>(frame1->FrameData, frame1->FrameData + frame1->Length - nixnet_grpc::ENET_FRAME_HEADER_LENGTH - nixnet_grpc::ENET_FRAME_FCS_SIZE), ::testing::ElementsAreArray(frame2.frame_data()));
 }
 
 void assert_frames_are_equal(nxFrameVar_t* frame1, nixnet_grpc::FrameResponse frame2)


### PR DESCRIPTION
### What does this Pull Request accomplish?
Changes made to fix the issue #658 

`releases\1.5` branch will be fast-forwarded to include this fix and minor/patch release will be published with this bug fix as it fixes showstopper bug for ENET frames in XNET.

### Why should this Pull Request be merged?
While calling `WriteFrame` API, we need to pass in buffer with last 4 bytes of buffer reserved for adding FCS (frame checksum). in gRPC service we take payload data as input from user and allocate buffer and copy payload that user has sent in. Earlier we had missed allocating extra 4 bytes for the FCS while allocating buffer for copying data. Hence, 4 bytes of the payload were not being written correctly. I have added a new constant called `ETHERNET_FRAME_FCS_SIZE` which is now used for calculating payload sizes while reading and writing frames.

### What testing has been done?
Ran system tests in #654 to confirm the whole payload is read correctly.
Before : 
![image](https://user-images.githubusercontent.com/47028785/162918398-86d2bdd1-ea98-4d33-a8ec-e5a77bbbb866.png)

After : 
![image](https://user-images.githubusercontent.com/47028785/162918327-9faec822-7427-42a9-ac3c-fa6e1c340b00.png)


