### PR TITLE
Generate release notes as reference instead of changelog link for auto draft releases.

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -70,10 +70,8 @@ jobs:
         artifacts: "downloads/artifacts/*"
         commit: ${{ github.sha }}
         draft: true
+        generateReleaseNotes: true
         body: |
-          Note: To populate the "Updates" and "Breaking Changes" sections below, look at the [full changelog](https://github.com/grpc-device/compare/${{ steps.previoustag.outputs.tag}}...${{ github.sha }})
-          Breaking change PRs will have the 'breaking-change' label on them.
-
           Updates since release ${{ steps.previoustag.outputs.tag }}:
           * List any bug fixes or general updates for this release vs. the previous one.
 
@@ -85,6 +83,8 @@ jobs:
           It also contains client bundles that contain the proto files needed to build a gRPC client as well as several example clients.
 
           Documentation on using this release can be found in our [README](https://github.com/ni/grpc-device#downloading-a-release) and [wiki](https://github.com/ni/grpc-device/wiki).
+
+          ⚠ Use the below generated release notes to populate the "Updates" and "Breaking Changes" sections above. Any PRs with a breaking change should be tagged with the 'breaking-change' label. ⚠
         name: "NI gRPC Device Server ${{ steps.semvers.outputs.patch }}"
         tag: ${{ steps.semvers.outputs.v_patch }}
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### What does this Pull Request accomplish?

Instead of just posting a link to the full changelog for the draft release, we now just generate the release notes which will provide all the PRs submitted inline.

### Why should this Pull Request be merged?

Makes it easier to fill out the sections in the draft release.

Fixes [AB#2060750](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2060750).

### What testing has been done?

Generated draft release notes on this release and it looks good. Easier to pull the PR titles / Links into the appropriate sections this way.
