### PR TITLE
Mark existing response error message for Init methods as deprecated.

### DIFF
--- a/generated/nidcpower/nidcpower.proto
+++ b/generated/nidcpower/nidcpower.proto
@@ -791,7 +791,7 @@ message InitializeWithIndependentChannelsRequest {
 message InitializeWithIndependentChannelsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitiateWithChannelsRequest {
@@ -1367,7 +1367,7 @@ message ErrorMessageRequest {
 
 message ErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
 }
 
 message ExportAttributeConfigurationBufferRequest {
@@ -1613,7 +1613,7 @@ message InitializeWithChannelsRequest {
 message InitializeWithChannelsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitiateRequest {

--- a/generated/nidcpower/nidcpower.proto
+++ b/generated/nidcpower/nidcpower.proto
@@ -1367,7 +1367,7 @@ message ErrorMessageRequest {
 
 message ErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2 [deprecated = true];
+  string error_message = 2;
 }
 
 message ExportAttributeConfigurationBufferRequest {

--- a/generated/nidigitalpattern/nidigitalpattern.proto
+++ b/generated/nidigitalpattern/nidigitalpattern.proto
@@ -950,7 +950,7 @@ message ErrorMessageRequest {
 
 message ErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
 }
 
 message ExportSignalRequest {
@@ -1324,7 +1324,7 @@ message InitRequest {
 message InitResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitWithOptionsRequest {
@@ -1338,7 +1338,7 @@ message InitWithOptionsRequest {
 message InitWithOptionsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitiateRequest {

--- a/generated/nidigitalpattern/nidigitalpattern.proto
+++ b/generated/nidigitalpattern/nidigitalpattern.proto
@@ -950,7 +950,7 @@ message ErrorMessageRequest {
 
 message ErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2 [deprecated = true];
+  string error_message = 2;
 }
 
 message ExportSignalRequest {

--- a/generated/nidmm/nidmm.proto
+++ b/generated/nidmm/nidmm.proto
@@ -1148,7 +1148,7 @@ message GetErrorMessageRequest {
 
 message GetErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2 [deprecated = true];
+  string error_message = 2;
 }
 
 message GetExtCalRecommendedIntervalRequest {

--- a/generated/nidmm/nidmm.proto
+++ b/generated/nidmm/nidmm.proto
@@ -1148,7 +1148,7 @@ message GetErrorMessageRequest {
 
 message GetErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
 }
 
 message GetExtCalRecommendedIntervalRequest {
@@ -1237,7 +1237,7 @@ message InitRequest {
 message InitResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitWithOptionsRequest {
@@ -1251,7 +1251,7 @@ message InitWithOptionsRequest {
 message InitWithOptionsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitiateRequest {

--- a/generated/nifake_non_ivi/nifake_non_ivi.proto
+++ b/generated/nifake_non_ivi/nifake_non_ivi.proto
@@ -201,7 +201,7 @@ message InitRequest {
 message InitResponse {
   int32 status = 1;
   nidevice_grpc.Session handle = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitFromCrossDriverSessionRequest {

--- a/generated/nifgen/nifgen.proto
+++ b/generated/nifgen/nifgen.proto
@@ -1374,7 +1374,7 @@ message ErrorHandlerRequest {
 
 message ErrorHandlerResponse {
   int32 status = 1;
-  string error_message = 2 [deprecated = true];
+  string error_message = 2;
 }
 
 message ErrorMessageRequest {
@@ -1384,7 +1384,7 @@ message ErrorMessageRequest {
 
 message ErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2 [deprecated = true];
+  string error_message = 2;
 }
 
 message ErrorQueryRequest {
@@ -1394,7 +1394,7 @@ message ErrorQueryRequest {
 message ErrorQueryResponse {
   int32 status = 1;
   sint32 error_code = 2;
-  string error_message = 3 [deprecated = true];
+  string error_message = 3;
 }
 
 message ExportAttributeConfigurationBufferRequest {

--- a/generated/nifgen/nifgen.proto
+++ b/generated/nifgen/nifgen.proto
@@ -1374,7 +1374,7 @@ message ErrorHandlerRequest {
 
 message ErrorHandlerResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
 }
 
 message ErrorMessageRequest {
@@ -1384,7 +1384,7 @@ message ErrorMessageRequest {
 
 message ErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
 }
 
 message ErrorQueryRequest {
@@ -1394,7 +1394,7 @@ message ErrorQueryRequest {
 message ErrorQueryResponse {
   int32 status = 1;
   sint32 error_code = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message ExportAttributeConfigurationBufferRequest {
@@ -1654,7 +1654,7 @@ message InitRequest {
 message InitResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitWithOptionsRequest {
@@ -1668,7 +1668,7 @@ message InitWithOptionsRequest {
 message InitWithOptionsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitializeWithChannelsRequest {
@@ -1682,7 +1682,7 @@ message InitializeWithChannelsRequest {
 message InitializeWithChannelsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitiateGenerationRequest {

--- a/generated/nirfmxbluetooth/nirfmxbluetooth.proto
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth.proto
@@ -1373,7 +1373,7 @@ message InitializeResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
   int32 is_new_session = 3;
-  string error_message = 4;
+  string error_message = 4 [deprecated = true];
 }
 
 message InitializeFromNIRFSASessionRequest {
@@ -1384,7 +1384,7 @@ message InitializeFromNIRFSASessionRequest {
 message InitializeFromNIRFSASessionResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitiateRequest {

--- a/generated/nirfmxinstr/nirfmxinstr.proto
+++ b/generated/nirfmxinstr/nirfmxinstr.proto
@@ -1067,7 +1067,7 @@ message InitializeResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
   int32 is_new_session = 3;
-  string error_message = 4;
+  string error_message = 4 [deprecated = true];
 }
 
 message InitializeFromNIRFSASessionRequest {
@@ -1078,7 +1078,7 @@ message InitializeFromNIRFSASessionRequest {
 message InitializeFromNIRFSASessionResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitializeFromNIRFSASessionArrayRequest {
@@ -1089,7 +1089,7 @@ message InitializeFromNIRFSASessionArrayRequest {
 message InitializeFromNIRFSASessionArrayResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message IsSelfCalibrateValidRequest {

--- a/generated/nirfmxlte/nirfmxlte.proto
+++ b/generated/nirfmxlte/nirfmxlte.proto
@@ -3019,7 +3019,7 @@ message InitializeResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
   int32 is_new_session = 3;
-  string error_message = 4;
+  string error_message = 4 [deprecated = true];
 }
 
 message InitializeFromNIRFSASessionRequest {
@@ -3030,7 +3030,7 @@ message InitializeFromNIRFSASessionRequest {
 message InitializeFromNIRFSASessionResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitiateRequest {

--- a/generated/nirfmxnr/nirfmxnr.proto
+++ b/generated/nirfmxnr/nirfmxnr.proto
@@ -2516,7 +2516,7 @@ message InitializeResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
   int32 is_new_session = 3;
-  string error_message = 4;
+  string error_message = 4 [deprecated = true];
 }
 
 message InitializeFromNIRFSASessionRequest {
@@ -2527,7 +2527,7 @@ message InitializeFromNIRFSASessionRequest {
 message InitializeFromNIRFSASessionResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitiateRequest {

--- a/generated/nirfmxspecan/nirfmxspecan.proto
+++ b/generated/nirfmxspecan/nirfmxspecan.proto
@@ -5475,7 +5475,7 @@ message InitializeResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
   int32 is_new_session = 3;
-  string error_message = 4;
+  string error_message = 4 [deprecated = true];
 }
 
 message InitializeFromNIRFSASessionRequest {
@@ -5486,7 +5486,7 @@ message InitializeFromNIRFSASessionRequest {
 message InitializeFromNIRFSASessionResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitiateRequest {

--- a/generated/nirfmxwlan/nirfmxwlan.proto
+++ b/generated/nirfmxwlan/nirfmxwlan.proto
@@ -2044,7 +2044,7 @@ message InitializeResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
   int32 is_new_session = 3;
-  string error_message = 4;
+  string error_message = 4 [deprecated = true];
 }
 
 message InitializeFromNIRFSASessionRequest {
@@ -2055,7 +2055,7 @@ message InitializeFromNIRFSASessionRequest {
 message InitializeFromNIRFSASessionResponse {
   int32 status = 1;
   nidevice_grpc.Session instrument = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitiateRequest {

--- a/generated/nirfsa/nirfsa.proto
+++ b/generated/nirfsa/nirfsa.proto
@@ -1175,7 +1175,7 @@ message ErrorMessageRequest {
 
 message ErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
 }
 
 message ErrorQueryRequest {
@@ -1185,7 +1185,7 @@ message ErrorQueryRequest {
 message ErrorQueryResponse {
   int32 status = 1;
   sint32 error_code = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message ExportSignalRequest {
@@ -1603,7 +1603,7 @@ message InitRequest {
 message InitResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitWithOptionsRequest {
@@ -1617,7 +1617,7 @@ message InitWithOptionsRequest {
 message InitWithOptionsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitiateRequest {

--- a/generated/nirfsa/nirfsa.proto
+++ b/generated/nirfsa/nirfsa.proto
@@ -1175,7 +1175,7 @@ message ErrorMessageRequest {
 
 message ErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2 [deprecated = true];
+  string error_message = 2;
 }
 
 message ErrorQueryRequest {
@@ -1185,7 +1185,7 @@ message ErrorQueryRequest {
 message ErrorQueryResponse {
   int32 status = 1;
   sint32 error_code = 2;
-  string error_message = 3 [deprecated = true];
+  string error_message = 3;
 }
 
 message ExportSignalRequest {

--- a/generated/nirfsg/nirfsg.proto
+++ b/generated/nirfsg/nirfsg.proto
@@ -1310,7 +1310,7 @@ message ErrorMessageRequest {
 
 message ErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2 [deprecated = true];
+  string error_message = 2;
 }
 
 message ErrorQueryRequest {
@@ -1320,7 +1320,7 @@ message ErrorQueryRequest {
 message ErrorQueryResponse {
   int32 status = 1;
   sint32 error_code = 2;
-  string error_message = 3 [deprecated = true];
+  string error_message = 3;
 }
 
 message ExportSignalRequest {

--- a/generated/nirfsg/nirfsg.proto
+++ b/generated/nirfsg/nirfsg.proto
@@ -1310,7 +1310,7 @@ message ErrorMessageRequest {
 
 message ErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
 }
 
 message ErrorQueryRequest {
@@ -1320,7 +1320,7 @@ message ErrorQueryRequest {
 message ErrorQueryResponse {
   int32 status = 1;
   sint32 error_code = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message ExportSignalRequest {
@@ -1556,7 +1556,7 @@ message InitRequest {
 message InitResponse {
   int32 status = 1;
   nidevice_grpc.Session new_vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitWithOptionsRequest {
@@ -1570,7 +1570,7 @@ message InitWithOptionsRequest {
 message InitWithOptionsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitiateRequest {

--- a/generated/niscope/niscope.proto
+++ b/generated/niscope/niscope.proto
@@ -1641,7 +1641,7 @@ message GetErrorMessageRequest {
 
 message GetErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
 }
 
 message GetFrequencyResponseRequest {
@@ -1718,7 +1718,7 @@ message InitRequest {
 message InitResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitWithOptionsRequest {
@@ -1732,7 +1732,7 @@ message InitWithOptionsRequest {
 message InitWithOptionsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitiateAcquisitionRequest {

--- a/generated/niscope/niscope.proto
+++ b/generated/niscope/niscope.proto
@@ -1641,7 +1641,7 @@ message GetErrorMessageRequest {
 
 message GetErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2 [deprecated = true];
+  string error_message = 2;
 }
 
 message GetFrequencyResponseRequest {

--- a/generated/niswitch/niswitch.proto
+++ b/generated/niswitch/niswitch.proto
@@ -547,7 +547,7 @@ message ErrorMessageRequest {
 
 message ErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2 [deprecated = true];
+  string error_message = 2;
 }
 
 message ErrorQueryRequest {
@@ -557,7 +557,7 @@ message ErrorQueryRequest {
 message ErrorQueryResponse {
   int32 status = 1;
   sint32 error_code = 2;
-  string error_message = 3 [deprecated = true];
+  string error_message = 3;
 }
 
 message GetAttributeViBooleanRequest {

--- a/generated/niswitch/niswitch.proto
+++ b/generated/niswitch/niswitch.proto
@@ -547,7 +547,7 @@ message ErrorMessageRequest {
 
 message ErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
 }
 
 message ErrorQueryRequest {
@@ -557,7 +557,7 @@ message ErrorQueryRequest {
 message ErrorQueryResponse {
   int32 status = 1;
   sint32 error_code = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message GetAttributeViBooleanRequest {
@@ -705,7 +705,7 @@ message InitRequest {
 message InitResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitWithOptionsRequest {
@@ -719,7 +719,7 @@ message InitWithOptionsRequest {
 message InitWithOptionsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitWithTopologyRequest {
@@ -733,7 +733,7 @@ message InitWithTopologyRequest {
 message InitWithTopologyResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
 }
 
 message InitiateScanRequest {

--- a/generated/nisync/nisync.proto
+++ b/generated/nisync/nisync.proto
@@ -227,7 +227,7 @@ message ErrorMessageRequest {
 
 message ErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2 [deprecated = true];
+  string error_message = 2;
 }
 
 message ResetRequest {

--- a/generated/nisync/nisync.proto
+++ b/generated/nisync/nisync.proto
@@ -227,7 +227,7 @@ message ErrorMessageRequest {
 
 message ErrorMessageResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
 }
 
 message ResetRequest {

--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -259,7 +259,7 @@ message AcceptResponse {
   SockAddr addr = 2;
   nidevice_grpc.Session socket = 3;
   string error_message = 4 [deprecated = true];
-  int32 error_num = 5;
+  int32 error_num = 5 [deprecated = true];
 }
 
 message BindRequest {
@@ -270,7 +270,7 @@ message BindRequest {
 message BindResponse {
   int32 status = 1;
   string error_message = 2 [deprecated = true];
-  int32 error_num = 3;
+  int32 error_num = 3 [deprecated = true];
 }
 
 message CloseRequest {
@@ -280,7 +280,7 @@ message CloseRequest {
 message CloseResponse {
   int32 status = 1;
   string error_message = 2 [deprecated = true];
-  int32 error_num = 3;
+  int32 error_num = 3 [deprecated = true];
 }
 
 message ConnectRequest {
@@ -291,7 +291,7 @@ message ConnectRequest {
 message ConnectResponse {
   int32 status = 1;
   string error_message = 2 [deprecated = true];
-  int32 error_num = 3;
+  int32 error_num = 3 [deprecated = true];
 }
 
 message FdIsSetRequest {
@@ -303,7 +303,7 @@ message FdIsSetResponse {
   int32 status = 1;
   int32 is_set = 2;
   string error_message = 3 [deprecated = true];
-  int32 error_num = 4;
+  int32 error_num = 4 [deprecated = true];
 }
 
 message GetAddrInfoRequest {
@@ -317,7 +317,7 @@ message GetAddrInfoResponse {
   int32 status = 1;
   repeated AddrInfo res = 2;
   string error_message = 3 [deprecated = true];
-  int32 error_num = 4;
+  int32 error_num = 4 [deprecated = true];
 }
 
 message GetNameInfoRequest {
@@ -334,7 +334,7 @@ message GetNameInfoResponse {
   string host = 2;
   string serv = 3;
   string error_message = 4 [deprecated = true];
-  int32 error_num = 5;
+  int32 error_num = 5 [deprecated = true];
 }
 
 message GetPeerNameRequest {
@@ -345,7 +345,7 @@ message GetPeerNameResponse {
   int32 status = 1;
   SockAddr addr = 2;
   string error_message = 3 [deprecated = true];
-  int32 error_num = 4;
+  int32 error_num = 4 [deprecated = true];
 }
 
 message GetSockNameRequest {
@@ -356,7 +356,7 @@ message GetSockNameResponse {
   int32 status = 1;
   SockAddr addr = 2;
   string error_message = 3 [deprecated = true];
-  int32 error_num = 4;
+  int32 error_num = 4 [deprecated = true];
 }
 
 message GetSockOptRequest {
@@ -375,7 +375,7 @@ message GetSockOptResponse {
   int32 status = 1;
   SockOptData optval = 2;
   string error_message = 3 [deprecated = true];
-  int32 error_num = 4;
+  int32 error_num = 4 [deprecated = true];
 }
 
 message InetAddrRequest {
@@ -387,7 +387,7 @@ message InetAddrResponse {
   int32 status = 1;
   uint32 addr = 2;
   string error_message = 3 [deprecated = true];
-  int32 error_num = 4;
+  int32 error_num = 4 [deprecated = true];
 }
 
 message InetAToNRequest {
@@ -399,7 +399,7 @@ message InetAToNResponse {
   int32 status = 1;
   InAddr name = 2;
   string error_message = 3 [deprecated = true];
-  int32 error_num = 4;
+  int32 error_num = 4 [deprecated = true];
 }
 
 message InetNToARequest {
@@ -411,7 +411,7 @@ message InetNToAResponse {
   int32 status = 1;
   string address = 2;
   string error_message = 3 [deprecated = true];
-  int32 error_num = 4;
+  int32 error_num = 4 [deprecated = true];
 }
 
 message InetNToPRequest {
@@ -423,7 +423,7 @@ message InetNToPResponse {
   int32 status = 1;
   string address = 2;
   string error_message = 3 [deprecated = true];
-  int32 error_num = 4;
+  int32 error_num = 4 [deprecated = true];
 }
 
 message InetPToNRequest {
@@ -439,7 +439,7 @@ message InetPToNResponse {
   int32 status = 1;
   Addr addr = 2;
   string error_message = 3 [deprecated = true];
-  int32 error_num = 4;
+  int32 error_num = 4 [deprecated = true];
 }
 
 message IpStackClearRequest {
@@ -449,7 +449,7 @@ message IpStackClearRequest {
 message IpStackClearResponse {
   int32 status = 1;
   string error_message = 2 [deprecated = true];
-  int32 error_num = 3;
+  int32 error_num = 3 [deprecated = true];
 }
 
 message IpStackCreateRequest {
@@ -462,7 +462,7 @@ message IpStackCreateResponse {
   int32 status = 1;
   nidevice_grpc.Session stack_ref = 2;
   string error_message = 3 [deprecated = true];
-  int32 error_num = 4;
+  int32 error_num = 4 [deprecated = true];
 }
 
 message IpStackGetAllStacksInfoStrRequest {
@@ -476,7 +476,7 @@ message IpStackGetAllStacksInfoStrResponse {
   int32 status = 1;
   string info = 2;
   string error_message = 3 [deprecated = true];
-  int32 error_num = 4;
+  int32 error_num = 4 [deprecated = true];
 }
 
 message IpStackGetInfoRequest {
@@ -487,7 +487,7 @@ message IpStackGetInfoResponse {
   int32 status = 1;
   repeated VirtualInterface virtual_interfaces = 2;
   string error_message = 3 [deprecated = true];
-  int32 error_num = 4;
+  int32 error_num = 4 [deprecated = true];
 }
 
 message IpStackOpenRequest {
@@ -499,7 +499,7 @@ message IpStackOpenResponse {
   int32 status = 1;
   nidevice_grpc.Session stack_ref = 2;
   string error_message = 3 [deprecated = true];
-  int32 error_num = 4;
+  int32 error_num = 4 [deprecated = true];
 }
 
 message IpStackWaitForInterfaceRequest {
@@ -511,7 +511,7 @@ message IpStackWaitForInterfaceRequest {
 message IpStackWaitForInterfaceResponse {
   int32 status = 1;
   string error_message = 2 [deprecated = true];
-  int32 error_num = 3;
+  int32 error_num = 3 [deprecated = true];
 }
 
 message ListenRequest {
@@ -522,7 +522,7 @@ message ListenRequest {
 message ListenResponse {
   int32 status = 1;
   string error_message = 2 [deprecated = true];
-  int32 error_num = 3;
+  int32 error_num = 3 [deprecated = true];
 }
 
 message RecvRequest {
@@ -536,7 +536,7 @@ message RecvResponse {
   int32 status = 1;
   bytes data = 2;
   string error_message = 3 [deprecated = true];
-  int32 error_num = 4;
+  int32 error_num = 4 [deprecated = true];
 }
 
 message RecvFromRequest {
@@ -551,7 +551,7 @@ message RecvFromResponse {
   bytes data = 2;
   SockAddr from_addr = 3;
   string error_message = 4 [deprecated = true];
-  int32 error_num = 5;
+  int32 error_num = 5 [deprecated = true];
 }
 
 message SelectRequest {
@@ -564,7 +564,7 @@ message SelectRequest {
 message SelectResponse {
   int32 status = 1;
   string error_message = 2 [deprecated = true];
-  int32 error_num = 3;
+  int32 error_num = 3 [deprecated = true];
 }
 
 message SendRequest {
@@ -576,7 +576,7 @@ message SendRequest {
 message SendResponse {
   int32 status = 1;
   string error_message = 2 [deprecated = true];
-  int32 error_num = 3;
+  int32 error_num = 3 [deprecated = true];
 }
 
 message SendToRequest {
@@ -589,7 +589,7 @@ message SendToRequest {
 message SendToResponse {
   int32 status = 1;
   string error_message = 2 [deprecated = true];
-  int32 error_num = 3;
+  int32 error_num = 3 [deprecated = true];
 }
 
 message SetSockOptRequest {
@@ -608,7 +608,7 @@ message SetSockOptRequest {
 message SetSockOptResponse {
   int32 status = 1;
   string error_message = 2 [deprecated = true];
-  int32 error_num = 3;
+  int32 error_num = 3 [deprecated = true];
 }
 
 message ShutdownRequest {
@@ -622,7 +622,7 @@ message ShutdownRequest {
 message ShutdownResponse {
   int32 status = 1;
   string error_message = 2 [deprecated = true];
-  int32 error_num = 3;
+  int32 error_num = 3 [deprecated = true];
 }
 
 message SocketRequest {
@@ -646,7 +646,7 @@ message SocketResponse {
   int32 status = 1;
   nidevice_grpc.Session socket = 2;
   string error_message = 3 [deprecated = true];
-  int32 error_num = 4;
+  int32 error_num = 4 [deprecated = true];
 }
 
 message StrErrRRequest {

--- a/generated/nixnetsocket/nixnetsocket.proto
+++ b/generated/nixnetsocket/nixnetsocket.proto
@@ -258,7 +258,7 @@ message AcceptResponse {
   int32 status = 1;
   SockAddr addr = 2;
   nidevice_grpc.Session socket = 3;
-  string error_message = 4;
+  string error_message = 4 [deprecated = true];
   int32 error_num = 5;
 }
 
@@ -269,7 +269,7 @@ message BindRequest {
 
 message BindResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
   int32 error_num = 3;
 }
 
@@ -279,7 +279,7 @@ message CloseRequest {
 
 message CloseResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
   int32 error_num = 3;
 }
 
@@ -290,7 +290,7 @@ message ConnectRequest {
 
 message ConnectResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
   int32 error_num = 3;
 }
 
@@ -302,7 +302,7 @@ message FdIsSetRequest {
 message FdIsSetResponse {
   int32 status = 1;
   int32 is_set = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
   int32 error_num = 4;
 }
 
@@ -316,7 +316,7 @@ message GetAddrInfoRequest {
 message GetAddrInfoResponse {
   int32 status = 1;
   repeated AddrInfo res = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
   int32 error_num = 4;
 }
 
@@ -333,7 +333,7 @@ message GetNameInfoResponse {
   int32 status = 1;
   string host = 2;
   string serv = 3;
-  string error_message = 4;
+  string error_message = 4 [deprecated = true];
   int32 error_num = 5;
 }
 
@@ -344,7 +344,7 @@ message GetPeerNameRequest {
 message GetPeerNameResponse {
   int32 status = 1;
   SockAddr addr = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
   int32 error_num = 4;
 }
 
@@ -355,7 +355,7 @@ message GetSockNameRequest {
 message GetSockNameResponse {
   int32 status = 1;
   SockAddr addr = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
   int32 error_num = 4;
 }
 
@@ -374,7 +374,7 @@ message GetSockOptRequest {
 message GetSockOptResponse {
   int32 status = 1;
   SockOptData optval = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
   int32 error_num = 4;
 }
 
@@ -386,7 +386,7 @@ message InetAddrRequest {
 message InetAddrResponse {
   int32 status = 1;
   uint32 addr = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
   int32 error_num = 4;
 }
 
@@ -398,7 +398,7 @@ message InetAToNRequest {
 message InetAToNResponse {
   int32 status = 1;
   InAddr name = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
   int32 error_num = 4;
 }
 
@@ -410,7 +410,7 @@ message InetNToARequest {
 message InetNToAResponse {
   int32 status = 1;
   string address = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
   int32 error_num = 4;
 }
 
@@ -422,7 +422,7 @@ message InetNToPRequest {
 message InetNToPResponse {
   int32 status = 1;
   string address = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
   int32 error_num = 4;
 }
 
@@ -438,7 +438,7 @@ message InetPToNRequest {
 message InetPToNResponse {
   int32 status = 1;
   Addr addr = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
   int32 error_num = 4;
 }
 
@@ -448,7 +448,7 @@ message IpStackClearRequest {
 
 message IpStackClearResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
   int32 error_num = 3;
 }
 
@@ -461,7 +461,7 @@ message IpStackCreateRequest {
 message IpStackCreateResponse {
   int32 status = 1;
   nidevice_grpc.Session stack_ref = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
   int32 error_num = 4;
 }
 
@@ -475,7 +475,7 @@ message IpStackGetAllStacksInfoStrRequest {
 message IpStackGetAllStacksInfoStrResponse {
   int32 status = 1;
   string info = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
   int32 error_num = 4;
 }
 
@@ -486,7 +486,7 @@ message IpStackGetInfoRequest {
 message IpStackGetInfoResponse {
   int32 status = 1;
   repeated VirtualInterface virtual_interfaces = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
   int32 error_num = 4;
 }
 
@@ -498,7 +498,7 @@ message IpStackOpenRequest {
 message IpStackOpenResponse {
   int32 status = 1;
   nidevice_grpc.Session stack_ref = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
   int32 error_num = 4;
 }
 
@@ -510,7 +510,7 @@ message IpStackWaitForInterfaceRequest {
 
 message IpStackWaitForInterfaceResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
   int32 error_num = 3;
 }
 
@@ -521,7 +521,7 @@ message ListenRequest {
 
 message ListenResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
   int32 error_num = 3;
 }
 
@@ -535,7 +535,7 @@ message RecvRequest {
 message RecvResponse {
   int32 status = 1;
   bytes data = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
   int32 error_num = 4;
 }
 
@@ -550,7 +550,7 @@ message RecvFromResponse {
   int32 status = 1;
   bytes data = 2;
   SockAddr from_addr = 3;
-  string error_message = 4;
+  string error_message = 4 [deprecated = true];
   int32 error_num = 5;
 }
 
@@ -563,7 +563,7 @@ message SelectRequest {
 
 message SelectResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
   int32 error_num = 3;
 }
 
@@ -575,7 +575,7 @@ message SendRequest {
 
 message SendResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
   int32 error_num = 3;
 }
 
@@ -588,7 +588,7 @@ message SendToRequest {
 
 message SendToResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
   int32 error_num = 3;
 }
 
@@ -607,7 +607,7 @@ message SetSockOptRequest {
 
 message SetSockOptResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
   int32 error_num = 3;
 }
 
@@ -621,7 +621,7 @@ message ShutdownRequest {
 
 message ShutdownResponse {
   int32 status = 1;
-  string error_message = 2;
+  string error_message = 2 [deprecated = true];
   int32 error_num = 3;
 }
 
@@ -645,7 +645,7 @@ message SocketRequest {
 message SocketResponse {
   int32 status = 1;
   nidevice_grpc.Session socket = 2;
-  string error_message = 3;
+  string error_message = 3 [deprecated = true];
   int32 error_num = 4;
 }
 

--- a/source/codegen/proto_helpers.py
+++ b/source/codegen/proto_helpers.py
@@ -135,15 +135,15 @@ def get_message_parameter_definitions(parameters):
                 # type.
                 parameter_type = f'repeated {parameter["enum"]}'
             grpc_field_number = generate_parameter_field_number(parameter, used_indexes)
-            get_last_error = 0
+            is_get_last_error_output_param = False
             if common_helpers.is_get_last_error_output_param(parameter):
-                get_last_error = 1
+                is_get_last_error_output_param = True
             parameter_definitions.append(
                 {
                     "name": parameter_name,
                     "type": parameter_type,
                     "grpc_field_number": grpc_field_number,
-                    "get_last_error": get_last_error,
+                    "is_get_last_error_output_param": is_get_last_error_output_param,
                 }
             )
     return parameter_definitions

--- a/source/codegen/proto_helpers.py
+++ b/source/codegen/proto_helpers.py
@@ -135,13 +135,13 @@ def get_message_parameter_definitions(parameters):
                 # type.
                 parameter_type = f'repeated {parameter["enum"]}'
             grpc_field_number = generate_parameter_field_number(parameter, used_indexes)
-            is_get_last_error_output_param = common_helpers.is_get_last_error_output_param(parameter)
+            is_get_last_error_output = common_helpers.is_get_last_error_output_param(parameter)
             parameter_definitions.append(
                 {
                     "name": parameter_name,
                     "type": parameter_type,
                     "grpc_field_number": grpc_field_number,
-                    "is_get_last_error_output_param": is_get_last_error_output_param,
+                    "is_get_last_error_output": is_get_last_error_output,
                 }
             )
     return parameter_definitions

--- a/source/codegen/proto_helpers.py
+++ b/source/codegen/proto_helpers.py
@@ -135,11 +135,15 @@ def get_message_parameter_definitions(parameters):
                 # type.
                 parameter_type = f'repeated {parameter["enum"]}'
             grpc_field_number = generate_parameter_field_number(parameter, used_indexes)
+            get_last_error = 0
+            if common_helpers.is_get_last_error_output_param(parameter):
+                get_last_error = 1
             parameter_definitions.append(
                 {
                     "name": parameter_name,
                     "type": parameter_type,
                     "grpc_field_number": grpc_field_number,
+                    "get_last_error": get_last_error,
                 }
             )
     return parameter_definitions

--- a/source/codegen/proto_helpers.py
+++ b/source/codegen/proto_helpers.py
@@ -135,9 +135,7 @@ def get_message_parameter_definitions(parameters):
                 # type.
                 parameter_type = f'repeated {parameter["enum"]}'
             grpc_field_number = generate_parameter_field_number(parameter, used_indexes)
-            is_get_last_error_output_param = False
-            if common_helpers.is_get_last_error_output_param(parameter):
-                is_get_last_error_output_param = True
+            is_get_last_error_output_param = common_helpers.is_get_last_error_output_param(parameter)
             parameter_definitions.append(
                 {
                     "name": parameter_name,

--- a/source/codegen/templates/proto_helpers.mako
+++ b/source/codegen/templates/proto_helpers.mako
@@ -103,12 +103,8 @@ message ${common_helpers.snake_to_pascal(function)}Response {
 <%
   parameter_name = parameter["name"]
 %>\
-% if (parameter.get("is_get_last_error_output_param", True)):
-%   if ((parameter_name == "error_message") | (parameter_name == "error_num")):
+% if (parameter.get("is_get_last_error_output", False)):
   ${parameter["type"]} ${parameter_name} = ${parameter["grpc_field_number"]} [deprecated = true];
-%   else:
-  ${parameter["type"]} ${parameter_name} = ${parameter["grpc_field_number"]};
-%   endif
 % else:
   ${parameter["type"]} ${parameter_name} = ${parameter["grpc_field_number"]};
 % endif

--- a/source/codegen/templates/proto_helpers.mako
+++ b/source/codegen/templates/proto_helpers.mako
@@ -100,13 +100,10 @@ message ${common_helpers.snake_to_pascal(function)}Request {
 %>\
 message ${common_helpers.snake_to_pascal(function)}Response {
 % for parameter in response_parameters:
-<%
-  parameter_name = parameter["name"]
-%>\
 % if (parameter.get("is_get_last_error_output", False)):
-  ${parameter["type"]} ${parameter_name} = ${parameter["grpc_field_number"]} [deprecated = true];
+  ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]} [deprecated = true];
 % else:
-  ${parameter["type"]} ${parameter_name} = ${parameter["grpc_field_number"]};
+  ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]};
 % endif
 % endfor
 }

--- a/source/codegen/templates/proto_helpers.mako
+++ b/source/codegen/templates/proto_helpers.mako
@@ -100,7 +100,7 @@ message ${common_helpers.snake_to_pascal(function)}Request {
 %>\
 message ${common_helpers.snake_to_pascal(function)}Response {
 % for parameter in response_parameters:
-% if common_helpers.is_get_last_error_output_param(parameter) & (parameter["name"] == "error_message"):
+% if (parameter.get("get_last_error", 1)) & (parameter["name"] == "error_message"):
   ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]} [deprecated = true];
 % else:
   ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]};

--- a/source/codegen/templates/proto_helpers.mako
+++ b/source/codegen/templates/proto_helpers.mako
@@ -103,10 +103,14 @@ message ${common_helpers.snake_to_pascal(function)}Response {
 <%
   parameter_name = parameter["name"]
 %>\
-% if (parameter.get("is_get_last_error_output_param", True)) & ((parameter_name == "error_message") | (parameter_name == "error_num")):
-  ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]} [deprecated = true];
+% if (parameter.get("is_get_last_error_output_param", True)):
+%   if ((parameter_name == "error_message") | (parameter_name == "error_num")):
+  ${parameter["type"]} ${parameter_name} = ${parameter["grpc_field_number"]} [deprecated = true];
+%   else:
+  ${parameter["type"]} ${parameter_name} = ${parameter["grpc_field_number"]};
+%   endif
 % else:
-  ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]};
+  ${parameter["type"]} ${parameter_name} = ${parameter["grpc_field_number"]};
 % endif
 % endfor
 }

--- a/source/codegen/templates/proto_helpers.mako
+++ b/source/codegen/templates/proto_helpers.mako
@@ -100,7 +100,10 @@ message ${common_helpers.snake_to_pascal(function)}Request {
 %>\
 message ${common_helpers.snake_to_pascal(function)}Response {
 % for parameter in response_parameters:
-% if (parameter.get("is_get_last_error_output_param", True)) & (parameter["name"] == "error_message"):
+<%
+  parameter_name = parameter["name"]
+%>\
+% if (parameter.get("is_get_last_error_output_param", True)) & ((parameter_name == "error_message") | (parameter_name == "error_num")):
   ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]} [deprecated = true];
 % else:
   ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]};

--- a/source/codegen/templates/proto_helpers.mako
+++ b/source/codegen/templates/proto_helpers.mako
@@ -100,7 +100,11 @@ message ${common_helpers.snake_to_pascal(function)}Request {
 %>\
 message ${common_helpers.snake_to_pascal(function)}Response {
 % for parameter in response_parameters:
+% if common_helpers.is_get_last_error_output_param(parameter) & (parameter["name"] == "error_message"):
+  ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]} [deprecated = true];
+% else:
   ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]};
+% endif
 % endfor
 }
 </%def>

--- a/source/codegen/templates/proto_helpers.mako
+++ b/source/codegen/templates/proto_helpers.mako
@@ -100,7 +100,7 @@ message ${common_helpers.snake_to_pascal(function)}Request {
 %>\
 message ${common_helpers.snake_to_pascal(function)}Response {
 % for parameter in response_parameters:
-% if (parameter.get("get_last_error", 1)) & (parameter["name"] == "error_message"):
+% if (parameter.get("is_get_last_error_output_param", True)) & (parameter["name"] == "error_message"):
   ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]} [deprecated = true];
 % else:
   ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]};


### PR DESCRIPTION
### What does this Pull Request accomplish?

Updates the `proto_helpers` to automatically mark deprecated any response fields that are `get_last_error` output parameters named "error_message" or "error_num".

### Why should this Pull Request be merged?

Fixes [AB#2103384](https://ni.visualstudio.com/DevCentral/_workitems/edit/2103384/)

We should mark these fields deprecated since the way we report errors has changed (see also: #692 )

### What testing has been done?

grpc-device builds in Debug configuration locally, and the generated proto files mark the intended response fields deprecated.
