### PR TITLE
Trigger script to validate linux rt feed after a new tag is pushed.

### DIFF
--- a/.github/update-linux-rt-template.md
+++ b/.github/update-linux-rt-template.md
@@ -1,0 +1,9 @@
+---
+title: Update Linux RT Feed to point to new release {{ env.NEW_RELEASE }}
+---
+
+Linux RT needs to be updated to point to the new grpc-device release.
+
+Update the following lines in `recipes-ni/ni-grpc-device/ni-grpc-device_git.bb` in [ni/meta-nilrt](https://github.com/ni/meta-nilrt)
+- PV = {{ env.NEW_RELEASE }}
+- SRCREV_grpc-device = "{{ env.GITHUB_SHA }}"

--- a/.github/update-linux-rt-template.md
+++ b/.github/update-linux-rt-template.md
@@ -5,5 +5,5 @@ title: Update Linux RT Feed to point to new release {{ env.NEW_RELEASE }}
 Linux RT needs to be updated to point to the new grpc-device release.
 
 Update the following lines in `recipes-ni/ni-grpc-device/ni-grpc-device_git.bb` in [ni/meta-nilrt](https://github.com/ni/meta-nilrt)
-- PV = {{ env.NEW_RELEASE }}
+- PV = "{{ env.NEW_RELEASE }}"
 - SRCREV_grpc-device = "{{ env.GITHUB_SHA }}"

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Fail if new tag is not latest tag
       if: ${{ github.ref_name != steps.latesttag.outputs.tag}}
       uses: actions/github-script@v3
+      with:
         script: |
             core.setFailed('The new tag is not the latest tag. Checking if the linux rt feed needs updating doesn't make sense on a patch to a previous release.')
 

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -29,6 +29,6 @@ jobs:
           git describe --abbrev=0 --tags ${{github.ref_name}}^
         )"
 
-    - name: Run validate_linux_rt.py
+    - name: Update Linux RT Feed to ${{ github.ref_name }}?
       run: |
         git diff --name-only ${{ steps.previoustag.outputs.tag}}..${{ github.ref_name }} | python source/codegen/validate-linux-rt.py source/codegen/metadata

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -26,7 +26,7 @@ jobs:
       id: previoustag
       run: >-
         echo "::set-output name=tag::$(
-          git describe --abbrev=0 ${{github.ref_name}}^
+          git describe --abbrev=0 --tags ${{github.ref_name}}^
         )"
 
     - name: Run validate_linux_rt.py

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -25,4 +25,4 @@ jobs:
 
     - name: Run validate_linux_rt.py
       run: |
-        git diff --name-only ${{ steps.previoustag.outputs.tag}}..${{github.ref_name}} | python source/codegen/validate-linux-rt.py
+        git diff --name-only v1.5.1..${{github.ref_name}} | python source/codegen/validate-linux-rt.py

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -28,4 +28,4 @@ jobs:
 
     - name: Run validate_linux_rt.py
       run: |
-        git diff --name-only v1.5.1..${{github.ref_name}} | python source/codegen/validate-linux-rt.py
+        git diff --name-only v1.5.1..${{github.ref_name}} | python source/codegen/validate-linux-rt.py source/codegen/metadata

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -19,30 +19,30 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: Install build dependencies
-      run: python -m pip install -r python_build_requirements.txt
-
-    - name: Get latest tag
+    - name: Get the latest tag
       id: latesttag
       run: >-
         echo "::set-output name=tag::$(
           git tag --list --sort=-version:refname | grep '^\(v[0-9]\+.[0-9]\+.[0-9]\+\)$' | head -1
         )"
 
-    - name: Get second latest tag
+    - name: Get the second latest tag
       id: secondlatesttag
       run: >-
         echo "::set-output name=tag::$(
-          git tag --list --sort=-version:refname | grep '^\(v[0-9]\+.[0-9]\+.[0-9]\+\)$' | head -2
+          git tag --list --sort=-version:refname | grep '^\(v[0-9]\+.[0-9]\+.[0-9]\+\)$' | sed '1d' | head -1
         )"
 
     - name: Fail if new tag is not latest tag
       if: ${{ github.ref_name != steps.latesttag.outputs.tag}}
-      uses: actions/github-script@v3
+      uses: actions/github-script@v6
       with:
         script: |
