### PR TITLE
Add ProductId to device enumeration

### DIFF
--- a/source/protobuf/session.proto
+++ b/source/protobuf/session.proto
@@ -39,6 +39,7 @@ message DeviceProperties {
   string model = 2;
   string vendor = 3;
   string serial_number = 4;
+  bytes product_id = 5;
 }
 
 message EnumerateDevicesRequest {}

--- a/source/protobuf/session.proto
+++ b/source/protobuf/session.proto
@@ -39,7 +39,7 @@ message DeviceProperties {
   string model = 2;
   string vendor = 3;
   string serial_number = 4;
-  bytes product_id = 5;
+  uint32 product_id = 5;
 }
 
 message EnumerateDevicesRequest {}

--- a/source/server/device_enumerator.cpp
+++ b/source/server/device_enumerator.cpp
@@ -27,6 +27,7 @@ DeviceEnumerator::~DeviceEnumerator()
   char model[NISYSCFG_SIMPLE_STRING_LENGTH] = "";
   char vendor[NISYSCFG_SIMPLE_STRING_LENGTH] = "";
   char serial_number[NISYSCFG_SIMPLE_STRING_LENGTH] = "";
+  char product_id[NISYSCFG_SIMPLE_STRING_LENGTH] = "";
   NISysCfgBool is_ni_product = NISysCfgBoolFalse;
 
   try {
@@ -46,10 +47,12 @@ DeviceEnumerator::~DeviceEnumerator()
               library_->GetResourceProperty(resource, NISysCfgResourcePropertyProductName, model);
               library_->GetResourceProperty(resource, NISysCfgResourcePropertyVendorName, vendor);
               library_->GetResourceProperty(resource, NISysCfgResourcePropertySerialNumber, serial_number);
+              library_->GetResourceProperty(resource, NISysCfgResourcePropertyProductId, product_id);
               properties->set_name(name);
               properties->set_model(model);
               properties->set_vendor(vendor);
               properties->set_serial_number(serial_number);
+              properties->set_product_id(product_id);
             }
             library_->CloseHandle(resource);
           }

--- a/source/server/device_enumerator.cpp
+++ b/source/server/device_enumerator.cpp
@@ -27,7 +27,7 @@ DeviceEnumerator::~DeviceEnumerator()
   char model[NISYSCFG_SIMPLE_STRING_LENGTH] = "";
   char vendor[NISYSCFG_SIMPLE_STRING_LENGTH] = "";
   char serial_number[NISYSCFG_SIMPLE_STRING_LENGTH] = "";
-  char product_id[NISYSCFG_SIMPLE_STRING_LENGTH] = "";
+  uint32_t product_id = 0;
   NISysCfgBool is_ni_product = NISysCfgBoolFalse;
 
   try {
@@ -47,7 +47,7 @@ DeviceEnumerator::~DeviceEnumerator()
               library_->GetResourceProperty(resource, NISysCfgResourcePropertyProductName, model);
               library_->GetResourceProperty(resource, NISysCfgResourcePropertyVendorName, vendor);
               library_->GetResourceProperty(resource, NISysCfgResourcePropertySerialNumber, serial_number);
-              library_->GetResourceProperty(resource, NISysCfgResourcePropertyProductId, product_id);
+              library_->GetResourceProperty(resource, NISysCfgResourcePropertyProductId, &product_id);
               properties->set_name(name);
               properties->set_model(model);
               properties->set_vendor(vendor);

--- a/source/tests/system/session_utilities_service_tests.cpp
+++ b/source/tests/system/session_utilities_service_tests.cpp
@@ -57,7 +57,7 @@ TEST_F(SessionUtilitiesServiceTests, SysCfgLibraryPresent_EnumerateDevices_Devic
     EXPECT_NE(device.model().c_str(), nullptr);
     EXPECT_THAT(device.vendor(), Not(IsEmpty()));
     EXPECT_NE(device.serial_number().c_str(), nullptr);
-    EXPECT_THAT(device.product_id(), Not(IsEmpty()));
+    EXPECT_NE(device.product_id(), 0);
   }
 }
 

--- a/source/tests/system/session_utilities_service_tests.cpp
+++ b/source/tests/system/session_utilities_service_tests.cpp
@@ -44,7 +44,7 @@ TEST_F(SessionUtilitiesServiceTests, SysCfgLibraryPresent_EnumerateDevices_Respo
   EXPECT_GE(response.devices_size(), 1);
 }
 
-TEST_F(SessionUtilitiesServiceTests, SysCfgLibraryPresent_EnumerateDevices_DevicePropertiesIncludesNameModelVendorSerialNumber)
+TEST_F(SessionUtilitiesServiceTests, SysCfgLibraryPresent_EnumerateDevices_DevicePropertiesIncludesNameModelVendorSerialNumberProductId)
 {
   nidevice_grpc::EnumerateDevicesRequest request;
   nidevice_grpc::EnumerateDevicesResponse response;
@@ -57,6 +57,7 @@ TEST_F(SessionUtilitiesServiceTests, SysCfgLibraryPresent_EnumerateDevices_Devic
     EXPECT_NE(device.model().c_str(), nullptr);
     EXPECT_THAT(device.vendor(), Not(IsEmpty()));
     EXPECT_NE(device.serial_number().c_str(), nullptr);
+    EXPECT_THAT(device.product_id(), Not(IsEmpty()));
   }
 }
 

--- a/source/tests/unit/device_enumerator_tests.cpp
+++ b/source/tests/unit/device_enumerator_tests.cpp
@@ -18,7 +18,7 @@ static const char* kScopeName = "MyScope";
 static const char* kModel = "NI PXIe-5122";
 static const char* kVendor = "NI";
 static const char* kSerialNumber = "37ED39FC0D17";
-static const char* kProductId = "42";
+static const uint32_t kProductId = 0x42;
 
 TEST(DeviceEnumeratorTests, SysCfgApiNotInstalled_EnumerateDevices_ReturnsNotFoundGrpcStatusCode)
 {
@@ -511,8 +511,8 @@ TEST(DeviceEnumeratorTests, GetResourcePropertySetsSerialNumber_EnumerateDevices
 
 NISysCfgStatus SetProductId(void* value)
 {
-  char* product_id = (char*)value;
-  strcpy(product_id, kProductId);
+  uint32_t* product_id = (uint32_t*)value;
+  product_id = &kProductId;
   return NISysCfg_OK;
 }
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds `ProductId` to the `DeviceProperties` returned with an `EnumerateDevicesResponse`. This is desired for clients that want to easily determine the actual HW products that match the enumerated devices.

### Why should this Pull Request be merged?

Simple change that just adds further information available via the already-in-use SystemConfigurationAPI to the enumerate device response.

Since the `DeviceProperties` data structure is only adding a new field, there's no need for existing clients or servers to update unless they want to take advantage of the new information.

### What testing has been done?

* Added a unit test and verified that all unit tests pass.
* All integration tests pass.
* Added to an existing system test and it still passes.