### PR TITLE
Fix AzDo area path in sync_github_issues_to_azdo.yml

### DIFF
--- a/.github/workflows/sync_github_issues_to_azdo.yml
+++ b/.github/workflows/sync_github_issues_to_azdo.yml
@@ -15,7 +15,7 @@ jobs:
           github_token: "${{ secrets.GH_REPO_TOKEN }}"
           ado_organization: "ni"
           ado_project: "DevCentral"
-          ado_area_path: "DevCentral\\Product RnD\\PlatformSW\\CBS\\HW Config"
+          ado_area_path: "DevCentral\\Product RnD\\PlatformSW\\Test System SW\\CBS\\HW Config"
           ado_wit: "Bug"
           ado_new_state: "New"
           ado_active_state: "Active"


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes the azure area path in `sync_github_issues_to_azdo.yml`

### Why should this Pull Request be merged?

The area path changed at some point so this fixes it.

Noticed the action has been failing for a bit due to the area path such as the most recent run here: https://github.com/ni/grpc-device/actions/runs/2417639199

### What testing has been done?

None. I'll double check when there's a new issue that the Bug sync works again.