-            core.setFailed('The new tag is not the latest tag. Checking if the linux rt feed needs updating doesn't make sense on a patch to a previous release.')
+            core.setFailed(`The new tag is not an update to the latest released tag. Checking if the Linux RT Feed needs updating doesn't make sense on a patch to a previous release.`)
 
-    - name: Update Linux RT's grpc-device dependency to ${{ github.ref_name }}?
+    - name: Install build dependencies
+      run: python -m pip install -r python_build_requirements.txt
+
+    - name: Update Linux RT's grpc-device dependency to ${{ steps.latesttag.outputs.tag }}?
       run: |
-        git diff --name-only ${{ steps.secondlatesttag.outputs.tag}}..${{ github.ref_name }} | python source/codegen/validate-linux-rt.py source/codegen/metadata
+        git diff --name-only ${{ steps.secondlatesttag.outputs.tag}}..${{ steps.latesttag.outputs.tag }} | python source/codegen/validate-linux-rt.py source/codegen/metadata

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -49,4 +49,11 @@ jobs:
 
     - name: Create GitHub Issue
       if: ${{ env.SHOULD_UPDATE_LINUX_RT == True}}
-      run: echo ${{ env.SHOULD_UPDATE_LINUX_RT}}
+      uses: JasonEtco/create-an-issue@v2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        NEW_RELEASE: ${{ steps.latesttag.outputs.tag }}
+        PREV_RELEASE: ${{ steps.secondlatesttag.outputs.tag }}
+        GITHUB_SHA: ${{ github.sha}}
+      with:
+        filename: .github/update-linux-rt-template.md

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -1,4 +1,4 @@
-name: Validate Linux RT Feed
+name: Validate Linux RT Feed Package Version
 on:
   push:
     tags:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   validate_linux_rt:
-    name: Validate Linux RT Feed
+    name: Validate Linux RT Feed Package Version
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repo
@@ -43,7 +43,7 @@ jobs:
     - name: Install build dependencies
       run: python -m pip install -r python_build_requirements.txt
 
-    - name: Update Linux RT's grpc-device dependency to ${{ steps.latesttag.outputs.tag }}?
+    - name: Check if Linux RT needs updating
       run: |
         git diff --name-only ${{ steps.secondlatesttag.outputs.tag}}..${{ steps.latesttag.outputs.tag }} | python source/codegen/validate-linux-rt.py source/codegen/metadata
 

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -19,6 +19,9 @@ jobs:
       with:
         python-version: '3.x'
 
+    - name: Install build dependencies
+      run: python -m pip install -r python_build_requirements.txt
+
     - name: "Get previous tag"
       id: previoustag
       uses: "WyriHaximus/github-action-get-previous-tag@v1"

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -22,13 +22,13 @@ jobs:
     - name: Install build dependencies
       run: python -m pip install -r python_build_requirements.txt
 
-    - name: "Get previous tag"
+    - name: Get previous tag
       id: previoustag
       run: >-
         echo "::set-output name=tag::$(
           git describe --abbrev=0 --tags ${{github.ref_name}}^
         )"
 
-    - name: Update Linux RT Feed to ${{ github.ref_name }}?
+    - name: Update Linux RT's grpc-device dependency to ${{ github.ref_name }}?
       run: |
         git diff --name-only ${{ steps.previoustag.outputs.tag}}..${{ github.ref_name }} | python source/codegen/validate-linux-rt.py source/codegen/metadata

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -48,7 +48,7 @@ jobs:
         git diff --name-only ${{ steps.secondlatesttag.outputs.tag}}..${{ steps.latesttag.outputs.tag }} | python source/codegen/validate-linux-rt.py source/codegen/metadata
 
     - name: Create GitHub Issue
-      if: ${{ env.SHOULD_UPDATE_LINUX_RT == True}}
+      if: ${{ env.SHOULD_UPDATE_LINUX_RT == 'True'}}
       uses: JasonEtco/create-an-issue@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -26,6 +26,13 @@ jobs:
           git tag --list --sort=-version:refname | grep '^\(v[0-9]\+.[0-9]\+.[0-9]\+\)$' | head -1
         )"
 
+    - name: Get latest tag without leading v
+      id: latesttagwithoutv
+      run: >-
+        echo "::set-output name=tag::$(
+          git tag --list --sort=-version:refname | grep '^\(v[0-9]\+.[0-9]\+.[0-9]\+\)$' | head -1 | cut -c2-
+        )"
+
     - name: Get the second latest tag
       id: secondlatesttag
       run: >-
@@ -51,9 +58,7 @@ jobs:
       if: ${{ env.SHOULD_UPDATE_LINUX_RT == 'True'}}
       uses: JasonEtco/create-an-issue@v2
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NEW_RELEASE: ${{ steps.latesttag.outputs.tag }}
-        PREV_RELEASE: ${{ steps.secondlatesttag.outputs.tag }}
+        NEW_RELEASE: ${{ steps.latesttagwithoutv.outputs.tag }}
         GITHUB_SHA: ${{ github.sha}}
       with:
         filename: .github/update-linux-rt-template.md

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -38,7 +38,7 @@ jobs:
       uses: actions/github-script@v6
       with:
         script: |
