### PR TITLE
Updates behavior when new session name is in use in different resource repository.

### DIFF
--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -6709,6 +6709,9 @@ namespace nidaqmx_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -6761,6 +6764,9 @@ namespace nidaqmx_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -6792,6 +6798,9 @@ namespace nidaqmx_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 
@@ -12145,6 +12154,9 @@ namespace nidaqmx_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -791,6 +791,9 @@ namespace nidcpower_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -2879,6 +2882,9 @@ namespace nidcpower_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -2478,6 +2478,9 @@ namespace nidigitalpattern_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -2514,6 +2517,9 @@ namespace nidigitalpattern_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -2005,6 +2005,9 @@ namespace nidmm_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -2041,6 +2044,9 @@ namespace nidmm_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -1265,6 +1265,9 @@ namespace nifake_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -1295,6 +1298,9 @@ namespace nifake_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 
@@ -1345,6 +1351,9 @@ namespace nifake_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -120,6 +120,9 @@ namespace nifake_non_ivi_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -362,6 +365,9 @@ namespace nifake_non_ivi_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -392,6 +398,9 @@ namespace nifake_non_ivi_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 
@@ -430,6 +439,9 @@ namespace nifake_non_ivi_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -458,6 +470,9 @@ namespace nifake_non_ivi_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 
@@ -489,6 +504,9 @@ namespace nifake_non_ivi_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -518,6 +536,9 @@ namespace nifake_non_ivi_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -2447,6 +2447,9 @@ namespace nifgen_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -2484,6 +2487,9 @@ namespace nifgen_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -2520,6 +2526,9 @@ namespace nifgen_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
@@ -2417,6 +2417,9 @@ namespace nirfmxbluetooth_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -2451,6 +2454,9 @@ namespace nirfmxbluetooth_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -1717,6 +1717,9 @@ namespace nirfmxinstr_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -1898,6 +1901,9 @@ namespace nirfmxinstr_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -1932,6 +1938,9 @@ namespace nirfmxinstr_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 
@@ -1973,6 +1982,9 @@ namespace nirfmxinstr_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/nirfmxlte/nirfmxlte_service.cpp
+++ b/generated/nirfmxlte/nirfmxlte_service.cpp
@@ -4241,6 +4241,9 @@ namespace nirfmxlte_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -4275,6 +4278,9 @@ namespace nirfmxlte_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/nirfmxnr/nirfmxnr_service.cpp
+++ b/generated/nirfmxnr/nirfmxnr_service.cpp
@@ -3324,6 +3324,9 @@ namespace nirfmxnr_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -3358,6 +3361,9 @@ namespace nirfmxnr_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/nirfmxspecan/nirfmxspecan_service.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_service.cpp
@@ -7727,6 +7727,9 @@ namespace nirfmxspecan_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -7761,6 +7764,9 @@ namespace nirfmxspecan_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/nirfmxwlan/nirfmxwlan_service.cpp
+++ b/generated/nirfmxwlan/nirfmxwlan_service.cpp
@@ -2641,6 +2641,9 @@ namespace nirfmxwlan_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -2675,6 +2678,9 @@ namespace nirfmxwlan_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -2283,6 +2283,9 @@ namespace nirfsa_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -2319,6 +2322,9 @@ namespace nirfsa_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/nirfsg/nirfsg_service.cpp
+++ b/generated/nirfsg/nirfsg_service.cpp
@@ -2280,6 +2280,9 @@ namespace nirfsg_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -2316,6 +2319,9 @@ namespace nirfsg_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -2016,6 +2016,9 @@ namespace niscope_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -2052,6 +2055,9 @@ namespace niscope_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -1031,6 +1031,9 @@ namespace niswitch_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -1068,6 +1071,9 @@ namespace niswitch_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -1104,6 +1110,9 @@ namespace niswitch_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -74,6 +74,9 @@ namespace nisync_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -1564,6 +1567,9 @@ namespace nisync_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/nixnet/nixnet_service.cpp
+++ b/generated/nixnet/nixnet_service.cpp
@@ -395,6 +395,9 @@ namespace nixnet_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -448,6 +451,9 @@ namespace nixnet_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 
@@ -543,6 +549,9 @@ namespace nixnet_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -619,6 +628,9 @@ namespace nixnet_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 
@@ -795,6 +807,9 @@ namespace nixnet_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 
@@ -1396,6 +1411,9 @@ namespace nixnet_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -83,6 +83,9 @@ namespace nixnetsocket_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -638,6 +641,9 @@ namespace nixnetsocket_grpc {
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
   }
 
   //---------------------------------------------------------------------
