### PR TITLE
Create script to check if Linux RT feed needs updating.

### DIFF
--- a/source/codegen/validate-linux-rt.py
+++ b/source/codegen/validate-linux-rt.py
@@ -1,0 +1,69 @@
+"""Script for validating if a set of changed files warrants updating the Linux RT Feed.
+Expects output of git diff --name-only <last-release-commit> <current-commit> to be piped in so it can be read from sys.stdin"""
+
+import argparse
+import fnmatch
+import os
+import sys
+from template_helpers import load_metadata
+from typing import List
+
+
+def _check_core_files_affecting_rt(changed_files: List[str]) -> bool:
+    files_affecting_linux_rt = [
+        "source/config/*",
+        "source/custom/ivi_errors.h",
+        "source/protobuf/*",
+        "source/server/*",
+    ]
+
+    for pattern in files_affecting_linux_rt:
+        if fnmatch.filter(changed_files, pattern):
+            return True
+    return False
+
+
+def _check_driver_files_affecting_rt(driver_name: str, changed_files: List[str]) -> bool:
+    files_affecting_linux_rt = [
+        f"generated/{driver_name}/*",
+        f"examples/{driver_name}/*",
+        f"source/custom/{driver_name}*",
+    ]
+
+    for pattern in files_affecting_linux_rt:
+        if fnmatch.filter(changed_files, pattern):
+            return True
+    return False
+
+
+def _check_all(metadata_dir: str, changed_files: List[str]) -> bool:
+
+    if _check_core_files_affecting_rt(changed_files):
+        return True
+    rt_supported_drivers = [
+        driver
+        for driver in os.listdir(metadata_dir)
+        if load_metadata(f"{metadata_dir}/{driver}/")["config"]["linux_rt_support"]
+    ]
+    for driver in rt_supported_drivers:
+        if _check_driver_files_affecting_rt(driver, changed_files):
+            return True
+    return False
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Check if any file has changed that affects the Linux RT Feed."
+    )
+    parser.add_argument(
+        "metadata",
+        help="The path to the directory containing all of the metadata.",
+    )
+    args = parser.parse_args()
+    changed_files = list()
+    for line in sys.stdin:
+        changed_files.append(line.strip())
+    if _check_all(args.metadata, changed_files):
+        print("Linux RT Feed needs updating.")
+    else:
+        print("Linux RT Feed does not need updating.")


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes AB#2009217

Creates a script to detect if the Linux RT Feed needs updating. The script will be supplied with a list of files that have changed and determine if any of them 

### Why should this Pull Request be merged?

Stepping stone to be able to plug this into a GitHub Action to run on the releases branch so the developer creating a release knows if they need to update the Linux RT feed to point to the new release or not.

### What testing has been done?

Ran the script against several inputs to make sure it's working as intended:

```
PS ...\grpc-device> "source/custom/niscope_service.custom.cpp" | python source/codegen/validate-linux-rt.py C:\dev\reckenro-git\grpc-device\source\codegen\metadata\
Linux RT Feed needs updating.
PS ...\grpc-device> "source/custom/rfsg_service.custom.cpp" | python source/codegen/validate-linux-rt.py ...\grpc-device\source\codegen\metadata\
Linux RT Feed does not need updating.
PS ...\grpc-device> git diff --name-only 46e1b9edd846505c21a9ee34bcdfc1689cc13cc9 HEAD | python source/codegen/validate-linux-rt.py ...\grpc-device\source\codegen\metadata\
Linux RT Feed needs updating.
PS ...\grpc-device>
```
