### PR TITLE
RFC: prototype of custom trailing metadata for status info

### DIFF
--- a/examples/nidcpower/measure-record.py
+++ b/examples/nidcpower/measure-record.py
@@ -218,6 +218,9 @@ try:
 
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
+    for key, value in rpc_error.trailing_metadata() or []:
+        if key == "nidevice-status-code":
+            error_message = f"Error {int(value)}: {error_message}"
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {SERVER_ADDRESS}:{SERVER_PORT}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -58,6 +58,7 @@ namespace nidaqmx_grpc {
       auto port_list = request->port_list().c_str();
       auto status = library_->AddCDAQSyncConnection(port_list);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -81,6 +82,7 @@ namespace nidaqmx_grpc {
       auto channel_names = request->channel_names().c_str();
       auto status = library_->AddGlobalChansToTask(task, channel_names);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -107,6 +109,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->AddNetworkDevice(ip_address, device_name, attempt_reservation, timeout, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 device_name_out_buffer_size = status;
@@ -121,6 +124,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -147,6 +151,7 @@ namespace nidaqmx_grpc {
       bool32 disconnected_ports_exist {};
       auto status = library_->AreConfiguredCDAQSyncPortsDisconnected(chassis_devices_ports, timeout, &disconnected_ports_exist);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -170,6 +175,7 @@ namespace nidaqmx_grpc {
       float64 timeout = request->timeout();
       auto status = library_->AutoConfigureCDAQSyncConnections(chassis_devices_ports, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -198,6 +204,7 @@ namespace nidaqmx_grpc {
       float64* reverse_coeffs = response->mutable_reverse_coeffs()->mutable_data();
       auto status = library_->CalculateReversePolyCoeff(forward_coeffs, num_forward_coeffs_in, min_val_x, max_val_x, num_points_to_compute, reverse_poly_order, reverse_coeffs);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -239,6 +246,7 @@ namespace nidaqmx_grpc {
       uInt32 pretrigger_samples = request->pretrigger_samples();
       auto status = library_->CfgAnlgEdgeRefTrig(task, trigger_source, trigger_slope, trigger_level, pretrigger_samples);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -279,6 +287,7 @@ namespace nidaqmx_grpc {
       float64 trigger_level = request->trigger_level();
       auto status = library_->CfgAnlgEdgeStartTrig(task, trigger_source, trigger_slope, trigger_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -317,6 +326,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->CfgAnlgMultiEdgeRefTrig(task, trigger_sources, trigger_slope_array, trigger_level_array, pretrigger_samples, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -354,6 +364,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->CfgAnlgMultiEdgeStartTrig(task, trigger_sources, trigger_slope_array, trigger_level_array, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -396,6 +407,7 @@ namespace nidaqmx_grpc {
       uInt32 pretrigger_samples = request->pretrigger_samples();
       auto status = library_->CfgAnlgWindowRefTrig(task, trigger_source, trigger_when, window_top, window_bottom, pretrigger_samples);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -437,6 +449,7 @@ namespace nidaqmx_grpc {
       float64 window_bottom = request->window_bottom();
       auto status = library_->CfgAnlgWindowStartTrig(task, trigger_source, trigger_when, window_top, window_bottom);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -526,6 +539,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->CfgBurstHandshakingTimingExportClock(task, sample_mode, samps_per_chan, sample_clk_rate, sample_clk_outp_term, sample_clk_pulse_polarity, pause_when, ready_event_active_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -615,6 +629,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->CfgBurstHandshakingTimingImportClock(task, sample_mode, samps_per_chan, sample_clk_rate, sample_clk_src, sample_clk_active_edge, pause_when, ready_event_active_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -656,6 +671,7 @@ namespace nidaqmx_grpc {
       uInt64 samps_per_chan = request->samps_per_chan();
       auto status = library_->CfgChangeDetectionTiming(task, rising_edge_chan, falling_edge_chan, sample_mode, samps_per_chan);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -696,6 +712,7 @@ namespace nidaqmx_grpc {
       uInt32 pretrigger_samples = request->pretrigger_samples();
       auto status = library_->CfgDigEdgeRefTrig(task, trigger_source, trigger_edge, pretrigger_samples);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -735,6 +752,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->CfgDigEdgeStartTrig(task, trigger_source, trigger_edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -776,6 +794,7 @@ namespace nidaqmx_grpc {
       uInt32 pretrigger_samples = request->pretrigger_samples();
       auto status = library_->CfgDigPatternRefTrig(task, trigger_source, trigger_pattern, trigger_when, pretrigger_samples);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -816,6 +835,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->CfgDigPatternStartTrig(task, trigger_source, trigger_pattern, trigger_when);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -855,6 +875,7 @@ namespace nidaqmx_grpc {
       uInt64 samps_per_chan = request->samps_per_chan();
       auto status = library_->CfgHandshakingTiming(task, sample_mode, samps_per_chan);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -894,6 +915,7 @@ namespace nidaqmx_grpc {
       uInt64 samps_per_chan = request->samps_per_chan();
       auto status = library_->CfgImplicitTiming(task, sample_mode, samps_per_chan);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -917,6 +939,7 @@ namespace nidaqmx_grpc {
       uInt32 num_samps_per_chan = request->num_samps_per_chan();
       auto status = library_->CfgInputBuffer(task, num_samps_per_chan);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -940,6 +963,7 @@ namespace nidaqmx_grpc {
       uInt32 num_samps_per_chan = request->num_samps_per_chan();
       auto status = library_->CfgOutputBuffer(task, num_samps_per_chan);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -997,6 +1021,7 @@ namespace nidaqmx_grpc {
       uInt64 samps_per_chan = request->samps_per_chan();
       auto status = library_->CfgPipelinedSampClkTiming(task, source, rate, active_edge, sample_mode, samps_per_chan);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -1054,6 +1079,7 @@ namespace nidaqmx_grpc {
       uInt64 samps_per_chan = request->samps_per_chan();
       auto status = library_->CfgSampClkTiming(task, source, rate, active_edge, sample_mode, samps_per_chan);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -1093,6 +1119,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->CfgTimeStartTrig(task, when, timescale);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -1138,6 +1165,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->CfgWatchdogAOExpirStates(task, channel_names, expir_state_array, output_type_array, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -1171,6 +1199,7 @@ namespace nidaqmx_grpc {
       uInt32 array_size = static_cast<uInt32>(request->expir_state_array().size());
       auto status = library_->CfgWatchdogCOExpirStates(task, channel_names, expir_state_array, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -1204,6 +1233,7 @@ namespace nidaqmx_grpc {
       uInt32 array_size = static_cast<uInt32>(request->expir_state_array().size());
       auto status = library_->CfgWatchdogDOExpirStates(task, channel_names, expir_state_array, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -1225,6 +1255,7 @@ namespace nidaqmx_grpc {
       auto physical_channel = request->physical_channel().c_str();
       auto status = library_->ClearTEDS(physical_channel);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -1248,6 +1279,7 @@ namespace nidaqmx_grpc {
       session_repository_->remove_session(task_grpc_session.id(), task_grpc_session.name());
       auto status = library_->ClearTask(task);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -1304,6 +1336,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->ConfigureLogging(task, file_path, logging_mode, group_name, operation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -1326,6 +1359,7 @@ namespace nidaqmx_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->ConfigureTEDS(physical_channel, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -1364,6 +1398,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->ConnectTerms(source_terminal, destination_terminal, signal_modifiers);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -1402,6 +1437,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->ControlWatchdogTask(task, action);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -1496,6 +1532,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIAccel4WireDCVoltageChan(task, physical_channel, name_to_assign_to_channel, terminal_config, min_val, max_val, units, sensitivity, sensitivity_units, voltage_excit_source, voltage_excit_val, use_excit_for_scaling, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -1589,6 +1626,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIAccelChan(task, physical_channel, name_to_assign_to_channel, terminal_config, min_val, max_val, units, sensitivity, sensitivity_units, current_excit_source, current_excit_val, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -1665,6 +1703,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIAccelChargeChan(task, physical_channel, name_to_assign_to_channel, terminal_config, min_val, max_val, units, sensitivity, sensitivity_units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -1742,6 +1781,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIBridgeChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, bridge_config, voltage_excit_source, voltage_excit_val, nominal_bridge_resistance, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -1801,6 +1841,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIChargeChan(task, physical_channel, name_to_assign_to_channel, terminal_config, min_val, max_val, units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -1877,6 +1918,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAICurrentChan(task, physical_channel, name_to_assign_to_channel, terminal_config, min_val, max_val, units, shunt_resistor_loc, ext_shunt_resistor_val, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -1953,6 +1995,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAICurrentRMSChan(task, physical_channel, name_to_assign_to_channel, terminal_config, min_val, max_val, units, shunt_resistor_loc, ext_shunt_resistor_val, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -2066,6 +2109,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIForceBridgePolynomialChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, bridge_config, voltage_excit_source, voltage_excit_val, nominal_bridge_resistance, forward_coeffs, num_forward_coeffs, reverse_coeffs, num_reverse_coeffs, electrical_units, physical_units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -2179,6 +2223,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIForceBridgeTableChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, bridge_config, voltage_excit_source, voltage_excit_val, nominal_bridge_resistance, electrical_vals, num_electrical_vals, electrical_units, physical_vals, num_physical_vals, physical_units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -2292,6 +2337,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIForceBridgeTwoPointLinChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, bridge_config, voltage_excit_source, voltage_excit_val, nominal_bridge_resistance, first_electrical_val, second_electrical_val, electrical_units, first_physical_val, second_physical_val, physical_units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -2385,6 +2431,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIForceIEPEChan(task, physical_channel, name_to_assign_to_channel, terminal_config, min_val, max_val, units, sensitivity, sensitivity_units, current_excit_source, current_excit_val, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -2430,6 +2477,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIFreqVoltageChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, threshold_level, hysteresis, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -2506,6 +2554,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIMicrophoneChan(task, physical_channel, name_to_assign_to_channel, terminal_config, units, mic_sensitivity, max_snd_press_level, current_excit_source, current_excit_val, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -2566,6 +2615,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIPosEddyCurrProxProbeChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, sensitivity, sensitivity_units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -2660,6 +2710,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIPosLVDTChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, sensitivity, sensitivity_units, voltage_excit_source, voltage_excit_val, voltage_excit_freq, ac_excit_wire_mode, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -2754,6 +2805,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIPosRVDTChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, sensitivity, sensitivity_units, voltage_excit_source, voltage_excit_val, voltage_excit_freq, ac_excit_wire_mode, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -2867,6 +2919,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIPressureBridgePolynomialChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, bridge_config, voltage_excit_source, voltage_excit_val, nominal_bridge_resistance, forward_coeffs, num_forward_coeffs, reverse_coeffs, num_reverse_coeffs, electrical_units, physical_units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -2980,6 +3033,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIPressureBridgeTableChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, bridge_config, voltage_excit_source, voltage_excit_val, nominal_bridge_resistance, electrical_vals, num_electrical_vals, electrical_units, physical_vals, num_physical_vals, physical_units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -3093,6 +3147,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIPressureBridgeTwoPointLinChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, bridge_config, voltage_excit_source, voltage_excit_val, nominal_bridge_resistance, first_electrical_val, second_electrical_val, electrical_units, first_physical_val, second_physical_val, physical_units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -3185,6 +3240,7 @@ namespace nidaqmx_grpc {
       float64 r0 = request->r0();
       auto status = library_->CreateAIRTDChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, rtd_type, resistance_config, current_excit_source, current_excit_val, r0);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -3261,6 +3317,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIResistanceChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, resistance_config, current_excit_source, current_excit_val, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -3343,6 +3400,7 @@ namespace nidaqmx_grpc {
       float64 lead_wire_resistance = request->lead_wire_resistance();
       auto status = library_->CreateAIRosetteStrainGageChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, rosette_type, gage_orientation, rosette_meas_types, num_rosette_meas_types, strain_config, voltage_excit_source, voltage_excit_val, gage_factor, nominal_gage_resistance, poisson_ratio, lead_wire_resistance);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -3424,6 +3482,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIStrainGageChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, strain_config, voltage_excit_source, voltage_excit_val, gage_factor, initial_bridge_voltage, nominal_gage_resistance, poisson_ratio, lead_wire_resistance, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -3464,6 +3523,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->CreateAITempBuiltInSensorChan(task, physical_channel, name_to_assign_to_channel, units);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -3540,6 +3600,7 @@ namespace nidaqmx_grpc {
       auto cjc_channel = request->cjc_channel().c_str();
       auto status = library_->CreateAIThrmcplChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, thermocouple_type, cjc_source, cjc_val, cjc_channel);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -3618,6 +3679,7 @@ namespace nidaqmx_grpc {
       float64 c = request->c();
       auto status = library_->CreateAIThrmstrChanIex(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, resistance_config, current_excit_source, current_excit_val, a, b, c);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -3697,6 +3759,7 @@ namespace nidaqmx_grpc {
       float64 r1 = request->r1();
       auto status = library_->CreateAIThrmstrChanVex(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, resistance_config, voltage_excit_source, voltage_excit_val, a, b, c, r1);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -3810,6 +3873,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAITorqueBridgePolynomialChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, bridge_config, voltage_excit_source, voltage_excit_val, nominal_bridge_resistance, forward_coeffs, num_forward_coeffs, reverse_coeffs, num_reverse_coeffs, electrical_units, physical_units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -3923,6 +3987,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAITorqueBridgeTableChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, bridge_config, voltage_excit_source, voltage_excit_val, nominal_bridge_resistance, electrical_vals, num_electrical_vals, electrical_units, physical_vals, num_physical_vals, physical_units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -4036,6 +4101,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAITorqueBridgeTwoPointLinChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, bridge_config, voltage_excit_source, voltage_excit_val, nominal_bridge_resistance, first_electrical_val, second_electrical_val, electrical_units, first_physical_val, second_physical_val, physical_units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -4129,6 +4195,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIVelocityIEPEChan(task, physical_channel, name_to_assign_to_channel, terminal_config, min_val, max_val, units, sensitivity, sensitivity_units, current_excit_source, current_excit_val, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -4188,6 +4255,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIVoltageChan(task, physical_channel, name_to_assign_to_channel, terminal_config, min_val, max_val, units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -4281,6 +4349,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIVoltageChanWithExcit(task, physical_channel, name_to_assign_to_channel, terminal_config, min_val, max_val, units, bridge_config, voltage_excit_source, voltage_excit_val, use_excit_for_scaling, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -4340,6 +4409,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAIVoltageRMSChan(task, physical_channel, name_to_assign_to_channel, terminal_config, min_val, max_val, units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -4383,6 +4453,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAOCurrentChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -4426,6 +4497,7 @@ namespace nidaqmx_grpc {
       float64 offset = request->offset();
       auto status = library_->CreateAOFuncGenChan(task, physical_channel, name_to_assign_to_channel, type, freq, amplitude, offset);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -4469,6 +4541,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateAOVoltageChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -4546,6 +4619,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateCIAngEncoderChan(task, counter, name_to_assign_to_channel, decoding_type, zidx_enable, zidx_val, zidx_phase, units, pulses_per_rev, initial_angle, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -4606,6 +4680,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateCIAngVelocityChan(task, counter, name_to_assign_to_channel, min_val, max_val, decoding_type, units, pulses_per_rev, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -4663,6 +4738,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->CreateCICountEdgesChan(task, counter, name_to_assign_to_channel, edge, initial_count, count_direction);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -4706,6 +4782,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateCIDutyCycleChan(task, counter, name_to_assign_to_channel, min_freq, max_freq, edge, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -4783,6 +4860,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateCIFreqChan(task, counter, name_to_assign_to_channel, min_val, max_val, units, edge, meas_method, meas_time, divisor, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -4840,6 +4918,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateCIGPSTimestampChan(task, counter, name_to_assign_to_channel, units, sync_method, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -4917,6 +4996,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateCILinEncoderChan(task, counter, name_to_assign_to_channel, decoding_type, zidx_enable, zidx_val, zidx_phase, units, dist_per_pulse, initial_pos, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -4977,6 +5057,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateCILinVelocityChan(task, counter, name_to_assign_to_channel, min_val, max_val, decoding_type, units, dist_per_pulse, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -5054,6 +5135,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateCIPeriodChan(task, counter, name_to_assign_to_channel, min_val, max_val, units, edge, meas_method, meas_time, divisor, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -5096,6 +5178,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->CreateCIPulseChanFreq(task, counter, name_to_assign_to_channel, min_val, max_val, units);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -5123,6 +5206,7 @@ namespace nidaqmx_grpc {
       float64 max_val = request->max_val();
       auto status = library_->CreateCIPulseChanTicks(task, counter, name_to_assign_to_channel, source_terminal, min_val, max_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -5165,6 +5249,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->CreateCIPulseChanTime(task, counter, name_to_assign_to_channel, min_val, max_val, units);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -5224,6 +5309,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateCIPulseWidthChan(task, counter, name_to_assign_to_channel, min_val, max_val, units, starting_edge, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -5267,6 +5353,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateCISemiPeriodChan(task, counter, name_to_assign_to_channel, min_val, max_val, units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -5342,6 +5429,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateCITwoEdgeSepChan(task, counter, name_to_assign_to_channel, min_val, max_val, units, first_edge, second_edge, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -5401,6 +5489,7 @@ namespace nidaqmx_grpc {
       float64 duty_cycle = request->duty_cycle();
       auto status = library_->CreateCOPulseChanFreq(task, counter, name_to_assign_to_channel, units, idle_state, initial_delay, freq, duty_cycle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -5445,6 +5534,7 @@ namespace nidaqmx_grpc {
       int32 high_ticks = request->high_ticks();
       auto status = library_->CreateCOPulseChanTicks(task, counter, name_to_assign_to_channel, source_terminal, idle_state, initial_delay, low_ticks, high_ticks);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -5504,6 +5594,7 @@ namespace nidaqmx_grpc {
       float64 high_time = request->high_time();
       auto status = library_->CreateCOPulseChanTime(task, counter, name_to_assign_to_channel, units, idle_state, initial_delay, low_time, high_time);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -5544,6 +5635,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->CreateDIChan(task, lines, name_to_assign_to_lines, line_grouping);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -5584,6 +5676,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->CreateDOChan(task, lines, name_to_assign_to_lines, line_grouping);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -5624,6 +5717,7 @@ namespace nidaqmx_grpc {
       auto scaled_units = request->scaled_units().c_str();
       auto status = library_->CreateLinScale(name, slope, y_intercept, pre_scaled_units, scaled_units);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -5666,6 +5760,7 @@ namespace nidaqmx_grpc {
       auto scaled_units = request->scaled_units().c_str();
       auto status = library_->CreateMapScale(name, prescaled_min, prescaled_max, scaled_min, scaled_max, pre_scaled_units, scaled_units);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -5708,6 +5803,7 @@ namespace nidaqmx_grpc {
       auto scaled_units = request->scaled_units().c_str();
       auto status = library_->CreatePolynomialScale(name, forward_coeffs, num_forward_coeffs_in, reverse_coeffs, num_reverse_coeffs_in, pre_scaled_units, scaled_units);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -5784,6 +5880,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateTEDSAIAccelChan(task, physical_channel, name_to_assign_to_channel, terminal_config, min_val, max_val, units, current_excit_source, current_excit_val, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -5844,6 +5941,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateTEDSAIBridgeChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, voltage_excit_source, voltage_excit_val, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -5920,6 +6018,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateTEDSAICurrentChan(task, physical_channel, name_to_assign_to_channel, terminal_config, min_val, max_val, units, shunt_resistor_loc, ext_shunt_resistor_val, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -5980,6 +6079,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateTEDSAIForceBridgeChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, voltage_excit_source, voltage_excit_val, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -6056,6 +6156,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateTEDSAIForceIEPEChan(task, physical_channel, name_to_assign_to_channel, terminal_config, min_val, max_val, units, current_excit_source, current_excit_val, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -6131,6 +6232,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateTEDSAIMicrophoneChan(task, physical_channel, name_to_assign_to_channel, terminal_config, units, max_snd_press_level, current_excit_source, current_excit_val, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -6208,6 +6310,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateTEDSAIPosLVDTChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, voltage_excit_source, voltage_excit_val, voltage_excit_freq, ac_excit_wire_mode, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -6285,6 +6388,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateTEDSAIPosRVDTChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, voltage_excit_source, voltage_excit_val, voltage_excit_freq, ac_excit_wire_mode, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -6345,6 +6449,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateTEDSAIPressureBridgeChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, voltage_excit_source, voltage_excit_val, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -6420,6 +6525,7 @@ namespace nidaqmx_grpc {
       float64 current_excit_val = request->current_excit_val();
       auto status = library_->CreateTEDSAIRTDChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, resistance_config, current_excit_source, current_excit_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -6496,6 +6602,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateTEDSAIResistanceChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, resistance_config, current_excit_source, current_excit_val, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -6558,6 +6665,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateTEDSAIStrainGageChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, voltage_excit_source, voltage_excit_val, initial_bridge_voltage, lead_wire_resistance, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -6618,6 +6726,7 @@ namespace nidaqmx_grpc {
       auto cjc_channel = request->cjc_channel().c_str();
       auto status = library_->CreateTEDSAIThrmcplChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, cjc_source, cjc_val, cjc_channel);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -6693,6 +6802,7 @@ namespace nidaqmx_grpc {
       float64 current_excit_val = request->current_excit_val();
       auto status = library_->CreateTEDSAIThrmstrChanIex(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, resistance_config, current_excit_source, current_excit_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -6769,6 +6879,7 @@ namespace nidaqmx_grpc {
       float64 r1 = request->r1();
       auto status = library_->CreateTEDSAIThrmstrChanVex(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, resistance_config, voltage_excit_source, voltage_excit_val, r1);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -6829,6 +6940,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateTEDSAITorqueBridgeChan(task, physical_channel, name_to_assign_to_channel, min_val, max_val, units, voltage_excit_source, voltage_excit_val, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -6888,6 +7000,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateTEDSAIVoltageChan(task, physical_channel, name_to_assign_to_channel, terminal_config, min_val, max_val, units, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -6964,6 +7077,7 @@ namespace nidaqmx_grpc {
       auto custom_scale_name = request->custom_scale_name().c_str();
       auto status = library_->CreateTEDSAIVoltageChanWithExcit(task, physical_channel, name_to_assign_to_channel, terminal_config, min_val, max_val, units, voltage_excit_source, voltage_excit_val, custom_scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -7006,6 +7120,7 @@ namespace nidaqmx_grpc {
       auto scaled_units = request->scaled_units().c_str();
       auto status = library_->CreateTableScale(name, prescaled_vals, num_prescaled_vals_in, scaled_vals, num_scaled_vals_in, pre_scaled_units, scaled_units);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -7036,6 +7151,7 @@ namespace nidaqmx_grpc {
       auto cleanup_lambda = [&] (TaskHandle id) { library_->ClearTask(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -7092,6 +7208,7 @@ namespace nidaqmx_grpc {
       auto cleanup_lambda = [&] (TaskHandle id) { library_->ClearTask(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -7128,6 +7245,7 @@ namespace nidaqmx_grpc {
       auto cleanup_lambda = [&] (TaskHandle id) { library_->ClearTask(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -7153,6 +7271,7 @@ namespace nidaqmx_grpc {
       auto device_name = request->device_name().c_str();
       auto status = library_->DeleteNetworkDevice(device_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -7174,6 +7293,7 @@ namespace nidaqmx_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->DeleteSavedGlobalChan(channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -7195,6 +7315,7 @@ namespace nidaqmx_grpc {
       auto scale_name = request->scale_name().c_str();
       auto status = library_->DeleteSavedScale(scale_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -7216,6 +7337,7 @@ namespace nidaqmx_grpc {
       auto task_name = request->task_name().c_str();
       auto status = library_->DeleteSavedTask(task_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -7238,6 +7360,7 @@ namespace nidaqmx_grpc {
       bool32 cal_supported {};
       auto status = library_->DeviceSupportsCal(device_name, &cal_supported);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -7261,6 +7384,7 @@ namespace nidaqmx_grpc {
       TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
       auto status = library_->DisableRefTrig(task);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -7283,6 +7407,7 @@ namespace nidaqmx_grpc {
       TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
       auto status = library_->DisableStartTrig(task);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -7305,6 +7430,7 @@ namespace nidaqmx_grpc {
       auto destination_terminal = request->destination_terminal().c_str();
       auto status = library_->DisconnectTerms(source_terminal, destination_terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -7344,6 +7470,7 @@ namespace nidaqmx_grpc {
       auto output_terminal = request->output_terminal().c_str();
       auto status = library_->ExportSignal(task, signal_id, output_terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -7372,6 +7499,7 @@ namespace nidaqmx_grpc {
       uInt32 minute {};
       auto status = library_->GetAIChanCalCalDate(task, channel_name, &year, &month, &day, &hour, &minute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -7405,6 +7533,7 @@ namespace nidaqmx_grpc {
       uInt32 minute {};
       auto status = library_->GetAIChanCalExpDate(task, channel_name, &year, &month, &day, &hour, &minute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -7459,6 +7588,7 @@ namespace nidaqmx_grpc {
       stateVector.resize(channels.size());
       auto status = ((NiDAQmxLibrary*)library_)->GetAnalogPowerUpStates(device_name, get_channelName_if(channels, 0), get_state_if(stateVector, 0), get_channelType_if(channels, 0), get_channelName_if(channels, 1), get_state_if(stateVector, 1), get_channelType_if(channels, 1), get_channelName_if(channels, 2), get_state_if(stateVector, 2), get_channelType_if(channels, 2), get_channelName_if(channels, 3), get_state_if(stateVector, 3), get_channelType_if(channels, 3), get_channelName_if(channels, 4), get_state_if(stateVector, 4), get_channelType_if(channels, 4), get_channelName_if(channels, 5), get_state_if(stateVector, 5), get_channelType_if(channels, 5), get_channelName_if(channels, 6), get_state_if(stateVector, 6), get_channelType_if(channels, 6), get_channelName_if(channels, 7), get_state_if(stateVector, 7), get_channelType_if(channels, 7), get_channelName_if(channels, 8), get_state_if(stateVector, 8), get_channelType_if(channels, 8), get_channelName_if(channels, 9), get_state_if(stateVector, 9), get_channelType_if(channels, 9), get_channelName_if(channels, 10), get_state_if(stateVector, 10), get_channelType_if(channels, 10), get_channelName_if(channels, 11), get_state_if(stateVector, 11), get_channelType_if(channels, 11), get_channelName_if(channels, 12), get_state_if(stateVector, 12), get_channelType_if(channels, 12), get_channelName_if(channels, 13), get_state_if(stateVector, 13), get_channelType_if(channels, 13), get_channelName_if(channels, 14), get_state_if(stateVector, 14), get_channelType_if(channels, 14), get_channelName_if(channels, 15), get_state_if(stateVector, 15), get_channelType_if(channels, 15), get_channelName_if(channels, 16), get_state_if(stateVector, 16), get_channelType_if(channels, 16), get_channelName_if(channels, 17), get_state_if(stateVector, 17), get_channelType_if(channels, 17), get_channelName_if(channels, 18), get_state_if(stateVector, 18), get_channelType_if(channels, 18), get_channelName_if(channels, 19), get_state_if(stateVector, 19), get_channelType_if(channels, 19), get_channelName_if(channels, 20), get_state_if(stateVector, 20), get_channelType_if(channels, 20), get_channelName_if(channels, 21), get_state_if(stateVector, 21), get_channelType_if(channels, 21), get_channelName_if(channels, 22), get_state_if(stateVector, 22), get_channelType_if(channels, 22), get_channelName_if(channels, 23), get_state_if(stateVector, 23), get_channelType_if(channels, 23), get_channelName_if(channels, 24), get_state_if(stateVector, 24), get_channelType_if(channels, 24), get_channelName_if(channels, 25), get_state_if(stateVector, 25), get_channelType_if(channels, 25), get_channelName_if(channels, 26), get_state_if(stateVector, 26), get_channelType_if(channels, 26), get_channelName_if(channels, 27), get_state_if(stateVector, 27), get_channelType_if(channels, 27), get_channelName_if(channels, 28), get_state_if(stateVector, 28), get_channelType_if(channels, 28), get_channelName_if(channels, 29), get_state_if(stateVector, 29), get_channelType_if(channels, 29), get_channelName_if(channels, 30), get_state_if(stateVector, 30), get_channelType_if(channels, 30), get_channelName_if(channels, 31), get_state_if(stateVector, 31), get_channelType_if(channels, 31), get_channelName_if(channels, 32), get_state_if(stateVector, 32), get_channelType_if(channels, 32), get_channelName_if(channels, 33), get_state_if(stateVector, 33), get_channelType_if(channels, 33), get_channelName_if(channels, 34), get_state_if(stateVector, 34), get_channelType_if(channels, 34), get_channelName_if(channels, 35), get_state_if(stateVector, 35), get_channelType_if(channels, 35), get_channelName_if(channels, 36), get_state_if(stateVector, 36), get_channelType_if(channels, 36), get_channelName_if(channels, 37), get_state_if(stateVector, 37), get_channelType_if(channels, 37), get_channelName_if(channels, 38), get_state_if(stateVector, 38), get_channelType_if(channels, 38), get_channelName_if(channels, 39), get_state_if(stateVector, 39), get_channelType_if(channels, 39), get_channelName_if(channels, 40), get_state_if(stateVector, 40), get_channelType_if(channels, 40), get_channelName_if(channels, 41), get_state_if(stateVector, 41), get_channelType_if(channels, 41), get_channelName_if(channels, 42), get_state_if(stateVector, 42), get_channelType_if(channels, 42), get_channelName_if(channels, 43), get_state_if(stateVector, 43), get_channelType_if(channels, 43), get_channelName_if(channels, 44), get_state_if(stateVector, 44), get_channelType_if(channels, 44), get_channelName_if(channels, 45), get_state_if(stateVector, 45), get_channelType_if(channels, 45), get_channelName_if(channels, 46), get_state_if(stateVector, 46), get_channelType_if(channels, 46), get_channelName_if(channels, 47), get_state_if(stateVector, 47), get_channelType_if(channels, 47), get_channelName_if(channels, 48), get_state_if(stateVector, 48), get_channelType_if(channels, 48), get_channelName_if(channels, 49), get_state_if(stateVector, 49), get_channelType_if(channels, 49), get_channelName_if(channels, 50), get_state_if(stateVector, 50), get_channelType_if(channels, 50), get_channelName_if(channels, 51), get_state_if(stateVector, 51), get_channelType_if(channels, 51), get_channelName_if(channels, 52), get_state_if(stateVector, 52), get_channelType_if(channels, 52), get_channelName_if(channels, 53), get_state_if(stateVector, 53), get_channelType_if(channels, 53), get_channelName_if(channels, 54), get_state_if(stateVector, 54), get_channelType_if(channels, 54), get_channelName_if(channels, 55), get_state_if(stateVector, 55), get_channelType_if(channels, 55), get_channelName_if(channels, 56), get_state_if(stateVector, 56), get_channelType_if(channels, 56), get_channelName_if(channels, 57), get_state_if(stateVector, 57), get_channelType_if(channels, 57), get_channelName_if(channels, 58), get_state_if(stateVector, 58), get_channelType_if(channels, 58), get_channelName_if(channels, 59), get_state_if(stateVector, 59), get_channelType_if(channels, 59), get_channelName_if(channels, 60), get_state_if(stateVector, 60), get_channelType_if(channels, 60), get_channelName_if(channels, 61), get_state_if(stateVector, 61), get_channelType_if(channels, 61), get_channelName_if(channels, 62), get_state_if(stateVector, 62), get_channelType_if(channels, 62), get_channelName_if(channels, 63), get_state_if(stateVector, 63), get_channelType_if(channels, 63), get_channelName_if(channels, 64), get_state_if(stateVector, 64), get_channelType_if(channels, 64), get_channelName_if(channels, 65), get_state_if(stateVector, 65), get_channelType_if(channels, 65), get_channelName_if(channels, 66), get_state_if(stateVector, 66), get_channelType_if(channels, 66), get_channelName_if(channels, 67), get_state_if(stateVector, 67), get_channelType_if(channels, 67), get_channelName_if(channels, 68), get_state_if(stateVector, 68), get_channelType_if(channels, 68), get_channelName_if(channels, 69), get_state_if(stateVector, 69), get_channelType_if(channels, 69), get_channelName_if(channels, 70), get_state_if(stateVector, 70), get_channelType_if(channels, 70), get_channelName_if(channels, 71), get_state_if(stateVector, 71), get_channelType_if(channels, 71), get_channelName_if(channels, 72), get_state_if(stateVector, 72), get_channelType_if(channels, 72), get_channelName_if(channels, 73), get_state_if(stateVector, 73), get_channelType_if(channels, 73), get_channelName_if(channels, 74), get_state_if(stateVector, 74), get_channelType_if(channels, 74), get_channelName_if(channels, 75), get_state_if(stateVector, 75), get_channelType_if(channels, 75), get_channelName_if(channels, 76), get_state_if(stateVector, 76), get_channelType_if(channels, 76), get_channelName_if(channels, 77), get_state_if(stateVector, 77), get_channelType_if(channels, 77), get_channelName_if(channels, 78), get_state_if(stateVector, 78), get_channelType_if(channels, 78), get_channelName_if(channels, 79), get_state_if(stateVector, 79), get_channelType_if(channels, 79), get_channelName_if(channels, 80), get_state_if(stateVector, 80), get_channelType_if(channels, 80), get_channelName_if(channels, 81), get_state_if(stateVector, 81), get_channelType_if(channels, 81), get_channelName_if(channels, 82), get_state_if(stateVector, 82), get_channelType_if(channels, 82), get_channelName_if(channels, 83), get_state_if(stateVector, 83), get_channelType_if(channels, 83), get_channelName_if(channels, 84), get_state_if(stateVector, 84), get_channelType_if(channels, 84), get_channelName_if(channels, 85), get_state_if(stateVector, 85), get_channelType_if(channels, 85), get_channelName_if(channels, 86), get_state_if(stateVector, 86), get_channelType_if(channels, 86), get_channelName_if(channels, 87), get_state_if(stateVector, 87), get_channelType_if(channels, 87), get_channelName_if(channels, 88), get_state_if(stateVector, 88), get_channelType_if(channels, 88), get_channelName_if(channels, 89), get_state_if(stateVector, 89), get_channelType_if(channels, 89), get_channelName_if(channels, 90), get_state_if(stateVector, 90), get_channelType_if(channels, 90), get_channelName_if(channels, 91), get_state_if(stateVector, 91), get_channelType_if(channels, 91), get_channelName_if(channels, 92), get_state_if(stateVector, 92), get_channelType_if(channels, 92), get_channelName_if(channels, 93), get_state_if(stateVector, 93), get_channelType_if(channels, 93), get_channelName_if(channels, 94), get_state_if(stateVector, 94), get_channelType_if(channels, 94), get_channelName_if(channels, 95), get_state_if(stateVector, 95), get_channelType_if(channels, 95), get_channelName_if(channels, 96), get_state_if(stateVector, 96), get_channelType_if(channels, 96));
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -7488,6 +7618,7 @@ namespace nidaqmx_grpc {
       int32* channel_type_array = reinterpret_cast<int32*>(response->mutable_channel_type_array_raw()->mutable_data());
       auto status = library_->GetAnalogPowerUpStatesWithOutputType(channel_names, state_array, channel_type_array, &array_size_copy);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -7521,6 +7652,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime data {};
       auto status = library_->GetArmStartTrigTimestampVal(task, &data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -7545,6 +7677,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime data {};
       auto status = library_->GetArmStartTrigTrigWhen(task, &data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -7568,6 +7701,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetAutoConfiguredCDAQSyncConnections(nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 port_list_size = status;
@@ -7582,6 +7716,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -7627,6 +7762,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetBufferAttributeUInt32(task, attribute, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -7670,6 +7806,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetCalInfoAttributeBool(device_name, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -7713,6 +7850,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetCalInfoAttributeDouble(device_name, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -7756,6 +7894,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetCalInfoAttributeString(device_name, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 size = status;
@@ -7770,6 +7909,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -7815,6 +7955,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetCalInfoAttributeUInt32(device_name, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -7860,6 +8001,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetChanAttributeBool(task, channel, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -7905,6 +8047,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetChanAttributeDouble(task, channel, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -7950,6 +8093,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetChanAttributeDoubleArray(task, channel, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         uInt32 size = status;
@@ -7962,6 +8106,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         response->set_status(status);
@@ -8007,6 +8152,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetChanAttributeInt32(task, channel, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -8058,6 +8204,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetChanAttributeString(task, channel, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         uInt32 size = status;
@@ -8072,6 +8219,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         response->set_status(status);
@@ -8119,6 +8267,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetChanAttributeUInt32(task, channel, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -8162,6 +8311,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetDeviceAttributeBool(device_name, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -8205,6 +8355,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetDeviceAttributeDouble(device_name, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -8248,6 +8399,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetDeviceAttributeDoubleArray(device_name, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 size = status;
@@ -8260,6 +8412,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -8303,6 +8456,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetDeviceAttributeInt32(device_name, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -8352,6 +8506,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetDeviceAttributeInt32Array(device_name, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 size = status;
@@ -8364,6 +8519,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -8421,6 +8577,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetDeviceAttributeString(device_name, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 size = status;
@@ -8435,6 +8592,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -8480,6 +8638,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetDeviceAttributeUInt32(device_name, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -8523,6 +8682,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetDeviceAttributeUInt32Array(device_name, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 size = status;
@@ -8535,6 +8695,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -8558,6 +8719,7 @@ namespace nidaqmx_grpc {
       int32 logic_family {};
       auto status = library_->GetDigitalLogicFamilyPowerUpState(device_name, &logic_family);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -8602,6 +8764,7 @@ namespace nidaqmx_grpc {
       stateVector.resize(channel_name.size());
       auto status = ((NiDAQmxLibrary*)library_)->GetDigitalPowerUpStates(device_name, get_channelName_if(channel_name, 0), get_state_if(stateVector, 0), get_channelName_if(channel_name, 1), get_state_if(stateVector, 1), get_channelName_if(channel_name, 2), get_state_if(stateVector, 2), get_channelName_if(channel_name, 3), get_state_if(stateVector, 3), get_channelName_if(channel_name, 4), get_state_if(stateVector, 4), get_channelName_if(channel_name, 5), get_state_if(stateVector, 5), get_channelName_if(channel_name, 6), get_state_if(stateVector, 6), get_channelName_if(channel_name, 7), get_state_if(stateVector, 7), get_channelName_if(channel_name, 8), get_state_if(stateVector, 8), get_channelName_if(channel_name, 9), get_state_if(stateVector, 9), get_channelName_if(channel_name, 10), get_state_if(stateVector, 10), get_channelName_if(channel_name, 11), get_state_if(stateVector, 11), get_channelName_if(channel_name, 12), get_state_if(stateVector, 12), get_channelName_if(channel_name, 13), get_state_if(stateVector, 13), get_channelName_if(channel_name, 14), get_state_if(stateVector, 14), get_channelName_if(channel_name, 15), get_state_if(stateVector, 15), get_channelName_if(channel_name, 16), get_state_if(stateVector, 16), get_channelName_if(channel_name, 17), get_state_if(stateVector, 17), get_channelName_if(channel_name, 18), get_state_if(stateVector, 18), get_channelName_if(channel_name, 19), get_state_if(stateVector, 19), get_channelName_if(channel_name, 20), get_state_if(stateVector, 20), get_channelName_if(channel_name, 21), get_state_if(stateVector, 21), get_channelName_if(channel_name, 22), get_state_if(stateVector, 22), get_channelName_if(channel_name, 23), get_state_if(stateVector, 23), get_channelName_if(channel_name, 24), get_state_if(stateVector, 24), get_channelName_if(channel_name, 25), get_state_if(stateVector, 25), get_channelName_if(channel_name, 26), get_state_if(stateVector, 26), get_channelName_if(channel_name, 27), get_state_if(stateVector, 27), get_channelName_if(channel_name, 28), get_state_if(stateVector, 28), get_channelName_if(channel_name, 29), get_state_if(stateVector, 29), get_channelName_if(channel_name, 30), get_state_if(stateVector, 30), get_channelName_if(channel_name, 31), get_state_if(stateVector, 31), get_channelName_if(channel_name, 32), get_state_if(stateVector, 32), get_channelName_if(channel_name, 33), get_state_if(stateVector, 33), get_channelName_if(channel_name, 34), get_state_if(stateVector, 34), get_channelName_if(channel_name, 35), get_state_if(stateVector, 35), get_channelName_if(channel_name, 36), get_state_if(stateVector, 36), get_channelName_if(channel_name, 37), get_state_if(stateVector, 37), get_channelName_if(channel_name, 38), get_state_if(stateVector, 38), get_channelName_if(channel_name, 39), get_state_if(stateVector, 39), get_channelName_if(channel_name, 40), get_state_if(stateVector, 40), get_channelName_if(channel_name, 41), get_state_if(stateVector, 41), get_channelName_if(channel_name, 42), get_state_if(stateVector, 42), get_channelName_if(channel_name, 43), get_state_if(stateVector, 43), get_channelName_if(channel_name, 44), get_state_if(stateVector, 44), get_channelName_if(channel_name, 45), get_state_if(stateVector, 45), get_channelName_if(channel_name, 46), get_state_if(stateVector, 46), get_channelName_if(channel_name, 47), get_state_if(stateVector, 47), get_channelName_if(channel_name, 48), get_state_if(stateVector, 48), get_channelName_if(channel_name, 49), get_state_if(stateVector, 49), get_channelName_if(channel_name, 50), get_state_if(stateVector, 50), get_channelName_if(channel_name, 51), get_state_if(stateVector, 51), get_channelName_if(channel_name, 52), get_state_if(stateVector, 52), get_channelName_if(channel_name, 53), get_state_if(stateVector, 53), get_channelName_if(channel_name, 54), get_state_if(stateVector, 54), get_channelName_if(channel_name, 55), get_state_if(stateVector, 55), get_channelName_if(channel_name, 56), get_state_if(stateVector, 56), get_channelName_if(channel_name, 57), get_state_if(stateVector, 57), get_channelName_if(channel_name, 58), get_state_if(stateVector, 58), get_channelName_if(channel_name, 59), get_state_if(stateVector, 59), get_channelName_if(channel_name, 60), get_state_if(stateVector, 60), get_channelName_if(channel_name, 61), get_state_if(stateVector, 61), get_channelName_if(channel_name, 62), get_state_if(stateVector, 62), get_channelName_if(channel_name, 63), get_state_if(stateVector, 63), get_channelName_if(channel_name, 64), get_state_if(stateVector, 64), get_channelName_if(channel_name, 65), get_state_if(stateVector, 65), get_channelName_if(channel_name, 66), get_state_if(stateVector, 66), get_channelName_if(channel_name, 67), get_state_if(stateVector, 67), get_channelName_if(channel_name, 68), get_state_if(stateVector, 68), get_channelName_if(channel_name, 69), get_state_if(stateVector, 69), get_channelName_if(channel_name, 70), get_state_if(stateVector, 70), get_channelName_if(channel_name, 71), get_state_if(stateVector, 71), get_channelName_if(channel_name, 72), get_state_if(stateVector, 72), get_channelName_if(channel_name, 73), get_state_if(stateVector, 73), get_channelName_if(channel_name, 74), get_state_if(stateVector, 74), get_channelName_if(channel_name, 75), get_state_if(stateVector, 75), get_channelName_if(channel_name, 76), get_state_if(stateVector, 76), get_channelName_if(channel_name, 77), get_state_if(stateVector, 77), get_channelName_if(channel_name, 78), get_state_if(stateVector, 78), get_channelName_if(channel_name, 79), get_state_if(stateVector, 79), get_channelName_if(channel_name, 80), get_state_if(stateVector, 80), get_channelName_if(channel_name, 81), get_state_if(stateVector, 81), get_channelName_if(channel_name, 82), get_state_if(stateVector, 82), get_channelName_if(channel_name, 83), get_state_if(stateVector, 83), get_channelName_if(channel_name, 84), get_state_if(stateVector, 84), get_channelName_if(channel_name, 85), get_state_if(stateVector, 85), get_channelName_if(channel_name, 86), get_state_if(stateVector, 86), get_channelName_if(channel_name, 87), get_state_if(stateVector, 87), get_channelName_if(channel_name, 88), get_state_if(stateVector, 88), get_channelName_if(channel_name, 89), get_state_if(stateVector, 89), get_channelName_if(channel_name, 90), get_state_if(stateVector, 90), get_channelName_if(channel_name, 91), get_state_if(stateVector, 91), get_channelName_if(channel_name, 92), get_state_if(stateVector, 92), get_channelName_if(channel_name, 93), get_state_if(stateVector, 93), get_channelName_if(channel_name, 94), get_state_if(stateVector, 94), get_channelName_if(channel_name, 95), get_state_if(stateVector, 95), get_channelName_if(channel_name, 96), get_state_if(stateVector, 96));
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -8648,6 +8811,7 @@ namespace nidaqmx_grpc {
       stateVector.resize(channel_name.size());
       auto status = ((NiDAQmxLibrary*)library_)->GetDigitalPullUpPullDownStates(device_name, get_channelName_if(channel_name, 0), get_state_if(stateVector, 0), get_channelName_if(channel_name, 1), get_state_if(stateVector, 1), get_channelName_if(channel_name, 2), get_state_if(stateVector, 2), get_channelName_if(channel_name, 3), get_state_if(stateVector, 3), get_channelName_if(channel_name, 4), get_state_if(stateVector, 4), get_channelName_if(channel_name, 5), get_state_if(stateVector, 5), get_channelName_if(channel_name, 6), get_state_if(stateVector, 6), get_channelName_if(channel_name, 7), get_state_if(stateVector, 7), get_channelName_if(channel_name, 8), get_state_if(stateVector, 8), get_channelName_if(channel_name, 9), get_state_if(stateVector, 9), get_channelName_if(channel_name, 10), get_state_if(stateVector, 10), get_channelName_if(channel_name, 11), get_state_if(stateVector, 11), get_channelName_if(channel_name, 12), get_state_if(stateVector, 12), get_channelName_if(channel_name, 13), get_state_if(stateVector, 13), get_channelName_if(channel_name, 14), get_state_if(stateVector, 14), get_channelName_if(channel_name, 15), get_state_if(stateVector, 15), get_channelName_if(channel_name, 16), get_state_if(stateVector, 16), get_channelName_if(channel_name, 17), get_state_if(stateVector, 17), get_channelName_if(channel_name, 18), get_state_if(stateVector, 18), get_channelName_if(channel_name, 19), get_state_if(stateVector, 19), get_channelName_if(channel_name, 20), get_state_if(stateVector, 20), get_channelName_if(channel_name, 21), get_state_if(stateVector, 21), get_channelName_if(channel_name, 22), get_state_if(stateVector, 22), get_channelName_if(channel_name, 23), get_state_if(stateVector, 23), get_channelName_if(channel_name, 24), get_state_if(stateVector, 24), get_channelName_if(channel_name, 25), get_state_if(stateVector, 25), get_channelName_if(channel_name, 26), get_state_if(stateVector, 26), get_channelName_if(channel_name, 27), get_state_if(stateVector, 27), get_channelName_if(channel_name, 28), get_state_if(stateVector, 28), get_channelName_if(channel_name, 29), get_state_if(stateVector, 29), get_channelName_if(channel_name, 30), get_state_if(stateVector, 30), get_channelName_if(channel_name, 31), get_state_if(stateVector, 31), get_channelName_if(channel_name, 32), get_state_if(stateVector, 32), get_channelName_if(channel_name, 33), get_state_if(stateVector, 33), get_channelName_if(channel_name, 34), get_state_if(stateVector, 34), get_channelName_if(channel_name, 35), get_state_if(stateVector, 35), get_channelName_if(channel_name, 36), get_state_if(stateVector, 36), get_channelName_if(channel_name, 37), get_state_if(stateVector, 37), get_channelName_if(channel_name, 38), get_state_if(stateVector, 38), get_channelName_if(channel_name, 39), get_state_if(stateVector, 39), get_channelName_if(channel_name, 40), get_state_if(stateVector, 40), get_channelName_if(channel_name, 41), get_state_if(stateVector, 41), get_channelName_if(channel_name, 42), get_state_if(stateVector, 42), get_channelName_if(channel_name, 43), get_state_if(stateVector, 43), get_channelName_if(channel_name, 44), get_state_if(stateVector, 44), get_channelName_if(channel_name, 45), get_state_if(stateVector, 45), get_channelName_if(channel_name, 46), get_state_if(stateVector, 46), get_channelName_if(channel_name, 47), get_state_if(stateVector, 47), get_channelName_if(channel_name, 48), get_state_if(stateVector, 48), get_channelName_if(channel_name, 49), get_state_if(stateVector, 49), get_channelName_if(channel_name, 50), get_state_if(stateVector, 50), get_channelName_if(channel_name, 51), get_state_if(stateVector, 51), get_channelName_if(channel_name, 52), get_state_if(stateVector, 52), get_channelName_if(channel_name, 53), get_state_if(stateVector, 53), get_channelName_if(channel_name, 54), get_state_if(stateVector, 54), get_channelName_if(channel_name, 55), get_state_if(stateVector, 55), get_channelName_if(channel_name, 56), get_state_if(stateVector, 56), get_channelName_if(channel_name, 57), get_state_if(stateVector, 57), get_channelName_if(channel_name, 58), get_state_if(stateVector, 58), get_channelName_if(channel_name, 59), get_state_if(stateVector, 59), get_channelName_if(channel_name, 60), get_state_if(stateVector, 60), get_channelName_if(channel_name, 61), get_state_if(stateVector, 61), get_channelName_if(channel_name, 62), get_state_if(stateVector, 62), get_channelName_if(channel_name, 63), get_state_if(stateVector, 63), get_channelName_if(channel_name, 64), get_state_if(stateVector, 64), get_channelName_if(channel_name, 65), get_state_if(stateVector, 65), get_channelName_if(channel_name, 66), get_state_if(stateVector, 66), get_channelName_if(channel_name, 67), get_state_if(stateVector, 67), get_channelName_if(channel_name, 68), get_state_if(stateVector, 68), get_channelName_if(channel_name, 69), get_state_if(stateVector, 69), get_channelName_if(channel_name, 70), get_state_if(stateVector, 70), get_channelName_if(channel_name, 71), get_state_if(stateVector, 71), get_channelName_if(channel_name, 72), get_state_if(stateVector, 72), get_channelName_if(channel_name, 73), get_state_if(stateVector, 73), get_channelName_if(channel_name, 74), get_state_if(stateVector, 74), get_channelName_if(channel_name, 75), get_state_if(stateVector, 75), get_channelName_if(channel_name, 76), get_state_if(stateVector, 76), get_channelName_if(channel_name, 77), get_state_if(stateVector, 77), get_channelName_if(channel_name, 78), get_state_if(stateVector, 78), get_channelName_if(channel_name, 79), get_state_if(stateVector, 79), get_channelName_if(channel_name, 80), get_state_if(stateVector, 80), get_channelName_if(channel_name, 81), get_state_if(stateVector, 81), get_channelName_if(channel_name, 82), get_state_if(stateVector, 82), get_channelName_if(channel_name, 83), get_state_if(stateVector, 83), get_channelName_if(channel_name, 84), get_state_if(stateVector, 84), get_channelName_if(channel_name, 85), get_state_if(stateVector, 85), get_channelName_if(channel_name, 86), get_state_if(stateVector, 86), get_channelName_if(channel_name, 87), get_state_if(stateVector, 87), get_channelName_if(channel_name, 88), get_state_if(stateVector, 88), get_channelName_if(channel_name, 89), get_state_if(stateVector, 89), get_channelName_if(channel_name, 90), get_state_if(stateVector, 90), get_channelName_if(channel_name, 91), get_state_if(stateVector, 91), get_channelName_if(channel_name, 92), get_state_if(stateVector, 92), get_channelName_if(channel_name, 93), get_state_if(stateVector, 93), get_channelName_if(channel_name, 94), get_state_if(stateVector, 94), get_channelName_if(channel_name, 95), get_state_if(stateVector, 95), get_channelName_if(channel_name, 96), get_state_if(stateVector, 96));
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -8673,6 +8837,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetDisconnectedCDAQSyncPorts(nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 port_list_size = status;
@@ -8687,6 +8852,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -8713,6 +8879,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetErrorString(error_code, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 buffer_size = status;
@@ -8727,6 +8894,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -8773,6 +8941,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetExportedSignalAttributeBool(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -8817,6 +8986,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetExportedSignalAttributeDouble(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -8861,6 +9031,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetExportedSignalAttributeInt32(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -8911,6 +9082,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetExportedSignalAttributeString(task, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         uInt32 size = status;
@@ -8925,6 +9097,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         response->set_status(status);
@@ -8971,6 +9144,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetExportedSignalAttributeUInt32(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -8994,6 +9168,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetExtendedErrorInfo(nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 buffer_size = status;
@@ -9008,6 +9183,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -9034,6 +9210,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime data {};
       auto status = library_->GetFirstSampClkWhen(task, &data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -9058,6 +9235,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime data {};
       auto status = library_->GetFirstSampTimestampVal(task, &data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -9084,6 +9262,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetNthTaskChannel(task, index, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         int32 buffer_size = status;
@@ -9098,6 +9277,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         response->set_status(status);
@@ -9126,6 +9306,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetNthTaskDevice(task, index, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         int32 buffer_size = status;
@@ -9140,6 +9321,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         response->set_status(status);
@@ -9168,6 +9350,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetNthTaskReadChannel(task, index, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         int32 buffer_size = status;
@@ -9182,6 +9365,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         response->set_status(status);
@@ -9227,6 +9411,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetPersistedChanAttributeBool(channel, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -9270,6 +9455,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetPersistedChanAttributeString(channel, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 size = status;
@@ -9284,6 +9470,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -9329,6 +9516,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetPersistedScaleAttributeBool(scale_name, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -9372,6 +9560,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetPersistedScaleAttributeString(scale_name, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 size = status;
@@ -9386,6 +9575,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -9431,6 +9621,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetPersistedTaskAttributeBool(task_name, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -9474,6 +9665,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetPersistedTaskAttributeString(task_name, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 size = status;
@@ -9488,6 +9680,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -9533,6 +9726,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetPhysicalChanAttributeBool(physical_channel, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -9576,6 +9770,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetPhysicalChanAttributeBytes(physical_channel, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 size = status;
@@ -9587,6 +9782,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -9631,6 +9827,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetPhysicalChanAttributeDouble(physical_channel, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -9674,6 +9871,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetPhysicalChanAttributeDoubleArray(physical_channel, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 size = status;
@@ -9686,6 +9884,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -9729,6 +9928,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetPhysicalChanAttributeInt32(physical_channel, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -9778,6 +9978,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetPhysicalChanAttributeInt32Array(physical_channel, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 size = status;
@@ -9790,6 +9991,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -9847,6 +10049,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetPhysicalChanAttributeString(physical_channel, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 size = status;
@@ -9861,6 +10064,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -9906,6 +10110,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetPhysicalChanAttributeUInt32(physical_channel, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -9949,6 +10154,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetPhysicalChanAttributeUInt32Array(physical_channel, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 size = status;
@@ -9961,6 +10167,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -10005,6 +10212,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetReadAttributeBool(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -10049,6 +10257,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetReadAttributeDouble(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -10093,6 +10302,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetReadAttributeInt32(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -10143,6 +10353,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetReadAttributeString(task, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         uInt32 size = status;
@@ -10157,6 +10368,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         response->set_status(status);
@@ -10203,6 +10415,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetReadAttributeUInt32(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -10247,6 +10460,7 @@ namespace nidaqmx_grpc {
       uInt64 value {};
       auto status = library_->GetReadAttributeUInt64(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -10291,6 +10505,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetRealTimeAttributeBool(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -10335,6 +10550,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetRealTimeAttributeInt32(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -10385,6 +10601,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetRealTimeAttributeUInt32(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -10409,6 +10626,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime data {};
       auto status = library_->GetRefTrigTimestampVal(task, &data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -10452,6 +10670,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetScaleAttributeDouble(scale_name, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -10495,6 +10714,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetScaleAttributeDoubleArray(scale_name, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 size = status;
@@ -10507,6 +10727,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -10550,6 +10771,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetScaleAttributeInt32(scale_name, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -10599,6 +10821,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetScaleAttributeString(scale_name, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 size = status;
@@ -10613,6 +10836,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -10642,6 +10866,7 @@ namespace nidaqmx_grpc {
       uInt32 minute {};
       auto status = library_->GetSelfCalLastDateAndTime(device_name, &year, &month, &day, &hour, &minute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -10670,6 +10895,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime data {};
       auto status = library_->GetStartTrigTimestampVal(task, &data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -10694,6 +10920,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime data {};
       auto status = library_->GetStartTrigTrigWhen(task, &data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -10718,6 +10945,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime data {};
       auto status = library_->GetSyncPulseTimeWhen(task, &data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -10760,6 +10988,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetSystemInfoAttributeString(attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         uInt32 size = status;
@@ -10774,6 +11003,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, 0);
         }
         response->set_status(status);
@@ -10818,6 +11048,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetSystemInfoAttributeUInt32(attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -10862,6 +11093,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetTaskAttributeBool(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -10906,6 +11138,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetTaskAttributeString(task, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         uInt32 size = status;
@@ -10920,6 +11153,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         response->set_status(status);
@@ -10966,6 +11200,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetTaskAttributeUInt32(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -11010,6 +11245,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetTimingAttributeBool(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -11054,6 +11290,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetTimingAttributeDouble(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -11099,6 +11336,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetTimingAttributeExBool(task, device_names, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -11144,6 +11382,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetTimingAttributeExDouble(task, device_names, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -11189,6 +11428,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetTimingAttributeExInt32(task, device_names, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -11240,6 +11480,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetTimingAttributeExString(task, device_names, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         uInt32 size = status;
@@ -11254,6 +11495,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         response->set_status(status);
@@ -11301,6 +11543,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime value {};
       auto status = library_->GetTimingAttributeExTimestamp(task, device_names, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -11346,6 +11589,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetTimingAttributeExUInt32(task, device_names, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -11391,6 +11635,7 @@ namespace nidaqmx_grpc {
       uInt64 value {};
       auto status = library_->GetTimingAttributeExUInt64(task, device_names, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -11435,6 +11680,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetTimingAttributeInt32(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -11485,6 +11731,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetTimingAttributeString(task, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         uInt32 size = status;
@@ -11499,6 +11746,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         response->set_status(status);
@@ -11545,6 +11793,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime value {};
       auto status = library_->GetTimingAttributeTimestamp(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -11589,6 +11838,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetTimingAttributeUInt32(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -11633,6 +11883,7 @@ namespace nidaqmx_grpc {
       uInt64 value {};
       auto status = library_->GetTimingAttributeUInt64(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -11677,6 +11928,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetTrigAttributeBool(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -11721,6 +11973,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetTrigAttributeDouble(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -11765,6 +12018,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetTrigAttributeDoubleArray(task, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         uInt32 size = status;
@@ -11777,6 +12031,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         response->set_status(status);
@@ -11821,6 +12076,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetTrigAttributeInt32(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -11871,6 +12127,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetTrigAttributeInt32Array(task, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         uInt32 size = status;
@@ -11883,6 +12140,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         response->set_status(status);
@@ -11941,6 +12199,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetTrigAttributeString(task, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         uInt32 size = status;
@@ -11955,6 +12214,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         response->set_status(status);
@@ -12001,6 +12261,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime value {};
       auto status = library_->GetTrigAttributeTimestamp(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12045,6 +12306,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetTrigAttributeUInt32(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12090,6 +12352,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetWatchdogAttributeBool(task, lines, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12135,6 +12398,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetWatchdogAttributeDouble(task, lines, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12180,6 +12444,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetWatchdogAttributeInt32(task, lines, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12231,6 +12496,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetWatchdogAttributeString(task, lines, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         uInt32 size = status;
@@ -12245,6 +12511,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         response->set_status(status);
@@ -12291,6 +12558,7 @@ namespace nidaqmx_grpc {
       bool32 value {};
       auto status = library_->GetWriteAttributeBool(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12335,6 +12603,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->GetWriteAttributeDouble(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12379,6 +12648,7 @@ namespace nidaqmx_grpc {
       int32 value {};
       auto status = library_->GetWriteAttributeInt32(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12429,6 +12699,7 @@ namespace nidaqmx_grpc {
       while (true) {
         auto status = library_->GetWriteAttributeString(task, attribute, nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         uInt32 size = status;
@@ -12443,6 +12714,7 @@ namespace nidaqmx_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForTaskHandle(status, task);
         }
         response->set_status(status);
@@ -12489,6 +12761,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->GetWriteAttributeUInt32(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12533,6 +12806,7 @@ namespace nidaqmx_grpc {
       uInt64 value {};
       auto status = library_->GetWriteAttributeUInt64(task, attribute, &value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12557,6 +12831,7 @@ namespace nidaqmx_grpc {
       bool32 is_task_done {};
       auto status = library_->IsTaskDone(task, &is_task_done);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12588,6 +12863,7 @@ namespace nidaqmx_grpc {
       auto cleanup_lambda = [&] (TaskHandle id) { library_->ClearTask(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -12637,6 +12913,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadAnalogF64(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12663,6 +12940,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->ReadAnalogScalarF64(task, timeout, &value, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12708,6 +12986,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadBinaryI16(task, num_samps_per_chan, timeout, fill_mode, read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12763,6 +13042,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadBinaryI32(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12808,6 +13088,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadBinaryU16(task, num_samps_per_chan, timeout, fill_mode, read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12863,6 +13144,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadBinaryU32(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12893,6 +13175,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadCounterF64(task, num_samps_per_chan, timeout, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12939,6 +13222,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadCounterF64Ex(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12965,6 +13249,7 @@ namespace nidaqmx_grpc {
       float64 value {};
       auto status = library_->ReadCounterScalarF64(task, timeout, &value, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -12991,6 +13276,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->ReadCounterScalarU32(task, timeout, &value, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13021,6 +13307,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadCounterU32(task, num_samps_per_chan, timeout, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13067,6 +13354,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadCounterU32Ex(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13115,6 +13403,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadCtrFreq(task, num_samps_per_chan, timeout, interleaved, read_array_frequency, read_array_duty_cycle, array_size_in_samps, &samps_per_chan_read, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13142,6 +13431,7 @@ namespace nidaqmx_grpc {
       float64 duty_cycle {};
       auto status = library_->ReadCtrFreqScalar(task, timeout, &frequency, &duty_cycle, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13191,6 +13481,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadCtrTicks(task, num_samps_per_chan, timeout, interleaved, read_array_high_ticks, read_array_low_ticks, array_size_in_samps, &samps_per_chan_read, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13218,6 +13509,7 @@ namespace nidaqmx_grpc {
       uInt32 low_ticks {};
       auto status = library_->ReadCtrTicksScalar(task, timeout, &high_ticks, &low_ticks, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13267,6 +13559,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadCtrTime(task, num_samps_per_chan, timeout, interleaved, read_array_high_time, read_array_low_time, array_size_in_samps, &samps_per_chan_read, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13294,6 +13587,7 @@ namespace nidaqmx_grpc {
       float64 low_time {};
       auto status = library_->ReadCtrTimeScalar(task, timeout, &high_time, &low_time, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13341,6 +13635,7 @@ namespace nidaqmx_grpc {
       int32 num_bytes_per_samp {};
       auto status = library_->ReadDigitalLines(task, num_samps_per_chan, timeout, fill_mode, (uInt8*)read_array.data(), array_size_in_bytes, &samps_per_chan_read, &num_bytes_per_samp, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13369,6 +13664,7 @@ namespace nidaqmx_grpc {
       uInt32 value {};
       auto status = library_->ReadDigitalScalarU32(task, timeout, &value, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13414,6 +13710,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadDigitalU16(task, num_samps_per_chan, timeout, fill_mode, read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13469,6 +13766,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadDigitalU32(task, num_samps_per_chan, timeout, fill_mode, read_array, array_size_in_samps, &samps_per_chan_read, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13514,6 +13812,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_read {};
       auto status = library_->ReadDigitalU8(task, num_samps_per_chan, timeout, fill_mode, (uInt8*)read_array.data(), array_size_in_samps, &samps_per_chan_read, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13545,6 +13844,7 @@ namespace nidaqmx_grpc {
       int32 num_bytes_per_samp {};
       auto status = library_->ReadRaw(task, num_samps_per_chan, timeout, (uInt8*)read_array.data(), array_size_in_bytes, &samps_read, &num_bytes_per_samp, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13772,6 +14072,7 @@ namespace nidaqmx_grpc {
       auto port_list = request->port_list().c_str();
       auto status = library_->RemoveCDAQSyncConnection(port_list);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -13794,6 +14095,7 @@ namespace nidaqmx_grpc {
       bool32 override_reservation = request->override_reservation();
       auto status = library_->ReserveNetworkDevice(device_name, override_reservation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -13835,6 +14137,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->ResetBufferAttribute(task, attribute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13877,6 +14180,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->ResetChanAttribute(task, channel, attribute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13898,6 +14202,7 @@ namespace nidaqmx_grpc {
       auto device_name = request->device_name().c_str();
       auto status = library_->ResetDevice(device_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -13939,6 +14244,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->ResetExportedSignalAttribute(task, attribute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -13980,6 +14286,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->ResetReadAttribute(task, attribute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -14021,6 +14328,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->ResetRealTimeAttribute(task, attribute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -14062,6 +14370,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->ResetTimingAttribute(task, attribute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -14104,6 +14413,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->ResetTimingAttributeEx(task, device_names, attribute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -14145,6 +14455,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->ResetTrigAttribute(task, attribute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -14187,6 +14498,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->ResetWatchdogAttribute(task, lines, attribute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -14228,6 +14540,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->ResetWriteAttribute(task, attribute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -14269,6 +14582,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->SaveGlobalChan(task, channel_name, save_as, author, options);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -14308,6 +14622,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->SaveScale(scale_name, save_as, author, options);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -14348,6 +14663,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->SaveTask(task, save_as, author, options);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -14369,6 +14685,7 @@ namespace nidaqmx_grpc {
       auto device_name = request->device_name().c_str();
       auto status = library_->SelfCal(device_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -14390,6 +14707,7 @@ namespace nidaqmx_grpc {
       auto device_name = request->device_name().c_str();
       auto status = library_->SelfTestDevice(device_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -14418,6 +14736,7 @@ namespace nidaqmx_grpc {
       uInt32 minute = request->minute();
       auto status = library_->SetAIChanCalCalDate(task, channel_name, year, month, day, hour, minute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -14446,6 +14765,7 @@ namespace nidaqmx_grpc {
       uInt32 minute = request->minute();
       auto status = library_->SetAIChanCalExpDate(task, channel_name, year, month, day, hour, minute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -14493,6 +14813,7 @@ namespace nidaqmx_grpc {
 
       auto status = ((NiDAQmxLibrary*)library_)->SetAnalogPowerUpStates(device_name, get_channelNames_if(power_up_states, 0), get_state_if(power_up_states, 0), get_channelType_if(power_up_states, 0), get_channelNames_if(power_up_states, 1), get_state_if(power_up_states, 1), get_channelType_if(power_up_states, 1), get_channelNames_if(power_up_states, 2), get_state_if(power_up_states, 2), get_channelType_if(power_up_states, 2), get_channelNames_if(power_up_states, 3), get_state_if(power_up_states, 3), get_channelType_if(power_up_states, 3), get_channelNames_if(power_up_states, 4), get_state_if(power_up_states, 4), get_channelType_if(power_up_states, 4), get_channelNames_if(power_up_states, 5), get_state_if(power_up_states, 5), get_channelType_if(power_up_states, 5), get_channelNames_if(power_up_states, 6), get_state_if(power_up_states, 6), get_channelType_if(power_up_states, 6), get_channelNames_if(power_up_states, 7), get_state_if(power_up_states, 7), get_channelType_if(power_up_states, 7), get_channelNames_if(power_up_states, 8), get_state_if(power_up_states, 8), get_channelType_if(power_up_states, 8), get_channelNames_if(power_up_states, 9), get_state_if(power_up_states, 9), get_channelType_if(power_up_states, 9), get_channelNames_if(power_up_states, 10), get_state_if(power_up_states, 10), get_channelType_if(power_up_states, 10), get_channelNames_if(power_up_states, 11), get_state_if(power_up_states, 11), get_channelType_if(power_up_states, 11), get_channelNames_if(power_up_states, 12), get_state_if(power_up_states, 12), get_channelType_if(power_up_states, 12), get_channelNames_if(power_up_states, 13), get_state_if(power_up_states, 13), get_channelType_if(power_up_states, 13), get_channelNames_if(power_up_states, 14), get_state_if(power_up_states, 14), get_channelType_if(power_up_states, 14), get_channelNames_if(power_up_states, 15), get_state_if(power_up_states, 15), get_channelType_if(power_up_states, 15), get_channelNames_if(power_up_states, 16), get_state_if(power_up_states, 16), get_channelType_if(power_up_states, 16), get_channelNames_if(power_up_states, 17), get_state_if(power_up_states, 17), get_channelType_if(power_up_states, 17), get_channelNames_if(power_up_states, 18), get_state_if(power_up_states, 18), get_channelType_if(power_up_states, 18), get_channelNames_if(power_up_states, 19), get_state_if(power_up_states, 19), get_channelType_if(power_up_states, 19), get_channelNames_if(power_up_states, 20), get_state_if(power_up_states, 20), get_channelType_if(power_up_states, 20), get_channelNames_if(power_up_states, 21), get_state_if(power_up_states, 21), get_channelType_if(power_up_states, 21), get_channelNames_if(power_up_states, 22), get_state_if(power_up_states, 22), get_channelType_if(power_up_states, 22), get_channelNames_if(power_up_states, 23), get_state_if(power_up_states, 23), get_channelType_if(power_up_states, 23), get_channelNames_if(power_up_states, 24), get_state_if(power_up_states, 24), get_channelType_if(power_up_states, 24), get_channelNames_if(power_up_states, 25), get_state_if(power_up_states, 25), get_channelType_if(power_up_states, 25), get_channelNames_if(power_up_states, 26), get_state_if(power_up_states, 26), get_channelType_if(power_up_states, 26), get_channelNames_if(power_up_states, 27), get_state_if(power_up_states, 27), get_channelType_if(power_up_states, 27), get_channelNames_if(power_up_states, 28), get_state_if(power_up_states, 28), get_channelType_if(power_up_states, 28), get_channelNames_if(power_up_states, 29), get_state_if(power_up_states, 29), get_channelType_if(power_up_states, 29), get_channelNames_if(power_up_states, 30), get_state_if(power_up_states, 30), get_channelType_if(power_up_states, 30), get_channelNames_if(power_up_states, 31), get_state_if(power_up_states, 31), get_channelType_if(power_up_states, 31), get_channelNames_if(power_up_states, 32), get_state_if(power_up_states, 32), get_channelType_if(power_up_states, 32), get_channelNames_if(power_up_states, 33), get_state_if(power_up_states, 33), get_channelType_if(power_up_states, 33), get_channelNames_if(power_up_states, 34), get_state_if(power_up_states, 34), get_channelType_if(power_up_states, 34), get_channelNames_if(power_up_states, 35), get_state_if(power_up_states, 35), get_channelType_if(power_up_states, 35), get_channelNames_if(power_up_states, 36), get_state_if(power_up_states, 36), get_channelType_if(power_up_states, 36), get_channelNames_if(power_up_states, 37), get_state_if(power_up_states, 37), get_channelType_if(power_up_states, 37), get_channelNames_if(power_up_states, 38), get_state_if(power_up_states, 38), get_channelType_if(power_up_states, 38), get_channelNames_if(power_up_states, 39), get_state_if(power_up_states, 39), get_channelType_if(power_up_states, 39), get_channelNames_if(power_up_states, 40), get_state_if(power_up_states, 40), get_channelType_if(power_up_states, 40), get_channelNames_if(power_up_states, 41), get_state_if(power_up_states, 41), get_channelType_if(power_up_states, 41), get_channelNames_if(power_up_states, 42), get_state_if(power_up_states, 42), get_channelType_if(power_up_states, 42), get_channelNames_if(power_up_states, 43), get_state_if(power_up_states, 43), get_channelType_if(power_up_states, 43), get_channelNames_if(power_up_states, 44), get_state_if(power_up_states, 44), get_channelType_if(power_up_states, 44), get_channelNames_if(power_up_states, 45), get_state_if(power_up_states, 45), get_channelType_if(power_up_states, 45), get_channelNames_if(power_up_states, 46), get_state_if(power_up_states, 46), get_channelType_if(power_up_states, 46), get_channelNames_if(power_up_states, 47), get_state_if(power_up_states, 47), get_channelType_if(power_up_states, 47), get_channelNames_if(power_up_states, 48), get_state_if(power_up_states, 48), get_channelType_if(power_up_states, 48), get_channelNames_if(power_up_states, 49), get_state_if(power_up_states, 49), get_channelType_if(power_up_states, 49), get_channelNames_if(power_up_states, 50), get_state_if(power_up_states, 50), get_channelType_if(power_up_states, 50), get_channelNames_if(power_up_states, 51), get_state_if(power_up_states, 51), get_channelType_if(power_up_states, 51), get_channelNames_if(power_up_states, 52), get_state_if(power_up_states, 52), get_channelType_if(power_up_states, 52), get_channelNames_if(power_up_states, 53), get_state_if(power_up_states, 53), get_channelType_if(power_up_states, 53), get_channelNames_if(power_up_states, 54), get_state_if(power_up_states, 54), get_channelType_if(power_up_states, 54), get_channelNames_if(power_up_states, 55), get_state_if(power_up_states, 55), get_channelType_if(power_up_states, 55), get_channelNames_if(power_up_states, 56), get_state_if(power_up_states, 56), get_channelType_if(power_up_states, 56), get_channelNames_if(power_up_states, 57), get_state_if(power_up_states, 57), get_channelType_if(power_up_states, 57), get_channelNames_if(power_up_states, 58), get_state_if(power_up_states, 58), get_channelType_if(power_up_states, 58), get_channelNames_if(power_up_states, 59), get_state_if(power_up_states, 59), get_channelType_if(power_up_states, 59), get_channelNames_if(power_up_states, 60), get_state_if(power_up_states, 60), get_channelType_if(power_up_states, 60), get_channelNames_if(power_up_states, 61), get_state_if(power_up_states, 61), get_channelType_if(power_up_states, 61), get_channelNames_if(power_up_states, 62), get_state_if(power_up_states, 62), get_channelType_if(power_up_states, 62), get_channelNames_if(power_up_states, 63), get_state_if(power_up_states, 63), get_channelType_if(power_up_states, 63), get_channelNames_if(power_up_states, 64), get_state_if(power_up_states, 64), get_channelType_if(power_up_states, 64), get_channelNames_if(power_up_states, 65), get_state_if(power_up_states, 65), get_channelType_if(power_up_states, 65), get_channelNames_if(power_up_states, 66), get_state_if(power_up_states, 66), get_channelType_if(power_up_states, 66), get_channelNames_if(power_up_states, 67), get_state_if(power_up_states, 67), get_channelType_if(power_up_states, 67), get_channelNames_if(power_up_states, 68), get_state_if(power_up_states, 68), get_channelType_if(power_up_states, 68), get_channelNames_if(power_up_states, 69), get_state_if(power_up_states, 69), get_channelType_if(power_up_states, 69), get_channelNames_if(power_up_states, 70), get_state_if(power_up_states, 70), get_channelType_if(power_up_states, 70), get_channelNames_if(power_up_states, 71), get_state_if(power_up_states, 71), get_channelType_if(power_up_states, 71), get_channelNames_if(power_up_states, 72), get_state_if(power_up_states, 72), get_channelType_if(power_up_states, 72), get_channelNames_if(power_up_states, 73), get_state_if(power_up_states, 73), get_channelType_if(power_up_states, 73), get_channelNames_if(power_up_states, 74), get_state_if(power_up_states, 74), get_channelType_if(power_up_states, 74), get_channelNames_if(power_up_states, 75), get_state_if(power_up_states, 75), get_channelType_if(power_up_states, 75), get_channelNames_if(power_up_states, 76), get_state_if(power_up_states, 76), get_channelType_if(power_up_states, 76), get_channelNames_if(power_up_states, 77), get_state_if(power_up_states, 77), get_channelType_if(power_up_states, 77), get_channelNames_if(power_up_states, 78), get_state_if(power_up_states, 78), get_channelType_if(power_up_states, 78), get_channelNames_if(power_up_states, 79), get_state_if(power_up_states, 79), get_channelType_if(power_up_states, 79), get_channelNames_if(power_up_states, 80), get_state_if(power_up_states, 80), get_channelType_if(power_up_states, 80), get_channelNames_if(power_up_states, 81), get_state_if(power_up_states, 81), get_channelType_if(power_up_states, 81), get_channelNames_if(power_up_states, 82), get_state_if(power_up_states, 82), get_channelType_if(power_up_states, 82), get_channelNames_if(power_up_states, 83), get_state_if(power_up_states, 83), get_channelType_if(power_up_states, 83), get_channelNames_if(power_up_states, 84), get_state_if(power_up_states, 84), get_channelType_if(power_up_states, 84), get_channelNames_if(power_up_states, 85), get_state_if(power_up_states, 85), get_channelType_if(power_up_states, 85), get_channelNames_if(power_up_states, 86), get_state_if(power_up_states, 86), get_channelType_if(power_up_states, 86), get_channelNames_if(power_up_states, 87), get_state_if(power_up_states, 87), get_channelType_if(power_up_states, 87), get_channelNames_if(power_up_states, 88), get_state_if(power_up_states, 88), get_channelType_if(power_up_states, 88), get_channelNames_if(power_up_states, 89), get_state_if(power_up_states, 89), get_channelType_if(power_up_states, 89), get_channelNames_if(power_up_states, 90), get_state_if(power_up_states, 90), get_channelType_if(power_up_states, 90), get_channelNames_if(power_up_states, 91), get_state_if(power_up_states, 91), get_channelType_if(power_up_states, 91), get_channelNames_if(power_up_states, 92), get_state_if(power_up_states, 92), get_channelType_if(power_up_states, 92), get_channelNames_if(power_up_states, 93), get_state_if(power_up_states, 93), get_channelType_if(power_up_states, 93), get_channelNames_if(power_up_states, 94), get_state_if(power_up_states, 94), get_channelType_if(power_up_states, 94), get_channelNames_if(power_up_states, 95), get_state_if(power_up_states, 95), get_channelType_if(power_up_states, 95), get_channelNames_if(power_up_states, 96), get_state_if(power_up_states, 96), get_channelType_if(power_up_states, 96));
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -14536,6 +14857,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->SetAnalogPowerUpStatesWithOutputType(channel_names, state_array, channel_type_array, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -14559,6 +14881,7 @@ namespace nidaqmx_grpc {
       auto data = convert_from_grpc<CVIAbsoluteTime>(request->data());
       auto status = library_->SetArmStartTrigTrigWhen(task, data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -14601,6 +14924,7 @@ namespace nidaqmx_grpc {
       uInt32 value = request->value();
       auto status = library_->SetBufferAttributeUInt32(task, attribute, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -14643,6 +14967,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetCalInfoAttributeBool(device_name, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -14685,6 +15010,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetCalInfoAttributeDouble(device_name, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -14727,6 +15053,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetCalInfoAttributeString(device_name, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -14769,6 +15096,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetCalInfoAttributeUInt32(device_name, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -14813,6 +15141,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetChanAttributeBool(task, channel, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -14857,6 +15186,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetChanAttributeDouble(task, channel, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -14901,6 +15231,7 @@ namespace nidaqmx_grpc {
       uInt32 size = static_cast<uInt32>(request->value().size());
       auto status = library_->SetChanAttributeDoubleArray(task, channel, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -14960,6 +15291,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetChanAttributeInt32(task, channel, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15004,6 +15336,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetChanAttributeString(task, channel, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15048,6 +15381,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetChanAttributeUInt32(task, channel, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15085,6 +15419,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->SetDigitalLogicFamilyPowerUpState(device_name, logic_family);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -15126,6 +15461,7 @@ namespace nidaqmx_grpc {
 
       auto status = ((NiDAQmxLibrary*)library_)->SetDigitalPowerUpStates(device_name, get_channelNames_if(power_up_states, 0), get_state_if(power_up_states, 0), get_channelNames_if(power_up_states, 1), get_state_if(power_up_states, 1), get_channelNames_if(power_up_states, 2), get_state_if(power_up_states, 2), get_channelNames_if(power_up_states, 3), get_state_if(power_up_states, 3), get_channelNames_if(power_up_states, 4), get_state_if(power_up_states, 4), get_channelNames_if(power_up_states, 5), get_state_if(power_up_states, 5), get_channelNames_if(power_up_states, 6), get_state_if(power_up_states, 6), get_channelNames_if(power_up_states, 7), get_state_if(power_up_states, 7), get_channelNames_if(power_up_states, 8), get_state_if(power_up_states, 8), get_channelNames_if(power_up_states, 9), get_state_if(power_up_states, 9), get_channelNames_if(power_up_states, 10), get_state_if(power_up_states, 10), get_channelNames_if(power_up_states, 11), get_state_if(power_up_states, 11), get_channelNames_if(power_up_states, 12), get_state_if(power_up_states, 12), get_channelNames_if(power_up_states, 13), get_state_if(power_up_states, 13), get_channelNames_if(power_up_states, 14), get_state_if(power_up_states, 14), get_channelNames_if(power_up_states, 15), get_state_if(power_up_states, 15), get_channelNames_if(power_up_states, 16), get_state_if(power_up_states, 16), get_channelNames_if(power_up_states, 17), get_state_if(power_up_states, 17), get_channelNames_if(power_up_states, 18), get_state_if(power_up_states, 18), get_channelNames_if(power_up_states, 19), get_state_if(power_up_states, 19), get_channelNames_if(power_up_states, 20), get_state_if(power_up_states, 20), get_channelNames_if(power_up_states, 21), get_state_if(power_up_states, 21), get_channelNames_if(power_up_states, 22), get_state_if(power_up_states, 22), get_channelNames_if(power_up_states, 23), get_state_if(power_up_states, 23), get_channelNames_if(power_up_states, 24), get_state_if(power_up_states, 24), get_channelNames_if(power_up_states, 25), get_state_if(power_up_states, 25), get_channelNames_if(power_up_states, 26), get_state_if(power_up_states, 26), get_channelNames_if(power_up_states, 27), get_state_if(power_up_states, 27), get_channelNames_if(power_up_states, 28), get_state_if(power_up_states, 28), get_channelNames_if(power_up_states, 29), get_state_if(power_up_states, 29), get_channelNames_if(power_up_states, 30), get_state_if(power_up_states, 30), get_channelNames_if(power_up_states, 31), get_state_if(power_up_states, 31), get_channelNames_if(power_up_states, 32), get_state_if(power_up_states, 32), get_channelNames_if(power_up_states, 33), get_state_if(power_up_states, 33), get_channelNames_if(power_up_states, 34), get_state_if(power_up_states, 34), get_channelNames_if(power_up_states, 35), get_state_if(power_up_states, 35), get_channelNames_if(power_up_states, 36), get_state_if(power_up_states, 36), get_channelNames_if(power_up_states, 37), get_state_if(power_up_states, 37), get_channelNames_if(power_up_states, 38), get_state_if(power_up_states, 38), get_channelNames_if(power_up_states, 39), get_state_if(power_up_states, 39), get_channelNames_if(power_up_states, 40), get_state_if(power_up_states, 40), get_channelNames_if(power_up_states, 41), get_state_if(power_up_states, 41), get_channelNames_if(power_up_states, 42), get_state_if(power_up_states, 42), get_channelNames_if(power_up_states, 43), get_state_if(power_up_states, 43), get_channelNames_if(power_up_states, 44), get_state_if(power_up_states, 44), get_channelNames_if(power_up_states, 45), get_state_if(power_up_states, 45), get_channelNames_if(power_up_states, 46), get_state_if(power_up_states, 46), get_channelNames_if(power_up_states, 47), get_state_if(power_up_states, 47), get_channelNames_if(power_up_states, 48), get_state_if(power_up_states, 48), get_channelNames_if(power_up_states, 49), get_state_if(power_up_states, 49), get_channelNames_if(power_up_states, 50), get_state_if(power_up_states, 50), get_channelNames_if(power_up_states, 51), get_state_if(power_up_states, 51), get_channelNames_if(power_up_states, 52), get_state_if(power_up_states, 52), get_channelNames_if(power_up_states, 53), get_state_if(power_up_states, 53), get_channelNames_if(power_up_states, 54), get_state_if(power_up_states, 54), get_channelNames_if(power_up_states, 55), get_state_if(power_up_states, 55), get_channelNames_if(power_up_states, 56), get_state_if(power_up_states, 56), get_channelNames_if(power_up_states, 57), get_state_if(power_up_states, 57), get_channelNames_if(power_up_states, 58), get_state_if(power_up_states, 58), get_channelNames_if(power_up_states, 59), get_state_if(power_up_states, 59), get_channelNames_if(power_up_states, 60), get_state_if(power_up_states, 60), get_channelNames_if(power_up_states, 61), get_state_if(power_up_states, 61), get_channelNames_if(power_up_states, 62), get_state_if(power_up_states, 62), get_channelNames_if(power_up_states, 63), get_state_if(power_up_states, 63), get_channelNames_if(power_up_states, 64), get_state_if(power_up_states, 64), get_channelNames_if(power_up_states, 65), get_state_if(power_up_states, 65), get_channelNames_if(power_up_states, 66), get_state_if(power_up_states, 66), get_channelNames_if(power_up_states, 67), get_state_if(power_up_states, 67), get_channelNames_if(power_up_states, 68), get_state_if(power_up_states, 68), get_channelNames_if(power_up_states, 69), get_state_if(power_up_states, 69), get_channelNames_if(power_up_states, 70), get_state_if(power_up_states, 70), get_channelNames_if(power_up_states, 71), get_state_if(power_up_states, 71), get_channelNames_if(power_up_states, 72), get_state_if(power_up_states, 72), get_channelNames_if(power_up_states, 73), get_state_if(power_up_states, 73), get_channelNames_if(power_up_states, 74), get_state_if(power_up_states, 74), get_channelNames_if(power_up_states, 75), get_state_if(power_up_states, 75), get_channelNames_if(power_up_states, 76), get_state_if(power_up_states, 76), get_channelNames_if(power_up_states, 77), get_state_if(power_up_states, 77), get_channelNames_if(power_up_states, 78), get_state_if(power_up_states, 78), get_channelNames_if(power_up_states, 79), get_state_if(power_up_states, 79), get_channelNames_if(power_up_states, 80), get_state_if(power_up_states, 80), get_channelNames_if(power_up_states, 81), get_state_if(power_up_states, 81), get_channelNames_if(power_up_states, 82), get_state_if(power_up_states, 82), get_channelNames_if(power_up_states, 83), get_state_if(power_up_states, 83), get_channelNames_if(power_up_states, 84), get_state_if(power_up_states, 84), get_channelNames_if(power_up_states, 85), get_state_if(power_up_states, 85), get_channelNames_if(power_up_states, 86), get_state_if(power_up_states, 86), get_channelNames_if(power_up_states, 87), get_state_if(power_up_states, 87), get_channelNames_if(power_up_states, 88), get_state_if(power_up_states, 88), get_channelNames_if(power_up_states, 89), get_state_if(power_up_states, 89), get_channelNames_if(power_up_states, 90), get_state_if(power_up_states, 90), get_channelNames_if(power_up_states, 91), get_state_if(power_up_states, 91), get_channelNames_if(power_up_states, 92), get_state_if(power_up_states, 92), get_channelNames_if(power_up_states, 93), get_state_if(power_up_states, 93), get_channelNames_if(power_up_states, 94), get_state_if(power_up_states, 94), get_channelNames_if(power_up_states, 95), get_state_if(power_up_states, 95), get_channelNames_if(power_up_states, 96), get_state_if(power_up_states, 96));
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -15167,6 +15503,7 @@ namespace nidaqmx_grpc {
 
       auto status = ((NiDAQmxLibrary*)library_)->SetDigitalPullUpPullDownStates(device_name, get_channelNames_if(pull_up_pull_down_states, 0), get_state_if(pull_up_pull_down_states, 0), get_channelNames_if(pull_up_pull_down_states, 1), get_state_if(pull_up_pull_down_states, 1), get_channelNames_if(pull_up_pull_down_states, 2), get_state_if(pull_up_pull_down_states, 2), get_channelNames_if(pull_up_pull_down_states, 3), get_state_if(pull_up_pull_down_states, 3), get_channelNames_if(pull_up_pull_down_states, 4), get_state_if(pull_up_pull_down_states, 4), get_channelNames_if(pull_up_pull_down_states, 5), get_state_if(pull_up_pull_down_states, 5), get_channelNames_if(pull_up_pull_down_states, 6), get_state_if(pull_up_pull_down_states, 6), get_channelNames_if(pull_up_pull_down_states, 7), get_state_if(pull_up_pull_down_states, 7), get_channelNames_if(pull_up_pull_down_states, 8), get_state_if(pull_up_pull_down_states, 8), get_channelNames_if(pull_up_pull_down_states, 9), get_state_if(pull_up_pull_down_states, 9), get_channelNames_if(pull_up_pull_down_states, 10), get_state_if(pull_up_pull_down_states, 10), get_channelNames_if(pull_up_pull_down_states, 11), get_state_if(pull_up_pull_down_states, 11), get_channelNames_if(pull_up_pull_down_states, 12), get_state_if(pull_up_pull_down_states, 12), get_channelNames_if(pull_up_pull_down_states, 13), get_state_if(pull_up_pull_down_states, 13), get_channelNames_if(pull_up_pull_down_states, 14), get_state_if(pull_up_pull_down_states, 14), get_channelNames_if(pull_up_pull_down_states, 15), get_state_if(pull_up_pull_down_states, 15), get_channelNames_if(pull_up_pull_down_states, 16), get_state_if(pull_up_pull_down_states, 16), get_channelNames_if(pull_up_pull_down_states, 17), get_state_if(pull_up_pull_down_states, 17), get_channelNames_if(pull_up_pull_down_states, 18), get_state_if(pull_up_pull_down_states, 18), get_channelNames_if(pull_up_pull_down_states, 19), get_state_if(pull_up_pull_down_states, 19), get_channelNames_if(pull_up_pull_down_states, 20), get_state_if(pull_up_pull_down_states, 20), get_channelNames_if(pull_up_pull_down_states, 21), get_state_if(pull_up_pull_down_states, 21), get_channelNames_if(pull_up_pull_down_states, 22), get_state_if(pull_up_pull_down_states, 22), get_channelNames_if(pull_up_pull_down_states, 23), get_state_if(pull_up_pull_down_states, 23), get_channelNames_if(pull_up_pull_down_states, 24), get_state_if(pull_up_pull_down_states, 24), get_channelNames_if(pull_up_pull_down_states, 25), get_state_if(pull_up_pull_down_states, 25), get_channelNames_if(pull_up_pull_down_states, 26), get_state_if(pull_up_pull_down_states, 26), get_channelNames_if(pull_up_pull_down_states, 27), get_state_if(pull_up_pull_down_states, 27), get_channelNames_if(pull_up_pull_down_states, 28), get_state_if(pull_up_pull_down_states, 28), get_channelNames_if(pull_up_pull_down_states, 29), get_state_if(pull_up_pull_down_states, 29), get_channelNames_if(pull_up_pull_down_states, 30), get_state_if(pull_up_pull_down_states, 30), get_channelNames_if(pull_up_pull_down_states, 31), get_state_if(pull_up_pull_down_states, 31), get_channelNames_if(pull_up_pull_down_states, 32), get_state_if(pull_up_pull_down_states, 32), get_channelNames_if(pull_up_pull_down_states, 33), get_state_if(pull_up_pull_down_states, 33), get_channelNames_if(pull_up_pull_down_states, 34), get_state_if(pull_up_pull_down_states, 34), get_channelNames_if(pull_up_pull_down_states, 35), get_state_if(pull_up_pull_down_states, 35), get_channelNames_if(pull_up_pull_down_states, 36), get_state_if(pull_up_pull_down_states, 36), get_channelNames_if(pull_up_pull_down_states, 37), get_state_if(pull_up_pull_down_states, 37), get_channelNames_if(pull_up_pull_down_states, 38), get_state_if(pull_up_pull_down_states, 38), get_channelNames_if(pull_up_pull_down_states, 39), get_state_if(pull_up_pull_down_states, 39), get_channelNames_if(pull_up_pull_down_states, 40), get_state_if(pull_up_pull_down_states, 40), get_channelNames_if(pull_up_pull_down_states, 41), get_state_if(pull_up_pull_down_states, 41), get_channelNames_if(pull_up_pull_down_states, 42), get_state_if(pull_up_pull_down_states, 42), get_channelNames_if(pull_up_pull_down_states, 43), get_state_if(pull_up_pull_down_states, 43), get_channelNames_if(pull_up_pull_down_states, 44), get_state_if(pull_up_pull_down_states, 44), get_channelNames_if(pull_up_pull_down_states, 45), get_state_if(pull_up_pull_down_states, 45), get_channelNames_if(pull_up_pull_down_states, 46), get_state_if(pull_up_pull_down_states, 46), get_channelNames_if(pull_up_pull_down_states, 47), get_state_if(pull_up_pull_down_states, 47), get_channelNames_if(pull_up_pull_down_states, 48), get_state_if(pull_up_pull_down_states, 48), get_channelNames_if(pull_up_pull_down_states, 49), get_state_if(pull_up_pull_down_states, 49), get_channelNames_if(pull_up_pull_down_states, 50), get_state_if(pull_up_pull_down_states, 50), get_channelNames_if(pull_up_pull_down_states, 51), get_state_if(pull_up_pull_down_states, 51), get_channelNames_if(pull_up_pull_down_states, 52), get_state_if(pull_up_pull_down_states, 52), get_channelNames_if(pull_up_pull_down_states, 53), get_state_if(pull_up_pull_down_states, 53), get_channelNames_if(pull_up_pull_down_states, 54), get_state_if(pull_up_pull_down_states, 54), get_channelNames_if(pull_up_pull_down_states, 55), get_state_if(pull_up_pull_down_states, 55), get_channelNames_if(pull_up_pull_down_states, 56), get_state_if(pull_up_pull_down_states, 56), get_channelNames_if(pull_up_pull_down_states, 57), get_state_if(pull_up_pull_down_states, 57), get_channelNames_if(pull_up_pull_down_states, 58), get_state_if(pull_up_pull_down_states, 58), get_channelNames_if(pull_up_pull_down_states, 59), get_state_if(pull_up_pull_down_states, 59), get_channelNames_if(pull_up_pull_down_states, 60), get_state_if(pull_up_pull_down_states, 60), get_channelNames_if(pull_up_pull_down_states, 61), get_state_if(pull_up_pull_down_states, 61), get_channelNames_if(pull_up_pull_down_states, 62), get_state_if(pull_up_pull_down_states, 62), get_channelNames_if(pull_up_pull_down_states, 63), get_state_if(pull_up_pull_down_states, 63), get_channelNames_if(pull_up_pull_down_states, 64), get_state_if(pull_up_pull_down_states, 64), get_channelNames_if(pull_up_pull_down_states, 65), get_state_if(pull_up_pull_down_states, 65), get_channelNames_if(pull_up_pull_down_states, 66), get_state_if(pull_up_pull_down_states, 66), get_channelNames_if(pull_up_pull_down_states, 67), get_state_if(pull_up_pull_down_states, 67), get_channelNames_if(pull_up_pull_down_states, 68), get_state_if(pull_up_pull_down_states, 68), get_channelNames_if(pull_up_pull_down_states, 69), get_state_if(pull_up_pull_down_states, 69), get_channelNames_if(pull_up_pull_down_states, 70), get_state_if(pull_up_pull_down_states, 70), get_channelNames_if(pull_up_pull_down_states, 71), get_state_if(pull_up_pull_down_states, 71), get_channelNames_if(pull_up_pull_down_states, 72), get_state_if(pull_up_pull_down_states, 72), get_channelNames_if(pull_up_pull_down_states, 73), get_state_if(pull_up_pull_down_states, 73), get_channelNames_if(pull_up_pull_down_states, 74), get_state_if(pull_up_pull_down_states, 74), get_channelNames_if(pull_up_pull_down_states, 75), get_state_if(pull_up_pull_down_states, 75), get_channelNames_if(pull_up_pull_down_states, 76), get_state_if(pull_up_pull_down_states, 76), get_channelNames_if(pull_up_pull_down_states, 77), get_state_if(pull_up_pull_down_states, 77), get_channelNames_if(pull_up_pull_down_states, 78), get_state_if(pull_up_pull_down_states, 78), get_channelNames_if(pull_up_pull_down_states, 79), get_state_if(pull_up_pull_down_states, 79), get_channelNames_if(pull_up_pull_down_states, 80), get_state_if(pull_up_pull_down_states, 80), get_channelNames_if(pull_up_pull_down_states, 81), get_state_if(pull_up_pull_down_states, 81), get_channelNames_if(pull_up_pull_down_states, 82), get_state_if(pull_up_pull_down_states, 82), get_channelNames_if(pull_up_pull_down_states, 83), get_state_if(pull_up_pull_down_states, 83), get_channelNames_if(pull_up_pull_down_states, 84), get_state_if(pull_up_pull_down_states, 84), get_channelNames_if(pull_up_pull_down_states, 85), get_state_if(pull_up_pull_down_states, 85), get_channelNames_if(pull_up_pull_down_states, 86), get_state_if(pull_up_pull_down_states, 86), get_channelNames_if(pull_up_pull_down_states, 87), get_state_if(pull_up_pull_down_states, 87), get_channelNames_if(pull_up_pull_down_states, 88), get_state_if(pull_up_pull_down_states, 88), get_channelNames_if(pull_up_pull_down_states, 89), get_state_if(pull_up_pull_down_states, 89), get_channelNames_if(pull_up_pull_down_states, 90), get_state_if(pull_up_pull_down_states, 90), get_channelNames_if(pull_up_pull_down_states, 91), get_state_if(pull_up_pull_down_states, 91), get_channelNames_if(pull_up_pull_down_states, 92), get_state_if(pull_up_pull_down_states, 92), get_channelNames_if(pull_up_pull_down_states, 93), get_state_if(pull_up_pull_down_states, 93), get_channelNames_if(pull_up_pull_down_states, 94), get_state_if(pull_up_pull_down_states, 94), get_channelNames_if(pull_up_pull_down_states, 95), get_state_if(pull_up_pull_down_states, 95), get_channelNames_if(pull_up_pull_down_states, 96), get_state_if(pull_up_pull_down_states, 96));
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -15210,6 +15547,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetExportedSignalAttributeBool(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15253,6 +15591,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetExportedSignalAttributeDouble(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15311,6 +15650,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetExportedSignalAttributeInt32(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15354,6 +15694,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetExportedSignalAttributeString(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15397,6 +15738,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetExportedSignalAttributeUInt32(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15420,6 +15762,7 @@ namespace nidaqmx_grpc {
       auto data = convert_from_grpc<CVIAbsoluteTime>(request->data());
       auto status = library_->SetFirstSampClkWhen(task, data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15463,6 +15806,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetReadAttributeBool(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15506,6 +15850,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetReadAttributeDouble(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15564,6 +15909,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetReadAttributeInt32(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15607,6 +15953,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetReadAttributeString(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15650,6 +15997,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetReadAttributeUInt32(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15693,6 +16041,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetReadAttributeUInt64(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15736,6 +16085,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetRealTimeAttributeBool(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15794,6 +16144,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetRealTimeAttributeInt32(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15837,6 +16188,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetRealTimeAttributeUInt32(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -15879,6 +16231,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetScaleAttributeDouble(scale_name, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -15921,6 +16274,7 @@ namespace nidaqmx_grpc {
       uInt32 size = static_cast<uInt32>(request->value().size());
       auto status = library_->SetScaleAttributeDoubleArray(scale_name, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -15978,6 +16332,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetScaleAttributeInt32(scale_name, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -16020,6 +16375,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetScaleAttributeString(scale_name, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -16043,6 +16399,7 @@ namespace nidaqmx_grpc {
       auto data = convert_from_grpc<CVIAbsoluteTime>(request->data());
       auto status = library_->SetStartTrigTrigWhen(task, data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16066,6 +16423,7 @@ namespace nidaqmx_grpc {
       auto data = convert_from_grpc<CVIAbsoluteTime>(request->data());
       auto status = library_->SetSyncPulseTimeWhen(task, data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16109,6 +16467,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTimingAttributeBool(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16152,6 +16511,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTimingAttributeDouble(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16196,6 +16556,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTimingAttributeExBool(task, device_names, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16240,6 +16601,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTimingAttributeExDouble(task, device_names, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16299,6 +16661,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTimingAttributeExInt32(task, device_names, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16343,6 +16706,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTimingAttributeExString(task, device_names, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16387,6 +16751,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTimingAttributeExTimestamp(task, device_names, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16431,6 +16796,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTimingAttributeExUInt32(task, device_names, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16475,6 +16841,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTimingAttributeExUInt64(task, device_names, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16533,6 +16900,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTimingAttributeInt32(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16576,6 +16944,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTimingAttributeString(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16619,6 +16988,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTimingAttributeTimestamp(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16662,6 +17032,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTimingAttributeUInt32(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16705,6 +17076,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTimingAttributeUInt64(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16748,6 +17120,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTrigAttributeBool(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16791,6 +17164,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTrigAttributeDouble(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16834,6 +17208,7 @@ namespace nidaqmx_grpc {
       uInt32 size = static_cast<uInt32>(request->value().size());
       auto status = library_->SetTrigAttributeDoubleArray(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16892,6 +17267,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTrigAttributeInt32(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16935,6 +17311,7 @@ namespace nidaqmx_grpc {
       uInt32 size = static_cast<uInt32>(request->value().size());
       auto status = library_->SetTrigAttributeInt32Array(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -16978,6 +17355,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTrigAttributeString(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17021,6 +17399,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTrigAttributeTimestamp(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17064,6 +17443,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetTrigAttributeUInt32(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17108,6 +17488,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetWatchdogAttributeBool(task, lines, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17152,6 +17533,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetWatchdogAttributeDouble(task, lines, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17211,6 +17593,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetWatchdogAttributeInt32(task, lines, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17255,6 +17638,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetWatchdogAttributeString(task, lines, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17298,6 +17682,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetWriteAttributeBool(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17341,6 +17726,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetWriteAttributeDouble(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17399,6 +17785,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetWriteAttributeInt32(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17442,6 +17829,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetWriteAttributeString(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17485,6 +17873,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetWriteAttributeUInt32(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17528,6 +17917,7 @@ namespace nidaqmx_grpc {
       auto size = 0U;
       auto status = library_->SetWriteAttributeUInt64(task, attribute, value, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17551,6 +17941,7 @@ namespace nidaqmx_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->StartNewFile(task, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17573,6 +17964,7 @@ namespace nidaqmx_grpc {
       TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
       auto status = library_->StartTask(task);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17595,6 +17987,7 @@ namespace nidaqmx_grpc {
       TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
       auto status = library_->StopTask(task);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17633,6 +18026,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->TaskControl(task, action);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17654,6 +18048,7 @@ namespace nidaqmx_grpc {
       auto output_terminal = request->output_terminal().c_str();
       auto status = library_->TristateOutputTerm(output_terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -17675,6 +18070,7 @@ namespace nidaqmx_grpc {
       auto device_name = request->device_name().c_str();
       auto status = library_->UnreserveNetworkDevice(device_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -17699,6 +18095,7 @@ namespace nidaqmx_grpc {
       bool32 is_late {};
       auto status = library_->WaitForNextSampleClock(task, timeout, &is_late);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17740,6 +18137,7 @@ namespace nidaqmx_grpc {
       CVIAbsoluteTime timestamp {};
       auto status = library_->WaitForValidTimestamp(task, timestamp_event, timeout, &timestamp);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17764,6 +18162,7 @@ namespace nidaqmx_grpc {
       float64 time_to_wait = request->time_to_wait();
       auto status = library_->WaitUntilTaskDone(task, time_to_wait);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17808,6 +18207,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteAnalogF64(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17835,6 +18235,7 @@ namespace nidaqmx_grpc {
       auto reserved = nullptr;
       auto status = library_->WriteAnalogScalarF64(task, auto_start, timeout, value, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17896,6 +18297,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteBinaryI16(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array.data(), &samps_per_chan_written, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -17944,6 +18346,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteBinaryI32(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -18006,6 +18409,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteBinaryU16(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array.data(), &samps_per_chan_written, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -18054,6 +18458,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteBinaryU32(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -18100,6 +18505,7 @@ namespace nidaqmx_grpc {
       int32 num_samps_per_chan_written {};
       auto status = library_->WriteCtrFreq(task, num_samps_per_chan, auto_start, timeout, data_layout, frequency, duty_cycle, &num_samps_per_chan_written, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -18128,6 +18534,7 @@ namespace nidaqmx_grpc {
       auto reserved = nullptr;
       auto status = library_->WriteCtrFreqScalar(task, auto_start, timeout, frequency, duty_cycle, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -18173,6 +18580,7 @@ namespace nidaqmx_grpc {
       int32 num_samps_per_chan_written {};
       auto status = library_->WriteCtrTicks(task, num_samps_per_chan, auto_start, timeout, data_layout, high_ticks, low_ticks, &num_samps_per_chan_written, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -18201,6 +18609,7 @@ namespace nidaqmx_grpc {
       auto reserved = nullptr;
       auto status = library_->WriteCtrTicksScalar(task, auto_start, timeout, high_ticks, low_ticks, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -18246,6 +18655,7 @@ namespace nidaqmx_grpc {
       int32 num_samps_per_chan_written {};
       auto status = library_->WriteCtrTime(task, num_samps_per_chan, auto_start, timeout, data_layout, high_time, low_time, &num_samps_per_chan_written, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -18274,6 +18684,7 @@ namespace nidaqmx_grpc {
       auto reserved = nullptr;
       auto status = library_->WriteCtrTimeScalar(task, auto_start, timeout, high_time, low_time, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -18318,6 +18729,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteDigitalLines(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -18345,6 +18757,7 @@ namespace nidaqmx_grpc {
       auto reserved = nullptr;
       auto status = library_->WriteDigitalScalarU32(task, auto_start, timeout, value, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -18406,6 +18819,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteDigitalU16(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array.data(), &samps_per_chan_written, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -18454,6 +18868,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteDigitalU32(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -18499,6 +18914,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteDigitalU8(task, num_samps_per_chan, auto_start, timeout, data_layout, write_array, &samps_per_chan_written, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -18528,6 +18944,7 @@ namespace nidaqmx_grpc {
       int32 samps_per_chan_written {};
       auto status = library_->WriteRaw(task, num_samps, auto_start, timeout, write_array, &samps_per_chan_written, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, task);
       }
       response->set_status(status);
@@ -18568,6 +18985,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->WriteToTEDSFromArray(physical_channel, bit_stream, array_size, basic_teds_options);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);
@@ -18606,6 +19024,7 @@ namespace nidaqmx_grpc {
 
       auto status = library_->WriteToTEDSFromFile(physical_channel, file_path, basic_teds_options);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForTaskHandle(status, 0);
       }
       response->set_status(status);

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -58,6 +58,7 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->AbortWithChannels(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -81,6 +82,7 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->CommitWithChannels(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -121,6 +123,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigureDigitalEdgeMeasureTriggerWithChannels(vi, channel_name, input_terminal, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -161,6 +164,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigureDigitalEdgePulseTriggerWithChannels(vi, channel_name, input_terminal, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -201,6 +205,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigureDigitalEdgeSequenceAdvanceTriggerWithChannels(vi, channel_name, input_terminal, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -241,6 +246,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigureDigitalEdgeShutdownTriggerWithChannels(vi, channel_name, input_terminal, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -281,6 +287,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigureDigitalEdgeSourceTriggerWithChannels(vi, channel_name, input_terminal, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -321,6 +328,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigureDigitalEdgeStartTriggerWithChannels(vi, channel_name, input_terminal, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -346,6 +354,7 @@ namespace nidcpower_grpc {
       ViReal64 limit = request->limit();
       auto status = library_->ConfigureOvp(vi, channel_name, enabled, limit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -369,6 +378,7 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->ConfigureSoftwareEdgeMeasureTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -392,6 +402,7 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->ConfigureSoftwareEdgePulseTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -415,6 +426,7 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->ConfigureSoftwareEdgeSequenceAdvanceTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -438,6 +450,7 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->ConfigureSoftwareEdgeShutdownTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -461,6 +474,7 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->ConfigureSoftwareEdgeSourceTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -484,6 +498,7 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->ConfigureSoftwareEdgeStartTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -523,6 +538,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigureSourceModeWithChannels(vi, channel_name, source_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -547,6 +563,7 @@ namespace nidcpower_grpc {
       ViBoolean set_as_active_step = request->set_as_active_step();
       auto status = library_->CreateAdvancedSequenceCommitStepWithChannels(vi, channel_name, set_as_active_step);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -571,6 +588,7 @@ namespace nidcpower_grpc {
       ViBoolean set_as_active_step = request->set_as_active_step();
       auto status = library_->CreateAdvancedSequenceStepWithChannels(vi, channel_name, set_as_active_step);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -598,6 +616,7 @@ namespace nidcpower_grpc {
       ViBoolean set_as_active_sequence = request->set_as_active_sequence();
       auto status = library_->CreateAdvancedSequenceWithChannels(vi, channel_name, sequence_name, attribute_id_count, attribute_ids, set_as_active_sequence);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -624,6 +643,7 @@ namespace nidcpower_grpc {
       ViBoolean set_as_active_sequence = request->set_as_active_sequence();
       auto status = library_->CreateAdvancedSequence(vi, sequence_name, attribute_id_count, attribute_ids, set_as_active_sequence);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -648,6 +668,7 @@ namespace nidcpower_grpc {
       auto sequence_name = request->sequence_name().c_str();
       auto status = library_->DeleteAdvancedSequenceWithChannels(vi, channel_name, sequence_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -671,6 +692,7 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->DisablePulseTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -694,6 +716,7 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->DisableSequenceAdvanceTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -717,6 +740,7 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->DisableShutdownTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -740,6 +764,7 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->DisableSourceTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -763,6 +788,7 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->DisableStartTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -787,6 +813,7 @@ namespace nidcpower_grpc {
       ViInt32 error_code {};
       auto status = library_->ErrorQuery(vi, &error_code, error_message);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -829,6 +856,7 @@ namespace nidcpower_grpc {
       auto output_terminal = request->output_terminal().c_str();
       auto status = library_->ExportSignalWithChannels(vi, channel_name, signal, signal_identifier, output_terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -861,6 +889,7 @@ namespace nidcpower_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -888,6 +917,7 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->InitiateWithChannels(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -910,6 +940,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->InvalidateAllAttributes(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -933,6 +964,7 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->ResetWithChannels(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -972,6 +1004,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->SendSoftwareEdgeTriggerWithChannels(vi, channel_name, trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1012,6 +1045,7 @@ namespace nidcpower_grpc {
       ViReal64 timeout = request->timeout();
       auto status = library_->WaitForEventWithChannels(vi, channel_name, event_id, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1034,6 +1068,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Abort(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1057,6 +1092,7 @@ namespace nidcpower_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->CalSelfCalibrate(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1079,6 +1115,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ClearError(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1101,6 +1138,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ClearInterchangeWarnings(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1124,6 +1162,7 @@ namespace nidcpower_grpc {
       session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1146,6 +1185,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Commit(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1186,6 +1226,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigureApertureTime(vi, channel_name, aperture_time, units);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1225,6 +1266,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigureAutoZero(vi, channel_name, auto_zero);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1249,6 +1291,7 @@ namespace nidcpower_grpc {
       ViReal64 level = request->level();
       auto status = library_->ConfigureCurrentLevel(vi, channel_name, level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1273,6 +1316,7 @@ namespace nidcpower_grpc {
       ViReal64 range = request->range();
       auto status = library_->ConfigureCurrentLevelRange(vi, channel_name, range);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1313,6 +1357,7 @@ namespace nidcpower_grpc {
       ViReal64 limit = request->limit();
       auto status = library_->ConfigureCurrentLimit(vi, channel_name, behavior, limit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1337,6 +1382,7 @@ namespace nidcpower_grpc {
       ViReal64 range = request->range();
       auto status = library_->ConfigureCurrentLimitRange(vi, channel_name, range);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1376,6 +1422,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigureDigitalEdgeMeasureTrigger(vi, input_terminal, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1415,6 +1462,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigureDigitalEdgePulseTrigger(vi, input_terminal, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1454,6 +1502,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigureDigitalEdgeSequenceAdvanceTrigger(vi, input_terminal, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1493,6 +1542,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigureDigitalEdgeSourceTrigger(vi, input_terminal, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1532,6 +1582,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigureDigitalEdgeStartTrigger(vi, input_terminal, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1556,6 +1607,7 @@ namespace nidcpower_grpc {
       ViBoolean enabled = request->enabled();
       auto status = library_->ConfigureOutputEnabled(vi, channel_name, enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1595,6 +1647,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigureOutputFunction(vi, channel_name, function);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1619,6 +1672,7 @@ namespace nidcpower_grpc {
       ViReal64 resistance = request->resistance();
       auto status = library_->ConfigureOutputResistance(vi, channel_name, resistance);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1657,6 +1711,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigurePowerLineFrequency(vi, powerline_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1681,6 +1736,7 @@ namespace nidcpower_grpc {
       ViReal64 level = request->level();
       auto status = library_->ConfigurePulseBiasCurrentLevel(vi, channel_name, level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1705,6 +1761,7 @@ namespace nidcpower_grpc {
       ViReal64 limit = request->limit();
       auto status = library_->ConfigurePulseBiasCurrentLimit(vi, channel_name, limit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1729,6 +1786,7 @@ namespace nidcpower_grpc {
       ViReal64 level = request->level();
       auto status = library_->ConfigurePulseBiasVoltageLevel(vi, channel_name, level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1753,6 +1811,7 @@ namespace nidcpower_grpc {
       ViReal64 limit = request->limit();
       auto status = library_->ConfigurePulseBiasVoltageLimit(vi, channel_name, limit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1777,6 +1836,7 @@ namespace nidcpower_grpc {
       ViReal64 level = request->level();
       auto status = library_->ConfigurePulseCurrentLevel(vi, channel_name, level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1801,6 +1861,7 @@ namespace nidcpower_grpc {
       ViReal64 range = request->range();
       auto status = library_->ConfigurePulseCurrentLevelRange(vi, channel_name, range);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1825,6 +1886,7 @@ namespace nidcpower_grpc {
       ViReal64 limit = request->limit();
       auto status = library_->ConfigurePulseCurrentLimit(vi, channel_name, limit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1849,6 +1911,7 @@ namespace nidcpower_grpc {
       ViReal64 range = request->range();
       auto status = library_->ConfigurePulseCurrentLimitRange(vi, channel_name, range);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1873,6 +1936,7 @@ namespace nidcpower_grpc {
       ViReal64 level = request->level();
       auto status = library_->ConfigurePulseVoltageLevel(vi, channel_name, level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1897,6 +1961,7 @@ namespace nidcpower_grpc {
       ViReal64 range = request->range();
       auto status = library_->ConfigurePulseVoltageLevelRange(vi, channel_name, range);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1921,6 +1986,7 @@ namespace nidcpower_grpc {
       ViReal64 limit = request->limit();
       auto status = library_->ConfigurePulseVoltageLimit(vi, channel_name, limit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1945,6 +2011,7 @@ namespace nidcpower_grpc {
       ViReal64 range = request->range();
       auto status = library_->ConfigurePulseVoltageLimitRange(vi, channel_name, range);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1984,6 +2051,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigureSense(vi, channel_name, sense);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2006,6 +2074,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgeMeasureTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2028,6 +2097,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgePulseTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2050,6 +2120,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgeSequenceAdvanceTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2072,6 +2143,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgeSourceTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2094,6 +2166,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgeStartTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2132,6 +2205,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->ConfigureSourceMode(vi, source_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2156,6 +2230,7 @@ namespace nidcpower_grpc {
       ViReal64 level = request->level();
       auto status = library_->ConfigureVoltageLevel(vi, channel_name, level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2180,6 +2255,7 @@ namespace nidcpower_grpc {
       ViReal64 range = request->range();
       auto status = library_->ConfigureVoltageLevelRange(vi, channel_name, range);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2204,6 +2280,7 @@ namespace nidcpower_grpc {
       ViReal64 limit = request->limit();
       auto status = library_->ConfigureVoltageLimit(vi, channel_name, limit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2228,6 +2305,7 @@ namespace nidcpower_grpc {
       ViReal64 range = request->range();
       auto status = library_->ConfigureVoltageLimitRange(vi, channel_name, range);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2251,6 +2329,7 @@ namespace nidcpower_grpc {
       ViBoolean set_as_active_step = request->set_as_active_step();
       auto status = library_->CreateAdvancedSequenceStep(vi, set_as_active_step);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2274,6 +2353,7 @@ namespace nidcpower_grpc {
       auto sequence_name = request->sequence_name().c_str();
       auto status = library_->DeleteAdvancedSequence(vi, sequence_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2296,6 +2376,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Disable(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2318,6 +2399,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->DisablePulseTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2340,6 +2422,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->DisableSequenceAdvanceTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2362,6 +2445,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->DisableSourceTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2384,6 +2468,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->DisableStartTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2408,6 +2493,7 @@ namespace nidcpower_grpc {
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2434,6 +2520,7 @@ namespace nidcpower_grpc {
       while (true) {
         auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 size = status;
@@ -2446,6 +2533,7 @@ namespace nidcpower_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2470,6 +2558,7 @@ namespace nidcpower_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->ExportAttributeConfigurationFile(vi, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2510,6 +2599,7 @@ namespace nidcpower_grpc {
       auto output_terminal = request->output_terminal().c_str();
       auto status = library_->ExportSignal(vi, signal, signal_identifier, output_terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2541,6 +2631,7 @@ namespace nidcpower_grpc {
       ViInt32 actual_count {};
       auto status = library_->FetchMultiple(vi, channel_name, timeout, count, voltage_measurements, current_measurements, in_compliance.data(), &actual_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2568,6 +2659,7 @@ namespace nidcpower_grpc {
       ViBoolean attribute_value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2594,6 +2686,7 @@ namespace nidcpower_grpc {
       ViInt32 attribute_value {};
       auto status = library_->GetAttributeViInt32(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2620,6 +2713,7 @@ namespace nidcpower_grpc {
       ViInt64 attribute_value {};
       auto status = library_->GetAttributeViInt64(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2646,6 +2740,7 @@ namespace nidcpower_grpc {
       ViReal64 attribute_value {};
       auto status = library_->GetAttributeViReal64(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2672,6 +2767,7 @@ namespace nidcpower_grpc {
       ViSession attribute_value {};
       auto status = library_->GetAttributeViSession(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2700,6 +2796,7 @@ namespace nidcpower_grpc {
       while (true) {
         auto status = library_->GetAttributeViString(vi, channel_name, attribute_id, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -2714,6 +2811,7 @@ namespace nidcpower_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2742,6 +2840,7 @@ namespace nidcpower_grpc {
       while (true) {
         auto status = library_->GetChannelName(vi, index, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -2756,6 +2855,7 @@ namespace nidcpower_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2784,6 +2884,7 @@ namespace nidcpower_grpc {
       while (true) {
         auto status = library_->GetChannelNameFromString(vi, index, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -2798,6 +2899,7 @@ namespace nidcpower_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2825,6 +2927,7 @@ namespace nidcpower_grpc {
       while (true) {
         auto status = library_->GetError(vi, nullptr, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -2840,6 +2943,7 @@ namespace nidcpower_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2871,6 +2975,7 @@ namespace nidcpower_grpc {
       ViInt32 minute {};
       auto status = library_->GetExtCalLastDateAndTime(vi, &year, &month, &day, &hour, &minute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2899,6 +3004,7 @@ namespace nidcpower_grpc {
       ViReal64 temperature {};
       auto status = library_->GetExtCalLastTemp(vi, &temperature);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2923,6 +3029,7 @@ namespace nidcpower_grpc {
       ViInt32 months {};
       auto status = library_->GetExtCalRecommendedInterval(vi, &months);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2948,6 +3055,7 @@ namespace nidcpower_grpc {
       while (true) {
         auto status = library_->GetNextCoercionRecord(vi, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -2962,6 +3070,7 @@ namespace nidcpower_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2989,6 +3098,7 @@ namespace nidcpower_grpc {
       while (true) {
         auto status = library_->GetNextInterchangeWarning(vi, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -3003,6 +3113,7 @@ namespace nidcpower_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -3033,6 +3144,7 @@ namespace nidcpower_grpc {
       ViInt32 minute {};
       auto status = library_->GetSelfCalLastDateAndTime(vi, &year, &month, &day, &hour, &minute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3061,6 +3173,7 @@ namespace nidcpower_grpc {
       ViReal64 temperature {};
       auto status = library_->GetSelfCalLastTemp(vi, &temperature);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3086,6 +3199,7 @@ namespace nidcpower_grpc {
       auto configuration = const_cast<ViAddr*>(reinterpret_cast<const ViAddr*>(request->configuration().data()));
       auto status = library_->ImportAttributeConfigurationBuffer(vi, size, configuration);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3109,6 +3223,7 @@ namespace nidcpower_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->ImportAttributeConfigurationFile(vi, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3142,6 +3257,7 @@ namespace nidcpower_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -3168,6 +3284,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Initiate(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3208,6 +3325,7 @@ namespace nidcpower_grpc {
       ViReal64 measurement {};
       auto status = library_->Measure(vi, channel_name, measurement_type, &measurement);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3233,6 +3351,7 @@ namespace nidcpower_grpc {
       ViBoolean in_compliance {};
       auto status = library_->QueryInCompliance(vi, channel_name, &in_compliance);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3259,6 +3378,7 @@ namespace nidcpower_grpc {
       ViReal64 max_current_limit {};
       auto status = library_->QueryMaxCurrentLimit(vi, channel_name, voltage_level, &max_current_limit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3285,6 +3405,7 @@ namespace nidcpower_grpc {
       ViReal64 max_voltage_level {};
       auto status = library_->QueryMaxVoltageLevel(vi, channel_name, current_limit, &max_voltage_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3311,6 +3432,7 @@ namespace nidcpower_grpc {
       ViReal64 min_current_limit {};
       auto status = library_->QueryMinCurrentLimit(vi, channel_name, voltage_level, &min_current_limit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3352,6 +3474,7 @@ namespace nidcpower_grpc {
       ViBoolean in_state {};
       auto status = library_->QueryOutputState(vi, channel_name, output_state, &in_state);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3376,6 +3499,7 @@ namespace nidcpower_grpc {
       ViReal64 temperature {};
       auto status = library_->ReadCurrentTemperature(vi, &temperature);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3399,6 +3523,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3421,6 +3546,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ResetDevice(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3443,6 +3569,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ResetInterchangeCheck(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3465,6 +3592,7 @@ namespace nidcpower_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ResetWithDefaults(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3489,6 +3617,7 @@ namespace nidcpower_grpc {
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3517,6 +3646,7 @@ namespace nidcpower_grpc {
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3558,6 +3688,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->SendSoftwareEdgeTrigger(vi, trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3583,6 +3714,7 @@ namespace nidcpower_grpc {
       ViBoolean attribute_value = request->attribute_value();
       auto status = library_->SetAttributeViBoolean(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3623,6 +3755,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->SetAttributeViInt32(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3648,6 +3781,7 @@ namespace nidcpower_grpc {
       ViInt64 attribute_value = request->attribute_value_raw();
       auto status = library_->SetAttributeViInt64(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3688,6 +3822,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->SetAttributeViReal64(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3714,6 +3849,7 @@ namespace nidcpower_grpc {
       ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.id(), attribute_value_grpc_session.name());
       auto status = library_->SetAttributeViSession(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3739,6 +3875,7 @@ namespace nidcpower_grpc {
       auto attribute_value = request->attribute_value_raw().c_str();
       auto status = library_->SetAttributeViString(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3776,6 +3913,7 @@ namespace nidcpower_grpc {
 
       auto status = library_->SetSequence(vi, channel_name, values, source_delays, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3815,6 +3953,7 @@ namespace nidcpower_grpc {
       ViReal64 timeout = request->timeout();
       auto status = library_->WaitForEvent(vi, event_id, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -66,6 +66,7 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Abort(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -88,6 +89,7 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->AbortKeepAlive(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -116,6 +118,7 @@ namespace nidigitalpattern_grpc {
       auto initial_state_tristate_pins = request->initial_state_tristate_pins().c_str();
       auto status = library_->ApplyLevelsAndTiming(vi, site_list, levels_sheet, timing_sheet, initial_state_high_pins, initial_state_low_pins, initial_state_tristate_pins);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -141,6 +144,7 @@ namespace nidigitalpattern_grpc {
       auto offsets = const_cast<ViReal64*>(request->offsets().data());
       auto status = library_->ApplyTDROffsets(vi, channel_list, num_offsets, offsets);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -168,6 +172,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 timeout = request->timeout();
       auto status = library_->BurstPattern(vi, site_list, start_label, select_digital_function, wait_until_done, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -201,6 +206,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 timeout = request->timeout();
       auto status = library_->BurstPatternSynchronized(session_count, sessions.data(), site_list, start_label, select_digital_function, wait_until_done, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -223,6 +229,7 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ClearError(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -246,6 +253,7 @@ namespace nidigitalpattern_grpc {
       auto channel_list = request->channel_list().c_str();
       auto status = library_->ClockGeneratorAbort(vi, channel_list);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -271,6 +279,7 @@ namespace nidigitalpattern_grpc {
       ViBoolean select_digital_function = request->select_digital_function();
       auto status = library_->ClockGeneratorGenerateClock(vi, channel_list, frequency, select_digital_function);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -294,6 +303,7 @@ namespace nidigitalpattern_grpc {
       auto channel_list = request->channel_list().c_str();
       auto status = library_->ClockGeneratorInitiate(vi, channel_list);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -317,6 +327,7 @@ namespace nidigitalpattern_grpc {
       session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -339,6 +350,7 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Commit(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -365,6 +377,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 vcom = request->vcom();
       auto status = library_->ConfigureActiveLoadLevels(vi, channel_list, iol, ioh, vcom);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -389,6 +402,7 @@ namespace nidigitalpattern_grpc {
       ViInt32 pretrigger_samples = request->pretrigger_samples();
       auto status = library_->ConfigureCycleNumberHistoryRAMTrigger(vi, cycle_number, pretrigger_samples);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -429,6 +443,7 @@ namespace nidigitalpattern_grpc {
 
       auto status = library_->ConfigureDigitalEdgeConditionalJumpTrigger(vi, trigger_identifier, source, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -468,6 +483,7 @@ namespace nidigitalpattern_grpc {
 
       auto status = library_->ConfigureDigitalEdgeStartTrigger(vi, source, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -491,6 +507,7 @@ namespace nidigitalpattern_grpc {
       ViInt32 pretrigger_samples = request->pretrigger_samples();
       auto status = library_->ConfigureFirstFailureHistoryRAMTrigger(vi, pretrigger_samples);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -529,6 +546,7 @@ namespace nidigitalpattern_grpc {
 
       auto status = library_->ConfigureHistoryRAMCyclesToAcquire(vi, cycles_to_acquire);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -552,6 +570,7 @@ namespace nidigitalpattern_grpc {
       auto site_list = request->site_list().c_str();
       auto status = library_->ConfigurePatternBurstSites(vi, site_list);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -578,6 +597,7 @@ namespace nidigitalpattern_grpc {
       ViInt32 pretrigger_samples = request->pretrigger_samples();
       auto status = library_->ConfigurePatternLabelHistoryRAMTrigger(vi, label, vector_offset, cycle_offset, pretrigger_samples);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -601,6 +621,7 @@ namespace nidigitalpattern_grpc {
       auto label = request->label().c_str();
       auto status = library_->ConfigureStartLabel(vi, label);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -624,6 +645,7 @@ namespace nidigitalpattern_grpc {
       auto trigger_identifier = request->trigger_identifier().c_str();
       auto status = library_->ConfigureSoftwareEdgeConditionalJumpTrigger(vi, trigger_identifier);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -646,6 +668,7 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgeStartTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -685,6 +708,7 @@ namespace nidigitalpattern_grpc {
 
       auto status = library_->ConfigureTerminationMode(vi, channel_list, mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -710,6 +734,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 strobe_edge = request->strobe_edge();
       auto status = library_->ConfigureTimeSetCompareEdgesStrobe(vi, pin_list, time_set_name, strobe_edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -736,6 +761,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 strobe2_edge = request->strobe2_edge();
       auto status = library_->ConfigureTimeSetCompareEdgesStrobe2x(vi, pin_list, time_set_name, strobe_edge, strobe2_edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -780,6 +806,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 drive_off_edge = request->drive_off_edge();
       auto status = library_->ConfigureTimeSetDriveEdges(vi, pin_list, time_set_name, format, drive_on_edge, drive_data_edge, drive_return_edge, drive_off_edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -826,6 +853,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 drive_return2_edge = request->drive_return2_edge();
       auto status = library_->ConfigureTimeSetDriveEdges2x(vi, pin_list, time_set_name, format, drive_on_edge, drive_data_edge, drive_return_edge, drive_off_edge, drive_data2_edge, drive_return2_edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -866,6 +894,7 @@ namespace nidigitalpattern_grpc {
 
       auto status = library_->ConfigureTimeSetDriveFormat(vi, pin_list, time_set_name, drive_format);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -907,6 +936,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 time = request->time();
       auto status = library_->ConfigureTimeSetEdge(vi, pin_list, time_set_name, edge, time);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -932,6 +962,7 @@ namespace nidigitalpattern_grpc {
       ViInt32 edge_multiplier = request->edge_multiplier();
       auto status = library_->ConfigureTimeSetEdgeMultiplier(vi, pin_list, time_set_name, edge_multiplier);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -956,6 +987,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 period = request->period();
       auto status = library_->ConfigureTimeSetPeriod(vi, time_set_name, period);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -984,6 +1016,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 vterm = request->vterm();
       auto status = library_->ConfigureVoltageLevels(vi, channel_list, vil, vih, vol, voh, vterm);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1008,6 +1041,7 @@ namespace nidigitalpattern_grpc {
       auto waveform_file_path = request->waveform_file_path().c_str();
       auto status = library_->CreateCaptureWaveformFromFileDigicapture(vi, waveform_name, waveform_file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1032,6 +1066,7 @@ namespace nidigitalpattern_grpc {
       auto waveform_name = request->waveform_name().c_str();
       auto status = library_->CreateCaptureWaveformParallel(vi, pin_list, waveform_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1073,6 +1108,7 @@ namespace nidigitalpattern_grpc {
 
       auto status = library_->CreateCaptureWaveformSerial(vi, pin_list, waveform_name, sample_width, bit_order);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1096,6 +1132,7 @@ namespace nidigitalpattern_grpc {
       ViInt32 num_sites = request->num_sites();
       auto status = library_->CreateChannelMap(vi, num_sites);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1121,6 +1158,7 @@ namespace nidigitalpattern_grpc {
       ViBoolean write_waveform_data = request->write_waveform_data();
       auto status = library_->CreateSourceWaveformFromFileTDMS(vi, waveform_name, waveform_file_path, write_waveform_data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1145,6 +1183,7 @@ namespace nidigitalpattern_grpc {
       auto system_pin_list = request->system_pin_list().c_str();
       auto status = library_->CreatePinMap(vi, dut_pin_list, system_pin_list);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1169,6 +1208,7 @@ namespace nidigitalpattern_grpc {
       auto pin_list = request->pin_list().c_str();
       auto status = library_->CreatePinGroup(vi, pin_group_name, pin_list);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1209,6 +1249,7 @@ namespace nidigitalpattern_grpc {
 
       auto status = library_->CreateSourceWaveformParallel(vi, pin_list, waveform_name, data_mapping);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1266,6 +1307,7 @@ namespace nidigitalpattern_grpc {
 
       auto status = library_->CreateSourceWaveformSerial(vi, pin_list, waveform_name, data_mapping, sample_width, bit_order);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1289,6 +1331,7 @@ namespace nidigitalpattern_grpc {
       auto name = request->name().c_str();
       auto status = library_->CreateTimeSet(vi, name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1311,6 +1354,7 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->DeleteAllTimeSets(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1334,6 +1378,7 @@ namespace nidigitalpattern_grpc {
       auto trigger_identifier = request->trigger_identifier().c_str();
       auto status = library_->DisableConditionalJumpTrigger(vi, trigger_identifier);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1357,6 +1402,7 @@ namespace nidigitalpattern_grpc {
       auto site_list = request->site_list().c_str();
       auto status = library_->DisableSites(vi, site_list);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1379,6 +1425,7 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->DisableStartTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1409,6 +1456,7 @@ namespace nidigitalpattern_grpc {
       ViSession sync_session = session_repository_->access_session(sync_session_grpc_session.id(), sync_session_grpc_session.name());
       auto status = library_->EnableMatchFailCombination(session_count, sessions.data(), sync_session);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, sync_session);
       }
       response->set_status(status);
@@ -1432,6 +1480,7 @@ namespace nidigitalpattern_grpc {
       auto site_list = request->site_list().c_str();
       auto status = library_->EnableSites(vi, site_list);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1454,6 +1503,7 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->EndChannelMap(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1478,6 +1528,7 @@ namespace nidigitalpattern_grpc {
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1520,6 +1571,7 @@ namespace nidigitalpattern_grpc {
       auto output_terminal = request->output_terminal().c_str();
       auto status = library_->ExportSignal(vi, signal, signal_identifier, output_terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1549,6 +1601,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->FetchCaptureWaveformU32(vi, site_list, waveform_name, samples_to_read, timeout, 0, nullptr, &actual_num_waveforms, &actual_samples_per_waveform);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->mutable_data()->Resize(actual_num_waveforms, 0);
@@ -1560,6 +1613,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1593,6 +1647,7 @@ namespace nidigitalpattern_grpc {
       ViInt32 num_dut_cycles {};
       auto status = library_->FetchHistoryRAMCycleInformation(vi, site, sample_index, &pattern_index, &time_set_index, &vector_number, &cycle_number, &num_dut_cycles);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1626,6 +1681,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->FetchHistoryRAMCyclePinData(vi, site, pin_list, sample_index, dut_cycle_index, 0, nullptr, nullptr, nullptr, &actual_num_pin_data);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         std::string expected_pin_states(actual_num_pin_data, '\0');
@@ -1638,6 +1694,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1673,6 +1730,7 @@ namespace nidigitalpattern_grpc {
       ViInt64 scan_cycle_number {};
       auto status = library_->FetchHistoryRAMScanCycleNumber(vi, site, sample_index, &scan_cycle_number);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1712,6 +1770,7 @@ namespace nidigitalpattern_grpc {
 
       auto status = library_->FrequencyCounterConfigureMeasurementMode(vi, measurement_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1736,6 +1795,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 measurement_time = request->measurement_time();
       auto status = library_->FrequencyCounterConfigureMeasurementTime(vi, channel_list, measurement_time);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1761,6 +1821,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->FrequencyCounterMeasureFrequency(vi, channel_list, 0, nullptr, &actual_num_frequencies);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->mutable_frequencies()->Resize(actual_num_frequencies, 0);
@@ -1772,6 +1833,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1800,6 +1862,7 @@ namespace nidigitalpattern_grpc {
       ViBoolean value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_name, attribute, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1826,6 +1889,7 @@ namespace nidigitalpattern_grpc {
       ViInt32 value {};
       auto status = library_->GetAttributeViInt32(vi, channel_name, attribute, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1852,6 +1916,7 @@ namespace nidigitalpattern_grpc {
       ViInt64 value {};
       auto status = library_->GetAttributeViInt64(vi, channel_name, attribute, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1878,6 +1943,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 value {};
       auto status = library_->GetAttributeViReal64(vi, channel_name, attribute, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1904,6 +1970,7 @@ namespace nidigitalpattern_grpc {
       ViSession value {};
       auto status = library_->GetAttributeViSession(vi, channel_list, attribute, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1932,6 +1999,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->GetAttributeViString(vi, channel_name, attribute, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -1946,6 +2014,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1974,6 +2043,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->GetChannelName(vi, index, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 name_buffer_size = status;
@@ -1988,6 +2058,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2016,6 +2087,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->GetChannelNameFromString(vi, indices, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 name_buffer_size = status;
@@ -2030,6 +2102,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2057,6 +2130,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->GetError(vi, nullptr, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 error_description_buffer_size = status;
@@ -2072,6 +2146,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2101,6 +2176,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->GetFailCount(vi, channel_list, 0, nullptr, &actual_num_read);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->mutable_failure_count()->Resize(actual_num_read, 0);
@@ -2112,6 +2188,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2139,6 +2216,7 @@ namespace nidigitalpattern_grpc {
       ViInt64 sample_count {};
       auto status = library_->GetHistoryRAMSampleCount(vi, site, &sample_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2165,6 +2243,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->GetPatternPinIndexes(vi, start_label, 0, nullptr, &actual_num_pins);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->mutable_pin_indexes()->Resize(actual_num_pins, 0);
@@ -2176,6 +2255,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2204,6 +2284,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->GetPatternName(vi, pattern_index, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 name_buffer_size = status;
@@ -2218,6 +2299,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2246,6 +2328,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->GetPatternPinList(vi, start_label, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 pin_list_buffer_size = status;
@@ -2260,6 +2343,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2288,6 +2372,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->GetPinName(vi, pin_index, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 name_buffer_size = status;
@@ -2302,6 +2387,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2330,6 +2416,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->GetPinResultsPinInformation(vi, channel_list, 0, nullptr, nullptr, nullptr, &actual_num_values);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->mutable_pin_indexes()->Resize(actual_num_values, 0);
@@ -2345,6 +2432,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2375,6 +2463,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->GetSitePassFail(vi, site_list, 0, nullptr, &actual_num_sites);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         std::vector<ViBoolean> pass_fail(actual_num_sites, ViBoolean());
@@ -2385,6 +2474,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2430,6 +2520,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->GetSiteResultsSiteNumbers(vi, site_list, site_result_type, 0, nullptr, &actual_num_site_numbers);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->mutable_site_numbers()->Resize(actual_num_site_numbers, 0);
@@ -2441,6 +2532,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2469,6 +2561,7 @@ namespace nidigitalpattern_grpc {
       ViInt32 format {};
       auto status = library_->GetTimeSetDriveFormat(vi, pin, time_set_name, &format);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2512,6 +2605,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 time {};
       auto status = library_->GetTimeSetEdge(vi, pin, time_set_name, edge, &time);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2538,6 +2632,7 @@ namespace nidigitalpattern_grpc {
       ViInt32 edge_multiplier {};
       auto status = library_->GetTimeSetEdgeMultiplier(vi, pin, time_set_name, &edge_multiplier);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2564,6 +2659,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->GetTimeSetName(vi, time_set_index, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 name_buffer_size = status;
@@ -2578,6 +2674,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2605,6 +2702,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 period {};
       auto status = library_->GetTimeSetPeriod(vi, time_set_name, &period);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2638,6 +2736,7 @@ namespace nidigitalpattern_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -2675,6 +2774,7 @@ namespace nidigitalpattern_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -2701,6 +2801,7 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Initiate(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2724,6 +2825,7 @@ namespace nidigitalpattern_grpc {
       ViBoolean done {};
       auto status = library_->IsDone(vi, &done);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2749,6 +2851,7 @@ namespace nidigitalpattern_grpc {
       ViBoolean enable {};
       auto status = library_->IsSiteEnabled(vi, site, &enable);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2773,6 +2876,7 @@ namespace nidigitalpattern_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->LoadLevels(vi, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2796,6 +2900,7 @@ namespace nidigitalpattern_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->LoadPattern(vi, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2819,6 +2924,7 @@ namespace nidigitalpattern_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->LoadPinMap(vi, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2842,6 +2948,7 @@ namespace nidigitalpattern_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->LoadSpecifications(vi, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2865,6 +2972,7 @@ namespace nidigitalpattern_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->LoadTiming(vi, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2890,6 +2998,7 @@ namespace nidigitalpattern_grpc {
       auto channel = request->channel().c_str();
       auto status = library_->MapPinToChannel(vi, pin, site, channel);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2930,6 +3039,7 @@ namespace nidigitalpattern_grpc {
 
       auto status = library_->PPMUConfigureApertureTime(vi, channel_list, aperture_time, units);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2954,6 +3064,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 current_level = request->current_level();
       auto status = library_->PPMUConfigureCurrentLevel(vi, channel_list, current_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2978,6 +3089,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 range = request->range();
       auto status = library_->PPMUConfigureCurrentLevelRange(vi, channel_list, range);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3018,6 +3130,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 limit = request->limit();
       auto status = library_->PPMUConfigureCurrentLimit(vi, channel_list, behavior, limit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3042,6 +3155,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 range = request->range();
       auto status = library_->PPMUConfigureCurrentLimitRange(vi, channel_list, range);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3081,6 +3195,7 @@ namespace nidigitalpattern_grpc {
 
       auto status = library_->PPMUConfigureOutputFunction(vi, channel_list, output_function);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3105,6 +3220,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 voltage_level = request->voltage_level();
       auto status = library_->PPMUConfigureVoltageLevel(vi, channel_list, voltage_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3130,6 +3246,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 upper_voltage_limit = request->upper_voltage_limit();
       auto status = library_->PPMUConfigureVoltageLimits(vi, channel_list, lower_voltage_limit, upper_voltage_limit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3171,6 +3288,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->PPMUMeasure(vi, channel_list, measurement_type, 0, nullptr, &actual_num_read);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->mutable_measurements()->Resize(actual_num_read, 0);
@@ -3182,6 +3300,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -3208,6 +3327,7 @@ namespace nidigitalpattern_grpc {
       auto channel_list = request->channel_list().c_str();
       auto status = library_->PPMUSource(vi, channel_list);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3232,6 +3352,7 @@ namespace nidigitalpattern_grpc {
       ViBoolean value {};
       auto status = library_->ReadSequencerFlag(vi, flag, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3257,6 +3378,7 @@ namespace nidigitalpattern_grpc {
       ViInt32 value {};
       auto status = library_->ReadSequencerRegister(vi, reg, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3283,6 +3405,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->ReadStatic(vi, channel_list, 0, nullptr, &actual_num_read);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         std::string data(actual_num_read, '\0');
@@ -3293,6 +3416,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -3320,6 +3444,7 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3344,6 +3469,7 @@ namespace nidigitalpattern_grpc {
       ViAttr attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(vi, channel_name, attribute_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3366,6 +3492,7 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ResetDevice(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3405,6 +3532,7 @@ namespace nidigitalpattern_grpc {
 
       auto status = library_->SelectFunction(vi, channel_list, function);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3427,6 +3555,7 @@ namespace nidigitalpattern_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->SelfCalibrate(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3451,6 +3580,7 @@ namespace nidigitalpattern_grpc {
       std::string test_message(2048 - 1, '\0');
       auto status = library_->SelfTest(vi, &test_result, (ViChar*)test_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3493,6 +3623,7 @@ namespace nidigitalpattern_grpc {
       auto trigger_identifier = request->trigger_identifier().c_str();
       auto status = library_->SendSoftwareEdgeTrigger(vi, trigger, trigger_identifier);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3518,6 +3649,7 @@ namespace nidigitalpattern_grpc {
       ViBoolean value = request->value();
       auto status = library_->SetAttributeViBoolean(vi, channel_name, attribute, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3558,6 +3690,7 @@ namespace nidigitalpattern_grpc {
 
       auto status = library_->SetAttributeViInt32(vi, channel_name, attribute, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3583,6 +3716,7 @@ namespace nidigitalpattern_grpc {
       ViInt64 value = request->value_raw();
       auto status = library_->SetAttributeViInt64(vi, channel_name, attribute, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3608,6 +3742,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 value = request->value_raw();
       auto status = library_->SetAttributeViReal64(vi, channel_name, attribute, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3634,6 +3769,7 @@ namespace nidigitalpattern_grpc {
       ViSession value = session_repository_->access_session(value_grpc_session.id(), value_grpc_session.name());
       auto status = library_->SetAttributeViSession(vi, channel_list, attribute, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3659,6 +3795,7 @@ namespace nidigitalpattern_grpc {
       auto value = request->value_raw().c_str();
       auto status = library_->SetAttributeViString(vi, channel_name, attribute, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3685,6 +3822,7 @@ namespace nidigitalpattern_grpc {
       while (true) {
         auto status = library_->TDR(vi, channel_list, apply_offsets, 0, nullptr, &actual_num_offsets);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->mutable_offsets()->Resize(actual_num_offsets, 0);
@@ -3696,6 +3834,7 @@ namespace nidigitalpattern_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -3722,6 +3861,7 @@ namespace nidigitalpattern_grpc {
       ViBoolean unload_keep_alive_pattern = request->unload_keep_alive_pattern();
       auto status = library_->UnloadAllPatterns(vi, unload_keep_alive_pattern);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3745,6 +3885,7 @@ namespace nidigitalpattern_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->UnloadSpecifications(vi, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3768,6 +3909,7 @@ namespace nidigitalpattern_grpc {
       ViReal64 timeout = request->timeout();
       auto status = library_->WaitUntilDone(vi, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3792,6 +3934,7 @@ namespace nidigitalpattern_grpc {
       ViBoolean value = request->value();
       auto status = library_->WriteSequencerFlag(vi, flag, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3822,6 +3965,7 @@ namespace nidigitalpattern_grpc {
       ViBoolean value = request->value();
       auto status = library_->WriteSequencerFlagSynchronized(session_count, sessions.data(), flag, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -3846,6 +3990,7 @@ namespace nidigitalpattern_grpc {
       ViInt32 value = request->value();
       auto status = library_->WriteSequencerRegister(vi, reg, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3871,6 +4016,7 @@ namespace nidigitalpattern_grpc {
       auto waveform_data = const_cast<ViUInt32*>(reinterpret_cast<const ViUInt32*>(request->waveform_data().data()));
       auto status = library_->WriteSourceWaveformBroadcastU32(vi, waveform_name, waveform_size, waveform_data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3895,6 +4041,7 @@ namespace nidigitalpattern_grpc {
       auto waveform_file_path = request->waveform_file_path().c_str();
       auto status = library_->WriteSourceWaveformDataFromFileTDMS(vi, waveform_name, waveform_file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3934,6 +4081,7 @@ namespace nidigitalpattern_grpc {
 
       auto status = library_->WriteStatic(vi, channel_list, state);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3961,6 +4109,7 @@ namespace nidigitalpattern_grpc {
       auto waveform_data = const_cast<ViUInt32*>(reinterpret_cast<const ViUInt32*>(request->waveform_data().data()));
       auto status = library_->WriteSourceWaveformSiteUniqueU32(vi, site_list, waveform_name, num_waveforms, samples_per_waveform, waveform_data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -72,6 +72,7 @@ namespace nidmm_grpc {
 
       auto status = library_->Control4022(resource_name, configuration);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -94,6 +95,7 @@ namespace nidmm_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Abort(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -119,6 +121,7 @@ namespace nidmm_grpc {
       ViBoolean attribute_value = request->attribute_value();
       auto status = library_->CheckAttributeViBoolean(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -159,6 +162,7 @@ namespace nidmm_grpc {
 
       auto status = library_->CheckAttributeViInt32(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -199,6 +203,7 @@ namespace nidmm_grpc {
 
       auto status = library_->CheckAttributeViReal64(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -225,6 +230,7 @@ namespace nidmm_grpc {
       ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.id(), attribute_value_grpc_session.name());
       auto status = library_->CheckAttributeViSession(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -250,6 +256,7 @@ namespace nidmm_grpc {
       ViString attribute_value = (ViString)request->attribute_value_raw().c_str();
       auto status = library_->CheckAttributeViString(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -272,6 +279,7 @@ namespace nidmm_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ClearError(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -294,6 +302,7 @@ namespace nidmm_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ClearInterchangeWarnings(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -317,6 +326,7 @@ namespace nidmm_grpc {
       session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -341,6 +351,7 @@ namespace nidmm_grpc {
       ViReal64 ac_maximum_frequency_hz = request->ac_maximum_frequency_hz();
       auto status = library_->ConfigureACBandwidth(vi, ac_minimum_frequency_hz, ac_maximum_frequency_hz);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -364,6 +375,7 @@ namespace nidmm_grpc {
       ViInt32 adc_calibration = request->adc_calibration();
       auto status = library_->ConfigureADCCalibration(vi, adc_calibration);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -387,6 +399,7 @@ namespace nidmm_grpc {
       ViInt32 auto_zero_mode = request->auto_zero_mode();
       auto status = library_->ConfigureAutoZeroMode(vi, auto_zero_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -410,6 +423,7 @@ namespace nidmm_grpc {
       ViInt32 cable_comp_type = request->cable_comp_type();
       auto status = library_->ConfigureCableCompType(vi, cable_comp_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -433,6 +447,7 @@ namespace nidmm_grpc {
       ViReal64 current_source = request->current_source();
       auto status = library_->ConfigureCurrentSource(vi, current_source);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -456,6 +471,7 @@ namespace nidmm_grpc {
       ViReal64 fixed_reference_junction = request->fixed_reference_junction();
       auto status = library_->ConfigureFixedRefJunction(vi, fixed_reference_junction);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -494,6 +510,7 @@ namespace nidmm_grpc {
 
       auto status = library_->ConfigureFrequencyVoltageRange(vi, voltage_range);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -517,6 +534,7 @@ namespace nidmm_grpc {
       ViInt32 meas_complete_destination = request->meas_complete_destination();
       auto status = library_->ConfigureMeasCompleteDest(vi, meas_complete_destination);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -557,6 +575,7 @@ namespace nidmm_grpc {
       ViReal64 resolution_absolute = request->resolution_absolute();
       auto status = library_->ConfigureMeasurementAbsolute(vi, measurement_function, range, resolution_absolute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -580,6 +599,7 @@ namespace nidmm_grpc {
       ViInt32 meas_complete_slope = request->meas_complete_slope();
       auto status = library_->ConfigureMeasCompleteSlope(vi, meas_complete_slope);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -620,6 +640,7 @@ namespace nidmm_grpc {
       ViReal64 resolution_digits = request->resolution_digits();
       auto status = library_->ConfigureMeasurementDigits(vi, measurement_function, range, resolution_digits);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -706,6 +727,7 @@ namespace nidmm_grpc {
 
       auto status = library_->ConfigureMultiPoint(vi, trigger_count, sample_count, sample_trigger, sample_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -744,6 +766,7 @@ namespace nidmm_grpc {
 
       auto status = library_->ConfigureOffsetCompOhms(vi, offset_comp_ohms);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -768,6 +791,7 @@ namespace nidmm_grpc {
       ViReal64 susceptance = request->susceptance();
       auto status = library_->ConfigureOpenCableCompValues(vi, conductance, susceptance);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -806,6 +830,7 @@ namespace nidmm_grpc {
 
       auto status = library_->ConfigurePowerLineFrequency(vi, power_line_frequency_hz);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -830,6 +855,7 @@ namespace nidmm_grpc {
       ViReal64 reactance = request->reactance();
       auto status = library_->ConfigureShortCableCompValues(vi, resistance, reactance);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -855,6 +881,7 @@ namespace nidmm_grpc {
       ViReal64 rtd_c = request->rtd_c();
       auto status = library_->ConfigureRTDCustom(vi, rtd_a, rtd_b, rtd_c);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -894,6 +921,7 @@ namespace nidmm_grpc {
       ViReal64 rtd_resistance = request->rtd_resistance();
       auto status = library_->ConfigureRTDType(vi, rtd_type, rtd_resistance);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -932,6 +960,7 @@ namespace nidmm_grpc {
 
       auto status = library_->ConfigureSampleTriggerSlope(vi, sample_trigger_slope);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -957,6 +986,7 @@ namespace nidmm_grpc {
       ViReal64 thermistor_c = request->thermistor_c();
       auto status = library_->ConfigureThermistorCustom(vi, thermistor_a, thermistor_b, thermistor_c);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1011,6 +1041,7 @@ namespace nidmm_grpc {
 
       auto status = library_->ConfigureThermocouple(vi, thermocouple_type, reference_junction_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1034,6 +1065,7 @@ namespace nidmm_grpc {
       ViInt32 thermistor_type = request->thermistor_type();
       auto status = library_->ConfigureThermistorType(vi, thermistor_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1057,6 +1089,7 @@ namespace nidmm_grpc {
       ViInt32 transducer_type = request->transducer_type();
       auto status = library_->ConfigureTransducerType(vi, transducer_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1111,6 +1144,7 @@ namespace nidmm_grpc {
 
       auto status = library_->ConfigureTrigger(vi, trigger_source, trigger_delay);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1149,6 +1183,7 @@ namespace nidmm_grpc {
 
       auto status = library_->ConfigureTriggerSlope(vi, trigger_slope);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1190,6 +1225,7 @@ namespace nidmm_grpc {
       ViInt32 waveform_points = request->waveform_points();
       auto status = library_->ConfigureWaveformAcquisition(vi, measurement_function, range, rate, waveform_points);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1213,6 +1249,7 @@ namespace nidmm_grpc {
       ViInt32 waveform_coupling = request->waveform_coupling();
       auto status = library_->ConfigureWaveformCoupling(vi, waveform_coupling);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1251,6 +1288,7 @@ namespace nidmm_grpc {
 
       auto status = library_->Control(vi, control_action);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1273,6 +1311,7 @@ namespace nidmm_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Disable(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1297,6 +1336,7 @@ namespace nidmm_grpc {
       while (true) {
         auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 size = status;
@@ -1308,6 +1348,7 @@ namespace nidmm_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1333,6 +1374,7 @@ namespace nidmm_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->ExportAttributeConfigurationFile(vi, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1372,6 +1414,7 @@ namespace nidmm_grpc {
       ViReal64 reading {};
       auto status = library_->Fetch(vi, maximum_time, &reading);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1415,6 +1458,7 @@ namespace nidmm_grpc {
       ViInt32 actual_number_of_points {};
       auto status = library_->FetchMultiPoint(vi, maximum_time, array_size, reading_array, &actual_number_of_points);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1458,6 +1502,7 @@ namespace nidmm_grpc {
       ViInt32 actual_number_of_points {};
       auto status = library_->FetchWaveform(vi, maximum_time, array_size, waveform_array, &actual_number_of_points);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1483,6 +1528,7 @@ namespace nidmm_grpc {
       ViInt32 aperture_time_units {};
       auto status = library_->GetApertureTimeInfo(vi, &aperture_time, &aperture_time_units);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1514,6 +1560,7 @@ namespace nidmm_grpc {
       ViBoolean attribute_value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1540,6 +1587,7 @@ namespace nidmm_grpc {
       ViInt32 attribute_value {};
       auto status = library_->GetAttributeViInt32(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1566,6 +1614,7 @@ namespace nidmm_grpc {
       ViReal64 attribute_value {};
       auto status = library_->GetAttributeViReal64(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1592,6 +1641,7 @@ namespace nidmm_grpc {
       ViSession attribute_value {};
       auto status = library_->GetAttributeViSession(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1620,6 +1670,7 @@ namespace nidmm_grpc {
       while (true) {
         auto status = library_->GetAttributeViString(vi, channel_name, attribute_id, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -1634,6 +1685,7 @@ namespace nidmm_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1660,6 +1712,7 @@ namespace nidmm_grpc {
       ViReal64 actual_range {};
       auto status = library_->GetAutoRangeValue(vi, &actual_range);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1704,6 +1757,7 @@ namespace nidmm_grpc {
       ViInt32 minute {};
       auto status = library_->GetCalDateAndTime(vi, cal_type, &month, &day, &year, &hour, &minute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1734,6 +1788,7 @@ namespace nidmm_grpc {
       while (true) {
         auto status = library_->GetChannelName(vi, index, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -1748,6 +1803,7 @@ namespace nidmm_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1775,6 +1831,7 @@ namespace nidmm_grpc {
       ViReal64 temperature {};
       auto status = library_->GetDevTemp(vi, options, &temperature);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1800,6 +1857,7 @@ namespace nidmm_grpc {
       while (true) {
         auto status = library_->GetError(vi, nullptr, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -1815,6 +1873,7 @@ namespace nidmm_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1844,6 +1903,7 @@ namespace nidmm_grpc {
       while (true) {
         auto status = library_->GetErrorMessage(vi, error_code, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -1858,6 +1918,7 @@ namespace nidmm_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1884,6 +1945,7 @@ namespace nidmm_grpc {
       ViInt32 months {};
       auto status = library_->GetExtCalRecommendedInterval(vi, &months);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1924,6 +1986,7 @@ namespace nidmm_grpc {
       ViReal64 temperature {};
       auto status = library_->GetLastCalTemp(vi, cal_type, &temperature);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1948,6 +2011,7 @@ namespace nidmm_grpc {
       ViReal64 period {};
       auto status = library_->GetMeasurementPeriod(vi, &period);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1973,6 +2037,7 @@ namespace nidmm_grpc {
       while (true) {
         auto status = library_->GetNextCoercionRecord(vi, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -1987,6 +2052,7 @@ namespace nidmm_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2014,6 +2080,7 @@ namespace nidmm_grpc {
       while (true) {
         auto status = library_->GetNextInterchangeWarning(vi, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -2028,6 +2095,7 @@ namespace nidmm_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2054,6 +2122,7 @@ namespace nidmm_grpc {
       ViBoolean self_cal_supported {};
       auto status = library_->GetSelfCalSupported(vi, &self_cal_supported);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2079,6 +2148,7 @@ namespace nidmm_grpc {
       ViInt8* configuration = (ViInt8*)request->configuration().c_str();
       auto status = library_->ImportAttributeConfigurationBuffer(vi, size, configuration);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2102,6 +2172,7 @@ namespace nidmm_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->ImportAttributeConfigurationFile(vi, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2134,6 +2205,7 @@ namespace nidmm_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -2171,6 +2243,7 @@ namespace nidmm_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -2197,6 +2270,7 @@ namespace nidmm_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Initiate(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2219,6 +2293,7 @@ namespace nidmm_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->InvalidateAllAttributes(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2243,6 +2318,7 @@ namespace nidmm_grpc {
       ViBoolean is_over_range {};
       auto status = library_->IsOverRange(vi, measurement_value, &is_over_range);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2268,6 +2344,7 @@ namespace nidmm_grpc {
       ViBoolean is_under_range {};
       auto status = library_->IsUnderRange(vi, measurement_value, &is_under_range);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2293,6 +2370,7 @@ namespace nidmm_grpc {
       ViReal64 susceptance {};
       auto status = library_->PerformOpenCableComp(vi, &conductance, &susceptance);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2319,6 +2397,7 @@ namespace nidmm_grpc {
       ViReal64 reactance {};
       auto status = library_->PerformShortCableComp(vi, &resistance, &reactance);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2360,6 +2439,7 @@ namespace nidmm_grpc {
       ViReal64 reading {};
       auto status = library_->Read(vi, maximum_time, &reading);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2403,6 +2483,7 @@ namespace nidmm_grpc {
       ViInt32 actual_number_of_points {};
       auto status = library_->ReadMultiPoint(vi, maximum_time, array_size, reading_array, &actual_number_of_points);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2428,6 +2509,7 @@ namespace nidmm_grpc {
       ViInt16 acquisition_status {};
       auto status = library_->ReadStatus(vi, &acquisition_backlog, &acquisition_status);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2473,6 +2555,7 @@ namespace nidmm_grpc {
       ViInt32 actual_number_of_points {};
       auto status = library_->ReadWaveform(vi, maximum_time, array_size, waveform_array, &actual_number_of_points);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2496,6 +2579,7 @@ namespace nidmm_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2518,6 +2602,7 @@ namespace nidmm_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ResetInterchangeCheck(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2540,6 +2625,7 @@ namespace nidmm_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ResetWithDefaults(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2564,6 +2650,7 @@ namespace nidmm_grpc {
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2590,6 +2677,7 @@ namespace nidmm_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->SelfCal(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2614,6 +2702,7 @@ namespace nidmm_grpc {
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2639,6 +2728,7 @@ namespace nidmm_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->SendSoftwareTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2664,6 +2754,7 @@ namespace nidmm_grpc {
       ViBoolean attribute_value = request->attribute_value();
       auto status = library_->SetAttributeViBoolean(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2704,6 +2795,7 @@ namespace nidmm_grpc {
 
       auto status = library_->SetAttributeViInt32(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2744,6 +2836,7 @@ namespace nidmm_grpc {
 
       auto status = library_->SetAttributeViReal64(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2770,6 +2863,7 @@ namespace nidmm_grpc {
       ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.id(), attribute_value_grpc_session.name());
       auto status = library_->SetAttributeViSession(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2795,6 +2889,7 @@ namespace nidmm_grpc {
       ViString attribute_value = (ViString)request->attribute_value_raw().c_str();
       auto status = library_->SetAttributeViString(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -66,6 +66,7 @@ namespace nifake_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Abort(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -90,6 +91,7 @@ namespace nifake_grpc {
       auto delays = const_cast<ViReal64*>(request->delays().data());
       auto status = library_->AcceptListOfDurationsInSeconds(vi, count, delays);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -118,6 +120,7 @@ namespace nifake_grpc {
         [&](auto session) { return session_repository_->access_session(session.id(), session.name()); }); 
       auto status = library_->AcceptViSessionArray(session_count, session_array.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -142,6 +145,7 @@ namespace nifake_grpc {
       auto u_int32_array = const_cast<ViUInt32*>(reinterpret_cast<const ViUInt32*>(request->u_int32_array().data()));
       auto status = library_->AcceptViUInt32Array(vi, array_len, u_int32_array);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -166,6 +170,7 @@ namespace nifake_grpc {
       auto an_array = convert_from_grpc<ViBoolean>(request->an_array());
       auto status = library_->BoolArrayInputFunction(vi, number_of_elements, an_array.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -190,6 +195,7 @@ namespace nifake_grpc {
       std::vector<ViBoolean> an_array(number_of_elements, ViBoolean());
       auto status = library_->BoolArrayOutputFunction(vi, number_of_elements, an_array.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -215,6 +221,7 @@ namespace nifake_grpc {
       session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->CloseExtCal(vi, action);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -238,6 +245,7 @@ namespace nifake_grpc {
       auto reserved = nullptr;
       auto status = library_->CommandWithReservedParam(vi, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -260,6 +268,7 @@ namespace nifake_grpc {
       auto list_attribute_ids = const_cast<ViAttr*>(reinterpret_cast<const ViAttr*>(request->list_attribute_ids().data()));
       auto status = library_->CreateConfigurationList(number_of_list_attributes, list_attribute_ids);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -284,6 +293,7 @@ namespace nifake_grpc {
       auto numbers = const_cast<ViReal64*>(request->numbers().data());
       auto status = library_->DoubleAllTheNums(vi, number_count, numbers);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -337,6 +347,7 @@ namespace nifake_grpc {
 
       auto status = library_->EnumInputFunctionWithDefaults(vi, a_turtle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -361,6 +372,7 @@ namespace nifake_grpc {
       while (true) {
         auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 size_in_bytes = status;
@@ -372,6 +384,7 @@ namespace nifake_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -400,6 +413,7 @@ namespace nifake_grpc {
       ViInt32 actual_number_of_samples {};
       auto status = library_->FetchWaveform(vi, number_of_samples, waveform_data, &actual_number_of_samples);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -424,6 +438,7 @@ namespace nifake_grpc {
       ViBoolean a_boolean {};
       auto status = library_->GetABoolean(vi, &a_boolean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -448,6 +463,7 @@ namespace nifake_grpc {
       ViInt16 a_number {};
       auto status = library_->GetANumber(vi, &a_number);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -472,6 +488,7 @@ namespace nifake_grpc {
       std::string a_string(256 - 1, '\0');
       auto status = library_->GetAStringOfFixedMaximumSize(vi, (ViChar*)a_string.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -498,6 +515,7 @@ namespace nifake_grpc {
       while (true) {
         auto status = library_->GetAnIviDanceString(vi, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -512,6 +530,7 @@ namespace nifake_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -540,6 +559,7 @@ namespace nifake_grpc {
       while (true) {
         auto status = library_->GetAnIviDanceWithATwistArray(vi, a_string, 0, nullptr, &actual_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->mutable_array_out()->Resize(actual_size, 0);
@@ -551,6 +571,7 @@ namespace nifake_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -578,6 +599,7 @@ namespace nifake_grpc {
       while (true) {
         auto status = library_->GetAnIviDanceWithATwistArrayOfCustomType(vi, 0, nullptr, &actual_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         std::vector<CustomStruct> array_out(actual_size, CustomStruct());
@@ -588,6 +610,7 @@ namespace nifake_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -622,6 +645,7 @@ namespace nifake_grpc {
       while (true) {
         auto status = library_->GetAnIviDanceWithATwistArrayWithInputArray(data_in, array_size_in, 0, nullptr, &actual_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, 0);
         }
         response->mutable_array_out()->Resize(actual_size, 0);
@@ -633,6 +657,7 @@ namespace nifake_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, 0);
         }
         response->set_status(status);
@@ -658,6 +683,7 @@ namespace nifake_grpc {
       while (true) {
         auto status = library_->GetAnIviDanceWithATwistByteArray(0, nullptr, &actual_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, 0);
         }
         std::string array_out(actual_size, '\0');
@@ -668,6 +694,7 @@ namespace nifake_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, 0);
         }
         response->set_status(status);
@@ -694,6 +721,7 @@ namespace nifake_grpc {
       while (true) {
         auto status = library_->GetAnIviDanceWithATwistString(0, nullptr, &actual_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, 0);
         }
         std::string array_out;
@@ -707,6 +735,7 @@ namespace nifake_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, 0);
         }
         response->set_status(status);
@@ -733,6 +762,7 @@ namespace nifake_grpc {
       while (true) {
         auto status = library_->GetAnIviDanceWithATwistStringStrlenBug(0, nullptr, &actual_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, 0);
         }
         std::string string_out;
@@ -746,6 +776,7 @@ namespace nifake_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, 0);
         }
         response->set_status(status);
@@ -773,6 +804,7 @@ namespace nifake_grpc {
       ViInt32 size_out {};
       auto status = library_->GetArraySizeForCustomCode(vi, &size_out);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -798,6 +830,7 @@ namespace nifake_grpc {
       while (true) {
         auto status = library_->GetArrayUsingIviDance(vi, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 array_size = status;
@@ -810,6 +843,7 @@ namespace nifake_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -835,6 +869,7 @@ namespace nifake_grpc {
       std::string u_int8_enum_array(array_len, '\0');
       auto status = library_->GetArrayViUInt8WithEnum(vi, array_len, (ViUInt8*)u_int8_enum_array.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -862,6 +897,7 @@ namespace nifake_grpc {
       ViBoolean attribute_value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -888,6 +924,7 @@ namespace nifake_grpc {
       ViInt32 attribute_value {};
       auto status = library_->GetAttributeViInt32(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -914,6 +951,7 @@ namespace nifake_grpc {
       ViInt64 attribute_value {};
       auto status = library_->GetAttributeViInt64(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -940,6 +978,7 @@ namespace nifake_grpc {
       ViReal64 attribute_value {};
       auto status = library_->GetAttributeViReal64(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -965,6 +1004,7 @@ namespace nifake_grpc {
       ViSession session_out {};
       auto status = library_->GetAttributeViSession(vi, attribute_id, &session_out);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -993,6 +1033,7 @@ namespace nifake_grpc {
       while (true) {
         auto status = library_->GetAttributeViString(vi, channel_name, attribute_id, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -1007,6 +1048,7 @@ namespace nifake_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1031,6 +1073,7 @@ namespace nifake_grpc {
       ViInt64 flags {};
       auto status = library_->GetBitfieldAsEnumArray(&flags);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -1068,6 +1111,7 @@ namespace nifake_grpc {
       ViInt32 minute {};
       auto status = library_->GetCalDateAndTime(vi, cal_type, &month, &day, &year, &hour, &minute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1096,6 +1140,7 @@ namespace nifake_grpc {
       ViInt32 months {};
       auto status = library_->GetCalInterval(vi, &months);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1120,6 +1165,7 @@ namespace nifake_grpc {
       CustomStruct cs {};
       auto status = library_->GetCustomType(vi, &cs);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1145,6 +1191,7 @@ namespace nifake_grpc {
       std::vector<CustomStruct> cs(number_of_elements, CustomStruct());
       auto status = library_->GetCustomTypeArray(vi, number_of_elements, cs.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1170,6 +1217,7 @@ namespace nifake_grpc {
       ViInt16 a_turtle {};
       auto status = library_->GetEnumValue(vi, &a_quantity, &a_turtle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1198,6 +1246,7 @@ namespace nifake_grpc {
       ViInt32* int32_array = reinterpret_cast<ViInt32*>(response->mutable_int32_array()->mutable_data());
       auto status = library_->GetViInt32Array(vi, array_len, int32_array);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1223,6 +1272,7 @@ namespace nifake_grpc {
       ViUInt32* u_int32_array = reinterpret_cast<ViUInt32*>(response->mutable_u_int32_array()->mutable_data());
       auto status = library_->GetViUInt32Array(vi, array_len, u_int32_array);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1246,6 +1296,7 @@ namespace nifake_grpc {
       ViUInt8 a_uint8_number {};
       auto status = library_->GetViUInt8(vi, &a_uint8_number);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1271,6 +1322,7 @@ namespace nifake_grpc {
       ViInt8* configuration = (ViInt8*)request->configuration().c_str();
       auto status = library_->ImportAttributeConfigurationBuffer(vi, size_in_bytes, configuration);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1302,6 +1354,7 @@ namespace nifake_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->CloseExtCal(id, 0); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -1339,6 +1392,7 @@ namespace nifake_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -1393,6 +1447,7 @@ namespace nifake_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -1444,6 +1499,7 @@ namespace nifake_grpc {
       ViReal64* output_array_of_fixed_length = response->mutable_output_array_of_fixed_length()->mutable_data();
       auto status = library_->MultipleArrayTypes(vi, output_array_size, output_array, output_array_of_fixed_length, input_array_sizes, input_array_of_floats, input_array_of_integers.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1484,6 +1540,7 @@ namespace nifake_grpc {
 
       auto status = library_->MultipleArraysSameSize(vi, values1, values2, values3, values4, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1534,6 +1591,7 @@ namespace nifake_grpc {
 
       auto status = library_->MultipleArraysSameSizeWithOptional(vi, values1, values2, values3, values4, values5.data(), size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1557,6 +1615,7 @@ namespace nifake_grpc {
       ViInt32 a_number = request->a_number();
       auto status = library_->OneInputFunction(vi, a_number);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1621,6 +1680,7 @@ namespace nifake_grpc {
       auto a_string = request->a_string().c_str();
       auto status = library_->ParametersAreMultipleTypes(vi, a_boolean, an_int32, an_int64, an_int_enum, a_float, a_float_enum, string_size, a_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1643,6 +1703,7 @@ namespace nifake_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->PoorlyNamedSimpleFunction(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1667,6 +1728,7 @@ namespace nifake_grpc {
       ViReal64 reading {};
       auto status = library_->Read(vi, maximum_time, &reading);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1690,6 +1752,7 @@ namespace nifake_grpc {
       while (true) {
         auto status = library_->ReadDataWithInOutIviTwist(nullptr, &buffer_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, 0);
         }
         response->mutable_data()->Resize(buffer_size, 0);
@@ -1700,6 +1763,7 @@ namespace nifake_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, 0);
         }
         response->set_status(status);
@@ -1726,6 +1790,7 @@ namespace nifake_grpc {
       while (true) {
         auto status = library_->ReadDataWithMultipleIviTwistParamSets(0, nullptr, &actual_size, 0, nullptr, &other_actual_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, 0);
         }
         response->mutable_array_out()->Resize(actual_size, 0);
@@ -1740,6 +1805,7 @@ namespace nifake_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, 0);
         }
         response->set_status(status);
@@ -1770,6 +1836,7 @@ namespace nifake_grpc {
       ViReal64 reading {};
       auto status = library_->ReadFromChannel(vi, channel_name, maximum_time, &reading);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1795,6 +1862,7 @@ namespace nifake_grpc {
       std::string a_string(256 - 1, '\0');
       auto status = library_->ReturnANumberAndAString(vi, &a_number, (ViChar*)a_string.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1821,6 +1889,7 @@ namespace nifake_grpc {
       ViReal64 timedelta {};
       auto status = library_->ReturnDurationInSeconds(vi, &timedelta);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1847,6 +1916,7 @@ namespace nifake_grpc {
       ViReal64* timedeltas = response->mutable_timedeltas()->mutable_data();
       auto status = library_->ReturnListOfDurationsInSeconds(vi, number_of_elements, timedeltas);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1872,6 +1942,7 @@ namespace nifake_grpc {
       while (true) {
         auto status = library_->ReturnMultipleTypes(vi, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 0, nullptr, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 string_size = status;
@@ -1894,6 +1965,7 @@ namespace nifake_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1931,6 +2003,7 @@ namespace nifake_grpc {
       auto cs = convert_from_grpc<CustomStruct>(request->cs());
       auto status = library_->SetCustomType(vi, cs);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1955,6 +2028,7 @@ namespace nifake_grpc {
       auto cs = convert_from_grpc<CustomStruct>(request->cs());
       auto status = library_->SetCustomTypeArray(vi, number_of_elements, cs.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1997,6 +2071,7 @@ namespace nifake_grpc {
 
       auto status = library_->StringValuedEnumInputFunctionWithDefaults(vi, a_mobile_os_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2021,6 +2096,7 @@ namespace nifake_grpc {
       ViString a_string = (ViString)request->a_string().c_str();
       auto status = library_->TwoInputFunction(vi, a_number, a_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2045,6 +2121,7 @@ namespace nifake_grpc {
       ViInt64 output {};
       auto status = library_->Use64BitNumber(vi, input, &output);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2077,6 +2154,7 @@ namespace nifake_grpc {
       ViInt32 array_size = static_cast<ViInt32>(request->array_lengths().size());
       auto status = library_->UseATwoDimensionParameter(vi, array, array_lengths, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2107,6 +2185,7 @@ namespace nifake_grpc {
         [](auto x) { return (ViInt16)x; }); 
       auto status = library_->ViInt16ArrayInputFunction(vi, number_of_elements, an_array.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2131,6 +2210,7 @@ namespace nifake_grpc {
       ViUInt8* an_array = (ViUInt8*)request->an_array().c_str();
       auto status = library_->ViUInt8ArrayInputFunction(vi, number_of_elements, an_array);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2155,6 +2235,7 @@ namespace nifake_grpc {
       std::string an_array(number_of_elements, '\0');
       auto status = library_->ViUInt8ArrayOutputFunction(vi, number_of_elements, (ViUInt8*)an_array.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2180,6 +2261,7 @@ namespace nifake_grpc {
       auto waveform = const_cast<ViReal64*>(request->waveform().data());
       auto status = library_->WriteWaveform(vi, number_of_samples, waveform);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2203,6 +2285,7 @@ namespace nifake_grpc {
       session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->close(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);

--- a/generated/nifake_extension/nifake_extension_service.cpp
+++ b/generated/nifake_extension/nifake_extension_service.cpp
@@ -54,6 +54,7 @@ namespace nifake_extension_grpc {
       ViInt32 param = request->param();
       auto status = library_->AddCoolFunctionality(vi, param);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -64,6 +64,7 @@ namespace nifake_non_ivi_grpc {
       session_repository_->remove_session(handle_grpc_session.id(), handle_grpc_session.name());
       auto status = library_->Close(handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, handle);
       }
       response->set_status(status);
@@ -87,6 +88,7 @@ namespace nifake_non_ivi_grpc {
       secondary_session_handle_resource_repository_->remove_session(secondary_session_handle_grpc_session.id(), secondary_session_handle_grpc_session.name());
       auto status = library_->CloseSecondarySession(secondary_session_handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForSecondarySessionHandle(status, secondary_session_handle);
       }
       response->set_status(status);
@@ -143,6 +145,7 @@ namespace nifake_non_ivi_grpc {
       while (true) {
         auto status = library_->GetLatestErrorMessage(nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForFakeHandle(status, 0);
         }
         uInt32 size = status;
@@ -157,6 +160,7 @@ namespace nifake_non_ivi_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForFakeHandle(status, 0);
         }
         response->set_status(status);
@@ -182,6 +186,7 @@ namespace nifake_non_ivi_grpc {
       auto string_out = library_->GetStringAsReturnedValue((char*)buf.data());
       auto status = string_out ? 0 : -1;
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -226,6 +231,7 @@ namespace nifake_non_ivi_grpc {
       double value {};
       auto status = library_->GetMarbleAttributeDouble(handle, attribute, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, handle);
       }
       response->set_status(status);
@@ -269,6 +275,7 @@ namespace nifake_non_ivi_grpc {
       int32 value {};
       auto status = library_->GetMarbleAttributeInt32(handle, attribute, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, handle);
       }
       response->set_status(status);
@@ -319,6 +326,7 @@ namespace nifake_non_ivi_grpc {
       int32* value = reinterpret_cast<int32*>(response->mutable_value_raw()->mutable_data());
       auto status = library_->GetMarbleAttributeInt32Array(handle, attribute, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, handle);
       }
       response->set_status(status);
@@ -363,6 +371,7 @@ namespace nifake_non_ivi_grpc {
       auto cleanup_lambda = [&] (FakeHandle id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -398,6 +407,7 @@ namespace nifake_non_ivi_grpc {
       auto cleanup_lambda = [&] (FakeHandle id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -439,6 +449,7 @@ namespace nifake_non_ivi_grpc {
       auto cleanup_lambda = [&] (FakeHandle id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -472,6 +483,7 @@ namespace nifake_non_ivi_grpc {
       auto cleanup_lambda = [&] (SecondarySessionHandle id) { library_->CloseSecondarySession(id); };
       int status = secondary_session_handle_resource_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -506,6 +518,7 @@ namespace nifake_non_ivi_grpc {
       auto cleanup_lambda = [&] (FakeHandle id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -540,6 +553,7 @@ namespace nifake_non_ivi_grpc {
       auto cleanup_lambda = [&] (FakeHandle id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -618,6 +632,7 @@ namespace nifake_non_ivi_grpc {
 
       auto status = library_->InputArraysWithNarrowIntegerTypes(u16_array.data(), i16_array.data(), i8_array.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -645,6 +660,7 @@ namespace nifake_non_ivi_grpc {
       int32* data = reinterpret_cast<int32*>(response->mutable_data()->mutable_data());
       auto status = library_->IotaWithCustomSize(size_one, size_two, data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -671,6 +687,7 @@ namespace nifake_non_ivi_grpc {
       std::vector<myInt8> i8_data(number_of_i8_samples);
       auto status = library_->OutputArraysWithNarrowIntegerTypes(number_of_u16_samples, u16_data.data(), number_of_i16_samples, i16_data.data(), number_of_i8_samples, i8_data.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -719,6 +736,7 @@ namespace nifake_non_ivi_grpc {
       const myUInt8* u8_array = (const myUInt8*)request->u8_array().c_str();
       auto status = library_->InputArrayOfBytes(u8_array);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -741,6 +759,7 @@ namespace nifake_non_ivi_grpc {
       std::string u8_data(number_of_u8_samples, '\0');
       auto status = library_->OutputArrayOfBytes(number_of_u8_samples, (myUInt8*)u8_data.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -766,6 +785,7 @@ namespace nifake_non_ivi_grpc {
       std::vector<myUInt16> u16_data(array_size_copy);
       auto status = library_->OutputArraysWithPassedInByPtrMechanism(i32_data, u16_data.data(), &array_size_copy);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -851,6 +871,7 @@ namespace nifake_non_ivi_grpc {
       auto when = convert_from_grpc<CVIAbsoluteTime>(request->when());
       auto status = library_->InputTimestamp(when);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -872,6 +893,7 @@ namespace nifake_non_ivi_grpc {
       CVIAbsoluteTime when {};
       auto status = library_->OutputTimestamp(&when);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -920,6 +942,7 @@ namespace nifake_non_ivi_grpc {
 
       auto status = library_->InputVarArgs(input_name, get_channelName_if(string_and_enums, 0), get_color_if(string_and_enums, 0), get_powerUpState_if(string_and_enums, 0), get_channelName_if(string_and_enums, 1), get_color_if(string_and_enums, 1), get_powerUpState_if(string_and_enums, 1), get_channelName_if(string_and_enums, 2), get_color_if(string_and_enums, 2), get_powerUpState_if(string_and_enums, 2), get_channelName_if(string_and_enums, 3), get_color_if(string_and_enums, 3), get_powerUpState_if(string_and_enums, 3));
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -963,6 +986,7 @@ namespace nifake_non_ivi_grpc {
       colorVector.resize(channel_names.size());
       auto status = library_->OutputVarArgs(input_name, get_channelName_if(channel_names, 0), get_color_if(colorVector, 0), get_channelName_if(channel_names, 1), get_color_if(colorVector, 1), get_channelName_if(channel_names, 2), get_color_if(colorVector, 2), get_channelName_if(channel_names, 3), get_color_if(colorVector, 3));
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -1007,6 +1031,7 @@ namespace nifake_non_ivi_grpc {
 
       auto status = library_->ResetMarbleAttribute(handle, attribute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, handle);
       }
       response->set_status(status);
@@ -1057,6 +1082,7 @@ namespace nifake_non_ivi_grpc {
 
       auto status = library_->ScalarsWithNarrowIntegerTypes(u16, i16, i8);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -1102,6 +1128,7 @@ namespace nifake_non_ivi_grpc {
       double value = request->value();
       auto status = library_->SetMarbleAttributeDouble(handle, attribute, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, handle);
       }
       response->set_status(status);
@@ -1159,6 +1186,7 @@ namespace nifake_non_ivi_grpc {
 
       auto status = library_->SetMarbleAttributeInt32(handle, attribute, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, handle);
       }
       response->set_status(status);
@@ -1189,6 +1217,7 @@ namespace nifake_non_ivi_grpc {
       int32 size = request->size();
       auto status = library_->SetColors(colors, size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -1211,6 +1240,7 @@ namespace nifake_non_ivi_grpc {
       std::vector<StructWithCoercion_struct> structs(number_of_structs, StructWithCoercion_struct());
       auto status = library_->GetStructsWithCoercion(number_of_structs, structs.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -1233,6 +1263,7 @@ namespace nifake_non_ivi_grpc {
       auto structs = convert_from_grpc<StructWithCoercion_struct>(request->structs());
       auto status = library_->SetStructsWithCoercion(structs.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -1276,6 +1307,7 @@ namespace nifake_non_ivi_grpc {
 
       auto status = library_->InputStringValuedEnum(a_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);
@@ -1298,6 +1330,7 @@ namespace nifake_non_ivi_grpc {
       int32 size = static_cast<int32>(request->bools().size());
       auto status = library_->WriteBooleanArray(bools.data(), size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForFakeHandle(status, 0);
       }
       response->set_status(status);

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -57,6 +57,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->AbortGeneration(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -80,6 +81,7 @@ namespace nifgen_grpc {
       ViReal64 adjustment_time = request->adjustment_time();
       auto status = library_->AdjustSampleClockRelativeDelay(vi, adjustment_time);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -105,6 +107,7 @@ namespace nifgen_grpc {
       ViInt32 waveform_size = request->waveform_size();
       auto status = library_->AllocateNamedWaveform(vi, channel_name, waveform_name, waveform_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -130,6 +133,7 @@ namespace nifgen_grpc {
       ViInt32 waveform_handle {};
       auto status = library_->AllocateWaveform(vi, channel_name, waveform_size, &waveform_handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -156,6 +160,7 @@ namespace nifgen_grpc {
       ViBoolean attribute_value = request->attribute_value();
       auto status = library_->CheckAttributeViBoolean(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -196,6 +201,7 @@ namespace nifgen_grpc {
 
       auto status = library_->CheckAttributeViInt32(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -221,6 +227,7 @@ namespace nifgen_grpc {
       ViInt64 attribute_value = request->attribute_value_raw();
       auto status = library_->CheckAttributeViInt64(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -261,6 +268,7 @@ namespace nifgen_grpc {
 
       auto status = library_->CheckAttributeViReal64(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -287,6 +295,7 @@ namespace nifgen_grpc {
       ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.id(), attribute_value_grpc_session.name());
       auto status = library_->CheckAttributeViSession(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -312,6 +321,7 @@ namespace nifgen_grpc {
       auto attribute_value = request->attribute_value_raw().c_str();
       auto status = library_->CheckAttributeViString(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -334,6 +344,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ClearArbMemory(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -372,6 +383,7 @@ namespace nifgen_grpc {
 
       auto status = library_->ClearArbSequence(vi, sequence_handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -410,6 +422,7 @@ namespace nifgen_grpc {
 
       auto status = library_->ClearArbWaveform(vi, waveform_handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -432,6 +445,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ClearError(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -470,6 +484,7 @@ namespace nifgen_grpc {
 
       auto status = library_->ClearFreqList(vi, frequency_list_handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -492,6 +507,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ClearInterchangeWarnings(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -515,6 +531,7 @@ namespace nifgen_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->ClearUserStandardWaveform(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -538,6 +555,7 @@ namespace nifgen_grpc {
       session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -560,6 +578,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Commit(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -584,6 +603,7 @@ namespace nifgen_grpc {
       ViReal64 amplitude = request->amplitude();
       auto status = library_->ConfigureAmplitude(vi, channel_name, amplitude);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -610,6 +630,7 @@ namespace nifgen_grpc {
       ViReal64 offset = request->offset();
       auto status = library_->ConfigureArbSequence(vi, channel_name, sequence_handle, gain, offset);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -636,6 +657,7 @@ namespace nifgen_grpc {
       ViReal64 offset = request->offset();
       auto status = library_->ConfigureArbWaveform(vi, channel_name, waveform_handle, gain, offset);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -659,6 +681,7 @@ namespace nifgen_grpc {
       auto channels = request->channels().c_str();
       auto status = library_->ConfigureChannels(vi, channels);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -697,6 +720,7 @@ namespace nifgen_grpc {
 
       auto status = library_->ConfigureClockMode(vi, clock_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -722,6 +746,7 @@ namespace nifgen_grpc {
       auto coefficients_array = const_cast<ViReal64*>(request->coefficients_array().data());
       auto status = library_->ConfigureCustomFIRFilterCoefficients(vi, channel_name, number_of_coefficients, coefficients_array);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -747,6 +772,7 @@ namespace nifgen_grpc {
       ViInt32 edge = request->edge();
       auto status = library_->ConfigureDigitalEdgeScriptTrigger(vi, trigger_id, source, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -771,6 +797,7 @@ namespace nifgen_grpc {
       ViInt32 edge = request->edge();
       auto status = library_->ConfigureDigitalEdgeStartTrigger(vi, source, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -811,6 +838,7 @@ namespace nifgen_grpc {
 
       auto status = library_->ConfigureDigitalLevelScriptTrigger(vi, trigger_id, source, trigger_when);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -838,6 +866,7 @@ namespace nifgen_grpc {
       ViReal64 start_phase = request->start_phase();
       auto status = library_->ConfigureFreqList(vi, channel_name, frequency_list_handle, amplitude, dc_offset, start_phase);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -862,6 +891,7 @@ namespace nifgen_grpc {
       ViReal64 frequency = request->frequency();
       auto status = library_->ConfigureFrequency(vi, channel_name, frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -886,6 +916,7 @@ namespace nifgen_grpc {
       ViInt32 operation_mode = request->operation_mode();
       auto status = library_->ConfigureOperationMode(vi, channel_name, operation_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -910,6 +941,7 @@ namespace nifgen_grpc {
       ViBoolean enabled = request->enabled();
       auto status = library_->ConfigureOutputEnabled(vi, channel_name, enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -934,6 +966,7 @@ namespace nifgen_grpc {
       ViReal64 impedance = request->impedance();
       auto status = library_->ConfigureOutputImpedance(vi, channel_name, impedance);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -972,6 +1005,7 @@ namespace nifgen_grpc {
 
       auto status = library_->ConfigureOutputMode(vi, output_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -995,6 +1029,7 @@ namespace nifgen_grpc {
       ViInt32 p2p_endpoint_fullness_level = request->p2p_endpoint_fullness_level();
       auto status = library_->ConfigureP2PEndpointFullnessStartTrigger(vi, p2p_endpoint_fullness_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1019,6 +1054,7 @@ namespace nifgen_grpc {
       ViReal64 reference_clock_frequency = request->reference_clock_frequency();
       auto status = library_->ConfigureReferenceClock(vi, reference_clock_source, reference_clock_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1042,6 +1078,7 @@ namespace nifgen_grpc {
       auto sample_clock_source = request->sample_clock_source().c_str();
       auto status = library_->ConfigureSampleClockSource(vi, sample_clock_source);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1065,6 +1102,7 @@ namespace nifgen_grpc {
       ViReal64 sample_rate = request->sample_rate();
       auto status = library_->ConfigureSampleRate(vi, sample_rate);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1088,6 +1126,7 @@ namespace nifgen_grpc {
       auto trigger_id = request->trigger_id().c_str();
       auto status = library_->ConfigureSoftwareEdgeScriptTrigger(vi, trigger_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1110,6 +1149,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgeStartTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1153,6 +1193,7 @@ namespace nifgen_grpc {
       ViReal64 start_phase = request->start_phase();
       auto status = library_->ConfigureStandardWaveform(vi, channel_name, waveform, amplitude, dc_offset, frequency, start_phase);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1177,6 +1218,7 @@ namespace nifgen_grpc {
       ViInt32 synchronization_source = request->synchronization_source();
       auto status = library_->ConfigureSynchronization(vi, channel_name, synchronization_source);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1216,6 +1258,7 @@ namespace nifgen_grpc {
 
       auto status = library_->ConfigureTriggerMode(vi, channel_name, trigger_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1253,6 +1296,7 @@ namespace nifgen_grpc {
       ViInt32 sequence_handle {};
       auto status = library_->CreateArbSequence(vi, sequence_length, waveform_handles_array, loop_counts_array, &sequence_handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1307,6 +1351,7 @@ namespace nifgen_grpc {
       ViInt32 frequency_list_handle {};
       auto status = library_->CreateFreqList(vi, waveform, frequency_list_length, frequency_array, duration_array, &frequency_list_handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1334,6 +1379,7 @@ namespace nifgen_grpc {
       ViInt32 waveform_handle {};
       auto status = library_->CreateWaveformComplexF64(vi, channel_name, number_of_samples, waveform_data_array.data(), &waveform_handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1361,6 +1407,7 @@ namespace nifgen_grpc {
       ViInt32 waveform_handle {};
       auto status = library_->CreateWaveformF64(vi, channel_name, waveform_size, waveform_data_array, &waveform_handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1403,6 +1450,7 @@ namespace nifgen_grpc {
       ViInt32 waveform_handle {};
       auto status = library_->CreateWaveformFromFileF64(vi, channel_name, file_name, byte_order, &waveform_handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1431,6 +1479,7 @@ namespace nifgen_grpc {
       ViInt32 waveform_handle {};
       auto status = library_->CreateWaveformFromFileHWS(vi, channel_name, file_name, use_rate_from_waveform, use_gain_and_offset_from_waveform, &waveform_handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1464,6 +1513,7 @@ namespace nifgen_grpc {
       ViInt32 waveform_handle {};
       auto status = library_->CreateWaveformI16(vi, channel_name, waveform_size, waveform_data_array.data(), &waveform_handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1506,6 +1556,7 @@ namespace nifgen_grpc {
       ViInt32 waveform_handle {};
       auto status = library_->CreateWaveformFromFileI16(vi, channel_name, file_name, byte_order, &waveform_handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1532,6 +1583,7 @@ namespace nifgen_grpc {
       auto waveform_data_array = const_cast<ViReal64*>(request->waveform_data_array().data());
       auto status = library_->DefineUserStandardWaveform(vi, channel_name, waveform_size, waveform_data_array);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1556,6 +1608,7 @@ namespace nifgen_grpc {
       auto waveform_name = request->waveform_name().c_str();
       auto status = library_->DeleteNamedWaveform(vi, channel_name, waveform_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1580,6 +1633,7 @@ namespace nifgen_grpc {
       auto script_name = request->script_name().c_str();
       auto status = library_->DeleteScript(vi, channel_name, script_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1602,6 +1656,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Disable(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1625,6 +1680,7 @@ namespace nifgen_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->DisableAnalogFilter(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1648,6 +1704,7 @@ namespace nifgen_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->DisableDigitalFilter(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1671,6 +1728,7 @@ namespace nifgen_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->DisableDigitalPatterning(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1694,6 +1752,7 @@ namespace nifgen_grpc {
       auto trigger_id = request->trigger_id().c_str();
       auto status = library_->DisableScriptTrigger(vi, trigger_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1716,6 +1775,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->DisableStartTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1740,6 +1800,7 @@ namespace nifgen_grpc {
       ViReal64 filter_correction_frequency = request->filter_correction_frequency();
       auto status = library_->EnableAnalogFilter(vi, channel_name, filter_correction_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1763,6 +1824,7 @@ namespace nifgen_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->EnableDigitalFilter(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1786,6 +1848,7 @@ namespace nifgen_grpc {
       auto channel_name = request->channel_name().c_str();
       auto status = library_->EnableDigitalPatterning(vi, channel_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1810,6 +1873,7 @@ namespace nifgen_grpc {
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorHandler(vi, error_code, (ViChar*)error_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1836,6 +1900,7 @@ namespace nifgen_grpc {
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1862,6 +1927,7 @@ namespace nifgen_grpc {
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorQuery(vi, &error_code, (ViChar*)error_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1889,6 +1955,7 @@ namespace nifgen_grpc {
       while (true) {
         auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 size_in_bytes = status;
@@ -1901,6 +1968,7 @@ namespace nifgen_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1925,6 +1993,7 @@ namespace nifgen_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->ExportAttributeConfigurationFile(vi, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1965,6 +2034,7 @@ namespace nifgen_grpc {
       auto output_terminal = request->output_terminal().c_str();
       auto status = library_->ExportSignal(vi, signal, signal_identifier, output_terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1990,6 +2060,7 @@ namespace nifgen_grpc {
       ViBoolean attribute_value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2016,6 +2087,7 @@ namespace nifgen_grpc {
       ViInt32 attribute_value {};
       auto status = library_->GetAttributeViInt32(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2042,6 +2114,7 @@ namespace nifgen_grpc {
       ViInt64 attribute_value {};
       auto status = library_->GetAttributeViInt64(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2068,6 +2141,7 @@ namespace nifgen_grpc {
       ViReal64 attribute_value {};
       auto status = library_->GetAttributeViReal64(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2094,6 +2168,7 @@ namespace nifgen_grpc {
       ViSession attribute_value {};
       auto status = library_->GetAttributeViSession(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2122,6 +2197,7 @@ namespace nifgen_grpc {
       while (true) {
         auto status = library_->GetAttributeViString(vi, channel_name, attribute_id, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 array_size = status;
@@ -2136,6 +2212,7 @@ namespace nifgen_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2164,6 +2241,7 @@ namespace nifgen_grpc {
       while (true) {
         auto status = library_->GetChannelName(vi, index, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -2178,6 +2256,7 @@ namespace nifgen_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2205,6 +2284,7 @@ namespace nifgen_grpc {
       while (true) {
         auto status = library_->GetError(vi, nullptr, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 error_description_buffer_size = status;
@@ -2220,6 +2300,7 @@ namespace nifgen_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2251,6 +2332,7 @@ namespace nifgen_grpc {
       ViInt32 minute {};
       auto status = library_->GetExtCalLastDateAndTime(vi, &year, &month, &day, &hour, &minute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2279,6 +2361,7 @@ namespace nifgen_grpc {
       ViReal64 temperature {};
       auto status = library_->GetExtCalLastTemp(vi, &temperature);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2303,6 +2386,7 @@ namespace nifgen_grpc {
       ViInt32 months {};
       auto status = library_->GetExtCalRecommendedInterval(vi, &months);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2329,6 +2413,7 @@ namespace nifgen_grpc {
       while (true) {
         auto status = library_->GetFIRFilterCoefficients(vi, channel_name, 0, nullptr, &number_of_coefficients_read);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->mutable_coefficients_array()->Resize(number_of_coefficients_read, 0);
@@ -2340,6 +2425,7 @@ namespace nifgen_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2366,6 +2452,7 @@ namespace nifgen_grpc {
       ViInt32 state {};
       auto status = library_->GetHardwareState(vi, &state);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2392,6 +2479,7 @@ namespace nifgen_grpc {
       while (true) {
         auto status = library_->GetNextCoercionRecord(vi, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -2406,6 +2494,7 @@ namespace nifgen_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2433,6 +2522,7 @@ namespace nifgen_grpc {
       while (true) {
         auto status = library_->GetNextInterchangeWarning(vi, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -2447,6 +2537,7 @@ namespace nifgen_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2477,6 +2568,7 @@ namespace nifgen_grpc {
       ViInt32 minute {};
       auto status = library_->GetSelfCalLastDateAndTime(vi, &year, &month, &day, &hour, &minute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2505,6 +2597,7 @@ namespace nifgen_grpc {
       ViReal64 temperature {};
       auto status = library_->GetSelfCalLastTemp(vi, &temperature);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2529,6 +2622,7 @@ namespace nifgen_grpc {
       ViBoolean self_cal_supported {};
       auto status = library_->GetSelfCalSupported(vi, &self_cal_supported);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2554,6 +2648,7 @@ namespace nifgen_grpc {
       ViUInt32 reader_handle {};
       auto status = library_->GetStreamEndpointHandle(vi, stream_endpoint, &reader_handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2579,6 +2674,7 @@ namespace nifgen_grpc {
       auto configuration = const_cast<ViAddr*>(reinterpret_cast<const ViAddr*>(request->configuration().data()));
       auto status = library_->ImportAttributeConfigurationBuffer(vi, size_in_bytes, configuration);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2602,6 +2698,7 @@ namespace nifgen_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->ImportAttributeConfigurationFile(vi, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2634,6 +2731,7 @@ namespace nifgen_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -2671,6 +2769,7 @@ namespace nifgen_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -2708,6 +2807,7 @@ namespace nifgen_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -2734,6 +2834,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->InitiateGeneration(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2756,6 +2857,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->InvalidateAllAttributes(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2779,6 +2881,7 @@ namespace nifgen_grpc {
       ViBoolean done {};
       auto status = library_->IsDone(vi, &done);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2803,6 +2906,7 @@ namespace nifgen_grpc {
       auto endpoint_name = request->endpoint_name().c_str();
       auto status = library_->ManualEnableP2PStream(vi, endpoint_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2829,6 +2933,7 @@ namespace nifgen_grpc {
       ViInt32 maximum_loop_count {};
       auto status = library_->QueryArbSeqCapabilities(vi, &maximum_number_of_sequences, &minimum_sequence_length, &maximum_sequence_length, &maximum_loop_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2859,6 +2964,7 @@ namespace nifgen_grpc {
       ViInt32 maximum_waveform_size {};
       auto status = library_->QueryArbWfmCapabilities(vi, &maximum_number_of_waveforms, &waveform_quantum, &minimum_waveform_size, &maximum_waveform_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2891,6 +2997,7 @@ namespace nifgen_grpc {
       ViReal64 frequency_list_duration_quantum {};
       auto status = library_->QueryFreqListCapabilities(vi, &maximum_number_of_freq_lists, &minimum_frequency_list_length, &maximum_frequency_list_length, &minimum_frequency_list_duration, &maximum_frequency_list_duration, &frequency_list_duration_quantum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2920,6 +3027,7 @@ namespace nifgen_grpc {
       ViReal64 temperature {};
       auto status = library_->ReadCurrentTemperature(vi, &temperature);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2943,6 +3051,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2967,6 +3076,7 @@ namespace nifgen_grpc {
       ViAttr attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(vi, channel_name, attribute_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2989,6 +3099,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ResetDevice(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3011,6 +3122,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ResetInterchangeCheck(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3033,6 +3145,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ResetWithDefaults(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3057,6 +3170,7 @@ namespace nifgen_grpc {
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3116,6 +3230,7 @@ namespace nifgen_grpc {
 
       auto status = library_->RouteSignalOut(vi, channel_name, route_signal_from, route_signal_to);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3138,6 +3253,7 @@ namespace nifgen_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->SelfCal(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3162,6 +3278,7 @@ namespace nifgen_grpc {
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3204,6 +3321,7 @@ namespace nifgen_grpc {
       ViString trigger_id = (ViString)request->trigger_id().c_str();
       auto status = library_->SendSoftwareEdgeTrigger(vi, trigger, trigger_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3229,6 +3347,7 @@ namespace nifgen_grpc {
       ViBoolean attribute_value = request->attribute_value();
       auto status = library_->SetAttributeViBoolean(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3269,6 +3388,7 @@ namespace nifgen_grpc {
 
       auto status = library_->SetAttributeViInt32(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3294,6 +3414,7 @@ namespace nifgen_grpc {
       ViInt64 attribute_value = request->attribute_value_raw();
       auto status = library_->SetAttributeViInt64(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3334,6 +3455,7 @@ namespace nifgen_grpc {
 
       auto status = library_->SetAttributeViReal64(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3360,6 +3482,7 @@ namespace nifgen_grpc {
       ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.id(), attribute_value_grpc_session.name());
       auto status = library_->SetAttributeViSession(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3385,6 +3508,7 @@ namespace nifgen_grpc {
       auto attribute_value = request->attribute_value_raw().c_str();
       auto status = library_->SetAttributeViString(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3426,6 +3550,7 @@ namespace nifgen_grpc {
       ViInt32 offset = request->offset();
       auto status = library_->SetNamedWaveformNextWritePosition(vi, channel_name, waveform_name, relative_to, offset);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3467,6 +3592,7 @@ namespace nifgen_grpc {
       ViInt32 offset = request->offset();
       auto status = library_->SetWaveformNextWritePosition(vi, channel_name, waveform_handle, relative_to, offset);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3490,6 +3616,7 @@ namespace nifgen_grpc {
       ViInt32 max_time = request->max_time();
       auto status = library_->WaitUntilDone(vi, max_time);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3522,6 +3649,7 @@ namespace nifgen_grpc {
         [](auto x) { return (ViInt16)x; }); 
       auto status = library_->WriteBinary16Waveform(vi, channel_name, waveform_handle, size, data.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3548,6 +3676,7 @@ namespace nifgen_grpc {
       auto data = convert_from_grpc<NIComplexI16_struct>(request->data());
       auto status = library_->WriteComplexBinary16Waveform(vi, channel_name, waveform_handle, size, data.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3574,6 +3703,7 @@ namespace nifgen_grpc {
       auto data = const_cast<ViReal64*>(request->data().data());
       auto status = library_->WriteNamedWaveformF64(vi, channel_name, waveform_name, size, data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3606,6 +3736,7 @@ namespace nifgen_grpc {
         [](auto x) { return (ViInt16)x; }); 
       auto status = library_->WriteNamedWaveformI16(vi, channel_name, waveform_name, size, data.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3637,6 +3768,7 @@ namespace nifgen_grpc {
         [](auto x) { return (ViInt16)x; }); 
       auto status = library_->WriteP2PEndpointI16(vi, endpoint_name, number_of_samples, endpoint_data.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3661,6 +3793,7 @@ namespace nifgen_grpc {
       auto script = request->script().c_str();
       auto status = library_->WriteScript(vi, channel_name, script);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3687,6 +3820,7 @@ namespace nifgen_grpc {
       auto data = const_cast<ViReal64*>(request->data().data());
       auto status = library_->WriteWaveform(vi, channel_name, waveform_handle, size, data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3713,6 +3847,7 @@ namespace nifgen_grpc {
       ViInt32 waveform_handle = request->waveform_handle();
       auto status = library_->WriteWaveformComplexF64(vi, channel_name, number_of_samples, data.data(), waveform_handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3739,6 +3874,7 @@ namespace nifgen_grpc {
       auto data = convert_from_grpc<NIComplexNumber_struct>(request->data());
       auto status = library_->WriteNamedWaveformComplexF64(vi, channel_name, waveform_name, size, data.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3765,6 +3901,7 @@ namespace nifgen_grpc {
       auto data = convert_from_grpc<NIComplexI16_struct>(request->data());
       auto status = library_->WriteNamedWaveformComplexI16(vi, channel_name, waveform_name, size, data.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
@@ -77,6 +77,7 @@ namespace nirfmxbluetooth_grpc {
       int32 averaging_count = request->averaging_count();
       auto status = library_->ACPCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -116,6 +117,7 @@ namespace nirfmxbluetooth_grpc {
 
       auto status = library_->ACPCfgBurstSynchronizationType(instrument, selector_string, burst_synchronization_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -140,6 +142,7 @@ namespace nirfmxbluetooth_grpc {
       int32 number_of_offsets = request->number_of_offsets();
       auto status = library_->ACPCfgNumberOfOffsets(instrument, selector_string, number_of_offsets);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -179,6 +182,7 @@ namespace nirfmxbluetooth_grpc {
 
       auto status = library_->ACPCfgOffsetChannelMode(instrument, selector_string, offset_channel_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -207,6 +211,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->ACPFetchAbsolutePowerTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_absolute_power()->Resize(actual_array_size, 0);
@@ -218,6 +223,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -251,6 +257,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->ACPFetchMaskTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_limit_with_exception_mask()->Resize(actual_array_size, 0);
@@ -264,6 +271,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -295,6 +303,7 @@ namespace nirfmxbluetooth_grpc {
       int32 measurement_status {};
       auto status = library_->ACPFetchMeasurementStatus(instrument, selector_string, timeout, &measurement_status);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -327,6 +336,7 @@ namespace nirfmxbluetooth_grpc {
       float64 upper_margin {};
       auto status = library_->ACPFetchOffsetMeasurement(instrument, selector_string, timeout, &lower_absolute_power, &upper_absolute_power, &lower_relative_power, &upper_relative_power, &lower_margin, &upper_margin);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -359,6 +369,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->ACPFetchOffsetMeasurementArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_lower_absolute_power()->Resize(actual_array_size, 0);
@@ -380,6 +391,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -413,6 +425,7 @@ namespace nirfmxbluetooth_grpc {
       float64 reference_channel_power {};
       auto status = library_->ACPFetchReferenceChannelPower(instrument, selector_string, timeout, &reference_channel_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -442,6 +455,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->ACPFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -453,6 +467,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -481,6 +496,7 @@ namespace nirfmxbluetooth_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->AbortMeasurements(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -511,6 +527,7 @@ namespace nirfmxbluetooth_grpc {
       auto reserved = 0;
       auto status = library_->AnalyzeIQ1Waveform(instrument, selector_string, result_name, x0, dx, iq.data(), array_size, reset, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -535,6 +552,7 @@ namespace nirfmxbluetooth_grpc {
       float64 timeout = request->timeout();
       auto status = library_->AutoDetectSignal(instrument, selector_string, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -560,6 +578,7 @@ namespace nirfmxbluetooth_grpc {
       float64 reference_level {};
       auto status = library_->AutoLevel(instrument, selector_string, measurement_interval, &reference_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -585,6 +604,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->BuildOffsetString(selector_string, offset_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -599,6 +619,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -626,6 +647,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->BuildSignalString(signal_name, result_name, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_length = status;
@@ -640,6 +662,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -667,6 +690,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->BuildSlotString(selector_string, slot_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -681,6 +705,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -708,6 +733,7 @@ namespace nirfmxbluetooth_grpc {
       int32 channel_number = request->channel_number();
       auto status = library_->CfgChannelNumber(instrument, selector_string, channel_number);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -732,6 +758,7 @@ namespace nirfmxbluetooth_grpc {
       int32 data_rate = request->data_rate();
       auto status = library_->CfgDataRate(instrument, selector_string, data_rate);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -774,6 +801,7 @@ namespace nirfmxbluetooth_grpc {
       int32 enable_trigger = request->enable_trigger();
       auto status = library_->CfgDigitalEdgeTrigger(instrument, selector_string, digital_edge_source, digital_edge, trigger_delay, enable_trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -798,6 +826,7 @@ namespace nirfmxbluetooth_grpc {
       float64 external_attenuation = request->external_attenuation();
       auto status = library_->CfgExternalAttenuation(instrument, selector_string, external_attenuation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -822,6 +851,7 @@ namespace nirfmxbluetooth_grpc {
       float64 center_frequency = request->center_frequency();
       auto status = library_->CfgFrequency(instrument, selector_string, center_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -862,6 +892,7 @@ namespace nirfmxbluetooth_grpc {
       int32 channel_number = request->channel_number();
       auto status = library_->CfgFrequencyChannelNumber(instrument, selector_string, standard, channel_number);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -906,6 +937,7 @@ namespace nirfmxbluetooth_grpc {
       float64 frequency_reference_frequency = request->frequency_reference_frequency();
       auto status = library_->CfgFrequencyReference(instrument, channel_name, frequency_reference_source, frequency_reference_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -982,6 +1014,7 @@ namespace nirfmxbluetooth_grpc {
       int32 enable_trigger = request->enable_trigger();
       auto status = library_->CfgIQPowerEdgeTrigger(instrument, selector_string, iq_power_edge_source, iq_power_edge_slope, iq_power_edge_level, trigger_delay, trigger_min_quiet_time_mode, trigger_min_quiet_time_duration, iq_power_edge_level_type, enable_trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1023,6 +1056,7 @@ namespace nirfmxbluetooth_grpc {
       float64 cte_slot_duration = request->cte_slot_duration();
       auto status = library_->CfgLEDirectionFinding(instrument, selector_string, direction_finding_mode, cte_length, cte_slot_duration);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1063,6 +1097,7 @@ namespace nirfmxbluetooth_grpc {
       float64 mechanical_attenuation_value = request->mechanical_attenuation_value();
       auto status = library_->CfgMechanicalAttenuation(instrument, channel_name, mechanical_attenuation_auto, mechanical_attenuation_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1102,6 +1137,7 @@ namespace nirfmxbluetooth_grpc {
 
       auto status = library_->CfgPacketType(instrument, selector_string, packet_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1141,6 +1177,7 @@ namespace nirfmxbluetooth_grpc {
 
       auto status = library_->CfgPayloadBitPattern(instrument, selector_string, payload_bit_pattern);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1181,6 +1218,7 @@ namespace nirfmxbluetooth_grpc {
       int32 payload_length = request->payload_length();
       auto status = library_->CfgPayloadLength(instrument, selector_string, payload_length_mode, payload_length);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1207,6 +1245,7 @@ namespace nirfmxbluetooth_grpc {
       float64 external_attenuation = request->external_attenuation();
       auto status = library_->CfgRF(instrument, selector_string, center_frequency, reference_level, external_attenuation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1247,6 +1286,7 @@ namespace nirfmxbluetooth_grpc {
       float64 rf_attenuation_value = request->rf_attenuation_value();
       auto status = library_->CfgRFAttenuation(instrument, channel_name, rf_attenuation_auto, rf_attenuation_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1271,6 +1311,7 @@ namespace nirfmxbluetooth_grpc {
       float64 reference_level = request->reference_level();
       auto status = library_->CfgReferenceLevel(instrument, selector_string, reference_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1296,6 +1337,7 @@ namespace nirfmxbluetooth_grpc {
       int32 enable_trigger = request->enable_trigger();
       auto status = library_->CfgSoftwareEdgeTrigger(instrument, selector_string, trigger_delay, enable_trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1320,6 +1362,7 @@ namespace nirfmxbluetooth_grpc {
       int32 is_done {};
       auto status = library_->CheckMeasurementStatus(instrument, selector_string, &is_done);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1344,6 +1387,7 @@ namespace nirfmxbluetooth_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearAllNamedResults(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1367,6 +1411,7 @@ namespace nirfmxbluetooth_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearNamedResult(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1391,6 +1436,7 @@ namespace nirfmxbluetooth_grpc {
       char* new_signal_name = (char*)request->new_signal_name().c_str();
       auto status = library_->CloneSignalConfiguration(instrument, old_signal_name, new_signal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1415,6 +1461,7 @@ namespace nirfmxbluetooth_grpc {
       session_repository_->remove_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->Close(instrument, force_destroy);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1438,6 +1485,7 @@ namespace nirfmxbluetooth_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->Commit(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1461,6 +1509,7 @@ namespace nirfmxbluetooth_grpc {
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->CreateSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1484,6 +1533,7 @@ namespace nirfmxbluetooth_grpc {
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->DeleteSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1507,6 +1557,7 @@ namespace nirfmxbluetooth_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->DisableTrigger(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1547,6 +1598,7 @@ namespace nirfmxbluetooth_grpc {
       int32 averaging_count = request->averaging_count();
       auto status = library_->FrequencyRangeCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1571,6 +1623,7 @@ namespace nirfmxbluetooth_grpc {
       float64 span = request->span();
       auto status = library_->FrequencyRangeCfgSpan(instrument, selector_string, span);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1597,6 +1650,7 @@ namespace nirfmxbluetooth_grpc {
       float64 low_frequency {};
       auto status = library_->FrequencyRangeFetchMeasurement(instrument, selector_string, timeout, &high_frequency, &low_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1627,6 +1681,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->FrequencyRangeFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -1638,6 +1693,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1669,6 +1725,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->GetAllNamedResultNames(instrument, selector_string, nullptr, 0, &actual_result_names_size, &default_result_exists);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::string result_names;
@@ -1682,6 +1739,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1712,6 +1770,7 @@ namespace nirfmxbluetooth_grpc {
       float32 attr_val {};
       auto status = library_->GetAttributeF32(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1739,6 +1798,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->GetAttributeF32Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -1750,6 +1810,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1778,6 +1839,7 @@ namespace nirfmxbluetooth_grpc {
       float64 attr_val {};
       auto status = library_->GetAttributeF64(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1805,6 +1867,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->GetAttributeF64Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -1816,6 +1879,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1844,6 +1908,7 @@ namespace nirfmxbluetooth_grpc {
       int16 attr_val {};
       auto status = library_->GetAttributeI16(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1870,6 +1935,7 @@ namespace nirfmxbluetooth_grpc {
       int32 attr_val {};
       auto status = library_->GetAttributeI32(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1903,6 +1969,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->GetAttributeI32Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val_raw()->Resize(actual_array_size, 0);
@@ -1914,6 +1981,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1956,6 +2024,7 @@ namespace nirfmxbluetooth_grpc {
       int64 attr_val {};
       auto status = library_->GetAttributeI64(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1983,6 +2052,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->GetAttributeI64Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -1994,6 +2064,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2022,6 +2093,7 @@ namespace nirfmxbluetooth_grpc {
       int8 attr_val {};
       auto status = library_->GetAttributeI8(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2049,6 +2121,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->GetAttributeI8Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<int8> attr_val(actual_array_size);
@@ -2059,6 +2132,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2097,6 +2171,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->GetAttributeNIComplexDoubleArray(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexDouble> attr_val(actual_array_size, NIComplexDouble());
@@ -2107,6 +2182,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2143,6 +2219,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->GetAttributeNIComplexSingleArray(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> attr_val(actual_array_size, NIComplexSingle());
@@ -2153,6 +2230,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2189,6 +2267,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->GetAttributeString(instrument, selector_string, attribute_id, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 array_size = status;
@@ -2203,6 +2282,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2231,6 +2311,7 @@ namespace nirfmxbluetooth_grpc {
       uInt16 attr_val {};
       auto status = library_->GetAttributeU16(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2257,6 +2338,7 @@ namespace nirfmxbluetooth_grpc {
       uInt32 attr_val {};
       auto status = library_->GetAttributeU32(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2284,6 +2366,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->GetAttributeU32Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -2295,6 +2378,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2324,6 +2408,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->GetAttributeU64Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -2335,6 +2420,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2363,6 +2449,7 @@ namespace nirfmxbluetooth_grpc {
       uInt8 attr_val {};
       auto status = library_->GetAttributeU8(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2390,6 +2477,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->GetAttributeU8Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::string attr_val(actual_array_size, '\0');
@@ -2400,6 +2488,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2428,6 +2517,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->GetError(instrument, nullptr, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 error_description_buffer_size = status;
@@ -2443,6 +2533,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2472,6 +2563,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->GetErrorString(instrument, error_code, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 error_description_buffer_size = status;
@@ -2486,6 +2578,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2521,6 +2614,7 @@ namespace nirfmxbluetooth_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXBT_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
       }
       response->set_status(status);
@@ -2557,6 +2651,7 @@ namespace nirfmxbluetooth_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXBT_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
       }
       response->set_status(status);
@@ -2585,6 +2680,7 @@ namespace nirfmxbluetooth_grpc {
       char* result_name = (char*)request->result_name().c_str();
       auto status = library_->Initiate(instrument, selector_string, result_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2625,6 +2721,7 @@ namespace nirfmxbluetooth_grpc {
       int32 averaging_count = request->averaging_count();
       auto status = library_->ModAccCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2664,6 +2761,7 @@ namespace nirfmxbluetooth_grpc {
 
       auto status = library_->ModAccCfgBurstSynchronizationType(instrument, selector_string, burst_synchronization_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2690,6 +2788,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->ModAccFetchConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> constellation(actual_array_size, NIComplexSingle());
@@ -2700,6 +2799,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2737,6 +2837,7 @@ namespace nirfmxbluetooth_grpc {
       float64 ninetynine_percent_devm {};
       auto status = library_->ModAccFetchDEVM(instrument, selector_string, timeout, &peak_rms_devm_maximum, &peak_devm_maximum, &ninetynine_percent_devm);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2766,6 +2867,7 @@ namespace nirfmxbluetooth_grpc {
       float64 peak_rms_magnitude_error_maximum {};
       auto status = library_->ModAccFetchDEVMMagnitudeError(instrument, selector_string, timeout, &average_rms_magnitude_error_mean, &peak_rms_magnitude_error_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2794,6 +2896,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->ModAccFetchDEVMPerSymbolTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_devm_per_symbol()->Resize(actual_array_size, 0);
@@ -2805,6 +2908,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2834,6 +2938,7 @@ namespace nirfmxbluetooth_grpc {
       float64 peak_rms_phase_error_maximum {};
       auto status = library_->ModAccFetchDEVMPhaseError(instrument, selector_string, timeout, &average_rms_phase_error_mean, &peak_rms_phase_error_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2862,6 +2967,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->ModAccFetchDemodulatedBitTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<int8> demodulated_bits(actual_array_size);
@@ -2872,6 +2978,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2910,6 +3017,7 @@ namespace nirfmxbluetooth_grpc {
       float64 df1avg_minimum {};
       auto status = library_->ModAccFetchDf1(instrument, selector_string, timeout, &df1avg_maximum, &df1avg_minimum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2938,6 +3046,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->ModAccFetchDf1maxTrace(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_time()->Resize(actual_array_size, 0);
@@ -2951,6 +3060,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2981,6 +3091,7 @@ namespace nirfmxbluetooth_grpc {
       float64 percentage_of_symbols_above_df2max_threshold {};
       auto status = library_->ModAccFetchDf2(instrument, selector_string, timeout, &df2avg_minimum, &percentage_of_symbols_above_df2max_threshold);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3009,6 +3120,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->ModAccFetchDf2maxTrace(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_time()->Resize(actual_array_size, 0);
@@ -3022,6 +3134,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3053,6 +3166,7 @@ namespace nirfmxbluetooth_grpc {
       float64 peak_frequency_drift_rate_maximum {};
       auto status = library_->ModAccFetchFrequencyErrorBR(instrument, selector_string, timeout, &initial_frequency_error_maximum, &peak_frequency_drift_maximum, &peak_frequency_drift_rate_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3083,6 +3197,7 @@ namespace nirfmxbluetooth_grpc {
       float64 peak_frequency_error_w0_maximum {};
       auto status = library_->ModAccFetchFrequencyErrorEDR(instrument, selector_string, timeout, &header_frequency_error_wi_maximum, &peak_frequency_error_wi_plus_w0_maximum, &peak_frequency_error_w0_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3114,6 +3229,7 @@ namespace nirfmxbluetooth_grpc {
       float64 peak_frequency_drift_rate_maximum {};
       auto status = library_->ModAccFetchFrequencyErrorLE(instrument, selector_string, timeout, &peak_frequency_error_maximum, &initial_frequency_drift_maximum, &peak_frequency_drift_maximum, &peak_frequency_drift_rate_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3144,6 +3260,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->ModAccFetchFrequencyErrorTraceBR(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_time()->Resize(actual_array_size, 0);
@@ -3157,6 +3274,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3187,6 +3305,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->ModAccFetchFrequencyErrorTraceLE(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_time()->Resize(actual_array_size, 0);
@@ -3200,6 +3319,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3230,6 +3350,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->ModAccFetchFrequencyErrorWiPlusW0TraceEDR(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_time()->Resize(actual_array_size, 0);
@@ -3243,6 +3364,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3275,6 +3397,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->ModAccFetchFrequencyTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_frequency()->Resize(actual_array_size, 0);
@@ -3286,6 +3409,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3317,6 +3441,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->ModAccFetchRMSDEVMTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_rms_devm()->Resize(actual_array_size, 0);
@@ -3328,6 +3453,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3355,6 +3481,7 @@ namespace nirfmxbluetooth_grpc {
       int32 attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(instrument, selector_string, attribute_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3378,6 +3505,7 @@ namespace nirfmxbluetooth_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ResetToDefault(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3418,6 +3546,7 @@ namespace nirfmxbluetooth_grpc {
       int32 enable_all_traces = request->enable_all_traces();
       auto status = library_->SelectMeasurements(instrument, selector_string, measurements, enable_all_traces);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3440,6 +3569,7 @@ namespace nirfmxbluetooth_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->SendSoftwareEdgeTrigger(instrument);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3465,6 +3595,7 @@ namespace nirfmxbluetooth_grpc {
       float32 attr_val = request->attr_val();
       auto status = library_->SetAttributeF32(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3491,6 +3622,7 @@ namespace nirfmxbluetooth_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeF32Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3516,6 +3648,7 @@ namespace nirfmxbluetooth_grpc {
       float64 attr_val = request->attr_val();
       auto status = library_->SetAttributeF64(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3542,6 +3675,7 @@ namespace nirfmxbluetooth_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeF64Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3576,6 +3710,7 @@ namespace nirfmxbluetooth_grpc {
 
       auto status = library_->SetAttributeI16(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3619,6 +3754,7 @@ namespace nirfmxbluetooth_grpc {
 
       auto status = library_->SetAttributeI32(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3653,6 +3789,7 @@ namespace nirfmxbluetooth_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI32Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3678,6 +3815,7 @@ namespace nirfmxbluetooth_grpc {
       int64 attr_val = request->attr_val();
       auto status = library_->SetAttributeI64(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3704,6 +3842,7 @@ namespace nirfmxbluetooth_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI64Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3738,6 +3877,7 @@ namespace nirfmxbluetooth_grpc {
 
       auto status = library_->SetAttributeI8(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3784,6 +3924,7 @@ namespace nirfmxbluetooth_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI8Array(instrument, selector_string, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3813,6 +3954,7 @@ namespace nirfmxbluetooth_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeNIComplexDoubleArray(instrument, selector_string, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3839,6 +3981,7 @@ namespace nirfmxbluetooth_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeNIComplexSingleArray(instrument, selector_string, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3883,6 +4026,7 @@ namespace nirfmxbluetooth_grpc {
 
       auto status = library_->SetAttributeString(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3917,6 +4061,7 @@ namespace nirfmxbluetooth_grpc {
 
       auto status = library_->SetAttributeU16(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3945,6 +4090,7 @@ namespace nirfmxbluetooth_grpc {
       uInt32 attr_val = request->attr_val();
       auto status = library_->SetAttributeU32(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3971,6 +4117,7 @@ namespace nirfmxbluetooth_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU32Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3997,6 +4144,7 @@ namespace nirfmxbluetooth_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU64Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4022,6 +4170,7 @@ namespace nirfmxbluetooth_grpc {
       uInt8 attr_val = request->attr_val();
       auto status = library_->SetAttributeU8(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4048,6 +4197,7 @@ namespace nirfmxbluetooth_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU8Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4088,6 +4238,7 @@ namespace nirfmxbluetooth_grpc {
       int32 averaging_count = request->averaging_count();
       auto status = library_->TXPCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4127,6 +4278,7 @@ namespace nirfmxbluetooth_grpc {
 
       auto status = library_->TXPCfgBurstSynchronizationType(instrument, selector_string, burst_synchronization_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4154,6 +4306,7 @@ namespace nirfmxbluetooth_grpc {
       float64 edr_dpsk_gfsk_average_power_ratio_mean {};
       auto status = library_->TXPFetchEDRPowers(instrument, selector_string, timeout, &edr_gfsk_average_power_mean, &edr_dpsk_average_power_mean, &edr_dpsk_gfsk_average_power_ratio_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4183,6 +4336,7 @@ namespace nirfmxbluetooth_grpc {
       float64 reference_period_peak_absolute_power_deviation_maximum {};
       auto status = library_->TXPFetchLECTEReferencePeriodPowers(instrument, selector_string, timeout, &reference_period_average_power_mean, &reference_period_peak_absolute_power_deviation_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4211,6 +4365,7 @@ namespace nirfmxbluetooth_grpc {
       float64 transmit_slot_peak_absolute_power_deviation_maximum {};
       auto status = library_->TXPFetchLECTETransmitSlotPowers(instrument, selector_string, timeout, &transmit_slot_average_power_mean, &transmit_slot_peak_absolute_power_deviation_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4239,6 +4394,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->TXPFetchLECTETransmitSlotPowersArray(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_transmit_slot_average_power_mean()->Resize(actual_array_size, 0);
@@ -4252,6 +4408,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4284,6 +4441,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->TXPFetchPowerTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_power()->Resize(actual_array_size, 0);
@@ -4295,6 +4453,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4328,6 +4487,7 @@ namespace nirfmxbluetooth_grpc {
       float64 peak_to_average_power_ratio_maximum {};
       auto status = library_->TXPFetchPowers(instrument, selector_string, timeout, &average_power_mean, &average_power_maximum, &average_power_minimum, &peak_to_average_power_ratio_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4372,6 +4532,7 @@ namespace nirfmxbluetooth_grpc {
       int32 averaging_count = request->averaging_count();
       auto status = library_->TwentydBBandwidthCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4400,6 +4561,7 @@ namespace nirfmxbluetooth_grpc {
       float64 low_frequency {};
       auto status = library_->TwentydBBandwidthFetchMeasurement(instrument, selector_string, timeout, &peak_power, &bandwidth, &high_frequency, &low_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4432,6 +4594,7 @@ namespace nirfmxbluetooth_grpc {
       while (true) {
         auto status = library_->TwentydBBandwidthFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -4443,6 +4606,7 @@ namespace nirfmxbluetooth_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4471,6 +4635,7 @@ namespace nirfmxbluetooth_grpc {
       float64 timeout = request->timeout();
       auto status = library_->WaitForAcquisitionComplete(instrument, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4495,6 +4660,7 @@ namespace nirfmxbluetooth_grpc {
       float64 timeout = request->timeout();
       auto status = library_->WaitForMeasurementComplete(instrument, selector_string, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -60,6 +60,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->BuildCalibrationPlaneString(calibration_plane_name, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_length = status;
@@ -74,6 +75,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -101,6 +103,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->BuildInstrumentString(selector_string, instrument_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -115,6 +118,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -142,6 +146,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->BuildLOString(selector_string, lo_index, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -156,6 +161,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -183,6 +189,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->BuildModuleString(selector_string, module_name, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -197,6 +204,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -240,6 +248,7 @@ namespace nirfmxinstr_grpc {
 
       auto status = library_->CfgExternalAttenuationInterpolationLinear(instrument, selector_string, table_name, format);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -264,6 +273,7 @@ namespace nirfmxinstr_grpc {
       char* table_name = (char*)request->table_name().c_str();
       auto status = library_->CfgExternalAttenuationInterpolationNearest(instrument, selector_string, table_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -288,6 +298,7 @@ namespace nirfmxinstr_grpc {
       char* table_name = (char*)request->table_name().c_str();
       auto status = library_->CfgExternalAttenuationInterpolationSpline(instrument, selector_string, table_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -331,6 +342,7 @@ namespace nirfmxinstr_grpc {
 
       auto status = library_->CfgExternalAttenuationTable(instrument, selector_string, table_name, frequency, external_attenuation, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -375,6 +387,7 @@ namespace nirfmxinstr_grpc {
       float64 frequency_reference_frequency = request->frequency_reference_frequency();
       auto status = library_->CfgFrequencyReference(instrument, channel_name, frequency_reference_source, frequency_reference_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -415,6 +428,7 @@ namespace nirfmxinstr_grpc {
       float64 mechanical_attenuation_value = request->mechanical_attenuation_value();
       auto status = library_->CfgMechanicalAttenuation(instrument, channel_name, mechanical_attenuation_auto, mechanical_attenuation_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -455,6 +469,7 @@ namespace nirfmxinstr_grpc {
       float64 rf_attenuation_value = request->rf_attenuation_value();
       auto status = library_->CfgRFAttenuation(instrument, channel_name, rf_attenuation_auto, rf_attenuation_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -500,6 +515,7 @@ namespace nirfmxinstr_grpc {
 
       auto status = library_->CfgSParameterExternalAttenuationTable(instrument, selector_string, table_name, frequency, frequency_array_size, s_parameters.data(), s_parameter_table_size, number_of_ports, s_parameter_orientation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -539,6 +555,7 @@ namespace nirfmxinstr_grpc {
 
       auto status = library_->CfgSParameterExternalAttenuationType(instrument, selector_string, s_parameter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -562,6 +579,7 @@ namespace nirfmxinstr_grpc {
       int32 acquisition_done {};
       auto status = library_->CheckAcquisitionStatus(instrument, &acquisition_done);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -588,6 +606,7 @@ namespace nirfmxinstr_grpc {
       int32 personality {};
       auto status = library_->CheckIfListExists(instrument, list_name, &list_exists, &personality);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -616,6 +635,7 @@ namespace nirfmxinstr_grpc {
       int32 personality {};
       auto status = library_->CheckIfSignalConfigurationExists(instrument, signal_name, &signal_configuration_exists, &personality);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -643,6 +663,7 @@ namespace nirfmxinstr_grpc {
       session_repository_->remove_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->Close(instrument, force_destroy);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -666,6 +687,7 @@ namespace nirfmxinstr_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->DeleteAllExternalAttenuationTables(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -690,6 +712,7 @@ namespace nirfmxinstr_grpc {
       char* table_name = (char*)request->table_name().c_str();
       auto status = library_->DeleteExternalAttenuationTable(instrument, selector_string, table_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -713,6 +736,7 @@ namespace nirfmxinstr_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->DisableCalibrationPlane(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -736,6 +760,7 @@ namespace nirfmxinstr_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->EnableCalibrationPlane(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -794,6 +819,7 @@ namespace nirfmxinstr_grpc {
 
       auto status = library_->ExportSignal(instrument, export_signal_source, export_signal_output_terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -819,6 +845,7 @@ namespace nirfmxinstr_grpc {
       float32 attr_val {};
       auto status = library_->GetAttributeF32(instrument, channel_name, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -846,6 +873,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->GetAttributeF32Array(instrument, channel_name, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -857,6 +885,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -885,6 +914,7 @@ namespace nirfmxinstr_grpc {
       float64 attr_val {};
       auto status = library_->GetAttributeF64(instrument, channel_name, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -912,6 +942,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->GetAttributeF64Array(instrument, channel_name, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -923,6 +954,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -951,6 +983,7 @@ namespace nirfmxinstr_grpc {
       int16 attr_val {};
       auto status = library_->GetAttributeI16(instrument, channel_name, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -977,6 +1010,7 @@ namespace nirfmxinstr_grpc {
       int32 attr_val {};
       auto status = library_->GetAttributeI32(instrument, channel_name, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1010,6 +1044,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->GetAttributeI32Array(instrument, channel_name, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val_raw()->Resize(actual_array_size, 0);
@@ -1021,6 +1056,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1063,6 +1099,7 @@ namespace nirfmxinstr_grpc {
       int64 attr_val {};
       auto status = library_->GetAttributeI64(instrument, channel_name, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1090,6 +1127,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->GetAttributeI64Array(instrument, channel_name, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -1101,6 +1139,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1129,6 +1168,7 @@ namespace nirfmxinstr_grpc {
       int8 attr_val {};
       auto status = library_->GetAttributeI8(instrument, channel_name, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1156,6 +1196,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->GetAttributeI8Array(instrument, channel_name, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<int8> attr_val(actual_array_size);
@@ -1166,6 +1207,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1204,6 +1246,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->GetAttributeNIComplexDoubleArray(instrument, channel_name, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexDouble> attr_val(actual_array_size, NIComplexDouble());
@@ -1214,6 +1257,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1250,6 +1294,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->GetAttributeNIComplexSingleArray(instrument, channel_name, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> attr_val(actual_array_size, NIComplexSingle());
@@ -1260,6 +1305,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1296,6 +1342,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->GetAttributeString(instrument, channel_name, attribute_id, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 array_size = status;
@@ -1310,6 +1357,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1338,6 +1386,7 @@ namespace nirfmxinstr_grpc {
       uInt16 attr_val {};
       auto status = library_->GetAttributeU16(instrument, channel_name, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1364,6 +1413,7 @@ namespace nirfmxinstr_grpc {
       uInt32 attr_val {};
       auto status = library_->GetAttributeU32(instrument, channel_name, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1391,6 +1441,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->GetAttributeU32Array(instrument, channel_name, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -1402,6 +1453,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1431,6 +1483,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->GetAttributeU64Array(instrument, channel_name, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -1442,6 +1495,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1470,6 +1524,7 @@ namespace nirfmxinstr_grpc {
       uInt8 attr_val {};
       auto status = library_->GetAttributeU8(instrument, channel_name, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1497,6 +1552,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->GetAttributeU8Array(instrument, channel_name, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::string attr_val(actual_array_size, '\0');
@@ -1507,6 +1563,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1536,6 +1593,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->GetAvailablePorts(instrument, selector_string, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 array_size = status;
@@ -1550,6 +1608,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1577,6 +1636,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->GetError(instrument, nullptr, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 error_description_buffer_size = status;
@@ -1592,6 +1652,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1621,6 +1682,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->GetErrorString(instrument, error_code, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 error_description_buffer_size = status;
@@ -1635,6 +1697,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1662,6 +1725,7 @@ namespace nirfmxinstr_grpc {
       float64 external_attenuation {};
       auto status = library_->GetExternalAttenuationTableActualValue(instrument, selector_string, &external_attenuation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1705,6 +1769,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->GetListNames(instrument, selector_string, personality_filter, nullptr, 0, &actual_list_names_size, nullptr, 0, &actual_personality_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::string list_names;
@@ -1721,6 +1786,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1794,6 +1860,7 @@ namespace nirfmxinstr_grpc {
       int32 s_parameter_type {};
       auto status = library_->GetSParameterExternalAttenuationType(instrument, selector_string, &s_parameter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1836,6 +1903,7 @@ namespace nirfmxinstr_grpc {
       CVIAbsoluteTime timestamp {};
       auto status = library_->GetSelfCalibrateLastDateAndTime(instrument, selector_string, self_calibrate_step, &timestamp);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1877,6 +1945,7 @@ namespace nirfmxinstr_grpc {
       float64 temperature {};
       auto status = library_->GetSelfCalibrateLastTemperature(instrument, selector_string, self_calibrate_step, &temperature);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1920,6 +1989,7 @@ namespace nirfmxinstr_grpc {
       while (true) {
         auto status = library_->GetSignalConfigurationNames(instrument, selector_string, personality_filter, nullptr, 0, &actual_signal_names_size, nullptr, 0, &actual_personality_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::string signal_names;
@@ -1936,6 +2006,7 @@ namespace nirfmxinstr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1974,6 +2045,7 @@ namespace nirfmxinstr_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXINSTR_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
       }
       response->set_status(status);
@@ -2010,6 +2082,7 @@ namespace nirfmxinstr_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXINSTR_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
       }
       response->set_status(status);
@@ -2051,6 +2124,7 @@ namespace nirfmxinstr_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXINSTR_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
       }
       response->set_status(status);
@@ -2080,6 +2154,7 @@ namespace nirfmxinstr_grpc {
       int32 valid_steps {};
       auto status = library_->IsSelfCalibrateValid(instrument, selector_string, &self_calibrate_valid, &valid_steps);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2126,6 +2201,7 @@ namespace nirfmxinstr_grpc {
       int32 load_rf_instr_configuration = request->load_rf_instr_configuration();
       auto status = library_->LoadAllConfigurations(instrument, file_path, load_rf_instr_configuration);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2167,6 +2243,7 @@ namespace nirfmxinstr_grpc {
 
       auto status = library_->LoadSParameterExternalAttenuationTableFromS2PFile(instrument, selector_string, table_name, s2p_file_path, s_parameter_orientation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2191,6 +2268,7 @@ namespace nirfmxinstr_grpc {
       int32 attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(instrument, channel_name, attribute_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2213,6 +2291,7 @@ namespace nirfmxinstr_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->ResetDriver(instrument);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2235,6 +2314,7 @@ namespace nirfmxinstr_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->ResetEntireSession(instrument);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2257,6 +2337,7 @@ namespace nirfmxinstr_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->ResetToDefault(instrument);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2280,6 +2361,7 @@ namespace nirfmxinstr_grpc {
       char* file_path = (char*)request->file_path().c_str();
       auto status = library_->SaveAllConfigurations(instrument, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2304,6 +2386,7 @@ namespace nirfmxinstr_grpc {
       char* table_name = (char*)request->table_name().c_str();
       auto status = library_->SelectActiveExternalAttenuationTable(instrument, selector_string, table_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2343,6 +2426,7 @@ namespace nirfmxinstr_grpc {
 
       auto status = library_->SelfCalibrate(instrument, selector_string, steps_to_omit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2386,6 +2470,7 @@ namespace nirfmxinstr_grpc {
       float64 maximum_reference_level = request->maximum_reference_level();
       auto status = library_->SelfCalibrateRange(instrument, selector_string, steps_to_omit, minimum_frequency, maximum_frequency, minimum_reference_level, maximum_reference_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2408,6 +2493,7 @@ namespace nirfmxinstr_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->SendSoftwareEdgeAdvanceTrigger(instrument);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2430,6 +2516,7 @@ namespace nirfmxinstr_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->SendSoftwareEdgeStartTrigger(instrument);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2455,6 +2542,7 @@ namespace nirfmxinstr_grpc {
       float32 attr_val = request->attr_val();
       auto status = library_->SetAttributeF32(instrument, channel_name, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2481,6 +2569,7 @@ namespace nirfmxinstr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeF32Array(instrument, channel_name, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2506,6 +2595,7 @@ namespace nirfmxinstr_grpc {
       float64 attr_val = request->attr_val();
       auto status = library_->SetAttributeF64(instrument, channel_name, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2532,6 +2622,7 @@ namespace nirfmxinstr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeF64Array(instrument, channel_name, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2566,6 +2657,7 @@ namespace nirfmxinstr_grpc {
 
       auto status = library_->SetAttributeI16(instrument, channel_name, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2609,6 +2701,7 @@ namespace nirfmxinstr_grpc {
 
       auto status = library_->SetAttributeI32(instrument, channel_name, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2643,6 +2736,7 @@ namespace nirfmxinstr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI32Array(instrument, channel_name, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2668,6 +2762,7 @@ namespace nirfmxinstr_grpc {
       int64 attr_val = request->attr_val();
       auto status = library_->SetAttributeI64(instrument, channel_name, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2694,6 +2789,7 @@ namespace nirfmxinstr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI64Array(instrument, channel_name, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2728,6 +2824,7 @@ namespace nirfmxinstr_grpc {
 
       auto status = library_->SetAttributeI8(instrument, channel_name, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2774,6 +2871,7 @@ namespace nirfmxinstr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI8Array(instrument, channel_name, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2803,6 +2901,7 @@ namespace nirfmxinstr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeNIComplexDoubleArray(instrument, channel_name, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2829,6 +2928,7 @@ namespace nirfmxinstr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeNIComplexSingleArray(instrument, channel_name, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2873,6 +2973,7 @@ namespace nirfmxinstr_grpc {
 
       auto status = library_->SetAttributeString(instrument, channel_name, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2907,6 +3008,7 @@ namespace nirfmxinstr_grpc {
 
       auto status = library_->SetAttributeU16(instrument, channel_name, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2935,6 +3037,7 @@ namespace nirfmxinstr_grpc {
       uInt32 attr_val = request->attr_val();
       auto status = library_->SetAttributeU32(instrument, channel_name, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2961,6 +3064,7 @@ namespace nirfmxinstr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU32Array(instrument, channel_name, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2987,6 +3091,7 @@ namespace nirfmxinstr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU64Array(instrument, channel_name, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3012,6 +3117,7 @@ namespace nirfmxinstr_grpc {
       uInt8 attr_val = request->attr_val();
       auto status = library_->SetAttributeU8(instrument, channel_name, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3038,6 +3144,7 @@ namespace nirfmxinstr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU8Array(instrument, channel_name, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3061,6 +3168,7 @@ namespace nirfmxinstr_grpc {
       CVIAbsoluteTime timestamp {};
       auto status = library_->TimestampFromValues(seconds_since_1970, fractional_seconds, &timestamp);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
       }
       response->set_status(status);
@@ -3085,6 +3193,7 @@ namespace nirfmxinstr_grpc {
       float64 fractional_seconds {};
       auto status = library_->ValuesFromTimestamp(timestamp, &seconds_since_1970, &fractional_seconds);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
       }
       response->set_status(status);
@@ -3110,6 +3219,7 @@ namespace nirfmxinstr_grpc {
       float64 timeout = request->timeout();
       auto status = library_->WaitForAcquisitionComplete(instrument, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
@@ -62,6 +62,7 @@ namespace nirfmxinstr_restricted_grpc {
       float64 reference_or_trigger_level_out {};
       auto status = library_->ConvertForPowerUnitsUtility(instrument, reference_or_trigger_level_in, input_power_units, output_power_units, terminal_configuration, bandwidth, &reference_or_trigger_level_out);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -87,6 +88,7 @@ namespace nirfmxinstr_restricted_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->DeleteSnapshot(instrument, personality, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -114,6 +116,7 @@ namespace nirfmxinstr_restricted_grpc {
       while (true) {
         auto status = library_->GetActiveResultName(instrument, signal_name, signal_type, 0, nullptr, &actual_result_size, &result_state);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::string result_name;
@@ -127,6 +130,7 @@ namespace nirfmxinstr_restricted_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -157,6 +161,7 @@ namespace nirfmxinstr_restricted_grpc {
       while (true) {
         auto status = library_->GetActiveTableName(instrument, selector_string, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 array_size = status;
@@ -171,6 +176,7 @@ namespace nirfmxinstr_restricted_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -199,6 +205,7 @@ namespace nirfmxinstr_restricted_grpc {
       int32 attr_val {};
       auto status = library_->GetAttributeAuthor(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -225,6 +232,7 @@ namespace nirfmxinstr_restricted_grpc {
       float32 attr_val {};
       auto status = library_->GetAttributeDesiredF32(instrument, channel_name, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -252,6 +260,7 @@ namespace nirfmxinstr_restricted_grpc {
       while (true) {
         auto status = library_->GetAttributeDesiredF32Array(instrument, channel_name, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -263,6 +272,7 @@ namespace nirfmxinstr_restricted_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -291,6 +301,7 @@ namespace nirfmxinstr_restricted_grpc {
       float64 attr_val {};
       auto status = library_->GetAttributeDesiredF64(instrument, channel_name, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -318,6 +329,7 @@ namespace nirfmxinstr_restricted_grpc {
       while (true) {
         auto status = library_->GetAttributeDesiredF64Array(instrument, channel_name, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -329,6 +341,7 @@ namespace nirfmxinstr_restricted_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -357,6 +370,7 @@ namespace nirfmxinstr_restricted_grpc {
       int32 attr_val {};
       auto status = library_->GetAttributeDesiredI32(instrument, channel_name, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -383,6 +397,7 @@ namespace nirfmxinstr_restricted_grpc {
       int64 attr_val {};
       auto status = library_->GetAttributeDesiredI64(instrument, channel_name, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -410,6 +425,7 @@ namespace nirfmxinstr_restricted_grpc {
       while (true) {
         auto status = library_->GetAttributeDesiredString(instrument, channel_name, attribute_id, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 array_size = status;
@@ -424,6 +440,7 @@ namespace nirfmxinstr_restricted_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -451,6 +468,7 @@ namespace nirfmxinstr_restricted_grpc {
       int32 calibration_plane_enabled {};
       auto status = library_->GetCalibrationPlaneEnabled(instrument, selector_string, &calibration_plane_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -477,6 +495,7 @@ namespace nirfmxinstr_restricted_grpc {
       while (true) {
         auto status = library_->GetCalibrationPlaneNames(instrument, selector_string, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 array_size = status;
@@ -491,6 +510,7 @@ namespace nirfmxinstr_restricted_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -519,6 +539,7 @@ namespace nirfmxinstr_restricted_grpc {
       while (true) {
         auto status = library_->GetExternalAttenuationTableNames(instrument, selector_string, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 array_size = status;
@@ -533,6 +554,7 @@ namespace nirfmxinstr_restricted_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -560,6 +582,7 @@ namespace nirfmxinstr_restricted_grpc {
       int32 attr_val {};
       auto status = library_->GetForceAllTracesEnabled(instrument, channel_name, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -590,6 +613,7 @@ namespace nirfmxinstr_restricted_grpc {
       while (true) {
         auto status = library_->GetInitiaitedSnapshotStrings(instrument, &snapshot_info_cache_index, nullptr, 0, &personality_id_array_actual_size, nullptr, 0, &signal_names_actual_size, nullptr, 0, &result_names_actual_size, nullptr, 0, &snapshot_identifiers_actual_size, nullptr, 0, &snapshot_timestamp_array_actual_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_personality_id_array()->Resize(personality_id_array_actual_size, 0);
@@ -619,6 +643,7 @@ namespace nirfmxinstr_restricted_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -663,6 +688,7 @@ namespace nirfmxinstr_restricted_grpc {
       while (true) {
         auto status = library_->GetLatestConfigurationSnapshot(instrument, &snapshot_info_cache_index, &personality_id, nullptr, 0, &signal_name_actual_size, nullptr, 0, &snapshot_identifier_actual_size, &signal_configuration_state, &signal_timestamp);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::string signal_name;
@@ -681,6 +707,7 @@ namespace nirfmxinstr_restricted_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -715,6 +742,7 @@ namespace nirfmxinstr_restricted_grpc {
       while (true) {
         auto status = library_->GetOpenSessionsInformation(resource_name, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 info_json_size = status;
@@ -729,6 +757,7 @@ namespace nirfmxinstr_restricted_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -756,6 +785,7 @@ namespace nirfmxinstr_restricted_grpc {
       int32 privilege_level {};
       auto status = library_->GetPrivilegeLevel(instrument, &is_connection_alive, &privilege_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -782,6 +812,7 @@ namespace nirfmxinstr_restricted_grpc {
       while (true) {
         auto status = library_->GetRFmxVersion(instrument, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 array_size = status;
@@ -796,6 +827,7 @@ namespace nirfmxinstr_restricted_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -825,6 +857,7 @@ namespace nirfmxinstr_restricted_grpc {
       uInt64 time_stamp {};
       auto status = library_->GetSignalConfigurationState64(instrument, signal_name, signal_type, &signal_state, &time_stamp);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -852,6 +885,7 @@ namespace nirfmxinstr_restricted_grpc {
       int32 snapshot_state {};
       auto status = library_->GetSnapshotState(instrument, personality, selector_string, &snapshot_state);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -877,6 +911,7 @@ namespace nirfmxinstr_restricted_grpc {
       int32 all_traces_enabled {};
       auto status = library_->GetTracesInfoForMonitorSnapshot(instrument, selector_string, &all_traces_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -901,6 +936,7 @@ namespace nirfmxinstr_restricted_grpc {
       char* file_path = (char*)request->file_path().c_str();
       auto status = library_->LoadAllForRevert(instrument, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -925,6 +961,7 @@ namespace nirfmxinstr_restricted_grpc {
       int32 array_size = static_cast<int32>(request->json_string().size());
       auto status = library_->LoadConfigurationsFromJSON(instrument, json_string, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -946,6 +983,7 @@ namespace nirfmxinstr_restricted_grpc {
       char* resource_name = (char*)request->resource_name().c_str();
       auto status = library_->RegisterSpecialClientSnapshotInterest(resource_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
       }
       response->set_status(status);
@@ -969,6 +1007,7 @@ namespace nirfmxinstr_restricted_grpc {
       int32 privilege_level = request->privilege_level();
       auto status = library_->RequestPrivilege(instrument, privilege_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -992,6 +1031,7 @@ namespace nirfmxinstr_restricted_grpc {
       char* file_path = (char*)request->file_path().c_str();
       auto status = library_->SaveAllForRevert(instrument, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1017,6 +1057,7 @@ namespace nirfmxinstr_restricted_grpc {
       while (true) {
         auto status = library_->SaveConfigurationsToJSON(instrument, signal_names, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::string json_string_out;
@@ -1030,6 +1071,7 @@ namespace nirfmxinstr_restricted_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1058,6 +1100,7 @@ namespace nirfmxinstr_restricted_grpc {
       int32 attr_val = request->attr_val();
       auto status = library_->SetForceAllTracesEnabled(instrument, channel_name, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1081,6 +1124,7 @@ namespace nirfmxinstr_restricted_grpc {
       int32 io_trace_status = request->io_trace_status();
       auto status = library_->SetIOTraceStatus(instrument, io_trace_status);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1102,6 +1146,7 @@ namespace nirfmxinstr_restricted_grpc {
       char* resource_name = (char*)request->resource_name().c_str();
       auto status = library_->UnregisterSpecialClientSnapshotInterest(resource_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
       }
       response->set_status(status);

--- a/generated/nirfmxlte/nirfmxlte_service.cpp
+++ b/generated/nirfmxlte/nirfmxlte_service.cpp
@@ -93,6 +93,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->ACPCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -132,6 +133,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->ACPCfgConfigurableNumberOfOffsetsEnabled(instrument, selector_string, configurable_number_of_offsets_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -171,6 +173,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->ACPCfgMeasurementMethod(instrument, selector_string, measurement_method);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -210,6 +213,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->ACPCfgNoiseCompensationEnabled(instrument, selector_string, noise_compensation_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -234,6 +238,7 @@ namespace nirfmxlte_grpc {
       int32 number_of_eutra_offsets = request->number_of_eutra_offsets();
       auto status = library_->ACPCfgNumberOfEUTRAOffsets(instrument, selector_string, number_of_eutra_offsets);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -258,6 +263,7 @@ namespace nirfmxlte_grpc {
       int32 number_of_gsm_offsets = request->number_of_gsm_offsets();
       auto status = library_->ACPCfgNumberOfGSMOffsets(instrument, selector_string, number_of_gsm_offsets);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -282,6 +288,7 @@ namespace nirfmxlte_grpc {
       int32 number_of_utra_offsets = request->number_of_utra_offsets();
       auto status = library_->ACPCfgNumberOfUTRAOffsets(instrument, selector_string, number_of_utra_offsets);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -321,6 +328,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->ACPCfgPowerUnits(instrument, selector_string, power_units);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -377,6 +385,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->ACPCfgRBWFilter(instrument, selector_string, rbw_auto, rbw, rbw_filter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -417,6 +426,7 @@ namespace nirfmxlte_grpc {
       float64 sweep_time_interval = request->sweep_time_interval();
       auto status = library_->ACPCfgSweepTime(instrument, selector_string, sweep_time_auto, sweep_time_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -442,6 +452,7 @@ namespace nirfmxlte_grpc {
       int32 number_of_eutra_offsets = request->number_of_eutra_offsets();
       auto status = library_->ACPCfgUTRAAndEUTRAOffsets(instrument, selector_string, number_of_utra_offsets, number_of_eutra_offsets);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -471,6 +482,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ACPFetchAbsolutePowersTrace(instrument, selector_string, timeout, trace_index, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_absolute_powers_trace()->Resize(actual_array_size, 0);
@@ -482,6 +494,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -513,6 +526,7 @@ namespace nirfmxlte_grpc {
       float64 relative_power {};
       auto status = library_->ACPFetchComponentCarrierMeasurement(instrument, selector_string, timeout, &absolute_power, &relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -541,6 +555,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ACPFetchComponentCarrierMeasurementArray(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_absolute_power()->Resize(actual_array_size, 0);
@@ -554,6 +569,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -586,6 +602,7 @@ namespace nirfmxlte_grpc {
       float64 upper_absolute_power {};
       auto status = library_->ACPFetchOffsetMeasurement(instrument, selector_string, timeout, &lower_relative_power, &upper_relative_power, &lower_absolute_power, &upper_absolute_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -616,6 +633,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ACPFetchOffsetMeasurementArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_lower_relative_power()->Resize(actual_array_size, 0);
@@ -633,6 +651,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -668,6 +687,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ACPFetchRelativePowersTrace(instrument, selector_string, timeout, trace_index, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_relative_powers_trace()->Resize(actual_array_size, 0);
@@ -679,6 +699,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -712,6 +733,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ACPFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -723,6 +745,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -755,6 +778,7 @@ namespace nirfmxlte_grpc {
       float64 frequency {};
       auto status = library_->ACPFetchSubblockMeasurement(instrument, selector_string, timeout, &subblock_power, &integration_bandwidth, &frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -783,6 +807,7 @@ namespace nirfmxlte_grpc {
       float64 total_aggregated_power {};
       auto status = library_->ACPFetchTotalAggregatedPower(instrument, selector_string, timeout, &total_aggregated_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -808,6 +833,7 @@ namespace nirfmxlte_grpc {
       int32 noise_calibration_data_valid {};
       auto status = library_->ACPValidateNoiseCalibrationData(instrument, selector_string, &noise_calibration_data_valid);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -833,6 +859,7 @@ namespace nirfmxlte_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->AbortMeasurements(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -863,6 +890,7 @@ namespace nirfmxlte_grpc {
       auto reserved = 0;
       auto status = library_->AnalyzeIQ1Waveform(instrument, selector_string, result_name, x0, dx, iq.data(), array_size, reset, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -893,6 +921,7 @@ namespace nirfmxlte_grpc {
       auto reserved = 0;
       auto status = library_->AnalyzeSpectrum1Waveform(instrument, selector_string, result_name, x0, dx, spectrum, array_size, reset, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -918,6 +947,7 @@ namespace nirfmxlte_grpc {
       float64 reference_level {};
       auto status = library_->AutoLevel(instrument, selector_string, measurement_interval, &reference_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -943,6 +973,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->BuildCarrierString(selector_string, carrier_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -957,6 +988,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -984,6 +1016,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->BuildClusterString(selector_string, cluster_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -998,6 +1031,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1025,6 +1059,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->BuildOffsetString(selector_string, offset_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -1039,6 +1074,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1066,6 +1102,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->BuildPDSCHString(selector_string, pdsch_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -1080,6 +1117,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1107,6 +1145,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->BuildSignalString(signal_name, result_name, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_length = status;
@@ -1121,6 +1160,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1148,6 +1188,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->BuildSubblockString(selector_string, subblock_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -1162,6 +1203,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1189,6 +1231,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->BuildSubframeString(selector_string, subframe_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -1203,6 +1246,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1262,6 +1306,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CHPCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1301,6 +1346,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CHPCfgIntegrationBandwidthType(instrument, selector_string, integration_bandwidth_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1357,6 +1403,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CHPCfgRBWFilter(instrument, selector_string, rbw_auto, rbw, rbw_filter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1397,6 +1444,7 @@ namespace nirfmxlte_grpc {
       float64 sweep_time_interval = request->sweep_time_interval();
       auto status = library_->CHPCfgSweepTime(instrument, selector_string, sweep_time_auto, sweep_time_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1423,6 +1471,7 @@ namespace nirfmxlte_grpc {
       float64 relative_power {};
       auto status = library_->CHPFetchComponentCarrierMeasurement(instrument, selector_string, timeout, &absolute_power, &relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1451,6 +1500,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->CHPFetchComponentCarrierMeasurementArray(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_absolute_power()->Resize(actual_array_size, 0);
@@ -1464,6 +1514,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1496,6 +1547,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->CHPFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -1507,6 +1559,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1539,6 +1592,7 @@ namespace nirfmxlte_grpc {
       float64 frequency {};
       auto status = library_->CHPFetchSubblockMeasurement(instrument, selector_string, timeout, &subblock_power, &integration_bandwidth, &frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1567,6 +1621,7 @@ namespace nirfmxlte_grpc {
       float64 total_aggregated_power {};
       auto status = library_->CHPFetchTotalAggregatedPower(instrument, selector_string, timeout, &total_aggregated_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1592,6 +1647,7 @@ namespace nirfmxlte_grpc {
       int32 noise_calibration_data_valid {};
       auto status = library_->CHPValidateNoiseCalibrationData(instrument, selector_string, &noise_calibration_data_valid);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1633,6 +1689,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CfgAutoDMRSDetectionEnabled(instrument, selector_string, auto_dmrs_detection_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1672,6 +1729,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CfgAutoNPUSCHChannelDetectionEnabled(instrument, selector_string, auto_npusch_channel_detection_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1711,6 +1769,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CfgAutoResourceBlockDetectionEnabled(instrument, selector_string, auto_resource_block_detection_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1735,6 +1794,7 @@ namespace nirfmxlte_grpc {
       int32 band = request->band();
       auto status = library_->CfgBand(instrument, selector_string, band);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1774,6 +1834,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CfgCellSpecificRatio(instrument, selector_string, cell_specific_ratio);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1800,6 +1861,7 @@ namespace nirfmxlte_grpc {
       int32 cell_id = request->cell_id();
       auto status = library_->CfgComponentCarrier(instrument, selector_string, component_carrier_bandwidth, component_carrier_frequency, cell_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1845,6 +1907,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CfgComponentCarrierArray(instrument, selector_string, component_carrier_bandwidth, component_carrier_frequency, cell_id, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1885,6 +1948,7 @@ namespace nirfmxlte_grpc {
       int32 component_carrier_at_center_frequency = request->component_carrier_at_center_frequency();
       auto status = library_->CfgComponentCarrierSpacing(instrument, selector_string, component_carrier_spacing_type, component_carrier_at_center_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1946,6 +2010,7 @@ namespace nirfmxlte_grpc {
       int32 enable_trigger = request->enable_trigger();
       auto status = library_->CfgDigitalEdgeTrigger(instrument, selector_string, digital_edge_source, digital_edge, trigger_delay, enable_trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1985,6 +2050,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CfgDownlinkAutoCellIDDetectionEnabled(instrument, selector_string, auto_cell_id_detection_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2057,6 +2123,7 @@ namespace nirfmxlte_grpc {
       auto reserved = 0;
       auto status = library_->CfgDownlinkAutoChannelDetection(instrument, selector_string, auto_pdsch_channel_detection_enabled, auto_control_channel_power_detection_enabled, auto_pcfich_cfi_detection_enabled, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2096,6 +2163,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CfgDownlinkChannelConfigurationMode(instrument, selector_string, channel_configuration_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2120,6 +2188,7 @@ namespace nirfmxlte_grpc {
       int32 number_of_subframes = request->number_of_subframes();
       auto status = library_->CfgDownlinkNumberOfSubframes(instrument, selector_string, number_of_subframes);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2145,6 +2214,7 @@ namespace nirfmxlte_grpc {
       float64 sss_power = request->sss_power();
       auto status = library_->CfgDownlinkSynchronizationSignal(instrument, selector_string, pss_power, sss_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2184,6 +2254,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CfgDownlinkTestModel(instrument, selector_string, downlink_test_model);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2217,6 +2288,7 @@ namespace nirfmxlte_grpc {
       int32 number_of_elements = static_cast<int32>(request->downlink_test_model().size());
       auto status = library_->CfgDownlinkTestModelArray(instrument, selector_string, downlink_test_model, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2272,6 +2344,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CfgDuplexScheme(instrument, selector_string, duplex_scheme, uplink_downlink_configuration);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2311,6 +2384,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CfgEMTCAnalysisEnabled(instrument, selector_string, emtc_analysis_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2335,6 +2409,7 @@ namespace nirfmxlte_grpc {
       float64 external_attenuation = request->external_attenuation();
       auto status = library_->CfgExternalAttenuation(instrument, selector_string, external_attenuation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2359,6 +2434,7 @@ namespace nirfmxlte_grpc {
       float64 center_frequency = request->center_frequency();
       auto status = library_->CfgFrequency(instrument, selector_string, center_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2400,6 +2476,7 @@ namespace nirfmxlte_grpc {
       int32 earfcn = request->earfcn();
       auto status = library_->CfgFrequencyEARFCN(instrument, selector_string, link_direction, band, earfcn);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2444,6 +2521,7 @@ namespace nirfmxlte_grpc {
       float64 frequency_reference_frequency = request->frequency_reference_frequency();
       auto status = library_->CfgFrequencyReference(instrument, channel_name, frequency_reference_source, frequency_reference_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2520,6 +2598,7 @@ namespace nirfmxlte_grpc {
       int32 enable_trigger = request->enable_trigger();
       auto status = library_->CfgIQPowerEdgeTrigger(instrument, selector_string, iq_power_edge_source, iq_power_edge_slope, iq_power_edge_level, trigger_delay, trigger_min_quiet_time_mode, trigger_min_quiet_time_duration, iq_power_edge_level_type, enable_trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2559,6 +2638,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CfgLinkDirection(instrument, selector_string, link_direction);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2599,6 +2679,7 @@ namespace nirfmxlte_grpc {
       float64 mechanical_attenuation_value = request->mechanical_attenuation_value();
       auto status = library_->CfgMechanicalAttenuation(instrument, channel_name, mechanical_attenuation_auto, mechanical_attenuation_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2639,6 +2720,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CfgNBIoTComponentCarrier(instrument, selector_string, n_cell_id, uplink_subcarrier_spacing);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2697,6 +2779,7 @@ namespace nirfmxlte_grpc {
       int32 npusch_dmrs_delta_ss = request->npusch_dmrs_delta_ss();
       auto status = library_->CfgNPUSCHDMRS(instrument, selector_string, npusch_dmrs_base_sequence_mode, npusch_dmrs_base_sequence_index, npusch_dmrs_cyclic_shift, npusch_dmrs_group_hopping_enabled, npusch_dmrs_delta_ss);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2721,6 +2804,7 @@ namespace nirfmxlte_grpc {
       int32 format = request->format();
       auto status = library_->CfgNPUSCHFormat(instrument, selector_string, format);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2745,6 +2829,7 @@ namespace nirfmxlte_grpc {
       int32 starting_slot = request->starting_slot();
       auto status = library_->CfgNPUSCHStartingSlot(instrument, selector_string, starting_slot);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2786,6 +2871,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CfgNPUSCHTones(instrument, selector_string, tone_offset, number_of_tones, modulation_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2810,6 +2896,7 @@ namespace nirfmxlte_grpc {
       int32 number_of_component_carriers = request->number_of_component_carriers();
       auto status = library_->CfgNumberOfComponentCarriers(instrument, selector_string, number_of_component_carriers);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2834,6 +2921,7 @@ namespace nirfmxlte_grpc {
       int32 number_of_dut_antennas = request->number_of_dut_antennas();
       auto status = library_->CfgNumberOfDUTAntennas(instrument, selector_string, number_of_dut_antennas);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2858,6 +2946,7 @@ namespace nirfmxlte_grpc {
       int32 number_of_pdsch_channels = request->number_of_pdsch_channels();
       auto status = library_->CfgNumberOfPDSCHChannels(instrument, selector_string, number_of_pdsch_channels);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2882,6 +2971,7 @@ namespace nirfmxlte_grpc {
       int32 number_of_resource_block_clusters = request->number_of_resource_block_clusters();
       auto status = library_->CfgNumberOfPUSCHResourceBlockClusters(instrument, selector_string, number_of_resource_block_clusters);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2906,6 +2996,7 @@ namespace nirfmxlte_grpc {
       int32 number_of_subblocks = request->number_of_subblocks();
       auto status = library_->CfgNumberOfSubblocks(instrument, selector_string, number_of_subblocks);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2930,6 +3021,7 @@ namespace nirfmxlte_grpc {
       float64 pbch_power = request->pbch_power();
       auto status = library_->CfgPBCH(instrument, selector_string, pbch_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2955,6 +3047,7 @@ namespace nirfmxlte_grpc {
       float64 power = request->power();
       auto status = library_->CfgPCFICH(instrument, selector_string, cfi, power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2979,6 +3072,7 @@ namespace nirfmxlte_grpc {
       float64 pdcch_power = request->pdcch_power();
       auto status = library_->CfgPDCCH(instrument, selector_string, pdcch_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3020,6 +3114,7 @@ namespace nirfmxlte_grpc {
       float64 power = request->power();
       auto status = library_->CfgPDSCH(instrument, selector_string, cw0_modulation_type, resource_block_allocation, power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3076,6 +3171,7 @@ namespace nirfmxlte_grpc {
       float64 power = request->power();
       auto status = library_->CfgPHICH(instrument, selector_string, resource, duration, power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3100,6 +3196,7 @@ namespace nirfmxlte_grpc {
       int32 modulation_type = request->modulation_type();
       auto status = library_->CfgPSSCHModulationType(instrument, selector_string, modulation_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3125,6 +3222,7 @@ namespace nirfmxlte_grpc {
       int32 number_of_resource_blocks = request->number_of_resource_blocks();
       auto status = library_->CfgPSSCHResourceBlocks(instrument, selector_string, resource_block_offset, number_of_resource_blocks);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3164,6 +3262,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CfgPUSCHModulationType(instrument, selector_string, modulation_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3189,6 +3288,7 @@ namespace nirfmxlte_grpc {
       int32 number_of_resource_blocks = request->number_of_resource_blocks();
       auto status = library_->CfgPUSCHResourceBlocks(instrument, selector_string, resource_block_offset, number_of_resource_blocks);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3215,6 +3315,7 @@ namespace nirfmxlte_grpc {
       float64 external_attenuation = request->external_attenuation();
       auto status = library_->CfgRF(instrument, selector_string, center_frequency, reference_level, external_attenuation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3255,6 +3356,7 @@ namespace nirfmxlte_grpc {
       float64 rf_attenuation_value = request->rf_attenuation_value();
       auto status = library_->CfgRFAttenuation(instrument, channel_name, rf_attenuation_auto, rf_attenuation_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3279,6 +3381,7 @@ namespace nirfmxlte_grpc {
       float64 reference_level = request->reference_level();
       auto status = library_->CfgReferenceLevel(instrument, selector_string, reference_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3304,6 +3407,7 @@ namespace nirfmxlte_grpc {
       int32 enable_trigger = request->enable_trigger();
       auto status = library_->CfgSoftwareEdgeTrigger(instrument, selector_string, trigger_delay, enable_trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3328,6 +3432,7 @@ namespace nirfmxlte_grpc {
       int32 transmit_antenna_to_analyze = request->transmit_antenna_to_analyze();
       auto status = library_->CfgTransmitAntennaToAnalyze(instrument, selector_string, transmit_antenna_to_analyze);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3367,6 +3472,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->CfgeNodeBCategory(instrument, selector_string, enodeb_category);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3391,6 +3497,7 @@ namespace nirfmxlte_grpc {
       int32 is_done {};
       auto status = library_->CheckMeasurementStatus(instrument, selector_string, &is_done);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3415,6 +3522,7 @@ namespace nirfmxlte_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearAllNamedResults(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3438,6 +3546,7 @@ namespace nirfmxlte_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearNamedResult(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3461,6 +3570,7 @@ namespace nirfmxlte_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearNoiseCalibrationDatabase(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3485,6 +3595,7 @@ namespace nirfmxlte_grpc {
       char* new_signal_name = (char*)request->new_signal_name().c_str();
       auto status = library_->CloneSignalConfiguration(instrument, old_signal_name, new_signal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3509,6 +3620,7 @@ namespace nirfmxlte_grpc {
       session_repository_->remove_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->Close(instrument, force_destroy);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3532,6 +3644,7 @@ namespace nirfmxlte_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->Commit(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3555,6 +3668,7 @@ namespace nirfmxlte_grpc {
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->CreateSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3578,6 +3692,7 @@ namespace nirfmxlte_grpc {
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->DeleteSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3601,6 +3716,7 @@ namespace nirfmxlte_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->DisableTrigger(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3627,6 +3743,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->GetAllNamedResultNames(instrument, selector_string, nullptr, 0, &actual_result_names_size, &default_result_exists);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::string result_names;
@@ -3640,6 +3757,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3670,6 +3788,7 @@ namespace nirfmxlte_grpc {
       float32 attr_val {};
       auto status = library_->GetAttributeF32(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3697,6 +3816,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->GetAttributeF32Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -3708,6 +3828,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3736,6 +3857,7 @@ namespace nirfmxlte_grpc {
       float64 attr_val {};
       auto status = library_->GetAttributeF64(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3763,6 +3885,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->GetAttributeF64Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -3774,6 +3897,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3802,6 +3926,7 @@ namespace nirfmxlte_grpc {
       int16 attr_val {};
       auto status = library_->GetAttributeI16(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3828,6 +3953,7 @@ namespace nirfmxlte_grpc {
       int32 attr_val {};
       auto status = library_->GetAttributeI32(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3861,6 +3987,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->GetAttributeI32Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val_raw()->Resize(actual_array_size, 0);
@@ -3872,6 +3999,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3914,6 +4042,7 @@ namespace nirfmxlte_grpc {
       int64 attr_val {};
       auto status = library_->GetAttributeI64(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3941,6 +4070,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->GetAttributeI64Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -3952,6 +4082,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3980,6 +4111,7 @@ namespace nirfmxlte_grpc {
       int8 attr_val {};
       auto status = library_->GetAttributeI8(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4007,6 +4139,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->GetAttributeI8Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<int8> attr_val(actual_array_size);
@@ -4017,6 +4150,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4055,6 +4189,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->GetAttributeNIComplexDoubleArray(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexDouble> attr_val(actual_array_size, NIComplexDouble());
@@ -4065,6 +4200,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4101,6 +4237,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->GetAttributeNIComplexSingleArray(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> attr_val(actual_array_size, NIComplexSingle());
@@ -4111,6 +4248,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4147,6 +4285,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->GetAttributeString(instrument, selector_string, attribute_id, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 array_size = status;
@@ -4161,6 +4300,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4189,6 +4329,7 @@ namespace nirfmxlte_grpc {
       uInt16 attr_val {};
       auto status = library_->GetAttributeU16(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4215,6 +4356,7 @@ namespace nirfmxlte_grpc {
       uInt32 attr_val {};
       auto status = library_->GetAttributeU32(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4242,6 +4384,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->GetAttributeU32Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -4253,6 +4396,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4282,6 +4426,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->GetAttributeU64Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -4293,6 +4438,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4321,6 +4467,7 @@ namespace nirfmxlte_grpc {
       uInt8 attr_val {};
       auto status = library_->GetAttributeU8(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4348,6 +4495,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->GetAttributeU8Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::string attr_val(actual_array_size, '\0');
@@ -4358,6 +4506,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4386,6 +4535,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->GetError(instrument, nullptr, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 error_description_buffer_size = status;
@@ -4401,6 +4551,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4430,6 +4581,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->GetErrorString(instrument, error_code, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 error_description_buffer_size = status;
@@ -4444,6 +4596,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4479,6 +4632,7 @@ namespace nirfmxlte_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXLTE_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
       }
       response->set_status(status);
@@ -4515,6 +4669,7 @@ namespace nirfmxlte_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXLTE_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
       }
       response->set_status(status);
@@ -4543,6 +4698,7 @@ namespace nirfmxlte_grpc {
       char* result_name = (char*)request->result_name().c_str();
       auto status = library_->Initiate(instrument, selector_string, result_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4583,6 +4739,7 @@ namespace nirfmxlte_grpc {
       int32 averaging_count = request->averaging_count();
       auto status = library_->ModAccCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4622,6 +4779,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->ModAccCfgCommonClockSourceEnabled(instrument, selector_string, common_clock_source_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4661,6 +4819,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->ModAccCfgEVMUnit(instrument, selector_string, evm_unit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4685,6 +4844,7 @@ namespace nirfmxlte_grpc {
       float64 fft_window_offset = request->fft_window_offset();
       auto status = library_->ModAccCfgFFTWindowOffset(instrument, selector_string, fft_window_offset);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4726,6 +4886,7 @@ namespace nirfmxlte_grpc {
       float64 fft_window_length = request->fft_window_length();
       auto status = library_->ModAccCfgFFTWindowPosition(instrument, selector_string, fft_window_type, fft_window_offset, fft_window_length);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4765,6 +4926,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->ModAccCfgInBandEmissionMaskType(instrument, selector_string, in_band_emission_mask_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4806,6 +4968,7 @@ namespace nirfmxlte_grpc {
       int32 measurement_length = request->measurement_length();
       auto status = library_->ModAccCfgSynchronizationModeAndInterval(instrument, selector_string, synchronization_mode, measurement_offset, measurement_length);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4832,6 +4995,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchCSRSConstellation(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> csrs_constellation(actual_array_size, NIComplexSingle());
@@ -4842,6 +5006,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4877,6 +5042,7 @@ namespace nirfmxlte_grpc {
       float64 mean_rms_csrs_evm {};
       auto status = library_->ModAccFetchCSRSEVM(instrument, selector_string, timeout, &mean_rms_csrs_evm);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4904,6 +5070,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchCSRSEVMArray(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_mean_rms_csrs_evm()->Resize(actual_array_size, 0);
@@ -4915,6 +5082,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4948,6 +5116,7 @@ namespace nirfmxlte_grpc {
       int32 peak_composite_evm_slot_index {};
       auto status = library_->ModAccFetchCompositeEVM(instrument, selector_string, timeout, &mean_rms_composite_evm, &maximum_peak_composite_evm, &mean_frequency_error, &peak_composite_evm_symbol_index, &peak_composite_evm_subcarrier_index, &peak_composite_evm_slot_index);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4980,6 +5149,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchCompositeEVMArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_mean_rms_composite_evm()->Resize(actual_array_size, 0);
@@ -5001,6 +5171,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5037,6 +5208,7 @@ namespace nirfmxlte_grpc {
       float64 max_peak_composite_phase_error {};
       auto status = library_->ModAccFetchCompositeMagnitudeAndPhaseError(instrument, selector_string, timeout, &mean_rms_composite_magnitude_error, &max_peak_composite_magnitude_error, &mean_rms_composite_phase_error, &max_peak_composite_phase_error);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5067,6 +5239,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchCompositeMagnitudeAndPhaseErrorArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_mean_rms_composite_magnitude_error()->Resize(actual_array_size, 0);
@@ -5084,6 +5257,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5115,6 +5289,7 @@ namespace nirfmxlte_grpc {
       int32 detected_cell_id {};
       auto status = library_->ModAccFetchDownlinkDetectedCellID(instrument, selector_string, timeout, &detected_cell_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5142,6 +5317,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchDownlinkDetectedCellIDArray(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_detected_cell_id()->Resize(actual_array_size, 0);
@@ -5153,6 +5329,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5182,6 +5359,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchDownlinkPBCHConstellation(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> pbch_constellation(actual_array_size, NIComplexSingle());
@@ -5192,6 +5370,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5228,6 +5407,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchDownlinkPCFICHConstellation(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> pcfich_constellation(actual_array_size, NIComplexSingle());
@@ -5238,6 +5418,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5274,6 +5455,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchDownlinkPDCCHConstellation(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> pdcch_constellation(actual_array_size, NIComplexSingle());
@@ -5284,6 +5466,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5320,6 +5503,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchDownlinkPHICHConstellation(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> phich_constellation(actual_array_size, NIComplexSingle());
@@ -5330,6 +5514,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5368,6 +5553,7 @@ namespace nirfmxlte_grpc {
       float64 ofdm_symbol_transmit_power {};
       auto status = library_->ModAccFetchDownlinkTransmitPower(instrument, selector_string, timeout, &rs_transmit_power, &ofdm_symbol_transmit_power, reserved1, reserved2);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5398,6 +5584,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchDownlinkTransmitPowerArray(instrument, selector_string, timeout, nullptr, nullptr, reserved1, reserved2, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_rs_transmit_power()->Resize(actual_array_size, 0);
@@ -5411,6 +5598,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5443,6 +5631,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchEVMHighPerSymbolTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_evm_high_per_symbol()->Resize(actual_array_size, 0);
@@ -5454,6 +5643,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5487,6 +5677,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchEVMLowPerSymbolTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_evm_low_per_symbol()->Resize(actual_array_size, 0);
@@ -5498,6 +5689,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5531,6 +5723,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchEVMPerSlotTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_rms_evm_per_slot()->Resize(actual_array_size, 0);
@@ -5542,6 +5735,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5575,6 +5769,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchEVMPerSubcarrierTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_mean_rms_evm_per_subcarrier()->Resize(actual_array_size, 0);
@@ -5586,6 +5781,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5619,6 +5815,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchEVMPerSymbolTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_rms_evm_per_symbol()->Resize(actual_array_size, 0);
@@ -5630,6 +5827,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5662,6 +5860,7 @@ namespace nirfmxlte_grpc {
       float64 mean_iq_quadrature_error {};
       auto status = library_->ModAccFetchIQImpairments(instrument, selector_string, timeout, &mean_iq_origin_offset, &mean_iq_gain_imbalance, &mean_iq_quadrature_error);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5691,6 +5890,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchIQImpairmentsArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_mean_iq_origin_offset()->Resize(actual_array_size, 0);
@@ -5706,6 +5906,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5736,6 +5937,7 @@ namespace nirfmxlte_grpc {
       float64 in_band_emission_margin {};
       auto status = library_->ModAccFetchInBandEmissionMargin(instrument, selector_string, timeout, &in_band_emission_margin);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5763,6 +5965,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchInBandEmissionMarginArray(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_in_band_emission_margin()->Resize(actual_array_size, 0);
@@ -5774,6 +5977,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5805,6 +6009,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchInBandEmissionTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_in_band_emission()->Resize(actual_array_size, 0);
@@ -5818,6 +6023,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5852,6 +6058,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchMaximumEVMPerSlotTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_maximum_evm_per_slot()->Resize(actual_array_size, 0);
@@ -5863,6 +6070,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5896,6 +6104,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchMaximumEVMPerSubcarrierTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_maximum_evm_per_subcarrier()->Resize(actual_array_size, 0);
@@ -5907,6 +6116,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5940,6 +6150,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchMaximumEVMPerSymbolTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_maximum_evm_per_symbol()->Resize(actual_array_size, 0);
@@ -5951,6 +6162,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5984,6 +6196,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchMaximumMagnitudeErrorPerSymbolTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_maximum_magnitude_error_per_symbol()->Resize(actual_array_size, 0);
@@ -5995,6 +6208,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6028,6 +6242,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchMaximumPhaseErrorPerSymbolTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_maximum_phase_error_per_symbol()->Resize(actual_array_size, 0);
@@ -6039,6 +6254,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6071,6 +6287,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchNPUSCHConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &data_constellation_actual_array_size, nullptr, 0, &dmrs_constellation_actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> data_constellation(data_constellation_actual_array_size, NIComplexSingle());
@@ -6083,6 +6300,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6128,6 +6346,7 @@ namespace nirfmxlte_grpc {
       float64 npusch_maximum_peak_dmrs_evm {};
       auto status = library_->ModAccFetchNPUSCHDMRSEVM(instrument, selector_string, timeout, &npusch_mean_rms_dmrs_evm, &npusch_maximum_peak_dmrs_evm);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6156,6 +6375,7 @@ namespace nirfmxlte_grpc {
       float64 npusch_maximum_peak_data_evm {};
       auto status = library_->ModAccFetchNPUSCHDataEVM(instrument, selector_string, timeout, &npusch_mean_rms_data_evm, &npusch_maximum_peak_data_evm);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6184,6 +6404,7 @@ namespace nirfmxlte_grpc {
       float64 npusch_mean_dmrs_power {};
       auto status = library_->ModAccFetchNPUSCHSymbolPower(instrument, selector_string, timeout, &npusch_mean_data_power, &npusch_mean_dmrs_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6212,6 +6433,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchPDSCH1024QAMConstellation(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> qam1024_constellation(actual_array_size, NIComplexSingle());
@@ -6222,6 +6444,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6257,6 +6480,7 @@ namespace nirfmxlte_grpc {
       float64 mean_rms_1024qam_evm {};
       auto status = library_->ModAccFetchPDSCH1024QAMEVM(instrument, selector_string, timeout, &mean_rms_1024qam_evm);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6284,6 +6508,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchPDSCH1024QAMEVMArray(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_mean_rms_1024qam_evm()->Resize(actual_array_size, 0);
@@ -6295,6 +6520,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6324,6 +6550,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchPDSCH16QAMConstellation(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> qam16_constellation(actual_array_size, NIComplexSingle());
@@ -6334,6 +6561,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6370,6 +6598,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchPDSCH256QAMConstellation(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> qam256_constellation(actual_array_size, NIComplexSingle());
@@ -6380,6 +6609,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6416,6 +6646,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchPDSCH64QAMConstellation(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> qam64_constellation(actual_array_size, NIComplexSingle());
@@ -6426,6 +6657,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6465,6 +6697,7 @@ namespace nirfmxlte_grpc {
       float64 mean_rms_256qam_evm {};
       auto status = library_->ModAccFetchPDSCHEVM(instrument, selector_string, timeout, &mean_rms_evm, &mean_rms_qpsk_evm, &mean_rms_16qam_evm, &mean_rms_64qam_evm, &mean_rms_256qam_evm);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6496,6 +6729,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchPDSCHEVMArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_mean_rms_evm()->Resize(actual_array_size, 0);
@@ -6515,6 +6749,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6548,6 +6783,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchPDSCHQPSKConstellation(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> qpsk_constellation(actual_array_size, NIComplexSingle());
@@ -6558,6 +6794,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6595,6 +6832,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchPSSCHConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &data_constellation_actual_array_size, nullptr, 0, &dmrs_constellation_actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> data_constellation(data_constellation_actual_array_size, NIComplexSingle());
@@ -6607,6 +6845,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6652,6 +6891,7 @@ namespace nirfmxlte_grpc {
       float64 pssch_maximum_peak_dmrs_evm {};
       auto status = library_->ModAccFetchPSSCHDMRSEVM(instrument, selector_string, timeout, &pssch_mean_rms_dmrs_evm, &pssch_maximum_peak_dmrs_evm);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6680,6 +6920,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchPSSCHDMRSEVMArray(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_pssch_mean_rms_dmrs_evm()->Resize(actual_array_size, 0);
@@ -6693,6 +6934,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6723,6 +6965,7 @@ namespace nirfmxlte_grpc {
       float64 pssch_maximum_peak_data_evm {};
       auto status = library_->ModAccFetchPSSCHDataEVM(instrument, selector_string, timeout, &pssch_mean_rms_data_evm, &pssch_maximum_peak_data_evm);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6751,6 +6994,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchPSSCHDataEVMArray(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_pssch_mean_rms_data_evm()->Resize(actual_array_size, 0);
@@ -6764,6 +7008,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6794,6 +7039,7 @@ namespace nirfmxlte_grpc {
       float64 pssch_mean_dmrs_power {};
       auto status = library_->ModAccFetchPSSCHSymbolPower(instrument, selector_string, timeout, &pssch_mean_data_power, &pssch_mean_dmrs_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6822,6 +7068,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchPSSCHSymbolPowerArray(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_pssch_mean_data_power()->Resize(actual_array_size, 0);
@@ -6835,6 +7082,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6866,6 +7114,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchPUSCHConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &data_constellation_actual_array_size, nullptr, 0, &dmrs_constellation_actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> data_constellation(data_constellation_actual_array_size, NIComplexSingle());
@@ -6878,6 +7127,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6923,6 +7173,7 @@ namespace nirfmxlte_grpc {
       float64 maximum_peak_dmrs_evm {};
       auto status = library_->ModAccFetchPUSCHDMRSEVM(instrument, selector_string, timeout, &mean_rms_dmrs_evm, &maximum_peak_dmrs_evm);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6951,6 +7202,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchPUSCHDMRSEVMArray(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_mean_rms_dmrs_evm()->Resize(actual_array_size, 0);
@@ -6964,6 +7216,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6994,6 +7247,7 @@ namespace nirfmxlte_grpc {
       float64 maximum_peak_data_evm {};
       auto status = library_->ModAccFetchPUSCHDataEVM(instrument, selector_string, timeout, &mean_rms_data_evm, &maximum_peak_data_evm);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7022,6 +7276,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchPUSCHDataEVMArray(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_mean_rms_data_evm()->Resize(actual_array_size, 0);
@@ -7035,6 +7290,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7065,6 +7321,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchPUSCHDemodulatedBits(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<int8> bits(actual_array_size);
@@ -7075,6 +7332,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7113,6 +7371,7 @@ namespace nirfmxlte_grpc {
       float64 pusch_mean_dmrs_power {};
       auto status = library_->ModAccFetchPUSCHSymbolPower(instrument, selector_string, timeout, &pusch_mean_data_power, &pusch_mean_dmrs_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7141,6 +7400,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchPUSCHSymbolPowerArray(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_pusch_mean_data_power()->Resize(actual_array_size, 0);
@@ -7154,6 +7414,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7186,6 +7447,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchRMSMagnitudeErrorPerSymbolTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_rms_magnitude_error_per_symbol()->Resize(actual_array_size, 0);
@@ -7197,6 +7459,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7230,6 +7493,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchRMSPhaseErrorPerSymbolTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_rms_phase_error_per_symbol()->Resize(actual_array_size, 0);
@@ -7241,6 +7505,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7272,6 +7537,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchSRSConstellation(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> srs_constellation(actual_array_size, NIComplexSingle());
@@ -7282,6 +7548,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7318,6 +7585,7 @@ namespace nirfmxlte_grpc {
       float64 mean_srs_power {};
       auto status = library_->ModAccFetchSRSEVM(instrument, selector_string, timeout, &mean_rms_srs_evm, &mean_srs_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7346,6 +7614,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchSRSEVMArray(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_mean_rms_srs_evm()->Resize(actual_array_size, 0);
@@ -7359,6 +7628,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7391,6 +7661,7 @@ namespace nirfmxlte_grpc {
       float64 range2_maximum_to_range1_minimum {};
       auto status = library_->ModAccFetchSpectralFlatness(instrument, selector_string, timeout, &range1_maximum_to_range1_minimum, &range2_maximum_to_range2_minimum, &range1_maximum_to_range2_minimum, &range2_maximum_to_range1_minimum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7421,6 +7692,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchSpectralFlatnessArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_range1_maximum_to_range1_minimum()->Resize(actual_array_size, 0);
@@ -7438,6 +7710,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7472,6 +7745,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchSpectralFlatnessTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectral_flatness()->Resize(actual_array_size, 0);
@@ -7487,6 +7761,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7521,6 +7796,7 @@ namespace nirfmxlte_grpc {
       float64 subblock_mean_iq_quadrature_error {};
       auto status = library_->ModAccFetchSubblockIQImpairments(instrument, selector_string, timeout, &subblock_mean_iq_origin_offset, &subblock_mean_iq_gain_imbalance, &subblock_mean_iq_quadrature_error);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7549,6 +7825,7 @@ namespace nirfmxlte_grpc {
       float64 subblock_in_band_emission_margin {};
       auto status = library_->ModAccFetchSubblockInBandEmissionMargin(instrument, selector_string, timeout, &subblock_in_band_emission_margin);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7576,6 +7853,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchSubblockInBandEmissionTrace(instrument, selector_string, timeout, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_subblock_in_band_emission()->Resize(actual_array_size, 0);
@@ -7591,6 +7869,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7622,6 +7901,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchSynchronizationSignalConstellation(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> sss_constellation(actual_array_size, NIComplexSingle());
@@ -7633,6 +7913,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7677,6 +7958,7 @@ namespace nirfmxlte_grpc {
       float64 mean_rms_sss_evm {};
       auto status = library_->ModAccFetchSynchronizationSignalEVM(instrument, selector_string, timeout, &mean_rms_pss_evm, &mean_rms_sss_evm);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7705,6 +7987,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->ModAccFetchSynchronizationSignalEVMArray(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_mean_rms_pss_evm()->Resize(actual_array_size, 0);
@@ -7718,6 +8001,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7778,6 +8062,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->OBWCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7834,6 +8119,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->OBWCfgRBWFilter(instrument, selector_string, rbw_auto, rbw, rbw_filter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7874,6 +8160,7 @@ namespace nirfmxlte_grpc {
       float64 sweep_time_interval = request->sweep_time_interval();
       auto status = library_->OBWCfgSweepTime(instrument, selector_string, sweep_time_auto, sweep_time_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7902,6 +8189,7 @@ namespace nirfmxlte_grpc {
       float64 stop_frequency {};
       auto status = library_->OBWFetchMeasurement(instrument, selector_string, timeout, &occupied_bandwidth, &absolute_power, &start_frequency, &stop_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7934,6 +8222,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->OBWFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -7945,6 +8234,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -8006,6 +8296,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->PVTCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8045,6 +8336,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->PVTCfgMeasurementMethod(instrument, selector_string, measurement_method);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8070,6 +8362,7 @@ namespace nirfmxlte_grpc {
       float64 off_power_exclusion_after = request->off_power_exclusion_after();
       auto status = library_->PVTCfgOFFPowerExclusionPeriods(instrument, selector_string, off_power_exclusion_before, off_power_exclusion_after);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8099,6 +8392,7 @@ namespace nirfmxlte_grpc {
       float64 burst_width {};
       auto status = library_->PVTFetchMeasurement(instrument, selector_string, timeout, &measurement_status, &mean_absolute_off_power_before, &mean_absolute_off_power_after, &mean_absolute_on_power, &burst_width);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8131,6 +8425,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->PVTFetchMeasurementArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_measurement_status_raw()->Resize(actual_array_size, 0);
@@ -8150,6 +8445,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -8194,6 +8490,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->PVTFetchSignalPowerTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_signal_power()->Resize(actual_array_size, 0);
@@ -8207,6 +8504,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -8237,6 +8535,7 @@ namespace nirfmxlte_grpc {
       int32 attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(instrument, selector_string, attribute_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8260,6 +8559,7 @@ namespace nirfmxlte_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ResetToDefault(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8316,6 +8616,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->SEMCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8340,6 +8641,7 @@ namespace nirfmxlte_grpc {
       float64 component_carrier_maximum_output_power = request->component_carrier_maximum_output_power();
       auto status = library_->SEMCfgComponentCarrierMaximumOutputPower(instrument, selector_string, component_carrier_maximum_output_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8365,6 +8667,7 @@ namespace nirfmxlte_grpc {
       int32 number_of_elements = static_cast<int32>(request->component_carrier_maximum_output_power().size());
       auto status = library_->SEMCfgComponentCarrierMaximumOutputPowerArray(instrument, selector_string, component_carrier_maximum_output_power, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8406,6 +8709,7 @@ namespace nirfmxlte_grpc {
       float64 aggregated_maximum_power = request->aggregated_maximum_power();
       auto status = library_->SEMCfgDownlinkMask(instrument, selector_string, downlink_mask_type, delta_f_maximum, aggregated_maximum_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8430,6 +8734,7 @@ namespace nirfmxlte_grpc {
       int32 number_of_offsets = request->number_of_offsets();
       auto status = library_->SEMCfgNumberOfOffsets(instrument, selector_string, number_of_offsets);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8455,6 +8760,7 @@ namespace nirfmxlte_grpc {
       float64 offset_absolute_limit_stop = request->offset_absolute_limit_stop();
       auto status = library_->SEMCfgOffsetAbsoluteLimit(instrument, selector_string, offset_absolute_limit_start, offset_absolute_limit_stop);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8497,6 +8803,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->SEMCfgOffsetAbsoluteLimitArray(instrument, selector_string, offset_absolute_limit_start, offset_absolute_limit_stop, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8521,6 +8828,7 @@ namespace nirfmxlte_grpc {
       int32 offset_bandwidth_integral = request->offset_bandwidth_integral();
       auto status = library_->SEMCfgOffsetBandwidthIntegral(instrument, selector_string, offset_bandwidth_integral);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8546,6 +8854,7 @@ namespace nirfmxlte_grpc {
       int32 number_of_elements = static_cast<int32>(request->offset_bandwidth_integral().size());
       auto status = library_->SEMCfgOffsetBandwidthIntegralArray(instrument, selector_string, offset_bandwidth_integral, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8587,6 +8896,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->SEMCfgOffsetFrequency(instrument, selector_string, offset_start_frequency, offset_stop_frequency, offset_sideband);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8640,6 +8950,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->SEMCfgOffsetFrequencyArray(instrument, selector_string, offset_start_frequency, offset_stop_frequency, offset_sideband, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8679,6 +8990,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->SEMCfgOffsetLimitFailMask(instrument, selector_string, limit_fail_mask);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8712,6 +9024,7 @@ namespace nirfmxlte_grpc {
       int32 number_of_elements = static_cast<int32>(request->limit_fail_mask().size());
       auto status = library_->SEMCfgOffsetLimitFailMaskArray(instrument, selector_string, limit_fail_mask, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8752,6 +9065,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->SEMCfgOffsetRBWFilter(instrument, selector_string, offset_rbw, offset_rbw_filter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8802,6 +9116,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->SEMCfgOffsetRBWFilterArray(instrument, selector_string, offset_rbw, offset_rbw_filter_type, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8827,6 +9142,7 @@ namespace nirfmxlte_grpc {
       float64 relative_limit_stop = request->relative_limit_stop();
       auto status = library_->SEMCfgOffsetRelativeLimit(instrument, selector_string, relative_limit_start, relative_limit_stop);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8869,6 +9185,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->SEMCfgOffsetRelativeLimitArray(instrument, selector_string, relative_limit_start, relative_limit_stop, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8909,6 +9226,7 @@ namespace nirfmxlte_grpc {
       float64 sweep_time_interval = request->sweep_time_interval();
       auto status = library_->SEMCfgSweepTime(instrument, selector_string, sweep_time_auto, sweep_time_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8948,6 +9266,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->SEMCfgUplinkMaskType(instrument, selector_string, uplink_mask_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8974,6 +9293,7 @@ namespace nirfmxlte_grpc {
       float64 relative_integrated_power {};
       auto status = library_->SEMFetchComponentCarrierMeasurement(instrument, selector_string, timeout, &absolute_integrated_power, &relative_integrated_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9002,6 +9322,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->SEMFetchComponentCarrierMeasurementArray(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_absolute_integrated_power()->Resize(actual_array_size, 0);
@@ -9015,6 +9336,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -9048,6 +9370,7 @@ namespace nirfmxlte_grpc {
       float64 margin_relative_power {};
       auto status = library_->SEMFetchLowerOffsetMargin(instrument, selector_string, timeout, &measurement_status, &margin, &margin_frequency, &margin_absolute_power, &margin_relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9080,6 +9403,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->SEMFetchLowerOffsetMarginArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_measurement_status_raw()->Resize(actual_array_size, 0);
@@ -9099,6 +9423,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -9144,6 +9469,7 @@ namespace nirfmxlte_grpc {
       float64 relative_peak_power {};
       auto status = library_->SEMFetchLowerOffsetPower(instrument, selector_string, timeout, &absolute_integrated_power, &relative_integrated_power, &absolute_peak_power, &peak_frequency, &relative_peak_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9175,6 +9501,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->SEMFetchLowerOffsetPowerArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_absolute_integrated_power()->Resize(actual_array_size, 0);
@@ -9194,6 +9521,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -9226,6 +9554,7 @@ namespace nirfmxlte_grpc {
       int32 measurement_status {};
       auto status = library_->SEMFetchMeasurementStatus(instrument, selector_string, timeout, &measurement_status);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9256,6 +9585,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->SEMFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -9269,6 +9599,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -9302,6 +9633,7 @@ namespace nirfmxlte_grpc {
       float64 frequency {};
       auto status = library_->SEMFetchSubblockMeasurement(instrument, selector_string, timeout, &subblock_power, &integration_bandwidth, &frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9330,6 +9662,7 @@ namespace nirfmxlte_grpc {
       float64 total_aggregated_power {};
       auto status = library_->SEMFetchTotalAggregatedPower(instrument, selector_string, timeout, &total_aggregated_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9360,6 +9693,7 @@ namespace nirfmxlte_grpc {
       float64 margin_relative_power {};
       auto status = library_->SEMFetchUpperOffsetMargin(instrument, selector_string, timeout, &measurement_status, &margin, &margin_frequency, &margin_absolute_power, &margin_relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9392,6 +9726,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->SEMFetchUpperOffsetMarginArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_measurement_status_raw()->Resize(actual_array_size, 0);
@@ -9411,6 +9746,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -9456,6 +9792,7 @@ namespace nirfmxlte_grpc {
       float64 relative_peak_power {};
       auto status = library_->SEMFetchUpperOffsetPower(instrument, selector_string, timeout, &absolute_integrated_power, &relative_integrated_power, &absolute_peak_power, &peak_frequency, &relative_peak_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9487,6 +9824,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->SEMFetchUpperOffsetPowerArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_absolute_integrated_power()->Resize(actual_array_size, 0);
@@ -9506,6 +9844,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -9553,6 +9892,7 @@ namespace nirfmxlte_grpc {
       int32 enable_all_traces = request->enable_all_traces();
       auto status = library_->SelectMeasurements(instrument, selector_string, measurements, enable_all_traces);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9575,6 +9915,7 @@ namespace nirfmxlte_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->SendSoftwareEdgeTrigger(instrument);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9600,6 +9941,7 @@ namespace nirfmxlte_grpc {
       float32 attr_val = request->attr_val();
       auto status = library_->SetAttributeF32(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9626,6 +9968,7 @@ namespace nirfmxlte_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeF32Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9651,6 +9994,7 @@ namespace nirfmxlte_grpc {
       float64 attr_val = request->attr_val();
       auto status = library_->SetAttributeF64(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9677,6 +10021,7 @@ namespace nirfmxlte_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeF64Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9711,6 +10056,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->SetAttributeI16(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9754,6 +10100,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->SetAttributeI32(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9788,6 +10135,7 @@ namespace nirfmxlte_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI32Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9813,6 +10161,7 @@ namespace nirfmxlte_grpc {
       int64 attr_val = request->attr_val();
       auto status = library_->SetAttributeI64(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9839,6 +10188,7 @@ namespace nirfmxlte_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI64Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9873,6 +10223,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->SetAttributeI8(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9919,6 +10270,7 @@ namespace nirfmxlte_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI8Array(instrument, selector_string, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9948,6 +10300,7 @@ namespace nirfmxlte_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeNIComplexDoubleArray(instrument, selector_string, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9974,6 +10327,7 @@ namespace nirfmxlte_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeNIComplexSingleArray(instrument, selector_string, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10018,6 +10372,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->SetAttributeString(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10052,6 +10407,7 @@ namespace nirfmxlte_grpc {
 
       auto status = library_->SetAttributeU16(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10080,6 +10436,7 @@ namespace nirfmxlte_grpc {
       uInt32 attr_val = request->attr_val();
       auto status = library_->SetAttributeU32(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10106,6 +10463,7 @@ namespace nirfmxlte_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU32Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10132,6 +10490,7 @@ namespace nirfmxlte_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU64Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10157,6 +10516,7 @@ namespace nirfmxlte_grpc {
       uInt8 attr_val = request->attr_val();
       auto status = library_->SetAttributeU8(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10183,6 +10543,7 @@ namespace nirfmxlte_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU8Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10224,6 +10585,7 @@ namespace nirfmxlte_grpc {
       int32 measurement_length = request->measurement_length();
       auto status = library_->SlotPhaseCfgSynchronizationModeAndInterval(instrument, selector_string, synchronization_mode, measurement_offset, measurement_length);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10249,6 +10611,7 @@ namespace nirfmxlte_grpc {
       float64 maximum_phase_discontinuity {};
       auto status = library_->SlotPhaseFetchMaximumPhaseDiscontinuity(instrument, selector_string, timeout, &maximum_phase_discontinuity);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10276,6 +10639,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->SlotPhaseFetchMaximumPhaseDiscontinuityArray(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_maximum_phase_discontinuity()->Resize(actual_array_size, 0);
@@ -10287,6 +10651,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -10316,6 +10681,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->SlotPhaseFetchPhaseDiscontinuities(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_slot_phase_discontinuity()->Resize(actual_array_size, 0);
@@ -10327,6 +10693,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -10358,6 +10725,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->SlotPhaseFetchSamplePhaseError(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_sample_phase_error()->Resize(actual_array_size, 0);
@@ -10369,6 +10737,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -10402,6 +10771,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->SlotPhaseFetchSamplePhaseErrorLinearFitTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_sample_phase_error_linear_fit()->Resize(actual_array_size, 0);
@@ -10413,6 +10783,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -10443,6 +10814,7 @@ namespace nirfmxlte_grpc {
       int32 measurement_length = request->measurement_length();
       auto status = library_->SlotPowerCfgMeasurementInterval(instrument, selector_string, measurement_offset, measurement_length);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10469,6 +10841,7 @@ namespace nirfmxlte_grpc {
       while (true) {
         auto status = library_->SlotPowerFetchPowers(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_subframe_power()->Resize(actual_array_size, 0);
@@ -10482,6 +10855,7 @@ namespace nirfmxlte_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -10509,6 +10883,7 @@ namespace nirfmxlte_grpc {
       float64 timeout = request->timeout();
       auto status = library_->WaitForAcquisitionComplete(instrument, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10533,6 +10908,7 @@ namespace nirfmxlte_grpc {
       float64 timeout = request->timeout();
       auto status = library_->WaitForMeasurementComplete(instrument, selector_string, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);

--- a/generated/nirfmxnr/nirfmxnr_service.cpp
+++ b/generated/nirfmxnr/nirfmxnr_service.cpp
@@ -93,6 +93,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->ACPCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -132,6 +133,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->ACPCfgMeasurementMethod(instrument, selector_string, measurement_method);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -171,6 +173,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->ACPCfgNoiseCompensationEnabled(instrument, selector_string, noise_compensation_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -195,6 +198,7 @@ namespace nirfmxnr_grpc {
       int32 number_of_endc_offsets = request->number_of_endc_offsets();
       auto status = library_->ACPCfgNumberOfENDCOffsets(instrument, selector_string, number_of_endc_offsets);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -219,6 +223,7 @@ namespace nirfmxnr_grpc {
       int32 number_of_eutra_offsets = request->number_of_eutra_offsets();
       auto status = library_->ACPCfgNumberOfEUTRAOffsets(instrument, selector_string, number_of_eutra_offsets);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -243,6 +248,7 @@ namespace nirfmxnr_grpc {
       int32 number_of_nr_offsets = request->number_of_nr_offsets();
       auto status = library_->ACPCfgNumberOfNROffsets(instrument, selector_string, number_of_nr_offsets);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -267,6 +273,7 @@ namespace nirfmxnr_grpc {
       int32 number_of_utra_offsets = request->number_of_utra_offsets();
       auto status = library_->ACPCfgNumberOfUTRAOffsets(instrument, selector_string, number_of_utra_offsets);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -306,6 +313,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->ACPCfgPowerUnits(instrument, selector_string, power_units);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -362,6 +370,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->ACPCfgRBWFilter(instrument, selector_string, rbw_auto, rbw, rbw_filter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -402,6 +411,7 @@ namespace nirfmxnr_grpc {
       float64 sweep_time_interval = request->sweep_time_interval();
       auto status = library_->ACPCfgSweepTime(instrument, selector_string, sweep_time_auto, sweep_time_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -431,6 +441,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ACPFetchAbsolutePowersTrace(instrument, selector_string, timeout, trace_index, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_absolute_powers_trace()->Resize(actual_array_size, 0);
@@ -442,6 +453,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -473,6 +485,7 @@ namespace nirfmxnr_grpc {
       float64 relative_power {};
       auto status = library_->ACPFetchComponentCarrierMeasurement(instrument, selector_string, timeout, &absolute_power, &relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -501,6 +514,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ACPFetchComponentCarrierMeasurementArray(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_absolute_power()->Resize(actual_array_size, 0);
@@ -514,6 +528,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -546,6 +561,7 @@ namespace nirfmxnr_grpc {
       float64 upper_absolute_power {};
       auto status = library_->ACPFetchOffsetMeasurement(instrument, selector_string, timeout, &lower_relative_power, &upper_relative_power, &lower_absolute_power, &upper_absolute_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -576,6 +592,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ACPFetchOffsetMeasurementArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_lower_relative_power()->Resize(actual_array_size, 0);
@@ -593,6 +610,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -628,6 +646,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ACPFetchRelativePowersTrace(instrument, selector_string, timeout, trace_index, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_relative_powers_trace()->Resize(actual_array_size, 0);
@@ -639,6 +658,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -672,6 +692,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ACPFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -683,6 +704,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -715,6 +737,7 @@ namespace nirfmxnr_grpc {
       float64 frequency {};
       auto status = library_->ACPFetchSubblockMeasurement(instrument, selector_string, timeout, &subblock_power, &integration_bandwidth, &frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -743,6 +766,7 @@ namespace nirfmxnr_grpc {
       float64 total_aggregated_power {};
       auto status = library_->ACPFetchTotalAggregatedPower(instrument, selector_string, timeout, &total_aggregated_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -768,6 +792,7 @@ namespace nirfmxnr_grpc {
       int32 noise_calibration_data_valid {};
       auto status = library_->ACPValidateNoiseCalibrationData(instrument, selector_string, &noise_calibration_data_valid);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -793,6 +818,7 @@ namespace nirfmxnr_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->AbortMeasurements(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -823,6 +849,7 @@ namespace nirfmxnr_grpc {
       auto reserved = 0;
       auto status = library_->AnalyzeIQ1Waveform(instrument, selector_string, result_name, x0, dx, iq.data(), array_size, reset, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -853,6 +880,7 @@ namespace nirfmxnr_grpc {
       auto reserved = 0;
       auto status = library_->AnalyzeSpectrum1Waveform(instrument, selector_string, result_name, x0, dx, spectrum, array_size, reset, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -878,6 +906,7 @@ namespace nirfmxnr_grpc {
       float64 reference_level {};
       auto status = library_->AutoLevel(instrument, selector_string, measurement_interval, &reference_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -903,6 +932,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->BuildBandwidthPartString(selector_string, bandwidth_part_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -917,6 +947,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -944,6 +975,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->BuildCORESETClusterString(selector_string, coreset_cluster_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -958,6 +990,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -985,6 +1018,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->BuildCORESETString(selector_string, coreset_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -999,6 +1033,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1026,6 +1061,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->BuildCarrierString(selector_string, carrier_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -1040,6 +1076,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1068,6 +1105,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->BuildListStepString(list_name, result_name, step_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_length = status;
@@ -1082,6 +1120,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1109,6 +1148,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->BuildListString(list_name, result_name, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_length = status;
@@ -1123,6 +1163,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1150,6 +1191,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->BuildOffsetString(selector_string, offset_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -1164,6 +1206,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1191,6 +1234,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->BuildPDCCHString(selector_string, pdcch_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -1205,6 +1249,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1232,6 +1277,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->BuildPDSCHClusterString(selector_string, pdsch_cluster_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -1246,6 +1292,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1273,6 +1320,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->BuildPDSCHString(selector_string, pdsch_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -1287,6 +1335,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1314,6 +1363,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->BuildPUSCHClusterString(selector_string, pusch_cluster_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -1328,6 +1378,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1355,6 +1406,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->BuildPUSCHString(selector_string, pusch_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -1369,6 +1421,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1396,6 +1449,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->BuildSignalString(signal_name, result_name, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_length = status;
@@ -1410,6 +1464,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1437,6 +1492,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->BuildSubblockString(selector_string, subblock_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -1451,6 +1507,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1478,6 +1535,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->BuildUserString(selector_string, user_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -1492,6 +1550,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -1551,6 +1610,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->CHPCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1607,6 +1667,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->CHPCfgRBWFilter(instrument, selector_string, rbw_auto, rbw, rbw_filter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1647,6 +1708,7 @@ namespace nirfmxnr_grpc {
       float64 sweep_time_interval = request->sweep_time_interval();
       auto status = library_->CHPCfgSweepTime(instrument, selector_string, sweep_time_auto, sweep_time_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1673,6 +1735,7 @@ namespace nirfmxnr_grpc {
       float64 relative_power {};
       auto status = library_->CHPFetchComponentCarrierMeasurement(instrument, selector_string, timeout, &absolute_power, &relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1701,6 +1764,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->CHPFetchComponentCarrierMeasurementArray(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_absolute_power()->Resize(actual_array_size, 0);
@@ -1714,6 +1778,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1746,6 +1811,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->CHPFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -1757,6 +1823,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1787,6 +1854,7 @@ namespace nirfmxnr_grpc {
       float64 subblock_power {};
       auto status = library_->CHPFetchSubblockPower(instrument, selector_string, timeout, &subblock_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1813,6 +1881,7 @@ namespace nirfmxnr_grpc {
       float64 total_aggregated_power {};
       auto status = library_->CHPFetchTotalAggregatedPower(instrument, selector_string, timeout, &total_aggregated_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1838,6 +1907,7 @@ namespace nirfmxnr_grpc {
       int32 noise_calibration_data_valid {};
       auto status = library_->CHPValidateNoiseCalibrationData(instrument, selector_string, &noise_calibration_data_valid);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1901,6 +1971,7 @@ namespace nirfmxnr_grpc {
       int32 enable_trigger = request->enable_trigger();
       auto status = library_->CfgDigitalEdgeTrigger(instrument, selector_string, digital_edge_source, digital_edge, trigger_delay, enable_trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1925,6 +1996,7 @@ namespace nirfmxnr_grpc {
       float64 external_attenuation = request->external_attenuation();
       auto status = library_->CfgExternalAttenuation(instrument, selector_string, external_attenuation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1949,6 +2021,7 @@ namespace nirfmxnr_grpc {
       float64 center_frequency = request->center_frequency();
       auto status = library_->CfgFrequency(instrument, selector_string, center_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1993,6 +2066,7 @@ namespace nirfmxnr_grpc {
       float64 frequency_reference_frequency = request->frequency_reference_frequency();
       auto status = library_->CfgFrequencyReference(instrument, channel_name, frequency_reference_source, frequency_reference_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2069,6 +2143,7 @@ namespace nirfmxnr_grpc {
       int32 enable_trigger = request->enable_trigger();
       auto status = library_->CfgIQPowerEdgeTrigger(instrument, selector_string, iq_power_edge_source, iq_power_edge_slope, iq_power_edge_level, trigger_delay, trigger_min_quiet_time_mode, trigger_min_quiet_time_duration, iq_power_edge_level_type, enable_trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2109,6 +2184,7 @@ namespace nirfmxnr_grpc {
       float64 mechanical_attenuation_value = request->mechanical_attenuation_value();
       auto status = library_->CfgMechanicalAttenuation(instrument, channel_name, mechanical_attenuation_auto, mechanical_attenuation_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2135,6 +2211,7 @@ namespace nirfmxnr_grpc {
       float64 external_attenuation = request->external_attenuation();
       auto status = library_->CfgRF(instrument, selector_string, center_frequency, reference_level, external_attenuation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2175,6 +2252,7 @@ namespace nirfmxnr_grpc {
       float64 rf_attenuation_value = request->rf_attenuation_value();
       auto status = library_->CfgRFAttenuation(instrument, channel_name, rf_attenuation_auto, rf_attenuation_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2199,6 +2277,7 @@ namespace nirfmxnr_grpc {
       float64 reference_level = request->reference_level();
       auto status = library_->CfgReferenceLevel(instrument, selector_string, reference_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2224,6 +2303,7 @@ namespace nirfmxnr_grpc {
       int32 enable_trigger = request->enable_trigger();
       auto status = library_->CfgSoftwareEdgeTrigger(instrument, selector_string, trigger_delay, enable_trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2263,6 +2343,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->CfggNodeBCategory(instrument, selector_string, gnodeb_category);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2287,6 +2368,7 @@ namespace nirfmxnr_grpc {
       int32 is_done {};
       auto status = library_->CheckMeasurementStatus(instrument, selector_string, &is_done);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2311,6 +2393,7 @@ namespace nirfmxnr_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearAllNamedResults(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2334,6 +2417,7 @@ namespace nirfmxnr_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearNamedResult(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2357,6 +2441,7 @@ namespace nirfmxnr_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearNoiseCalibrationDatabase(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2381,6 +2466,7 @@ namespace nirfmxnr_grpc {
       char* new_signal_name = (char*)request->new_signal_name().c_str();
       auto status = library_->CloneSignalConfiguration(instrument, old_signal_name, new_signal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2405,6 +2491,7 @@ namespace nirfmxnr_grpc {
       session_repository_->remove_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->Close(instrument, force_destroy);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2428,6 +2515,7 @@ namespace nirfmxnr_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->Commit(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2451,6 +2539,7 @@ namespace nirfmxnr_grpc {
       char* list_name = (char*)request->list_name().c_str();
       auto status = library_->CreateList(instrument, list_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2475,6 +2564,7 @@ namespace nirfmxnr_grpc {
       int32 created_step_index {};
       auto status = library_->CreateListStep(instrument, selector_string, &created_step_index);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2499,6 +2589,7 @@ namespace nirfmxnr_grpc {
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->CreateSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2522,6 +2613,7 @@ namespace nirfmxnr_grpc {
       char* list_name = (char*)request->list_name().c_str();
       auto status = library_->DeleteList(instrument, list_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2545,6 +2637,7 @@ namespace nirfmxnr_grpc {
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->DeleteSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2568,6 +2661,7 @@ namespace nirfmxnr_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->DisableTrigger(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2594,6 +2688,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->GetAllNamedResultNames(instrument, selector_string, nullptr, 0, &actual_result_names_size, &default_result_exists);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::string result_names;
@@ -2607,6 +2702,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2637,6 +2733,7 @@ namespace nirfmxnr_grpc {
       float32 attr_val {};
       auto status = library_->GetAttributeF32(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2664,6 +2761,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->GetAttributeF32Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -2675,6 +2773,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2703,6 +2802,7 @@ namespace nirfmxnr_grpc {
       float64 attr_val {};
       auto status = library_->GetAttributeF64(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2730,6 +2830,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->GetAttributeF64Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -2741,6 +2842,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2769,6 +2871,7 @@ namespace nirfmxnr_grpc {
       int16 attr_val {};
       auto status = library_->GetAttributeI16(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2795,6 +2898,7 @@ namespace nirfmxnr_grpc {
       int32 attr_val {};
       auto status = library_->GetAttributeI32(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2828,6 +2932,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->GetAttributeI32Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val_raw()->Resize(actual_array_size, 0);
@@ -2839,6 +2944,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2881,6 +2987,7 @@ namespace nirfmxnr_grpc {
       int64 attr_val {};
       auto status = library_->GetAttributeI64(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2908,6 +3015,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->GetAttributeI64Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -2919,6 +3027,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2947,6 +3056,7 @@ namespace nirfmxnr_grpc {
       int8 attr_val {};
       auto status = library_->GetAttributeI8(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2974,6 +3084,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->GetAttributeI8Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<int8> attr_val(actual_array_size);
@@ -2984,6 +3095,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3022,6 +3134,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->GetAttributeNIComplexDoubleArray(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexDouble> attr_val(actual_array_size, NIComplexDouble());
@@ -3032,6 +3145,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3068,6 +3182,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->GetAttributeNIComplexSingleArray(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> attr_val(actual_array_size, NIComplexSingle());
@@ -3078,6 +3193,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3114,6 +3230,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->GetAttributeString(instrument, selector_string, attribute_id, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 array_size = status;
@@ -3128,6 +3245,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3156,6 +3274,7 @@ namespace nirfmxnr_grpc {
       uInt16 attr_val {};
       auto status = library_->GetAttributeU16(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3182,6 +3301,7 @@ namespace nirfmxnr_grpc {
       uInt32 attr_val {};
       auto status = library_->GetAttributeU32(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3209,6 +3329,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->GetAttributeU32Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -3220,6 +3341,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3249,6 +3371,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->GetAttributeU64Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -3260,6 +3383,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3288,6 +3412,7 @@ namespace nirfmxnr_grpc {
       uInt8 attr_val {};
       auto status = library_->GetAttributeU8(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3315,6 +3440,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->GetAttributeU8Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::string attr_val(actual_array_size, '\0');
@@ -3325,6 +3451,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3353,6 +3480,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->GetError(instrument, nullptr, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 error_description_buffer_size = status;
@@ -3368,6 +3496,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3397,6 +3526,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->GetErrorString(instrument, error_code, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 error_description_buffer_size = status;
@@ -3411,6 +3541,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3446,6 +3577,7 @@ namespace nirfmxnr_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXNR_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
       }
       response->set_status(status);
@@ -3482,6 +3614,7 @@ namespace nirfmxnr_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXNR_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
       }
       response->set_status(status);
@@ -3510,6 +3643,7 @@ namespace nirfmxnr_grpc {
       char* result_name = (char*)request->result_name().c_str();
       auto status = library_->Initiate(instrument, selector_string, result_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3534,6 +3668,7 @@ namespace nirfmxnr_grpc {
       float64 timeout = request->timeout();
       auto status = library_->ModAccAutoLevel(instrument, selector_string, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3573,6 +3708,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->ModAccCfgMeasurementMode(instrument, selector_string, measurement_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3612,6 +3748,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->ModAccCfgNoiseCompensationEnabled(instrument, selector_string, noise_compensation_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3639,6 +3776,7 @@ namespace nirfmxnr_grpc {
       int32 array_size = static_cast<int32>(request->reference_waveform().size());
       auto status = library_->ModAccCfgReferenceWaveform(instrument, selector_string, x0, dx, reference_waveform.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3661,6 +3799,7 @@ namespace nirfmxnr_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->ModAccClearNoiseCalibrationDatabase(instrument);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3687,6 +3826,7 @@ namespace nirfmxnr_grpc {
       float64 composite_peak_evm_maximum {};
       auto status = library_->ModAccFetchCompositeEVM(instrument, selector_string, timeout, &composite_rms_evm_mean, &composite_peak_evm_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3714,6 +3854,7 @@ namespace nirfmxnr_grpc {
       float64 frequency_error_mean {};
       auto status = library_->ModAccFetchFrequencyErrorMean(instrument, selector_string, timeout, &frequency_error_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3743,6 +3884,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchIQGainImbalancePerSubcarrierMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_iq_gain_imbalance_per_subcarrier_mean()->Resize(actual_array_size, 0);
@@ -3754,6 +3896,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3787,6 +3930,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchIQQuadratureErrorPerSubcarrierMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_iq_quadrature_error_per_subcarrier_mean()->Resize(actual_array_size, 0);
@@ -3798,6 +3942,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3831,6 +3976,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchInBandEmissionTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_in_band_emission()->Resize(actual_array_size, 0);
@@ -3844,6 +3990,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3876,6 +4023,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPBCHDMRSConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> pbch_dmrs_constellation(actual_array_size, NIComplexSingle());
@@ -3886,6 +4034,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3924,6 +4073,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPBCHDMRSRMSEVMPerSubcarrierMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_pbch_dmrs_rms_evm_per_subcarrier_mean()->Resize(actual_array_size, 0);
@@ -3935,6 +4085,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3968,6 +4119,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPBCHDMRSRMSEVMPerSymbolMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_pbch_dmrs_rms_evm_per_symbol_mean()->Resize(actual_array_size, 0);
@@ -3979,6 +4131,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4010,6 +4163,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPBCHDataConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> pbch_data_constellation(actual_array_size, NIComplexSingle());
@@ -4020,6 +4174,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4058,6 +4213,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPBCHDataRMSEVMPerSubcarrierMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_pbch_data_rms_evm_per_subcarrier_mean()->Resize(actual_array_size, 0);
@@ -4069,6 +4225,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4102,6 +4259,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPBCHDataRMSEVMPerSymbolMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_pbch_data_rms_evm_per_symbol_mean()->Resize(actual_array_size, 0);
@@ -4113,6 +4271,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4144,6 +4303,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPDSCH1024QAMConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> qam1024_constellation(actual_array_size, NIComplexSingle());
@@ -4154,6 +4314,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4190,6 +4351,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPDSCH16QAMConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> qam16_constellation(actual_array_size, NIComplexSingle());
@@ -4200,6 +4362,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4236,6 +4399,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPDSCH256QAMConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> qam256_constellation(actual_array_size, NIComplexSingle());
@@ -4246,6 +4410,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4282,6 +4447,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPDSCH64QAMConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> qam64_constellation(actual_array_size, NIComplexSingle());
@@ -4292,6 +4458,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4328,6 +4495,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPDSCH8PSKConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> psk8_constellation(actual_array_size, NIComplexSingle());
@@ -4338,6 +4506,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4374,6 +4543,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPDSCHDMRSConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> pdsch_dmrs_constellation(actual_array_size, NIComplexSingle());
@@ -4384,6 +4554,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4420,6 +4591,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPDSCHDataConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> pdsch_data_constellation(actual_array_size, NIComplexSingle());
@@ -4430,6 +4602,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4466,6 +4639,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPDSCHDemodulatedBits(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<int8> bits(actual_array_size);
@@ -4476,6 +4650,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4514,6 +4689,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPDSCHPTRSConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> pdsch_ptrs_constellation(actual_array_size, NIComplexSingle());
@@ -4524,6 +4700,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4560,6 +4737,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPDSCHQPSKConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> qpsk_constellation(actual_array_size, NIComplexSingle());
@@ -4570,6 +4748,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4606,6 +4785,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPSSConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> pss_constellation(actual_array_size, NIComplexSingle());
@@ -4616,6 +4796,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4654,6 +4835,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPSSRMSEVMPerSubcarrierMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_pss_rms_evm_per_subcarrier_mean()->Resize(actual_array_size, 0);
@@ -4665,6 +4847,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4698,6 +4881,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPSSRMSEVMPerSymbolMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_pss_rms_evm_per_symbol_mean()->Resize(actual_array_size, 0);
@@ -4709,6 +4893,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4740,6 +4925,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPUSCHDMRSConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> pusch_dmrs_constellation(actual_array_size, NIComplexSingle());
@@ -4750,6 +4936,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4786,6 +4973,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPUSCHDataConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> pusch_data_constellation(actual_array_size, NIComplexSingle());
@@ -4796,6 +4984,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4832,6 +5021,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPUSCHDemodulatedBits(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<int8> bits(actual_array_size);
@@ -4842,6 +5032,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4880,6 +5071,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPUSCHPTRSConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> pusch_ptrs_constellation(actual_array_size, NIComplexSingle());
@@ -4890,6 +5082,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4928,6 +5121,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPeakEVMPerSlotMaximumTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_peak_evm_per_slot_maximum()->Resize(actual_array_size, 0);
@@ -4939,6 +5133,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4972,6 +5167,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPeakEVMPerSubcarrierMaximumTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_peak_evm_per_subcarrier_maximum()->Resize(actual_array_size, 0);
@@ -4983,6 +5179,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5016,6 +5213,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchPeakEVMPerSymbolMaximumTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_peak_evm_per_symbol_maximum()->Resize(actual_array_size, 0);
@@ -5027,6 +5225,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5060,6 +5259,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchRMSEVMHighPerSymbolMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_rms_evm_high_per_symbol_mean()->Resize(actual_array_size, 0);
@@ -5071,6 +5271,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5104,6 +5305,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchRMSEVMLowPerSymbolMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_rms_evm_low_per_symbol_mean()->Resize(actual_array_size, 0);
@@ -5115,6 +5317,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5148,6 +5351,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchRMSEVMPerSlotMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_rms_evm_per_slot_mean()->Resize(actual_array_size, 0);
@@ -5159,6 +5363,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5192,6 +5397,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchRMSEVMPerSubcarrierMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_rms_evm_per_subcarrier_mean()->Resize(actual_array_size, 0);
@@ -5203,6 +5409,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5236,6 +5443,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchRMSEVMPerSymbolMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_rms_evm_per_symbol_mean()->Resize(actual_array_size, 0);
@@ -5247,6 +5455,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5278,6 +5487,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchSSSConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> sss_constellation(actual_array_size, NIComplexSingle());
@@ -5288,6 +5498,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5326,6 +5537,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchSSSRMSEVMPerSubcarrierMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_sss_rms_evm_per_subcarrier_mean()->Resize(actual_array_size, 0);
@@ -5337,6 +5549,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5370,6 +5583,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchSSSRMSEVMPerSymbolMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_sss_rms_evm_per_symbol_mean()->Resize(actual_array_size, 0);
@@ -5381,6 +5595,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5414,6 +5629,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchSpectralFlatnessTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectral_flatness()->Resize(actual_array_size, 0);
@@ -5429,6 +5645,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5462,6 +5679,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->ModAccFetchSubblockInBandEmissionTrace(instrument, selector_string, timeout, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_subblock_in_band_emission()->Resize(actual_array_size, 0);
@@ -5477,6 +5695,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5506,6 +5725,7 @@ namespace nirfmxnr_grpc {
       int32 calibration_data_valid {};
       auto status = library_->ModAccValidateCalibrationData(instrument, selector_string, &calibration_data_valid);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5564,6 +5784,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->OBWCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5620,6 +5841,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->OBWCfgRBWFilter(instrument, selector_string, rbw_auto, rbw, rbw_filter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5660,6 +5882,7 @@ namespace nirfmxnr_grpc {
       float64 sweep_time_interval = request->sweep_time_interval();
       auto status = library_->OBWCfgSweepTime(instrument, selector_string, sweep_time_auto, sweep_time_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5688,6 +5911,7 @@ namespace nirfmxnr_grpc {
       float64 stop_frequency {};
       auto status = library_->OBWFetchMeasurement(instrument, selector_string, timeout, &occupied_bandwidth, &absolute_power, &start_frequency, &stop_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5720,6 +5944,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->OBWFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -5731,6 +5956,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5792,6 +6018,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->PVTCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5831,6 +6058,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->PVTCfgMeasurementMethod(instrument, selector_string, measurement_method);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5856,6 +6084,7 @@ namespace nirfmxnr_grpc {
       float64 off_power_exclusion_after = request->off_power_exclusion_after();
       auto status = library_->PVTCfgOFFPowerExclusionPeriods(instrument, selector_string, off_power_exclusion_before, off_power_exclusion_after);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5885,6 +6114,7 @@ namespace nirfmxnr_grpc {
       float64 burst_width {};
       auto status = library_->PVTFetchMeasurement(instrument, selector_string, timeout, &measurement_status, &absolute_off_power_before, &absolute_off_power_after, &absolute_on_power, &burst_width);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5917,6 +6147,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->PVTFetchMeasurementArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_measurement_status_raw()->Resize(actual_array_size, 0);
@@ -5936,6 +6167,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5980,6 +6212,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->PVTFetchSignalPowerTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_signal_power()->Resize(actual_array_size, 0);
@@ -5993,6 +6226,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6027,6 +6261,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->PVTFetchWindowedSignalPowerTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_windowed_signal_power()->Resize(actual_array_size, 0);
@@ -6038,6 +6273,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6067,6 +6303,7 @@ namespace nirfmxnr_grpc {
       int32 attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(instrument, selector_string, attribute_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6090,6 +6327,7 @@ namespace nirfmxnr_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ResetToDefault(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6146,6 +6384,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->SEMCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6170,6 +6409,7 @@ namespace nirfmxnr_grpc {
       float64 component_carrier_rated_output_power = request->component_carrier_rated_output_power();
       auto status = library_->SEMCfgComponentCarrierRatedOutputPower(instrument, selector_string, component_carrier_rated_output_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6195,6 +6435,7 @@ namespace nirfmxnr_grpc {
       int32 number_of_elements = static_cast<int32>(request->component_carrier_rated_output_power().size());
       auto status = library_->SEMCfgComponentCarrierRatedOutputPowerArray(instrument, selector_string, component_carrier_rated_output_power, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6219,6 +6460,7 @@ namespace nirfmxnr_grpc {
       int32 number_of_offsets = request->number_of_offsets();
       auto status = library_->SEMCfgNumberOfOffsets(instrument, selector_string, number_of_offsets);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6244,6 +6486,7 @@ namespace nirfmxnr_grpc {
       float64 absolute_limit_stop = request->absolute_limit_stop();
       auto status = library_->SEMCfgOffsetAbsoluteLimit(instrument, selector_string, absolute_limit_start, absolute_limit_stop);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6286,6 +6529,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->SEMCfgOffsetAbsoluteLimitArray(instrument, selector_string, absolute_limit_start, absolute_limit_stop, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6310,6 +6554,7 @@ namespace nirfmxnr_grpc {
       int32 bandwidth_integral = request->bandwidth_integral();
       auto status = library_->SEMCfgOffsetBandwidthIntegral(instrument, selector_string, bandwidth_integral);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6335,6 +6580,7 @@ namespace nirfmxnr_grpc {
       int32 number_of_elements = static_cast<int32>(request->bandwidth_integral().size());
       auto status = library_->SEMCfgOffsetBandwidthIntegralArray(instrument, selector_string, bandwidth_integral, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6376,6 +6622,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->SEMCfgOffsetFrequency(instrument, selector_string, offset_start_frequency, offset_stop_frequency, offset_sideband);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6429,6 +6676,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->SEMCfgOffsetFrequencyArray(instrument, selector_string, offset_start_frequency, offset_stop_frequency, offset_sideband, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6468,6 +6716,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->SEMCfgOffsetLimitFailMask(instrument, selector_string, limit_fail_mask);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6501,6 +6750,7 @@ namespace nirfmxnr_grpc {
       int32 number_of_elements = static_cast<int32>(request->limit_fail_mask().size());
       auto status = library_->SEMCfgOffsetLimitFailMaskArray(instrument, selector_string, limit_fail_mask, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6541,6 +6791,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->SEMCfgOffsetRBWFilter(instrument, selector_string, offset_rbw, offset_rbw_filter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6591,6 +6842,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->SEMCfgOffsetRBWFilterArray(instrument, selector_string, offset_rbw, offset_rbw_filter_type, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6616,6 +6868,7 @@ namespace nirfmxnr_grpc {
       float64 relative_limit_stop = request->relative_limit_stop();
       auto status = library_->SEMCfgOffsetRelativeLimit(instrument, selector_string, relative_limit_start, relative_limit_stop);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6658,6 +6911,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->SEMCfgOffsetRelativeLimitArray(instrument, selector_string, relative_limit_start, relative_limit_stop, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6698,6 +6952,7 @@ namespace nirfmxnr_grpc {
       float64 sweep_time_interval = request->sweep_time_interval();
       auto status = library_->SEMCfgSweepTime(instrument, selector_string, sweep_time_auto, sweep_time_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6737,6 +6992,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->SEMCfgUplinkMaskType(instrument, selector_string, uplink_mask_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6765,6 +7021,7 @@ namespace nirfmxnr_grpc {
       float64 relative_power {};
       auto status = library_->SEMFetchComponentCarrierMeasurement(instrument, selector_string, timeout, &absolute_power, &peak_absolute_power, &peak_frequency, &relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6795,6 +7052,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->SEMFetchComponentCarrierMeasurementArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_absolute_power()->Resize(actual_array_size, 0);
@@ -6812,6 +7070,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6847,6 +7106,7 @@ namespace nirfmxnr_grpc {
       float64 margin_relative_power {};
       auto status = library_->SEMFetchLowerOffsetMargin(instrument, selector_string, timeout, &measurement_status, &margin, &margin_frequency, &margin_absolute_power, &margin_relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6879,6 +7139,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->SEMFetchLowerOffsetMarginArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_measurement_status_raw()->Resize(actual_array_size, 0);
@@ -6898,6 +7159,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6943,6 +7205,7 @@ namespace nirfmxnr_grpc {
       float64 peak_relative_power {};
       auto status = library_->SEMFetchLowerOffsetPower(instrument, selector_string, timeout, &total_absolute_power, &total_relative_power, &peak_absolute_power, &peak_frequency, &peak_relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6974,6 +7237,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->SEMFetchLowerOffsetPowerArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_total_absolute_power()->Resize(actual_array_size, 0);
@@ -6993,6 +7257,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7025,6 +7290,7 @@ namespace nirfmxnr_grpc {
       int32 measurement_status {};
       auto status = library_->SEMFetchMeasurementStatus(instrument, selector_string, timeout, &measurement_status);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7055,6 +7321,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->SEMFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -7068,6 +7335,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7101,6 +7369,7 @@ namespace nirfmxnr_grpc {
       float64 frequency {};
       auto status = library_->SEMFetchSubblockMeasurement(instrument, selector_string, timeout, &subblock_power, &integration_bandwidth, &frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7129,6 +7398,7 @@ namespace nirfmxnr_grpc {
       float64 total_aggregated_power {};
       auto status = library_->SEMFetchTotalAggregatedPower(instrument, selector_string, timeout, &total_aggregated_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7159,6 +7429,7 @@ namespace nirfmxnr_grpc {
       float64 margin_relative_power {};
       auto status = library_->SEMFetchUpperOffsetMargin(instrument, selector_string, timeout, &measurement_status, &margin, &margin_frequency, &margin_absolute_power, &margin_relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7191,6 +7462,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->SEMFetchUpperOffsetMarginArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_measurement_status_raw()->Resize(actual_array_size, 0);
@@ -7210,6 +7482,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7255,6 +7528,7 @@ namespace nirfmxnr_grpc {
       float64 peak_relative_power {};
       auto status = library_->SEMFetchUpperOffsetPower(instrument, selector_string, timeout, &total_absolute_power, &total_relative_power, &peak_absolute_power, &peak_frequency, &peak_relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7286,6 +7560,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->SEMFetchUpperOffsetPowerArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_total_absolute_power()->Resize(actual_array_size, 0);
@@ -7305,6 +7580,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7352,6 +7628,7 @@ namespace nirfmxnr_grpc {
       int32 enable_all_traces = request->enable_all_traces();
       auto status = library_->SelectMeasurements(instrument, selector_string, measurements, enable_all_traces);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7374,6 +7651,7 @@ namespace nirfmxnr_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->SendSoftwareEdgeTrigger(instrument);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7399,6 +7677,7 @@ namespace nirfmxnr_grpc {
       float32 attr_val = request->attr_val();
       auto status = library_->SetAttributeF32(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7425,6 +7704,7 @@ namespace nirfmxnr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeF32Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7450,6 +7730,7 @@ namespace nirfmxnr_grpc {
       float64 attr_val = request->attr_val();
       auto status = library_->SetAttributeF64(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7476,6 +7757,7 @@ namespace nirfmxnr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeF64Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7510,6 +7792,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->SetAttributeI16(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7553,6 +7836,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->SetAttributeI32(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7587,6 +7871,7 @@ namespace nirfmxnr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI32Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7612,6 +7897,7 @@ namespace nirfmxnr_grpc {
       int64 attr_val = request->attr_val();
       auto status = library_->SetAttributeI64(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7638,6 +7924,7 @@ namespace nirfmxnr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI64Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7672,6 +7959,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->SetAttributeI8(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7718,6 +8006,7 @@ namespace nirfmxnr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI8Array(instrument, selector_string, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7747,6 +8036,7 @@ namespace nirfmxnr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeNIComplexDoubleArray(instrument, selector_string, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7773,6 +8063,7 @@ namespace nirfmxnr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeNIComplexSingleArray(instrument, selector_string, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7817,6 +8108,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->SetAttributeString(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7851,6 +8143,7 @@ namespace nirfmxnr_grpc {
 
       auto status = library_->SetAttributeU16(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7879,6 +8172,7 @@ namespace nirfmxnr_grpc {
       uInt32 attr_val = request->attr_val();
       auto status = library_->SetAttributeU32(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7905,6 +8199,7 @@ namespace nirfmxnr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU32Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7931,6 +8226,7 @@ namespace nirfmxnr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU64Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7956,6 +8252,7 @@ namespace nirfmxnr_grpc {
       uInt8 attr_val = request->attr_val();
       auto status = library_->SetAttributeU8(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7982,6 +8279,7 @@ namespace nirfmxnr_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU8Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8008,6 +8306,7 @@ namespace nirfmxnr_grpc {
       float64 peak_power_maximum {};
       auto status = library_->TXPFetchMeasurement(instrument, selector_string, timeout, &average_power_mean, &peak_power_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8038,6 +8337,7 @@ namespace nirfmxnr_grpc {
       while (true) {
         auto status = library_->TXPFetchPowerTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_power()->Resize(actual_array_size, 0);
@@ -8049,6 +8349,7 @@ namespace nirfmxnr_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -8077,6 +8378,7 @@ namespace nirfmxnr_grpc {
       float64 timeout = request->timeout();
       auto status = library_->WaitForAcquisitionComplete(instrument, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8101,6 +8403,7 @@ namespace nirfmxnr_grpc {
       float64 timeout = request->timeout();
       auto status = library_->WaitForMeasurementComplete(instrument, selector_string, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);

--- a/generated/nirfmxspecan/nirfmxspecan_service.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_service.cpp
@@ -93,6 +93,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->ACPCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -119,6 +120,7 @@ namespace nirfmxspecan_grpc {
       float64 channel_spacing = request->channel_spacing();
       auto status = library_->ACPCfgCarrierAndOffsets(instrument, selector_string, integration_bandwidth, number_of_offsets, channel_spacing);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -143,6 +145,7 @@ namespace nirfmxspecan_grpc {
       float64 carrier_frequency = request->carrier_frequency();
       auto status = library_->ACPCfgCarrierFrequency(instrument, selector_string, carrier_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -167,6 +170,7 @@ namespace nirfmxspecan_grpc {
       float64 integration_bandwidth = request->integration_bandwidth();
       auto status = library_->ACPCfgCarrierIntegrationBandwidth(instrument, selector_string, integration_bandwidth);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -206,6 +210,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->ACPCfgCarrierMode(instrument, selector_string, carrier_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -246,6 +251,7 @@ namespace nirfmxspecan_grpc {
       float64 rrc_alpha = request->rrc_alpha();
       auto status = library_->ACPCfgCarrierRRCFilter(instrument, selector_string, rrc_filter_enabled, rrc_alpha);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -286,6 +292,7 @@ namespace nirfmxspecan_grpc {
       float64 fft_padding = request->fft_padding();
       auto status = library_->ACPCfgFFT(instrument, selector_string, fft_window, fft_padding);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -325,6 +332,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->ACPCfgMeasurementMethod(instrument, selector_string, measurement_method);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -364,6 +372,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->ACPCfgNoiseCompensationEnabled(instrument, selector_string, noise_compensation_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -388,6 +397,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_carriers = request->number_of_carriers();
       auto status = library_->ACPCfgNumberOfCarriers(instrument, selector_string, number_of_carriers);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -412,6 +422,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_offsets = request->number_of_offsets();
       auto status = library_->ACPCfgNumberOfOffsets(instrument, selector_string, number_of_offsets);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -468,6 +479,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->ACPCfgOffset(instrument, selector_string, offset_frequency, offset_sideband, offset_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -529,6 +541,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->ACPCfgOffsetArray(instrument, selector_string, offset_frequency, offset_sideband, offset_enabled, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -568,6 +581,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->ACPCfgOffsetFrequencyDefinition(instrument, selector_string, offset_frequency_definition);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -592,6 +606,7 @@ namespace nirfmxspecan_grpc {
       float64 integration_bandwidth = request->integration_bandwidth();
       auto status = library_->ACPCfgOffsetIntegrationBandwidth(instrument, selector_string, integration_bandwidth);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -617,6 +632,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_elements = static_cast<int32>(request->integration_bandwidth().size());
       auto status = library_->ACPCfgOffsetIntegrationBandwidthArray(instrument, selector_string, integration_bandwidth, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -657,6 +673,7 @@ namespace nirfmxspecan_grpc {
       int32 offset_reference_specific = request->offset_reference_specific();
       auto status = library_->ACPCfgOffsetPowerReference(instrument, selector_string, offset_reference_carrier, offset_reference_specific);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -707,6 +724,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->ACPCfgOffsetPowerReferenceArray(instrument, selector_string, offset_power_reference_carrier, offset_power_reference_specific, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -747,6 +765,7 @@ namespace nirfmxspecan_grpc {
       float64 rrc_alpha = request->rrc_alpha();
       auto status = library_->ACPCfgOffsetRRCFilter(instrument, selector_string, rrc_filter_enabled, rrc_alpha);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -797,6 +816,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->ACPCfgOffsetRRCFilterArray(instrument, selector_string, rrc_filter_enabled, rrc_alpha, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -821,6 +841,7 @@ namespace nirfmxspecan_grpc {
       float64 relative_attenuation = request->relative_attenuation();
       auto status = library_->ACPCfgOffsetRelativeAttenuation(instrument, selector_string, relative_attenuation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -846,6 +867,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_elements = static_cast<int32>(request->relative_attenuation().size());
       auto status = library_->ACPCfgOffsetRelativeAttenuationArray(instrument, selector_string, relative_attenuation, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -885,6 +907,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->ACPCfgPowerUnits(instrument, selector_string, power_units);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -941,6 +964,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->ACPCfgRBWFilter(instrument, selector_string, rbw_auto, rbw, rbw_filter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -981,6 +1005,7 @@ namespace nirfmxspecan_grpc {
       float64 sweep_time_interval = request->sweep_time_interval();
       auto status = library_->ACPCfgSweepTime(instrument, selector_string, sweep_time_auto, sweep_time_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1010,6 +1035,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->ACPFetchAbsolutePowersTrace(instrument, selector_string, timeout, trace_index, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_absolute_powers_trace()->Resize(actual_array_size, 0);
@@ -1021,6 +1047,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1054,6 +1081,7 @@ namespace nirfmxspecan_grpc {
       float64 integration_bandwidth {};
       auto status = library_->ACPFetchCarrierMeasurement(instrument, selector_string, timeout, &absolute_power, &total_relative_power, &carrier_offset, &integration_bandwidth);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1083,6 +1111,7 @@ namespace nirfmxspecan_grpc {
       float64 frequency_resolution {};
       auto status = library_->ACPFetchFrequencyResolution(instrument, selector_string, timeout, &frequency_resolution);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1112,6 +1141,7 @@ namespace nirfmxspecan_grpc {
       float64 upper_absolute_power {};
       auto status = library_->ACPFetchOffsetMeasurement(instrument, selector_string, timeout, &lower_relative_power, &upper_relative_power, &lower_absolute_power, &upper_absolute_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1142,6 +1172,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->ACPFetchOffsetMeasurementArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_lower_relative_power()->Resize(actual_array_size, 0);
@@ -1159,6 +1190,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1194,6 +1226,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->ACPFetchRelativePowersTrace(instrument, selector_string, timeout, trace_index, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_relative_powers_trace()->Resize(actual_array_size, 0);
@@ -1205,6 +1238,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1238,6 +1272,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->ACPFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -1249,6 +1284,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1279,6 +1315,7 @@ namespace nirfmxspecan_grpc {
       float64 total_carrier_power {};
       auto status = library_->ACPFetchTotalCarrierPower(instrument, selector_string, timeout, &total_carrier_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1309,6 +1346,7 @@ namespace nirfmxspecan_grpc {
       float64 offset_ch1_upper_relative_power {};
       auto status = library_->ACPRead(instrument, selector_string, timeout, &carrier_absolute_power, &offset_ch0_lower_relative_power, &offset_ch0_upper_relative_power, &offset_ch1_lower_relative_power, &offset_ch1_upper_relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1338,6 +1376,7 @@ namespace nirfmxspecan_grpc {
       int32 noise_calibration_data_valid {};
       auto status = library_->ACPValidateNoiseCalibrationData(instrument, selector_string, &noise_calibration_data_valid);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1380,6 +1419,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->AMPMCfgAMToAMCurveFit(instrument, selector_string, am_to_am_curve_fit_order, am_to_am_curve_fit_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1420,6 +1460,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->AMPMCfgAMToPMCurveFit(instrument, selector_string, am_to_pm_curve_fit_order, am_to_pm_curve_fit_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1460,6 +1501,7 @@ namespace nirfmxspecan_grpc {
       int32 averaging_count = request->averaging_count();
       auto status = library_->AMPMCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1501,6 +1543,7 @@ namespace nirfmxspecan_grpc {
       int32 array_size = static_cast<int32>(request->compression_level().size());
       auto status = library_->AMPMCfgCompressionPoints(instrument, selector_string, compression_point_enabled, compression_level, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1525,6 +1568,7 @@ namespace nirfmxspecan_grpc {
       float64 dut_average_input_power = request->dut_average_input_power();
       auto status = library_->AMPMCfgDUTAverageInputPower(instrument, selector_string, dut_average_input_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1549,6 +1593,7 @@ namespace nirfmxspecan_grpc {
       float64 measurement_interval = request->measurement_interval();
       auto status = library_->AMPMCfgMeasurementInterval(instrument, selector_string, measurement_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1589,6 +1634,7 @@ namespace nirfmxspecan_grpc {
       float64 sample_rate = request->sample_rate();
       auto status = library_->AMPMCfgMeasurementSampleRate(instrument, selector_string, sample_rate_mode, sample_rate);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1628,6 +1674,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->AMPMCfgReferencePowerType(instrument, selector_string, reference_power_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1687,6 +1734,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->AMPMCfgReferenceWaveform(instrument, selector_string, x0, dx, reference_waveform.data(), array_size, idle_duration_present, signal_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1726,6 +1774,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->AMPMCfgSynchronizationMethod(instrument, selector_string, synchronization_method);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1782,6 +1831,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->AMPMCfgThreshold(instrument, selector_string, threshold_enabled, threshold_level, threshold_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1808,6 +1858,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->AMPMFetchAMToAMTrace(instrument, selector_string, timeout, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_reference_powers()->Resize(actual_array_size, 0);
@@ -1823,6 +1874,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1854,6 +1906,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->AMPMFetchAMToPMTrace(instrument, selector_string, timeout, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_reference_powers()->Resize(actual_array_size, 0);
@@ -1869,6 +1922,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1900,6 +1954,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->AMPMFetchCompressionPoints(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_input_compression_point()->Resize(actual_array_size, 0);
@@ -1913,6 +1968,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1943,6 +1999,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->AMPMFetchCurveFitCoefficients(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_am_to_am_coefficients()->Resize(actual_array_size, 0);
@@ -1956,6 +2013,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1986,6 +2044,7 @@ namespace nirfmxspecan_grpc {
       float64 am_to_pm_residual {};
       auto status = library_->AMPMFetchCurveFitResidual(instrument, selector_string, timeout, &am_to_am_residual, &am_to_pm_residual);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2015,6 +2074,7 @@ namespace nirfmxspecan_grpc {
       float64 mean_rms_evm {};
       auto status = library_->AMPMFetchDUTCharacteristics(instrument, selector_string, timeout, &mean_linear_gain, &one_db_compression_point, &mean_rms_evm);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2045,6 +2105,7 @@ namespace nirfmxspecan_grpc {
       float64 mean_phase_error {};
       auto status = library_->AMPMFetchError(instrument, selector_string, timeout, &gain_error_range, &phase_error_range, &mean_phase_error);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2076,6 +2137,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->AMPMFetchProcessedMeanAcquiredWaveform(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> processed_mean_acquired_waveform(actual_array_size, NIComplexSingle());
@@ -2086,6 +2148,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2126,6 +2189,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->AMPMFetchProcessedReferenceWaveform(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> processed_reference_waveform(actual_array_size, NIComplexSingle());
@@ -2136,6 +2200,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2176,6 +2241,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->AMPMFetchRelativePhaseTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_relative_phase()->Resize(actual_array_size, 0);
@@ -2187,6 +2253,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2220,6 +2287,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->AMPMFetchRelativePowerTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_relative_power()->Resize(actual_array_size, 0);
@@ -2231,6 +2299,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2259,6 +2328,7 @@ namespace nirfmxspecan_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->AbortMeasurements(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2289,6 +2359,7 @@ namespace nirfmxspecan_grpc {
       auto reserved = 0;
       auto status = library_->AnalyzeIQ1Waveform(instrument, selector_string, result_name, x0, dx, iq.data(), array_size, reset, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2319,6 +2390,7 @@ namespace nirfmxspecan_grpc {
       auto reserved = 0;
       auto status = library_->AnalyzeSpectrum1Waveform(instrument, selector_string, result_name, x0, dx, spectrum, array_size, reset, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2345,6 +2417,7 @@ namespace nirfmxspecan_grpc {
       float64 reference_level {};
       auto status = library_->AutoLevel(instrument, selector_string, bandwidth, measurement_interval, &reference_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2370,6 +2443,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->BuildCarrierString(selector_string, carrier_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -2384,6 +2458,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -2411,6 +2486,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->BuildHarmonicString(selector_string, harmonic_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -2425,6 +2501,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -2452,6 +2529,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->BuildIntermodString(selector_string, intermod_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -2466,6 +2544,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -2494,6 +2573,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->BuildListStepString(list_name, result_name, step_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_length = status;
@@ -2508,6 +2588,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -2535,6 +2616,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->BuildListString(list_name, result_name, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_length = status;
@@ -2549,6 +2631,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -2576,6 +2659,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->BuildMarkerString(selector_string, marker_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -2590,6 +2674,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -2617,6 +2702,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->BuildOffsetString(selector_string, offset_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -2631,6 +2717,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -2660,6 +2747,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->BuildRangeSpurString(signal_name, result_name, range_number, spur_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_length = status;
@@ -2674,6 +2762,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -2701,6 +2790,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->BuildRangeString(selector_string, range_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -2715,6 +2805,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -2742,6 +2833,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->BuildSegmentString(selector_string, segment_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -2756,6 +2848,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -2783,6 +2876,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->BuildSignalString(signal_name, result_name, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_length = status;
@@ -2797,6 +2891,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -2824,6 +2919,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->BuildSpurString(selector_string, spur_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -2838,6 +2934,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -2865,6 +2962,7 @@ namespace nirfmxspecan_grpc {
       float64 measurement_interval = request->measurement_interval();
       auto status = library_->CCDFCfgMeasurementInterval(instrument, selector_string, measurement_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2889,6 +2987,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_records = request->number_of_records();
       auto status = library_->CCDFCfgNumberOfRecords(instrument, selector_string, number_of_records);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2930,6 +3029,7 @@ namespace nirfmxspecan_grpc {
       float64 rrc_alpha = request->rrc_alpha();
       auto status = library_->CCDFCfgRBWFilter(instrument, selector_string, rbw, rbw_filter_type, rrc_alpha);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2986,6 +3086,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->CCDFCfgThreshold(instrument, selector_string, threshold_enabled, threshold_level, threshold_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3016,6 +3117,7 @@ namespace nirfmxspecan_grpc {
       float64 one_ten_thousandth_percent_power {};
       auto status = library_->CCDFFetchBasicPowerProbabilities(instrument, selector_string, timeout, &ten_percent_power, &one_percent_power, &one_tenth_percent_power, &one_hundredth_percent_power, &one_thousandth_percent_power, &one_ten_thousandth_percent_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3050,6 +3152,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->CCDFFetchGaussianProbabilitiesTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_gaussian_probabilities()->Resize(actual_array_size, 0);
@@ -3061,6 +3164,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3094,6 +3198,7 @@ namespace nirfmxspecan_grpc {
       int32 measured_samples_count {};
       auto status = library_->CCDFFetchPower(instrument, selector_string, timeout, &mean_power, &mean_power_percentile, &peak_power, &measured_samples_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3126,6 +3231,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->CCDFFetchProbabilitiesTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_probabilities()->Resize(actual_array_size, 0);
@@ -3137,6 +3243,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3170,6 +3277,7 @@ namespace nirfmxspecan_grpc {
       int32 measured_samples_count {};
       auto status = library_->CCDFRead(instrument, selector_string, timeout, &mean_power, &mean_power_percentile, &peak_power, &measured_samples_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3230,6 +3338,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->CHPCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3254,6 +3363,7 @@ namespace nirfmxspecan_grpc {
       float64 carrier_frequency = request->carrier_frequency();
       auto status = library_->CHPCfgCarrierOffset(instrument, selector_string, carrier_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3294,6 +3404,7 @@ namespace nirfmxspecan_grpc {
       float64 fft_padding = request->fft_padding();
       auto status = library_->CHPCfgFFT(instrument, selector_string, fft_window, fft_padding);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3318,6 +3429,7 @@ namespace nirfmxspecan_grpc {
       float64 integration_bandwidth = request->integration_bandwidth();
       auto status = library_->CHPCfgIntegrationBandwidth(instrument, selector_string, integration_bandwidth);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3342,6 +3454,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_carriers = request->number_of_carriers();
       auto status = library_->CHPCfgNumberOfCarriers(instrument, selector_string, number_of_carriers);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3398,6 +3511,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->CHPCfgRBWFilter(instrument, selector_string, rbw_auto, rbw, rbw_filter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3438,6 +3552,7 @@ namespace nirfmxspecan_grpc {
       float64 rrc_alpha = request->rrc_alpha();
       auto status = library_->CHPCfgRRCFilter(instrument, selector_string, rrc_filter_enabled, rrc_alpha);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3462,6 +3577,7 @@ namespace nirfmxspecan_grpc {
       float64 span = request->span();
       auto status = library_->CHPCfgSpan(instrument, selector_string, span);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3502,6 +3618,7 @@ namespace nirfmxspecan_grpc {
       float64 sweep_time_interval = request->sweep_time_interval();
       auto status = library_->CHPCfgSweepTime(instrument, selector_string, sweep_time_auto, sweep_time_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3529,6 +3646,7 @@ namespace nirfmxspecan_grpc {
       float64 relative_power {};
       auto status = library_->CHPFetchCarrierMeasurement(instrument, selector_string, timeout, &absolute_power, &psd, &relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3560,6 +3678,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->CHPFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -3571,6 +3690,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3601,6 +3721,7 @@ namespace nirfmxspecan_grpc {
       float64 total_carrier_power {};
       auto status = library_->CHPFetchTotalCarrierPower(instrument, selector_string, timeout, &total_carrier_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3628,6 +3749,7 @@ namespace nirfmxspecan_grpc {
       float64 psd {};
       auto status = library_->CHPRead(instrument, selector_string, timeout, &absolute_power, &psd);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3654,6 +3776,7 @@ namespace nirfmxspecan_grpc {
       int32 noise_calibration_data_valid {};
       auto status = library_->CHPValidateNoiseCalibrationData(instrument, selector_string, &noise_calibration_data_valid);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3717,6 +3840,7 @@ namespace nirfmxspecan_grpc {
       int32 enable_trigger = request->enable_trigger();
       auto status = library_->CfgDigitalEdgeTrigger(instrument, selector_string, digital_edge_source, digital_edge, trigger_delay, enable_trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3741,6 +3865,7 @@ namespace nirfmxspecan_grpc {
       float64 external_attenuation = request->external_attenuation();
       auto status = library_->CfgExternalAttenuation(instrument, selector_string, external_attenuation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3765,6 +3890,7 @@ namespace nirfmxspecan_grpc {
       float64 center_frequency = request->center_frequency();
       auto status = library_->CfgFrequency(instrument, selector_string, center_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3809,6 +3935,7 @@ namespace nirfmxspecan_grpc {
       float64 frequency_reference_frequency = request->frequency_reference_frequency();
       auto status = library_->CfgFrequencyReference(instrument, channel_name, frequency_reference_source, frequency_reference_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3869,6 +3996,7 @@ namespace nirfmxspecan_grpc {
       int32 enable_trigger = request->enable_trigger();
       auto status = library_->CfgIQPowerEdgeTrigger(instrument, selector_string, iq_power_edge_source, iq_power_edge_level, iq_power_edge_slope, trigger_delay, trigger_min_quiet_time_mode, trigger_min_quiet_time_duration, enable_trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3909,6 +4037,7 @@ namespace nirfmxspecan_grpc {
       float64 mechanical_attenuation_value = request->mechanical_attenuation_value();
       auto status = library_->CfgMechanicalAttenuation(instrument, channel_name, mechanical_attenuation_auto, mechanical_attenuation_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3935,6 +4064,7 @@ namespace nirfmxspecan_grpc {
       float64 external_attenuation = request->external_attenuation();
       auto status = library_->CfgRF(instrument, selector_string, center_frequency, reference_level, external_attenuation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3975,6 +4105,7 @@ namespace nirfmxspecan_grpc {
       float64 rf_attenuation_value = request->rf_attenuation_value();
       auto status = library_->CfgRFAttenuation(instrument, channel_name, rf_attenuation_auto, rf_attenuation_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3999,6 +4130,7 @@ namespace nirfmxspecan_grpc {
       float64 reference_level = request->reference_level();
       auto status = library_->CfgReferenceLevel(instrument, selector_string, reference_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4024,6 +4156,7 @@ namespace nirfmxspecan_grpc {
       int32 enable_trigger = request->enable_trigger();
       auto status = library_->CfgSoftwareEdgeTrigger(instrument, selector_string, trigger_delay, enable_trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4048,6 +4181,7 @@ namespace nirfmxspecan_grpc {
       int32 is_done {};
       auto status = library_->CheckMeasurementStatus(instrument, selector_string, &is_done);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4072,6 +4206,7 @@ namespace nirfmxspecan_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearAllNamedResults(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4095,6 +4230,7 @@ namespace nirfmxspecan_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearNamedResult(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4118,6 +4254,7 @@ namespace nirfmxspecan_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearNoiseCalibrationDatabase(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4142,6 +4279,7 @@ namespace nirfmxspecan_grpc {
       char* new_signal_name = (char*)request->new_signal_name().c_str();
       auto status = library_->CloneSignalConfiguration(instrument, old_signal_name, new_signal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4166,6 +4304,7 @@ namespace nirfmxspecan_grpc {
       session_repository_->remove_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->Close(instrument, force_destroy);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4189,6 +4328,7 @@ namespace nirfmxspecan_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->Commit(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4212,6 +4352,7 @@ namespace nirfmxspecan_grpc {
       char* list_name = (char*)request->list_name().c_str();
       auto status = library_->CreateList(instrument, list_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4236,6 +4377,7 @@ namespace nirfmxspecan_grpc {
       int32 created_step_index {};
       auto status = library_->CreateListStep(instrument, selector_string, &created_step_index);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4260,6 +4402,7 @@ namespace nirfmxspecan_grpc {
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->CreateSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4310,6 +4453,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->DPDApplyDigitalPredistortion(instrument, selector_string, x0_in, dx_in, waveform_in.data(), array_size_in, idle_duration_present, measurement_timeout, &x0_out, &dx_out, nullptr, 0, &actual_array_size, &papr, &power_offset);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> waveform_out(actual_array_size, NIComplexSingle());
@@ -4320,6 +4464,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4382,6 +4527,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->DPDApplyPreDPDSignalConditioning(instrument, selector_string, x0_in, dx_in, waveform_in.data(), array_size_in, idle_duration_present, &x0_out, &dx_out, nullptr, 0, &actual_array_size, &papr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> waveform_out(actual_array_size, NIComplexSingle());
@@ -4392,6 +4538,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4444,6 +4591,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->DPDCfgApplyDPDConfigurationInput(instrument, selector_string, configuration_input);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4483,6 +4631,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->DPDCfgApplyDPDLookupTableCorrectionType(instrument, selector_string, lut_correction_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4522,6 +4671,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->DPDCfgApplyDPDMemoryModelCorrectionType(instrument, selector_string, memory_model_correction_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4547,6 +4697,7 @@ namespace nirfmxspecan_grpc {
       int32 array_size = static_cast<int32>(request->dpd_polynomial().size());
       auto status = library_->DPDCfgApplyDPDUserDPDPolynomial(instrument, selector_string, dpd_polynomial.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4589,6 +4740,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->DPDCfgApplyDPDUserLookupTable(instrument, selector_string, lut_input_powers, lut_complex_gains.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4629,6 +4781,7 @@ namespace nirfmxspecan_grpc {
       int32 averaging_count = request->averaging_count();
       auto status = library_->DPDCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4668,6 +4821,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->DPDCfgDPDModel(instrument, selector_string, dpd_model);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4692,6 +4846,7 @@ namespace nirfmxspecan_grpc {
       float64 dut_average_input_power = request->dut_average_input_power();
       auto status = library_->DPDCfgDUTAverageInputPower(instrument, selector_string, dut_average_input_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4721,6 +4876,7 @@ namespace nirfmxspecan_grpc {
       int32 memory_polynomial_maximum_lag = request->memory_polynomial_maximum_lag();
       auto status = library_->DPDCfgGeneralizedMemoryPolynomialCrossTerms(instrument, selector_string, memory_polynomial_lead_order, memory_polynomial_lag_order, memory_polynomial_lead_memory_depth, memory_polynomial_lag_memory_depth, memory_polynomial_maximum_lead, memory_polynomial_maximum_lag);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4760,6 +4916,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->DPDCfgIterativeDPDEnabled(instrument, selector_string, iterative_dpd_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4800,6 +4957,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->DPDCfgLookupTableAMToAMCurveFit(instrument, selector_string, am_to_am_curve_fit_order, am_to_am_curve_fit_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4840,6 +4998,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->DPDCfgLookupTableAMToPMCurveFit(instrument, selector_string, am_to_pm_curve_fit_order, am_to_pm_curve_fit_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4864,6 +5023,7 @@ namespace nirfmxspecan_grpc {
       float64 step_size = request->step_size();
       auto status = library_->DPDCfgLookupTableStepSize(instrument, selector_string, step_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4920,6 +5080,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->DPDCfgLookupTableThreshold(instrument, selector_string, threshold_enabled, threshold_level, threshold_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4959,6 +5120,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->DPDCfgLookupTableType(instrument, selector_string, lookup_table_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4983,6 +5145,7 @@ namespace nirfmxspecan_grpc {
       float64 measurement_interval = request->measurement_interval();
       auto status = library_->DPDCfgMeasurementInterval(instrument, selector_string, measurement_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5023,6 +5186,7 @@ namespace nirfmxspecan_grpc {
       float64 sample_rate = request->sample_rate();
       auto status = library_->DPDCfgMeasurementSampleRate(instrument, selector_string, sample_rate_mode, sample_rate);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5048,6 +5212,7 @@ namespace nirfmxspecan_grpc {
       int32 memory_polynomial_memory_depth = request->memory_polynomial_memory_depth();
       auto status = library_->DPDCfgMemoryPolynomial(instrument, selector_string, memory_polynomial_order, memory_polynomial_memory_depth);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5073,6 +5238,7 @@ namespace nirfmxspecan_grpc {
       int32 array_size = static_cast<int32>(request->previous_dpd_polynomial().size());
       auto status = library_->DPDCfgPreviousDPDPolynomial(instrument, selector_string, previous_dpd_polynomial.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5132,6 +5298,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->DPDCfgReferenceWaveform(instrument, selector_string, x0, dx, reference_waveform.data(), array_size, idle_duration_present, signal_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5171,6 +5338,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->DPDCfgSynchronizationMethod(instrument, selector_string, synchronization_method);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5196,6 +5364,7 @@ namespace nirfmxspecan_grpc {
       float64 pre_cfr_papr {};
       auto status = library_->DPDFetchApplyDPDPreCFRPAPR(instrument, selector_string, timeout, &pre_cfr_papr);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5222,6 +5391,7 @@ namespace nirfmxspecan_grpc {
       float64 average_gain {};
       auto status = library_->DPDFetchAverageGain(instrument, selector_string, timeout, &average_gain);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5249,6 +5419,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->DPDFetchDPDPolynomial(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> dpd_polynomial(actual_array_size, NIComplexSingle());
@@ -5259,6 +5430,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5295,6 +5467,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->DPDFetchLookupTable(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_input_powers()->Resize(actual_array_size, 0);
@@ -5307,6 +5480,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5343,6 +5517,7 @@ namespace nirfmxspecan_grpc {
       float64 nmse {};
       auto status = library_->DPDFetchNMSE(instrument, selector_string, timeout, &nmse);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5372,6 +5547,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->DPDFetchProcessedMeanAcquiredWaveform(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> processed_mean_acquired_waveform(actual_array_size, NIComplexSingle());
@@ -5382,6 +5558,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5422,6 +5599,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->DPDFetchProcessedReferenceWaveform(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> processed_reference_waveform(actual_array_size, NIComplexSingle());
@@ -5432,6 +5610,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5467,6 +5646,7 @@ namespace nirfmxspecan_grpc {
       char* list_name = (char*)request->list_name().c_str();
       auto status = library_->DeleteList(instrument, list_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5490,6 +5670,7 @@ namespace nirfmxspecan_grpc {
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->DeleteSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5513,6 +5694,7 @@ namespace nirfmxspecan_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->DisableTrigger(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5569,6 +5751,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->FCntCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5593,6 +5776,7 @@ namespace nirfmxspecan_grpc {
       float64 measurement_interval = request->measurement_interval();
       auto status = library_->FCntCfgMeasurementInterval(instrument, selector_string, measurement_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5634,6 +5818,7 @@ namespace nirfmxspecan_grpc {
       float64 rrc_alpha = request->rrc_alpha();
       auto status = library_->FCntCfgRBWFilter(instrument, selector_string, rbw, rbw_filter_type, rrc_alpha);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5690,6 +5875,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->FCntCfgThreshold(instrument, selector_string, threshold_enabled, threshold_level, threshold_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5715,6 +5901,7 @@ namespace nirfmxspecan_grpc {
       float64 allan_deviation {};
       auto status = library_->FCntFetchAllanDeviation(instrument, selector_string, timeout, &allan_deviation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5744,6 +5931,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->FCntFetchFrequencyTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_frequency_trace()->Resize(actual_array_size, 0);
@@ -5755,6 +5943,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5787,6 +5976,7 @@ namespace nirfmxspecan_grpc {
       float64 mean_phase {};
       auto status = library_->FCntFetchMeasurement(instrument, selector_string, timeout, &average_relative_frequency, &average_absolute_frequency, &mean_phase);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5818,6 +6008,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->FCntFetchPhaseTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_phase_trace()->Resize(actual_array_size, 0);
@@ -5829,6 +6020,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5862,6 +6054,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->FCntFetchPowerTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_power_trace()->Resize(actual_array_size, 0);
@@ -5873,6 +6066,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5905,6 +6099,7 @@ namespace nirfmxspecan_grpc {
       float64 mean_phase {};
       auto status = library_->FCntRead(instrument, selector_string, timeout, &average_relative_frequency, &average_absolute_frequency, &mean_phase);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5934,6 +6129,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->GetAllNamedResultNames(instrument, selector_string, nullptr, 0, &actual_result_names_size, &default_result_exists);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::string result_names;
@@ -5947,6 +6143,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5977,6 +6174,7 @@ namespace nirfmxspecan_grpc {
       float32 attr_val {};
       auto status = library_->GetAttributeF32(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6004,6 +6202,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->GetAttributeF32Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -6015,6 +6214,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6043,6 +6243,7 @@ namespace nirfmxspecan_grpc {
       float64 attr_val {};
       auto status = library_->GetAttributeF64(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6070,6 +6271,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->GetAttributeF64Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -6081,6 +6283,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6109,6 +6312,7 @@ namespace nirfmxspecan_grpc {
       int16 attr_val {};
       auto status = library_->GetAttributeI16(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6135,6 +6339,7 @@ namespace nirfmxspecan_grpc {
       int32 attr_val {};
       auto status = library_->GetAttributeI32(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6168,6 +6373,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->GetAttributeI32Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val_raw()->Resize(actual_array_size, 0);
@@ -6179,6 +6385,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6221,6 +6428,7 @@ namespace nirfmxspecan_grpc {
       int64 attr_val {};
       auto status = library_->GetAttributeI64(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6248,6 +6456,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->GetAttributeI64Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -6259,6 +6468,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6287,6 +6497,7 @@ namespace nirfmxspecan_grpc {
       int8 attr_val {};
       auto status = library_->GetAttributeI8(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6314,6 +6525,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->GetAttributeI8Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<int8> attr_val(actual_array_size);
@@ -6324,6 +6536,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6362,6 +6575,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->GetAttributeNIComplexDoubleArray(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexDouble> attr_val(actual_array_size, NIComplexDouble());
@@ -6372,6 +6586,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6408,6 +6623,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->GetAttributeNIComplexSingleArray(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> attr_val(actual_array_size, NIComplexSingle());
@@ -6418,6 +6634,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6454,6 +6671,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->GetAttributeString(instrument, selector_string, attribute_id, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 array_size = status;
@@ -6468,6 +6686,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6496,6 +6715,7 @@ namespace nirfmxspecan_grpc {
       uInt16 attr_val {};
       auto status = library_->GetAttributeU16(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6522,6 +6742,7 @@ namespace nirfmxspecan_grpc {
       uInt32 attr_val {};
       auto status = library_->GetAttributeU32(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6549,6 +6770,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->GetAttributeU32Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -6560,6 +6782,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6589,6 +6812,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->GetAttributeU64Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -6600,6 +6824,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6628,6 +6853,7 @@ namespace nirfmxspecan_grpc {
       uInt8 attr_val {};
       auto status = library_->GetAttributeU8(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6655,6 +6881,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->GetAttributeU8Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::string attr_val(actual_array_size, '\0');
@@ -6665,6 +6892,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6693,6 +6921,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->GetError(instrument, nullptr, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 error_description_buffer_size = status;
@@ -6708,6 +6937,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6737,6 +6967,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->GetErrorString(instrument, error_code, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 error_description_buffer_size = status;
@@ -6751,6 +6982,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6793,6 +7025,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->HarmCfgAutoHarmonics(instrument, selector_string, auto_harmonics_setup_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6849,6 +7082,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->HarmCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6873,6 +7107,7 @@ namespace nirfmxspecan_grpc {
       float64 measurement_interval = request->measurement_interval();
       auto status = library_->HarmCfgFundamentalMeasurementInterval(instrument, selector_string, measurement_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6914,6 +7149,7 @@ namespace nirfmxspecan_grpc {
       float64 rrc_alpha = request->rrc_alpha();
       auto status = library_->HarmCfgFundamentalRBW(instrument, selector_string, rbw, rbw_filter_type, rrc_alpha);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6956,6 +7192,7 @@ namespace nirfmxspecan_grpc {
       float64 harmonic_measurement_interval = request->harmonic_measurement_interval();
       auto status = library_->HarmCfgHarmonic(instrument, selector_string, harmonic_order, harmonic_bandwidth, harmonic_enabled, harmonic_measurement_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7012,6 +7249,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->HarmCfgHarmonicArray(instrument, selector_string, harmonic_order, harmonic_bandwidth, harmonic_enabled, harmonic_measurement_interval, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7036,6 +7274,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_harmonics = request->number_of_harmonics();
       auto status = library_->HarmCfgNumberOfHarmonics(instrument, selector_string, number_of_harmonics);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7064,6 +7303,7 @@ namespace nirfmxspecan_grpc {
       float64 frequency {};
       auto status = library_->HarmFetchHarmonicMeasurement(instrument, selector_string, timeout, &average_relative_power, &average_absolute_power, &rbw, &frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7094,6 +7334,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->HarmFetchHarmonicMeasurementArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_average_relative_power()->Resize(actual_array_size, 0);
@@ -7111,6 +7352,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7145,6 +7387,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->HarmFetchHarmonicPowerTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_power()->Resize(actual_array_size, 0);
@@ -7156,6 +7399,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7188,6 +7432,7 @@ namespace nirfmxspecan_grpc {
       float64 fundamental_frequency {};
       auto status = library_->HarmFetchTHD(instrument, selector_string, timeout, &total_harmonic_distortion, &average_fundamental_power, &fundamental_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7217,6 +7462,7 @@ namespace nirfmxspecan_grpc {
       float64 average_fundamental_power {};
       auto status = library_->HarmRead(instrument, selector_string, timeout, &total_harmonic_distortion, &average_fundamental_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7259,6 +7505,7 @@ namespace nirfmxspecan_grpc {
       int32 maximum_intermod_order = request->maximum_intermod_order();
       auto status = library_->IMCfgAutoIntermodsSetup(instrument, selector_string, auto_intermods_setup_enabled, maximum_intermod_order);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7315,6 +7562,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->IMCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7355,6 +7603,7 @@ namespace nirfmxspecan_grpc {
       float64 fft_padding = request->fft_padding();
       auto status = library_->IMCfgFFT(instrument, selector_string, fft_window, fft_padding);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7394,6 +7643,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->IMCfgFrequencyDefinition(instrument, selector_string, frequency_definition);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7419,6 +7669,7 @@ namespace nirfmxspecan_grpc {
       float64 upper_tone_frequency = request->upper_tone_frequency();
       auto status = library_->IMCfgFundamentalTones(instrument, selector_string, lower_tone_frequency, upper_tone_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7477,6 +7728,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->IMCfgIntermod(instrument, selector_string, intermod_order, lower_intermod_frequency, upper_intermod_frequency, intermod_side, intermod_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7544,6 +7796,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->IMCfgIntermodArray(instrument, selector_string, intermod_order, lower_intermod_frequency, upper_intermod_frequency, intermod_side, intermod_enabled, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7583,6 +7836,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->IMCfgMeasurementMethod(instrument, selector_string, measurement_method);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7607,6 +7861,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_intermods = request->number_of_intermods();
       auto status = library_->IMCfgNumberOfIntermods(instrument, selector_string, number_of_intermods);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7663,6 +7918,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->IMCfgRBWFilter(instrument, selector_string, rbw_auto, rbw, rbw_filter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7703,6 +7959,7 @@ namespace nirfmxspecan_grpc {
       float64 sweep_time_interval = request->sweep_time_interval();
       auto status = library_->IMCfgSweepTime(instrument, selector_string, sweep_time_auto, sweep_time_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7729,6 +7986,7 @@ namespace nirfmxspecan_grpc {
       float64 upper_tone_power {};
       auto status = library_->IMFetchFundamentalMeasurement(instrument, selector_string, timeout, &lower_tone_power, &upper_tone_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7759,6 +8017,7 @@ namespace nirfmxspecan_grpc {
       float64 upper_output_intercept_power {};
       auto status = library_->IMFetchInterceptPower(instrument, selector_string, timeout, &intermod_order, &worst_case_output_intercept_power, &lower_output_intercept_power, &upper_output_intercept_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7789,6 +8048,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->IMFetchInterceptPowerArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_intermod_order()->Resize(actual_array_size, 0);
@@ -7806,6 +8066,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7839,6 +8100,7 @@ namespace nirfmxspecan_grpc {
       float64 upper_intermod_power {};
       auto status = library_->IMFetchIntermodMeasurement(instrument, selector_string, timeout, &intermod_order, &lower_intermod_power, &upper_intermod_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7868,6 +8130,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->IMFetchIntermodMeasurementArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_intermod_order()->Resize(actual_array_size, 0);
@@ -7883,6 +8146,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7917,6 +8181,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->IMFetchSpectrum(instrument, selector_string, timeout, spectrum_index, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -7928,6 +8193,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7960,6 +8226,7 @@ namespace nirfmxspecan_grpc {
       float64 pretrigger_time = request->pretrigger_time();
       auto status = library_->IQCfgAcquisition(instrument, selector_string, sample_rate, number_of_records, acquisition_time, pretrigger_time);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8000,6 +8267,7 @@ namespace nirfmxspecan_grpc {
       float64 bandwidth = request->bandwidth();
       auto status = library_->IQCfgBandwidth(instrument, selector_string, bandwidth_auto, bandwidth);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8030,6 +8298,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->IQFetchData(instrument, selector_string, timeout, record_to_fetch, samples_to_read, &t0, &dt, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> data(actual_array_size, NIComplexSingle());
@@ -8040,6 +8309,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -8076,6 +8346,7 @@ namespace nirfmxspecan_grpc {
       int32 records_done {};
       auto status = library_->IQGetRecordsDone(instrument, selector_string, &records_done);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8109,6 +8380,7 @@ namespace nirfmxspecan_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXSPECAN_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
       }
       response->set_status(status);
@@ -8145,6 +8417,7 @@ namespace nirfmxspecan_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXSPECAN_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
       }
       response->set_status(status);
@@ -8173,6 +8446,7 @@ namespace nirfmxspecan_grpc {
       char* result_name = (char*)request->result_name().c_str();
       auto status = library_->Initiate(instrument, selector_string, result_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8197,6 +8471,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_markers = request->number_of_markers();
       auto status = library_->MarkerCfgNumberOfMarkers(instrument, selector_string, number_of_markers);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8237,6 +8512,7 @@ namespace nirfmxspecan_grpc {
       float64 peak_excursion = request->peak_excursion();
       auto status = library_->MarkerCfgPeakExcursion(instrument, selector_string, peak_excursion_enabled, peak_excursion);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8261,6 +8537,7 @@ namespace nirfmxspecan_grpc {
       int32 reference_marker = request->reference_marker();
       auto status = library_->MarkerCfgReferenceMarker(instrument, selector_string, reference_marker);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8301,6 +8578,7 @@ namespace nirfmxspecan_grpc {
       float64 threshold = request->threshold();
       auto status = library_->MarkerCfgThreshold(instrument, selector_string, threshold_enabled, threshold);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8340,6 +8618,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->MarkerCfgTrace(instrument, selector_string, trace);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8379,6 +8658,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->MarkerCfgType(instrument, selector_string, marker_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8403,6 +8683,7 @@ namespace nirfmxspecan_grpc {
       float64 marker_x_location = request->marker_x_location();
       auto status = library_->MarkerCfgXLocation(instrument, selector_string, marker_x_location);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8428,6 +8709,7 @@ namespace nirfmxspecan_grpc {
       float64 marker_y_location {};
       auto status = library_->MarkerFetchXY(instrument, selector_string, &marker_x_location, &marker_y_location);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8470,6 +8752,7 @@ namespace nirfmxspecan_grpc {
       int32 next_peak_found {};
       auto status = library_->MarkerNextPeak(instrument, selector_string, next_peak, &next_peak_found);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8495,6 +8778,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_peaks {};
       auto status = library_->MarkerPeakSearch(instrument, selector_string, &number_of_peaks);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8536,6 +8820,7 @@ namespace nirfmxspecan_grpc {
       int32 averaging_count = request->averaging_count();
       auto status = library_->NFCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8595,6 +8880,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->NFCfgCalibrationLoss(instrument, selector_string, calibration_loss_compensation_enabled, calibration_loss_frequency, calibration_loss, calibration_loss_temperature, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8646,6 +8932,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->NFCfgColdSourceDUTSParameters(instrument, selector_string, dut_s_parameters_frequency, dut_s21, dut_s12, dut_s11, dut_s22, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8689,6 +8976,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->NFCfgColdSourceInputTermination(instrument, selector_string, termination_vswr, termination_vswr_frequency, termination_temperature, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8728,6 +9016,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->NFCfgColdSourceMode(instrument, selector_string, cold_source_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8787,6 +9076,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->NFCfgDUTInputLoss(instrument, selector_string, dut_input_loss_compensation_enabled, dut_input_loss_frequency, dut_input_loss, dut_input_loss_temperature, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8846,6 +9136,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->NFCfgDUTOutputLoss(instrument, selector_string, dut_output_loss_compensation_enabled, dut_output_loss_frequency, dut_output_loss, dut_output_loss_temperature, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8871,6 +9162,7 @@ namespace nirfmxspecan_grpc {
       int32 array_size = static_cast<int32>(request->frequency_list().size());
       auto status = library_->NFCfgFrequencyList(instrument, selector_string, frequency_list, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8897,6 +9189,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_points = request->number_of_points();
       auto status = library_->NFCfgFrequencyListStartStopPoints(instrument, selector_string, start_frequency, stop_frequency, number_of_points);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8923,6 +9216,7 @@ namespace nirfmxspecan_grpc {
       float64 step_size = request->step_size();
       auto status = library_->NFCfgFrequencyListStartStopStep(instrument, selector_string, start_frequency, stop_frequency, step_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8947,6 +9241,7 @@ namespace nirfmxspecan_grpc {
       float64 measurement_bandwidth = request->measurement_bandwidth();
       auto status = library_->NFCfgMeasurementBandwidth(instrument, selector_string, measurement_bandwidth);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8971,6 +9266,7 @@ namespace nirfmxspecan_grpc {
       float64 measurement_interval = request->measurement_interval();
       auto status = library_->NFCfgMeasurementInterval(instrument, selector_string, measurement_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9010,6 +9306,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->NFCfgMeasurementMethod(instrument, selector_string, measurement_method);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9049,6 +9346,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->NFCfgYFactorMode(instrument, selector_string, y_factor_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9093,6 +9391,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->NFCfgYFactorNoiseSourceENR(instrument, selector_string, enr_frequency, enr, cold_temperature, off_temperature, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9152,6 +9451,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->NFCfgYFactorNoiseSourceLoss(instrument, selector_string, noise_source_loss_compensation_enabled, noise_source_loss_frequency, noise_source_loss, noise_source_loss_temperature, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9176,6 +9476,7 @@ namespace nirfmxspecan_grpc {
       float64 settling_time = request->settling_time();
       auto status = library_->NFCfgYFactorNoiseSourceSettlingTime(instrument, selector_string, settling_time);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9199,6 +9500,7 @@ namespace nirfmxspecan_grpc {
       char* calibration_setup_id = (char*)request->calibration_setup_id().c_str();
       auto status = library_->NFClearCalibrationDatabase(instrument, calibration_setup_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9225,6 +9527,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->NFFetchAnalyzerNoiseFigure(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_analyzer_noise_figure()->Resize(actual_array_size, 0);
@@ -9236,6 +9539,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -9265,6 +9569,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->NFFetchColdSourcePower(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_cold_source_power()->Resize(actual_array_size, 0);
@@ -9276,6 +9581,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -9305,6 +9611,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->NFFetchDUTNoiseFigureAndGain(instrument, selector_string, timeout, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_dut_noise_figure()->Resize(actual_array_size, 0);
@@ -9320,6 +9627,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -9351,6 +9659,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->NFFetchYFactorPowers(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_hot_power()->Resize(actual_array_size, 0);
@@ -9364,6 +9673,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -9394,6 +9704,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->NFFetchYFactors(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_measurement_y_factor()->Resize(actual_array_size, 0);
@@ -9407,6 +9718,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -9437,6 +9749,7 @@ namespace nirfmxspecan_grpc {
       float64 reference_level {};
       auto status = library_->NFRecommendReferenceLevel(instrument, selector_string, dut_max_gain, dut_max_noise_figure, &reference_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9462,6 +9775,7 @@ namespace nirfmxspecan_grpc {
       int32 calibration_data_valid {};
       auto status = library_->NFValidateCalibrationData(instrument, selector_string, &calibration_data_valid);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9520,6 +9834,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->OBWCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9544,6 +9859,7 @@ namespace nirfmxspecan_grpc {
       float64 bandwidth_percentage = request->bandwidth_percentage();
       auto status = library_->OBWCfgBandwidthPercentage(instrument, selector_string, bandwidth_percentage);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9584,6 +9900,7 @@ namespace nirfmxspecan_grpc {
       float64 fft_padding = request->fft_padding();
       auto status = library_->OBWCfgFFT(instrument, selector_string, fft_window, fft_padding);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9623,6 +9940,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->OBWCfgPowerUnits(instrument, selector_string, power_units);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9679,6 +9997,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->OBWCfgRBWFilter(instrument, selector_string, rbw_auto, rbw, rbw_filter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9703,6 +10022,7 @@ namespace nirfmxspecan_grpc {
       float64 span = request->span();
       auto status = library_->OBWCfgSpan(instrument, selector_string, span);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9743,6 +10063,7 @@ namespace nirfmxspecan_grpc {
       float64 sweep_time_interval = request->sweep_time_interval();
       auto status = library_->OBWCfgSweepTime(instrument, selector_string, sweep_time_auto, sweep_time_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9772,6 +10093,7 @@ namespace nirfmxspecan_grpc {
       float64 stop_frequency {};
       auto status = library_->OBWFetchMeasurement(instrument, selector_string, timeout, &occupied_bandwidth, &average_power, &frequency_resolution, &start_frequency, &stop_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9805,6 +10127,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->OBWFetchSpectrumTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -9816,6 +10139,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -9850,6 +10174,7 @@ namespace nirfmxspecan_grpc {
       float64 stop_frequency {};
       auto status = library_->OBWRead(instrument, selector_string, timeout, &occupied_bandwidth, &average_power, &frequency_resolution, &start_frequency, &stop_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9879,6 +10204,7 @@ namespace nirfmxspecan_grpc {
       float64 measurement_bandwidth = request->measurement_bandwidth();
       auto status = library_->PAVTCfgMeasurementBandwidth(instrument, selector_string, measurement_bandwidth);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9904,6 +10230,7 @@ namespace nirfmxspecan_grpc {
       float64 measurement_length = request->measurement_length();
       auto status = library_->PAVTCfgMeasurementInterval(instrument, selector_string, measurement_offset, measurement_length);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9943,6 +10270,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->PAVTCfgMeasurementIntervalMode(instrument, selector_string, measurement_interval_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -9982,6 +10310,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->PAVTCfgMeasurementLocationType(instrument, selector_string, measurement_location_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10006,6 +10335,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_segments = request->number_of_segments();
       auto status = library_->PAVTCfgNumberOfSegments(instrument, selector_string, number_of_segments);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10031,6 +10361,7 @@ namespace nirfmxspecan_grpc {
       float64 segment_measurement_length = request->segment_measurement_length();
       auto status = library_->PAVTCfgSegmentMeasurementInterval(instrument, selector_string, segment_measurement_offset, segment_measurement_length);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10073,6 +10404,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->PAVTCfgSegmentMeasurementIntervalArray(instrument, selector_string, segment_measurement_offset, segment_measurement_length, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10098,6 +10430,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_elements = static_cast<int32>(request->segment_start_time().size());
       auto status = library_->PAVTCfgSegmentStartTimeList(instrument, selector_string, segment_start_time, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10124,6 +10457,7 @@ namespace nirfmxspecan_grpc {
       float64 segment_interval = request->segment_interval();
       auto status = library_->PAVTCfgSegmentStartTimeStep(instrument, selector_string, number_of_segments, segment0_start_time, segment_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10163,6 +10497,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->PAVTCfgSegmentType(instrument, selector_string, segment_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10196,6 +10531,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_elements = static_cast<int32>(request->segment_type().size());
       auto status = library_->PAVTCfgSegmentTypeArray(instrument, selector_string, segment_type, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10225,6 +10561,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->PAVTFetchAmplitudeTrace(instrument, selector_string, timeout, trace_index, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_amplitude()->Resize(actual_array_size, 0);
@@ -10236,6 +10573,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -10269,6 +10607,7 @@ namespace nirfmxspecan_grpc {
       float64 mean_absolute_amplitude {};
       auto status = library_->PAVTFetchPhaseAndAmplitude(instrument, selector_string, timeout, &mean_relative_phase, &mean_relative_amplitude, &mean_absolute_phase, &mean_absolute_amplitude);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10299,6 +10638,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->PAVTFetchPhaseAndAmplitudeArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_mean_relative_phase()->Resize(actual_array_size, 0);
@@ -10316,6 +10656,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -10351,6 +10692,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->PAVTFetchPhaseTrace(instrument, selector_string, timeout, trace_index, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_phase()->Resize(actual_array_size, 0);
@@ -10362,6 +10704,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -10393,6 +10736,7 @@ namespace nirfmxspecan_grpc {
       float64 rbw_percentage = request->rbw_percentage();
       auto status = library_->PhaseNoiseCfgAutoRange(instrument, selector_string, start_frequency, stop_frequency, rbw_percentage);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10417,6 +10761,7 @@ namespace nirfmxspecan_grpc {
       int32 averaging_multiplier = request->averaging_multiplier();
       auto status = library_->PhaseNoiseCfgAveragingMultiplier(instrument, selector_string, averaging_multiplier);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10476,6 +10821,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->PhaseNoiseCfgCancellation(instrument, selector_string, cancellation_enabled, cancellation_threshold, frequency, reference_phase_noise, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10534,6 +10880,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->PhaseNoiseCfgIntegratedNoise(instrument, selector_string, integrated_noise_range_definition, integrated_noise_start_frequency, integrated_noise_stop_frequency, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10558,6 +10905,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_ranges = request->number_of_ranges();
       auto status = library_->PhaseNoiseCfgNumberOfRanges(instrument, selector_string, number_of_ranges);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10606,6 +10954,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->PhaseNoiseCfgRangeArray(instrument, selector_string, range_start_frequency, range_stop_frequency, range_rbw_percentage, range_averaging_count, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10645,6 +10994,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->PhaseNoiseCfgRangeDefinition(instrument, selector_string, range_definition);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10685,6 +11035,7 @@ namespace nirfmxspecan_grpc {
       float64 smoothing_percentage = request->smoothing_percentage();
       auto status = library_->PhaseNoiseCfgSmoothing(instrument, selector_string, smoothing_type, smoothing_percentage);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10710,6 +11061,7 @@ namespace nirfmxspecan_grpc {
       int32 array_size = static_cast<int32>(request->frequency_list().size());
       auto status = library_->PhaseNoiseCfgSpotNoiseFrequencyList(instrument, selector_string, frequency_list, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10750,6 +11102,7 @@ namespace nirfmxspecan_grpc {
       float64 peak_excursion = request->peak_excursion();
       auto status = library_->PhaseNoiseCfgSpurRemoval(instrument, selector_string, spur_removal_enabled, peak_excursion);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10776,6 +11129,7 @@ namespace nirfmxspecan_grpc {
       float64 carrier_power {};
       auto status = library_->PhaseNoiseFetchCarrierMeasurement(instrument, selector_string, timeout, &carrier_frequency, &carrier_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -10804,6 +11158,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->PhaseNoiseFetchIntegratedNoise(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_integrated_phase_noise()->Resize(actual_array_size, 0);
@@ -10823,6 +11178,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -10856,6 +11212,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->PhaseNoiseFetchMeasuredLogPlotTrace(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_frequency()->Resize(actual_array_size, 0);
@@ -10869,6 +11226,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -10899,6 +11257,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->PhaseNoiseFetchSmoothedLogPlotTrace(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_frequency()->Resize(actual_array_size, 0);
@@ -10912,6 +11271,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -10942,6 +11302,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->PhaseNoiseFetchSpotNoise(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spot_phase_noise()->Resize(actual_array_size, 0);
@@ -10953,6 +11314,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -10980,6 +11342,7 @@ namespace nirfmxspecan_grpc {
       int32 attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(instrument, selector_string, attribute_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11003,6 +11366,7 @@ namespace nirfmxspecan_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ResetToDefault(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11059,6 +11423,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SEMCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11083,6 +11448,7 @@ namespace nirfmxspecan_grpc {
       float64 carrier_channel_bandwidth = request->carrier_channel_bandwidth();
       auto status = library_->SEMCfgCarrierChannelBandwidth(instrument, selector_string, carrier_channel_bandwidth);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11122,6 +11488,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SEMCfgCarrierEnabled(instrument, selector_string, carrier_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11146,6 +11513,7 @@ namespace nirfmxspecan_grpc {
       float64 carrier_frequency = request->carrier_frequency();
       auto status = library_->SEMCfgCarrierFrequency(instrument, selector_string, carrier_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11170,6 +11538,7 @@ namespace nirfmxspecan_grpc {
       float64 integration_bandwidth = request->integration_bandwidth();
       auto status = library_->SEMCfgCarrierIntegrationBandwidth(instrument, selector_string, integration_bandwidth);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11226,6 +11595,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SEMCfgCarrierRBWFilter(instrument, selector_string, rbw_auto, rbw, rbw_filter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11266,6 +11636,7 @@ namespace nirfmxspecan_grpc {
       float64 rrc_alpha = request->rrc_alpha();
       auto status = library_->SEMCfgCarrierRRCFilter(instrument, selector_string, rrc_filter_enabled, rrc_alpha);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11306,6 +11677,7 @@ namespace nirfmxspecan_grpc {
       float64 fft_padding = request->fft_padding();
       auto status = library_->SEMCfgFFT(instrument, selector_string, fft_window, fft_padding);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11330,6 +11702,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_carriers = request->number_of_carriers();
       auto status = library_->SEMCfgNumberOfCarriers(instrument, selector_string, number_of_carriers);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11354,6 +11727,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_offsets = request->number_of_offsets();
       auto status = library_->SEMCfgNumberOfOffsets(instrument, selector_string, number_of_offsets);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11395,6 +11769,7 @@ namespace nirfmxspecan_grpc {
       float64 absolute_limit_stop = request->absolute_limit_stop();
       auto status = library_->SEMCfgOffsetAbsoluteLimit(instrument, selector_string, absolute_limit_mode, absolute_limit_start, absolute_limit_stop);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11448,6 +11823,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SEMCfgOffsetAbsoluteLimitArray(instrument, selector_string, absolute_limit_mode, absolute_limit_start, absolute_limit_stop, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11472,6 +11848,7 @@ namespace nirfmxspecan_grpc {
       int32 bandwidth_integral = request->bandwidth_integral();
       auto status = library_->SEMCfgOffsetBandwidthIntegral(instrument, selector_string, bandwidth_integral);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11529,6 +11906,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SEMCfgOffsetFrequency(instrument, selector_string, offset_start_frequency, offset_stop_frequency, offset_enabled, offset_sideband);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11593,6 +11971,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SEMCfgOffsetFrequencyArray(instrument, selector_string, offset_start_frequency, offset_stop_frequency, offset_enabled, offset_sideband, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11632,6 +12011,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SEMCfgOffsetFrequencyDefinition(instrument, selector_string, offset_frequency_definition);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11671,6 +12051,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SEMCfgOffsetLimitFailMask(instrument, selector_string, limit_fail_mask);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11727,6 +12108,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SEMCfgOffsetRBWFilter(instrument, selector_string, rbw_auto, rbw, rbw_filter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11788,6 +12170,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SEMCfgOffsetRBWFilterArray(instrument, selector_string, rbw_auto, rbw, rbw_filter_type, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11812,6 +12195,7 @@ namespace nirfmxspecan_grpc {
       float64 relative_attenuation = request->relative_attenuation();
       auto status = library_->SEMCfgOffsetRelativeAttenuation(instrument, selector_string, relative_attenuation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11837,6 +12221,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_elements = static_cast<int32>(request->relative_attenuation().size());
       auto status = library_->SEMCfgOffsetRelativeAttenuationArray(instrument, selector_string, relative_attenuation, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11878,6 +12263,7 @@ namespace nirfmxspecan_grpc {
       float64 relative_limit_stop = request->relative_limit_stop();
       auto status = library_->SEMCfgOffsetRelativeLimit(instrument, selector_string, relative_limit_mode, relative_limit_start, relative_limit_stop);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11931,6 +12317,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SEMCfgOffsetRelativeLimitArray(instrument, selector_string, relative_limit_mode, relative_limit_start, relative_limit_stop, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -11970,6 +12357,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SEMCfgPowerUnits(instrument, selector_string, power_units);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12009,6 +12397,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SEMCfgReferenceType(instrument, selector_string, reference_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12049,6 +12438,7 @@ namespace nirfmxspecan_grpc {
       float64 sweep_time_interval = request->sweep_time_interval();
       auto status = library_->SEMCfgSweepTime(instrument, selector_string, sweep_time_auto, sweep_time_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12077,6 +12467,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->SEMFetchAbsoluteMaskTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_absolute_mask()->Resize(actual_array_size, 0);
@@ -12088,6 +12479,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -12121,6 +12513,7 @@ namespace nirfmxspecan_grpc {
       float64 total_relative_power {};
       auto status = library_->SEMFetchCarrierMeasurement(instrument, selector_string, timeout, &absolute_power, &peak_absolute_power, &peak_frequency, &total_relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12150,6 +12543,7 @@ namespace nirfmxspecan_grpc {
       int32 composite_measurement_status {};
       auto status = library_->SEMFetchCompositeMeasurementStatus(instrument, selector_string, timeout, &composite_measurement_status);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12177,6 +12571,7 @@ namespace nirfmxspecan_grpc {
       float64 frequency_resolution {};
       auto status = library_->SEMFetchFrequencyResolution(instrument, selector_string, timeout, &frequency_resolution);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12207,6 +12602,7 @@ namespace nirfmxspecan_grpc {
       float64 margin_relative_power {};
       auto status = library_->SEMFetchLowerOffsetMargin(instrument, selector_string, timeout, &measurement_status, &margin, &margin_frequency, &margin_absolute_power, &margin_relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12239,6 +12635,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->SEMFetchLowerOffsetMarginArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_measurement_status_raw()->Resize(actual_array_size, 0);
@@ -12258,6 +12655,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -12303,6 +12701,7 @@ namespace nirfmxspecan_grpc {
       float64 peak_relative_power {};
       auto status = library_->SEMFetchLowerOffsetPower(instrument, selector_string, timeout, &total_absolute_power, &total_relative_power, &peak_absolute_power, &peak_frequency, &peak_relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12334,6 +12733,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->SEMFetchLowerOffsetPowerArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_total_absolute_power()->Resize(actual_array_size, 0);
@@ -12353,6 +12753,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -12388,6 +12789,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->SEMFetchRelativeMaskTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_relative_mask()->Resize(actual_array_size, 0);
@@ -12399,6 +12801,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -12432,6 +12835,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->SEMFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -12443,6 +12847,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -12473,6 +12878,7 @@ namespace nirfmxspecan_grpc {
       float64 total_carrier_power {};
       auto status = library_->SEMFetchTotalCarrierPower(instrument, selector_string, timeout, &total_carrier_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12503,6 +12909,7 @@ namespace nirfmxspecan_grpc {
       float64 margin_relative_power {};
       auto status = library_->SEMFetchUpperOffsetMargin(instrument, selector_string, timeout, &measurement_status, &margin, &margin_frequency, &margin_absolute_power, &margin_relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12535,6 +12942,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->SEMFetchUpperOffsetMarginArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_measurement_status_raw()->Resize(actual_array_size, 0);
@@ -12554,6 +12962,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -12599,6 +13008,7 @@ namespace nirfmxspecan_grpc {
       float64 peak_relative_power {};
       auto status = library_->SEMFetchUpperOffsetPower(instrument, selector_string, timeout, &total_absolute_power, &total_relative_power, &peak_absolute_power, &peak_frequency, &peak_relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12630,6 +13040,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->SEMFetchUpperOffsetPowerArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_total_absolute_power()->Resize(actual_array_size, 0);
@@ -12649,6 +13060,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -12696,6 +13108,7 @@ namespace nirfmxspecan_grpc {
       int32 enable_all_traces = request->enable_all_traces();
       auto status = library_->SelectMeasurements(instrument, selector_string, measurements, enable_all_traces);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12718,6 +13131,7 @@ namespace nirfmxspecan_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->SendSoftwareEdgeTrigger(instrument);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12743,6 +13157,7 @@ namespace nirfmxspecan_grpc {
       float32 attr_val = request->attr_val();
       auto status = library_->SetAttributeF32(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12769,6 +13184,7 @@ namespace nirfmxspecan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeF32Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12794,6 +13210,7 @@ namespace nirfmxspecan_grpc {
       float64 attr_val = request->attr_val();
       auto status = library_->SetAttributeF64(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12820,6 +13237,7 @@ namespace nirfmxspecan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeF64Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12854,6 +13272,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SetAttributeI16(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12897,6 +13316,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SetAttributeI32(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12931,6 +13351,7 @@ namespace nirfmxspecan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI32Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12956,6 +13377,7 @@ namespace nirfmxspecan_grpc {
       int64 attr_val = request->attr_val();
       auto status = library_->SetAttributeI64(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -12982,6 +13404,7 @@ namespace nirfmxspecan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI64Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13016,6 +13439,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SetAttributeI8(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13062,6 +13486,7 @@ namespace nirfmxspecan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI8Array(instrument, selector_string, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13091,6 +13516,7 @@ namespace nirfmxspecan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeNIComplexDoubleArray(instrument, selector_string, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13117,6 +13543,7 @@ namespace nirfmxspecan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeNIComplexSingleArray(instrument, selector_string, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13161,6 +13588,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SetAttributeString(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13195,6 +13623,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SetAttributeU16(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13223,6 +13652,7 @@ namespace nirfmxspecan_grpc {
       uInt32 attr_val = request->attr_val();
       auto status = library_->SetAttributeU32(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13249,6 +13679,7 @@ namespace nirfmxspecan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU32Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13275,6 +13706,7 @@ namespace nirfmxspecan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU64Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13300,6 +13732,7 @@ namespace nirfmxspecan_grpc {
       uInt8 attr_val = request->attr_val();
       auto status = library_->SetAttributeU8(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13326,6 +13759,7 @@ namespace nirfmxspecan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU8Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13382,6 +13816,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SpectrumCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13422,6 +13857,7 @@ namespace nirfmxspecan_grpc {
       int32 detector_points = request->detector_points();
       auto status = library_->SpectrumCfgDetector(instrument, selector_string, detector_type, detector_points);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13462,6 +13898,7 @@ namespace nirfmxspecan_grpc {
       float64 fft_padding = request->fft_padding();
       auto status = library_->SpectrumCfgFFT(instrument, selector_string, fft_window, fft_padding);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13487,6 +13924,7 @@ namespace nirfmxspecan_grpc {
       float64 stop_frequency = request->stop_frequency();
       auto status = library_->SpectrumCfgFrequencyStartStop(instrument, selector_string, start_frequency, stop_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13526,6 +13964,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SpectrumCfgNoiseCompensationEnabled(instrument, selector_string, noise_compensation_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13565,6 +14004,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SpectrumCfgPowerUnits(instrument, selector_string, spectrum_power_units);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13621,6 +14061,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SpectrumCfgRBWFilter(instrument, selector_string, rbw_auto, rbw, rbw_filter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13645,6 +14086,7 @@ namespace nirfmxspecan_grpc {
       float64 span = request->span();
       auto status = library_->SpectrumCfgSpan(instrument, selector_string, span);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13685,6 +14127,7 @@ namespace nirfmxspecan_grpc {
       float64 sweep_time_interval = request->sweep_time_interval();
       auto status = library_->SpectrumCfgSweepTime(instrument, selector_string, sweep_time_auto, sweep_time_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13726,6 +14169,7 @@ namespace nirfmxspecan_grpc {
       float64 vbw_to_rbw_ratio = request->vbw_to_rbw_ratio();
       auto status = library_->SpectrumCfgVBWFilter(instrument, selector_string, vbw_auto, vbw, vbw_to_rbw_ratio);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13753,6 +14197,7 @@ namespace nirfmxspecan_grpc {
       float64 frequency_resolution {};
       auto status = library_->SpectrumFetchMeasurement(instrument, selector_string, timeout, &peak_amplitude, &peak_frequency, &frequency_resolution);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13784,6 +14229,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->SpectrumFetchPowerTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_power()->Resize(actual_array_size, 0);
@@ -13795,6 +14241,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -13828,6 +14275,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->SpectrumFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -13839,6 +14287,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -13872,6 +14321,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->SpectrumRead(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -13883,6 +14333,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -13912,6 +14363,7 @@ namespace nirfmxspecan_grpc {
       int32 noise_calibration_data_valid {};
       auto status = library_->SpectrumValidateNoiseCalibrationData(instrument, selector_string, &noise_calibration_data_valid);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -13970,6 +14422,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SpurCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14009,6 +14462,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SpurCfgFFTWindowType(instrument, selector_string, fft_window);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14033,6 +14487,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_ranges = request->number_of_ranges();
       auto status = library_->SpurCfgNumberOfRanges(instrument, selector_string, number_of_ranges);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14074,6 +14529,7 @@ namespace nirfmxspecan_grpc {
       float64 absolute_limit_stop = request->absolute_limit_stop();
       auto status = library_->SpurCfgRangeAbsoluteLimit(instrument, selector_string, absolute_limit_mode, absolute_limit_start, absolute_limit_stop);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14127,6 +14583,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SpurCfgRangeAbsoluteLimitArray(instrument, selector_string, absolute_limit_mode, absolute_limit_start, absolute_limit_stop, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14167,6 +14624,7 @@ namespace nirfmxspecan_grpc {
       int32 detector_points = request->detector_points();
       auto status = library_->SpurCfgRangeDetector(instrument, selector_string, detector_type, detector_points);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14217,6 +14675,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SpurCfgRangeDetectorArray(instrument, selector_string, detector_type, detector_points, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14258,6 +14717,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SpurCfgRangeFrequency(instrument, selector_string, start_frequency, stop_frequency, range_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14311,6 +14771,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SpurCfgRangeFrequencyArray(instrument, selector_string, start_frequency, stop_frequency, range_enabled, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14335,6 +14796,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_spurs_to_report = request->number_of_spurs_to_report();
       auto status = library_->SpurCfgRangeNumberOfSpursToReport(instrument, selector_string, number_of_spurs_to_report);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14360,6 +14822,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_elements = static_cast<int32>(request->number_of_spurs_to_report().size());
       auto status = library_->SpurCfgRangeNumberOfSpursToReportArray(instrument, selector_string, number_of_spurs_to_report, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14385,6 +14848,7 @@ namespace nirfmxspecan_grpc {
       float64 excursion = request->excursion();
       auto status = library_->SpurCfgRangePeakCriteria(instrument, selector_string, threshold, excursion);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14427,6 +14891,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SpurCfgRangePeakCriteriaArray(instrument, selector_string, threshold, excursion, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14488,6 +14953,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SpurCfgRangeRBWArray(instrument, selector_string, rbw_auto, rbw, rbw_filter_type, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14544,6 +15010,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SpurCfgRangeRBWFilter(instrument, selector_string, rbw_auto, rbw, rbw_filter_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14568,6 +15035,7 @@ namespace nirfmxspecan_grpc {
       float64 relative_attenuation = request->relative_attenuation();
       auto status = library_->SpurCfgRangeRelativeAttenuation(instrument, selector_string, relative_attenuation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14593,6 +15061,7 @@ namespace nirfmxspecan_grpc {
       int32 number_of_elements = static_cast<int32>(request->relative_attenuation().size());
       auto status = library_->SpurCfgRangeRelativeAttenuationArray(instrument, selector_string, relative_attenuation, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14633,6 +15102,7 @@ namespace nirfmxspecan_grpc {
       float64 sweep_time_interval = request->sweep_time_interval();
       auto status = library_->SpurCfgRangeSweepTime(instrument, selector_string, sweep_time_auto, sweep_time_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14683,6 +15153,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SpurCfgRangeSweepTimeArray(instrument, selector_string, sweep_time_auto, sweep_time_interval, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14724,6 +15195,7 @@ namespace nirfmxspecan_grpc {
       float64 vbw_to_rbw_ratio = request->vbw_to_rbw_ratio();
       auto status = library_->SpurCfgRangeVBWFilter(instrument, selector_string, vbw_auto, vbw, vbw_to_rbw_ratio);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14777,6 +15249,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->SpurCfgRangeVBWFilterArray(instrument, selector_string, vbw_auto, vbw, vbw_to_rbw_ratio, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14801,6 +15274,7 @@ namespace nirfmxspecan_grpc {
       int32 trace_range_index = request->trace_range_index();
       auto status = library_->SpurCfgTraceRangeIndex(instrument, selector_string, trace_range_index);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14827,6 +15301,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->SpurFetchAllSpurs(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spur_frequency()->Resize(actual_array_size, 0);
@@ -14846,6 +15321,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -14878,6 +15354,7 @@ namespace nirfmxspecan_grpc {
       int32 measurement_status {};
       auto status = library_->SpurFetchMeasurementStatus(instrument, selector_string, timeout, &measurement_status);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -14908,6 +15385,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->SpurFetchRangeAbsoluteLimitTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_absolute_limit()->Resize(actual_array_size, 0);
@@ -14919,6 +15397,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -14952,6 +15431,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->SpurFetchRangeSpectrumTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_range_spectrum()->Resize(actual_array_size, 0);
@@ -14963,6 +15443,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -14994,6 +15475,7 @@ namespace nirfmxspecan_grpc {
       int32 detected_spurs {};
       auto status = library_->SpurFetchRangeStatus(instrument, selector_string, timeout, &range_status, &detected_spurs);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -15023,6 +15505,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->SpurFetchRangeStatusArray(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_range_status_raw()->Resize(actual_array_size, 0);
@@ -15036,6 +15519,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -15077,6 +15561,7 @@ namespace nirfmxspecan_grpc {
       float64 spur_absolute_limit {};
       auto status = library_->SpurFetchSpurMeasurement(instrument, selector_string, timeout, &spur_frequency, &spur_amplitude, &spur_margin, &spur_absolute_limit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -15107,6 +15592,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->SpurFetchSpurMeasurementArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spur_frequency()->Resize(actual_array_size, 0);
@@ -15124,6 +15610,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -15186,6 +15673,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->TXPCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -15210,6 +15698,7 @@ namespace nirfmxspecan_grpc {
       float64 measurement_interval = request->measurement_interval();
       auto status = library_->TXPCfgMeasurementInterval(instrument, selector_string, measurement_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -15251,6 +15740,7 @@ namespace nirfmxspecan_grpc {
       float64 rrc_alpha = request->rrc_alpha();
       auto status = library_->TXPCfgRBWFilter(instrument, selector_string, rbw, rbw_filter_type, rrc_alpha);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -15307,6 +15797,7 @@ namespace nirfmxspecan_grpc {
 
       auto status = library_->TXPCfgThreshold(instrument, selector_string, threshold_enabled, threshold_level, threshold_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -15348,6 +15839,7 @@ namespace nirfmxspecan_grpc {
       float64 vbw_to_rbw_ratio = request->vbw_to_rbw_ratio();
       auto status = library_->TXPCfgVBWFilter(instrument, selector_string, vbw_auto, vbw, vbw_to_rbw_ratio);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -15376,6 +15868,7 @@ namespace nirfmxspecan_grpc {
       float64 minimum_power {};
       auto status = library_->TXPFetchMeasurement(instrument, selector_string, timeout, &average_mean_power, &peak_to_average_ratio, &maximum_power, &minimum_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -15408,6 +15901,7 @@ namespace nirfmxspecan_grpc {
       while (true) {
         auto status = library_->TXPFetchPowerTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_power()->Resize(actual_array_size, 0);
@@ -15419,6 +15913,7 @@ namespace nirfmxspecan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -15452,6 +15947,7 @@ namespace nirfmxspecan_grpc {
       float64 minimum_power {};
       auto status = library_->TXPRead(instrument, selector_string, timeout, &average_mean_power, &peak_to_average_ratio, &maximum_power, &minimum_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -15479,6 +15975,7 @@ namespace nirfmxspecan_grpc {
       float64 timeout = request->timeout();
       auto status = library_->WaitForAcquisitionComplete(instrument, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -15503,6 +16000,7 @@ namespace nirfmxspecan_grpc {
       float64 timeout = request->timeout();
       auto status = library_->WaitForMeasurementComplete(instrument, selector_string, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_service.cpp
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_service.cpp
@@ -62,6 +62,7 @@ namespace nirfmxspecan_restricted_grpc {
       }
       auto status = library_->CacheResult(instrument, selector_string, selector_string_out_size, (char*)selector_string_out.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -95,6 +96,7 @@ namespace nirfmxspecan_restricted_grpc {
       while (true) {
         auto status = library_->IQFetchDataOverrideBehavior(instrument, selector_string, timeout, record_to_fetch, samples_to_read, delete_on_fetch, &t0, &dt, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> data(actual_array_size, NIComplexSingle());
@@ -105,6 +107,7 @@ namespace nirfmxspecan_restricted_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);

--- a/generated/nirfmxwlan/nirfmxwlan_service.cpp
+++ b/generated/nirfmxwlan/nirfmxwlan_service.cpp
@@ -61,6 +61,7 @@ namespace nirfmxwlan_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->AbortMeasurements(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -91,6 +92,7 @@ namespace nirfmxwlan_grpc {
       auto reserved = 0;
       auto status = library_->AnalyzeIQ1Waveform(instrument, selector_string, result_name, x0, dx, iq.data(), array_size, reset, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -139,6 +141,7 @@ namespace nirfmxwlan_grpc {
       int32 reset = request->reset();
       auto status = library_->AnalyzeNWaveformsIQ(instrument, selector_string, result_name, x0, dx, iq.data(), iq_sizes, array_size, reset);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -187,6 +190,7 @@ namespace nirfmxwlan_grpc {
       int32 reset = request->reset();
       auto status = library_->AnalyzeNWaveformsSpectrum(instrument, selector_string, result_name, x0, dx, spectrum, spectrum_sizes, array_size, reset);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -217,6 +221,7 @@ namespace nirfmxwlan_grpc {
       auto reserved = 0;
       auto status = library_->AnalyzeSpectrum1Waveform(instrument, selector_string, result_name, x0, dx, spectrum, array_size, reset, reserved);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -241,6 +246,7 @@ namespace nirfmxwlan_grpc {
       float64 timeout = request->timeout();
       auto status = library_->AutoDetectSignal(instrument, selector_string, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -265,6 +271,7 @@ namespace nirfmxwlan_grpc {
       float64 measurement_interval = request->measurement_interval();
       auto status = library_->AutoLevel(instrument, selector_string, measurement_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -289,6 +296,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->BuildChainString(selector_string, chain_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -303,6 +311,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -330,6 +339,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->BuildGateString(selector_string, gate_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -344,6 +354,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -371,6 +382,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->BuildOffsetString(selector_string, offset_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -385,6 +397,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -412,6 +425,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->BuildSegmentString(selector_string, segment_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -426,6 +440,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -453,6 +468,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->BuildSignalString(signal_name, result_name, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_length = status;
@@ -467,6 +483,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -494,6 +511,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->BuildStreamString(selector_string, stream_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -508,6 +526,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -535,6 +554,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->BuildUserString(selector_string, user_number, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         int32 selector_string_out_length = status;
@@ -549,6 +569,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
         }
         response->set_status(status);
@@ -576,6 +597,7 @@ namespace nirfmxwlan_grpc {
       float64 channel_bandwidth = request->channel_bandwidth();
       auto status = library_->CfgChannelBandwidth(instrument, selector_string, channel_bandwidth);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -618,6 +640,7 @@ namespace nirfmxwlan_grpc {
       int32 enable_trigger = request->enable_trigger();
       auto status = library_->CfgDigitalEdgeTrigger(instrument, selector_string, digital_edge_source, digital_edge, trigger_delay, enable_trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -642,6 +665,7 @@ namespace nirfmxwlan_grpc {
       float64 external_attenuation = request->external_attenuation();
       auto status = library_->CfgExternalAttenuation(instrument, selector_string, external_attenuation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -666,6 +690,7 @@ namespace nirfmxwlan_grpc {
       float64 center_frequency = request->center_frequency();
       auto status = library_->CfgFrequency(instrument, selector_string, center_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -691,6 +716,7 @@ namespace nirfmxwlan_grpc {
       int32 number_of_elements = static_cast<int32>(request->center_frequency().size());
       auto status = library_->CfgFrequencyArray(instrument, selector_string, center_frequency, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -735,6 +761,7 @@ namespace nirfmxwlan_grpc {
       float64 frequency_reference_frequency = request->frequency_reference_frequency();
       auto status = library_->CfgFrequencyReference(instrument, channel_name, frequency_reference_source, frequency_reference_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -811,6 +838,7 @@ namespace nirfmxwlan_grpc {
       int32 enable_trigger = request->enable_trigger();
       auto status = library_->CfgIQPowerEdgeTrigger(instrument, selector_string, iq_power_edge_source, iq_power_edge_slope, iq_power_edge_level, trigger_delay, trigger_min_quiet_time_mode, trigger_min_quiet_time_duration, iq_power_edge_level_type, enable_trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -851,6 +879,7 @@ namespace nirfmxwlan_grpc {
       float64 mechanical_attenuation_value = request->mechanical_attenuation_value();
       auto status = library_->CfgMechanicalAttenuation(instrument, channel_name, mechanical_attenuation_auto, mechanical_attenuation_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -876,6 +905,7 @@ namespace nirfmxwlan_grpc {
       int32 number_of_receive_chains = request->number_of_receive_chains();
       auto status = library_->CfgNumberOfFrequencySegmentsAndReceiveChains(instrument, selector_string, number_of_frequency_segments, number_of_receive_chains);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -916,6 +946,7 @@ namespace nirfmxwlan_grpc {
       float64 rf_attenuation_value = request->rf_attenuation_value();
       auto status = library_->CfgRFAttenuation(instrument, channel_name, rf_attenuation_auto, rf_attenuation_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -940,6 +971,7 @@ namespace nirfmxwlan_grpc {
       float64 reference_level = request->reference_level();
       auto status = library_->CfgReferenceLevel(instrument, selector_string, reference_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -964,6 +996,7 @@ namespace nirfmxwlan_grpc {
       char* selected_ports = (char*)request->selected_ports().c_str();
       auto status = library_->CfgSelectedPortsMultiple(instrument, selector_string, selected_ports);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -989,6 +1022,7 @@ namespace nirfmxwlan_grpc {
       int32 enable_trigger = request->enable_trigger();
       auto status = library_->CfgSoftwareEdgeTrigger(instrument, selector_string, trigger_delay, enable_trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1028,6 +1062,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->CfgStandard(instrument, selector_string, standard);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1052,6 +1087,7 @@ namespace nirfmxwlan_grpc {
       int32 is_done {};
       auto status = library_->CheckMeasurementStatus(instrument, selector_string, &is_done);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1076,6 +1112,7 @@ namespace nirfmxwlan_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearAllNamedResults(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1099,6 +1136,7 @@ namespace nirfmxwlan_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearNamedResult(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1123,6 +1161,7 @@ namespace nirfmxwlan_grpc {
       char* new_signal_name = (char*)request->new_signal_name().c_str();
       auto status = library_->CloneSignalConfiguration(instrument, old_signal_name, new_signal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1147,6 +1186,7 @@ namespace nirfmxwlan_grpc {
       session_repository_->remove_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->Close(instrument, force_destroy);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1170,6 +1210,7 @@ namespace nirfmxwlan_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->Commit(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1193,6 +1234,7 @@ namespace nirfmxwlan_grpc {
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->CreateSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1233,6 +1275,7 @@ namespace nirfmxwlan_grpc {
       float64 acquisition_length = request->acquisition_length();
       auto status = library_->DSSSModAccCfgAcquisitionLength(instrument, selector_string, acquisition_length_mode, acquisition_length);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1273,6 +1316,7 @@ namespace nirfmxwlan_grpc {
       int32 averaging_count = request->averaging_count();
       auto status = library_->DSSSModAccCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1312,6 +1356,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->DSSSModAccCfgEVMUnit(instrument, selector_string, evm_unit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1337,6 +1382,7 @@ namespace nirfmxwlan_grpc {
       int32 maximum_measurement_length = request->maximum_measurement_length();
       auto status = library_->DSSSModAccCfgMeasurementLength(instrument, selector_string, measurement_offset, maximum_measurement_length);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1379,6 +1425,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->DSSSModAccCfgPowerMeasurementCustomGateArray(instrument, selector_string, start_time, stop_time, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1418,6 +1465,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->DSSSModAccCfgPowerMeasurementEnabled(instrument, selector_string, power_measurement_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1442,6 +1490,7 @@ namespace nirfmxwlan_grpc {
       int32 number_of_custom_gates = request->number_of_custom_gates();
       auto status = library_->DSSSModAccCfgPowerMeasurementNumberOfCustomGates(instrument, selector_string, number_of_custom_gates);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1470,6 +1519,7 @@ namespace nirfmxwlan_grpc {
       float64 ppdu_average_power_mean {};
       auto status = library_->DSSSModAccFetchAveragePowers(instrument, selector_string, timeout, &preamble_average_power_mean, &header_average_power_mean, &data_average_power_mean, &ppdu_average_power_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1500,6 +1550,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->DSSSModAccFetchConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> constellation(actual_array_size, NIComplexSingle());
@@ -1510,6 +1561,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1546,6 +1598,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->DSSSModAccFetchCustomGatePowersArray(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_average_power_mean()->Resize(actual_array_size, 0);
@@ -1559,6 +1612,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1589,6 +1643,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->DSSSModAccFetchDecodedHeaderBitsTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_decoded_header_bits()->Resize(actual_array_size, 0);
@@ -1600,6 +1655,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1629,6 +1685,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->DSSSModAccFetchDecodedPSDUBitsTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_decoded_psdu_bits()->Resize(actual_array_size, 0);
@@ -1640,6 +1697,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1674,6 +1732,7 @@ namespace nirfmxwlan_grpc {
       int32 number_of_chips_used {};
       auto status = library_->DSSSModAccFetchEVM(instrument, selector_string, timeout, &rms_evm_mean, &peak_evm_80211_2016_maximum, &peak_evm_80211_2007_maximum, &peak_evm_80211_1999_maximum, &frequency_error_mean, &chip_clock_error_mean, &number_of_chips_used);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1709,6 +1768,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->DSSSModAccFetchEVMPerChipMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_evm_per_chip_mean()->Resize(actual_array_size, 0);
@@ -1720,6 +1780,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1752,6 +1813,7 @@ namespace nirfmxwlan_grpc {
       float64 iq_quadrature_error_mean {};
       auto status = library_->DSSSModAccFetchIQImpairments(instrument, selector_string, timeout, &iq_origin_offset_mean, &iq_gain_imbalance_mean, &iq_quadrature_error_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1785,6 +1847,7 @@ namespace nirfmxwlan_grpc {
       int32 psdu_crc_status {};
       auto status = library_->DSSSModAccFetchPPDUInformation(instrument, selector_string, timeout, &data_modulation_format, &payload_length, &preamble_type, &locked_clocks_bit, &header_crc_status, &psdu_crc_status);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1823,6 +1886,7 @@ namespace nirfmxwlan_grpc {
       float64 ppdu_peak_power_maximum {};
       auto status = library_->DSSSModAccFetchPeakPowers(instrument, selector_string, timeout, &preamble_peak_power_maximum, &header_peak_power_maximum, &data_peak_power_maximum, &ppdu_peak_power_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1850,6 +1914,7 @@ namespace nirfmxwlan_grpc {
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->DeleteSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1873,6 +1938,7 @@ namespace nirfmxwlan_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->DisableTrigger(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1899,6 +1965,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->GetAllNamedResultNames(instrument, selector_string, nullptr, 0, &actual_result_names_size, &default_result_exists);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::string result_names;
@@ -1912,6 +1979,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -1942,6 +2010,7 @@ namespace nirfmxwlan_grpc {
       float32 attr_val {};
       auto status = library_->GetAttributeF32(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -1969,6 +2038,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->GetAttributeF32Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -1980,6 +2050,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2008,6 +2079,7 @@ namespace nirfmxwlan_grpc {
       float64 attr_val {};
       auto status = library_->GetAttributeF64(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2035,6 +2107,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->GetAttributeF64Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -2046,6 +2119,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2074,6 +2148,7 @@ namespace nirfmxwlan_grpc {
       int16 attr_val {};
       auto status = library_->GetAttributeI16(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2100,6 +2175,7 @@ namespace nirfmxwlan_grpc {
       int32 attr_val {};
       auto status = library_->GetAttributeI32(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2133,6 +2209,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->GetAttributeI32Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val_raw()->Resize(actual_array_size, 0);
@@ -2144,6 +2221,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2186,6 +2264,7 @@ namespace nirfmxwlan_grpc {
       int64 attr_val {};
       auto status = library_->GetAttributeI64(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2213,6 +2292,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->GetAttributeI64Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -2224,6 +2304,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2252,6 +2333,7 @@ namespace nirfmxwlan_grpc {
       int8 attr_val {};
       auto status = library_->GetAttributeI8(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2279,6 +2361,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->GetAttributeI8Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<int8> attr_val(actual_array_size);
@@ -2289,6 +2372,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2327,6 +2411,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->GetAttributeNIComplexDoubleArray(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexDouble> attr_val(actual_array_size, NIComplexDouble());
@@ -2337,6 +2422,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2373,6 +2459,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->GetAttributeNIComplexSingleArray(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> attr_val(actual_array_size, NIComplexSingle());
@@ -2383,6 +2470,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2419,6 +2507,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->GetAttributeString(instrument, selector_string, attribute_id, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 array_size = status;
@@ -2433,6 +2522,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2461,6 +2551,7 @@ namespace nirfmxwlan_grpc {
       uInt16 attr_val {};
       auto status = library_->GetAttributeU16(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2487,6 +2578,7 @@ namespace nirfmxwlan_grpc {
       uInt32 attr_val {};
       auto status = library_->GetAttributeU32(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2514,6 +2606,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->GetAttributeU32Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -2525,6 +2618,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2554,6 +2648,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->GetAttributeU64Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_attr_val()->Resize(actual_array_size, 0);
@@ -2565,6 +2660,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2593,6 +2689,7 @@ namespace nirfmxwlan_grpc {
       uInt8 attr_val {};
       auto status = library_->GetAttributeU8(instrument, selector_string, attribute_id, &attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2620,6 +2717,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->GetAttributeU8Array(instrument, selector_string, attribute_id, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::string attr_val(actual_array_size, '\0');
@@ -2630,6 +2728,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2658,6 +2757,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->GetError(instrument, nullptr, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 error_description_buffer_size = status;
@@ -2673,6 +2773,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2702,6 +2803,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->GetErrorString(instrument, error_code, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         int32 error_description_buffer_size = status;
@@ -2716,6 +2818,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -2751,6 +2854,7 @@ namespace nirfmxwlan_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXWLAN_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
       }
       response->set_status(status);
@@ -2787,6 +2891,7 @@ namespace nirfmxwlan_grpc {
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXWLAN_VAL_FALSE); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
       }
       response->set_status(status);
@@ -2815,6 +2920,7 @@ namespace nirfmxwlan_grpc {
       char* result_name = (char*)request->result_name().c_str();
       auto status = library_->Initiate(instrument, selector_string, result_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2839,6 +2945,7 @@ namespace nirfmxwlan_grpc {
       float64 timeout = request->timeout();
       auto status = library_->OFDMModAccAutoLevel(instrument, selector_string, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2866,6 +2973,7 @@ namespace nirfmxwlan_grpc {
       int32 array_size = static_cast<int32>(request->reference_waveform().size());
       auto status = library_->OFDMModAccCfg1ReferenceWaveform(instrument, selector_string, x0, dx, reference_waveform.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2906,6 +3014,7 @@ namespace nirfmxwlan_grpc {
       float64 acquisition_length = request->acquisition_length();
       auto status = library_->OFDMModAccCfgAcquisitionLength(instrument, selector_string, acquisition_length_mode, acquisition_length);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2945,6 +3054,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->OFDMModAccCfgAmplitudeTrackingEnabled(instrument, selector_string, amplitude_tracking_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -2985,6 +3095,7 @@ namespace nirfmxwlan_grpc {
       int32 averaging_count = request->averaging_count();
       auto status = library_->OFDMModAccCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3024,6 +3135,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->OFDMModAccCfgChannelEstimationType(instrument, selector_string, channel_estimation_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3063,6 +3175,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->OFDMModAccCfgCommonClockSourceEnabled(instrument, selector_string, common_clock_source_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3102,6 +3215,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->OFDMModAccCfgEVMUnit(instrument, selector_string, evm_unit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3141,6 +3255,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->OFDMModAccCfgFrequencyErrorEstimationMethod(instrument, selector_string, frequency_error_estimation_method);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3166,6 +3281,7 @@ namespace nirfmxwlan_grpc {
       int32 maximum_measurement_length = request->maximum_measurement_length();
       auto status = library_->OFDMModAccCfgMeasurementLength(instrument, selector_string, measurement_offset, maximum_measurement_length);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3205,6 +3321,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->OFDMModAccCfgMeasurementMode(instrument, selector_string, measurement_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3251,6 +3368,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->OFDMModAccCfgNReferenceWaveforms(instrument, selector_string, x0, dx, reference_waveform.data(), reference_waveform_sizes, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3290,6 +3408,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->OFDMModAccCfgNoiseCompensationEnabled(instrument, selector_string, noise_compensation_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3330,6 +3449,7 @@ namespace nirfmxwlan_grpc {
       double optimize_dynamic_range_for_evm_margin = request->optimize_dynamic_range_for_evm_margin();
       auto status = library_->OFDMModAccCfgOptimizeDynamicRangeForEVM(instrument, selector_string, optimize_dynamic_range_for_evm_enabled, optimize_dynamic_range_for_evm_margin);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3369,6 +3489,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->OFDMModAccCfgPhaseTrackingEnabled(instrument, selector_string, phase_tracking_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3408,6 +3529,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->OFDMModAccCfgSymbolClockErrorCorrectionEnabled(instrument, selector_string, symbol_clock_error_correction_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3430,6 +3552,7 @@ namespace nirfmxwlan_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->OFDMModAccClearNoiseCalibrationDatabase(instrument);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3458,6 +3581,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchChainDataRMSEVMPerSymbolMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_chain_data_rms_evm_per_symbol_mean()->Resize(actual_array_size, 0);
@@ -3469,6 +3593,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3502,6 +3627,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchChainPilotRMSEVMPerSymbolMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_chain_pilot_rms_evm_per_symbol_mean()->Resize(actual_array_size, 0);
@@ -3513,6 +3639,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3545,6 +3672,7 @@ namespace nirfmxwlan_grpc {
       float64 chain_pilot_rms_evm_mean {};
       auto status = library_->OFDMModAccFetchChainRMSEVM(instrument, selector_string, timeout, &chain_rms_evm_mean, &chain_data_rms_evm_mean, &chain_pilot_rms_evm_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3576,6 +3704,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchChainRMSEVMPerSubcarrierMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_chain_rms_evm_per_subcarrier_mean()->Resize(actual_array_size, 0);
@@ -3587,6 +3716,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3620,6 +3750,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchChainRMSEVMPerSymbolMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_chain_rms_evm_per_symbol_mean()->Resize(actual_array_size, 0);
@@ -3631,6 +3762,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3664,6 +3796,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchChannelFrequencyResponseMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_channel_frequency_response_mean_magnitude()->Resize(actual_array_size, 0);
@@ -3677,6 +3810,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3711,6 +3845,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchCommonPilotErrorTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_common_pilot_error_magnitude()->Resize(actual_array_size, 0);
@@ -3724,6 +3859,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3757,6 +3893,7 @@ namespace nirfmxwlan_grpc {
       float64 composite_pilot_rms_evm_mean {};
       auto status = library_->OFDMModAccFetchCompositeRMSEVM(instrument, selector_string, timeout, &composite_rms_evm_mean, &composite_data_rms_evm_mean, &composite_pilot_rms_evm_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3785,6 +3922,7 @@ namespace nirfmxwlan_grpc {
       float64 cross_power_mean {};
       auto status = library_->OFDMModAccFetchCrossPower(instrument, selector_string, timeout, &cross_power_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3812,6 +3950,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchCustomGatePowersArray(instrument, selector_string, timeout, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_average_power_mean()->Resize(actual_array_size, 0);
@@ -3825,6 +3964,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3854,6 +3994,7 @@ namespace nirfmxwlan_grpc {
       float64 data_average_power_mean {};
       auto status = library_->OFDMModAccFetchDataAveragePower(instrument, selector_string, timeout, &data_average_power_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3881,6 +4022,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchDataConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> data_constellation(actual_array_size, NIComplexSingle());
@@ -3891,6 +4033,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3926,6 +4069,7 @@ namespace nirfmxwlan_grpc {
       float64 data_peak_power_maximum {};
       auto status = library_->OFDMModAccFetchDataPeakPower(instrument, selector_string, timeout, &data_peak_power_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -3953,6 +4097,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchDecodedEHTSIGBitsTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_decoded_eht_sig_bits()->Resize(actual_array_size, 0);
@@ -3964,6 +4109,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -3993,6 +4139,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchDecodedLSIGBitsTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_decoded_l_sig_bits()->Resize(actual_array_size, 0);
@@ -4004,6 +4151,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4033,6 +4181,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchDecodedPSDUBitsTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_decoded_psdu_bits()->Resize(actual_array_size, 0);
@@ -4044,6 +4193,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4073,6 +4223,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchDecodedSIGBBitsTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_decoded_sig_b_bits()->Resize(actual_array_size, 0);
@@ -4084,6 +4235,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4113,6 +4265,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchDecodedSIGBitsTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_decoded_sig_bits()->Resize(actual_array_size, 0);
@@ -4124,6 +4277,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4153,6 +4307,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchDecodedServiceBitsTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_decoded_service_bits()->Resize(actual_array_size, 0);
@@ -4164,6 +4319,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4193,6 +4349,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchDecodedUSIGBitsTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_decoded_u_sig_bits()->Resize(actual_array_size, 0);
@@ -4204,6 +4361,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4233,6 +4391,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchEVMSubcarrierIndices(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_subcarrier_indices()->Resize(actual_array_size, 0);
@@ -4244,6 +4403,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4272,6 +4432,7 @@ namespace nirfmxwlan_grpc {
       float64 frequency_error_ccdf_10_percent {};
       auto status = library_->OFDMModAccFetchFrequencyErrorCCDF10Percent(instrument, selector_string, timeout, &frequency_error_ccdf_10_percent);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4298,6 +4459,7 @@ namespace nirfmxwlan_grpc {
       float64 frequency_error_mean {};
       auto status = library_->OFDMModAccFetchFrequencyErrorMean(instrument, selector_string, timeout, &frequency_error_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4327,6 +4489,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchGroupDelayMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_group_delay_mean()->Resize(actual_array_size, 0);
@@ -4338,6 +4501,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4368,6 +4532,7 @@ namespace nirfmxwlan_grpc {
       int32 guard_interval_type {};
       auto status = library_->OFDMModAccFetchGuardIntervalType(instrument, selector_string, timeout, &guard_interval_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4398,6 +4563,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchIQGainImbalancePerSubcarrierMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_iq_gain_imbalance_per_subcarrier_mean()->Resize(actual_array_size, 0);
@@ -4409,6 +4575,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4443,6 +4610,7 @@ namespace nirfmxwlan_grpc {
       float64 iq_timing_skew_mean {};
       auto status = library_->OFDMModAccFetchIQImpairments(instrument, selector_string, timeout, &relative_iq_origin_offset_mean, &iq_gain_imbalance_mean, &iq_quadrature_error_mean, &absolute_iq_origin_offset_mean, &iq_timing_skew_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4476,6 +4644,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchIQQuadratureErrorPerSubcarrierMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_iq_quadrature_error_per_subcarrier_mean()->Resize(actual_array_size, 0);
@@ -4487,6 +4656,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4517,6 +4687,7 @@ namespace nirfmxwlan_grpc {
       int32 l_sig_parity_check_status {};
       auto status = library_->OFDMModAccFetchLSIGParityCheckStatus(instrument, selector_string, timeout, &l_sig_parity_check_status);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4544,6 +4715,7 @@ namespace nirfmxwlan_grpc {
       int32 ltf_size {};
       auto status = library_->OFDMModAccFetchLTFSize(instrument, selector_string, timeout, &ltf_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4571,6 +4743,7 @@ namespace nirfmxwlan_grpc {
       int32 mcs_index {};
       auto status = library_->OFDMModAccFetchMCSIndex(instrument, selector_string, timeout, &mcs_index);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4597,6 +4770,7 @@ namespace nirfmxwlan_grpc {
       int32 number_of_he_sig_b_symbols {};
       auto status = library_->OFDMModAccFetchNumberOfHESIGBSymbols(instrument, selector_string, timeout, &number_of_he_sig_b_symbols);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4623,6 +4797,7 @@ namespace nirfmxwlan_grpc {
       int32 number_of_space_time_streams {};
       auto status = library_->OFDMModAccFetchNumberOfSpaceTimeStreams(instrument, selector_string, timeout, &number_of_space_time_streams);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4649,6 +4824,7 @@ namespace nirfmxwlan_grpc {
       int32 number_of_users {};
       auto status = library_->OFDMModAccFetchNumberOfUsers(instrument, selector_string, timeout, &number_of_users);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4675,6 +4851,7 @@ namespace nirfmxwlan_grpc {
       int32 number_of_symbols_used {};
       auto status = library_->OFDMModAccFetchNumberofSymbolsUsed(instrument, selector_string, timeout, &number_of_symbols_used);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4701,6 +4878,7 @@ namespace nirfmxwlan_grpc {
       float64 pe_average_power_mean {};
       auto status = library_->OFDMModAccFetchPEAveragePower(instrument, selector_string, timeout, &pe_average_power_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4727,6 +4905,7 @@ namespace nirfmxwlan_grpc {
       float64 pe_duration {};
       auto status = library_->OFDMModAccFetchPEDuration(instrument, selector_string, timeout, &pe_duration);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4753,6 +4932,7 @@ namespace nirfmxwlan_grpc {
       float64 pe_peak_power_maximum {};
       auto status = library_->OFDMModAccFetchPEPeakPower(instrument, selector_string, timeout, &pe_peak_power_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4779,6 +4959,7 @@ namespace nirfmxwlan_grpc {
       float64 ppdu_average_power_mean {};
       auto status = library_->OFDMModAccFetchPPDUAveragePower(instrument, selector_string, timeout, &ppdu_average_power_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4805,6 +4986,7 @@ namespace nirfmxwlan_grpc {
       float64 ppdu_peak_power_maximum {};
       auto status = library_->OFDMModAccFetchPPDUPeakPower(instrument, selector_string, timeout, &ppdu_peak_power_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4831,6 +5013,7 @@ namespace nirfmxwlan_grpc {
       int32 ppdu_type {};
       auto status = library_->OFDMModAccFetchPPDUType(instrument, selector_string, timeout, &ppdu_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4858,6 +5041,7 @@ namespace nirfmxwlan_grpc {
       int32 psdu_crc_status {};
       auto status = library_->OFDMModAccFetchPSDUCRCStatus(instrument, selector_string, timeout, &psdu_crc_status);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -4888,6 +5072,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchPhaseNoisePSDMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_phase_noise_psd_mean()->Resize(actual_array_size, 0);
@@ -4899,6 +5084,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4930,6 +5116,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchPilotConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> pilot_constellation(actual_array_size, NIComplexSingle());
@@ -4940,6 +5127,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -4978,6 +5166,7 @@ namespace nirfmxwlan_grpc {
       float64 vht_sig_b_average_power_mean {};
       auto status = library_->OFDMModAccFetchPreambleAveragePowers80211ac(instrument, selector_string, timeout, &vht_sig_a_average_power_mean, &vht_stf_average_power_mean, &vht_ltf_average_power_mean, &vht_sig_b_average_power_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5011,6 +5200,7 @@ namespace nirfmxwlan_grpc {
       float64 he_ltf_average_power_mean {};
       auto status = library_->OFDMModAccFetchPreambleAveragePowers80211ax(instrument, selector_string, timeout, &rl_sig_average_power_mean, &he_sig_a_average_power_mean, &he_sig_b_average_power_mean, &he_stf_average_power_mean, &he_ltf_average_power_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5044,6 +5234,7 @@ namespace nirfmxwlan_grpc {
       float64 ht_eltf_average_power_mean {};
       auto status = library_->OFDMModAccFetchPreambleAveragePowers80211n(instrument, selector_string, timeout, &ht_sig_average_power_mean, &ht_stf_average_power_mean, &ht_dltf_average_power_mean, &ht_eltf_average_power_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5075,6 +5266,7 @@ namespace nirfmxwlan_grpc {
       float64 l_sig_average_power_mean {};
       auto status = library_->OFDMModAccFetchPreambleAveragePowersCommon(instrument, selector_string, timeout, &l_stf_average_power_mean, &l_ltf_average_power_mean, &l_sig_average_power_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5106,6 +5298,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchPreambleFrequencyErrorTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_preamble_frequency_error()->Resize(actual_array_size, 0);
@@ -5117,6 +5310,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5150,6 +5344,7 @@ namespace nirfmxwlan_grpc {
       float64 vht_sig_b_peak_power_maximum {};
       auto status = library_->OFDMModAccFetchPreamblePeakPowers80211ac(instrument, selector_string, timeout, &vht_sig_a_peak_power_maximum, &vht_stf_peak_power_maximum, &vht_ltf_peak_power_maximum, &vht_sig_b_peak_power_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5183,6 +5378,7 @@ namespace nirfmxwlan_grpc {
       float64 he_ltf_peak_power_maximum {};
       auto status = library_->OFDMModAccFetchPreamblePeakPowers80211ax(instrument, selector_string, timeout, &rl_sig_peak_power_maximum, &he_sig_a_peak_power_maximum, &he_sig_b_peak_power_maximum, &he_stf_peak_power_maximum, &he_ltf_peak_power_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5216,6 +5412,7 @@ namespace nirfmxwlan_grpc {
       float64 ht_eltf_peak_power_maximum {};
       auto status = library_->OFDMModAccFetchPreamblePeakPowers80211n(instrument, selector_string, timeout, &ht_sig_peak_power_maximum, &ht_stf_peak_power_maximum, &ht_dltf_peak_power_maximum, &ht_eltf_peak_power_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5247,6 +5444,7 @@ namespace nirfmxwlan_grpc {
       float64 l_sig_peak_power_maximum {};
       auto status = library_->OFDMModAccFetchPreamblePeakPowersCommon(instrument, selector_string, timeout, &l_stf_peak_power_maximum, &l_ltf_peak_power_maximum, &l_sig_peak_power_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5276,6 +5474,7 @@ namespace nirfmxwlan_grpc {
       int32 ru_size {};
       auto status = library_->OFDMModAccFetchRUOffsetAndSize(instrument, selector_string, timeout, &ru_offset, &ru_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5303,6 +5502,7 @@ namespace nirfmxwlan_grpc {
       int32 sig_b_crc_status {};
       auto status = library_->OFDMModAccFetchSIGBCRCStatus(instrument, selector_string, timeout, &sig_b_crc_status);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5330,6 +5530,7 @@ namespace nirfmxwlan_grpc {
       int32 sig_crc_status {};
       auto status = library_->OFDMModAccFetchSIGCRCStatus(instrument, selector_string, timeout, &sig_crc_status);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5358,6 +5559,7 @@ namespace nirfmxwlan_grpc {
       int32 spectral_flatness_margin_subcarrier_index {};
       auto status = library_->OFDMModAccFetchSpectralFlatness(instrument, selector_string, timeout, &spectral_flatness_margin, &spectral_flatness_margin_subcarrier_index);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5388,6 +5590,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchSpectralFlatnessMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectral_flatness_mean()->Resize(actual_array_size, 0);
@@ -5403,6 +5606,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5438,6 +5642,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchStreamDataRMSEVMPerSymbolMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_stream_data_rms_evm_per_symbol_mean()->Resize(actual_array_size, 0);
@@ -5449,6 +5654,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5482,6 +5688,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchStreamPilotRMSEVMPerSymbolMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_stream_pilot_rms_evm_per_symbol_mean()->Resize(actual_array_size, 0);
@@ -5493,6 +5700,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5525,6 +5733,7 @@ namespace nirfmxwlan_grpc {
       float64 stream_pilot_rms_evm_mean {};
       auto status = library_->OFDMModAccFetchStreamRMSEVM(instrument, selector_string, timeout, &stream_rms_evm_mean, &stream_data_rms_evm_mean, &stream_pilot_rms_evm_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5556,6 +5765,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchStreamRMSEVMPerSubcarrierMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_stream_rms_evm_per_subcarrier_mean()->Resize(actual_array_size, 0);
@@ -5567,6 +5777,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5600,6 +5811,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchStreamRMSEVMPerSymbolMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_stream_rms_evm_per_symbol_mean()->Resize(actual_array_size, 0);
@@ -5611,6 +5823,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5645,6 +5858,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchSubcarrierChainEVMPerSymbolTrace(instrument, selector_string, timeout, subcarrier_index, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_subcarrier_chain_evm_per_symbol()->Resize(actual_array_size, 0);
@@ -5656,6 +5870,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5690,6 +5905,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchSubcarrierStreamEVMPerSymbolTrace(instrument, selector_string, timeout, subcarrier_index, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_subcarrier_stream_evm_per_symbol()->Resize(actual_array_size, 0);
@@ -5701,6 +5917,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5735,6 +5952,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchSymbolChainEVMPerSubcarrierTrace(instrument, selector_string, timeout, symbol_index, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_symbol_chain_evm_per_subcarrier()->Resize(actual_array_size, 0);
@@ -5746,6 +5964,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5776,6 +5995,7 @@ namespace nirfmxwlan_grpc {
       float64 symbol_clock_error_mean {};
       auto status = library_->OFDMModAccFetchSymbolClockErrorMean(instrument, selector_string, timeout, &symbol_clock_error_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5806,6 +6026,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchSymbolStreamEVMPerSubcarrierTrace(instrument, selector_string, timeout, symbol_index, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_symbol_stream_evm_per_subcarrier()->Resize(actual_array_size, 0);
@@ -5817,6 +6038,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5848,6 +6070,7 @@ namespace nirfmxwlan_grpc {
       int32 unused_tone_error_margin_ru_index {};
       auto status = library_->OFDMModAccFetchUnusedToneError(instrument, selector_string, timeout, &unused_tone_error_margin, &unused_tone_error_margin_ru_index);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -5876,6 +6099,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchUnusedToneErrorMarginPerRU(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_unused_tone_error_margin_per_ru()->Resize(actual_array_size, 0);
@@ -5887,6 +6111,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5918,6 +6143,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchUnusedToneErrorMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_unused_tone_error()->Resize(actual_array_size, 0);
@@ -5931,6 +6157,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -5963,6 +6190,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchUserDataConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> user_data_constellation(actual_array_size, NIComplexSingle());
@@ -5973,6 +6201,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6009,6 +6238,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchUserPilotConstellationTrace(instrument, selector_string, timeout, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         std::vector<NIComplexSingle> user_pilot_constellation(actual_array_size, NIComplexSingle());
@@ -6019,6 +6249,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6054,6 +6285,7 @@ namespace nirfmxwlan_grpc {
       float64 user_power_mean {};
       auto status = library_->OFDMModAccFetchUserPower(instrument, selector_string, timeout, &user_power_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6083,6 +6315,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchUserStreamDataRMSEVMPerSymbolMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_user_stream_data_rms_evm_per_symbol_mean()->Resize(actual_array_size, 0);
@@ -6094,6 +6327,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6127,6 +6361,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchUserStreamPilotRMSEVMPerSymbolMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_user_stream_pilot_rms_evm_per_symbol_mean()->Resize(actual_array_size, 0);
@@ -6138,6 +6373,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6170,6 +6406,7 @@ namespace nirfmxwlan_grpc {
       float64 user_stream_pilot_rms_evm_mean {};
       auto status = library_->OFDMModAccFetchUserStreamRMSEVM(instrument, selector_string, timeout, &user_stream_rms_evm_mean, &user_stream_data_rms_evm_mean, &user_stream_pilot_rms_evm_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6201,6 +6438,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchUserStreamRMSEVMPerSubcarrierMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_user_stream_rms_evm_per_subcarrier_mean()->Resize(actual_array_size, 0);
@@ -6212,6 +6450,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6245,6 +6484,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->OFDMModAccFetchUserStreamRMSEVMPerSymbolMeanTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_user_stream_rms_evm_per_symbol_mean()->Resize(actual_array_size, 0);
@@ -6256,6 +6496,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6285,6 +6526,7 @@ namespace nirfmxwlan_grpc {
       int32 calibration_data_valid {};
       auto status = library_->OFDMModAccValidateCalibrationData(instrument, selector_string, &calibration_data_valid);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6311,6 +6553,7 @@ namespace nirfmxwlan_grpc {
       float64 acquisition_length = request->acquisition_length();
       auto status = library_->PowerRampCfgAcquisitionLength(instrument, selector_string, acquisition_length);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6351,6 +6594,7 @@ namespace nirfmxwlan_grpc {
       int32 averaging_count = request->averaging_count();
       auto status = library_->PowerRampCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6379,6 +6623,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->PowerRampFetchFallTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_raw_waveform()->Resize(actual_array_size, 0);
@@ -6396,6 +6641,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6430,6 +6676,7 @@ namespace nirfmxwlan_grpc {
       float64 fall_time_mean {};
       auto status = library_->PowerRampFetchMeasurement(instrument, selector_string, timeout, &rise_time_mean, &fall_time_mean);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6460,6 +6707,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->PowerRampFetchRiseTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_raw_waveform()->Resize(actual_array_size, 0);
@@ -6477,6 +6725,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6509,6 +6758,7 @@ namespace nirfmxwlan_grpc {
       int32 attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(instrument, selector_string, attribute_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6532,6 +6782,7 @@ namespace nirfmxwlan_grpc {
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ResetToDefault(instrument, selector_string);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6588,6 +6839,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->SEMCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count, averaging_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6627,6 +6879,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->SEMCfgMaskType(instrument, selector_string, mask_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6651,6 +6904,7 @@ namespace nirfmxwlan_grpc {
       int32 number_of_offsets = request->number_of_offsets();
       auto status = library_->SEMCfgNumberOfOffsets(instrument, selector_string, number_of_offsets);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6704,6 +6958,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->SEMCfgOffsetFrequencyArray(instrument, selector_string, offset_start_frequency, offset_stop_frequency, offset_sideband, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6746,6 +7001,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->SEMCfgOffsetRelativeLimitArray(instrument, selector_string, relative_limit_start, relative_limit_stop, number_of_elements);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6786,6 +7042,7 @@ namespace nirfmxwlan_grpc {
       float64 span = request->span();
       auto status = library_->SEMCfgSpan(instrument, selector_string, span_auto, span);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6826,6 +7083,7 @@ namespace nirfmxwlan_grpc {
       float64 sweep_time_interval = request->sweep_time_interval();
       auto status = library_->SEMCfgSweepTime(instrument, selector_string, sweep_time_auto, sweep_time_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6852,6 +7110,7 @@ namespace nirfmxwlan_grpc {
       float64 relative_power {};
       auto status = library_->SEMFetchCarrierMeasurement(instrument, selector_string, timeout, &absolute_power, &relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6883,6 +7142,7 @@ namespace nirfmxwlan_grpc {
       float64 margin_relative_power {};
       auto status = library_->SEMFetchLowerOffsetMargin(instrument, selector_string, timeout, &measurement_status, &margin, &margin_frequency, &margin_absolute_power, &margin_relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -6915,6 +7175,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->SEMFetchLowerOffsetMarginArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_measurement_status_raw()->Resize(actual_array_size, 0);
@@ -6934,6 +7195,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -6979,6 +7241,7 @@ namespace nirfmxwlan_grpc {
       float64 peak_relative_power {};
       auto status = library_->SEMFetchLowerOffsetPower(instrument, selector_string, timeout, &total_absolute_power, &total_relative_power, &peak_absolute_power, &peak_frequency, &peak_relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7010,6 +7273,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->SEMFetchLowerOffsetPowerArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_total_absolute_power()->Resize(actual_array_size, 0);
@@ -7029,6 +7293,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7061,6 +7326,7 @@ namespace nirfmxwlan_grpc {
       int32 measurement_status {};
       auto status = library_->SEMFetchMeasurementStatus(instrument, selector_string, timeout, &measurement_status);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7091,6 +7357,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->SEMFetchSpectrum(instrument, selector_string, timeout, &x0, &dx, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_spectrum()->Resize(actual_array_size, 0);
@@ -7104,6 +7371,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7139,6 +7407,7 @@ namespace nirfmxwlan_grpc {
       float64 margin_relative_power {};
       auto status = library_->SEMFetchUpperOffsetMargin(instrument, selector_string, timeout, &measurement_status, &margin, &margin_frequency, &margin_absolute_power, &margin_relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7171,6 +7440,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->SEMFetchUpperOffsetMarginArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_measurement_status_raw()->Resize(actual_array_size, 0);
@@ -7190,6 +7460,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7235,6 +7506,7 @@ namespace nirfmxwlan_grpc {
       float64 peak_relative_power {};
       auto status = library_->SEMFetchUpperOffsetPower(instrument, selector_string, timeout, &total_absolute_power, &total_relative_power, &peak_absolute_power, &peak_frequency, &peak_relative_power);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7266,6 +7538,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->SEMFetchUpperOffsetPowerArray(instrument, selector_string, timeout, nullptr, nullptr, nullptr, nullptr, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_total_absolute_power()->Resize(actual_array_size, 0);
@@ -7285,6 +7558,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -7332,6 +7606,7 @@ namespace nirfmxwlan_grpc {
       int32 enable_all_traces = request->enable_all_traces();
       auto status = library_->SelectMeasurements(instrument, selector_string, measurements, enable_all_traces);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7354,6 +7629,7 @@ namespace nirfmxwlan_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
       auto status = library_->SendSoftwareEdgeTrigger(instrument);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7379,6 +7655,7 @@ namespace nirfmxwlan_grpc {
       float32 attr_val = request->attr_val();
       auto status = library_->SetAttributeF32(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7405,6 +7682,7 @@ namespace nirfmxwlan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeF32Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7430,6 +7708,7 @@ namespace nirfmxwlan_grpc {
       float64 attr_val = request->attr_val();
       auto status = library_->SetAttributeF64(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7456,6 +7735,7 @@ namespace nirfmxwlan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeF64Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7490,6 +7770,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->SetAttributeI16(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7533,6 +7814,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->SetAttributeI32(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7567,6 +7849,7 @@ namespace nirfmxwlan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI32Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7592,6 +7875,7 @@ namespace nirfmxwlan_grpc {
       int64 attr_val = request->attr_val();
       auto status = library_->SetAttributeI64(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7618,6 +7902,7 @@ namespace nirfmxwlan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI64Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7652,6 +7937,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->SetAttributeI8(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7698,6 +7984,7 @@ namespace nirfmxwlan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeI8Array(instrument, selector_string, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7727,6 +8014,7 @@ namespace nirfmxwlan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeNIComplexDoubleArray(instrument, selector_string, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7753,6 +8041,7 @@ namespace nirfmxwlan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeNIComplexSingleArray(instrument, selector_string, attribute_id, attr_val.data(), array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7797,6 +8086,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->SetAttributeString(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7831,6 +8121,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->SetAttributeU16(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7859,6 +8150,7 @@ namespace nirfmxwlan_grpc {
       uInt32 attr_val = request->attr_val();
       auto status = library_->SetAttributeU32(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7885,6 +8177,7 @@ namespace nirfmxwlan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU32Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7911,6 +8204,7 @@ namespace nirfmxwlan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU64Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7936,6 +8230,7 @@ namespace nirfmxwlan_grpc {
       uInt8 attr_val = request->attr_val();
       auto status = library_->SetAttributeU8(instrument, selector_string, attribute_id, attr_val);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -7962,6 +8257,7 @@ namespace nirfmxwlan_grpc {
       int32 array_size = static_cast<int32>(request->attr_val().size());
       auto status = library_->SetAttributeU8Array(instrument, selector_string, attribute_id, attr_val, array_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8002,6 +8298,7 @@ namespace nirfmxwlan_grpc {
       int32 averaging_count = request->averaging_count();
       auto status = library_->TXPCfgAveraging(instrument, selector_string, averaging_enabled, averaging_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8041,6 +8338,7 @@ namespace nirfmxwlan_grpc {
 
       auto status = library_->TXPCfgBurstDetectionEnabled(instrument, selector_string, burst_detection_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8065,6 +8363,7 @@ namespace nirfmxwlan_grpc {
       float64 maximum_measurement_interval = request->maximum_measurement_interval();
       auto status = library_->TXPCfgMaximumMeasurementInterval(instrument, selector_string, maximum_measurement_interval);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8091,6 +8390,7 @@ namespace nirfmxwlan_grpc {
       float64 peak_power_maximum {};
       auto status = library_->TXPFetchMeasurement(instrument, selector_string, timeout, &average_power_mean, &peak_power_maximum);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8121,6 +8421,7 @@ namespace nirfmxwlan_grpc {
       while (true) {
         auto status = library_->TXPFetchPowerTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->mutable_power()->Resize(actual_array_size, 0);
@@ -8132,6 +8433,7 @@ namespace nirfmxwlan_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
         }
         response->set_status(status);
@@ -8160,6 +8462,7 @@ namespace nirfmxwlan_grpc {
       float64 timeout = request->timeout();
       auto status = library_->WaitForAcquisitionComplete(instrument, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);
@@ -8184,6 +8487,7 @@ namespace nirfmxwlan_grpc {
       float64 timeout = request->timeout();
       auto status = library_->WaitForMeasurementComplete(instrument, selector_string, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNiRFmxInstrHandle(status, instrument);
       }
       response->set_status(status);

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -58,6 +58,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Abort(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -81,6 +82,7 @@ namespace nirfsa_grpc {
       ViBoolean is_done {};
       auto status = library_->CheckAcquisitionStatus(vi, &is_done);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -104,6 +106,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ClearError(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -126,6 +129,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ClearSelfCalibrateRange(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -149,6 +153,7 @@ namespace nirfsa_grpc {
       session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -171,6 +176,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Commit(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -209,6 +215,7 @@ namespace nirfsa_grpc {
 
       auto status = library_->ConfigureAcquisitionType(vi, acquisition_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -249,6 +256,7 @@ namespace nirfsa_grpc {
 
       auto status = library_->ConfigureDeembeddingTableInterpolationLinear(vi, port, table_name, format);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -273,6 +281,7 @@ namespace nirfsa_grpc {
       auto table_name = request->table_name().c_str();
       auto status = library_->ConfigureDeembeddingTableInterpolationNearest(vi, port, table_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -297,6 +306,7 @@ namespace nirfsa_grpc {
       auto table_name = request->table_name().c_str();
       auto status = library_->ConfigureDeembeddingTableInterpolationSpline(vi, port, table_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -355,6 +365,7 @@ namespace nirfsa_grpc {
 
       auto status = library_->ConfigureDigitalEdgeAdvanceTrigger(vi, source, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -414,6 +425,7 @@ namespace nirfsa_grpc {
       ViInt64 pretrigger_samples = request->pretrigger_samples();
       auto status = library_->ConfigureDigitalEdgeRefTrigger(vi, source, edge, pretrigger_samples);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -472,6 +484,7 @@ namespace nirfsa_grpc {
 
       auto status = library_->ConfigureDigitalEdgeStartTrigger(vi, source, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -496,6 +509,7 @@ namespace nirfsa_grpc {
       ViReal64 carrier_frequency = request->carrier_frequency();
       auto status = library_->ConfigureIQCarrierFrequency(vi, channel_list, carrier_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -537,6 +551,7 @@ namespace nirfsa_grpc {
       ViInt64 pretrigger_samples = request->pretrigger_samples();
       auto status = library_->ConfigureIQPowerEdgeRefTrigger(vi, source, level, slope, pretrigger_samples);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -561,6 +576,7 @@ namespace nirfsa_grpc {
       ViReal64 iq_rate = request->iq_rate();
       auto status = library_->ConfigureIQRate(vi, channel_list, iq_rate);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -586,6 +602,7 @@ namespace nirfsa_grpc {
       ViInt64 number_of_records = request->number_of_records();
       auto status = library_->ConfigureNumberOfRecords(vi, channel_list, number_of_records_is_finite, number_of_records);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -611,6 +628,7 @@ namespace nirfsa_grpc {
       ViInt64 samples_per_record = request->samples_per_record();
       auto status = library_->ConfigureNumberOfSamples(vi, channel_list, number_of_samples_is_finite, samples_per_record);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -653,6 +671,7 @@ namespace nirfsa_grpc {
 
       auto status = library_->ConfigurePXIChassisClk10(vi, pxi_clk10_source);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -696,6 +715,7 @@ namespace nirfsa_grpc {
       ViReal64 ref_clock_rate = request->ref_clock_rate();
       auto status = library_->ConfigureRefClock(vi, clock_source, ref_clock_rate);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -720,6 +740,7 @@ namespace nirfsa_grpc {
       ViReal64 reference_level = request->reference_level();
       auto status = library_->ConfigureReferenceLevel(vi, channel_list, reference_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -744,6 +765,7 @@ namespace nirfsa_grpc {
       ViReal64 resolution_bandwidth = request->resolution_bandwidth();
       auto status = library_->ConfigureResolutionBandwidth(vi, channel_list, resolution_bandwidth);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -766,6 +788,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgeAdvanceTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -789,6 +812,7 @@ namespace nirfsa_grpc {
       ViInt64 pretrigger_samples = request->pretrigger_samples();
       auto status = library_->ConfigureSoftwareEdgeRefTrigger(vi, pretrigger_samples);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -811,6 +835,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgeStartTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -836,6 +861,7 @@ namespace nirfsa_grpc {
       ViReal64 span = request->span();
       auto status = library_->ConfigureSpectrumFrequencyCenterSpan(vi, channel_list, center_frequency, span);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -861,6 +887,7 @@ namespace nirfsa_grpc {
       ViReal64 stop_frequency = request->stop_frequency();
       auto status = library_->ConfigureSpectrumFrequencyStartStop(vi, channel_list, start_frequency, stop_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -887,6 +914,7 @@ namespace nirfsa_grpc {
       ViBoolean set_as_active_list = request->set_as_active_list();
       auto status = library_->CreateConfigurationList(vi, list_name, number_of_list_attributes, list_attribute_ids, set_as_active_list);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -910,6 +938,7 @@ namespace nirfsa_grpc {
       ViBoolean set_as_active_step = request->set_as_active_step();
       auto status = library_->CreateConfigurationListStep(vi, set_as_active_step);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -955,6 +984,7 @@ namespace nirfsa_grpc {
 
       auto status = library_->CreateDeembeddingSparameterTableArray(vi, port, table_name, frequencies, frequencies_size, sparameter_table.data(), sparameter_table_size, number_of_ports, sparameter_orientation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -996,6 +1026,7 @@ namespace nirfsa_grpc {
 
       auto status = library_->CreateDeembeddingSparameterTableS2PFile(vi, port, table_name, s2p_file_path, sparameter_orientation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1018,6 +1049,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->DeleteAllDeembeddingTables(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1041,6 +1073,7 @@ namespace nirfsa_grpc {
       auto list_name = request->list_name().c_str();
       auto status = library_->DeleteConfigurationList(vi, list_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1065,6 +1098,7 @@ namespace nirfsa_grpc {
       auto table_name = request->table_name().c_str();
       auto status = library_->DeleteDeembeddingTable(vi, port, table_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1087,6 +1121,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Disable(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1109,6 +1144,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->DisableAdvanceTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1131,6 +1167,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->DisableRefTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1153,6 +1190,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->DisableStartTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1176,6 +1214,7 @@ namespace nirfsa_grpc {
       ViBoolean enable = request->enable();
       auto status = library_->EnableSessionAccess(vi, enable);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1200,6 +1239,7 @@ namespace nirfsa_grpc {
       std::string error_message(1024 - 1, '\0');
       auto status = library_->ErrorMessage(vi, status_code, (ViChar*)error_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1226,6 +1266,7 @@ namespace nirfsa_grpc {
       std::string error_message(1024 - 1, '\0');
       auto status = library_->ErrorQuery(vi, &error_code, (ViChar*)error_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1288,6 +1329,7 @@ namespace nirfsa_grpc {
 
       auto status = library_->ExportSignal(vi, signal, signal_identifier, output_terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1317,6 +1359,7 @@ namespace nirfsa_grpc {
       std::vector<niRFSA_wfmInfo_struct> wfm_info(number_of_records, niRFSA_wfmInfo_struct());
       auto status = library_->FetchIQMultiRecordComplexF32(vi, channel_list, starting_record, number_of_records, number_of_samples, timeout, data.data(), wfm_info.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1348,6 +1391,7 @@ namespace nirfsa_grpc {
       std::vector<niRFSA_wfmInfo_struct> wfm_info(number_of_records, niRFSA_wfmInfo_struct());
       auto status = library_->FetchIQMultiRecordComplexF64(vi, channel_list, starting_record, number_of_records, number_of_samples, timeout, data.data(), wfm_info.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1379,6 +1423,7 @@ namespace nirfsa_grpc {
       std::vector<niRFSA_wfmInfo_struct> wfm_info(number_of_records, niRFSA_wfmInfo_struct());
       auto status = library_->FetchIQMultiRecordComplexI16(vi, channel_list, starting_record, number_of_records, number_of_samples, timeout, data.data(), wfm_info.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1409,6 +1454,7 @@ namespace nirfsa_grpc {
       niRFSA_wfmInfo_struct wfm_info {};
       auto status = library_->FetchIQSingleRecordComplexF32(vi, channel_list, record_number, number_of_samples, timeout, data.data(), &wfm_info);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1439,6 +1485,7 @@ namespace nirfsa_grpc {
       niRFSA_wfmInfo_struct wfm_info {};
       auto status = library_->FetchIQSingleRecordComplexF64(vi, channel_list, record_number, number_of_samples, timeout, data.data(), &wfm_info);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1469,6 +1516,7 @@ namespace nirfsa_grpc {
       niRFSA_wfmInfo_struct wfm_info {};
       auto status = library_->FetchIQSingleRecordComplexI16(vi, channel_list, record_number, number_of_samples, timeout, data.data(), &wfm_info);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1496,6 +1544,7 @@ namespace nirfsa_grpc {
       ViBoolean value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_name, attribute_id, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1522,6 +1571,7 @@ namespace nirfsa_grpc {
       ViInt32 value {};
       auto status = library_->GetAttributeViInt32(vi, channel_name, attribute_id, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1548,6 +1598,7 @@ namespace nirfsa_grpc {
       ViInt64 value {};
       auto status = library_->GetAttributeViInt64(vi, channel_name, attribute_id, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1574,6 +1625,7 @@ namespace nirfsa_grpc {
       ViReal64 value {};
       auto status = library_->GetAttributeViReal64(vi, channel_name, attribute_id, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1600,6 +1652,7 @@ namespace nirfsa_grpc {
       ViSession value {};
       auto status = library_->GetAttributeViSession(vi, channel_name, attribute_id, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1628,6 +1681,7 @@ namespace nirfsa_grpc {
       while (true) {
         auto status = library_->GetAttributeViString(vi, channel_name, attribute_id, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buf_size = status;
@@ -1642,6 +1696,7 @@ namespace nirfsa_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1668,6 +1723,7 @@ namespace nirfsa_grpc {
       std::string info(2048 - 1, '\0');
       auto status = library_->GetCalUserDefinedInfo(vi, (ViChar*)info.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1693,6 +1749,7 @@ namespace nirfsa_grpc {
       ViInt32 info_size {};
       auto status = library_->GetCalUserDefinedInfoMaxSize(vi, &info_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1719,6 +1776,7 @@ namespace nirfsa_grpc {
       while (true) {
         auto status = library_->GetDeembeddingSparameters(vi, nullptr, 0, &number_of_sparameters, &number_of_ports);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         std::vector<NIComplexNumber_struct> sparameters(number_of_sparameters, NIComplexNumber_struct());
@@ -1729,6 +1787,7 @@ namespace nirfsa_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1781,6 +1840,7 @@ namespace nirfsa_grpc {
       while (true) {
         auto status = library_->GetDeviceResponse(vi, channel_list, response_type, 0, nullptr, nullptr, nullptr, &number_of_frequencies);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->mutable_frequencies()->Resize(number_of_frequencies, 0);
@@ -1796,6 +1856,7 @@ namespace nirfsa_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1825,6 +1886,7 @@ namespace nirfsa_grpc {
       while (true) {
         auto status = library_->GetError(vi, nullptr, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 error_description_buffer_size = status;
@@ -1840,6 +1902,7 @@ namespace nirfsa_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1871,6 +1934,7 @@ namespace nirfsa_grpc {
       ViInt32 minute {};
       auto status = library_->GetExtCalLastDateAndTime(vi, &year, &month, &day, &hour, &minute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1899,6 +1963,7 @@ namespace nirfsa_grpc {
       ViReal64 temperature {};
       auto status = library_->GetExtCalLastTemp(vi, &temperature);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1923,6 +1988,7 @@ namespace nirfsa_grpc {
       ViInt32 months {};
       auto status = library_->GetExtCalRecommendedInterval(vi, &months);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1949,6 +2015,7 @@ namespace nirfsa_grpc {
       ViInt64 backlog {};
       auto status = library_->GetFetchBacklog(vi, channel_list, record_number, &backlog);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1975,6 +2042,7 @@ namespace nirfsa_grpc {
       while (true) {
         auto status = library_->GetFrequencyResponse(vi, channel_list, 0, nullptr, nullptr, nullptr, &number_of_frequencies);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->mutable_frequencies()->Resize(number_of_frequencies, 0);
@@ -1990,6 +2058,7 @@ namespace nirfsa_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2020,6 +2089,7 @@ namespace nirfsa_grpc {
       while (true) {
         auto status = library_->GetNormalizationCoefficients(vi, channel_list, 0, nullptr, &number_of_coefficient_sets);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         std::vector<niRFSA_coefficientInfo_struct> coefficient_info(number_of_coefficient_sets, niRFSA_coefficientInfo_struct());
@@ -2030,6 +2100,7 @@ namespace nirfsa_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2064,6 +2135,7 @@ namespace nirfsa_grpc {
       ViInt32 number_of_spectral_lines {};
       auto status = library_->GetNumberOfSpectralLines(vi, channel_list, &number_of_spectral_lines);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2091,6 +2163,7 @@ namespace nirfsa_grpc {
       while (true) {
         auto status = library_->GetRelayName(vi, channel_list, index, nullptr, &buffer_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         std::string name;
@@ -2103,6 +2176,7 @@ namespace nirfsa_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2132,6 +2206,7 @@ namespace nirfsa_grpc {
       while (true) {
         auto status = library_->GetRelayOperationsCount(vi, channel_list, nullptr, &buffer_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->mutable_operations_count()->Resize(buffer_size, 0);
@@ -2142,6 +2217,7 @@ namespace nirfsa_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2170,6 +2246,7 @@ namespace nirfsa_grpc {
       while (true) {
         auto status = library_->GetScalingCoefficients(vi, channel_list, 0, nullptr, &number_of_coefficient_sets);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         std::vector<niRFSA_coefficientInfo_struct> coefficient_info(number_of_coefficient_sets, niRFSA_coefficientInfo_struct());
@@ -2180,6 +2257,7 @@ namespace nirfsa_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2218,6 +2296,7 @@ namespace nirfsa_grpc {
       ViInt32 minute {};
       auto status = library_->GetSelfCalLastDateAndTime(vi, self_calibration_step, &year, &month, &day, &hour, &minute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2247,6 +2326,7 @@ namespace nirfsa_grpc {
       ViReal64 temp {};
       auto status = library_->GetSelfCalLastTemp(vi, self_calibration_step, &temp);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2271,6 +2351,7 @@ namespace nirfsa_grpc {
       SmtSpectrumInfo_struct spectrum_info {};
       auto status = library_->GetSpectralInfoForSMT(vi, &spectrum_info);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2296,6 +2377,7 @@ namespace nirfsa_grpc {
       ViUInt32 writer_handle {};
       auto status = library_->GetStreamEndpointHandle(vi, stream_endpoint, &writer_handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2341,6 +2423,7 @@ namespace nirfsa_grpc {
       }
       auto status = library_->GetTerminalName(vi, signal, signal_identifier, buffer_size, (ViChar*)terminal_name.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2368,6 +2451,7 @@ namespace nirfsa_grpc {
       while (true) {
         auto status = library_->GetUserData(vi, identifier, 0, nullptr, &actual_data_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         std::string data(actual_data_size, '\0');
@@ -2378,6 +2462,7 @@ namespace nirfsa_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2414,6 +2499,7 @@ namespace nirfsa_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -2451,6 +2537,7 @@ namespace nirfsa_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -2477,6 +2564,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Initiate(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2499,6 +2587,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->InvalidateAllAttributes(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2523,6 +2612,7 @@ namespace nirfsa_grpc {
       ViInt64 valid_steps {};
       auto status = library_->IsSelfCalValid(vi, &self_cal_valid, &valid_steps);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2567,6 +2657,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->PerformThermalCorrection(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2594,6 +2685,7 @@ namespace nirfsa_grpc {
       niRFSA_wfmInfo_struct wfm_info {};
       auto status = library_->ReadIQSingleRecordComplexF64(vi, channel_list, timeout, data.data(), data_array_size, &wfm_info);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2624,6 +2716,7 @@ namespace nirfsa_grpc {
       niRFSA_spectrumInfo_struct spectrum_info {};
       auto status = library_->ReadPowerSpectrumF32(vi, channel_list, timeout, power_spectrum_data, data_array_size, &spectrum_info);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2653,6 +2746,7 @@ namespace nirfsa_grpc {
       niRFSA_spectrumInfo_struct spectrum_info {};
       auto status = library_->ReadPowerSpectrumF64(vi, channel_list, timeout, power_spectrum_data, data_array_size, &spectrum_info);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2676,6 +2770,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2700,6 +2795,7 @@ namespace nirfsa_grpc {
       ViAttr attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(vi, channel_name, attribute_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2722,6 +2818,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ResetDevice(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2744,6 +2841,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ResetWithDefaults(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2782,6 +2880,7 @@ namespace nirfsa_grpc {
 
       auto status = library_->ResetWithOptions(vi, steps_to_omit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2806,6 +2905,7 @@ namespace nirfsa_grpc {
       std::string instr_rev(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)driver_rev.data(), (ViChar*)instr_rev.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2832,6 +2932,7 @@ namespace nirfsa_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->SelfCal(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2870,6 +2971,7 @@ namespace nirfsa_grpc {
 
       auto status = library_->SelfCalibrate(vi, steps_to_omit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2912,6 +3014,7 @@ namespace nirfsa_grpc {
       ViReal64 max_reference_level = request->max_reference_level();
       auto status = library_->SelfCalibrateRange(vi, steps_to_omit, min_frequency, max_frequency, min_reference_level, max_reference_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2936,6 +3039,7 @@ namespace nirfsa_grpc {
       std::string test_message(2048 - 1, '\0');
       auto status = library_->SelfTest(vi, &test_result, (ViChar*)test_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2978,6 +3082,7 @@ namespace nirfsa_grpc {
       auto trigger_identifier = request->trigger_identifier().c_str();
       auto status = library_->SendSoftwareEdgeTrigger(vi, trigger, trigger_identifier);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3003,6 +3108,7 @@ namespace nirfsa_grpc {
       ViBoolean value = request->value();
       auto status = library_->SetAttributeViBoolean(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3043,6 +3149,7 @@ namespace nirfsa_grpc {
 
       auto status = library_->SetAttributeViInt32(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3068,6 +3175,7 @@ namespace nirfsa_grpc {
       ViInt64 value = request->value_raw();
       auto status = library_->SetAttributeViInt64(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3093,6 +3201,7 @@ namespace nirfsa_grpc {
       ViReal64 value = request->value_raw();
       auto status = library_->SetAttributeViReal64(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3119,6 +3228,7 @@ namespace nirfsa_grpc {
       ViSession value = session_repository_->access_session(value_grpc_session.id(), value_grpc_session.name());
       auto status = library_->SetAttributeViSession(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3163,6 +3273,7 @@ namespace nirfsa_grpc {
 
       auto status = library_->SetAttributeViString(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3186,6 +3297,7 @@ namespace nirfsa_grpc {
       auto info = request->info().c_str();
       auto status = library_->SetCalUserDefinedInfo(vi, info);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3211,6 +3323,7 @@ namespace nirfsa_grpc {
       std::string data(buffer_size, '\0');
       auto status = library_->SetUserData(vi, identifier, buffer_size, (ViInt8*)data.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);

--- a/generated/nirfsg/nirfsg_service.cpp
+++ b/generated/nirfsg/nirfsg_service.cpp
@@ -57,6 +57,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Abort(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -81,6 +82,7 @@ namespace nirfsg_grpc {
       ViInt32 size_in_samples = request->size_in_samples();
       auto status = library_->AllocateArbWaveform(vi, waveform_name, size_in_samples);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -106,6 +108,7 @@ namespace nirfsg_grpc {
       ViBoolean value = request->value();
       auto status = library_->CheckAttributeViBoolean(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -146,6 +149,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->CheckAttributeViInt32(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -171,6 +175,7 @@ namespace nirfsg_grpc {
       ViInt64 value = request->value_raw();
       auto status = library_->CheckAttributeViInt64(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -211,6 +216,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->CheckAttributeViReal64(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -237,6 +243,7 @@ namespace nirfsg_grpc {
       ViSession value = session_repository_->access_session(value_grpc_session.id(), value_grpc_session.name());
       auto status = library_->CheckAttributeViSession(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -281,6 +288,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->CheckAttributeViString(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -304,6 +312,7 @@ namespace nirfsg_grpc {
       ViBoolean is_done {};
       auto status = library_->CheckGenerationStatus(vi, &is_done);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -329,6 +338,7 @@ namespace nirfsg_grpc {
       ViBoolean list_exists {};
       auto status = library_->CheckIfConfigurationListExists(vi, list_name, &list_exists);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -354,6 +364,7 @@ namespace nirfsg_grpc {
       ViBoolean script_exists {};
       auto status = library_->CheckIfScriptExists(vi, script_name, &script_exists);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -379,6 +390,7 @@ namespace nirfsg_grpc {
       ViBoolean waveform_exists {};
       auto status = library_->CheckIfWaveformExists(vi, waveform_name, &waveform_exists);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -402,6 +414,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ClearAllArbWaveforms(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -425,6 +438,7 @@ namespace nirfsg_grpc {
       auto name = request->name().c_str();
       auto status = library_->ClearArbWaveform(vi, name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -447,6 +461,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ClearError(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -469,6 +484,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ClearSelfCalibrateRange(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -492,6 +508,7 @@ namespace nirfsg_grpc {
       session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -514,6 +531,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Commit(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -554,6 +572,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->ConfigureDeembeddingTableInterpolationLinear(vi, port, table_name, format);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -578,6 +597,7 @@ namespace nirfsg_grpc {
       auto table_name = request->table_name().c_str();
       auto status = library_->ConfigureDeembeddingTableInterpolationNearest(vi, port, table_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -602,6 +622,7 @@ namespace nirfsg_grpc {
       auto table_name = request->table_name().c_str();
       auto status = library_->ConfigureDeembeddingTableInterpolationSpline(vi, port, table_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -660,6 +681,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->ConfigureDigitalEdgeConfigurationListStepTrigger(vi, source, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -738,6 +760,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->ConfigureDigitalEdgeScriptTrigger(vi, trigger_id, source, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -796,6 +819,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->ConfigureDigitalEdgeStartTrigger(vi, source, edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -874,6 +898,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->ConfigureDigitalLevelScriptTrigger(vi, trigger_id, source, level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -898,6 +923,7 @@ namespace nirfsg_grpc {
       ViInt8* user_defined_waveform = (ViInt8*)request->user_defined_waveform().c_str();
       auto status = library_->ConfigureDigitalModulationUserDefinedWaveform(vi, number_of_samples, user_defined_waveform);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -936,6 +962,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->ConfigureGenerationMode(vi, generation_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -959,6 +986,7 @@ namespace nirfsg_grpc {
       ViBoolean output_enabled = request->output_enabled();
       auto status = library_->ConfigureOutputEnabled(vi, output_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -982,6 +1010,7 @@ namespace nirfsg_grpc {
       ViInt64 p2p_endpoint_fullness_level = request->p2p_endpoint_fullness_level();
       auto status = library_->ConfigureP2PEndpointFullnessStartTrigger(vi, p2p_endpoint_fullness_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1024,6 +1053,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->ConfigurePXIChassisClk10(vi, pxi_clk10_source);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1062,6 +1092,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->ConfigurePowerLevelType(vi, power_level_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1086,6 +1117,7 @@ namespace nirfsg_grpc {
       ViReal64 power_level = request->power_level();
       auto status = library_->ConfigureRF(vi, frequency, power_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1129,6 +1161,7 @@ namespace nirfsg_grpc {
       ViReal64 ref_clock_rate = request->ref_clock_rate();
       auto status = library_->ConfigureRefClock(vi, ref_clock_source, ref_clock_rate);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1152,6 +1185,7 @@ namespace nirfsg_grpc {
       ViReal64 signal_bandwidth = request->signal_bandwidth();
       auto status = library_->ConfigureSignalBandwidth(vi, signal_bandwidth);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1194,6 +1228,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->ConfigureSoftwareScriptTrigger(vi, trigger_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1216,6 +1251,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareStartTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1241,6 +1277,7 @@ namespace nirfsg_grpc {
       auto reserved_for_future_use = 0;
       auto status = library_->ConfigureUpconverterPLLSettlingTime(vi, pll_settling_time, ensure_pll_locked, reserved_for_future_use);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1267,6 +1304,7 @@ namespace nirfsg_grpc {
       ViBoolean set_as_active_list = request->set_as_active_list();
       auto status = library_->CreateConfigurationList(vi, list_name, number_of_attributes, configuration_list_attributes, set_as_active_list);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1290,6 +1328,7 @@ namespace nirfsg_grpc {
       ViBoolean set_as_active_step = request->set_as_active_step();
       auto status = library_->CreateConfigurationListStep(vi, set_as_active_step);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1335,6 +1374,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->CreateDeembeddingSparameterTableArray(vi, port, table_name, frequencies, frequencies_size, sparameter_table.data(), sparameter_table_size, number_of_ports, sparameter_orientation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1376,6 +1416,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->CreateDeembeddingSparameterTableS2PFile(vi, port, table_name, s2p_file_path, sparameter_orientation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1398,6 +1439,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->DeleteAllDeembeddingTables(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1421,6 +1463,7 @@ namespace nirfsg_grpc {
       auto list_name = request->list_name().c_str();
       auto status = library_->DeleteConfigurationList(vi, list_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1445,6 +1488,7 @@ namespace nirfsg_grpc {
       auto table_name = request->table_name().c_str();
       auto status = library_->DeleteDeembeddingTable(vi, port, table_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1468,6 +1512,7 @@ namespace nirfsg_grpc {
       auto script_name = request->script_name().c_str();
       auto status = library_->DeleteScript(vi, script_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1490,6 +1535,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Disable(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1512,6 +1558,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->DisableAllModulation(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1534,6 +1581,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->DisableConfigurationListStepTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1576,6 +1624,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->DisableScriptTrigger(vi, trigger_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1598,6 +1647,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->DisableStartTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1622,6 +1672,7 @@ namespace nirfsg_grpc {
       std::string error_message(1024 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1648,6 +1699,7 @@ namespace nirfsg_grpc {
       std::string error_message(1024 - 1, '\0');
       auto status = library_->ErrorQuery(vi, &error_code, (ViChar*)error_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1729,6 +1781,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->ExportSignal(vi, signal, signal_identifier, output_terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1754,6 +1807,7 @@ namespace nirfsg_grpc {
       ViBoolean value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_name, attribute_id, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1780,6 +1834,7 @@ namespace nirfsg_grpc {
       ViInt32 value {};
       auto status = library_->GetAttributeViInt32(vi, channel_name, attribute_id, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1806,6 +1861,7 @@ namespace nirfsg_grpc {
       ViInt64 value {};
       auto status = library_->GetAttributeViInt64(vi, channel_name, attribute_id, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1832,6 +1888,7 @@ namespace nirfsg_grpc {
       ViReal64 value {};
       auto status = library_->GetAttributeViReal64(vi, channel_name, attribute_id, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1858,6 +1915,7 @@ namespace nirfsg_grpc {
       ViSession value {};
       auto status = library_->GetAttributeViSession(vi, channel_name, attribute_id, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1886,6 +1944,7 @@ namespace nirfsg_grpc {
       while (true) {
         auto status = library_->GetAttributeViString(vi, channel_name, attribute_id, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buf_size = status;
@@ -1900,6 +1959,7 @@ namespace nirfsg_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1928,6 +1988,7 @@ namespace nirfsg_grpc {
       while (true) {
         auto status = library_->GetChannelName(vi, index, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -1942,6 +2003,7 @@ namespace nirfsg_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1970,6 +2032,7 @@ namespace nirfsg_grpc {
       while (true) {
         auto status = library_->GetDeembeddingSparameters(vi, nullptr, 0, &number_of_sparameters, &number_of_ports);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         std::vector<NIComplexNumber_struct> sparameters(number_of_sparameters, NIComplexNumber_struct());
@@ -1980,6 +2043,7 @@ namespace nirfsg_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2015,6 +2079,7 @@ namespace nirfsg_grpc {
       while (true) {
         auto status = library_->GetError(vi, nullptr, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 error_description_buffer_size = status;
@@ -2030,6 +2095,7 @@ namespace nirfsg_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2062,6 +2128,7 @@ namespace nirfsg_grpc {
       ViInt32 second {};
       auto status = library_->GetExternalCalibrationLastDateAndTime(vi, &year, &month, &day, &hour, &minute, &second);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2112,6 +2179,7 @@ namespace nirfsg_grpc {
       ViInt32 second {};
       auto status = library_->GetSelfCalibrationDateAndTime(vi, module, &year, &month, &day, &hour, &minute, &second);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2157,6 +2225,7 @@ namespace nirfsg_grpc {
       ViReal64 temperature {};
       auto status = library_->GetSelfCalibrationTemperature(vi, module, &temperature);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2218,6 +2287,7 @@ namespace nirfsg_grpc {
       while (true) {
         auto status = library_->GetTerminalName(vi, signal, signal_identifier, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -2232,6 +2302,7 @@ namespace nirfsg_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2260,6 +2331,7 @@ namespace nirfsg_grpc {
       while (true) {
         auto status = library_->GetUserData(vi, identifier, 0, nullptr, &actual_data_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         std::string data(actual_data_size, '\0');
@@ -2270,6 +2342,7 @@ namespace nirfsg_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2299,6 +2372,7 @@ namespace nirfsg_grpc {
       while (true) {
         auto status = library_->GetWaveformBurstStartLocations(vi, channel_name, 0, nullptr, &required_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->mutable_locations()->Resize(required_size, 0);
@@ -2310,6 +2384,7 @@ namespace nirfsg_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2338,6 +2413,7 @@ namespace nirfsg_grpc {
       while (true) {
         auto status = library_->GetWaveformBurstStopLocations(vi, channel_name, 0, nullptr, &required_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->mutable_locations()->Resize(required_size, 0);
@@ -2349,6 +2425,7 @@ namespace nirfsg_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2377,6 +2454,7 @@ namespace nirfsg_grpc {
       while (true) {
         auto status = library_->GetWaveformMarkerEventLocations(vi, channel_name, 0, nullptr, &required_size);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->mutable_locations()->Resize(required_size, 0);
@@ -2388,6 +2466,7 @@ namespace nirfsg_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2423,6 +2502,7 @@ namespace nirfsg_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -2460,6 +2540,7 @@ namespace nirfsg_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -2486,6 +2567,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Initiate(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2508,6 +2590,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->InvalidateAllAttributes(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2532,6 +2615,7 @@ namespace nirfsg_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->LoadConfigurationsFromFile(vi, channel_name, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2554,6 +2638,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->PerformPowerSearch(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2576,6 +2661,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->PerformThermalCorrection(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2602,6 +2688,7 @@ namespace nirfsg_grpc {
       ViInt32 max_waveform_size {};
       auto status = library_->QueryArbWaveformCapabilities(vi, &max_number_waveforms, &waveform_quantum, &min_waveform_size, &max_waveform_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2631,6 +2718,7 @@ namespace nirfsg_grpc {
       ViUInt32 waveform_index = request->waveform_index();
       auto status = library_->ReadAndDownloadWaveformFromFileTDMS(vi, waveform_name, file_path, waveform_index);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2653,6 +2741,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2677,6 +2766,7 @@ namespace nirfsg_grpc {
       ViAttr attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(vi, channel_name, attribute_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2699,6 +2789,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ResetDevice(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2721,6 +2812,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ResetWithDefaults(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2759,6 +2851,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->ResetWithOptions(vi, steps_to_omit);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2783,6 +2876,7 @@ namespace nirfsg_grpc {
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2811,6 +2905,7 @@ namespace nirfsg_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->SaveConfigurationsToFile(vi, channel_name, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2834,6 +2929,7 @@ namespace nirfsg_grpc {
       auto name = request->name().c_str();
       auto status = library_->SelectArbWaveform(vi, name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2856,6 +2952,7 @@ namespace nirfsg_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->SelfCal(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2898,6 +2995,7 @@ namespace nirfsg_grpc {
       ViReal64 max_power_level = request->max_power_level();
       auto status = library_->SelfCalibrateRange(vi, steps_to_omit, min_frequency, max_frequency, min_power_level, max_power_level);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2922,6 +3020,7 @@ namespace nirfsg_grpc {
       std::string self_test_message(2048 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2983,6 +3082,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->SendSoftwareEdgeTrigger(vi, trigger, trigger_identifier);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3023,6 +3123,7 @@ namespace nirfsg_grpc {
       ViInt32 offset = request->offset();
       auto status = library_->SetArbWaveformNextWritePosition(vi, waveform_name, relative_to, offset);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3048,6 +3149,7 @@ namespace nirfsg_grpc {
       ViBoolean value = request->value();
       auto status = library_->SetAttributeViBoolean(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3088,6 +3190,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->SetAttributeViInt32(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3113,6 +3216,7 @@ namespace nirfsg_grpc {
       ViInt64 value = request->value_raw();
       auto status = library_->SetAttributeViInt64(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3153,6 +3257,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->SetAttributeViReal64(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3179,6 +3284,7 @@ namespace nirfsg_grpc {
       ViSession value = session_repository_->access_session(value_grpc_session.id(), value_grpc_session.name());
       auto status = library_->SetAttributeViSession(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3223,6 +3329,7 @@ namespace nirfsg_grpc {
 
       auto status = library_->SetAttributeViString(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3248,6 +3355,7 @@ namespace nirfsg_grpc {
       ViInt8* data = (ViInt8*)request->data().c_str();
       auto status = library_->SetUserData(vi, identifier, buffer_size, data);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3273,6 +3381,7 @@ namespace nirfsg_grpc {
       auto locations = const_cast<ViReal64*>(request->locations().data());
       auto status = library_->SetWaveformBurstStartLocations(vi, channel_name, number_of_locations, locations);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3298,6 +3407,7 @@ namespace nirfsg_grpc {
       auto locations = const_cast<ViReal64*>(request->locations().data());
       auto status = library_->SetWaveformBurstStopLocations(vi, channel_name, number_of_locations, locations);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3323,6 +3433,7 @@ namespace nirfsg_grpc {
       auto locations = const_cast<ViReal64*>(request->locations().data());
       auto status = library_->SetWaveformMarkerEventLocations(vi, channel_name, number_of_locations, locations);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3346,6 +3457,7 @@ namespace nirfsg_grpc {
       ViInt32 max_time_milliseconds = request->max_time_milliseconds();
       auto status = library_->WaitUntilSettled(vi, max_time_milliseconds);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3384,6 +3496,7 @@ namespace nirfsg_grpc {
       ViBoolean more_data_pending = request->more_data_pending();
       auto status = library_->WriteArbWaveform(vi, waveform_name, number_of_samples, i_data, q_data, more_data_pending);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3410,6 +3523,7 @@ namespace nirfsg_grpc {
       ViBoolean more_data_pending = request->more_data_pending();
       auto status = library_->WriteArbWaveformComplexF32(vi, waveform_name, number_of_samples, wfm_data.data(), more_data_pending);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3436,6 +3550,7 @@ namespace nirfsg_grpc {
       ViBoolean more_data_pending = request->more_data_pending();
       auto status = library_->WriteArbWaveformComplexF64(vi, waveform_name, number_of_samples, wfm_data.data(), more_data_pending);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3461,6 +3576,7 @@ namespace nirfsg_grpc {
       auto wfm_data = convert_from_grpc<NIComplexI16_struct>(request->wfm_data());
       auto status = library_->WriteArbWaveformComplexI16(vi, waveform_name, number_of_samples, wfm_data.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3499,6 +3615,7 @@ namespace nirfsg_grpc {
       ViBoolean more_data_pending = request->more_data_pending();
       auto status = library_->WriteArbWaveformF32(vi, waveform_name, number_of_samples, i_data, q_data, more_data_pending);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -3522,6 +3639,7 @@ namespace nirfsg_grpc {
       auto script = request->script().c_str();
       auto status = library_->WriteScript(vi, script);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -57,6 +57,7 @@ namespace niscope_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Abort(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -80,6 +81,7 @@ namespace niscope_grpc {
       ViInt32 acquisition_status {};
       auto status = library_->AcquisitionStatus(vi, &acquisition_status);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -121,6 +123,7 @@ namespace niscope_grpc {
       ViInt32 meas_waveform_size {};
       auto status = library_->ActualMeasWfmSize(vi, array_meas_function, &meas_waveform_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -146,6 +149,7 @@ namespace niscope_grpc {
       ViInt32 num_wfms {};
       auto status = library_->ActualNumWfms(vi, channel_list, &num_wfms);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -170,6 +174,7 @@ namespace niscope_grpc {
       ViInt32 record_length {};
       auto status = library_->ActualRecordLength(vi, &record_length);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -210,6 +215,7 @@ namespace niscope_grpc {
 
       auto status = library_->AddWaveformProcessing(vi, channel_list, meas_function);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -233,6 +239,7 @@ namespace niscope_grpc {
       ViReal64 delay = request->delay();
       auto status = library_->AdjustSampleClockRelativeDelay(vi, delay);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -255,6 +262,7 @@ namespace niscope_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->AutoSetup(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -277,6 +285,7 @@ namespace niscope_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->CableSenseSignalStart(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -299,6 +308,7 @@ namespace niscope_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->CableSenseSignalStop(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -338,6 +348,7 @@ namespace niscope_grpc {
 
       auto status = library_->CalSelfCalibrate(vi, channel_list, option);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -363,6 +374,7 @@ namespace niscope_grpc {
       ViBoolean value = request->value();
       auto status = library_->CheckAttributeViBoolean(vi, channel_list, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -403,6 +415,7 @@ namespace niscope_grpc {
 
       auto status = library_->CheckAttributeViInt32(vi, channel_list, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -443,6 +456,7 @@ namespace niscope_grpc {
 
       auto status = library_->CheckAttributeViInt64(vi, channel_list, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -491,6 +505,7 @@ namespace niscope_grpc {
 
       auto status = library_->CheckAttributeViReal64(vi, channel_list, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -517,6 +532,7 @@ namespace niscope_grpc {
       ViSession value = session_repository_->access_session(value_grpc_session.id(), value_grpc_session.name());
       auto status = library_->CheckAttributeViSession(vi, channel_list, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -561,6 +577,7 @@ namespace niscope_grpc {
 
       auto status = library_->CheckAttributeViString(vi, channel_list, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -600,6 +617,7 @@ namespace niscope_grpc {
 
       auto status = library_->ClearWaveformMeasurementStats(vi, channel_list, clearable_measurement_function);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -623,6 +641,7 @@ namespace niscope_grpc {
       auto channel_list = request->channel_list().c_str();
       auto status = library_->ClearWaveformProcessing(vi, channel_list);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -646,6 +665,7 @@ namespace niscope_grpc {
       session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -668,6 +688,7 @@ namespace niscope_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Commit(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -691,6 +712,7 @@ namespace niscope_grpc {
       ViInt32 acquisition_type = request->acquisition_type();
       auto status = library_->ConfigureAcquisition(vi, acquisition_type);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -716,6 +738,7 @@ namespace niscope_grpc {
       ViReal64 max_input_frequency = request->max_input_frequency();
       auto status = library_->ConfigureChanCharacteristics(vi, channel_list, input_impedance, max_input_frequency);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -799,6 +822,7 @@ namespace niscope_grpc {
       ViBoolean master_enabled = request->master_enabled();
       auto status = library_->ConfigureClock(vi, input_clock_source, output_clock_source, clock_sync_pulse_source, master_enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -824,6 +848,7 @@ namespace niscope_grpc {
       auto coefficients = const_cast<ViReal64*>(request->coefficients().data());
       auto status = library_->ConfigureEqualizationFilterCoefficients(vi, channel_list, number_of_coefficients, coefficients);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -851,6 +876,7 @@ namespace niscope_grpc {
       ViBoolean enforce_realtime = request->enforce_realtime();
       auto status = library_->ConfigureHorizontalTiming(vi, min_sample_rate, min_num_pts, ref_position, num_records, enforce_realtime);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -892,6 +918,7 @@ namespace niscope_grpc {
       ViReal64 delay = request->delay();
       auto status = library_->ConfigureTriggerDigital(vi, trigger_source, slope, holdoff, delay);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -950,6 +977,7 @@ namespace niscope_grpc {
       ViReal64 delay = request->delay();
       auto status = library_->ConfigureTriggerEdge(vi, trigger_source, level, slope, trigger_coupling, holdoff, delay);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1025,6 +1053,7 @@ namespace niscope_grpc {
       ViReal64 delay = request->delay();
       auto status = library_->ConfigureTriggerGlitch(vi, trigger_source, level, width, polarity, glitch_condition, trigger_coupling, holdoff, delay);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1084,6 +1113,7 @@ namespace niscope_grpc {
       ViReal64 delay = request->delay();
       auto status = library_->ConfigureTriggerHysteresis(vi, trigger_source, level, hysteresis, slope, trigger_coupling, holdoff, delay);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1106,6 +1136,7 @@ namespace niscope_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ConfigureTriggerImmediate(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1165,6 +1196,7 @@ namespace niscope_grpc {
       ViReal64 delay = request->delay();
       auto status = library_->ConfigureTriggerRunt(vi, trigger_source, low_threshold, high_threshold, polarity, trigger_coupling, holdoff, delay);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1189,6 +1221,7 @@ namespace niscope_grpc {
       ViReal64 delay = request->delay();
       auto status = library_->ConfigureTriggerSoftware(vi, holdoff, delay);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1280,6 +1313,7 @@ namespace niscope_grpc {
       ViReal64 delay = request->delay();
       auto status = library_->ConfigureTriggerVideo(vi, trigger_source, enable_dc_restore, signal_format, event_parameter, line_number, polarity, trigger_coupling, holdoff, delay);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1356,6 +1390,7 @@ namespace niscope_grpc {
       ViReal64 delay = request->delay();
       auto status = library_->ConfigureTriggerWidth(vi, trigger_source, level, low_threshold, high_threshold, polarity, condition, trigger_coupling, holdoff, delay);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1415,6 +1450,7 @@ namespace niscope_grpc {
       ViReal64 delay = request->delay();
       auto status = library_->ConfigureTriggerWindow(vi, trigger_source, low_level, high_level, window_mode, trigger_coupling, holdoff, delay);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1458,6 +1494,7 @@ namespace niscope_grpc {
       ViBoolean enabled = request->enabled();
       auto status = library_->ConfigureVertical(vi, channel_list, range, offset, coupling, probe_attenuation, enabled);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1480,6 +1517,7 @@ namespace niscope_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Disable(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1505,6 +1543,7 @@ namespace niscope_grpc {
       std::string error_description(642 - 1, '\0');
       auto status = library_->ErrorHandler(vi, error_code, error_source, (ViChar*)error_description.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1531,6 +1570,7 @@ namespace niscope_grpc {
       while (true) {
         auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 size_in_bytes = status;
@@ -1542,6 +1582,7 @@ namespace niscope_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1567,6 +1608,7 @@ namespace niscope_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->ExportAttributeConfigurationFile(vi, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1626,6 +1668,7 @@ namespace niscope_grpc {
 
       auto status = library_->ExportSignal(vi, signal, signal_identifier, output_terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1651,6 +1694,7 @@ namespace niscope_grpc {
       ViBoolean value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_list, attribute_id, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1677,6 +1721,7 @@ namespace niscope_grpc {
       ViInt32 value {};
       auto status = library_->GetAttributeViInt32(vi, channel_list, attribute_id, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1703,6 +1748,7 @@ namespace niscope_grpc {
       ViInt64 value {};
       auto status = library_->GetAttributeViInt64(vi, channel_list, attribute_id, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1729,6 +1775,7 @@ namespace niscope_grpc {
       ViReal64 value {};
       auto status = library_->GetAttributeViReal64(vi, channel_list, attribute_id, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1755,6 +1802,7 @@ namespace niscope_grpc {
       ViSession value {};
       auto status = library_->GetAttributeViSession(vi, channel_list, attribute_id, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1783,6 +1831,7 @@ namespace niscope_grpc {
       while (true) {
         auto status = library_->GetAttributeViString(vi, channel_list, attribute_id, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buf_size = status;
@@ -1797,6 +1846,7 @@ namespace niscope_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1825,6 +1875,7 @@ namespace niscope_grpc {
       while (true) {
         auto status = library_->GetChannelName(vi, index, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -1839,6 +1890,7 @@ namespace niscope_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1867,6 +1919,7 @@ namespace niscope_grpc {
       while (true) {
         auto status = library_->GetChannelNameFromString(vi, index, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -1881,6 +1934,7 @@ namespace niscope_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1910,6 +1964,7 @@ namespace niscope_grpc {
       ViReal64* coefficients = response->mutable_coefficients()->mutable_data();
       auto status = library_->GetEqualizationFilterCoefficients(vi, channel, number_of_coefficients, coefficients);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1934,6 +1989,7 @@ namespace niscope_grpc {
       while (true) {
         auto status = library_->GetError(vi, nullptr, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -1949,6 +2005,7 @@ namespace niscope_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1978,6 +2035,7 @@ namespace niscope_grpc {
       while (true) {
         auto status = library_->GetErrorMessage(vi, error_code, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -1992,6 +2050,7 @@ namespace niscope_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2026,6 +2085,7 @@ namespace niscope_grpc {
       ViInt32 number_of_frequencies {};
       auto status = library_->GetFrequencyResponse(vi, channel, buffer_size, frequencies, amplitudes, phases, &number_of_frequencies);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2052,6 +2112,7 @@ namespace niscope_grpc {
       while (true) {
         auto status = library_->GetNormalizationCoefficients(vi, channel_list, 0, nullptr, &number_of_coefficient_sets);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         std::vector<niScope_coefficientInfo> coefficient_info(number_of_coefficient_sets, niScope_coefficientInfo());
@@ -2062,6 +2123,7 @@ namespace niscope_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2097,6 +2159,7 @@ namespace niscope_grpc {
       while (true) {
         auto status = library_->GetScalingCoefficients(vi, channel_list, 0, nullptr, &number_of_coefficient_sets);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         std::vector<niScope_coefficientInfo> coefficient_info(number_of_coefficient_sets, niScope_coefficientInfo());
@@ -2107,6 +2170,7 @@ namespace niscope_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -2141,6 +2205,7 @@ namespace niscope_grpc {
       ViUInt32 writer_handle {};
       auto status = library_->GetStreamEndpointHandle(vi, stream_name, &writer_handle);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2166,6 +2231,7 @@ namespace niscope_grpc {
       ViInt8* configuration = (ViInt8*)request->configuration().c_str();
       auto status = library_->ImportAttributeConfigurationBuffer(vi, size_in_bytes, configuration);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2189,6 +2255,7 @@ namespace niscope_grpc {
       auto file_path = request->file_path().c_str();
       auto status = library_->ImportAttributeConfigurationFile(vi, file_path);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2221,6 +2288,7 @@ namespace niscope_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -2258,6 +2326,7 @@ namespace niscope_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -2284,6 +2353,7 @@ namespace niscope_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->InitiateAcquisition(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2306,6 +2376,7 @@ namespace niscope_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ProbeCompensationSignalStart(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2328,6 +2399,7 @@ namespace niscope_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ProbeCompensationSignalStop(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2350,6 +2422,7 @@ namespace niscope_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2372,6 +2445,7 @@ namespace niscope_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ResetDevice(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2396,6 +2470,7 @@ namespace niscope_grpc {
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)driver_revision.data(), (ViChar*)firmware_revision.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2423,6 +2498,7 @@ namespace niscope_grpc {
       ViInt32 sample_mode {};
       auto status = library_->SampleMode(vi, &sample_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2447,6 +2523,7 @@ namespace niscope_grpc {
       ViReal64 sample_rate {};
       auto status = library_->SampleRate(vi, &sample_rate);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2472,6 +2549,7 @@ namespace niscope_grpc {
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2513,6 +2591,7 @@ namespace niscope_grpc {
 
       auto status = library_->SendSoftwareTriggerEdge(vi, which_trigger);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2538,6 +2617,7 @@ namespace niscope_grpc {
       ViBoolean value = request->value();
       auto status = library_->SetAttributeViBoolean(vi, channel_list, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2578,6 +2658,7 @@ namespace niscope_grpc {
 
       auto status = library_->SetAttributeViInt32(vi, channel_list, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2618,6 +2699,7 @@ namespace niscope_grpc {
 
       auto status = library_->SetAttributeViInt64(vi, channel_list, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2666,6 +2748,7 @@ namespace niscope_grpc {
 
       auto status = library_->SetAttributeViReal64(vi, channel_list, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2692,6 +2775,7 @@ namespace niscope_grpc {
       ViSession value = session_repository_->access_session(value_grpc_session.id(), value_grpc_session.name());
       auto status = library_->SetAttributeViSession(vi, channel_list, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -2736,6 +2820,7 @@ namespace niscope_grpc {
 
       auto status = library_->SetAttributeViString(vi, channel_list, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -57,6 +57,7 @@ namespace niswitch_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->AbortScan(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -82,6 +83,7 @@ namespace niswitch_grpc {
       ViInt32 path_capability {};
       auto status = library_->CanConnect(vi, channel1, channel2, &path_capability);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -109,6 +111,7 @@ namespace niswitch_grpc {
       ViBoolean attribute_value = request->attribute_value();
       auto status = library_->CheckAttributeViBoolean(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -149,6 +152,7 @@ namespace niswitch_grpc {
 
       auto status = library_->CheckAttributeViInt32(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -174,6 +178,7 @@ namespace niswitch_grpc {
       ViReal64 attribute_value = request->attribute_value_raw();
       auto status = library_->CheckAttributeViReal64(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -199,6 +204,7 @@ namespace niswitch_grpc {
       ViString attribute_value = (ViString)request->attribute_value_raw().c_str();
       auto status = library_->CheckAttributeViString(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -225,6 +231,7 @@ namespace niswitch_grpc {
       ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.id(), attribute_value_grpc_session.name());
       auto status = library_->CheckAttributeViSession(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -247,6 +254,7 @@ namespace niswitch_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ClearError(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -269,6 +277,7 @@ namespace niswitch_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ClearInterchangeWarnings(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -292,6 +301,7 @@ namespace niswitch_grpc {
       session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -314,6 +324,7 @@ namespace niswitch_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Commit(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -353,6 +364,7 @@ namespace niswitch_grpc {
 
       auto status = library_->ConfigureScanList(vi, scanlist, scan_mode);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -408,6 +420,7 @@ namespace niswitch_grpc {
 
       auto status = library_->ConfigureScanTrigger(vi, scan_delay, trigger_input, scan_advanced_output);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -432,6 +445,7 @@ namespace niswitch_grpc {
       auto channel2 = request->channel2().c_str();
       auto status = library_->Connect(vi, channel1, channel2);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -455,6 +469,7 @@ namespace niswitch_grpc {
       auto connection_list = request->connection_list().c_str();
       auto status = library_->ConnectMultiple(vi, connection_list);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -477,6 +492,7 @@ namespace niswitch_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Disable(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -501,6 +517,7 @@ namespace niswitch_grpc {
       auto channel2 = request->channel2().c_str();
       auto status = library_->Disconnect(vi, channel1, channel2);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -523,6 +540,7 @@ namespace niswitch_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->DisconnectAll(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -546,6 +564,7 @@ namespace niswitch_grpc {
       auto disconnection_list = request->disconnection_list().c_str();
       auto status = library_->DisconnectMultiple(vi, disconnection_list);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -570,6 +589,7 @@ namespace niswitch_grpc {
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -596,6 +616,7 @@ namespace niswitch_grpc {
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorQuery(vi, &error_code, (ViChar*)error_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -624,6 +645,7 @@ namespace niswitch_grpc {
       ViBoolean attribute_value {};
       auto status = library_->GetAttributeViBoolean(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -650,6 +672,7 @@ namespace niswitch_grpc {
       ViInt32 attribute_value {};
       auto status = library_->GetAttributeViInt32(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -676,6 +699,7 @@ namespace niswitch_grpc {
       ViReal64 attribute_value {};
       auto status = library_->GetAttributeViReal64(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -703,6 +727,7 @@ namespace niswitch_grpc {
       while (true) {
         auto status = library_->GetAttributeViString(vi, channel_name, attribute_id, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 array_size = status;
@@ -717,6 +742,7 @@ namespace niswitch_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -745,6 +771,7 @@ namespace niswitch_grpc {
       ViSession attribute_value {};
       auto status = library_->GetAttributeViSession(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -772,6 +799,7 @@ namespace niswitch_grpc {
       while (true) {
         auto status = library_->GetChannelName(vi, index, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -786,6 +814,7 @@ namespace niswitch_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -813,6 +842,7 @@ namespace niswitch_grpc {
       while (true) {
         auto status = library_->GetError(vi, nullptr, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -828,6 +858,7 @@ namespace niswitch_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -856,6 +887,7 @@ namespace niswitch_grpc {
       while (true) {
         auto status = library_->GetNextCoercionRecord(vi, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -870,6 +902,7 @@ namespace niswitch_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -897,6 +930,7 @@ namespace niswitch_grpc {
       while (true) {
         auto status = library_->GetNextInterchangeWarning(vi, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -911,6 +945,7 @@ namespace niswitch_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -940,6 +975,7 @@ namespace niswitch_grpc {
       while (true) {
         auto status = library_->GetPath(vi, channel1, channel2, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -954,6 +990,7 @@ namespace niswitch_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -981,6 +1018,7 @@ namespace niswitch_grpc {
       ViInt32 relay_count {};
       auto status = library_->GetRelayCount(vi, relay_name, &relay_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1007,6 +1045,7 @@ namespace niswitch_grpc {
       while (true) {
         auto status = library_->GetRelayName(vi, index, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 relay_name_buffer_size = status;
@@ -1021,6 +1060,7 @@ namespace niswitch_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1048,6 +1088,7 @@ namespace niswitch_grpc {
       ViInt32 relay_position {};
       auto status = library_->GetRelayPosition(vi, relay_name, &relay_position);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1082,6 +1123,7 @@ namespace niswitch_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -1119,6 +1161,7 @@ namespace niswitch_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -1156,6 +1199,7 @@ namespace niswitch_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -1182,6 +1226,7 @@ namespace niswitch_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->InitiateScan(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1204,6 +1249,7 @@ namespace niswitch_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->InvalidateAllAttributes(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1227,6 +1273,7 @@ namespace niswitch_grpc {
       ViBoolean is_debounced {};
       auto status = library_->IsDebounced(vi, &is_debounced);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1251,6 +1298,7 @@ namespace niswitch_grpc {
       ViBoolean is_scanning {};
       auto status = library_->IsScanning(vi, &is_scanning);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1291,6 +1339,7 @@ namespace niswitch_grpc {
 
       auto status = library_->RelayControl(vi, relay_name, relay_action);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1313,6 +1362,7 @@ namespace niswitch_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1335,6 +1385,7 @@ namespace niswitch_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ResetInterchangeCheck(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1357,6 +1408,7 @@ namespace niswitch_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ResetWithDefaults(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1381,6 +1433,7 @@ namespace niswitch_grpc {
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1440,6 +1493,7 @@ namespace niswitch_grpc {
       ViBoolean invert = request->invert();
       auto status = library_->RouteScanAdvancedOutput(vi, scan_advanced_output_connector, scan_advanced_output_bus_line, invert);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1495,6 +1549,7 @@ namespace niswitch_grpc {
       ViBoolean invert = request->invert();
       auto status = library_->RouteTriggerInput(vi, trigger_input_connector, trigger_input_bus_line, invert);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1534,6 +1589,7 @@ namespace niswitch_grpc {
 
       auto status = library_->Scan(vi, scanlist, initiation);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1558,6 +1614,7 @@ namespace niswitch_grpc {
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1583,6 +1640,7 @@ namespace niswitch_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->SendSoftwareTrigger(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1608,6 +1666,7 @@ namespace niswitch_grpc {
       ViBoolean attribute_value = request->attribute_value();
       auto status = library_->SetAttributeViBoolean(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1648,6 +1707,7 @@ namespace niswitch_grpc {
 
       auto status = library_->SetAttributeViInt32(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1673,6 +1733,7 @@ namespace niswitch_grpc {
       ViReal64 attribute_value = request->attribute_value_raw();
       auto status = library_->SetAttributeViReal64(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1698,6 +1759,7 @@ namespace niswitch_grpc {
       ViString attribute_value = (ViString)request->attribute_value_raw().c_str();
       auto status = library_->SetAttributeViString(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1724,6 +1786,7 @@ namespace niswitch_grpc {
       ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.id(), attribute_value_grpc_session.name());
       auto status = library_->SetAttributeViSession(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1747,6 +1810,7 @@ namespace niswitch_grpc {
       ViBoolean continuous_scan = request->continuous_scan();
       auto status = library_->SetContinuousScan(vi, continuous_scan);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1770,6 +1834,7 @@ namespace niswitch_grpc {
       auto path_list = request->path_list().c_str();
       auto status = library_->SetPath(vi, path_list);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1793,6 +1858,7 @@ namespace niswitch_grpc {
       ViInt32 maximum_time_ms = request->maximum_time_ms();
       auto status = library_->WaitForDebounce(vi, maximum_time_ms);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1816,6 +1882,7 @@ namespace niswitch_grpc {
       ViInt32 maximum_time_ms = request->maximum_time_ms();
       auto status = library_->WaitForScanComplete(vi, maximum_time_ms);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -66,6 +66,7 @@ namespace nisync_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -93,6 +94,7 @@ namespace nisync_grpc {
       session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -117,6 +119,7 @@ namespace nisync_grpc {
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -141,6 +144,7 @@ namespace nisync_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -163,6 +167,7 @@ namespace nisync_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->PersistConfig(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -187,6 +192,7 @@ namespace nisync_grpc {
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -214,6 +220,7 @@ namespace nisync_grpc {
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)driver_revision.data(), (ViChar*)firmware_revision.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -245,6 +252,7 @@ namespace nisync_grpc {
       ViInt32 update_edge = request->update_edge();
       auto status = library_->ConnectTrigTerminals(vi, src_terminal, dest_terminal, sync_clock, invert, update_edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -269,6 +277,7 @@ namespace nisync_grpc {
       auto dest_terminal = request->dest_terminal().c_str();
       auto status = library_->DisconnectTrigTerminals(vi, src_terminal, dest_terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -297,6 +306,7 @@ namespace nisync_grpc {
       ViReal64 delay = request->delay();
       auto status = library_->ConnectSWTrigToTerminal(vi, src_terminal, dest_terminal, sync_clock, invert, update_edge, delay);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -321,6 +331,7 @@ namespace nisync_grpc {
       auto dest_terminal = request->dest_terminal().c_str();
       auto status = library_->DisconnectSWTrigFromTerminal(vi, src_terminal, dest_terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -344,6 +355,7 @@ namespace nisync_grpc {
       auto src_terminal = request->src_terminal().c_str();
       auto status = library_->SendSoftwareTrigger(vi, src_terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -368,6 +380,7 @@ namespace nisync_grpc {
       auto dest_terminal = request->dest_terminal().c_str();
       auto status = library_->ConnectClkTerminals(vi, src_terminal, dest_terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -392,6 +405,7 @@ namespace nisync_grpc {
       auto dest_terminal = request->dest_terminal().c_str();
       auto status = library_->DisconnectClkTerminals(vi, src_terminal, dest_terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -419,6 +433,7 @@ namespace nisync_grpc {
       ViReal64 error {};
       auto status = library_->MeasureFrequency(vi, src_terminal, duration, &actual_duration, &frequency, &error);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -450,6 +465,7 @@ namespace nisync_grpc {
       ViReal64 frequency_error {};
       auto status = library_->MeasureFrequencyEx(vi, src_terminal, duration, decimation_count, &actual_duration, &frequency, &frequency_error);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -475,6 +491,7 @@ namespace nisync_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Start1588(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -497,6 +514,7 @@ namespace nisync_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Stop1588(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -519,6 +537,7 @@ namespace nisync_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Start8021AS(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -541,6 +560,7 @@ namespace nisync_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->Stop8021AS(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -567,6 +587,7 @@ namespace nisync_grpc {
       ViUInt16 time_fractional_nanoseconds = request->time_fractional_nanoseconds();
       auto status = library_->SetTime(vi, time_source, time_seconds, time_nanoseconds, time_fractional_nanoseconds);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -592,6 +613,7 @@ namespace nisync_grpc {
       ViUInt16 time_fractional_nanoseconds {};
       auto status = library_->GetTime(vi, &time_seconds, &time_nanoseconds, &time_fractional_nanoseconds);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -617,6 +639,7 @@ namespace nisync_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->ResetFrequency(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -644,6 +667,7 @@ namespace nisync_grpc {
       ViUInt16 time_fractional_nanoseconds = request->time_fractional_nanoseconds();
       auto status = library_->CreateFutureTimeEvent(vi, terminal, output_level, time_seconds, time_nanoseconds, time_fractional_nanoseconds);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -667,6 +691,7 @@ namespace nisync_grpc {
       auto terminal = request->terminal().c_str();
       auto status = library_->ClearFutureTimeEvents(vi, terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -691,6 +716,7 @@ namespace nisync_grpc {
       ViInt32 active_edge = request->active_edge();
       auto status = library_->EnableTimeStampTrigger(vi, terminal, active_edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -716,6 +742,7 @@ namespace nisync_grpc {
       ViUInt32 decimation_count = request->decimation_count();
       auto status = library_->EnableTimeStampTriggerWithDecimation(vi, terminal, active_edge, decimation_count);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -744,6 +771,7 @@ namespace nisync_grpc {
       ViInt32 detected_edge {};
       auto status = library_->ReadTriggerTimeStamp(vi, terminal, timeout, &time_seconds, &time_nanoseconds, &time_fractional_nanoseconds, &detected_edge);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -771,6 +799,7 @@ namespace nisync_grpc {
       auto terminal = request->terminal().c_str();
       auto status = library_->DisableTimeStampTrigger(vi, terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -802,6 +831,7 @@ namespace nisync_grpc {
       ViUInt16 stop_time_fractional_nanoseconds = request->stop_time_fractional_nanoseconds();
       auto status = library_->CreateClock(vi, terminal, high_ticks, low_ticks, start_time_seconds, start_time_nanoseconds, start_time_fractional_nanoseconds, stop_time_seconds, stop_time_nanoseconds, stop_time_fractional_nanoseconds);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -825,6 +855,7 @@ namespace nisync_grpc {
       auto terminal = request->terminal().c_str();
       auto status = library_->ClearClock(vi, terminal);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -847,6 +878,7 @@ namespace nisync_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->SetTimeReferenceFreeRunning(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -869,6 +901,7 @@ namespace nisync_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->SetTimeReferenceGPS(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -893,6 +926,7 @@ namespace nisync_grpc {
       auto terminal_name = request->terminal_name().c_str();
       auto status = library_->SetTimeReferenceIRIG(vi, irig_type, terminal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -920,6 +954,7 @@ namespace nisync_grpc {
       ViUInt16 initial_time_fractional_nanoseconds = request->initial_time_fractional_nanoseconds();
       auto status = library_->SetTimeReferencePPS(vi, terminal_name, use_manual_time, initial_time_seconds, initial_time_nanoseconds, initial_time_fractional_nanoseconds);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -942,6 +977,7 @@ namespace nisync_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->SetTimeReference1588OrdinaryClock(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -964,6 +1000,7 @@ namespace nisync_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->SetTimeReference8021AS(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -986,6 +1023,7 @@ namespace nisync_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->EnableGPSTimestamping(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1010,6 +1048,7 @@ namespace nisync_grpc {
       auto terminal_name = request->terminal_name().c_str();
       auto status = library_->EnableIRIGTimestamping(vi, irig_type, terminal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1038,6 +1077,7 @@ namespace nisync_grpc {
       ViUInt16 gps_fractional_nanoseconds {};
       auto status = library_->ReadLastGPSTimestamp(vi, &timestamp_seconds, &timestamp_nanoseconds, &timestamp_fractional_nanoseconds, &gps_seconds, &gps_nanoseconds, &gps_fractional_nanoseconds);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1073,6 +1113,7 @@ namespace nisync_grpc {
       ViUInt16 irigb_fractional_nanoseconds {};
       auto status = library_->ReadLastIRIGTimestamp(vi, terminal, &timestamp_seconds, &timestamp_nanoseconds, &timestamp_fractional_nanoseconds, &irigb_seconds, &irigb_nanoseconds, &irigb_fractional_nanoseconds);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1101,6 +1142,7 @@ namespace nisync_grpc {
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       auto status = library_->DisableGPSTimestamping(vi);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1124,6 +1166,7 @@ namespace nisync_grpc {
       auto terminal_name = request->terminal_name().c_str();
       auto status = library_->DisableIRIGTimestamping(vi, terminal_name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1149,6 +1192,7 @@ namespace nisync_grpc {
       ViReal64 up_velocity {};
       auto status = library_->GetVelocity(vi, &east_velocity, &north_velocity, &up_velocity);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1177,6 +1221,7 @@ namespace nisync_grpc {
       ViReal64 altitude {};
       auto status = library_->GetLocation(vi, &latitude, &longitude, &altitude);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1204,6 +1249,7 @@ namespace nisync_grpc {
       while (true) {
         auto status = library_->GetTimeReferenceNames(vi, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViUInt32 buffer_size = status;
@@ -1218,6 +1264,7 @@ namespace nisync_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1246,6 +1293,7 @@ namespace nisync_grpc {
       ViInt32 value {};
       auto status = library_->GetAttributeViInt32(vi, active_item, attribute, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1272,6 +1320,7 @@ namespace nisync_grpc {
       ViReal64 value {};
       auto status = library_->GetAttributeViReal64(vi, active_item, attribute, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1298,6 +1347,7 @@ namespace nisync_grpc {
       ViBoolean value {};
       auto status = library_->GetAttributeViBoolean(vi, active_item, attribute, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1325,6 +1375,7 @@ namespace nisync_grpc {
       while (true) {
         auto status = library_->GetAttributeViString(vi, active_item, attribute, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         ViInt32 buffer_size = status;
@@ -1339,6 +1390,7 @@ namespace nisync_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, vi);
         }
         response->set_status(status);
@@ -1367,6 +1419,7 @@ namespace nisync_grpc {
       ViInt32 value = request->value_raw();
       auto status = library_->SetAttributeViInt32(vi, active_item, attribute, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1392,6 +1445,7 @@ namespace nisync_grpc {
       ViReal64 value = request->value_raw();
       auto status = library_->SetAttributeViReal64(vi, active_item, attribute, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1417,6 +1471,7 @@ namespace nisync_grpc {
       ViBoolean value = request->value();
       auto status = library_->SetAttributeViBoolean(vi, active_item, attribute, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1442,6 +1497,7 @@ namespace nisync_grpc {
       auto value = request->value_raw().c_str();
       auto status = library_->SetAttributeViString(vi, active_item, attribute, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1469,6 +1525,7 @@ namespace nisync_grpc {
       ViInt32 minute {};
       auto status = library_->GetExtCalLastDateAndTime(vi, &year, &month, &day, &hour, &minute);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1497,6 +1554,7 @@ namespace nisync_grpc {
       ViReal64 temp {};
       auto status = library_->GetExtCalLastTemp(vi, &temp);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1521,6 +1579,7 @@ namespace nisync_grpc {
       ViInt32 months {};
       auto status = library_->GetExtCalRecommendedInterval(vi, &months);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1546,6 +1605,7 @@ namespace nisync_grpc {
       auto new_password = request->new_password().c_str();
       auto status = library_->ChangeExtCalPassword(vi, old_password, new_password);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1569,6 +1629,7 @@ namespace nisync_grpc {
       ViReal64 temperature {};
       auto status = library_->ReadCurrentTemperature(vi, &temperature);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1593,6 +1654,7 @@ namespace nisync_grpc {
       ViReal64 voltage {};
       auto status = library_->CalGetOscillatorVoltage(vi, &voltage);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1617,6 +1679,7 @@ namespace nisync_grpc {
       ViReal64 voltage {};
       auto status = library_->CalGetClk10PhaseVoltage(vi, &voltage);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1641,6 +1704,7 @@ namespace nisync_grpc {
       ViReal64 voltage {};
       auto status = library_->CalGetDDSStartPulsePhaseVoltage(vi, &voltage);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1665,6 +1729,7 @@ namespace nisync_grpc {
       ViReal64 phase {};
       auto status = library_->CalGetDDSInitialPhase(vi, &phase);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1697,6 +1762,7 @@ namespace nisync_grpc {
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -1724,6 +1790,7 @@ namespace nisync_grpc {
       ViInt32 action = request->action();
       auto status = library_->CloseExtCal(vi, action);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1748,6 +1815,7 @@ namespace nisync_grpc {
       ViReal64 old_voltage {};
       auto status = library_->CalAdjustOscillatorVoltage(vi, measured_voltage, &old_voltage);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1773,6 +1841,7 @@ namespace nisync_grpc {
       ViReal64 old_voltage {};
       auto status = library_->CalAdjustClk10PhaseVoltage(vi, measured_voltage, &old_voltage);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1798,6 +1867,7 @@ namespace nisync_grpc {
       ViReal64 old_voltage {};
       auto status = library_->CalAdjustDDSStartPulsePhaseVoltage(vi, measured_voltage, &old_voltage);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);
@@ -1823,6 +1893,7 @@ namespace nisync_grpc {
       ViReal64 old_phase {};
       auto status = library_->CalAdjustDDSInitialPhase(vi, measured_phase, &old_phase);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, vi);
       }
       response->set_status(status);

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -62,6 +62,7 @@ namespace nitclk_grpc {
         [&](auto session) { return session_repository_->access_session(session.id(), session.name()); }); 
       auto status = library_->ConfigureForHomogeneousTriggers(session_count, sessions.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -91,6 +92,7 @@ namespace nitclk_grpc {
       ViReal64 min_time = request->min_time();
       auto status = library_->FinishSyncPulseSenderSynchronize(session_count, sessions.data(), min_time);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -116,6 +118,7 @@ namespace nitclk_grpc {
       ViReal64 value {};
       auto status = library_->GetAttributeViReal64(session, channel_name, attribute_id, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, session);
       }
       response->set_status(status);
@@ -142,6 +145,7 @@ namespace nitclk_grpc {
       ViSession value {};
       auto status = library_->GetAttributeViSession(session, channel_name, attribute_id, &value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, session);
       }
       response->set_status(status);
@@ -170,6 +174,7 @@ namespace nitclk_grpc {
       while (true) {
         auto status = library_->GetAttributeViString(session, channel_name, attribute_id, 0, nullptr);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, session);
         }
         ViInt32 buf_size = status;
@@ -184,6 +189,7 @@ namespace nitclk_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, session);
         }
         response->set_status(status);
@@ -209,6 +215,7 @@ namespace nitclk_grpc {
       while (true) {
         auto status = library_->GetExtendedErrorInfo(nullptr, 0);
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, 0);
         }
         ViUInt32 error_string_size = status;
@@ -223,6 +230,7 @@ namespace nitclk_grpc {
           continue;
         }
         if (!status_ok(status)) {
+          context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
           return ConvertApiErrorStatusForViSession(status, 0);
         }
         response->set_status(status);
@@ -254,6 +262,7 @@ namespace nitclk_grpc {
         [&](auto session) { return session_repository_->access_session(session.id(), session.name()); }); 
       auto status = library_->Initiate(session_count, sessions.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -283,6 +292,7 @@ namespace nitclk_grpc {
       ViBoolean done {};
       auto status = library_->IsDone(session_count, sessions.data(), &done);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -309,6 +319,7 @@ namespace nitclk_grpc {
       ViReal64 value = request->value_raw();
       auto status = library_->SetAttributeViReal64(session, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, session);
       }
       response->set_status(status);
@@ -335,6 +346,7 @@ namespace nitclk_grpc {
       ViSession value = session_repository_->access_session(value_grpc_session.id(), value_grpc_session.name());
       auto status = library_->SetAttributeViSession(session, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, session);
       }
       response->set_status(status);
@@ -360,6 +372,7 @@ namespace nitclk_grpc {
       auto value = request->value_raw().c_str();
       auto status = library_->SetAttributeViString(session, channel_name, attribute_id, value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, session);
       }
       response->set_status(status);
@@ -389,6 +402,7 @@ namespace nitclk_grpc {
       ViReal64 min_time = request->min_time();
       auto status = library_->SetupForSyncPulseSenderSynchronize(session_count, sessions.data(), min_time);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -418,6 +432,7 @@ namespace nitclk_grpc {
       ViReal64 min_tclk_period = request->min_tclk_period();
       auto status = library_->Synchronize(session_count, sessions.data(), min_tclk_period);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -447,6 +462,7 @@ namespace nitclk_grpc {
       ViReal64 min_time = request->min_time();
       auto status = library_->SynchronizeToSyncPulseSender(session_count, sessions.data(), min_time);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);
@@ -476,6 +492,7 @@ namespace nitclk_grpc {
       ViReal64 timeout = request->timeout();
       auto status = library_->WaitUntilDone(session_count, sessions.data(), timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForViSession(status, 0);
       }
       response->set_status(status);

--- a/generated/nixnet/nixnet_service.cpp
+++ b/generated/nixnet/nixnet_service.cpp
@@ -72,6 +72,7 @@ namespace nixnet_grpc {
 
       auto status = library_->Blink(interface_ref, modifier);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, interface_ref);
       }
       response->set_status(status);
@@ -95,6 +96,7 @@ namespace nixnet_grpc {
       session_repository_->remove_session(session_grpc_session.id(), session_grpc_session.name());
       auto status = library_->Clear(session);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -157,6 +159,7 @@ namespace nixnet_grpc {
 
       auto status = library_->ConnectTerminals(session, source, destination);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -202,6 +205,7 @@ namespace nixnet_grpc {
       u32 number_of_bytes_returned {};
       auto status = library_->ConvertByteArrayToFramesSinglePoint(session, value_buffer, size_of_value_buffer, buffer.data(), size_of_buffer, &number_of_bytes_returned);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -229,6 +233,7 @@ namespace nixnet_grpc {
       std::string value_buffer(size_of_value_buffer, '\0');
       auto status = library_->ConvertFramesToByteArraySinglePoint(session, frame_buffer, number_of_bytes_for_frames, (u8*)value_buffer.data(), size_of_value_buffer);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -261,6 +266,7 @@ namespace nixnet_grpc {
       nxTimestamp100ns_t* timestamp_buffer = reinterpret_cast<nxTimestamp100ns_t*>(response->mutable_timestamp_buffer()->mutable_data());
       auto status = library_->ConvertFramesToSignalsSinglePoint(session, frame_buffer, number_of_bytes_for_frames, value_buffer, size_of_value_buffer, timestamp_buffer, size_of_timestamp_buffer);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -306,6 +312,7 @@ namespace nixnet_grpc {
       u32 number_of_bytes_returned {};
       auto status = library_->ConvertSignalsToFramesSinglePoint(session, value_buffer, size_of_value_buffer, buffer.data(), size_of_buffer, &number_of_bytes_returned);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -329,6 +336,7 @@ namespace nixnet_grpc {
       nxTimestamp1ns_t to_timestamp_1ns {};
       auto status = library_->ConvertTimestamp100nsTo1ns(from_timestamp_100ns, &to_timestamp_1ns);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, 0);
       }
       response->set_status(status);
@@ -352,6 +360,7 @@ namespace nixnet_grpc {
       nxTimestamp100ns_t to_timestamp_100ns {};
       auto status = library_->ConvertTimestamp1nsTo100ns(from_timestamp_1ns, &to_timestamp_100ns);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, 0);
       }
       response->set_status(status);
@@ -402,6 +411,7 @@ namespace nixnet_grpc {
       auto cleanup_lambda = [&] (nxSessionRef_t id) { library_->Clear(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, 0);
       }
       response->set_status(status);
@@ -460,6 +470,7 @@ namespace nixnet_grpc {
       auto cleanup_lambda = [&] (nxSessionRef_t id) { library_->Clear(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, 0);
       }
       response->set_status(status);
@@ -487,6 +498,7 @@ namespace nixnet_grpc {
       u32 default_baud_rate = request->default_baud_rate();
       auto status = library_->DbAddAlias(database_alias, database_filepath, default_baud_rate);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, 0);
       }
       response->set_status(status);
@@ -510,6 +522,7 @@ namespace nixnet_grpc {
       u64 default_baud_rate = request->default_baud_rate();
       auto status = library_->DbAddAlias64(database_alias, database_filepath, default_baud_rate);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, 0);
       }
       response->set_status(status);
@@ -534,6 +547,7 @@ namespace nixnet_grpc {
       nx_database_ref_t_resource_repository_->remove_session(database_grpc_session.id(), database_grpc_session.name());
       auto status = library_->DbCloseDatabase(database, close_all_refs);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxDatabaseRef_t(status, database);
       }
       response->set_status(status);
@@ -593,6 +607,7 @@ namespace nixnet_grpc {
       nx_database_ref_t_resource_repository_->remove_session(db_object_grpc_session.id(), db_object_grpc_session.name());
       auto status = library_->DbDeleteObject(db_object);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxDatabaseRef_t(status, db_object);
       }
       response->set_status(status);
@@ -617,6 +632,7 @@ namespace nixnet_grpc {
       u32 percent_complete {};
       auto status = library_->DbDeploy(ip_address, database_alias, wait_for_complete, &percent_complete);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, 0);
       }
       response->set_status(status);
@@ -694,6 +710,7 @@ namespace nixnet_grpc {
       u32 attribute_text_size {};
       auto status = library_->DbGetDBCAttributeSize(db_object, mode, attribute_name, &attribute_text_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxDatabaseRef_t(status, db_object);
       }
       response->set_status(status);
@@ -718,6 +735,7 @@ namespace nixnet_grpc {
       u32 sizeof_filepath_buffer {};
       auto status = library_->DbGetDatabaseListSizes(ip_address, &sizeof_alias_buffer, &sizeof_filepath_buffer);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, 0);
       }
       response->set_status(status);
@@ -759,6 +777,7 @@ namespace nixnet_grpc {
       u32 property_size {};
       auto status = library_->DbGetPropertySize(db_object, property_id, &property_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxDatabaseRef_t(status, db_object);
       }
       response->set_status(status);
@@ -803,6 +822,7 @@ namespace nixnet_grpc {
       u32 percent_complete {};
       auto status = library_->DbMerge(target_cluster, source_obj, copy_mode, prefix, wait_for_complete, &percent_complete);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxDatabaseRef_t(status, target_cluster);
       }
       response->set_status(status);
@@ -834,6 +854,7 @@ namespace nixnet_grpc {
       auto cleanup_lambda = [&] (nxDatabaseRef_t id) { library_->DbCloseDatabase(id, false); };
       int status = nx_database_ref_t_resource_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, 0);
       }
       response->set_status(status);
@@ -859,6 +880,7 @@ namespace nixnet_grpc {
       auto database_alias = request->database_alias().c_str();
       auto status = library_->DbRemoveAlias(database_alias);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, 0);
       }
       response->set_status(status);
@@ -882,6 +904,7 @@ namespace nixnet_grpc {
       auto db_filepath = request->db_filepath().c_str();
       auto status = library_->DbSaveDatabase(database, db_filepath);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxDatabaseRef_t(status, database);
       }
       response->set_status(status);
@@ -904,6 +927,7 @@ namespace nixnet_grpc {
       auto database_alias = request->database_alias().c_str();
       auto status = library_->DbUndeploy(ip_address, database_alias);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, 0);
       }
       response->set_status(status);
@@ -966,6 +990,7 @@ namespace nixnet_grpc {
 
       auto status = library_->DisconnectTerminals(session, source, destination);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -988,6 +1013,7 @@ namespace nixnet_grpc {
       nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
       auto status = library_->Flush(session);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -1027,6 +1053,7 @@ namespace nixnet_grpc {
 
       auto status = library_->FutureTimeTrigger(session, when, timescale);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -1066,6 +1093,7 @@ namespace nixnet_grpc {
       u32 property_size {};
       auto status = library_->GetPropertySize(session, property_id, &property_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -1107,6 +1135,7 @@ namespace nixnet_grpc {
       u32 property_size {};
       auto status = library_->GetSubPropertySize(session, active_index, property_id, &property_size);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -1167,6 +1196,7 @@ namespace nixnet_grpc {
       u32 number_of_bytes_returned {};
       auto status = library_->ReadFrame(session, buffer.data(), size_of_buffer, timeout, &number_of_bytes_returned);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -1197,6 +1227,7 @@ namespace nixnet_grpc {
       nxTimestamp100ns_t* timestamp_buffer = reinterpret_cast<nxTimestamp100ns_t*>(response->mutable_timestamp_buffer()->mutable_data());
       auto status = library_->ReadSignalSinglePoint(session, value_buffer, size_of_value_buffer, timestamp_buffer, size_of_timestamp_buffer);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -1242,6 +1273,7 @@ namespace nixnet_grpc {
       u32 number_of_values_returned {};
       auto status = library_->ReadSignalWaveform(session, timeout, &start_time, &delta_time, value_buffer.data(), size_of_value_buffer, &number_of_values_returned);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -1279,6 +1311,7 @@ namespace nixnet_grpc {
       u32* num_pairs_buffer = response->mutable_num_pairs_buffer()->mutable_data();
       auto status = library_->ReadSignalXY(session, &time_limit, value_buffer, size_of_value_buffer, timestamp_buffer, size_of_timestamp_buffer, num_pairs_buffer, size_of_num_pairs_buffer);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -1319,6 +1352,7 @@ namespace nixnet_grpc {
       _nxTimeLocalNetwork_t state_value {};
       auto status = library_->ReadStateTimeTrigger(session, timeout, state_size, &state_value);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -1358,6 +1392,7 @@ namespace nixnet_grpc {
 
       auto status = library_->Start(session, scope);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -1382,6 +1417,7 @@ namespace nixnet_grpc {
       library_->StatusToString(status_id, sizeof_string, (char*)status_description.data());
       auto status = 0;
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, 0);
       }
       response->set_status(status);
@@ -1422,6 +1458,7 @@ namespace nixnet_grpc {
 
       auto status = library_->Stop(session, scope);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -1445,6 +1482,7 @@ namespace nixnet_grpc {
       session_repository_->remove_session(system_grpc_session.id(), system_grpc_session.name());
       auto status = library_->SystemClose(system);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, system);
       }
       response->set_status(status);
@@ -1474,6 +1512,7 @@ namespace nixnet_grpc {
       auto cleanup_lambda = [&] (nxSessionRef_t id) { library_->SystemClose(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, 0);
       }
       response->set_status(status);
@@ -1519,6 +1558,7 @@ namespace nixnet_grpc {
       u32 param_out {};
       auto status = library_->Wait(session, condition, param_in, timeout, &param_out);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -1560,6 +1600,7 @@ namespace nixnet_grpc {
 
       auto status = library_->WriteFrame(session, buffer, number_of_bytes_for_frames, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -1584,6 +1625,7 @@ namespace nixnet_grpc {
       u32 size_of_value_buffer = static_cast<u32>(request->value_buffer().size() * sizeof(f64));
       auto status = library_->WriteSignalSinglePoint(session, value_buffer, size_of_value_buffer);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -1624,6 +1666,7 @@ namespace nixnet_grpc {
       u32 size_of_value_buffer = static_cast<u32>(request->value_buffer().size() * sizeof(f64));
       auto status = library_->WriteSignalWaveform(session, timeout, value_buffer, size_of_value_buffer);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);
@@ -1668,6 +1711,7 @@ namespace nixnet_grpc {
       u32 size_of_num_pairs_buffer = static_cast<u32>(request->num_pairs_buffer().size() * sizeof(u32));
       auto status = library_->WriteSignalXY(session, timeout, value_buffer, size_of_value_buffer, timestamp_buffer, size_of_timestamp_buffer, num_pairs_buffer, size_of_num_pairs_buffer);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSessionRef_t(status, session);
       }
       response->set_status(status);

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -68,6 +68,7 @@ namespace nixnetsocket_grpc {
       auto cleanup_lambda = [&] (nxSOCKET id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, socket);
       }
       response->set_status(status);
@@ -97,6 +98,7 @@ namespace nixnetsocket_grpc {
       auto namelen = name.size();
       auto status = library_->Bind(socket, name, namelen);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, socket);
       }
       response->set_status(status);
@@ -120,6 +122,7 @@ namespace nixnetsocket_grpc {
       session_repository_->remove_session(socket_grpc_session.id(), socket_grpc_session.name());
       auto status = library_->Close(socket);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, socket);
       }
       response->set_status(status);
@@ -144,6 +147,7 @@ namespace nixnetsocket_grpc {
       auto namelen = name.size();
       auto status = library_->Connect(socket, name, namelen);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, socket);
       }
       response->set_status(status);
@@ -168,6 +172,7 @@ namespace nixnetsocket_grpc {
       auto is_set = library_->FdIsSet(fd, set);
       auto status = 0;
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, fd);
       }
       response->set_status(status);
@@ -197,6 +202,7 @@ namespace nixnetsocket_grpc {
       auto res = allocate_output_storage<nxaddrinfo, google::protobuf::RepeatedPtrField<AddrInfo>>(library_);
       auto status = library_->GetAddrInfo(stack_ref, node_api, service_api, hints, &res);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxIpStackRef_t(status, stack_ref);
       }
       response->set_status(status);
@@ -236,6 +242,7 @@ namespace nixnetsocket_grpc {
       }
       auto status = library_->GetNameInfo(stack_ref, addr, addrlen, (char*)host.data(), hostlen, (char*)serv.data(), servlen, flags);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxIpStackRef_t(status, stack_ref);
       }
       response->set_status(status);
@@ -264,6 +271,7 @@ namespace nixnetsocket_grpc {
       auto addrlen = static_cast<nxsocklen_t>(sizeof(addr.storage));
       auto status = library_->GetPeerName(socket, &addr, &addrlen);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, socket);
       }
       response->set_status(status);
@@ -289,6 +297,7 @@ namespace nixnetsocket_grpc {
       auto addrlen = static_cast<nxsocklen_t>(sizeof(addr.storage));
       auto status = library_->GetSockName(socket, &addr, &addrlen);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, socket);
       }
       response->set_status(status);
@@ -346,6 +355,7 @@ namespace nixnetsocket_grpc {
       auto optlen = optval.size(socket, level);
       auto status = library_->GetSockOpt(socket, level, optname, optval.data(), &optlen);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, socket);
       }
       response->set_status(status);
@@ -371,6 +381,7 @@ namespace nixnetsocket_grpc {
       auto addr = library_->InetAddr(stack_ref, cp);
       auto status = addr == -1 ? -1 : 0;
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxIpStackRef_t(status, stack_ref);
       }
       response->set_status(status);
@@ -396,6 +407,7 @@ namespace nixnetsocket_grpc {
       auto name = allocate_output_storage<nxin_addr, InAddr>();
       auto status = library_->InetAToN(stack_ref, cp, &name);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxIpStackRef_t(status, stack_ref);
       }
       response->set_status(status);
@@ -421,6 +433,7 @@ namespace nixnetsocket_grpc {
       auto address = library_->InetNToA(stack_ref, in_addr);
       auto status = address ? 0 : -1;
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxIpStackRef_t(status, stack_ref);
       }
       response->set_status(status);
@@ -450,6 +463,7 @@ namespace nixnetsocket_grpc {
       auto address = library_->InetNToP(stack_ref, af, addr, (char*)dst.data(), size);
       auto status = address ? 0 : -1;
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxIpStackRef_t(status, stack_ref);
       }
       response->set_status(status);
@@ -492,6 +506,7 @@ namespace nixnetsocket_grpc {
       auto addr = allocate_output_storage<void, Addr>(af);
       auto status = library_->InetPToN(stack_ref, af, address, &addr);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxIpStackRef_t(status, stack_ref);
       }
       response->set_status(status);
@@ -516,6 +531,7 @@ namespace nixnetsocket_grpc {
       nx_ip_stack_ref_t_resource_repository_->remove_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
       auto status = library_->IpStackClear(stack_ref);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxIpStackRef_t(status, stack_ref);
       }
       response->set_status(status);
@@ -547,6 +563,7 @@ namespace nixnetsocket_grpc {
       auto cleanup_lambda = [&] (nxIpStackRef_t id) { library_->IpStackClear(id); };
       int status = nx_ip_stack_ref_t_resource_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, 0);
       }
       response->set_status(status);
@@ -588,6 +605,7 @@ namespace nixnetsocket_grpc {
       auto info = allocate_output_storage<nixnetsocket_grpc::IpStackInfoString, std::string>(library_);
       auto status = library_->IpStackGetAllStacksInfoStr(format, (nixnetsocket_grpc::IpStackInfoString*)info.data());
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, 0);
       }
       response->set_status(status);
@@ -614,6 +632,7 @@ namespace nixnetsocket_grpc {
       auto virtual_interfaces = allocate_output_storage<nxVirtualInterface_t, google::protobuf::RepeatedPtrField<VirtualInterface>>(library_);
       auto status = library_->IpStackGetInfo(stack_ref, info_id, &virtual_interfaces);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxIpStackRef_t(status, stack_ref);
       }
       response->set_status(status);
@@ -645,6 +664,7 @@ namespace nixnetsocket_grpc {
       auto cleanup_lambda = [&] (nxIpStackRef_t id) { library_->IpStackClear(id); };
       int status = nx_ip_stack_ref_t_resource_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, 0);
       }
       response->set_status(status);
@@ -673,6 +693,7 @@ namespace nixnetsocket_grpc {
       int32_t timeout_ms = request->timeout_ms();
       auto status = library_->IpStackWaitForInterface(stack_ref, local_interface, timeout_ms);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxIpStackRef_t(status, stack_ref);
       }
       response->set_status(status);
@@ -696,6 +717,7 @@ namespace nixnetsocket_grpc {
       int32_t backlog = request->backlog();
       auto status = library_->Listen(socket, backlog);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, socket);
       }
       response->set_status(status);
@@ -724,6 +746,7 @@ namespace nixnetsocket_grpc {
       std::string data(size, '\0');
       auto status = library_->Recv(socket, (char*)data.data(), size, flags);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, socket);
       }
       response->set_status(status);
@@ -755,6 +778,7 @@ namespace nixnetsocket_grpc {
       nxsocklen_t fromlen {};
       auto status = library_->RecvFrom(socket, (char*)data.data(), size, flags, &from_addr, &fromlen);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, socket);
       }
       response->set_status(status);
@@ -782,6 +806,7 @@ namespace nixnetsocket_grpc {
       auto timeout = convert_from_grpc<nxtimeval>(request->timeout());
       auto status = library_->Select(nfds, readfds, writefds, exceptfds, timeout);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, 0);
       }
       response->set_status(status);
@@ -807,6 +832,7 @@ namespace nixnetsocket_grpc {
       int32_t flags_raw = request->flags_raw();
       auto status = library_->Send(socket, data, size, flags_raw);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, socket);
       }
       response->set_status(status);
@@ -834,6 +860,7 @@ namespace nixnetsocket_grpc {
       auto tolen = to.size();
       auto status = library_->SendTo(socket, data, size, flags_raw, to, tolen);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, socket);
       }
       response->set_status(status);
@@ -891,6 +918,7 @@ namespace nixnetsocket_grpc {
       auto optlen = opt_data.size();
       auto status = library_->SetSockOpt(socket, level, optname, optval, optlen);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, socket);
       }
       response->set_status(status);
@@ -929,6 +957,7 @@ namespace nixnetsocket_grpc {
 
       auto status = library_->Shutdown(socket, how);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxSOCKET(status, socket);
       }
       response->set_status(status);
@@ -1008,6 +1037,7 @@ namespace nixnetsocket_grpc {
       auto cleanup_lambda = [&] (nxSOCKET id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return ConvertApiErrorStatusForNxIpStackRef_t(status, stack_ref);
       }
       response->set_status(status);
@@ -1039,6 +1069,7 @@ namespace nixnetsocket_grpc {
       auto error = library_->StrErrR(errnum, (char*)buf.data(), buf_len);
       auto status = error ? 0 : -1;
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         return nidevice_grpc::ApiErrorToStatus(status);
       }
       response->set_status(status);

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -752,6 +752,7 @@ ${set_response_values(normal_outputs, init_method)}\
     method_call = f'return ConvertApiErrorStatusFor{cpp_handle_type}(status, {session});'
 %>\
       if (!status_ok(status)) {
+        context->AddTrailingMetadata("nidevice-status-code", std::to_string(status));
         ${method_call}
       }
 </%block>\


### PR DESCRIPTION
### What does this Pull Request accomplish?

This shows what it would look like to return the status code as custom trailing metadata.

### Why should this Pull Request be merged?

It shouldn't, it's just an RFC. If we did this for real, it would make sense to pass the ServerContext into the status helper methods and stop encoding the message as JSON.

### What testing has been done?

Manually tested updated example:
```
(.venv) PS Z:\grpc-device\examples\nidcpower> python .\measure-record.py localhost 31763 PXI1Slot2
Error -1074135024: {"code":-1074135024,"message":"IVI: Invalid value for parameter or property.\n\nProperty: Measure When\nRequested Value: Automatically after Source Complete\nPossible Values: On Demand\n\nStatus Code: -200077"}
```
The new part is the "Error xxxx:" at the beginning.