### PR TITLE
Fix missing dc power and xnetxocket enums.

### DIFF
--- a/generated/nidcpower/nidcpower.proto
+++ b/generated/nidcpower/nidcpower.proto
@@ -1865,7 +1865,7 @@ message SetSequenceResponse {
 message WaitForEventRequest {
   nidevice_grpc.Session vi = 1;
   oneof event_id_enum {
-    ExportSignal event_id = 2;
+    Event event_id = 2;
     sint32 event_id_raw = 3;
   }
   double timeout = 4;

--- a/generated/nidcpower/nidcpower.proto
+++ b/generated/nidcpower/nidcpower.proto
@@ -343,6 +343,16 @@ enum DigitalEdge {
   DIGITAL_EDGE_NIDCPOWER_VAL_FALLING = 1017;
 }
 
+enum Event {
+  EVENT_UNSPECIFIED = 0;
+  EVENT_NIDCPOWER_VAL_SOURCE_COMPLETE = 1030;
+  EVENT_NIDCPOWER_VAL_MEASURE_COMPLETE = 1031;
+  EVENT_NIDCPOWER_VAL_SEQUENCE_ITERATION_COMPLETE = 1032;
+  EVENT_NIDCPOWER_VAL_SEQUENCE_ENGINE_DONE = 1033;
+  EVENT_NIDCPOWER_VAL_PULSE_COMPLETE = 1051;
+  EVENT_NIDCPOWER_VAL_READY_FOR_PULSE_TRIGGER = 1052;
+}
+
 enum ExportSignal {
   EXPORT_SIGNAL_UNSPECIFIED = 0;
   EXPORT_SIGNAL_NIDCPOWER_VAL_SOURCE_COMPLETE_EVENT = 1030;
@@ -378,6 +388,16 @@ enum OutputStates {
   OUTPUT_STATES_NIDCPOWER_VAL_OUTPUT_OVER_VOLTAGE = 2;
   OUTPUT_STATES_NIDCPOWER_VAL_OUTPUT_OVER_CURRENT = 3;
   OUTPUT_STATES_NIDCPOWER_VAL_OUTPUT_UNREGULATED = 4;
+}
+
+enum SendSoftwareEdgeTriggerType {
+  SEND_SOFTWARE_EDGE_TRIGGER_TYPE_UNSPECIFIED = 0;
+  SEND_SOFTWARE_EDGE_TRIGGER_TYPE_NIDCPOWER_VAL_START = 1034;
+  SEND_SOFTWARE_EDGE_TRIGGER_TYPE_NIDCPOWER_VAL_SOURCE = 1035;
+  SEND_SOFTWARE_EDGE_TRIGGER_TYPE_NIDCPOWER_VAL_MEASURE = 1036;
+  SEND_SOFTWARE_EDGE_TRIGGER_TYPE_NIDCPOWER_VAL_SEQUENCE_ADVANCE = 1037;
+  SEND_SOFTWARE_EDGE_TRIGGER_TYPE_NIDCPOWER_VAL_PULSE = 1053;
+  SEND_SOFTWARE_EDGE_TRIGGER_TYPE_NIDCPOWER_VAL_SHUTDOWN = 1118;
 }
 
 enum Sense {
@@ -804,7 +824,7 @@ message SendSoftwareEdgeTriggerWithChannelsRequest {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
   oneof trigger_enum {
-    ExportSignal trigger = 3;
+    SendSoftwareEdgeTriggerType trigger = 3;
     sint32 trigger_raw = 4;
   }
 }
@@ -817,7 +837,7 @@ message WaitForEventWithChannelsRequest {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
   oneof event_id_enum {
-    ExportSignal event_id = 3;
+    Event event_id = 3;
     sint32 event_id_raw = 4;
   }
   double timeout = 5;
@@ -1750,7 +1770,7 @@ message SelfTestResponse {
 message SendSoftwareEdgeTriggerRequest {
   nidevice_grpc.Session vi = 1;
   oneof trigger_enum {
-    ExportSignal trigger = 2;
+    SendSoftwareEdgeTriggerType trigger = 2;
     sint32 trigger_raw = 3;
   }
 }

--- a/generated/nidcpower/nidcpower_client.cpp
+++ b/generated/nidcpower/nidcpower_client.cpp
@@ -644,14 +644,14 @@ reset_with_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, const
 }
 
 SendSoftwareEdgeTriggerWithChannelsResponse
-send_software_edge_trigger_with_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const simple_variant<ExportSignal, pb::int32>& trigger)
+send_software_edge_trigger_with_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const simple_variant<SendSoftwareEdgeTriggerType, pb::int32>& trigger)
 {
   ::grpc::ClientContext context;
 
   auto request = SendSoftwareEdgeTriggerWithChannelsRequest{};
   request.mutable_vi()->CopyFrom(vi);
   request.set_channel_name(channel_name);
-  const auto trigger_ptr = trigger.get_if<ExportSignal>();
+  const auto trigger_ptr = trigger.get_if<SendSoftwareEdgeTriggerType>();
   const auto trigger_raw_ptr = trigger.get_if<pb::int32>();
   if (trigger_ptr) {
     request.set_trigger(*trigger_ptr);
@@ -669,14 +669,14 @@ send_software_edge_trigger_with_channels(const StubPtr& stub, const nidevice_grp
 }
 
 WaitForEventWithChannelsResponse
-wait_for_event_with_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const simple_variant<ExportSignal, pb::int32>& event_id, const double& timeout)
+wait_for_event_with_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const simple_variant<Event, pb::int32>& event_id, const double& timeout)
 {
   ::grpc::ClientContext context;
 
   auto request = WaitForEventWithChannelsRequest{};
   request.mutable_vi()->CopyFrom(vi);
   request.set_channel_name(channel_name);
-  const auto event_id_ptr = event_id.get_if<ExportSignal>();
+  const auto event_id_ptr = event_id.get_if<Event>();
   const auto event_id_raw_ptr = event_id.get_if<pb::int32>();
   if (event_id_ptr) {
     request.set_event_id(*event_id_ptr);
@@ -2348,13 +2348,13 @@ self_test(const StubPtr& stub, const nidevice_grpc::Session& vi)
 }
 
 SendSoftwareEdgeTriggerResponse
-send_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<ExportSignal, pb::int32>& trigger)
+send_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<SendSoftwareEdgeTriggerType, pb::int32>& trigger)
 {
   ::grpc::ClientContext context;
 
   auto request = SendSoftwareEdgeTriggerRequest{};
   request.mutable_vi()->CopyFrom(vi);
-  const auto trigger_ptr = trigger.get_if<ExportSignal>();
+  const auto trigger_ptr = trigger.get_if<SendSoftwareEdgeTriggerType>();
   const auto trigger_raw_ptr = trigger.get_if<pb::int32>();
   if (trigger_ptr) {
     request.set_trigger(*trigger_ptr);

--- a/generated/nidcpower/nidcpower_client.cpp
+++ b/generated/nidcpower/nidcpower_client.cpp
@@ -2519,13 +2519,13 @@ set_sequence(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::st
 }
 
 WaitForEventResponse
-wait_for_event(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<ExportSignal, pb::int32>& event_id, const double& timeout)
+wait_for_event(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<Event, pb::int32>& event_id, const double& timeout)
 {
   ::grpc::ClientContext context;
 
   auto request = WaitForEventRequest{};
   request.mutable_vi()->CopyFrom(vi);
-  const auto event_id_ptr = event_id.get_if<ExportSignal>();
+  const auto event_id_ptr = event_id.get_if<Event>();
   const auto event_id_raw_ptr = event_id.get_if<pb::int32>();
   if (event_id_ptr) {
     request.set_event_id(*event_id_ptr);

--- a/generated/nidcpower/nidcpower_client.h
+++ b/generated/nidcpower/nidcpower_client.h
@@ -154,7 +154,7 @@ SetAttributeViReal64Response set_attribute_vi_real64(const StubPtr& stub, const 
 SetAttributeViSessionResponse set_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiDCPowerAttribute& attribute_id, const nidevice_grpc::Session& attribute_value);
 SetAttributeViStringResponse set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiDCPowerAttribute& attribute_id, const pb::string& attribute_value);
 SetSequenceResponse set_sequence(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const std::vector<double>& values, const std::vector<double>& source_delays);
-WaitForEventResponse wait_for_event(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<ExportSignal, pb::int32>& event_id, const double& timeout);
+WaitForEventResponse wait_for_event(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<Event, pb::int32>& event_id, const double& timeout);
 
 } // namespace nidcpower_grpc::experimental::client
 

--- a/generated/nidcpower/nidcpower_client.h
+++ b/generated/nidcpower/nidcpower_client.h
@@ -54,8 +54,8 @@ InitializeWithIndependentChannelsResponse initialize_with_independent_channels(c
 InitiateWithChannelsResponse initiate_with_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name);
 InvalidateAllAttributesResponse invalidate_all_attributes(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ResetWithChannelsResponse reset_with_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name);
-SendSoftwareEdgeTriggerWithChannelsResponse send_software_edge_trigger_with_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const simple_variant<ExportSignal, pb::int32>& trigger);
-WaitForEventWithChannelsResponse wait_for_event_with_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const simple_variant<ExportSignal, pb::int32>& event_id, const double& timeout);
+SendSoftwareEdgeTriggerWithChannelsResponse send_software_edge_trigger_with_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const simple_variant<SendSoftwareEdgeTriggerType, pb::int32>& trigger);
+WaitForEventWithChannelsResponse wait_for_event_with_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const simple_variant<Event, pb::int32>& event_id, const double& timeout);
 AbortResponse abort(const StubPtr& stub, const nidevice_grpc::Session& vi);
 CalSelfCalibrateResponse cal_self_calibrate(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name);
 ClearErrorResponse clear_error(const StubPtr& stub, const nidevice_grpc::Session& vi);
