### PR TITLE
CMakeLists: use find_package for gtest dep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,7 +326,7 @@ add_custom_command(
 #----------------------------------------------------------------------
 if(CMAKE_CROSSCOMPILING AND NOT _GRPC_DEVICE_NILRT_LEGACY_TOOLCHAIN)
   find_package(nlohmann_json REQUIRED)
-  find_library(gtest REQUIRED)
+  find_package(GTest REQUIRED)
 else()
   add_subdirectory(third_party/json ${CMAKE_CURRENT_BINARY_DIR}/json EXCLUDE_FROM_ALL)
   enable_testing()


### PR DESCRIPTION
Within the context of an OpenEmbedded build, `find_library(gtest...`
fails to detect googletest in the recipe-sysroot-native, blocking
configuration.

Switch the find_ operation to `find_package()`, which functions
properly.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

### What does this Pull Request accomplish?

This PR enables OpenEmbedded builders to build grpc-device from source.

### Why should this Pull Request be merged?

NI's LInuxRT distribution uses OpenEmbedded to build grpc-device from source, as of release 9.0.

### What testing has been done?

* Built the grpc-device source as a part of the `ni-grpc-device` recipe in the NILRT 9.0 meta-nilrt layer. Everything builds correctly with this change.
* Built `grpc-device` on a `debian:10` docker container. The CMakeFile doesn't appear to be broken with this change. Though, deep into build (~44%), I get a bunch of error splat which kills the build like:
    ```
    In file included from /mnt/workspace/generated/nidaqmx/nidaqmx_service.cpp:7:
    /mnt/workspace/generated/nidaqmx/nidaqmx_service.h:35:7: note: forward declaration of 'class nidaqmx_grpc::NiDAQmxService'
     class NiDAQmxService final : public NiDAQmx::WithCallbackMethod_RegisterSignalEvent<NiDAQmx::WithCallbackMethod_RegisterEveryNSamplesEvent<NiDAQmx::WithCallbackMethod_RegisterDoneEvent<NiDAQmx::Service>>> {
           ^~~~~~~~~~~~~~
    /mnt/workspace/generated/nidaqmx/nidaqmx_service.cpp:17745:169: error: invalid use of incomplete type 'class nidaqmx_grpc::NiDAQmxService'
       ::grpc::Status NiDAQmxService::WriteToTEDSFromArray(::grpc::ServerContext* context, const WriteToTEDSFromArrayRequest* request, WriteToTEDSFromArrayResponse* response)
    ```
    I don't think that error is related to this change. So I'll ignore it.