### PR TITLE
Add GetSParameterExternalAttenuationType to nirfmxinstr

### DIFF
--- a/generated/nirfmxinstr/nirfmxinstr.proto
+++ b/generated/nirfmxinstr/nirfmxinstr.proto
@@ -68,6 +68,7 @@ service NiRFmxInstr {
   rpc GetListNames(GetListNamesRequest) returns (GetListNamesResponse);
   rpc GetNIRFSASession(GetNIRFSASessionRequest) returns (GetNIRFSASessionResponse);
   rpc GetNIRFSASessionArray(GetNIRFSASessionArrayRequest) returns (GetNIRFSASessionArrayResponse);
+  rpc GetSParameterExternalAttenuationType(GetSParameterExternalAttenuationTypeRequest) returns (GetSParameterExternalAttenuationTypeResponse);
   rpc GetSelfCalibrateLastDateAndTime(GetSelfCalibrateLastDateAndTimeRequest) returns (GetSelfCalibrateLastDateAndTimeResponse);
   rpc GetSelfCalibrateLastTemperature(GetSelfCalibrateLastTemperatureRequest) returns (GetSelfCalibrateLastTemperatureResponse);
   rpc GetSignalConfigurationNames(GetSignalConfigurationNamesRequest) returns (GetSignalConfigurationNamesResponse);
@@ -997,6 +998,17 @@ message GetNIRFSASessionArrayResponse {
   int32 status = 1;
   repeated nidevice_grpc.Session nirfsa_sessions = 2;
   int32 actual_array_size = 3;
+}
+
+message GetSParameterExternalAttenuationTypeRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+}
+
+message GetSParameterExternalAttenuationTypeResponse {
+  int32 status = 1;
+  SParameterType s_parameter_type = 2;
+  int32 s_parameter_type_raw = 3;
 }
 
 message GetSelfCalibrateLastDateAndTimeRequest {

--- a/generated/nirfmxinstr/nirfmxinstr_client.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_client.cpp
@@ -969,6 +969,23 @@ get_nirfsa_session_array(const StubPtr& stub, const nidevice_grpc::Session& inst
   return response;
 }
 
+GetSParameterExternalAttenuationTypeResponse
+get_s_parameter_external_attenuation_type(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string)
+{
+  ::grpc::ClientContext context;
+
+  auto request = GetSParameterExternalAttenuationTypeRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+
+  auto response = GetSParameterExternalAttenuationTypeResponse{};
+
+  raise_if_error(
+      stub->GetSParameterExternalAttenuationType(&context, request, &response));
+
+  return response;
+}
+
 GetSelfCalibrateLastDateAndTimeResponse
 get_self_calibrate_last_date_and_time(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const simple_variant<SelfCalStep, pb::int64>& self_calibrate_step)
 {

--- a/generated/nirfmxinstr/nirfmxinstr_client.h
+++ b/generated/nirfmxinstr/nirfmxinstr_client.h
@@ -72,6 +72,7 @@ GetExternalAttenuationTableActualValueResponse get_external_attenuation_table_ac
 GetListNamesResponse get_list_names(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const simple_variant<Personality, pb::int32>& personality_filter);
 GetNIRFSASessionResponse get_nirfsa_session(const StubPtr& stub, const nidevice_grpc::Session& instrument);
 GetNIRFSASessionArrayResponse get_nirfsa_session_array(const StubPtr& stub, const nidevice_grpc::Session& instrument);
+GetSParameterExternalAttenuationTypeResponse get_s_parameter_external_attenuation_type(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string);
 GetSelfCalibrateLastDateAndTimeResponse get_self_calibrate_last_date_and_time(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const simple_variant<SelfCalStep, pb::int64>& self_calibrate_step);
 GetSelfCalibrateLastTemperatureResponse get_self_calibrate_last_temperature(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const simple_variant<SelfCalStep, pb::int64>& self_calibrate_step);
 GetSignalConfigurationNamesResponse get_signal_configuration_names(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const simple_variant<Personality, pb::int32>& personality_filter);

--- a/generated/nirfmxinstr/nirfmxinstr_library.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_library.cpp
@@ -71,6 +71,7 @@ NiRFmxInstrLibrary::NiRFmxInstrLibrary() : shared_library_(kLibraryName)
   function_pointers_.GetListNames = reinterpret_cast<GetListNamesPtr>(shared_library_.get_function_pointer("RFmxInstr_GetListNames"));
   function_pointers_.GetNIRFSASession = reinterpret_cast<GetNIRFSASessionPtr>(shared_library_.get_function_pointer("RFmxInstr_GetNIRFSASession"));
   function_pointers_.GetNIRFSASessionArray = reinterpret_cast<GetNIRFSASessionArrayPtr>(shared_library_.get_function_pointer("RFmxInstr_GetNIRFSASessionArray"));
+  function_pointers_.GetSParameterExternalAttenuationType = reinterpret_cast<GetSParameterExternalAttenuationTypePtr>(shared_library_.get_function_pointer("RFmxInstr_GetSParameterExternalAttenuationType"));
   function_pointers_.GetSelfCalibrateLastDateAndTime = reinterpret_cast<GetSelfCalibrateLastDateAndTimePtr>(shared_library_.get_function_pointer("RFmxInstr_GetSelfCalibrateLastDateAndTime"));
   function_pointers_.GetSelfCalibrateLastTemperature = reinterpret_cast<GetSelfCalibrateLastTemperaturePtr>(shared_library_.get_function_pointer("RFmxInstr_GetSelfCalibrateLastTemperature"));
   function_pointers_.GetSignalConfigurationNames = reinterpret_cast<GetSignalConfigurationNamesPtr>(shared_library_.get_function_pointer("RFmxInstr_GetSignalConfigurationNames"));
@@ -723,6 +724,18 @@ int32 NiRFmxInstrLibrary::GetNIRFSASessionArray(niRFmxInstrHandle instrumentHand
   return RFmxInstr_GetNIRFSASessionArray(instrumentHandle, nirfsaSessions, arraySize, actualArraySize);
 #else
   return function_pointers_.GetNIRFSASessionArray(instrumentHandle, nirfsaSessions, arraySize, actualArraySize);
+#endif
+}
+
+int32 NiRFmxInstrLibrary::GetSParameterExternalAttenuationType(niRFmxInstrHandle instrumentHandle, char selectorString[], int32* sParameterType)
+{
+  if (!function_pointers_.GetSParameterExternalAttenuationType) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_GetSParameterExternalAttenuationType.");
+  }
+#if defined(_MSC_VER)
+  return RFmxInstr_GetSParameterExternalAttenuationType(instrumentHandle, selectorString, sParameterType);
+#else
+  return function_pointers_.GetSParameterExternalAttenuationType(instrumentHandle, selectorString, sParameterType);
 #endif
 }
 

--- a/generated/nirfmxinstr/nirfmxinstr_library.h
+++ b/generated/nirfmxinstr/nirfmxinstr_library.h
@@ -68,6 +68,7 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
   int32 GetListNames(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 personalityFilter, char listNames[], int32 listNamesSize, int32* actualListNamesSize, int32 personality[], int32 personalityArraySize, int32* actualPersonalityArraySize);
   int32 GetNIRFSASession(niRFmxInstrHandle instrumentHandle, uInt32* niRfsaSession);
   int32 GetNIRFSASessionArray(niRFmxInstrHandle instrumentHandle, uInt32 nirfsaSessions[], int32 arraySize, int32* actualArraySize);
+  int32 GetSParameterExternalAttenuationType(niRFmxInstrHandle instrumentHandle, char selectorString[], int32* sParameterType);
   int32 GetSelfCalibrateLastDateAndTime(niRFmxInstrHandle instrumentHandle, char selectorString[], int64 selfCalibrateStep, CVIAbsoluteTime* timestamp);
   int32 GetSelfCalibrateLastTemperature(niRFmxInstrHandle instrumentHandle, char selectorString[], int64 selfCalibrateStep, float64* temperature);
   int32 GetSignalConfigurationNames(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 personalityFilter, char signalNames[], int32 signalNamesSize, int32* actualSignalNamesSize, int32 personality[], int32 personalityArraySize, int32* actualPersonalityArraySize);
@@ -162,6 +163,7 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
   using GetListNamesPtr = decltype(&RFmxInstr_GetListNames);
   using GetNIRFSASessionPtr = decltype(&RFmxInstr_GetNIRFSASession);
   using GetNIRFSASessionArrayPtr = decltype(&RFmxInstr_GetNIRFSASessionArray);
+  using GetSParameterExternalAttenuationTypePtr = decltype(&RFmxInstr_GetSParameterExternalAttenuationType);
   using GetSelfCalibrateLastDateAndTimePtr = decltype(&RFmxInstr_GetSelfCalibrateLastDateAndTime);
   using GetSelfCalibrateLastTemperaturePtr = decltype(&RFmxInstr_GetSelfCalibrateLastTemperature);
   using GetSignalConfigurationNamesPtr = decltype(&RFmxInstr_GetSignalConfigurationNames);
@@ -256,6 +258,7 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
     GetListNamesPtr GetListNames;
     GetNIRFSASessionPtr GetNIRFSASession;
     GetNIRFSASessionArrayPtr GetNIRFSASessionArray;
+    GetSParameterExternalAttenuationTypePtr GetSParameterExternalAttenuationType;
     GetSelfCalibrateLastDateAndTimePtr GetSelfCalibrateLastDateAndTime;
     GetSelfCalibrateLastTemperaturePtr GetSelfCalibrateLastTemperature;
     GetSignalConfigurationNamesPtr GetSignalConfigurationNames;

--- a/generated/nirfmxinstr/nirfmxinstr_library_interface.h
+++ b/generated/nirfmxinstr/nirfmxinstr_library_interface.h
@@ -65,6 +65,7 @@ class NiRFmxInstrLibraryInterface {
   virtual int32 GetListNames(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 personalityFilter, char listNames[], int32 listNamesSize, int32* actualListNamesSize, int32 personality[], int32 personalityArraySize, int32* actualPersonalityArraySize) = 0;
   virtual int32 GetNIRFSASession(niRFmxInstrHandle instrumentHandle, uInt32* niRfsaSession) = 0;
   virtual int32 GetNIRFSASessionArray(niRFmxInstrHandle instrumentHandle, uInt32 nirfsaSessions[], int32 arraySize, int32* actualArraySize) = 0;
+  virtual int32 GetSParameterExternalAttenuationType(niRFmxInstrHandle instrumentHandle, char selectorString[], int32* sParameterType) = 0;
   virtual int32 GetSelfCalibrateLastDateAndTime(niRFmxInstrHandle instrumentHandle, char selectorString[], int64 selfCalibrateStep, CVIAbsoluteTime* timestamp) = 0;
   virtual int32 GetSelfCalibrateLastTemperature(niRFmxInstrHandle instrumentHandle, char selectorString[], int64 selfCalibrateStep, float64* temperature) = 0;
   virtual int32 GetSignalConfigurationNames(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 personalityFilter, char signalNames[], int32 signalNamesSize, int32* actualSignalNamesSize, int32 personality[], int32 personalityArraySize, int32* actualPersonalityArraySize) = 0;

--- a/generated/nirfmxinstr/nirfmxinstr_mock_library.h
+++ b/generated/nirfmxinstr/nirfmxinstr_mock_library.h
@@ -67,6 +67,7 @@ class NiRFmxInstrMockLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterf
   MOCK_METHOD(int32, GetListNames, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 personalityFilter, char listNames[], int32 listNamesSize, int32* actualListNamesSize, int32 personality[], int32 personalityArraySize, int32* actualPersonalityArraySize), (override));
   MOCK_METHOD(int32, GetNIRFSASession, (niRFmxInstrHandle instrumentHandle, uInt32* niRfsaSession), (override));
   MOCK_METHOD(int32, GetNIRFSASessionArray, (niRFmxInstrHandle instrumentHandle, uInt32 nirfsaSessions[], int32 arraySize, int32* actualArraySize), (override));
+  MOCK_METHOD(int32, GetSParameterExternalAttenuationType, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32* sParameterType), (override));
   MOCK_METHOD(int32, GetSelfCalibrateLastDateAndTime, (niRFmxInstrHandle instrumentHandle, char selectorString[], int64 selfCalibrateStep, CVIAbsoluteTime* timestamp), (override));
   MOCK_METHOD(int32, GetSelfCalibrateLastTemperature, (niRFmxInstrHandle instrumentHandle, char selectorString[], int64 selfCalibrateStep, float64* temperature), (override));
   MOCK_METHOD(int32, GetSignalConfigurationNames, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 personalityFilter, char signalNames[], int32 signalNamesSize, int32* actualSignalNamesSize, int32 personality[], int32 personalityArraySize, int32* actualPersonalityArraySize), (override));

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -1721,6 +1721,31 @@ namespace nirfmxinstr_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxInstrService::GetSParameterExternalAttenuationType(::grpc::ServerContext* context, const GetSParameterExternalAttenuationTypeRequest* request, GetSParameterExternalAttenuationTypeResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      char* selector_string = (char*)request->selector_string().c_str();
+      int32 s_parameter_type {};
+      auto status = library_->GetSParameterExternalAttenuationType(instrument, selector_string, &s_parameter_type);
+      response->set_status(status);
+      if (status_ok(status)) {
+        response->set_s_parameter_type(static_cast<nirfmxinstr_grpc::SParameterType>(s_parameter_type));
+        response->set_s_parameter_type_raw(s_parameter_type);
+      }
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiRFmxInstrService::GetSelfCalibrateLastDateAndTime(::grpc::ServerContext* context, const GetSelfCalibrateLastDateAndTimeRequest* request, GetSelfCalibrateLastDateAndTimeResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nirfmxinstr/nirfmxinstr_service.h
+++ b/generated/nirfmxinstr/nirfmxinstr_service.h
@@ -93,6 +93,7 @@ public:
   ::grpc::Status GetListNames(::grpc::ServerContext* context, const GetListNamesRequest* request, GetListNamesResponse* response) override;
   ::grpc::Status GetNIRFSASession(::grpc::ServerContext* context, const GetNIRFSASessionRequest* request, GetNIRFSASessionResponse* response) override;
   ::grpc::Status GetNIRFSASessionArray(::grpc::ServerContext* context, const GetNIRFSASessionArrayRequest* request, GetNIRFSASessionArrayResponse* response) override;
+  ::grpc::Status GetSParameterExternalAttenuationType(::grpc::ServerContext* context, const GetSParameterExternalAttenuationTypeRequest* request, GetSParameterExternalAttenuationTypeResponse* response) override;
   ::grpc::Status GetSelfCalibrateLastDateAndTime(::grpc::ServerContext* context, const GetSelfCalibrateLastDateAndTimeRequest* request, GetSelfCalibrateLastDateAndTimeResponse* response) override;
   ::grpc::Status GetSelfCalibrateLastTemperature(::grpc::ServerContext* context, const GetSelfCalibrateLastTemperatureRequest* request, GetSelfCalibrateLastTemperatureResponse* response) override;
   ::grpc::Status GetSignalConfigurationNames(::grpc::ServerContext* context, const GetSignalConfigurationNamesRequest* request, GetSignalConfigurationNamesResponse* response) override;

--- a/source/codegen/metadata/nirfmxinstr/CHANGES.md
+++ b/source/codegen/metadata/nirfmxinstr/CHANGES.md
@@ -4,3 +4,8 @@
 
 The following metadata was added:
 - 'linux_rt_support': False
+
+## functions.py
+
+The following function, not originally in the JSON metadata, was added:
+- `RFmxInstr_GetSParameterExternalAttenuationType`

--- a/source/codegen/metadata/nirfmxinstr/functions.py
+++ b/source/codegen/metadata/nirfmxinstr/functions.py
@@ -1543,6 +1543,28 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'GetSParameterExternalAttenuationType': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'out',
+                'enum': 'SParameterType',
+                'name': 'sParameterType',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
     'GetSelfCalibrateLastDateAndTime': {
         'parameters': [
             {


### PR DESCRIPTION
### What does this Pull Request accomplish?

* Manually updated `source/codegen/metadata/nirfmxinstr/functions.py` with missing method `GetSParameterExternalAttenuationType` (used scrapigen, see https://github.com/ni/grpc-device-scrapigen/commit/4789eebf9b2b4b1435735b8fe25710febbe96f99)
* Built grpc-device to regenerate nirfmxinstr files to include the new method

### Why should this Pull Request be merged?

This is a public method whose value doesn't come from an attribute getter.

### What testing has been done?

* Ran rebuilt server on a system with NI-RFSA
* Compiled updated nirfmxinstr.proto to get new support files for the client
* Used those in a small python module that creates an RFmxInstr session and invokes `GetSParameterExternalAttenuationType`
   * Verified that it does not throw an UNIMPLEMENTED error