@@ -146,7 +146,7 @@ ResetInterchangeCheckResponse reset_interchange_check(const StubPtr& stub, const
 ResetWithDefaultsResponse reset_with_defaults(const StubPtr& stub, const nidevice_grpc::Session& vi);
 RevisionQueryResponse revision_query(const StubPtr& stub, const nidevice_grpc::Session& vi);
 SelfTestResponse self_test(const StubPtr& stub, const nidevice_grpc::Session& vi);
-SendSoftwareEdgeTriggerResponse send_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<ExportSignal, pb::int32>& trigger);
+SendSoftwareEdgeTriggerResponse send_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<SendSoftwareEdgeTriggerType, pb::int32>& trigger);
 SetAttributeViBooleanResponse set_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiDCPowerAttribute& attribute_id, const bool& attribute_value);
 SetAttributeViInt32Response set_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiDCPowerAttribute& attribute_id, const simple_variant<NiDCPowerInt32AttributeValues, pb::int32>& attribute_value);
 SetAttributeViInt64Response set_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiDCPowerAttribute& attribute_id, const pb::int64& attribute_value);

--- a/source/codegen/metadata/nidcpower/enums.py
+++ b/source/codegen/metadata/nidcpower/enums.py
@@ -593,26 +593,6 @@ enums = {
             }
         ]
     },