@@ -747,6 +753,9 @@ namespace nixnetsocket_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 
@@ -1157,6 +1166,9 @@ namespace nixnetsocket_grpc {
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
     }
   }
 

--- a/source/codegen/templates/service.cpp.mako
+++ b/source/codegen/templates/service.cpp.mako
@@ -144,6 +144,11 @@ ${mako_helper.define_simple_method_body(function_name=function_name, function_da
     catch (nidevice_grpc::LibraryLoadException& ex) {
       return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
+% if common_helpers.is_init_method(function_data):
+    catch (nidevice_grpc::SessionException& ex) {
+      return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
+% endif
 % if service_helpers.requires_checked_conversion(parameters, custom_types):
     catch (nidevice_grpc::ValueOutOfRangeException& ex) {
       return ::grpc::Status(::grpc::OUT_OF_RANGE, ex.what());

--- a/source/server/session_resource_repository.h
+++ b/source/server/session_resource_repository.h
@@ -114,7 +114,7 @@ int SessionResourceRepository<TResourceHandle>::add_session(
 
   // session_name resolves to a session in a different resource repository.
   if (!resource_map_->contains(session_from_repository)) {
-    throw nidevice_grpc::SessionException("The session name \"" + session_name + "\" is already being used in a different driver's service. Please use a different name.");
+    throw nidevice_grpc::SessionException("The session name \"" + session_name + "\" is being used by a different driver.");
   }
 
   session_id = session_from_repository;

--- a/source/server/session_resource_repository.h
+++ b/source/server/session_resource_repository.h
@@ -6,6 +6,7 @@
 #include <unordered_map>
 
 #include "session_repository.h"
+#include "shared_library.h"
 
 namespace nidevice_grpc {
 
@@ -112,11 +113,8 @@ int SessionResourceRepository<TResourceHandle>::add_session(
   }
 
   // session_name resolves to a session in a different resource repository.
-  // Report error.
   if (!resource_map_->contains(session_from_repository)) {
-    session_id = 0;
-    const int kError_InvalidArg = 42;
-    return kError_InvalidArg;
+    throw nidevice_grpc::SessionException("The session name \"" + session_name + "\" is already being used in a different driver's service. Please use a different name.");
   }
 
   session_id = session_from_repository;

--- a/source/server/session_resource_repository.h
+++ b/source/server/session_resource_repository.h
@@ -115,7 +115,7 @@ int SessionResourceRepository<TResourceHandle>::add_session(
   // Report error.
   if (!resource_map_->contains(session_from_repository)) {
     session_id = 0;
-    const int kError_InvalidArg = 1;
+    const int kError_InvalidArg = 42;
     return kError_InvalidArg;
   }
 

--- a/source/server/shared_library.h
+++ b/source/server/shared_library.h
@@ -22,6 +22,12 @@ struct LibraryLoadException : std::runtime_error {
   LibraryLoadException(const LibraryLoadException& other) : std::runtime_error(other) {}
 };
 
+struct SessionException : std::runtime_error {
+  SessionException(const std::string& message) : std::runtime_error(message) {}
+  SessionException(const char* message) : std::runtime_error(message) {}
+  SessionException(const SessionException& other) : std::runtime_error(other) {}
+};
+
 class SharedLibrary {
  public:
   SharedLibrary();

--- a/source/tests/unit/session_resource_repository_tests.cpp
+++ b/source/tests/unit/session_resource_repository_tests.cpp
@@ -246,7 +246,7 @@ TEST(SessionResourceRepositoryTests, AddSessionResource_AccessFromDifferentRepos
   EXPECT_EQ(kNoSession, session_from_other_repository);
 }
 
-TEST(SessionResourceRepositoryTests, AddSessionResource_AddSessionWithSameNameFromDifferentRepository_FailsWithoutCallingInit)
+TEST(SessionResourceRepositoryTests, AddSessionResource_AddSessionWithSameNameFromDifferentRepository_ThrowsSessionException)
 {
   SessionRepository repository;
   SessionResourceRepository<int32_t> resource_repository(
@@ -265,15 +265,23 @@ TEST(SessionResourceRepositoryTests, AddSessionResource_AddSessionWithSameNameFr
   const int32_t kErrorCode = 9999;
   using MockInitDelegate = ::testing::MockFunction<std::tuple<int32_t, int32_t>(void)>;
   MockInitDelegate mock_init;
-  uint32_t second_session_id;
-  result = other_resource_repository.add_session(
-      kTestResource,
-      mock_init.AsStdFunction(),
-      [](int32_t handle) { FAIL() << "Unexpected Cleanup"; },
-      second_session_id);
-
+  uint32_t second_session_id = kNoSession;
+  EXPECT_THROW(
+      {
+        try {
+          result = other_resource_repository.add_session(
+              kTestResource,
+              mock_init.AsStdFunction(),
+              [](int32_t handle) { FAIL() << "Unexpected Cleanup"; },
+              second_session_id);
+        }
+        catch (const nidevice_grpc::SessionException& e) {
+          EXPECT_STREQ("Hello", e.what());  // TODO: Figure out what string we want displayed for the error.
+          throw;
+        }
+      },
+      nidevice_grpc::SessionException);
   EXPECT_EQ(kNoSession, second_session_id);
-  EXPECT_EQ(1, result);
 }
 
 template <typename TResource>

--- a/source/tests/unit/session_resource_repository_tests.cpp
+++ b/source/tests/unit/session_resource_repository_tests.cpp
@@ -275,8 +275,9 @@ TEST(SessionResourceRepositoryTests, AddSessionResource_AddSessionWithSameNameFr
               [](int32_t handle) { FAIL() << "Unexpected Cleanup"; },
               second_session_id);
         }
-        catch (const nidevice_grpc::SessionException& e) {
-          EXPECT_STREQ("Hello", e.what());  // TODO: Figure out what string we want displayed for the error.
+        catch (const nidevice_grpc::SessionException& ex) {
+          const std::string expected_message("The session name \"" + kTestResource + "\" is already being used in a different driver's service. Please use a different name.");
+          EXPECT_STREQ(expected_message.c_str(), ex.what());
           throw;
         }
       },

--- a/source/tests/unit/session_resource_repository_tests.cpp
+++ b/source/tests/unit/session_resource_repository_tests.cpp
@@ -276,7 +276,7 @@ TEST(SessionResourceRepositoryTests, AddSessionResource_AddSessionWithSameNameFr
               second_session_id);
         }
         catch (const nidevice_grpc::SessionException& ex) {
-          const std::string expected_message("The session name \"" + kTestResource + "\" is already being used in a different driver's service. Please use a different name.");
+          const std::string expected_message("The session name \"" + kTestResource + "\" is being used by a different driver.");
           EXPECT_STREQ(expected_message.c_str(), ex.what());
           throw;
         }

--- a/source/tests/unit/session_resource_repository_tests.cpp
+++ b/source/tests/unit/session_resource_repository_tests.cpp
@@ -273,7 +273,7 @@ TEST(SessionResourceRepositoryTests, AddSessionResource_AddSessionWithSameNameFr
       second_session_id);
 
   EXPECT_EQ(kNoSession, second_session_id);
-  EXPECT_NE(kNoError, result);
+  EXPECT_EQ(1, result);
 }
 
 template <typename TResource>


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Created a new `SessionException` struct in the shared library
- Throw a SessionException from the session resource repository when trying to add a session that's already in a different resource repository instead of returning a warning status of 1.
- Update codegen so all "Init" service handlers catch the new `SessionException` and return a gRPC Status of `INVALID_ARGUMENT` with the exception's message attached.
- Update the session resource repository unit test to now expect the `SessionException` to be thrown when trying to add a session where the session name is already in use in a different resource repository.

### Why should this Pull Request be merged?

Addresses #685 

If a proposed session name is already used by a different driver, grpc-device was returning a warning status 1 on the return message's status field. This both allows programs making the call to keep running since it's treated as a warning and if the client does check the status code it can be ambiguous depending on the driver.

This change addresses this by instead immediately returning a gRPC Status of `INVALID_ARGUMENT` with a message explaining that the session name is already in use.

### What testing has been done?

Updated a unit test testing the old behavior to now ensure the new SessionException is thrown if the session name is used in a different resource repository.

Ran the examples like they were specified in the Issue.

Now, running the daqmx example while dcpower is running using "my task" as the session name produces:
```console
PS ~\grpc-device\examples\nidaqmx> python .\analog-input.py
The session name "my task" is being used by a different driver.
```

And similarly, running the dcpower example while the daqmx example is running (with `time.wait(60.0)`) stops the program with the same message:
```console
PS ~\grpc-device\examples\nidcpower> python .\measure-record.py
The session name "my task" is being used by a different driver.
```