-            core.setFailed(`The new tag is not an update to the latest released tag. Checking if the Linux RT Feed needs updating doesn't make sense on a patch to a previous release.`)
+            core.setFailed(`The new release (${{ github.ref_name }}) is not a patch or update to the latest release (${{ steps.latesttag.outputs.tag }}). Checking if the Linux RT Feed needs updating doesn't make sense on a patch to a previous release.`)
 
     - name: Install build dependencies
       run: python -m pip install -r python_build_requirements.txt
@@ -47,5 +47,6 @@ jobs:
       run: |
         git diff --name-only ${{ steps.secondlatesttag.outputs.tag}}..${{ steps.latesttag.outputs.tag }} | python source/codegen/validate-linux-rt.py source/codegen/metadata
 
-    - name: Echo if Linux RT needs updating
+    - name: Create GitHub Issue
+      if: ${{ env.SHOULD_UPDATE_LINUX_RT == True}}
       run: echo ${{ env.SHOULD_UPDATE_LINUX_RT}}

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -48,4 +48,4 @@ jobs:
         git diff --name-only ${{ steps.secondlatesttag.outputs.tag}}..${{ steps.latesttag.outputs.tag }} | python source/codegen/validate-linux-rt.py source/codegen/metadata
 
     - name: Echo if Linux RT needs updating
-      run: echo ${{ env.SHOULD_UPDATE_RT}}
+      run: echo ${{ env.SHOULD_UPDATE_LINUX_RT}}

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -58,6 +58,7 @@ jobs:
       if: ${{ env.SHOULD_UPDATE_LINUX_RT == 'True'}}
       uses: JasonEtco/create-an-issue@v2
       env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         NEW_RELEASE: ${{ steps.latesttagwithoutv.outputs.tag }}
         GITHUB_SHA: ${{ github.sha}}
       with:

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -2,7 +2,7 @@ name: Validate Linux RT Feed
 on:
   push:
     tags:
-      - 'vtest*.*.*'
+      - 'v*.*.*'
 
 jobs:
   validate_linux_rt:

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -1,0 +1,29 @@
+name: Validate Linux RT Feed
+on:
+  push:
+    tags:
+      - 'vtest*.*.*'
+
+jobs:
+  validate_linux_rt:
+    name: Validate Linux RT Feed
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Setup python3
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: "Get previous tag"
+      id: previoustag
+      uses: "WyriHaximus/github-action-get-previous-tag@v1"
+
+    - name: Run validate_linux_rt.py
+      run: |
+        git diff --name-only ${{ steps.previoustag.outputs.tag}}..${{github.ref_name}} | python source/codegen/validate-linux-rt.py
+      

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -26,4 +26,3 @@ jobs:
     - name: Run validate_linux_rt.py
       run: |
         git diff --name-only ${{ steps.previoustag.outputs.tag}}..${{github.ref_name}} | python source/codegen/validate-linux-rt.py
-      

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -46,3 +46,6 @@ jobs:
     - name: Update Linux RT's grpc-device dependency to ${{ steps.latesttag.outputs.tag }}?
       run: |
         git diff --name-only ${{ steps.secondlatesttag.outputs.tag}}..${{ steps.latesttag.outputs.tag }} | python source/codegen/validate-linux-rt.py source/codegen/metadata
+
+    - name: Echo if Linux RT needs updating
+      run: echo ${{ env.SHOULD_UPDATE_RT}}

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -2,7 +2,7 @@ name: Validate Linux RT Feed
 on:
   push:
     tags:
-      - 'v*.*.*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   validate_linux_rt:
@@ -22,13 +22,26 @@ jobs:
     - name: Install build dependencies
       run: python -m pip install -r python_build_requirements.txt
 
-    - name: Get previous tag
-      id: previoustag
+    - name: Get latest tag
+      id: latesttag
       run: >-
         echo "::set-output name=tag::$(
-          git describe --abbrev=0 --tags ${{github.ref_name}}^
+          git tag --list --sort=-version:refname | grep '^\(v[0-9]\+.[0-9]\+.[0-9]\+\)$' | head -1
         )"