-    'SessionState': {
-        'values': [
-            {
-                'name': 'NIDCPOWER_VAL_IDLE',
-                'value': 1
-            },
-            {
-                'name': 'NIDCPOWER_VAL_VERIFIED',
-                'value': 2
-            },
-            {
-                'name': 'NIDCPOWER_VAL_COMMITTED',
-                'value': 4
-            },
-            {
-                'name': 'NIDCPOWER_VAL_RUNNING',
-                'value': 8
-            }
-        ]
-    },
     'SourceMode': {
         'values': [
             {

--- a/source/codegen/metadata/nidcpower/functions.py
+++ b/source/codegen/metadata/nidcpower/functions.py
@@ -2774,7 +2774,7 @@ functions = {
         'name': 'eventId',
         'direction': 'in',
         'type': 'ViInt32',
-        'enum': 'ExportSignal'
+        'enum': 'Event'
       },
       {
         'name': 'timeout',

--- a/source/codegen/metadata/nidcpower/functions.py
+++ b/source/codegen/metadata/nidcpower/functions.py
@@ -674,7 +674,7 @@ functions = {
         'name': 'trigger',
         'direction': 'in',
         'type': 'ViInt32',
-        'enum': 'ExportSignal'
+        'enum': 'SendSoftwareEdgeTriggerType'
       }
     ],
     'returns': 'ViStatus'
@@ -695,7 +695,7 @@ functions = {
         'name': 'eventId',
         'direction': 'in',
         'type': 'ViInt32',
-        'enum': 'ExportSignal'
+        'enum': 'Event'
       },
       {
         'name': 'timeout',
@@ -2554,7 +2554,7 @@ functions = {
         'name': 'trigger',
         'direction': 'in',
         'type': 'ViInt32',
-        'enum': 'ExportSignal'
+        'enum': 'SendSoftwareEdgeTriggerType'
       }
     ],
     'returns': 'ViStatus'

--- a/source/codegen/metadata/nixnetsocket/enums.py
+++ b/source/codegen/metadata/nixnetsocket/enums.py
@@ -219,18 +219,6 @@ enums = {
             },
         ]
     },
-    'ProtocolFamily': {
-        'values': [
-            {
-                'name': 'INET',
-                'value': 2
-            },
-            {
-                'name': 'INET6',
-                'value': 10
-            }
-        ]
-    },
     'RecvFlags': {
         'values': [
             {


### PR DESCRIPTION
### What does this Pull Request accomplish?
DCPower:
- `Event` enum referenced by `WaitForEvent` and `WaitForEventWithChannels`
- `SendSoftwareEdgeTriggerType` enum referenced by `SendSoftwareEdgeTrigger` and `SendSoftwareEdgeTriggerWithChannels`
- `SessionState` enum removed from metadata. Couldn't find any reference to it or its values anywhere, including header file.

XNETSocket:
- `ProtocolFamily` enum removed from metadata. It could arguably be used for `domain` param of `nxsocket` instead of `AddressFamily` enum but their values match, are often used interchangeably in implementations, and AddressFamily (nxAF _INET) is what's referenced in the documentation.

### Why should this Pull Request be merged?

Addresses the 3 enums in dc power not included in proto and 1 enum in xnetsocket not in the proto.

[AB#1991309](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1991309)
[AB#1991312](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/1991312)

### What testing has been done?

Visual inspection of generated proto files. Relying on unit tests since functions now referencing enums aren't used in system tests or examples.