### PR TITLE
Add metadata validation for enums not referenced by function/attribute.

### DIFF
--- a/source/codegen/metadata/nifake/enums.py
+++ b/source/codegen/metadata/nifake/enums.py
@@ -1,26 +1,6 @@
 # -*- coding: utf-8 -*-
 # This file is generated from NI-FAKE API metadata version 1.2.0d9
 enums = {
-    'BeautifulColor': {
-        'values': [
-            {
-                'name': 'PINK',
-                'value': 44
-            },
-            {
-                'name': 'AQUA',
-                'value': 43
-            },
-            {
-                'name': 'GREEN',
-                'value': 45
-            },
-            {
-                'name': 'BLACK',
-                'value': 42
-            }
-        ]
-    },
     'Bitfield': {
         'values': [
             {
@@ -44,58 +24,6 @@ enums = {
     'Color': {
         'values': [
             {
-                'documentation': {
-                    'description': 'Like blood.'
-                },
-                'name': 'RED',
-                'value': 1
-            },
-            {
-                'documentation': {
-                    'description': 'Like the sky.'
-                },
-                'name': 'BLUE',
-                'value': 2
-            },
-            {
-                'documentation': {
-                    'description': 'Like a banana.'
-                },
-                'name': 'YELLOW',
-                'value': 5
-            },
-            {
-                'documentation': {
-                    'description': "Like this developer's conscience."
-                },
-                'name': 'BLACK',
-                'value': 42
-            }
-        ]
-    },
-    'ColorObsolete': {
-        'values': [
-            {
-                'name': 'RED',
-                'value': 1
-            },
-            {
-                'name': 'BLUE',
-                'value': 2
-            },
-            {
-                'name': 'YELLOW',
-                'value': 5
-            },
-            {
-                'name': 'BLACK',
-                'value': 42
-            }
-        ]
-    },
-    'ColorPrivate': {
-        'values': [
-            {
                 'name': 'RED',
                 'value': 1
             },
@@ -117,37 +45,22 @@ enums = {
         'generate-mappings': True,
         'values': [
             {
-                'documentation': {
-                    'description': 'Specifies 3.5 digits resolution.'
-                },
                 'name': 'THREE_POINT_FIVE',
                 'value': 3.5
             },
             {
-                'documentation': {
-                    'description': 'Specifies 4.5 digits resolution.'
-                },
                 'name': 'FOUR_POINT_FIVE',
                 'value': 4.5
             },
             {
-                'documentation': {
-                    'description': 'Specifies 5.5 digits resolution.'
-                },
                 'name': 'FIVE_POINT_FIVE',
                 'value': 5.5
             },
             {
-                'documentation': {
-                    'description': 'Specifies 6.5 digits resolution.'
-                },
                 'name': 'SIX_POINT_FIVE',
                 'value': 6.5
             },
             {
-                'documentation': {
-                    'description': 'Specifies 7.5 digits resolution.'
-                },
                 'name': 'SEVEN_POINT_FIVE',
                 'value': 7.5
             }
@@ -157,23 +70,14 @@ enums = {
         'generate-mappings': True,
         'values': [
             {
-                'documentation': {
-                    'description': 'Most popular OS.'
-                },
                 'name': 'ANDROID',
                 'value': 'Android'
             },
             {
-                'documentation': {
-                    'description': 'Most secure OS.'
-                },
                 'name': 'IOS',
                 'value': 'iOS'
             },
             {
-                'documentation': {
-                    'description': 'Remember Symbian?.'
-                },
                 'name': 'NONE',
                 'value': 'None'
             }
@@ -182,30 +86,18 @@ enums = {
     'Turtle': {
         'values': [
             {
-                'documentation': {
-                    'description': 'Wields two katanas.'
-                },
                 'name': 'LEONARDO',
                 'value': 0
             },
             {
-                'documentation': {
-                    'description': 'Uses a bo staff.'
-                },
                 'name': 'DONATELLO',
                 'value': 1
             },
             {
-                'documentation': {
-                    'description': 'Has a pair of sai.'
-                },
                 'name': 'RAPHAEL',
                 'value': 2
             },
             {
-                'documentation': {
-                    'description': 'Owns nunchucks.'
-                },
                 'name': 'MICHELANGELO',
                 'value': 3
             }

--- a/source/codegen/metadata/nixnet/enums_addon.py
+++ b/source/codegen/metadata/nixnet/enums_addon.py
@@ -8,5 +8,6 @@ enums_validation_suppressions = {
     "PropertyValue": ["ENUMS_SHOULD_NOT_HAVE_DUPLICATE_VALUES"],
     "DBPropertyValue": ["ENUMS_SHOULD_NOT_HAVE_DUPLICATE_VALUES"],
     "StateValue": ["ENUMS_SHOULD_NOT_HAVE_DUPLICATE_VALUES"],
-    "SubPropertyValue": ["ENUMS_SHOULD_NOT_HAVE_DUPLICATE_VALUES"]
+    "SubPropertyValue": ["ENUMS_SHOULD_NOT_HAVE_DUPLICATE_VALUES"],
+    "FrameFlags": ["ENUMS_SHOULD_NOT_HAVE_DUPLICATE_VALUES"]
 }

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -1,10 +1,10 @@
 """Metadata validation."""
+import warnings
 
 from typing import Any, Dict, List, Set
 
 import common_helpers
 import service_helpers
-import warnings
 from schema import And, Optional, Or, Schema, Use  # type: ignore
 
 

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -323,12 +323,8 @@ def _validate_enum(enum_name: str, used_enums: Set[str], metadata: dict):
                     metadata, RULES.ENUMS_SHOULD_NOT_HAVE_DUPLICATE_VALUES, ["enums", enum_name]
                 ):
                     raise Exception(f"Duplicate values in enum!")
-        elif common_helpers.get_driver_readiness(metadata["config"]) == "Release":
-            # TODO AB#1991199: Raise exception instead of warning.
-            warnings.warn(
-                f"{metadata['config']['namespace_component']}::{enum_name} -> Enum is in metadata but is not referenced by a function/attribute or force-included."
-            )
         else:
+            # TODO AB#1991199: Raise exception instead of warning.
             warnings.warn(
                 f"{metadata['config']['namespace_component']}::{enum_name} -> Enum is in metadata but is not referenced by a function/attribute or force-included."
             )

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -1,6 +1,6 @@
 """Metadata validation."""
-from typing import Any, Dict, List, Set
 import warnings
+from typing import Any, Dict, List, Set
 
 import common_helpers
 import service_helpers

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -1,7 +1,6 @@
 """Metadata validation."""
-import warnings
-
 from typing import Any, Dict, List, Set
+import warnings
 
 import common_helpers
 import service_helpers

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -325,11 +325,11 @@ def _validate_enum(enum_name: str, used_enums: Set[str], metadata: dict):
         elif common_helpers.get_driver_readiness(metadata["config"]) == "Release":
             # TODO AB#1991199: Raise exception instead of warning.
             warnings.warn(
-                f"Enum {enum_name} is in metadata but not referenced by function/attribute in {metadata['config']['namespace_component']}."
+                f"{metadata['config']['namespace_component']}::{enum_name} -> Enum is in metadata but is not referenced by a function/attribute or force-included."
             )
         else:
             warnings.warn(
-                f"Enum {enum_name} is in metadata but not referenced by function/attribute in {metadata['config']['namespace_component']}."
+                f"{metadata['config']['namespace_component']}::{enum_name} -> Enum is in metadata but is not referenced by a function/attribute or force-included."
             )
     except Exception as e:
         raise Exception(f"Failed to validate enum with name {enum_name}") from e


### PR DESCRIPTION
### What does this Pull Request accomplish?

Introduces metadata validation for enums in the metadata but not being generated in the proto file (not referenced by function/attribute or not marked force-include). For now, this validation will just produce a warning. After we fix up the offending enums in the released drivers we'll switch it to raise an Exception that fails the build.

Also, fixed up ni-fake by deleting enums that weren't being generated as part of this change.

### Why should this Pull Request be merged?

[AB#1991162](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1991162)

There's some enums in the metadata that are not referenced by a function/attribute and are not marked force-include. These enums aren't being generated in the driver's corresponding proto file. We should start noting them and going through and fixing them up.

### What testing has been done?

Build passes locally. Before fixing up ni-fake it produced the following in the build output:
```
[build] [23/290   2% :: 0.818] Generating proto file and service for nifake
[build] ...\metadata_validation.py:328: UserWarning: nifake::BeautifulColor -> Enum is in metadata but is not referenced by a function/attribute or force-included
[build]   f"{metadata['config']['namespace_component']}::{enum_name} -> Enum is in metadata but is not referenced by a function/attribute or force-included."
[build] ...\metadata_validation.py:328: UserWarning: nifake::ColorObsolete -> Enum is in metadata but is not referenced by a function/attribute or force-included
[build]   f"{metadata['config']['namespace_component']}::{enum_name} -> Enum is in metadata but is not referenced by a function/attribute or force-included"
[build] ...\metadata_validation.py:328: UserWarning: nifake::ColorPrivate -> Enum is in metadata but is not referenced by a function/attribute or force-included.
[build]   f"{metadata['config']['namespace_component']}::{enum_name} -> Enum is in metadata but is not referenced by a function/attribute or force-included"
```