+
+    - name: Get second latest tag
+      id: secondlatesttag
+      run: >-
+        echo "::set-output name=tag::$(
+          git tag --list --sort=-version:refname | grep '^\(v[0-9]\+.[0-9]\+.[0-9]\+\)$' | head -2
+        )"
+
+    - name: Fail if new tag is not latest tag
+      if: ${{ github.ref_name != steps.latesttag.outputs.tag}}
+      uses: actions/github-script@v3
+        script: |
+            core.setFailed('The new tag is not the latest tag. Checking if the linux rt feed needs updating doesn't make sense on a patch to a previous release.')
 
     - name: Update Linux RT's grpc-device dependency to ${{ github.ref_name }}?
       run: |
-        git diff --name-only ${{ steps.previoustag.outputs.tag}}..${{ github.ref_name }} | python source/codegen/validate-linux-rt.py source/codegen/metadata
+        git diff --name-only ${{ steps.secondlatesttag.outputs.tag}}..${{ github.ref_name }} | python source/codegen/validate-linux-rt.py source/codegen/metadata

--- a/.github/workflows/validate_linux_rt.yml
+++ b/.github/workflows/validate_linux_rt.yml
@@ -24,8 +24,11 @@ jobs:
 
     - name: "Get previous tag"
       id: previoustag
-      uses: "WyriHaximus/github-action-get-previous-tag@v1"
+      run: >-
+        echo "::set-output name=tag::$(
+          git describe --abbrev=0 ${{github.ref_name}}^
+        )"
 
     - name: Run validate_linux_rt.py
       run: |
-        git diff --name-only v1.5.1..${{github.ref_name}} | python source/codegen/validate-linux-rt.py source/codegen/metadata
+        git diff --name-only ${{ steps.previoustag.outputs.tag}}..${{ github.ref_name }} | python source/codegen/validate-linux-rt.py source/codegen/metadata

--- a/source/codegen/validate-linux-rt.py
+++ b/source/codegen/validate-linux-rt.py
@@ -79,6 +79,6 @@ if __name__ == "__main__":
     for line in sys.stdin:
         changed_files.add(line.strip())
     if _need_linux_rt_feed_update(args.metadata, changed_files):
-        print("\nLinux RT Feed likely needs updating.")
+        print("\nLinux RT's grpc-device dependency needs updating.")
     else:
-        print("\nLinux RT Feed should not need updating.")
+        print("\nLinux RT's grpc-device dependency doesn't need updating.")

--- a/source/codegen/validate-linux-rt.py
+++ b/source/codegen/validate-linux-rt.py
@@ -87,4 +87,4 @@ if __name__ == "__main__":
         print("\nLinux RT's grpc-device dependency doesn't need updating.")
     if env_file:
         with open(env_file, "a") as myfile:
-            myfile.write(f"UPDATE_LINUX_RT_VAR={update_linux_rt}")
+            myfile.write(f"SHOULD_UPDATE_LINUX_RT={update_linux_rt}")

--- a/source/codegen/validate-linux-rt.py
+++ b/source/codegen/validate-linux-rt.py
@@ -8,8 +8,8 @@ import argparse
 import fnmatch
 import os
 import sys
-from typing import Set
 from pprint import pprint
+from typing import Set
 
 from template_helpers import load_metadata
 

--- a/source/codegen/validate-linux-rt.py
+++ b/source/codegen/validate-linux-rt.py
@@ -78,7 +78,13 @@ if __name__ == "__main__":
     changed_files = set()
     for line in sys.stdin:
         changed_files.add(line.strip())
+    env_file = os.getenv("GITHUB_ENV")
+    update_linux_rt = False
     if _need_linux_rt_feed_update(args.metadata, changed_files):
         print("\nLinux RT's grpc-device dependency needs updating.")
+        update_linux_rt = True
     else:
         print("\nLinux RT's grpc-device dependency doesn't need updating.")
+    if env_file:
+        with open(env_file, "a") as myfile:
+            myfile.write(f"UPDATE_LINUX_RT_VAR={update_linux_rt}")


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes [AB#2009227](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2009227).

Adds a validate_linux_rt GitHub Action to run whenever a new tag is pushed (i.e., a new release is published). It will get the files that have changed between the last release and the new one and call validate_linux_rt.py to see if the Linux RT dependency on grpc-device needs to be updated to the new release version or not.

### Why should this Pull Request be merged?

This will give a spot to check for developers creating releases in grpc-device to see if they need to update the Linux RT Feed post release.

### What testing has been done?

In my fork, I pushed up some tags to test out the different scenarios
- Patch to previous release (tag v1.4.1 pushed up)
  - Job failed early: https://github.com/reckenro/grpc-device/actions/runs/2586323611
- Pre-release tag pushed up (tag v1.5.2-rc1)
  - Workflow didn't trigger
- New release tag pushed up (tag v1.5.2)
  - Workflow ran to completion: https://github.com/reckenro/grpc-device/runs/7121479474?check_suite_focus=true
  - Workflow created an issue in my fork to update Linux RT Feed: https://github.com/reckenro/grpc-device/issues/9
