### PR TITLE
Make C++ exception be similar to C# RpcException

### DIFF
--- a/generated/nidaqmx/nidaqmx_client.cpp
+++ b/generated/nidaqmx/nidaqmx_client.cpp
@@ -28,7 +28,8 @@ add_cdaq_sync_connection(const StubPtr& stub, const pb::string& port_list)
   auto response = AddCDAQSyncConnectionResponse{};
 
   raise_if_error(
-      stub->AddCDAQSyncConnection(&context, request, &response));
+      stub->AddCDAQSyncConnection(&context, request, &response),
+      context);
 
   return response;
 }
@@ -45,7 +46,8 @@ add_global_chans_to_task(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = AddGlobalChansToTaskResponse{};
 
   raise_if_error(
-      stub->AddGlobalChansToTask(&context, request, &response));
+      stub->AddGlobalChansToTask(&context, request, &response),
+      context);
 
   return response;
 }
@@ -64,7 +66,8 @@ add_network_device(const StubPtr& stub, const pb::string& ip_address, const pb::
   auto response = AddNetworkDeviceResponse{};
 
   raise_if_error(
-      stub->AddNetworkDevice(&context, request, &response));
+      stub->AddNetworkDevice(&context, request, &response),
+      context);
 
   return response;
 }
@@ -81,7 +84,8 @@ are_configured_cdaq_sync_ports_disconnected(const StubPtr& stub, const pb::strin
   auto response = AreConfiguredCDAQSyncPortsDisconnectedResponse{};
 
   raise_if_error(
-      stub->AreConfiguredCDAQSyncPortsDisconnected(&context, request, &response));
+      stub->AreConfiguredCDAQSyncPortsDisconnected(&context, request, &response),
+      context);
 
   return response;
 }
@@ -98,7 +102,8 @@ auto_configure_cdaq_sync_connections(const StubPtr& stub, const pb::string& chas
   auto response = AutoConfigureCDAQSyncConnectionsResponse{};
 
   raise_if_error(
-      stub->AutoConfigureCDAQSyncConnections(&context, request, &response));
+      stub->AutoConfigureCDAQSyncConnections(&context, request, &response),
+      context);
 
   return response;
 }
@@ -118,7 +123,8 @@ calculate_reverse_poly_coeff(const StubPtr& stub, const std::vector<double>& for
   auto response = CalculateReversePolyCoeffResponse{};
 
   raise_if_error(
-      stub->CalculateReversePolyCoeff(&context, request, &response));
+      stub->CalculateReversePolyCoeff(&context, request, &response),
+      context);
 
   return response;
 }
@@ -145,7 +151,8 @@ cfg_anlg_edge_ref_trig(const StubPtr& stub, const nidevice_grpc::Session& task, 
   auto response = CfgAnlgEdgeRefTrigResponse{};
 
   raise_if_error(
-      stub->CfgAnlgEdgeRefTrig(&context, request, &response));
+      stub->CfgAnlgEdgeRefTrig(&context, request, &response),
+      context);
 
   return response;
 }
@@ -171,7 +178,8 @@ cfg_anlg_edge_start_trig(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = CfgAnlgEdgeStartTrigResponse{};
 
   raise_if_error(
-      stub->CfgAnlgEdgeStartTrig(&context, request, &response));
+      stub->CfgAnlgEdgeStartTrig(&context, request, &response),
+      context);
 
   return response;
 }
@@ -191,7 +199,8 @@ cfg_anlg_multi_edge_ref_trig(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = CfgAnlgMultiEdgeRefTrigResponse{};
 
   raise_if_error(
-      stub->CfgAnlgMultiEdgeRefTrig(&context, request, &response));
+      stub->CfgAnlgMultiEdgeRefTrig(&context, request, &response),
+      context);
 
   return response;
 }
@@ -210,7 +219,8 @@ cfg_anlg_multi_edge_start_trig(const StubPtr& stub, const nidevice_grpc::Session
   auto response = CfgAnlgMultiEdgeStartTrigResponse{};
 
   raise_if_error(
-      stub->CfgAnlgMultiEdgeStartTrig(&context, request, &response));
+      stub->CfgAnlgMultiEdgeStartTrig(&context, request, &response),
+      context);
 
   return response;
 }
@@ -238,7 +248,8 @@ cfg_anlg_window_ref_trig(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = CfgAnlgWindowRefTrigResponse{};
 
   raise_if_error(
-      stub->CfgAnlgWindowRefTrig(&context, request, &response));
+      stub->CfgAnlgWindowRefTrig(&context, request, &response),
+      context);
 
   return response;
 }
@@ -265,7 +276,8 @@ cfg_anlg_window_start_trig(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = CfgAnlgWindowStartTrigResponse{};
 
   raise_if_error(
-      stub->CfgAnlgWindowStartTrig(&context, request, &response));
+      stub->CfgAnlgWindowStartTrig(&context, request, &response),
+      context);
 
   return response;
 }
@@ -316,7 +328,8 @@ cfg_burst_handshaking_timing_export_clock(const StubPtr& stub, const nidevice_gr
   auto response = CfgBurstHandshakingTimingExportClockResponse{};
 
   raise_if_error(
-      stub->CfgBurstHandshakingTimingExportClock(&context, request, &response));
+      stub->CfgBurstHandshakingTimingExportClock(&context, request, &response),
+      context);
 
   return response;
 }
@@ -367,7 +380,8 @@ cfg_burst_handshaking_timing_import_clock(const StubPtr& stub, const nidevice_gr
   auto response = CfgBurstHandshakingTimingImportClockResponse{};
 
   raise_if_error(
-      stub->CfgBurstHandshakingTimingImportClock(&context, request, &response));
+      stub->CfgBurstHandshakingTimingImportClock(&context, request, &response),
+      context);
 
   return response;
 }
@@ -394,7 +408,8 @@ cfg_change_detection_timing(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = CfgChangeDetectionTimingResponse{};
 
   raise_if_error(
-      stub->CfgChangeDetectionTiming(&context, request, &response));
+      stub->CfgChangeDetectionTiming(&context, request, &response),
+      context);
 
   return response;
 }
@@ -420,7 +435,8 @@ cfg_dig_edge_ref_trig(const StubPtr& stub, const nidevice_grpc::Session& task, c
   auto response = CfgDigEdgeRefTrigResponse{};
 
   raise_if_error(
-      stub->CfgDigEdgeRefTrig(&context, request, &response));
+      stub->CfgDigEdgeRefTrig(&context, request, &response),
+      context);
 
   return response;
 }
@@ -445,7 +461,8 @@ cfg_dig_edge_start_trig(const StubPtr& stub, const nidevice_grpc::Session& task,
   auto response = CfgDigEdgeStartTrigResponse{};
 
   raise_if_error(
-      stub->CfgDigEdgeStartTrig(&context, request, &response));
+      stub->CfgDigEdgeStartTrig(&context, request, &response),
+      context);
 
   return response;
 }
@@ -472,7 +489,8 @@ cfg_dig_pattern_ref_trig(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = CfgDigPatternRefTrigResponse{};
 
   raise_if_error(
-      stub->CfgDigPatternRefTrig(&context, request, &response));
+      stub->CfgDigPatternRefTrig(&context, request, &response),
+      context);
 
   return response;
 }
@@ -498,7 +516,8 @@ cfg_dig_pattern_start_trig(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = CfgDigPatternStartTrigResponse{};
 
   raise_if_error(
-      stub->CfgDigPatternStartTrig(&context, request, &response));
+      stub->CfgDigPatternStartTrig(&context, request, &response),
+      context);
 
   return response;
 }
@@ -523,7 +542,8 @@ cfg_handshaking_timing(const StubPtr& stub, const nidevice_grpc::Session& task, 
   auto response = CfgHandshakingTimingResponse{};
 
   raise_if_error(
-      stub->CfgHandshakingTiming(&context, request, &response));
+      stub->CfgHandshakingTiming(&context, request, &response),
+      context);
 
   return response;
 }
@@ -548,7 +568,8 @@ cfg_implicit_timing(const StubPtr& stub, const nidevice_grpc::Session& task, con
   auto response = CfgImplicitTimingResponse{};
 
   raise_if_error(
-      stub->CfgImplicitTiming(&context, request, &response));
+      stub->CfgImplicitTiming(&context, request, &response),
+      context);
 
   return response;
 }
@@ -565,7 +586,8 @@ cfg_input_buffer(const StubPtr& stub, const nidevice_grpc::Session& task, const 
   auto response = CfgInputBufferResponse{};
 
   raise_if_error(
-      stub->CfgInputBuffer(&context, request, &response));
+      stub->CfgInputBuffer(&context, request, &response),
+      context);
 
   return response;
 }
@@ -582,7 +604,8 @@ cfg_output_buffer(const StubPtr& stub, const nidevice_grpc::Session& task, const
   auto response = CfgOutputBufferResponse{};
 
   raise_if_error(
-      stub->CfgOutputBuffer(&context, request, &response));
+      stub->CfgOutputBuffer(&context, request, &response),
+      context);
 
   return response;
 }
@@ -617,7 +640,8 @@ cfg_pipelined_samp_clk_timing(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = CfgPipelinedSampClkTimingResponse{};
 
   raise_if_error(
-      stub->CfgPipelinedSampClkTiming(&context, request, &response));
+      stub->CfgPipelinedSampClkTiming(&context, request, &response),
+      context);
 
   return response;
 }
@@ -652,7 +676,8 @@ cfg_samp_clk_timing(const StubPtr& stub, const nidevice_grpc::Session& task, con
   auto response = CfgSampClkTimingResponse{};
 
   raise_if_error(
-      stub->CfgSampClkTiming(&context, request, &response));
+      stub->CfgSampClkTiming(&context, request, &response),
+      context);
 
   return response;
 }
@@ -677,7 +702,8 @@ cfg_time_start_trig(const StubPtr& stub, const nidevice_grpc::Session& task, con
   auto response = CfgTimeStartTrigResponse{};
 
   raise_if_error(
-      stub->CfgTimeStartTrig(&context, request, &response));
+      stub->CfgTimeStartTrig(&context, request, &response),
+      context);
 
   return response;
 }
@@ -696,7 +722,8 @@ cfg_watchdog_ao_expir_states(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = CfgWatchdogAOExpirStatesResponse{};
 
   raise_if_error(
-      stub->CfgWatchdogAOExpirStates(&context, request, &response));
+      stub->CfgWatchdogAOExpirStates(&context, request, &response),
+      context);
 
   return response;
 }
@@ -714,7 +741,8 @@ cfg_watchdog_co_expir_states(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = CfgWatchdogCOExpirStatesResponse{};
 
   raise_if_error(
-      stub->CfgWatchdogCOExpirStates(&context, request, &response));
+      stub->CfgWatchdogCOExpirStates(&context, request, &response),
+      context);
 
   return response;
 }
@@ -732,7 +760,8 @@ cfg_watchdog_do_expir_states(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = CfgWatchdogDOExpirStatesResponse{};
 
   raise_if_error(
-      stub->CfgWatchdogDOExpirStates(&context, request, &response));
+      stub->CfgWatchdogDOExpirStates(&context, request, &response),
+      context);
 
   return response;
 }
@@ -748,7 +777,8 @@ clear_teds(const StubPtr& stub, const pb::string& physical_channel)
   auto response = ClearTEDSResponse{};
 
   raise_if_error(
-      stub->ClearTEDS(&context, request, &response));
+      stub->ClearTEDS(&context, request, &response),
+      context);
 
   return response;
 }
@@ -764,7 +794,8 @@ clear_task(const StubPtr& stub, const nidevice_grpc::Session& task)
   auto response = ClearTaskResponse{};
 
   raise_if_error(
-      stub->ClearTask(&context, request, &response));
+      stub->ClearTask(&context, request, &response),
+      context);
 
   return response;
 }
@@ -798,7 +829,8 @@ configure_logging(const StubPtr& stub, const nidevice_grpc::Session& task, const
   auto response = ConfigureLoggingResponse{};
 
   raise_if_error(
-      stub->ConfigureLogging(&context, request, &response));
+      stub->ConfigureLogging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -815,7 +847,8 @@ configure_teds(const StubPtr& stub, const pb::string& physical_channel, const pb
   auto response = ConfigureTEDSResponse{};
 
   raise_if_error(
-      stub->ConfigureTEDS(&context, request, &response));
+      stub->ConfigureTEDS(&context, request, &response),
+      context);
 
   return response;
 }
@@ -840,7 +873,8 @@ connect_terms(const StubPtr& stub, const pb::string& source_terminal, const pb::
   auto response = ConnectTermsResponse{};
 
   raise_if_error(
-      stub->ConnectTerms(&context, request, &response));
+      stub->ConnectTerms(&context, request, &response),
+      context);
 
   return response;
 }
@@ -864,7 +898,8 @@ control_watchdog_task(const StubPtr& stub, const nidevice_grpc::Session& task, c
   auto response = ControlWatchdogTaskResponse{};
 
   raise_if_error(
-      stub->ControlWatchdogTask(&context, request, &response));
+      stub->ControlWatchdogTask(&context, request, &response),
+      context);
 
   return response;
 }
@@ -920,7 +955,8 @@ create_ai_accel4_wire_dc_voltage_chan(const StubPtr& stub, const nidevice_grpc::
   auto response = CreateAIAccel4WireDCVoltageChanResponse{};
 
   raise_if_error(
-      stub->CreateAIAccel4WireDCVoltageChan(&context, request, &response));
+      stub->CreateAIAccel4WireDCVoltageChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -975,7 +1011,8 @@ create_ai_accel_chan(const StubPtr& stub, const nidevice_grpc::Session& task, co
   auto response = CreateAIAccelChanResponse{};
 
   raise_if_error(
-      stub->CreateAIAccelChan(&context, request, &response));
+      stub->CreateAIAccelChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1021,7 +1058,8 @@ create_ai_accel_charge_chan(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = CreateAIAccelChargeChanResponse{};
 
   raise_if_error(
-      stub->CreateAIAccelChargeChan(&context, request, &response));
+      stub->CreateAIAccelChargeChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1068,7 +1106,8 @@ create_ai_bridge_chan(const StubPtr& stub, const nidevice_grpc::Session& task, c
   auto response = CreateAIBridgeChanResponse{};
 
   raise_if_error(
-      stub->CreateAIBridgeChan(&context, request, &response));
+      stub->CreateAIBridgeChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1105,7 +1144,8 @@ create_ai_charge_chan(const StubPtr& stub, const nidevice_grpc::Session& task, c
   auto response = CreateAIChargeChanResponse{};
 
   raise_if_error(
-      stub->CreateAIChargeChan(&context, request, &response));
+      stub->CreateAIChargeChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1151,7 +1191,8 @@ create_ai_current_chan(const StubPtr& stub, const nidevice_grpc::Session& task, 
   auto response = CreateAICurrentChanResponse{};
 
   raise_if_error(
-      stub->CreateAICurrentChan(&context, request, &response));
+      stub->CreateAICurrentChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1197,7 +1238,8 @@ create_ai_current_rms_chan(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = CreateAICurrentRMSChanResponse{};
 
   raise_if_error(
-      stub->CreateAICurrentRMSChan(&context, request, &response));
+      stub->CreateAICurrentRMSChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1262,7 +1304,8 @@ create_ai_force_bridge_polynomial_chan(const StubPtr& stub, const nidevice_grpc:
   auto response = CreateAIForceBridgePolynomialChanResponse{};
 
   raise_if_error(
-      stub->CreateAIForceBridgePolynomialChan(&context, request, &response));
+      stub->CreateAIForceBridgePolynomialChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1327,7 +1370,8 @@ create_ai_force_bridge_table_chan(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = CreateAIForceBridgeTableChanResponse{};
 
   raise_if_error(
-      stub->CreateAIForceBridgeTableChan(&context, request, &response));
+      stub->CreateAIForceBridgeTableChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1394,7 +1438,8 @@ create_ai_force_bridge_two_point_lin_chan(const StubPtr& stub, const nidevice_gr
   auto response = CreateAIForceBridgeTwoPointLinChanResponse{};
 
   raise_if_error(
-      stub->CreateAIForceBridgeTwoPointLinChan(&context, request, &response));
+      stub->CreateAIForceBridgeTwoPointLinChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1449,7 +1494,8 @@ create_ai_force_iepe_chan(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = CreateAIForceIEPEChanResponse{};
 
   raise_if_error(
-      stub->CreateAIForceIEPEChan(&context, request, &response));
+      stub->CreateAIForceIEPEChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1480,7 +1526,8 @@ create_ai_freq_voltage_chan(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = CreateAIFreqVoltageChanResponse{};
 
   raise_if_error(
-      stub->CreateAIFreqVoltageChan(&context, request, &response));
+      stub->CreateAIFreqVoltageChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1526,7 +1573,8 @@ create_ai_microphone_chan(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = CreateAIMicrophoneChanResponse{};
 
   raise_if_error(
-      stub->CreateAIMicrophoneChan(&context, request, &response));
+      stub->CreateAIMicrophoneChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1564,7 +1612,8 @@ create_ai_pos_eddy_curr_prox_probe_chan(const StubPtr& stub, const nidevice_grpc
   auto response = CreateAIPosEddyCurrProxProbeChanResponse{};
 
   raise_if_error(
-      stub->CreateAIPosEddyCurrProxProbeChan(&context, request, &response));
+      stub->CreateAIPosEddyCurrProxProbeChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1620,7 +1669,8 @@ create_ai_pos_lvdt_chan(const StubPtr& stub, const nidevice_grpc::Session& task,
   auto response = CreateAIPosLVDTChanResponse{};
 
   raise_if_error(
-      stub->CreateAIPosLVDTChan(&context, request, &response));
+      stub->CreateAIPosLVDTChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1676,7 +1726,8 @@ create_ai_pos_rvdt_chan(const StubPtr& stub, const nidevice_grpc::Session& task,
   auto response = CreateAIPosRVDTChanResponse{};
 
   raise_if_error(
-      stub->CreateAIPosRVDTChan(&context, request, &response));
+      stub->CreateAIPosRVDTChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1741,7 +1792,8 @@ create_ai_pressure_bridge_polynomial_chan(const StubPtr& stub, const nidevice_gr
   auto response = CreateAIPressureBridgePolynomialChanResponse{};
 
   raise_if_error(
-      stub->CreateAIPressureBridgePolynomialChan(&context, request, &response));
+      stub->CreateAIPressureBridgePolynomialChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1806,7 +1858,8 @@ create_ai_pressure_bridge_table_chan(const StubPtr& stub, const nidevice_grpc::S
   auto response = CreateAIPressureBridgeTableChanResponse{};
 
   raise_if_error(
-      stub->CreateAIPressureBridgeTableChan(&context, request, &response));
+      stub->CreateAIPressureBridgeTableChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1873,7 +1926,8 @@ create_ai_pressure_bridge_two_point_lin_chan(const StubPtr& stub, const nidevice
   auto response = CreateAIPressureBridgeTwoPointLinChanResponse{};
 
   raise_if_error(
-      stub->CreateAIPressureBridgeTwoPointLinChan(&context, request, &response));
+      stub->CreateAIPressureBridgeTwoPointLinChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1927,7 +1981,8 @@ create_airtd_chan(const StubPtr& stub, const nidevice_grpc::Session& task, const
   auto response = CreateAIRTDChanResponse{};
 
   raise_if_error(
-      stub->CreateAIRTDChan(&context, request, &response));
+      stub->CreateAIRTDChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1973,7 +2028,8 @@ create_ai_resistance_chan(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = CreateAIResistanceChanResponse{};
 
   raise_if_error(
-      stub->CreateAIResistanceChan(&context, request, &response));
+      stub->CreateAIResistanceChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2024,7 +2080,8 @@ create_ai_rosette_strain_gage_chan(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = CreateAIRosetteStrainGageChanResponse{};
 
   raise_if_error(
-      stub->CreateAIRosetteStrainGageChan(&context, request, &response));
+      stub->CreateAIRosetteStrainGageChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2075,7 +2132,8 @@ create_ai_strain_gage_chan(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = CreateAIStrainGageChanResponse{};
 
   raise_if_error(
-      stub->CreateAIStrainGageChan(&context, request, &response));
+      stub->CreateAIStrainGageChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2101,7 +2159,8 @@ create_ai_temp_built_in_sensor_chan(const StubPtr& stub, const nidevice_grpc::Se
   auto response = CreateAITempBuiltInSensorChanResponse{};
 
   raise_if_error(
-      stub->CreateAITempBuiltInSensorChan(&context, request, &response));
+      stub->CreateAITempBuiltInSensorChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2147,7 +2206,8 @@ create_ai_thrmcpl_chan(const StubPtr& stub, const nidevice_grpc::Session& task, 
   auto response = CreateAIThrmcplChanResponse{};
 
   raise_if_error(
-      stub->CreateAIThrmcplChan(&context, request, &response));
+      stub->CreateAIThrmcplChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2195,7 +2255,8 @@ create_ai_thrmstr_chan_iex(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = CreateAIThrmstrChanIexResponse{};
 
   raise_if_error(
-      stub->CreateAIThrmstrChanIex(&context, request, &response));
+      stub->CreateAIThrmstrChanIex(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2244,7 +2305,8 @@ create_ai_thrmstr_chan_vex(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = CreateAIThrmstrChanVexResponse{};
 
   raise_if_error(
-      stub->CreateAIThrmstrChanVex(&context, request, &response));
+      stub->CreateAIThrmstrChanVex(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2309,7 +2371,8 @@ create_ai_torque_bridge_polynomial_chan(const StubPtr& stub, const nidevice_grpc
   auto response = CreateAITorqueBridgePolynomialChanResponse{};
 
   raise_if_error(
-      stub->CreateAITorqueBridgePolynomialChan(&context, request, &response));
+      stub->CreateAITorqueBridgePolynomialChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2374,7 +2437,8 @@ create_ai_torque_bridge_table_chan(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = CreateAITorqueBridgeTableChanResponse{};
 
   raise_if_error(
-      stub->CreateAITorqueBridgeTableChan(&context, request, &response));
+      stub->CreateAITorqueBridgeTableChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2441,7 +2505,8 @@ create_ai_torque_bridge_two_point_lin_chan(const StubPtr& stub, const nidevice_g
   auto response = CreateAITorqueBridgeTwoPointLinChanResponse{};
 
   raise_if_error(
-      stub->CreateAITorqueBridgeTwoPointLinChan(&context, request, &response));
+      stub->CreateAITorqueBridgeTwoPointLinChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2496,7 +2561,8 @@ create_ai_velocity_iepe_chan(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = CreateAIVelocityIEPEChanResponse{};
 
   raise_if_error(
-      stub->CreateAIVelocityIEPEChan(&context, request, &response));
+      stub->CreateAIVelocityIEPEChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2533,7 +2599,8 @@ create_ai_voltage_chan(const StubPtr& stub, const nidevice_grpc::Session& task, 
   auto response = CreateAIVoltageChanResponse{};
 
   raise_if_error(
-      stub->CreateAIVoltageChan(&context, request, &response));
+      stub->CreateAIVoltageChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2588,7 +2655,8 @@ create_ai_voltage_chan_with_excit(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = CreateAIVoltageChanWithExcitResponse{};
 
   raise_if_error(
-      stub->CreateAIVoltageChanWithExcit(&context, request, &response));
+      stub->CreateAIVoltageChanWithExcit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2625,7 +2693,8 @@ create_ai_voltage_rms_chan(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = CreateAIVoltageRMSChanResponse{};
 
   raise_if_error(
-      stub->CreateAIVoltageRMSChan(&context, request, &response));
+      stub->CreateAIVoltageRMSChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2654,7 +2723,8 @@ create_ao_current_chan(const StubPtr& stub, const nidevice_grpc::Session& task, 
   auto response = CreateAOCurrentChanResponse{};
 
   raise_if_error(
-      stub->CreateAOCurrentChan(&context, request, &response));
+      stub->CreateAOCurrentChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2683,7 +2753,8 @@ create_ao_func_gen_chan(const StubPtr& stub, const nidevice_grpc::Session& task,
   auto response = CreateAOFuncGenChanResponse{};
 
   raise_if_error(
-      stub->CreateAOFuncGenChan(&context, request, &response));
+      stub->CreateAOFuncGenChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2712,7 +2783,8 @@ create_ao_voltage_chan(const StubPtr& stub, const nidevice_grpc::Session& task, 
   auto response = CreateAOVoltageChanResponse{};
 
   raise_if_error(
-      stub->CreateAOVoltageChan(&context, request, &response));
+      stub->CreateAOVoltageChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2759,7 +2831,8 @@ create_ci_ang_encoder_chan(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = CreateCIAngEncoderChanResponse{};
 
   raise_if_error(
-      stub->CreateCIAngEncoderChan(&context, request, &response));
+      stub->CreateCIAngEncoderChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2797,7 +2870,8 @@ create_ci_ang_velocity_chan(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = CreateCIAngVelocityChanResponse{};
 
   raise_if_error(
-      stub->CreateCIAngVelocityChan(&context, request, &response));
+      stub->CreateCIAngVelocityChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2832,7 +2906,8 @@ create_ci_count_edges_chan(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = CreateCICountEdgesChanResponse{};
 
   raise_if_error(
-      stub->CreateCICountEdgesChan(&context, request, &response));
+      stub->CreateCICountEdgesChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2861,7 +2936,8 @@ create_ci_duty_cycle_chan(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = CreateCIDutyCycleChanResponse{};
 
   raise_if_error(
-      stub->CreateCIDutyCycleChan(&context, request, &response));
+      stub->CreateCIDutyCycleChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2908,7 +2984,8 @@ create_ci_freq_chan(const StubPtr& stub, const nidevice_grpc::Session& task, con
   auto response = CreateCIFreqChanResponse{};
 
   raise_if_error(
-      stub->CreateCIFreqChan(&context, request, &response));
+      stub->CreateCIFreqChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2943,7 +3020,8 @@ create_cigps_timestamp_chan(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = CreateCIGPSTimestampChanResponse{};
 
   raise_if_error(
-      stub->CreateCIGPSTimestampChan(&context, request, &response));
+      stub->CreateCIGPSTimestampChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2990,7 +3068,8 @@ create_ci_lin_encoder_chan(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = CreateCILinEncoderChanResponse{};
 
   raise_if_error(
-      stub->CreateCILinEncoderChan(&context, request, &response));
+      stub->CreateCILinEncoderChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3028,7 +3107,8 @@ create_ci_lin_velocity_chan(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = CreateCILinVelocityChanResponse{};
 
   raise_if_error(
-      stub->CreateCILinVelocityChan(&context, request, &response));
+      stub->CreateCILinVelocityChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3075,7 +3155,8 @@ create_ci_period_chan(const StubPtr& stub, const nidevice_grpc::Session& task, c
   auto response = CreateCIPeriodChanResponse{};
 
   raise_if_error(
-      stub->CreateCIPeriodChan(&context, request, &response));
+      stub->CreateCIPeriodChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3103,7 +3184,8 @@ create_ci_pulse_chan_freq(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = CreateCIPulseChanFreqResponse{};
 
   raise_if_error(
-      stub->CreateCIPulseChanFreq(&context, request, &response));
+      stub->CreateCIPulseChanFreq(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3124,7 +3206,8 @@ create_ci_pulse_chan_ticks(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = CreateCIPulseChanTicksResponse{};
 
   raise_if_error(
-      stub->CreateCIPulseChanTicks(&context, request, &response));
+      stub->CreateCIPulseChanTicks(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3152,7 +3235,8 @@ create_ci_pulse_chan_time(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = CreateCIPulseChanTimeResponse{};
 
   raise_if_error(
-      stub->CreateCIPulseChanTime(&context, request, &response));
+      stub->CreateCIPulseChanTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3189,7 +3273,8 @@ create_ci_pulse_width_chan(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = CreateCIPulseWidthChanResponse{};
 
   raise_if_error(
-      stub->CreateCIPulseWidthChan(&context, request, &response));
+      stub->CreateCIPulseWidthChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3218,7 +3303,8 @@ create_ci_semi_period_chan(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = CreateCISemiPeriodChanResponse{};
 
   raise_if_error(
-      stub->CreateCISemiPeriodChan(&context, request, &response));
+      stub->CreateCISemiPeriodChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3263,7 +3349,8 @@ create_ci_two_edge_sep_chan(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = CreateCITwoEdgeSepChanResponse{};
 
   raise_if_error(
-      stub->CreateCITwoEdgeSepChan(&context, request, &response));
+      stub->CreateCITwoEdgeSepChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3300,7 +3387,8 @@ create_co_pulse_chan_freq(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = CreateCOPulseChanFreqResponse{};
 
   raise_if_error(
-      stub->CreateCOPulseChanFreq(&context, request, &response));
+      stub->CreateCOPulseChanFreq(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3330,7 +3418,8 @@ create_co_pulse_chan_ticks(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = CreateCOPulseChanTicksResponse{};
 
   raise_if_error(
-      stub->CreateCOPulseChanTicks(&context, request, &response));
+      stub->CreateCOPulseChanTicks(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3367,7 +3456,8 @@ create_co_pulse_chan_time(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = CreateCOPulseChanTimeResponse{};
 
   raise_if_error(
-      stub->CreateCOPulseChanTime(&context, request, &response));
+      stub->CreateCOPulseChanTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3393,7 +3483,8 @@ create_di_chan(const StubPtr& stub, const nidevice_grpc::Session& task, const pb
   auto response = CreateDIChanResponse{};
 
   raise_if_error(
-      stub->CreateDIChan(&context, request, &response));
+      stub->CreateDIChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3419,7 +3510,8 @@ create_do_chan(const StubPtr& stub, const nidevice_grpc::Session& task, const pb
   auto response = CreateDOChanResponse{};
 
   raise_if_error(
-      stub->CreateDOChan(&context, request, &response));
+      stub->CreateDOChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3446,7 +3538,8 @@ create_lin_scale(const StubPtr& stub, const pb::string& name, const double& slop
   auto response = CreateLinScaleResponse{};
 
   raise_if_error(
-      stub->CreateLinScale(&context, request, &response));
+      stub->CreateLinScale(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3475,7 +3568,8 @@ create_map_scale(const StubPtr& stub, const pb::string& name, const double& pres
   auto response = CreateMapScaleResponse{};
 
   raise_if_error(
-      stub->CreateMapScale(&context, request, &response));
+      stub->CreateMapScale(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3502,7 +3596,8 @@ create_polynomial_scale(const StubPtr& stub, const pb::string& name, const std::
   auto response = CreatePolynomialScaleResponse{};
 
   raise_if_error(
-      stub->CreatePolynomialScale(&context, request, &response));
+      stub->CreatePolynomialScale(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3548,7 +3643,8 @@ create_tedsai_accel_chan(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = CreateTEDSAIAccelChanResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAIAccelChan(&context, request, &response));
+      stub->CreateTEDSAIAccelChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3586,7 +3682,8 @@ create_tedsai_bridge_chan(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = CreateTEDSAIBridgeChanResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAIBridgeChan(&context, request, &response));
+      stub->CreateTEDSAIBridgeChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3632,7 +3729,8 @@ create_tedsai_current_chan(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = CreateTEDSAICurrentChanResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAICurrentChan(&context, request, &response));
+      stub->CreateTEDSAICurrentChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3670,7 +3768,8 @@ create_tedsai_force_bridge_chan(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = CreateTEDSAIForceBridgeChanResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAIForceBridgeChan(&context, request, &response));
+      stub->CreateTEDSAIForceBridgeChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3716,7 +3815,8 @@ create_tedsai_force_iepe_chan(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = CreateTEDSAIForceIEPEChanResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAIForceIEPEChan(&context, request, &response));
+      stub->CreateTEDSAIForceIEPEChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3761,7 +3861,8 @@ create_tedsai_microphone_chan(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = CreateTEDSAIMicrophoneChanResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAIMicrophoneChan(&context, request, &response));
+      stub->CreateTEDSAIMicrophoneChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3808,7 +3909,8 @@ create_tedsai_pos_lvdt_chan(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = CreateTEDSAIPosLVDTChanResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAIPosLVDTChan(&context, request, &response));
+      stub->CreateTEDSAIPosLVDTChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3855,7 +3957,8 @@ create_tedsai_pos_rvdt_chan(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = CreateTEDSAIPosRVDTChanResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAIPosRVDTChan(&context, request, &response));
+      stub->CreateTEDSAIPosRVDTChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3893,7 +3996,8 @@ create_tedsai_pressure_bridge_chan(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = CreateTEDSAIPressureBridgeChanResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAIPressureBridgeChan(&context, request, &response));
+      stub->CreateTEDSAIPressureBridgeChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3938,7 +4042,8 @@ create_tedsairtd_chan(const StubPtr& stub, const nidevice_grpc::Session& task, c
   auto response = CreateTEDSAIRTDChanResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAIRTDChan(&context, request, &response));
+      stub->CreateTEDSAIRTDChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3984,7 +4089,8 @@ create_tedsai_resistance_chan(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = CreateTEDSAIResistanceChanResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAIResistanceChan(&context, request, &response));
+      stub->CreateTEDSAIResistanceChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4024,7 +4130,8 @@ create_tedsai_strain_gage_chan(const StubPtr& stub, const nidevice_grpc::Session
   auto response = CreateTEDSAIStrainGageChanResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAIStrainGageChan(&context, request, &response));
+      stub->CreateTEDSAIStrainGageChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4062,7 +4169,8 @@ create_tedsai_thrmcpl_chan(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = CreateTEDSAIThrmcplChanResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAIThrmcplChan(&context, request, &response));
+      stub->CreateTEDSAIThrmcplChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4107,7 +4215,8 @@ create_tedsai_thrmstr_chan_iex(const StubPtr& stub, const nidevice_grpc::Session
   auto response = CreateTEDSAIThrmstrChanIexResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAIThrmstrChanIex(&context, request, &response));
+      stub->CreateTEDSAIThrmstrChanIex(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4153,7 +4262,8 @@ create_tedsai_thrmstr_chan_vex(const StubPtr& stub, const nidevice_grpc::Session
   auto response = CreateTEDSAIThrmstrChanVexResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAIThrmstrChanVex(&context, request, &response));
+      stub->CreateTEDSAIThrmstrChanVex(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4191,7 +4301,8 @@ create_tedsai_torque_bridge_chan(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = CreateTEDSAITorqueBridgeChanResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAITorqueBridgeChan(&context, request, &response));
+      stub->CreateTEDSAITorqueBridgeChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4228,7 +4339,8 @@ create_tedsai_voltage_chan(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = CreateTEDSAIVoltageChanResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAIVoltageChan(&context, request, &response));
+      stub->CreateTEDSAIVoltageChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4274,7 +4386,8 @@ create_tedsai_voltage_chan_with_excit(const StubPtr& stub, const nidevice_grpc::
   auto response = CreateTEDSAIVoltageChanWithExcitResponse{};
 
   raise_if_error(
-      stub->CreateTEDSAIVoltageChanWithExcit(&context, request, &response));
+      stub->CreateTEDSAIVoltageChanWithExcit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4301,7 +4414,8 @@ create_table_scale(const StubPtr& stub, const pb::string& name, const std::vecto
   auto response = CreateTableScaleResponse{};
 
   raise_if_error(
-      stub->CreateTableScale(&context, request, &response));
+      stub->CreateTableScale(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4317,7 +4431,8 @@ create_task(const StubPtr& stub, const pb::string& session_name)
   auto response = CreateTaskResponse{};
 
   raise_if_error(
-      stub->CreateTask(&context, request, &response));
+      stub->CreateTask(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4336,7 +4451,8 @@ create_watchdog_timer_task(const StubPtr& stub, const pb::string& device_name, c
   auto response = CreateWatchdogTimerTaskResponse{};
 
   raise_if_error(
-      stub->CreateWatchdogTimerTask(&context, request, &response));
+      stub->CreateWatchdogTimerTask(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4354,7 +4470,8 @@ create_watchdog_timer_task_ex(const StubPtr& stub, const pb::string& device_name
   auto response = CreateWatchdogTimerTaskExResponse{};
 
   raise_if_error(
-      stub->CreateWatchdogTimerTaskEx(&context, request, &response));
+      stub->CreateWatchdogTimerTaskEx(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4370,7 +4487,8 @@ delete_network_device(const StubPtr& stub, const pb::string& device_name)
   auto response = DeleteNetworkDeviceResponse{};
 
   raise_if_error(
-      stub->DeleteNetworkDevice(&context, request, &response));
+      stub->DeleteNetworkDevice(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4386,7 +4504,8 @@ delete_saved_global_chan(const StubPtr& stub, const pb::string& channel_name)
   auto response = DeleteSavedGlobalChanResponse{};
 
   raise_if_error(
-      stub->DeleteSavedGlobalChan(&context, request, &response));
+      stub->DeleteSavedGlobalChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4402,7 +4521,8 @@ delete_saved_scale(const StubPtr& stub, const pb::string& scale_name)
   auto response = DeleteSavedScaleResponse{};
 
   raise_if_error(
-      stub->DeleteSavedScale(&context, request, &response));
+      stub->DeleteSavedScale(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4418,7 +4538,8 @@ delete_saved_task(const StubPtr& stub, const pb::string& task_name)
   auto response = DeleteSavedTaskResponse{};
 
   raise_if_error(
-      stub->DeleteSavedTask(&context, request, &response));
+      stub->DeleteSavedTask(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4434,7 +4555,8 @@ device_supports_cal(const StubPtr& stub, const pb::string& device_name)
   auto response = DeviceSupportsCalResponse{};
 
   raise_if_error(
-      stub->DeviceSupportsCal(&context, request, &response));
+      stub->DeviceSupportsCal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4450,7 +4572,8 @@ disable_ref_trig(const StubPtr& stub, const nidevice_grpc::Session& task)
   auto response = DisableRefTrigResponse{};
 
   raise_if_error(
-      stub->DisableRefTrig(&context, request, &response));
+      stub->DisableRefTrig(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4466,7 +4589,8 @@ disable_start_trig(const StubPtr& stub, const nidevice_grpc::Session& task)
   auto response = DisableStartTrigResponse{};
 
   raise_if_error(
-      stub->DisableStartTrig(&context, request, &response));
+      stub->DisableStartTrig(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4483,7 +4607,8 @@ disconnect_terms(const StubPtr& stub, const pb::string& source_terminal, const p
   auto response = DisconnectTermsResponse{};
 
   raise_if_error(
-      stub->DisconnectTerms(&context, request, &response));
+      stub->DisconnectTerms(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4508,7 +4633,8 @@ export_signal(const StubPtr& stub, const nidevice_grpc::Session& task, const sim
   auto response = ExportSignalResponse{};
 
   raise_if_error(
-      stub->ExportSignal(&context, request, &response));
+      stub->ExportSignal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4525,7 +4651,8 @@ get_ai_chan_cal_cal_date(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = GetAIChanCalCalDateResponse{};
 
   raise_if_error(
-      stub->GetAIChanCalCalDate(&context, request, &response));
+      stub->GetAIChanCalCalDate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4542,7 +4669,8 @@ get_ai_chan_cal_exp_date(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = GetAIChanCalExpDateResponse{};
 
   raise_if_error(
-      stub->GetAIChanCalExpDate(&context, request, &response));
+      stub->GetAIChanCalExpDate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4559,7 +4687,8 @@ get_analog_power_up_states(const StubPtr& stub, const pb::string& device_name, c
   auto response = GetAnalogPowerUpStatesResponse{};
 
   raise_if_error(
-      stub->GetAnalogPowerUpStates(&context, request, &response));
+      stub->GetAnalogPowerUpStates(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4576,7 +4705,8 @@ get_analog_power_up_states_with_output_type(const StubPtr& stub, const pb::strin
   auto response = GetAnalogPowerUpStatesWithOutputTypeResponse{};
 
   raise_if_error(
-      stub->GetAnalogPowerUpStatesWithOutputType(&context, request, &response));
+      stub->GetAnalogPowerUpStatesWithOutputType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4592,7 +4722,8 @@ get_arm_start_trig_timestamp_val(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = GetArmStartTrigTimestampValResponse{};
 
   raise_if_error(
-      stub->GetArmStartTrigTimestampVal(&context, request, &response));
+      stub->GetArmStartTrigTimestampVal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4608,7 +4739,8 @@ get_arm_start_trig_trig_when(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetArmStartTrigTrigWhenResponse{};
 
   raise_if_error(
-      stub->GetArmStartTrigTrigWhen(&context, request, &response));
+      stub->GetArmStartTrigTrigWhen(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4623,7 +4755,8 @@ get_auto_configured_cdaq_sync_connections(const StubPtr& stub)
   auto response = GetAutoConfiguredCDAQSyncConnectionsResponse{};
 
   raise_if_error(
-      stub->GetAutoConfiguredCDAQSyncConnections(&context, request, &response));
+      stub->GetAutoConfiguredCDAQSyncConnections(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4647,7 +4780,8 @@ get_buffer_attribute_uint32(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = GetBufferAttributeUInt32Response{};
 
   raise_if_error(
-      stub->GetBufferAttributeUInt32(&context, request, &response));
+      stub->GetBufferAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4671,7 +4805,8 @@ get_cal_info_attribute_bool(const StubPtr& stub, const pb::string& device_name, 
   auto response = GetCalInfoAttributeBoolResponse{};
 
   raise_if_error(
-      stub->GetCalInfoAttributeBool(&context, request, &response));
+      stub->GetCalInfoAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4695,7 +4830,8 @@ get_cal_info_attribute_double(const StubPtr& stub, const pb::string& device_name
   auto response = GetCalInfoAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->GetCalInfoAttributeDouble(&context, request, &response));
+      stub->GetCalInfoAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4719,7 +4855,8 @@ get_cal_info_attribute_string(const StubPtr& stub, const pb::string& device_name
   auto response = GetCalInfoAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetCalInfoAttributeString(&context, request, &response));
+      stub->GetCalInfoAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4743,7 +4880,8 @@ get_cal_info_attribute_uint32(const StubPtr& stub, const pb::string& device_name
   auto response = GetCalInfoAttributeUInt32Response{};
 
   raise_if_error(
-      stub->GetCalInfoAttributeUInt32(&context, request, &response));
+      stub->GetCalInfoAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4768,7 +4906,8 @@ get_chan_attribute_bool(const StubPtr& stub, const nidevice_grpc::Session& task,
   auto response = GetChanAttributeBoolResponse{};
 
   raise_if_error(
-      stub->GetChanAttributeBool(&context, request, &response));
+      stub->GetChanAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4793,7 +4932,8 @@ get_chan_attribute_double(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = GetChanAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->GetChanAttributeDouble(&context, request, &response));
+      stub->GetChanAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4818,7 +4958,8 @@ get_chan_attribute_double_array(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = GetChanAttributeDoubleArrayResponse{};
 
   raise_if_error(
-      stub->GetChanAttributeDoubleArray(&context, request, &response));
+      stub->GetChanAttributeDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4843,7 +4984,8 @@ get_chan_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = GetChanAttributeInt32Response{};
 
   raise_if_error(
-      stub->GetChanAttributeInt32(&context, request, &response));
+      stub->GetChanAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4868,7 +5010,8 @@ get_chan_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = GetChanAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetChanAttributeString(&context, request, &response));
+      stub->GetChanAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4893,7 +5036,8 @@ get_chan_attribute_uint32(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = GetChanAttributeUInt32Response{};
 
   raise_if_error(
-      stub->GetChanAttributeUInt32(&context, request, &response));
+      stub->GetChanAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4917,7 +5061,8 @@ get_device_attribute_bool(const StubPtr& stub, const pb::string& device_name, co
   auto response = GetDeviceAttributeBoolResponse{};
 
   raise_if_error(
-      stub->GetDeviceAttributeBool(&context, request, &response));
+      stub->GetDeviceAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4941,7 +5086,8 @@ get_device_attribute_double(const StubPtr& stub, const pb::string& device_name, 
   auto response = GetDeviceAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->GetDeviceAttributeDouble(&context, request, &response));
+      stub->GetDeviceAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4965,7 +5111,8 @@ get_device_attribute_double_array(const StubPtr& stub, const pb::string& device_
   auto response = GetDeviceAttributeDoubleArrayResponse{};
 
   raise_if_error(
-      stub->GetDeviceAttributeDoubleArray(&context, request, &response));
+      stub->GetDeviceAttributeDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4989,7 +5136,8 @@ get_device_attribute_int32(const StubPtr& stub, const pb::string& device_name, c
   auto response = GetDeviceAttributeInt32Response{};
 
   raise_if_error(
-      stub->GetDeviceAttributeInt32(&context, request, &response));
+      stub->GetDeviceAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5013,7 +5161,8 @@ get_device_attribute_int32_array(const StubPtr& stub, const pb::string& device_n
   auto response = GetDeviceAttributeInt32ArrayResponse{};
 
   raise_if_error(
-      stub->GetDeviceAttributeInt32Array(&context, request, &response));
+      stub->GetDeviceAttributeInt32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5037,7 +5186,8 @@ get_device_attribute_string(const StubPtr& stub, const pb::string& device_name, 
   auto response = GetDeviceAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetDeviceAttributeString(&context, request, &response));
+      stub->GetDeviceAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5061,7 +5211,8 @@ get_device_attribute_uint32(const StubPtr& stub, const pb::string& device_name, 
   auto response = GetDeviceAttributeUInt32Response{};
 
   raise_if_error(
-      stub->GetDeviceAttributeUInt32(&context, request, &response));
+      stub->GetDeviceAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5085,7 +5236,8 @@ get_device_attribute_uint32_array(const StubPtr& stub, const pb::string& device_
   auto response = GetDeviceAttributeUInt32ArrayResponse{};
 
   raise_if_error(
-      stub->GetDeviceAttributeUInt32Array(&context, request, &response));
+      stub->GetDeviceAttributeUInt32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5101,7 +5253,8 @@ get_digital_logic_family_power_up_state(const StubPtr& stub, const pb::string& d
   auto response = GetDigitalLogicFamilyPowerUpStateResponse{};
 
   raise_if_error(
-      stub->GetDigitalLogicFamilyPowerUpState(&context, request, &response));
+      stub->GetDigitalLogicFamilyPowerUpState(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5118,7 +5271,8 @@ get_digital_power_up_states(const StubPtr& stub, const pb::string& device_name, 
   auto response = GetDigitalPowerUpStatesResponse{};
 
   raise_if_error(
-      stub->GetDigitalPowerUpStates(&context, request, &response));
+      stub->GetDigitalPowerUpStates(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5135,7 +5289,8 @@ get_digital_pull_up_pull_down_states(const StubPtr& stub, const pb::string& devi
   auto response = GetDigitalPullUpPullDownStatesResponse{};
 
   raise_if_error(
-      stub->GetDigitalPullUpPullDownStates(&context, request, &response));
+      stub->GetDigitalPullUpPullDownStates(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5150,7 +5305,8 @@ get_disconnected_cdaq_sync_ports(const StubPtr& stub)
   auto response = GetDisconnectedCDAQSyncPortsResponse{};
 
   raise_if_error(
-      stub->GetDisconnectedCDAQSyncPorts(&context, request, &response));
+      stub->GetDisconnectedCDAQSyncPorts(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5166,7 +5322,8 @@ get_error_string(const StubPtr& stub, const pb::int32& error_code)
   auto response = GetErrorStringResponse{};
 
   raise_if_error(
-      stub->GetErrorString(&context, request, &response));
+      stub->GetErrorString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5190,7 +5347,8 @@ get_exported_signal_attribute_bool(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = GetExportedSignalAttributeBoolResponse{};
 
   raise_if_error(
-      stub->GetExportedSignalAttributeBool(&context, request, &response));
+      stub->GetExportedSignalAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5214,7 +5372,8 @@ get_exported_signal_attribute_double(const StubPtr& stub, const nidevice_grpc::S
   auto response = GetExportedSignalAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->GetExportedSignalAttributeDouble(&context, request, &response));
+      stub->GetExportedSignalAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5238,7 +5397,8 @@ get_exported_signal_attribute_int32(const StubPtr& stub, const nidevice_grpc::Se
   auto response = GetExportedSignalAttributeInt32Response{};
 
   raise_if_error(
-      stub->GetExportedSignalAttributeInt32(&context, request, &response));
+      stub->GetExportedSignalAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5262,7 +5422,8 @@ get_exported_signal_attribute_string(const StubPtr& stub, const nidevice_grpc::S
   auto response = GetExportedSignalAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetExportedSignalAttributeString(&context, request, &response));
+      stub->GetExportedSignalAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5286,7 +5447,8 @@ get_exported_signal_attribute_uint32(const StubPtr& stub, const nidevice_grpc::S
   auto response = GetExportedSignalAttributeUInt32Response{};
 
   raise_if_error(
-      stub->GetExportedSignalAttributeUInt32(&context, request, &response));
+      stub->GetExportedSignalAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5301,7 +5463,8 @@ get_extended_error_info(const StubPtr& stub)
   auto response = GetExtendedErrorInfoResponse{};
 
   raise_if_error(
-      stub->GetExtendedErrorInfo(&context, request, &response));
+      stub->GetExtendedErrorInfo(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5317,7 +5480,8 @@ get_first_samp_clk_when(const StubPtr& stub, const nidevice_grpc::Session& task)
   auto response = GetFirstSampClkWhenResponse{};
 
   raise_if_error(
-      stub->GetFirstSampClkWhen(&context, request, &response));
+      stub->GetFirstSampClkWhen(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5333,7 +5497,8 @@ get_first_samp_timestamp_val(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetFirstSampTimestampValResponse{};
 
   raise_if_error(
-      stub->GetFirstSampTimestampVal(&context, request, &response));
+      stub->GetFirstSampTimestampVal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5350,7 +5515,8 @@ get_nth_task_channel(const StubPtr& stub, const nidevice_grpc::Session& task, co
   auto response = GetNthTaskChannelResponse{};
 
   raise_if_error(
-      stub->GetNthTaskChannel(&context, request, &response));
+      stub->GetNthTaskChannel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5367,7 +5533,8 @@ get_nth_task_device(const StubPtr& stub, const nidevice_grpc::Session& task, con
   auto response = GetNthTaskDeviceResponse{};
 
   raise_if_error(
-      stub->GetNthTaskDevice(&context, request, &response));
+      stub->GetNthTaskDevice(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5384,7 +5551,8 @@ get_nth_task_read_channel(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = GetNthTaskReadChannelResponse{};
 
   raise_if_error(
-      stub->GetNthTaskReadChannel(&context, request, &response));
+      stub->GetNthTaskReadChannel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5408,7 +5576,8 @@ get_persisted_chan_attribute_bool(const StubPtr& stub, const pb::string& channel
   auto response = GetPersistedChanAttributeBoolResponse{};
 
   raise_if_error(
-      stub->GetPersistedChanAttributeBool(&context, request, &response));
+      stub->GetPersistedChanAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5432,7 +5601,8 @@ get_persisted_chan_attribute_string(const StubPtr& stub, const pb::string& chann
   auto response = GetPersistedChanAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetPersistedChanAttributeString(&context, request, &response));
+      stub->GetPersistedChanAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5456,7 +5626,8 @@ get_persisted_scale_attribute_bool(const StubPtr& stub, const pb::string& scale_
   auto response = GetPersistedScaleAttributeBoolResponse{};
 
   raise_if_error(
-      stub->GetPersistedScaleAttributeBool(&context, request, &response));
+      stub->GetPersistedScaleAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5480,7 +5651,8 @@ get_persisted_scale_attribute_string(const StubPtr& stub, const pb::string& scal
   auto response = GetPersistedScaleAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetPersistedScaleAttributeString(&context, request, &response));
+      stub->GetPersistedScaleAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5504,7 +5676,8 @@ get_persisted_task_attribute_bool(const StubPtr& stub, const pb::string& task_na
   auto response = GetPersistedTaskAttributeBoolResponse{};
 
   raise_if_error(
-      stub->GetPersistedTaskAttributeBool(&context, request, &response));
+      stub->GetPersistedTaskAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5528,7 +5701,8 @@ get_persisted_task_attribute_string(const StubPtr& stub, const pb::string& task_
   auto response = GetPersistedTaskAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetPersistedTaskAttributeString(&context, request, &response));
+      stub->GetPersistedTaskAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5552,7 +5726,8 @@ get_physical_chan_attribute_bool(const StubPtr& stub, const pb::string& physical
   auto response = GetPhysicalChanAttributeBoolResponse{};
 
   raise_if_error(
-      stub->GetPhysicalChanAttributeBool(&context, request, &response));
+      stub->GetPhysicalChanAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5576,7 +5751,8 @@ get_physical_chan_attribute_bytes(const StubPtr& stub, const pb::string& physica
   auto response = GetPhysicalChanAttributeBytesResponse{};
 
   raise_if_error(
-      stub->GetPhysicalChanAttributeBytes(&context, request, &response));
+      stub->GetPhysicalChanAttributeBytes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5600,7 +5776,8 @@ get_physical_chan_attribute_double(const StubPtr& stub, const pb::string& physic
   auto response = GetPhysicalChanAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->GetPhysicalChanAttributeDouble(&context, request, &response));
+      stub->GetPhysicalChanAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5624,7 +5801,8 @@ get_physical_chan_attribute_double_array(const StubPtr& stub, const pb::string& 
   auto response = GetPhysicalChanAttributeDoubleArrayResponse{};
 
   raise_if_error(
-      stub->GetPhysicalChanAttributeDoubleArray(&context, request, &response));
+      stub->GetPhysicalChanAttributeDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5648,7 +5826,8 @@ get_physical_chan_attribute_int32(const StubPtr& stub, const pb::string& physica
   auto response = GetPhysicalChanAttributeInt32Response{};
 
   raise_if_error(
-      stub->GetPhysicalChanAttributeInt32(&context, request, &response));
+      stub->GetPhysicalChanAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5672,7 +5851,8 @@ get_physical_chan_attribute_int32_array(const StubPtr& stub, const pb::string& p
   auto response = GetPhysicalChanAttributeInt32ArrayResponse{};
 
   raise_if_error(
-      stub->GetPhysicalChanAttributeInt32Array(&context, request, &response));
+      stub->GetPhysicalChanAttributeInt32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5696,7 +5876,8 @@ get_physical_chan_attribute_string(const StubPtr& stub, const pb::string& physic
   auto response = GetPhysicalChanAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetPhysicalChanAttributeString(&context, request, &response));
+      stub->GetPhysicalChanAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5720,7 +5901,8 @@ get_physical_chan_attribute_uint32(const StubPtr& stub, const pb::string& physic
   auto response = GetPhysicalChanAttributeUInt32Response{};
 
   raise_if_error(
-      stub->GetPhysicalChanAttributeUInt32(&context, request, &response));
+      stub->GetPhysicalChanAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5744,7 +5926,8 @@ get_physical_chan_attribute_uint32_array(const StubPtr& stub, const pb::string& 
   auto response = GetPhysicalChanAttributeUInt32ArrayResponse{};
 
   raise_if_error(
-      stub->GetPhysicalChanAttributeUInt32Array(&context, request, &response));
+      stub->GetPhysicalChanAttributeUInt32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5768,7 +5951,8 @@ get_read_attribute_bool(const StubPtr& stub, const nidevice_grpc::Session& task,
   auto response = GetReadAttributeBoolResponse{};
 
   raise_if_error(
-      stub->GetReadAttributeBool(&context, request, &response));
+      stub->GetReadAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5792,7 +5976,8 @@ get_read_attribute_double(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = GetReadAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->GetReadAttributeDouble(&context, request, &response));
+      stub->GetReadAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5816,7 +6001,8 @@ get_read_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = GetReadAttributeInt32Response{};
 
   raise_if_error(
-      stub->GetReadAttributeInt32(&context, request, &response));
+      stub->GetReadAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5840,7 +6026,8 @@ get_read_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = GetReadAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetReadAttributeString(&context, request, &response));
+      stub->GetReadAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5864,7 +6051,8 @@ get_read_attribute_uint32(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = GetReadAttributeUInt32Response{};
 
   raise_if_error(
-      stub->GetReadAttributeUInt32(&context, request, &response));
+      stub->GetReadAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5888,7 +6076,8 @@ get_read_attribute_uint64(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = GetReadAttributeUInt64Response{};
 
   raise_if_error(
-      stub->GetReadAttributeUInt64(&context, request, &response));
+      stub->GetReadAttributeUInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5912,7 +6101,8 @@ get_real_time_attribute_bool(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetRealTimeAttributeBoolResponse{};
 
   raise_if_error(
-      stub->GetRealTimeAttributeBool(&context, request, &response));
+      stub->GetRealTimeAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5936,7 +6126,8 @@ get_real_time_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = GetRealTimeAttributeInt32Response{};
 
   raise_if_error(
-      stub->GetRealTimeAttributeInt32(&context, request, &response));
+      stub->GetRealTimeAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5960,7 +6151,8 @@ get_real_time_attribute_uint32(const StubPtr& stub, const nidevice_grpc::Session
   auto response = GetRealTimeAttributeUInt32Response{};
 
   raise_if_error(
-      stub->GetRealTimeAttributeUInt32(&context, request, &response));
+      stub->GetRealTimeAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5976,7 +6168,8 @@ get_ref_trig_timestamp_val(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = GetRefTrigTimestampValResponse{};
 
   raise_if_error(
-      stub->GetRefTrigTimestampVal(&context, request, &response));
+      stub->GetRefTrigTimestampVal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6000,7 +6193,8 @@ get_scale_attribute_double(const StubPtr& stub, const pb::string& scale_name, co
   auto response = GetScaleAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->GetScaleAttributeDouble(&context, request, &response));
+      stub->GetScaleAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6024,7 +6218,8 @@ get_scale_attribute_double_array(const StubPtr& stub, const pb::string& scale_na
   auto response = GetScaleAttributeDoubleArrayResponse{};
 
   raise_if_error(
-      stub->GetScaleAttributeDoubleArray(&context, request, &response));
+      stub->GetScaleAttributeDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6048,7 +6243,8 @@ get_scale_attribute_int32(const StubPtr& stub, const pb::string& scale_name, con
   auto response = GetScaleAttributeInt32Response{};
 
   raise_if_error(
-      stub->GetScaleAttributeInt32(&context, request, &response));
+      stub->GetScaleAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6072,7 +6268,8 @@ get_scale_attribute_string(const StubPtr& stub, const pb::string& scale_name, co
   auto response = GetScaleAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetScaleAttributeString(&context, request, &response));
+      stub->GetScaleAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6088,7 +6285,8 @@ get_self_cal_last_date_and_time(const StubPtr& stub, const pb::string& device_na
   auto response = GetSelfCalLastDateAndTimeResponse{};
 
   raise_if_error(
-      stub->GetSelfCalLastDateAndTime(&context, request, &response));
+      stub->GetSelfCalLastDateAndTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6104,7 +6302,8 @@ get_start_trig_timestamp_val(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetStartTrigTimestampValResponse{};
 
   raise_if_error(
-      stub->GetStartTrigTimestampVal(&context, request, &response));
+      stub->GetStartTrigTimestampVal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6120,7 +6319,8 @@ get_start_trig_trig_when(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = GetStartTrigTrigWhenResponse{};
 
   raise_if_error(
-      stub->GetStartTrigTrigWhen(&context, request, &response));
+      stub->GetStartTrigTrigWhen(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6136,7 +6336,8 @@ get_sync_pulse_time_when(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = GetSyncPulseTimeWhenResponse{};
 
   raise_if_error(
-      stub->GetSyncPulseTimeWhen(&context, request, &response));
+      stub->GetSyncPulseTimeWhen(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6159,7 +6360,8 @@ get_system_info_attribute_string(const StubPtr& stub, const simple_variant<Syste
   auto response = GetSystemInfoAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetSystemInfoAttributeString(&context, request, &response));
+      stub->GetSystemInfoAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6182,7 +6384,8 @@ get_system_info_attribute_uint32(const StubPtr& stub, const simple_variant<Syste
   auto response = GetSystemInfoAttributeUInt32Response{};
 
   raise_if_error(
-      stub->GetSystemInfoAttributeUInt32(&context, request, &response));
+      stub->GetSystemInfoAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6206,7 +6409,8 @@ get_task_attribute_bool(const StubPtr& stub, const nidevice_grpc::Session& task,
   auto response = GetTaskAttributeBoolResponse{};
 
   raise_if_error(
-      stub->GetTaskAttributeBool(&context, request, &response));
+      stub->GetTaskAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6230,7 +6434,8 @@ get_task_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = GetTaskAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetTaskAttributeString(&context, request, &response));
+      stub->GetTaskAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6254,7 +6459,8 @@ get_task_attribute_uint32(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = GetTaskAttributeUInt32Response{};
 
   raise_if_error(
-      stub->GetTaskAttributeUInt32(&context, request, &response));
+      stub->GetTaskAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6278,7 +6484,8 @@ get_timing_attribute_bool(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = GetTimingAttributeBoolResponse{};
 
   raise_if_error(
-      stub->GetTimingAttributeBool(&context, request, &response));
+      stub->GetTimingAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6302,7 +6509,8 @@ get_timing_attribute_double(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = GetTimingAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->GetTimingAttributeDouble(&context, request, &response));
+      stub->GetTimingAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6327,7 +6535,8 @@ get_timing_attribute_ex_bool(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetTimingAttributeExBoolResponse{};
 
   raise_if_error(
-      stub->GetTimingAttributeExBool(&context, request, &response));
+      stub->GetTimingAttributeExBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6352,7 +6561,8 @@ get_timing_attribute_ex_double(const StubPtr& stub, const nidevice_grpc::Session
   auto response = GetTimingAttributeExDoubleResponse{};
 
   raise_if_error(
-      stub->GetTimingAttributeExDouble(&context, request, &response));
+      stub->GetTimingAttributeExDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6377,7 +6587,8 @@ get_timing_attribute_ex_int32(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = GetTimingAttributeExInt32Response{};
 
   raise_if_error(
-      stub->GetTimingAttributeExInt32(&context, request, &response));
+      stub->GetTimingAttributeExInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6402,7 +6613,8 @@ get_timing_attribute_ex_string(const StubPtr& stub, const nidevice_grpc::Session
   auto response = GetTimingAttributeExStringResponse{};
 
   raise_if_error(
-      stub->GetTimingAttributeExString(&context, request, &response));
+      stub->GetTimingAttributeExString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6427,7 +6639,8 @@ get_timing_attribute_ex_timestamp(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = GetTimingAttributeExTimestampResponse{};
 
   raise_if_error(
-      stub->GetTimingAttributeExTimestamp(&context, request, &response));
+      stub->GetTimingAttributeExTimestamp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6452,7 +6665,8 @@ get_timing_attribute_ex_uint32(const StubPtr& stub, const nidevice_grpc::Session
   auto response = GetTimingAttributeExUInt32Response{};
 
   raise_if_error(
-      stub->GetTimingAttributeExUInt32(&context, request, &response));
+      stub->GetTimingAttributeExUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6477,7 +6691,8 @@ get_timing_attribute_ex_uint64(const StubPtr& stub, const nidevice_grpc::Session
   auto response = GetTimingAttributeExUInt64Response{};
 
   raise_if_error(
-      stub->GetTimingAttributeExUInt64(&context, request, &response));
+      stub->GetTimingAttributeExUInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6501,7 +6716,8 @@ get_timing_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = GetTimingAttributeInt32Response{};
 
   raise_if_error(
-      stub->GetTimingAttributeInt32(&context, request, &response));
+      stub->GetTimingAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6525,7 +6741,8 @@ get_timing_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = GetTimingAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetTimingAttributeString(&context, request, &response));
+      stub->GetTimingAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6549,7 +6766,8 @@ get_timing_attribute_timestamp(const StubPtr& stub, const nidevice_grpc::Session
   auto response = GetTimingAttributeTimestampResponse{};
 
   raise_if_error(
-      stub->GetTimingAttributeTimestamp(&context, request, &response));
+      stub->GetTimingAttributeTimestamp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6573,7 +6791,8 @@ get_timing_attribute_uint32(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = GetTimingAttributeUInt32Response{};
 
   raise_if_error(
-      stub->GetTimingAttributeUInt32(&context, request, &response));
+      stub->GetTimingAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6597,7 +6816,8 @@ get_timing_attribute_uint64(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = GetTimingAttributeUInt64Response{};
 
   raise_if_error(
-      stub->GetTimingAttributeUInt64(&context, request, &response));
+      stub->GetTimingAttributeUInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6621,7 +6841,8 @@ get_trig_attribute_bool(const StubPtr& stub, const nidevice_grpc::Session& task,
   auto response = GetTrigAttributeBoolResponse{};
 
   raise_if_error(
-      stub->GetTrigAttributeBool(&context, request, &response));
+      stub->GetTrigAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6645,7 +6866,8 @@ get_trig_attribute_double(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = GetTrigAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->GetTrigAttributeDouble(&context, request, &response));
+      stub->GetTrigAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6669,7 +6891,8 @@ get_trig_attribute_double_array(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = GetTrigAttributeDoubleArrayResponse{};
 
   raise_if_error(
-      stub->GetTrigAttributeDoubleArray(&context, request, &response));
+      stub->GetTrigAttributeDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6693,7 +6916,8 @@ get_trig_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = GetTrigAttributeInt32Response{};
 
   raise_if_error(
-      stub->GetTrigAttributeInt32(&context, request, &response));
+      stub->GetTrigAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6717,7 +6941,8 @@ get_trig_attribute_int32_array(const StubPtr& stub, const nidevice_grpc::Session
   auto response = GetTrigAttributeInt32ArrayResponse{};
 
   raise_if_error(
-      stub->GetTrigAttributeInt32Array(&context, request, &response));
+      stub->GetTrigAttributeInt32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6741,7 +6966,8 @@ get_trig_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = GetTrigAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetTrigAttributeString(&context, request, &response));
+      stub->GetTrigAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6765,7 +6991,8 @@ get_trig_attribute_timestamp(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetTrigAttributeTimestampResponse{};
 
   raise_if_error(
-      stub->GetTrigAttributeTimestamp(&context, request, &response));
+      stub->GetTrigAttributeTimestamp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6789,7 +7016,8 @@ get_trig_attribute_uint32(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = GetTrigAttributeUInt32Response{};
 
   raise_if_error(
-      stub->GetTrigAttributeUInt32(&context, request, &response));
+      stub->GetTrigAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6814,7 +7042,8 @@ get_watchdog_attribute_bool(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = GetWatchdogAttributeBoolResponse{};
 
   raise_if_error(
-      stub->GetWatchdogAttributeBool(&context, request, &response));
+      stub->GetWatchdogAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6839,7 +7068,8 @@ get_watchdog_attribute_double(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = GetWatchdogAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->GetWatchdogAttributeDouble(&context, request, &response));
+      stub->GetWatchdogAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6864,7 +7094,8 @@ get_watchdog_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetWatchdogAttributeInt32Response{};
 
   raise_if_error(
-      stub->GetWatchdogAttributeInt32(&context, request, &response));
+      stub->GetWatchdogAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6889,7 +7120,8 @@ get_watchdog_attribute_string(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = GetWatchdogAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetWatchdogAttributeString(&context, request, &response));
+      stub->GetWatchdogAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6913,7 +7145,8 @@ get_write_attribute_bool(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = GetWriteAttributeBoolResponse{};
 
   raise_if_error(
-      stub->GetWriteAttributeBool(&context, request, &response));
+      stub->GetWriteAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6937,7 +7170,8 @@ get_write_attribute_double(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = GetWriteAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->GetWriteAttributeDouble(&context, request, &response));
+      stub->GetWriteAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6961,7 +7195,8 @@ get_write_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = GetWriteAttributeInt32Response{};
 
   raise_if_error(
-      stub->GetWriteAttributeInt32(&context, request, &response));
+      stub->GetWriteAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6985,7 +7220,8 @@ get_write_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = GetWriteAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetWriteAttributeString(&context, request, &response));
+      stub->GetWriteAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7009,7 +7245,8 @@ get_write_attribute_uint32(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = GetWriteAttributeUInt32Response{};
 
   raise_if_error(
-      stub->GetWriteAttributeUInt32(&context, request, &response));
+      stub->GetWriteAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7033,7 +7270,8 @@ get_write_attribute_uint64(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = GetWriteAttributeUInt64Response{};
 
   raise_if_error(
-      stub->GetWriteAttributeUInt64(&context, request, &response));
+      stub->GetWriteAttributeUInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7049,7 +7287,8 @@ is_task_done(const StubPtr& stub, const nidevice_grpc::Session& task)
   auto response = IsTaskDoneResponse{};
 
   raise_if_error(
-      stub->IsTaskDone(&context, request, &response));
+      stub->IsTaskDone(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7065,7 +7304,8 @@ load_task(const StubPtr& stub, const pb::string& session_name)
   auto response = LoadTaskResponse{};
 
   raise_if_error(
-      stub->LoadTask(&context, request, &response));
+      stub->LoadTask(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7092,7 +7332,8 @@ read_analog_f64(const StubPtr& stub, const nidevice_grpc::Session& task, const p
   auto response = ReadAnalogF64Response{};
 
   raise_if_error(
-      stub->ReadAnalogF64(&context, request, &response));
+      stub->ReadAnalogF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7109,7 +7350,8 @@ read_analog_scalar_f64(const StubPtr& stub, const nidevice_grpc::Session& task, 
   auto response = ReadAnalogScalarF64Response{};
 
   raise_if_error(
-      stub->ReadAnalogScalarF64(&context, request, &response));
+      stub->ReadAnalogScalarF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7136,7 +7378,8 @@ read_binary_i16(const StubPtr& stub, const nidevice_grpc::Session& task, const p
   auto response = ReadBinaryI16Response{};
 
   raise_if_error(
-      stub->ReadBinaryI16(&context, request, &response));
+      stub->ReadBinaryI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7163,7 +7406,8 @@ read_binary_i32(const StubPtr& stub, const nidevice_grpc::Session& task, const p
   auto response = ReadBinaryI32Response{};
 
   raise_if_error(
-      stub->ReadBinaryI32(&context, request, &response));
+      stub->ReadBinaryI32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7190,7 +7434,8 @@ read_binary_u16(const StubPtr& stub, const nidevice_grpc::Session& task, const p
   auto response = ReadBinaryU16Response{};
 
   raise_if_error(
-      stub->ReadBinaryU16(&context, request, &response));
+      stub->ReadBinaryU16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7217,7 +7462,8 @@ read_binary_u32(const StubPtr& stub, const nidevice_grpc::Session& task, const p
   auto response = ReadBinaryU32Response{};
 
   raise_if_error(
-      stub->ReadBinaryU32(&context, request, &response));
+      stub->ReadBinaryU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7236,7 +7482,8 @@ read_counter_f64(const StubPtr& stub, const nidevice_grpc::Session& task, const 
   auto response = ReadCounterF64Response{};
 
   raise_if_error(
-      stub->ReadCounterF64(&context, request, &response));
+      stub->ReadCounterF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7263,7 +7510,8 @@ read_counter_f64_ex(const StubPtr& stub, const nidevice_grpc::Session& task, con
   auto response = ReadCounterF64ExResponse{};
 
   raise_if_error(
-      stub->ReadCounterF64Ex(&context, request, &response));
+      stub->ReadCounterF64Ex(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7280,7 +7528,8 @@ read_counter_scalar_f64(const StubPtr& stub, const nidevice_grpc::Session& task,
   auto response = ReadCounterScalarF64Response{};
 
   raise_if_error(
-      stub->ReadCounterScalarF64(&context, request, &response));
+      stub->ReadCounterScalarF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7297,7 +7546,8 @@ read_counter_scalar_u32(const StubPtr& stub, const nidevice_grpc::Session& task,
   auto response = ReadCounterScalarU32Response{};
 
   raise_if_error(
-      stub->ReadCounterScalarU32(&context, request, &response));
+      stub->ReadCounterScalarU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7316,7 +7566,8 @@ read_counter_u32(const StubPtr& stub, const nidevice_grpc::Session& task, const 
   auto response = ReadCounterU32Response{};
 
   raise_if_error(
-      stub->ReadCounterU32(&context, request, &response));
+      stub->ReadCounterU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7343,7 +7594,8 @@ read_counter_u32_ex(const StubPtr& stub, const nidevice_grpc::Session& task, con
   auto response = ReadCounterU32ExResponse{};
 
   raise_if_error(
-      stub->ReadCounterU32Ex(&context, request, &response));
+      stub->ReadCounterU32Ex(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7370,7 +7622,8 @@ read_ctr_freq(const StubPtr& stub, const nidevice_grpc::Session& task, const pb:
   auto response = ReadCtrFreqResponse{};
 
   raise_if_error(
-      stub->ReadCtrFreq(&context, request, &response));
+      stub->ReadCtrFreq(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7387,7 +7640,8 @@ read_ctr_freq_scalar(const StubPtr& stub, const nidevice_grpc::Session& task, co
   auto response = ReadCtrFreqScalarResponse{};
 
   raise_if_error(
-      stub->ReadCtrFreqScalar(&context, request, &response));
+      stub->ReadCtrFreqScalar(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7414,7 +7668,8 @@ read_ctr_ticks(const StubPtr& stub, const nidevice_grpc::Session& task, const pb
   auto response = ReadCtrTicksResponse{};
 
   raise_if_error(
-      stub->ReadCtrTicks(&context, request, &response));
+      stub->ReadCtrTicks(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7431,7 +7686,8 @@ read_ctr_ticks_scalar(const StubPtr& stub, const nidevice_grpc::Session& task, c
   auto response = ReadCtrTicksScalarResponse{};
 
   raise_if_error(
-      stub->ReadCtrTicksScalar(&context, request, &response));
+      stub->ReadCtrTicksScalar(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7458,7 +7714,8 @@ read_ctr_time(const StubPtr& stub, const nidevice_grpc::Session& task, const pb:
   auto response = ReadCtrTimeResponse{};
 
   raise_if_error(
-      stub->ReadCtrTime(&context, request, &response));
+      stub->ReadCtrTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7475,7 +7732,8 @@ read_ctr_time_scalar(const StubPtr& stub, const nidevice_grpc::Session& task, co
   auto response = ReadCtrTimeScalarResponse{};
 
   raise_if_error(
-      stub->ReadCtrTimeScalar(&context, request, &response));
+      stub->ReadCtrTimeScalar(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7502,7 +7760,8 @@ read_digital_lines(const StubPtr& stub, const nidevice_grpc::Session& task, cons
   auto response = ReadDigitalLinesResponse{};
 
   raise_if_error(
-      stub->ReadDigitalLines(&context, request, &response));
+      stub->ReadDigitalLines(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7519,7 +7778,8 @@ read_digital_scalar_u32(const StubPtr& stub, const nidevice_grpc::Session& task,
   auto response = ReadDigitalScalarU32Response{};
 
   raise_if_error(
-      stub->ReadDigitalScalarU32(&context, request, &response));
+      stub->ReadDigitalScalarU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7546,7 +7806,8 @@ read_digital_u16(const StubPtr& stub, const nidevice_grpc::Session& task, const 
   auto response = ReadDigitalU16Response{};
 
   raise_if_error(
-      stub->ReadDigitalU16(&context, request, &response));
+      stub->ReadDigitalU16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7573,7 +7834,8 @@ read_digital_u32(const StubPtr& stub, const nidevice_grpc::Session& task, const 
   auto response = ReadDigitalU32Response{};
 
   raise_if_error(
-      stub->ReadDigitalU32(&context, request, &response));
+      stub->ReadDigitalU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7600,7 +7862,8 @@ read_digital_u8(const StubPtr& stub, const nidevice_grpc::Session& task, const p
   auto response = ReadDigitalU8Response{};
 
   raise_if_error(
-      stub->ReadDigitalU8(&context, request, &response));
+      stub->ReadDigitalU8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7619,7 +7882,8 @@ read_raw(const StubPtr& stub, const nidevice_grpc::Session& task, const pb::int3
   auto response = ReadRawResponse{};
 
   raise_if_error(
-      stub->ReadRaw(&context, request, &response));
+      stub->ReadRaw(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7679,7 +7943,8 @@ remove_cdaq_sync_connection(const StubPtr& stub, const pb::string& port_list)
   auto response = RemoveCDAQSyncConnectionResponse{};
 
   raise_if_error(
-      stub->RemoveCDAQSyncConnection(&context, request, &response));
+      stub->RemoveCDAQSyncConnection(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7696,7 +7961,8 @@ reserve_network_device(const StubPtr& stub, const pb::string& device_name, const
   auto response = ReserveNetworkDeviceResponse{};
 
   raise_if_error(
-      stub->ReserveNetworkDevice(&context, request, &response));
+      stub->ReserveNetworkDevice(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7720,7 +7986,8 @@ reset_buffer_attribute(const StubPtr& stub, const nidevice_grpc::Session& task, 
   auto response = ResetBufferAttributeResponse{};
 
   raise_if_error(
-      stub->ResetBufferAttribute(&context, request, &response));
+      stub->ResetBufferAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7745,7 +8012,8 @@ reset_chan_attribute(const StubPtr& stub, const nidevice_grpc::Session& task, co
   auto response = ResetChanAttributeResponse{};
 
   raise_if_error(
-      stub->ResetChanAttribute(&context, request, &response));
+      stub->ResetChanAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7761,7 +8029,8 @@ reset_device(const StubPtr& stub, const pb::string& device_name)
   auto response = ResetDeviceResponse{};
 
   raise_if_error(
-      stub->ResetDevice(&context, request, &response));
+      stub->ResetDevice(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7785,7 +8054,8 @@ reset_exported_signal_attribute(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = ResetExportedSignalAttributeResponse{};
 
   raise_if_error(
-      stub->ResetExportedSignalAttribute(&context, request, &response));
+      stub->ResetExportedSignalAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7809,7 +8079,8 @@ reset_read_attribute(const StubPtr& stub, const nidevice_grpc::Session& task, co
   auto response = ResetReadAttributeResponse{};
 
   raise_if_error(
-      stub->ResetReadAttribute(&context, request, &response));
+      stub->ResetReadAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7833,7 +8104,8 @@ reset_real_time_attribute(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = ResetRealTimeAttributeResponse{};
 
   raise_if_error(
-      stub->ResetRealTimeAttribute(&context, request, &response));
+      stub->ResetRealTimeAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7857,7 +8129,8 @@ reset_timing_attribute(const StubPtr& stub, const nidevice_grpc::Session& task, 
   auto response = ResetTimingAttributeResponse{};
 
   raise_if_error(
-      stub->ResetTimingAttribute(&context, request, &response));
+      stub->ResetTimingAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7882,7 +8155,8 @@ reset_timing_attribute_ex(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = ResetTimingAttributeExResponse{};
 
   raise_if_error(
-      stub->ResetTimingAttributeEx(&context, request, &response));
+      stub->ResetTimingAttributeEx(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7906,7 +8180,8 @@ reset_trig_attribute(const StubPtr& stub, const nidevice_grpc::Session& task, co
   auto response = ResetTrigAttributeResponse{};
 
   raise_if_error(
-      stub->ResetTrigAttribute(&context, request, &response));
+      stub->ResetTrigAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7931,7 +8206,8 @@ reset_watchdog_attribute(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = ResetWatchdogAttributeResponse{};
 
   raise_if_error(
-      stub->ResetWatchdogAttribute(&context, request, &response));
+      stub->ResetWatchdogAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7955,7 +8231,8 @@ reset_write_attribute(const StubPtr& stub, const nidevice_grpc::Session& task, c
   auto response = ResetWriteAttributeResponse{};
 
   raise_if_error(
-      stub->ResetWriteAttribute(&context, request, &response));
+      stub->ResetWriteAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7982,7 +8259,8 @@ save_global_chan(const StubPtr& stub, const nidevice_grpc::Session& task, const 
   auto response = SaveGlobalChanResponse{};
 
   raise_if_error(
-      stub->SaveGlobalChan(&context, request, &response));
+      stub->SaveGlobalChan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8008,7 +8286,8 @@ save_scale(const StubPtr& stub, const pb::string& scale_name, const pb::string& 
   auto response = SaveScaleResponse{};
 
   raise_if_error(
-      stub->SaveScale(&context, request, &response));
+      stub->SaveScale(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8034,7 +8313,8 @@ save_task(const StubPtr& stub, const nidevice_grpc::Session& task, const pb::str
   auto response = SaveTaskResponse{};
 
   raise_if_error(
-      stub->SaveTask(&context, request, &response));
+      stub->SaveTask(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8050,7 +8330,8 @@ self_cal(const StubPtr& stub, const pb::string& device_name)
   auto response = SelfCalResponse{};
 
   raise_if_error(
-      stub->SelfCal(&context, request, &response));
+      stub->SelfCal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8066,7 +8347,8 @@ self_test_device(const StubPtr& stub, const pb::string& device_name)
   auto response = SelfTestDeviceResponse{};
 
   raise_if_error(
-      stub->SelfTestDevice(&context, request, &response));
+      stub->SelfTestDevice(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8088,7 +8370,8 @@ set_ai_chan_cal_cal_date(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = SetAIChanCalCalDateResponse{};
 
   raise_if_error(
-      stub->SetAIChanCalCalDate(&context, request, &response));
+      stub->SetAIChanCalCalDate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8110,7 +8393,8 @@ set_ai_chan_cal_exp_date(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = SetAIChanCalExpDateResponse{};
 
   raise_if_error(
-      stub->SetAIChanCalExpDate(&context, request, &response));
+      stub->SetAIChanCalExpDate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8127,7 +8411,8 @@ set_analog_power_up_states(const StubPtr& stub, const pb::string& device_name, c
   auto response = SetAnalogPowerUpStatesResponse{};
 
   raise_if_error(
-      stub->SetAnalogPowerUpStates(&context, request, &response));
+      stub->SetAnalogPowerUpStates(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8145,7 +8430,8 @@ set_analog_power_up_states_with_output_type(const StubPtr& stub, const pb::strin
   auto response = SetAnalogPowerUpStatesWithOutputTypeResponse{};
 
   raise_if_error(
-      stub->SetAnalogPowerUpStatesWithOutputType(&context, request, &response));
+      stub->SetAnalogPowerUpStatesWithOutputType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8162,7 +8448,8 @@ set_arm_start_trig_trig_when(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SetArmStartTrigTrigWhenResponse{};
 
   raise_if_error(
-      stub->SetArmStartTrigTrigWhen(&context, request, &response));
+      stub->SetArmStartTrigTrigWhen(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8187,7 +8474,8 @@ set_buffer_attribute_uint32(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = SetBufferAttributeUInt32Response{};
 
   raise_if_error(
-      stub->SetBufferAttributeUInt32(&context, request, &response));
+      stub->SetBufferAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8212,7 +8500,8 @@ set_cal_info_attribute_bool(const StubPtr& stub, const pb::string& device_name, 
   auto response = SetCalInfoAttributeBoolResponse{};
 
   raise_if_error(
-      stub->SetCalInfoAttributeBool(&context, request, &response));
+      stub->SetCalInfoAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8237,7 +8526,8 @@ set_cal_info_attribute_double(const StubPtr& stub, const pb::string& device_name
   auto response = SetCalInfoAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->SetCalInfoAttributeDouble(&context, request, &response));
+      stub->SetCalInfoAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8262,7 +8552,8 @@ set_cal_info_attribute_string(const StubPtr& stub, const pb::string& device_name
   auto response = SetCalInfoAttributeStringResponse{};
 
   raise_if_error(
-      stub->SetCalInfoAttributeString(&context, request, &response));
+      stub->SetCalInfoAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8287,7 +8578,8 @@ set_cal_info_attribute_uint32(const StubPtr& stub, const pb::string& device_name
   auto response = SetCalInfoAttributeUInt32Response{};
 
   raise_if_error(
-      stub->SetCalInfoAttributeUInt32(&context, request, &response));
+      stub->SetCalInfoAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8313,7 +8605,8 @@ set_chan_attribute_bool(const StubPtr& stub, const nidevice_grpc::Session& task,
   auto response = SetChanAttributeBoolResponse{};
 
   raise_if_error(
-      stub->SetChanAttributeBool(&context, request, &response));
+      stub->SetChanAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8339,7 +8632,8 @@ set_chan_attribute_double(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = SetChanAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->SetChanAttributeDouble(&context, request, &response));
+      stub->SetChanAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8365,7 +8659,8 @@ set_chan_attribute_double_array(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = SetChanAttributeDoubleArrayResponse{};
 
   raise_if_error(
-      stub->SetChanAttributeDoubleArray(&context, request, &response));
+      stub->SetChanAttributeDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8398,7 +8693,8 @@ set_chan_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = SetChanAttributeInt32Response{};
 
   raise_if_error(
-      stub->SetChanAttributeInt32(&context, request, &response));
+      stub->SetChanAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8424,7 +8720,8 @@ set_chan_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = SetChanAttributeStringResponse{};
 
   raise_if_error(
-      stub->SetChanAttributeString(&context, request, &response));
+      stub->SetChanAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8450,7 +8747,8 @@ set_chan_attribute_uint32(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = SetChanAttributeUInt32Response{};
 
   raise_if_error(
-      stub->SetChanAttributeUInt32(&context, request, &response));
+      stub->SetChanAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8474,7 +8772,8 @@ set_digital_logic_family_power_up_state(const StubPtr& stub, const pb::string& d
   auto response = SetDigitalLogicFamilyPowerUpStateResponse{};
 
   raise_if_error(
-      stub->SetDigitalLogicFamilyPowerUpState(&context, request, &response));
+      stub->SetDigitalLogicFamilyPowerUpState(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8491,7 +8790,8 @@ set_digital_power_up_states(const StubPtr& stub, const pb::string& device_name, 
   auto response = SetDigitalPowerUpStatesResponse{};
 
   raise_if_error(
-      stub->SetDigitalPowerUpStates(&context, request, &response));
+      stub->SetDigitalPowerUpStates(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8508,7 +8808,8 @@ set_digital_pull_up_pull_down_states(const StubPtr& stub, const pb::string& devi
   auto response = SetDigitalPullUpPullDownStatesResponse{};
 
   raise_if_error(
-      stub->SetDigitalPullUpPullDownStates(&context, request, &response));
+      stub->SetDigitalPullUpPullDownStates(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8533,7 +8834,8 @@ set_exported_signal_attribute_bool(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = SetExportedSignalAttributeBoolResponse{};
 
   raise_if_error(
-      stub->SetExportedSignalAttributeBool(&context, request, &response));
+      stub->SetExportedSignalAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8558,7 +8860,8 @@ set_exported_signal_attribute_double(const StubPtr& stub, const nidevice_grpc::S
   auto response = SetExportedSignalAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->SetExportedSignalAttributeDouble(&context, request, &response));
+      stub->SetExportedSignalAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8590,7 +8893,8 @@ set_exported_signal_attribute_int32(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SetExportedSignalAttributeInt32Response{};
 
   raise_if_error(
-      stub->SetExportedSignalAttributeInt32(&context, request, &response));
+      stub->SetExportedSignalAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8615,7 +8919,8 @@ set_exported_signal_attribute_string(const StubPtr& stub, const nidevice_grpc::S
   auto response = SetExportedSignalAttributeStringResponse{};
 
   raise_if_error(
-      stub->SetExportedSignalAttributeString(&context, request, &response));
+      stub->SetExportedSignalAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8640,7 +8945,8 @@ set_exported_signal_attribute_uint32(const StubPtr& stub, const nidevice_grpc::S
   auto response = SetExportedSignalAttributeUInt32Response{};
 
   raise_if_error(
-      stub->SetExportedSignalAttributeUInt32(&context, request, &response));
+      stub->SetExportedSignalAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8657,7 +8963,8 @@ set_first_samp_clk_when(const StubPtr& stub, const nidevice_grpc::Session& task,
   auto response = SetFirstSampClkWhenResponse{};
 
   raise_if_error(
-      stub->SetFirstSampClkWhen(&context, request, &response));
+      stub->SetFirstSampClkWhen(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8682,7 +8989,8 @@ set_read_attribute_bool(const StubPtr& stub, const nidevice_grpc::Session& task,
   auto response = SetReadAttributeBoolResponse{};
 
   raise_if_error(
-      stub->SetReadAttributeBool(&context, request, &response));
+      stub->SetReadAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8707,7 +9015,8 @@ set_read_attribute_double(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = SetReadAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->SetReadAttributeDouble(&context, request, &response));
+      stub->SetReadAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8739,7 +9048,8 @@ set_read_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = SetReadAttributeInt32Response{};
 
   raise_if_error(
-      stub->SetReadAttributeInt32(&context, request, &response));
+      stub->SetReadAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8764,7 +9074,8 @@ set_read_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = SetReadAttributeStringResponse{};
 
   raise_if_error(
-      stub->SetReadAttributeString(&context, request, &response));
+      stub->SetReadAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8789,7 +9100,8 @@ set_read_attribute_uint32(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = SetReadAttributeUInt32Response{};
 
   raise_if_error(
-      stub->SetReadAttributeUInt32(&context, request, &response));
+      stub->SetReadAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8814,7 +9126,8 @@ set_read_attribute_uint64(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = SetReadAttributeUInt64Response{};
 
   raise_if_error(
-      stub->SetReadAttributeUInt64(&context, request, &response));
+      stub->SetReadAttributeUInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8839,7 +9152,8 @@ set_real_time_attribute_bool(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SetRealTimeAttributeBoolResponse{};
 
   raise_if_error(
-      stub->SetRealTimeAttributeBool(&context, request, &response));
+      stub->SetRealTimeAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8871,7 +9185,8 @@ set_real_time_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SetRealTimeAttributeInt32Response{};
 
   raise_if_error(
-      stub->SetRealTimeAttributeInt32(&context, request, &response));
+      stub->SetRealTimeAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8896,7 +9211,8 @@ set_real_time_attribute_uint32(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SetRealTimeAttributeUInt32Response{};
 
   raise_if_error(
-      stub->SetRealTimeAttributeUInt32(&context, request, &response));
+      stub->SetRealTimeAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8921,7 +9237,8 @@ set_scale_attribute_double(const StubPtr& stub, const pb::string& scale_name, co
   auto response = SetScaleAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->SetScaleAttributeDouble(&context, request, &response));
+      stub->SetScaleAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8946,7 +9263,8 @@ set_scale_attribute_double_array(const StubPtr& stub, const pb::string& scale_na
   auto response = SetScaleAttributeDoubleArrayResponse{};
 
   raise_if_error(
-      stub->SetScaleAttributeDoubleArray(&context, request, &response));
+      stub->SetScaleAttributeDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8978,7 +9296,8 @@ set_scale_attribute_int32(const StubPtr& stub, const pb::string& scale_name, con
   auto response = SetScaleAttributeInt32Response{};
 
   raise_if_error(
-      stub->SetScaleAttributeInt32(&context, request, &response));
+      stub->SetScaleAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9003,7 +9322,8 @@ set_scale_attribute_string(const StubPtr& stub, const pb::string& scale_name, co
   auto response = SetScaleAttributeStringResponse{};
 
   raise_if_error(
-      stub->SetScaleAttributeString(&context, request, &response));
+      stub->SetScaleAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9020,7 +9340,8 @@ set_start_trig_trig_when(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = SetStartTrigTrigWhenResponse{};
 
   raise_if_error(
-      stub->SetStartTrigTrigWhen(&context, request, &response));
+      stub->SetStartTrigTrigWhen(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9037,7 +9358,8 @@ set_sync_pulse_time_when(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = SetSyncPulseTimeWhenResponse{};
 
   raise_if_error(
-      stub->SetSyncPulseTimeWhen(&context, request, &response));
+      stub->SetSyncPulseTimeWhen(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9062,7 +9384,8 @@ set_timing_attribute_bool(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = SetTimingAttributeBoolResponse{};
 
   raise_if_error(
-      stub->SetTimingAttributeBool(&context, request, &response));
+      stub->SetTimingAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9087,7 +9410,8 @@ set_timing_attribute_double(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = SetTimingAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->SetTimingAttributeDouble(&context, request, &response));
+      stub->SetTimingAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9113,7 +9437,8 @@ set_timing_attribute_ex_bool(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SetTimingAttributeExBoolResponse{};
 
   raise_if_error(
-      stub->SetTimingAttributeExBool(&context, request, &response));
+      stub->SetTimingAttributeExBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9139,7 +9464,8 @@ set_timing_attribute_ex_double(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SetTimingAttributeExDoubleResponse{};
 
   raise_if_error(
-      stub->SetTimingAttributeExDouble(&context, request, &response));
+      stub->SetTimingAttributeExDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9172,7 +9498,8 @@ set_timing_attribute_ex_int32(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SetTimingAttributeExInt32Response{};
 
   raise_if_error(
-      stub->SetTimingAttributeExInt32(&context, request, &response));
+      stub->SetTimingAttributeExInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9198,7 +9525,8 @@ set_timing_attribute_ex_string(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SetTimingAttributeExStringResponse{};
 
   raise_if_error(
-      stub->SetTimingAttributeExString(&context, request, &response));
+      stub->SetTimingAttributeExString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9224,7 +9552,8 @@ set_timing_attribute_ex_timestamp(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = SetTimingAttributeExTimestampResponse{};
 
   raise_if_error(
-      stub->SetTimingAttributeExTimestamp(&context, request, &response));
+      stub->SetTimingAttributeExTimestamp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9250,7 +9579,8 @@ set_timing_attribute_ex_uint32(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SetTimingAttributeExUInt32Response{};
 
   raise_if_error(
-      stub->SetTimingAttributeExUInt32(&context, request, &response));
+      stub->SetTimingAttributeExUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9276,7 +9606,8 @@ set_timing_attribute_ex_uint64(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SetTimingAttributeExUInt64Response{};
 
   raise_if_error(
-      stub->SetTimingAttributeExUInt64(&context, request, &response));
+      stub->SetTimingAttributeExUInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9308,7 +9639,8 @@ set_timing_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = SetTimingAttributeInt32Response{};
 
   raise_if_error(
-      stub->SetTimingAttributeInt32(&context, request, &response));
+      stub->SetTimingAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9333,7 +9665,8 @@ set_timing_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = SetTimingAttributeStringResponse{};
 
   raise_if_error(
-      stub->SetTimingAttributeString(&context, request, &response));
+      stub->SetTimingAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9358,7 +9691,8 @@ set_timing_attribute_timestamp(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SetTimingAttributeTimestampResponse{};
 
   raise_if_error(
-      stub->SetTimingAttributeTimestamp(&context, request, &response));
+      stub->SetTimingAttributeTimestamp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9383,7 +9717,8 @@ set_timing_attribute_uint32(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = SetTimingAttributeUInt32Response{};
 
   raise_if_error(
-      stub->SetTimingAttributeUInt32(&context, request, &response));
+      stub->SetTimingAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9408,7 +9743,8 @@ set_timing_attribute_uint64(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = SetTimingAttributeUInt64Response{};
 
   raise_if_error(
-      stub->SetTimingAttributeUInt64(&context, request, &response));
+      stub->SetTimingAttributeUInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9433,7 +9769,8 @@ set_trig_attribute_bool(const StubPtr& stub, const nidevice_grpc::Session& task,
   auto response = SetTrigAttributeBoolResponse{};
 
   raise_if_error(
-      stub->SetTrigAttributeBool(&context, request, &response));
+      stub->SetTrigAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9458,7 +9795,8 @@ set_trig_attribute_double(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = SetTrigAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->SetTrigAttributeDouble(&context, request, &response));
+      stub->SetTrigAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9483,7 +9821,8 @@ set_trig_attribute_double_array(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = SetTrigAttributeDoubleArrayResponse{};
 
   raise_if_error(
-      stub->SetTrigAttributeDoubleArray(&context, request, &response));
+      stub->SetTrigAttributeDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9515,7 +9854,8 @@ set_trig_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = SetTrigAttributeInt32Response{};
 
   raise_if_error(
-      stub->SetTrigAttributeInt32(&context, request, &response));
+      stub->SetTrigAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9540,7 +9880,8 @@ set_trig_attribute_int32_array(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SetTrigAttributeInt32ArrayResponse{};
 
   raise_if_error(
-      stub->SetTrigAttributeInt32Array(&context, request, &response));
+      stub->SetTrigAttributeInt32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9565,7 +9906,8 @@ set_trig_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = SetTrigAttributeStringResponse{};
 
   raise_if_error(
-      stub->SetTrigAttributeString(&context, request, &response));
+      stub->SetTrigAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9590,7 +9932,8 @@ set_trig_attribute_timestamp(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SetTrigAttributeTimestampResponse{};
 
   raise_if_error(
-      stub->SetTrigAttributeTimestamp(&context, request, &response));
+      stub->SetTrigAttributeTimestamp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9615,7 +9958,8 @@ set_trig_attribute_uint32(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = SetTrigAttributeUInt32Response{};
 
   raise_if_error(
-      stub->SetTrigAttributeUInt32(&context, request, &response));
+      stub->SetTrigAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9641,7 +9985,8 @@ set_watchdog_attribute_bool(const StubPtr& stub, const nidevice_grpc::Session& t
   auto response = SetWatchdogAttributeBoolResponse{};
 
   raise_if_error(
-      stub->SetWatchdogAttributeBool(&context, request, &response));
+      stub->SetWatchdogAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9667,7 +10012,8 @@ set_watchdog_attribute_double(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SetWatchdogAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->SetWatchdogAttributeDouble(&context, request, &response));
+      stub->SetWatchdogAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9700,7 +10046,8 @@ set_watchdog_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SetWatchdogAttributeInt32Response{};
 
   raise_if_error(
-      stub->SetWatchdogAttributeInt32(&context, request, &response));
+      stub->SetWatchdogAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9726,7 +10073,8 @@ set_watchdog_attribute_string(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SetWatchdogAttributeStringResponse{};
 
   raise_if_error(
-      stub->SetWatchdogAttributeString(&context, request, &response));
+      stub->SetWatchdogAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9751,7 +10099,8 @@ set_write_attribute_bool(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = SetWriteAttributeBoolResponse{};
 
   raise_if_error(
-      stub->SetWriteAttributeBool(&context, request, &response));
+      stub->SetWriteAttributeBool(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9776,7 +10125,8 @@ set_write_attribute_double(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = SetWriteAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->SetWriteAttributeDouble(&context, request, &response));
+      stub->SetWriteAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9808,7 +10158,8 @@ set_write_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session& tas
   auto response = SetWriteAttributeInt32Response{};
 
   raise_if_error(
-      stub->SetWriteAttributeInt32(&context, request, &response));
+      stub->SetWriteAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9833,7 +10184,8 @@ set_write_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = SetWriteAttributeStringResponse{};
 
   raise_if_error(
-      stub->SetWriteAttributeString(&context, request, &response));
+      stub->SetWriteAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9858,7 +10210,8 @@ set_write_attribute_uint32(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = SetWriteAttributeUInt32Response{};
 
   raise_if_error(
-      stub->SetWriteAttributeUInt32(&context, request, &response));
+      stub->SetWriteAttributeUInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9883,7 +10236,8 @@ set_write_attribute_uint64(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = SetWriteAttributeUInt64Response{};
 
   raise_if_error(
-      stub->SetWriteAttributeUInt64(&context, request, &response));
+      stub->SetWriteAttributeUInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9900,7 +10254,8 @@ start_new_file(const StubPtr& stub, const nidevice_grpc::Session& task, const pb
   auto response = StartNewFileResponse{};
 
   raise_if_error(
-      stub->StartNewFile(&context, request, &response));
+      stub->StartNewFile(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9916,7 +10271,8 @@ start_task(const StubPtr& stub, const nidevice_grpc::Session& task)
   auto response = StartTaskResponse{};
 
   raise_if_error(
-      stub->StartTask(&context, request, &response));
+      stub->StartTask(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9932,7 +10288,8 @@ stop_task(const StubPtr& stub, const nidevice_grpc::Session& task)
   auto response = StopTaskResponse{};
 
   raise_if_error(
-      stub->StopTask(&context, request, &response));
+      stub->StopTask(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9956,7 +10313,8 @@ task_control(const StubPtr& stub, const nidevice_grpc::Session& task, const simp
   auto response = TaskControlResponse{};
 
   raise_if_error(
-      stub->TaskControl(&context, request, &response));
+      stub->TaskControl(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9972,7 +10330,8 @@ tristate_output_term(const StubPtr& stub, const pb::string& output_terminal)
   auto response = TristateOutputTermResponse{};
 
   raise_if_error(
-      stub->TristateOutputTerm(&context, request, &response));
+      stub->TristateOutputTerm(&context, request, &response),
+      context);
 
   return response;
 }
@@ -9988,7 +10347,8 @@ unreserve_network_device(const StubPtr& stub, const pb::string& device_name)
   auto response = UnreserveNetworkDeviceResponse{};
 
   raise_if_error(
-      stub->UnreserveNetworkDevice(&context, request, &response));
+      stub->UnreserveNetworkDevice(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10005,7 +10365,8 @@ wait_for_next_sample_clock(const StubPtr& stub, const nidevice_grpc::Session& ta
   auto response = WaitForNextSampleClockResponse{};
 
   raise_if_error(
-      stub->WaitForNextSampleClock(&context, request, &response));
+      stub->WaitForNextSampleClock(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10030,7 +10391,8 @@ wait_for_valid_timestamp(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = WaitForValidTimestampResponse{};
 
   raise_if_error(
-      stub->WaitForValidTimestamp(&context, request, &response));
+      stub->WaitForValidTimestamp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10047,7 +10409,8 @@ wait_until_task_done(const StubPtr& stub, const nidevice_grpc::Session& task, co
   auto response = WaitUntilTaskDoneResponse{};
 
   raise_if_error(
-      stub->WaitUntilTaskDone(&context, request, &response));
+      stub->WaitUntilTaskDone(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10075,7 +10438,8 @@ write_analog_f64(const StubPtr& stub, const nidevice_grpc::Session& task, const 
   auto response = WriteAnalogF64Response{};
 
   raise_if_error(
-      stub->WriteAnalogF64(&context, request, &response));
+      stub->WriteAnalogF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10094,7 +10458,8 @@ write_analog_scalar_f64(const StubPtr& stub, const nidevice_grpc::Session& task,
   auto response = WriteAnalogScalarF64Response{};
 
   raise_if_error(
-      stub->WriteAnalogScalarF64(&context, request, &response));
+      stub->WriteAnalogScalarF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10122,7 +10487,8 @@ write_binary_i16(const StubPtr& stub, const nidevice_grpc::Session& task, const 
   auto response = WriteBinaryI16Response{};
 
   raise_if_error(
-      stub->WriteBinaryI16(&context, request, &response));
+      stub->WriteBinaryI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10150,7 +10516,8 @@ write_binary_i32(const StubPtr& stub, const nidevice_grpc::Session& task, const 
   auto response = WriteBinaryI32Response{};
 
   raise_if_error(
-      stub->WriteBinaryI32(&context, request, &response));
+      stub->WriteBinaryI32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10178,7 +10545,8 @@ write_binary_u16(const StubPtr& stub, const nidevice_grpc::Session& task, const 
   auto response = WriteBinaryU16Response{};
 
   raise_if_error(
-      stub->WriteBinaryU16(&context, request, &response));
+      stub->WriteBinaryU16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10206,7 +10574,8 @@ write_binary_u32(const StubPtr& stub, const nidevice_grpc::Session& task, const 
   auto response = WriteBinaryU32Response{};
 
   raise_if_error(
-      stub->WriteBinaryU32(&context, request, &response));
+      stub->WriteBinaryU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10235,7 +10604,8 @@ write_ctr_freq(const StubPtr& stub, const nidevice_grpc::Session& task, const pb
   auto response = WriteCtrFreqResponse{};
 
   raise_if_error(
-      stub->WriteCtrFreq(&context, request, &response));
+      stub->WriteCtrFreq(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10255,7 +10625,8 @@ write_ctr_freq_scalar(const StubPtr& stub, const nidevice_grpc::Session& task, c
   auto response = WriteCtrFreqScalarResponse{};
 
   raise_if_error(
-      stub->WriteCtrFreqScalar(&context, request, &response));
+      stub->WriteCtrFreqScalar(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10284,7 +10655,8 @@ write_ctr_ticks(const StubPtr& stub, const nidevice_grpc::Session& task, const p
   auto response = WriteCtrTicksResponse{};
 
   raise_if_error(
-      stub->WriteCtrTicks(&context, request, &response));
+      stub->WriteCtrTicks(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10304,7 +10676,8 @@ write_ctr_ticks_scalar(const StubPtr& stub, const nidevice_grpc::Session& task, 
   auto response = WriteCtrTicksScalarResponse{};
 
   raise_if_error(
-      stub->WriteCtrTicksScalar(&context, request, &response));
+      stub->WriteCtrTicksScalar(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10333,7 +10706,8 @@ write_ctr_time(const StubPtr& stub, const nidevice_grpc::Session& task, const pb
   auto response = WriteCtrTimeResponse{};
 
   raise_if_error(
-      stub->WriteCtrTime(&context, request, &response));
+      stub->WriteCtrTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10353,7 +10727,8 @@ write_ctr_time_scalar(const StubPtr& stub, const nidevice_grpc::Session& task, c
   auto response = WriteCtrTimeScalarResponse{};
 
   raise_if_error(
-      stub->WriteCtrTimeScalar(&context, request, &response));
+      stub->WriteCtrTimeScalar(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10381,7 +10756,8 @@ write_digital_lines(const StubPtr& stub, const nidevice_grpc::Session& task, con
   auto response = WriteDigitalLinesResponse{};
 
   raise_if_error(
-      stub->WriteDigitalLines(&context, request, &response));
+      stub->WriteDigitalLines(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10400,7 +10776,8 @@ write_digital_scalar_u32(const StubPtr& stub, const nidevice_grpc::Session& task
   auto response = WriteDigitalScalarU32Response{};
 
   raise_if_error(
-      stub->WriteDigitalScalarU32(&context, request, &response));
+      stub->WriteDigitalScalarU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10428,7 +10805,8 @@ write_digital_u16(const StubPtr& stub, const nidevice_grpc::Session& task, const
   auto response = WriteDigitalU16Response{};
 
   raise_if_error(
-      stub->WriteDigitalU16(&context, request, &response));
+      stub->WriteDigitalU16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10456,7 +10834,8 @@ write_digital_u32(const StubPtr& stub, const nidevice_grpc::Session& task, const
   auto response = WriteDigitalU32Response{};
 
   raise_if_error(
-      stub->WriteDigitalU32(&context, request, &response));
+      stub->WriteDigitalU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10484,7 +10863,8 @@ write_digital_u8(const StubPtr& stub, const nidevice_grpc::Session& task, const 
   auto response = WriteDigitalU8Response{};
 
   raise_if_error(
-      stub->WriteDigitalU8(&context, request, &response));
+      stub->WriteDigitalU8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10504,7 +10884,8 @@ write_raw(const StubPtr& stub, const nidevice_grpc::Session& task, const pb::int
   auto response = WriteRawResponse{};
 
   raise_if_error(
-      stub->WriteRaw(&context, request, &response));
+      stub->WriteRaw(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10529,7 +10910,8 @@ write_to_teds_from_array(const StubPtr& stub, const pb::string& physical_channel
   auto response = WriteToTEDSFromArrayResponse{};
 
   raise_if_error(
-      stub->WriteToTEDSFromArray(&context, request, &response));
+      stub->WriteToTEDSFromArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -10554,7 +10936,8 @@ write_to_teds_from_file(const StubPtr& stub, const pb::string& physical_channel,
   auto response = WriteToTEDSFromFileResponse{};
 
   raise_if_error(
-      stub->WriteToTEDSFromFile(&context, request, &response));
+      stub->WriteToTEDSFromFile(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nidcpower/nidcpower_client.cpp
+++ b/generated/nidcpower/nidcpower_client.cpp
@@ -29,7 +29,8 @@ abort_with_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = AbortWithChannelsResponse{};
 
   raise_if_error(
-      stub->AbortWithChannels(&context, request, &response));
+      stub->AbortWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -46,7 +47,8 @@ commit_with_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, cons
   auto response = CommitWithChannelsResponse{};
 
   raise_if_error(
-      stub->CommitWithChannels(&context, request, &response));
+      stub->CommitWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -72,7 +74,8 @@ configure_digital_edge_measure_trigger_with_channels(const StubPtr& stub, const 
   auto response = ConfigureDigitalEdgeMeasureTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeMeasureTriggerWithChannels(&context, request, &response));
+      stub->ConfigureDigitalEdgeMeasureTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -98,7 +101,8 @@ configure_digital_edge_pulse_trigger_with_channels(const StubPtr& stub, const ni
   auto response = ConfigureDigitalEdgePulseTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgePulseTriggerWithChannels(&context, request, &response));
+      stub->ConfigureDigitalEdgePulseTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -124,7 +128,8 @@ configure_digital_edge_sequence_advance_trigger_with_channels(const StubPtr& stu
   auto response = ConfigureDigitalEdgeSequenceAdvanceTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeSequenceAdvanceTriggerWithChannels(&context, request, &response));
+      stub->ConfigureDigitalEdgeSequenceAdvanceTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -150,7 +155,8 @@ configure_digital_edge_shutdown_trigger_with_channels(const StubPtr& stub, const
   auto response = ConfigureDigitalEdgeShutdownTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeShutdownTriggerWithChannels(&context, request, &response));
+      stub->ConfigureDigitalEdgeShutdownTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -176,7 +182,8 @@ configure_digital_edge_source_trigger_with_channels(const StubPtr& stub, const n
   auto response = ConfigureDigitalEdgeSourceTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeSourceTriggerWithChannels(&context, request, &response));
+      stub->ConfigureDigitalEdgeSourceTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -202,7 +209,8 @@ configure_digital_edge_start_trigger_with_channels(const StubPtr& stub, const ni
   auto response = ConfigureDigitalEdgeStartTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeStartTriggerWithChannels(&context, request, &response));
+      stub->ConfigureDigitalEdgeStartTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -221,7 +229,8 @@ configure_ovp(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::s
   auto response = ConfigureOvpResponse{};
 
   raise_if_error(
-      stub->ConfigureOvp(&context, request, &response));
+      stub->ConfigureOvp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -238,7 +247,8 @@ configure_software_edge_measure_trigger_with_channels(const StubPtr& stub, const
   auto response = ConfigureSoftwareEdgeMeasureTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgeMeasureTriggerWithChannels(&context, request, &response));
+      stub->ConfigureSoftwareEdgeMeasureTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -255,7 +265,8 @@ configure_software_edge_pulse_trigger_with_channels(const StubPtr& stub, const n
   auto response = ConfigureSoftwareEdgePulseTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgePulseTriggerWithChannels(&context, request, &response));
+      stub->ConfigureSoftwareEdgePulseTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -272,7 +283,8 @@ configure_software_edge_sequence_advance_trigger_with_channels(const StubPtr& st
   auto response = ConfigureSoftwareEdgeSequenceAdvanceTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgeSequenceAdvanceTriggerWithChannels(&context, request, &response));
+      stub->ConfigureSoftwareEdgeSequenceAdvanceTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -289,7 +301,8 @@ configure_software_edge_shutdown_trigger_with_channels(const StubPtr& stub, cons
   auto response = ConfigureSoftwareEdgeShutdownTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgeShutdownTriggerWithChannels(&context, request, &response));
+      stub->ConfigureSoftwareEdgeShutdownTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -306,7 +319,8 @@ configure_software_edge_source_trigger_with_channels(const StubPtr& stub, const 
   auto response = ConfigureSoftwareEdgeSourceTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgeSourceTriggerWithChannels(&context, request, &response));
+      stub->ConfigureSoftwareEdgeSourceTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -323,7 +337,8 @@ configure_software_edge_start_trigger_with_channels(const StubPtr& stub, const n
   auto response = ConfigureSoftwareEdgeStartTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgeStartTriggerWithChannels(&context, request, &response));
+      stub->ConfigureSoftwareEdgeStartTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -348,7 +363,8 @@ configure_source_mode_with_channels(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ConfigureSourceModeWithChannelsResponse{};
 
   raise_if_error(
-      stub->ConfigureSourceModeWithChannels(&context, request, &response));
+      stub->ConfigureSourceModeWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -366,7 +382,8 @@ create_advanced_sequence_commit_step_with_channels(const StubPtr& stub, const ni
   auto response = CreateAdvancedSequenceCommitStepWithChannelsResponse{};
 
   raise_if_error(
-      stub->CreateAdvancedSequenceCommitStepWithChannels(&context, request, &response));
+      stub->CreateAdvancedSequenceCommitStepWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -384,7 +401,8 @@ create_advanced_sequence_step_with_channels(const StubPtr& stub, const nidevice_
   auto response = CreateAdvancedSequenceStepWithChannelsResponse{};
 
   raise_if_error(
-      stub->CreateAdvancedSequenceStepWithChannels(&context, request, &response));
+      stub->CreateAdvancedSequenceStepWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -404,7 +422,8 @@ create_advanced_sequence_with_channels(const StubPtr& stub, const nidevice_grpc:
   auto response = CreateAdvancedSequenceWithChannelsResponse{};
 
   raise_if_error(
-      stub->CreateAdvancedSequenceWithChannels(&context, request, &response));
+      stub->CreateAdvancedSequenceWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -423,7 +442,8 @@ create_advanced_sequence(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = CreateAdvancedSequenceResponse{};
 
   raise_if_error(
-      stub->CreateAdvancedSequence(&context, request, &response));
+      stub->CreateAdvancedSequence(&context, request, &response),
+      context);
 
   return response;
 }
@@ -441,7 +461,8 @@ delete_advanced_sequence_with_channels(const StubPtr& stub, const nidevice_grpc:
   auto response = DeleteAdvancedSequenceWithChannelsResponse{};
 
   raise_if_error(
-      stub->DeleteAdvancedSequenceWithChannels(&context, request, &response));
+      stub->DeleteAdvancedSequenceWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -458,7 +479,8 @@ disable_pulse_trigger_with_channels(const StubPtr& stub, const nidevice_grpc::Se
   auto response = DisablePulseTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->DisablePulseTriggerWithChannels(&context, request, &response));
+      stub->DisablePulseTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -475,7 +497,8 @@ disable_sequence_advance_trigger_with_channels(const StubPtr& stub, const nidevi
   auto response = DisableSequenceAdvanceTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->DisableSequenceAdvanceTriggerWithChannels(&context, request, &response));
+      stub->DisableSequenceAdvanceTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -492,7 +515,8 @@ disable_shutdown_trigger_with_channels(const StubPtr& stub, const nidevice_grpc:
   auto response = DisableShutdownTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->DisableShutdownTriggerWithChannels(&context, request, &response));
+      stub->DisableShutdownTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -509,7 +533,8 @@ disable_source_trigger_with_channels(const StubPtr& stub, const nidevice_grpc::S
   auto response = DisableSourceTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->DisableSourceTriggerWithChannels(&context, request, &response));
+      stub->DisableSourceTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -526,7 +551,8 @@ disable_start_trigger_with_channels(const StubPtr& stub, const nidevice_grpc::Se
   auto response = DisableStartTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->DisableStartTriggerWithChannels(&context, request, &response));
+      stub->DisableStartTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -543,7 +569,8 @@ error_query(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::str
   auto response = ErrorQueryResponse{};
 
   raise_if_error(
-      stub->ErrorQuery(&context, request, &response));
+      stub->ErrorQuery(&context, request, &response),
+      context);
 
   return response;
 }
@@ -570,7 +597,8 @@ export_signal_with_channels(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = ExportSignalWithChannelsResponse{};
 
   raise_if_error(
-      stub->ExportSignalWithChannels(&context, request, &response));
+      stub->ExportSignalWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -588,7 +616,8 @@ initialize_with_independent_channels(const StubPtr& stub, const pb::string& reso
   auto response = InitializeWithIndependentChannelsResponse{};
 
   raise_if_error(
-      stub->InitializeWithIndependentChannels(&context, request, &response));
+      stub->InitializeWithIndependentChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -605,7 +634,8 @@ initiate_with_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = InitiateWithChannelsResponse{};
 
   raise_if_error(
-      stub->InitiateWithChannels(&context, request, &response));
+      stub->InitiateWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -621,7 +651,8 @@ invalidate_all_attributes(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = InvalidateAllAttributesResponse{};
 
   raise_if_error(
-      stub->InvalidateAllAttributes(&context, request, &response));
+      stub->InvalidateAllAttributes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -638,7 +669,8 @@ reset_with_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = ResetWithChannelsResponse{};
 
   raise_if_error(
-      stub->ResetWithChannels(&context, request, &response));
+      stub->ResetWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -663,7 +695,8 @@ send_software_edge_trigger_with_channels(const StubPtr& stub, const nidevice_grp
   auto response = SendSoftwareEdgeTriggerWithChannelsResponse{};
 
   raise_if_error(
-      stub->SendSoftwareEdgeTriggerWithChannels(&context, request, &response));
+      stub->SendSoftwareEdgeTriggerWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -689,7 +722,8 @@ wait_for_event_with_channels(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = WaitForEventWithChannelsResponse{};
 
   raise_if_error(
-      stub->WaitForEventWithChannels(&context, request, &response));
+      stub->WaitForEventWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -705,7 +739,8 @@ abort(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = AbortResponse{};
 
   raise_if_error(
-      stub->Abort(&context, request, &response));
+      stub->Abort(&context, request, &response),
+      context);
 
   return response;
 }
@@ -722,7 +757,8 @@ cal_self_calibrate(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = CalSelfCalibrateResponse{};
 
   raise_if_error(
-      stub->CalSelfCalibrate(&context, request, &response));
+      stub->CalSelfCalibrate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -738,7 +774,8 @@ clear_error(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ClearErrorResponse{};
 
   raise_if_error(
-      stub->ClearError(&context, request, &response));
+      stub->ClearError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -754,7 +791,8 @@ clear_interchange_warnings(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = ClearInterchangeWarningsResponse{};
 
   raise_if_error(
-      stub->ClearInterchangeWarnings(&context, request, &response));
+      stub->ClearInterchangeWarnings(&context, request, &response),
+      context);
 
   return response;
 }
@@ -770,7 +808,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }
@@ -786,7 +825,8 @@ commit(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CommitResponse{};
 
   raise_if_error(
-      stub->Commit(&context, request, &response));
+      stub->Commit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -812,7 +852,8 @@ configure_aperture_time(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = ConfigureApertureTimeResponse{};
 
   raise_if_error(
-      stub->ConfigureApertureTime(&context, request, &response));
+      stub->ConfigureApertureTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -837,7 +878,8 @@ configure_auto_zero(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = ConfigureAutoZeroResponse{};
 
   raise_if_error(
-      stub->ConfigureAutoZero(&context, request, &response));
+      stub->ConfigureAutoZero(&context, request, &response),
+      context);
 
   return response;
 }
@@ -855,7 +897,8 @@ configure_current_level(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = ConfigureCurrentLevelResponse{};
 
   raise_if_error(
-      stub->ConfigureCurrentLevel(&context, request, &response));
+      stub->ConfigureCurrentLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -873,7 +916,8 @@ configure_current_level_range(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ConfigureCurrentLevelRangeResponse{};
 
   raise_if_error(
-      stub->ConfigureCurrentLevelRange(&context, request, &response));
+      stub->ConfigureCurrentLevelRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -899,7 +943,8 @@ configure_current_limit(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = ConfigureCurrentLimitResponse{};
 
   raise_if_error(
-      stub->ConfigureCurrentLimit(&context, request, &response));
+      stub->ConfigureCurrentLimit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -917,7 +962,8 @@ configure_current_limit_range(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ConfigureCurrentLimitRangeResponse{};
 
   raise_if_error(
-      stub->ConfigureCurrentLimitRange(&context, request, &response));
+      stub->ConfigureCurrentLimitRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -942,7 +988,8 @@ configure_digital_edge_measure_trigger(const StubPtr& stub, const nidevice_grpc:
   auto response = ConfigureDigitalEdgeMeasureTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeMeasureTrigger(&context, request, &response));
+      stub->ConfigureDigitalEdgeMeasureTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -967,7 +1014,8 @@ configure_digital_edge_pulse_trigger(const StubPtr& stub, const nidevice_grpc::S
   auto response = ConfigureDigitalEdgePulseTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgePulseTrigger(&context, request, &response));
+      stub->ConfigureDigitalEdgePulseTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -992,7 +1040,8 @@ configure_digital_edge_sequence_advance_trigger(const StubPtr& stub, const nidev
   auto response = ConfigureDigitalEdgeSequenceAdvanceTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeSequenceAdvanceTrigger(&context, request, &response));
+      stub->ConfigureDigitalEdgeSequenceAdvanceTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1017,7 +1066,8 @@ configure_digital_edge_source_trigger(const StubPtr& stub, const nidevice_grpc::
   auto response = ConfigureDigitalEdgeSourceTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeSourceTrigger(&context, request, &response));
+      stub->ConfigureDigitalEdgeSourceTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1042,7 +1092,8 @@ configure_digital_edge_start_trigger(const StubPtr& stub, const nidevice_grpc::S
   auto response = ConfigureDigitalEdgeStartTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeStartTrigger(&context, request, &response));
+      stub->ConfigureDigitalEdgeStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1060,7 +1111,8 @@ configure_output_enabled(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = ConfigureOutputEnabledResponse{};
 
   raise_if_error(
-      stub->ConfigureOutputEnabled(&context, request, &response));
+      stub->ConfigureOutputEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1085,7 +1137,8 @@ configure_output_function(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = ConfigureOutputFunctionResponse{};
 
   raise_if_error(
-      stub->ConfigureOutputFunction(&context, request, &response));
+      stub->ConfigureOutputFunction(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1103,7 +1156,8 @@ configure_output_resistance(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = ConfigureOutputResistanceResponse{};
 
   raise_if_error(
-      stub->ConfigureOutputResistance(&context, request, &response));
+      stub->ConfigureOutputResistance(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1127,7 +1181,8 @@ configure_power_line_frequency(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ConfigurePowerLineFrequencyResponse{};
 
   raise_if_error(
-      stub->ConfigurePowerLineFrequency(&context, request, &response));
+      stub->ConfigurePowerLineFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1145,7 +1200,8 @@ configure_pulse_bias_current_level(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ConfigurePulseBiasCurrentLevelResponse{};
 
   raise_if_error(
-      stub->ConfigurePulseBiasCurrentLevel(&context, request, &response));
+      stub->ConfigurePulseBiasCurrentLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1163,7 +1219,8 @@ configure_pulse_bias_current_limit(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ConfigurePulseBiasCurrentLimitResponse{};
 
   raise_if_error(
-      stub->ConfigurePulseBiasCurrentLimit(&context, request, &response));
+      stub->ConfigurePulseBiasCurrentLimit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1181,7 +1238,8 @@ configure_pulse_bias_voltage_level(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ConfigurePulseBiasVoltageLevelResponse{};
 
   raise_if_error(
-      stub->ConfigurePulseBiasVoltageLevel(&context, request, &response));
+      stub->ConfigurePulseBiasVoltageLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1199,7 +1257,8 @@ configure_pulse_bias_voltage_limit(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ConfigurePulseBiasVoltageLimitResponse{};
 
   raise_if_error(
-      stub->ConfigurePulseBiasVoltageLimit(&context, request, &response));
+      stub->ConfigurePulseBiasVoltageLimit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1217,7 +1276,8 @@ configure_pulse_current_level(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ConfigurePulseCurrentLevelResponse{};
 
   raise_if_error(
-      stub->ConfigurePulseCurrentLevel(&context, request, &response));
+      stub->ConfigurePulseCurrentLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1235,7 +1295,8 @@ configure_pulse_current_level_range(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ConfigurePulseCurrentLevelRangeResponse{};
 
   raise_if_error(
-      stub->ConfigurePulseCurrentLevelRange(&context, request, &response));
+      stub->ConfigurePulseCurrentLevelRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1253,7 +1314,8 @@ configure_pulse_current_limit(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ConfigurePulseCurrentLimitResponse{};
 
   raise_if_error(
-      stub->ConfigurePulseCurrentLimit(&context, request, &response));
+      stub->ConfigurePulseCurrentLimit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1271,7 +1333,8 @@ configure_pulse_current_limit_range(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ConfigurePulseCurrentLimitRangeResponse{};
 
   raise_if_error(
-      stub->ConfigurePulseCurrentLimitRange(&context, request, &response));
+      stub->ConfigurePulseCurrentLimitRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1289,7 +1352,8 @@ configure_pulse_voltage_level(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ConfigurePulseVoltageLevelResponse{};
 
   raise_if_error(
-      stub->ConfigurePulseVoltageLevel(&context, request, &response));
+      stub->ConfigurePulseVoltageLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1307,7 +1371,8 @@ configure_pulse_voltage_level_range(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ConfigurePulseVoltageLevelRangeResponse{};
 
   raise_if_error(
-      stub->ConfigurePulseVoltageLevelRange(&context, request, &response));
+      stub->ConfigurePulseVoltageLevelRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1325,7 +1390,8 @@ configure_pulse_voltage_limit(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ConfigurePulseVoltageLimitResponse{};
 
   raise_if_error(
-      stub->ConfigurePulseVoltageLimit(&context, request, &response));
+      stub->ConfigurePulseVoltageLimit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1343,7 +1409,8 @@ configure_pulse_voltage_limit_range(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ConfigurePulseVoltageLimitRangeResponse{};
 
   raise_if_error(
-      stub->ConfigurePulseVoltageLimitRange(&context, request, &response));
+      stub->ConfigurePulseVoltageLimitRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1368,7 +1435,8 @@ configure_sense(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb:
   auto response = ConfigureSenseResponse{};
 
   raise_if_error(
-      stub->ConfigureSense(&context, request, &response));
+      stub->ConfigureSense(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1384,7 +1452,8 @@ configure_software_edge_measure_trigger(const StubPtr& stub, const nidevice_grpc
   auto response = ConfigureSoftwareEdgeMeasureTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgeMeasureTrigger(&context, request, &response));
+      stub->ConfigureSoftwareEdgeMeasureTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1400,7 +1469,8 @@ configure_software_edge_pulse_trigger(const StubPtr& stub, const nidevice_grpc::
   auto response = ConfigureSoftwareEdgePulseTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgePulseTrigger(&context, request, &response));
+      stub->ConfigureSoftwareEdgePulseTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1416,7 +1486,8 @@ configure_software_edge_sequence_advance_trigger(const StubPtr& stub, const nide
   auto response = ConfigureSoftwareEdgeSequenceAdvanceTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgeSequenceAdvanceTrigger(&context, request, &response));
+      stub->ConfigureSoftwareEdgeSequenceAdvanceTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1432,7 +1503,8 @@ configure_software_edge_source_trigger(const StubPtr& stub, const nidevice_grpc:
   auto response = ConfigureSoftwareEdgeSourceTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgeSourceTrigger(&context, request, &response));
+      stub->ConfigureSoftwareEdgeSourceTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1448,7 +1520,8 @@ configure_software_edge_start_trigger(const StubPtr& stub, const nidevice_grpc::
   auto response = ConfigureSoftwareEdgeStartTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgeStartTrigger(&context, request, &response));
+      stub->ConfigureSoftwareEdgeStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1472,7 +1545,8 @@ configure_source_mode(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = ConfigureSourceModeResponse{};
 
   raise_if_error(
-      stub->ConfigureSourceMode(&context, request, &response));
+      stub->ConfigureSourceMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1490,7 +1564,8 @@ configure_voltage_level(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = ConfigureVoltageLevelResponse{};
 
   raise_if_error(
-      stub->ConfigureVoltageLevel(&context, request, &response));
+      stub->ConfigureVoltageLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1508,7 +1583,8 @@ configure_voltage_level_range(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ConfigureVoltageLevelRangeResponse{};
 
   raise_if_error(
-      stub->ConfigureVoltageLevelRange(&context, request, &response));
+      stub->ConfigureVoltageLevelRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1526,7 +1602,8 @@ configure_voltage_limit(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = ConfigureVoltageLimitResponse{};
 
   raise_if_error(
-      stub->ConfigureVoltageLimit(&context, request, &response));
+      stub->ConfigureVoltageLimit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1544,7 +1621,8 @@ configure_voltage_limit_range(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ConfigureVoltageLimitRangeResponse{};
 
   raise_if_error(
-      stub->ConfigureVoltageLimitRange(&context, request, &response));
+      stub->ConfigureVoltageLimitRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1561,7 +1639,8 @@ create_advanced_sequence_step(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = CreateAdvancedSequenceStepResponse{};
 
   raise_if_error(
-      stub->CreateAdvancedSequenceStep(&context, request, &response));
+      stub->CreateAdvancedSequenceStep(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1578,7 +1657,8 @@ delete_advanced_sequence(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = DeleteAdvancedSequenceResponse{};
 
   raise_if_error(
-      stub->DeleteAdvancedSequence(&context, request, &response));
+      stub->DeleteAdvancedSequence(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1594,7 +1674,8 @@ disable(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisableResponse{};
 
   raise_if_error(
-      stub->Disable(&context, request, &response));
+      stub->Disable(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1610,7 +1691,8 @@ disable_pulse_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisablePulseTriggerResponse{};
 
   raise_if_error(
-      stub->DisablePulseTrigger(&context, request, &response));
+      stub->DisablePulseTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1626,7 +1708,8 @@ disable_sequence_advance_trigger(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = DisableSequenceAdvanceTriggerResponse{};
 
   raise_if_error(
-      stub->DisableSequenceAdvanceTrigger(&context, request, &response));
+      stub->DisableSequenceAdvanceTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1642,7 +1725,8 @@ disable_source_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisableSourceTriggerResponse{};
 
   raise_if_error(
-      stub->DisableSourceTrigger(&context, request, &response));
+      stub->DisableSourceTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1658,7 +1742,8 @@ disable_start_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisableStartTriggerResponse{};
 
   raise_if_error(
-      stub->DisableStartTrigger(&context, request, &response));
+      stub->DisableStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1675,7 +1760,8 @@ error_message(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::i
   auto response = ErrorMessageResponse{};
 
   raise_if_error(
-      stub->ErrorMessage(&context, request, &response));
+      stub->ErrorMessage(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1691,7 +1777,8 @@ export_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::
   auto response = ExportAttributeConfigurationBufferResponse{};
 
   raise_if_error(
-      stub->ExportAttributeConfigurationBuffer(&context, request, &response));
+      stub->ExportAttributeConfigurationBuffer(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1708,7 +1795,8 @@ export_attribute_configuration_file(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ExportAttributeConfigurationFileResponse{};
 
   raise_if_error(
-      stub->ExportAttributeConfigurationFile(&context, request, &response));
+      stub->ExportAttributeConfigurationFile(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1734,7 +1822,8 @@ export_signal(const StubPtr& stub, const nidevice_grpc::Session& vi, const simpl
   auto response = ExportSignalResponse{};
 
   raise_if_error(
-      stub->ExportSignal(&context, request, &response));
+      stub->ExportSignal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1753,7 +1842,8 @@ fetch_multiple(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::
   auto response = FetchMultipleResponse{};
 
   raise_if_error(
-      stub->FetchMultiple(&context, request, &response));
+      stub->FetchMultiple(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1771,7 +1861,8 @@ get_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->GetAttributeViBoolean(&context, request, &response));
+      stub->GetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1789,7 +1880,8 @@ get_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->GetAttributeViInt32(&context, request, &response));
+      stub->GetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1807,7 +1899,8 @@ get_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetAttributeViInt64Response{};
 
   raise_if_error(
-      stub->GetAttributeViInt64(&context, request, &response));
+      stub->GetAttributeViInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1825,7 +1918,8 @@ get_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->GetAttributeViReal64(&context, request, &response));
+      stub->GetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1843,7 +1937,8 @@ get_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->GetAttributeViSession(&context, request, &response));
+      stub->GetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1861,7 +1956,8 @@ get_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeViString(&context, request, &response));
+      stub->GetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1878,7 +1974,8 @@ get_channel_name(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb
   auto response = GetChannelNameResponse{};
 
   raise_if_error(
-      stub->GetChannelName(&context, request, &response));
+      stub->GetChannelName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1895,7 +1992,8 @@ get_channel_name_from_string(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetChannelNameFromStringResponse{};
 
   raise_if_error(
-      stub->GetChannelNameFromString(&context, request, &response));
+      stub->GetChannelNameFromString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1911,7 +2009,8 @@ get_error(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetErrorResponse{};
 
   raise_if_error(
-      stub->GetError(&context, request, &response));
+      stub->GetError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1927,7 +2026,8 @@ get_ext_cal_last_date_and_time(const StubPtr& stub, const nidevice_grpc::Session
   auto response = GetExtCalLastDateAndTimeResponse{};
 
   raise_if_error(
-      stub->GetExtCalLastDateAndTime(&context, request, &response));
+      stub->GetExtCalLastDateAndTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1943,7 +2043,8 @@ get_ext_cal_last_temp(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetExtCalLastTempResponse{};
 
   raise_if_error(
-      stub->GetExtCalLastTemp(&context, request, &response));
+      stub->GetExtCalLastTemp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1959,7 +2060,8 @@ get_ext_cal_recommended_interval(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = GetExtCalRecommendedIntervalResponse{};
 
   raise_if_error(
-      stub->GetExtCalRecommendedInterval(&context, request, &response));
+      stub->GetExtCalRecommendedInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1975,7 +2077,8 @@ get_next_coercion_record(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetNextCoercionRecordResponse{};
 
   raise_if_error(
-      stub->GetNextCoercionRecord(&context, request, &response));
+      stub->GetNextCoercionRecord(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1991,7 +2094,8 @@ get_next_interchange_warning(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetNextInterchangeWarningResponse{};
 
   raise_if_error(
-      stub->GetNextInterchangeWarning(&context, request, &response));
+      stub->GetNextInterchangeWarning(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2007,7 +2111,8 @@ get_self_cal_last_date_and_time(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = GetSelfCalLastDateAndTimeResponse{};
 
   raise_if_error(
-      stub->GetSelfCalLastDateAndTime(&context, request, &response));
+      stub->GetSelfCalLastDateAndTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2023,7 +2128,8 @@ get_self_cal_last_temp(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetSelfCalLastTempResponse{};
 
   raise_if_error(
-      stub->GetSelfCalLastTemp(&context, request, &response));
+      stub->GetSelfCalLastTemp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2040,7 +2146,8 @@ import_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::
   auto response = ImportAttributeConfigurationBufferResponse{};
 
   raise_if_error(
-      stub->ImportAttributeConfigurationBuffer(&context, request, &response));
+      stub->ImportAttributeConfigurationBuffer(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2057,7 +2164,8 @@ import_attribute_configuration_file(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ImportAttributeConfigurationFileResponse{};
 
   raise_if_error(
-      stub->ImportAttributeConfigurationFile(&context, request, &response));
+      stub->ImportAttributeConfigurationFile(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2076,7 +2184,8 @@ initialize_with_channels(const StubPtr& stub, const pb::string& resource_name, c
   auto response = InitializeWithChannelsResponse{};
 
   raise_if_error(
-      stub->InitializeWithChannels(&context, request, &response));
+      stub->InitializeWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2092,7 +2201,8 @@ initiate(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = InitiateResponse{};
 
   raise_if_error(
-      stub->Initiate(&context, request, &response));
+      stub->Initiate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2117,7 +2227,8 @@ measure(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string&
   auto response = MeasureResponse{};
 
   raise_if_error(
-      stub->Measure(&context, request, &response));
+      stub->Measure(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2134,7 +2245,8 @@ measure_multiple(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb
   auto response = MeasureMultipleResponse{};
 
   raise_if_error(
-      stub->MeasureMultiple(&context, request, &response));
+      stub->MeasureMultiple(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2151,7 +2263,8 @@ query_in_compliance(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = QueryInComplianceResponse{};
 
   raise_if_error(
-      stub->QueryInCompliance(&context, request, &response));
+      stub->QueryInCompliance(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2169,7 +2282,8 @@ query_max_current_limit(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = QueryMaxCurrentLimitResponse{};
 
   raise_if_error(
-      stub->QueryMaxCurrentLimit(&context, request, &response));
+      stub->QueryMaxCurrentLimit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2187,7 +2301,8 @@ query_max_voltage_level(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = QueryMaxVoltageLevelResponse{};
 
   raise_if_error(
-      stub->QueryMaxVoltageLevel(&context, request, &response));
+      stub->QueryMaxVoltageLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2205,7 +2320,8 @@ query_min_current_limit(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = QueryMinCurrentLimitResponse{};
 
   raise_if_error(
-      stub->QueryMinCurrentLimit(&context, request, &response));
+      stub->QueryMinCurrentLimit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2230,7 +2346,8 @@ query_output_state(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = QueryOutputStateResponse{};
 
   raise_if_error(
-      stub->QueryOutputState(&context, request, &response));
+      stub->QueryOutputState(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2246,7 +2363,8 @@ read_current_temperature(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ReadCurrentTemperatureResponse{};
 
   raise_if_error(
-      stub->ReadCurrentTemperature(&context, request, &response));
+      stub->ReadCurrentTemperature(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2262,7 +2380,8 @@ reset(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetResponse{};
 
   raise_if_error(
-      stub->Reset(&context, request, &response));
+      stub->Reset(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2278,7 +2397,8 @@ reset_device(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetDeviceResponse{};
 
   raise_if_error(
-      stub->ResetDevice(&context, request, &response));
+      stub->ResetDevice(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2294,7 +2414,8 @@ reset_interchange_check(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetInterchangeCheckResponse{};
 
   raise_if_error(
-      stub->ResetInterchangeCheck(&context, request, &response));
+      stub->ResetInterchangeCheck(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2310,7 +2431,8 @@ reset_with_defaults(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetWithDefaultsResponse{};
 
   raise_if_error(
-      stub->ResetWithDefaults(&context, request, &response));
+      stub->ResetWithDefaults(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2326,7 +2448,8 @@ revision_query(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = RevisionQueryResponse{};
 
   raise_if_error(
-      stub->RevisionQuery(&context, request, &response));
+      stub->RevisionQuery(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2342,7 +2465,8 @@ self_test(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SelfTestResponse{};
 
   raise_if_error(
-      stub->SelfTest(&context, request, &response));
+      stub->SelfTest(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2366,7 +2490,8 @@ send_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = SendSoftwareEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->SendSoftwareEdgeTrigger(&context, request, &response));
+      stub->SendSoftwareEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2385,7 +2510,8 @@ set_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = SetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->SetAttributeViBoolean(&context, request, &response));
+      stub->SetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2411,7 +2537,8 @@ set_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = SetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->SetAttributeViInt32(&context, request, &response));
+      stub->SetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2430,7 +2557,8 @@ set_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = SetAttributeViInt64Response{};
 
   raise_if_error(
-      stub->SetAttributeViInt64(&context, request, &response));
+      stub->SetAttributeViInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2456,7 +2584,8 @@ set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->SetAttributeViReal64(&context, request, &response));
+      stub->SetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2475,7 +2604,8 @@ set_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = SetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->SetAttributeViSession(&context, request, &response));
+      stub->SetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2494,7 +2624,8 @@ set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->SetAttributeViString(&context, request, &response));
+      stub->SetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2513,7 +2644,8 @@ set_sequence(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::st
   auto response = SetSequenceResponse{};
 
   raise_if_error(
-      stub->SetSequence(&context, request, &response));
+      stub->SetSequence(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2538,7 +2670,8 @@ wait_for_event(const StubPtr& stub, const nidevice_grpc::Session& vi, const simp
   auto response = WaitForEventResponse{};
 
   raise_if_error(
-      stub->WaitForEvent(&context, request, &response));
+      stub->WaitForEvent(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nidigitalpattern/nidigitalpattern_client.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_client.cpp
@@ -28,7 +28,8 @@ abort(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = AbortResponse{};
 
   raise_if_error(
-      stub->Abort(&context, request, &response));
+      stub->Abort(&context, request, &response),
+      context);
 
   return response;
 }
@@ -44,7 +45,8 @@ abort_keep_alive(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = AbortKeepAliveResponse{};
 
   raise_if_error(
-      stub->AbortKeepAlive(&context, request, &response));
+      stub->AbortKeepAlive(&context, request, &response),
+      context);
 
   return response;
 }
@@ -66,7 +68,8 @@ apply_levels_and_timing(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = ApplyLevelsAndTimingResponse{};
 
   raise_if_error(
-      stub->ApplyLevelsAndTiming(&context, request, &response));
+      stub->ApplyLevelsAndTiming(&context, request, &response),
+      context);
 
   return response;
 }
@@ -84,7 +87,8 @@ apply_tdr_offsets(const StubPtr& stub, const nidevice_grpc::Session& vi, const p
   auto response = ApplyTDROffsetsResponse{};
 
   raise_if_error(
-      stub->ApplyTDROffsets(&context, request, &response));
+      stub->ApplyTDROffsets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -105,7 +109,8 @@ burst_pattern(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::s
   auto response = BurstPatternResponse{};
 
   raise_if_error(
-      stub->BurstPattern(&context, request, &response));
+      stub->BurstPattern(&context, request, &response),
+      context);
 
   return response;
 }
@@ -127,7 +132,8 @@ burst_pattern_synchronized(const StubPtr& stub, const pb::uint32& session_count,
   auto response = BurstPatternSynchronizedResponse{};
 
   raise_if_error(
-      stub->BurstPatternSynchronized(&context, request, &response));
+      stub->BurstPatternSynchronized(&context, request, &response),
+      context);
 
   return response;
 }
@@ -143,7 +149,8 @@ clear_error(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ClearErrorResponse{};
 
   raise_if_error(
-      stub->ClearError(&context, request, &response));
+      stub->ClearError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -160,7 +167,8 @@ clock_generator_abort(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = ClockGeneratorAbortResponse{};
 
   raise_if_error(
-      stub->ClockGeneratorAbort(&context, request, &response));
+      stub->ClockGeneratorAbort(&context, request, &response),
+      context);
 
   return response;
 }
@@ -179,7 +187,8 @@ clock_generator_generate_clock(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ClockGeneratorGenerateClockResponse{};
 
   raise_if_error(
-      stub->ClockGeneratorGenerateClock(&context, request, &response));
+      stub->ClockGeneratorGenerateClock(&context, request, &response),
+      context);
 
   return response;
 }
@@ -196,7 +205,8 @@ clock_generator_initiate(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = ClockGeneratorInitiateResponse{};
 
   raise_if_error(
-      stub->ClockGeneratorInitiate(&context, request, &response));
+      stub->ClockGeneratorInitiate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -212,7 +222,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }
@@ -228,7 +239,8 @@ commit(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CommitResponse{};
 
   raise_if_error(
-      stub->Commit(&context, request, &response));
+      stub->Commit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -248,7 +260,8 @@ configure_active_load_levels(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ConfigureActiveLoadLevelsResponse{};
 
   raise_if_error(
-      stub->ConfigureActiveLoadLevels(&context, request, &response));
+      stub->ConfigureActiveLoadLevels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -266,7 +279,8 @@ configure_cycle_number_history_ram_trigger(const StubPtr& stub, const nidevice_g
   auto response = ConfigureCycleNumberHistoryRAMTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureCycleNumberHistoryRAMTrigger(&context, request, &response));
+      stub->ConfigureCycleNumberHistoryRAMTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -292,7 +306,8 @@ configure_digital_edge_conditional_jump_trigger(const StubPtr& stub, const nidev
   auto response = ConfigureDigitalEdgeConditionalJumpTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeConditionalJumpTrigger(&context, request, &response));
+      stub->ConfigureDigitalEdgeConditionalJumpTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -317,7 +332,8 @@ configure_digital_edge_start_trigger(const StubPtr& stub, const nidevice_grpc::S
   auto response = ConfigureDigitalEdgeStartTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeStartTrigger(&context, request, &response));
+      stub->ConfigureDigitalEdgeStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -334,7 +350,8 @@ configure_first_failure_history_ram_trigger(const StubPtr& stub, const nidevice_
   auto response = ConfigureFirstFailureHistoryRAMTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureFirstFailureHistoryRAMTrigger(&context, request, &response));
+      stub->ConfigureFirstFailureHistoryRAMTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -358,7 +375,8 @@ configure_history_ram_cycles_to_acquire(const StubPtr& stub, const nidevice_grpc
   auto response = ConfigureHistoryRAMCyclesToAcquireResponse{};
 
   raise_if_error(
-      stub->ConfigureHistoryRAMCyclesToAcquire(&context, request, &response));
+      stub->ConfigureHistoryRAMCyclesToAcquire(&context, request, &response),
+      context);
 
   return response;
 }
@@ -375,7 +393,8 @@ configure_pattern_burst_sites(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ConfigurePatternBurstSitesResponse{};
 
   raise_if_error(
-      stub->ConfigurePatternBurstSites(&context, request, &response));
+      stub->ConfigurePatternBurstSites(&context, request, &response),
+      context);
 
   return response;
 }
@@ -395,7 +414,8 @@ configure_pattern_label_history_ram_trigger(const StubPtr& stub, const nidevice_
   auto response = ConfigurePatternLabelHistoryRAMTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigurePatternLabelHistoryRAMTrigger(&context, request, &response));
+      stub->ConfigurePatternLabelHistoryRAMTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -412,7 +432,8 @@ configure_start_label(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = ConfigureStartLabelResponse{};
 
   raise_if_error(
-      stub->ConfigureStartLabel(&context, request, &response));
+      stub->ConfigureStartLabel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -429,7 +450,8 @@ configure_software_edge_conditional_jump_trigger(const StubPtr& stub, const nide
   auto response = ConfigureSoftwareEdgeConditionalJumpTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgeConditionalJumpTrigger(&context, request, &response));
+      stub->ConfigureSoftwareEdgeConditionalJumpTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -445,7 +467,8 @@ configure_software_edge_start_trigger(const StubPtr& stub, const nidevice_grpc::
   auto response = ConfigureSoftwareEdgeStartTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgeStartTrigger(&context, request, &response));
+      stub->ConfigureSoftwareEdgeStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -470,7 +493,8 @@ configure_termination_mode(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = ConfigureTerminationModeResponse{};
 
   raise_if_error(
-      stub->ConfigureTerminationMode(&context, request, &response));
+      stub->ConfigureTerminationMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -489,7 +513,8 @@ configure_time_set_compare_edges_strobe(const StubPtr& stub, const nidevice_grpc
   auto response = ConfigureTimeSetCompareEdgesStrobeResponse{};
 
   raise_if_error(
-      stub->ConfigureTimeSetCompareEdgesStrobe(&context, request, &response));
+      stub->ConfigureTimeSetCompareEdgesStrobe(&context, request, &response),
+      context);
 
   return response;
 }
@@ -509,7 +534,8 @@ configure_time_set_compare_edges_strobe2x(const StubPtr& stub, const nidevice_gr
   auto response = ConfigureTimeSetCompareEdgesStrobe2xResponse{};
 
   raise_if_error(
-      stub->ConfigureTimeSetCompareEdgesStrobe2x(&context, request, &response));
+      stub->ConfigureTimeSetCompareEdgesStrobe2x(&context, request, &response),
+      context);
 
   return response;
 }
@@ -539,7 +565,8 @@ configure_time_set_drive_edges(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ConfigureTimeSetDriveEdgesResponse{};
 
   raise_if_error(
-      stub->ConfigureTimeSetDriveEdges(&context, request, &response));
+      stub->ConfigureTimeSetDriveEdges(&context, request, &response),
+      context);
 
   return response;
 }
@@ -571,7 +598,8 @@ configure_time_set_drive_edges2x(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ConfigureTimeSetDriveEdges2xResponse{};
 
   raise_if_error(
-      stub->ConfigureTimeSetDriveEdges2x(&context, request, &response));
+      stub->ConfigureTimeSetDriveEdges2x(&context, request, &response),
+      context);
 
   return response;
 }
@@ -597,7 +625,8 @@ configure_time_set_drive_format(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = ConfigureTimeSetDriveFormatResponse{};
 
   raise_if_error(
-      stub->ConfigureTimeSetDriveFormat(&context, request, &response));
+      stub->ConfigureTimeSetDriveFormat(&context, request, &response),
+      context);
 
   return response;
 }
@@ -624,7 +653,8 @@ configure_time_set_edge(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = ConfigureTimeSetEdgeResponse{};
 
   raise_if_error(
-      stub->ConfigureTimeSetEdge(&context, request, &response));
+      stub->ConfigureTimeSetEdge(&context, request, &response),
+      context);
 
   return response;
 }
@@ -643,7 +673,8 @@ configure_time_set_edge_multiplier(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ConfigureTimeSetEdgeMultiplierResponse{};
 
   raise_if_error(
-      stub->ConfigureTimeSetEdgeMultiplier(&context, request, &response));
+      stub->ConfigureTimeSetEdgeMultiplier(&context, request, &response),
+      context);
 
   return response;
 }
@@ -661,7 +692,8 @@ configure_time_set_period(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = ConfigureTimeSetPeriodResponse{};
 
   raise_if_error(
-      stub->ConfigureTimeSetPeriod(&context, request, &response));
+      stub->ConfigureTimeSetPeriod(&context, request, &response),
+      context);
 
   return response;
 }
@@ -683,7 +715,8 @@ configure_voltage_levels(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = ConfigureVoltageLevelsResponse{};
 
   raise_if_error(
-      stub->ConfigureVoltageLevels(&context, request, &response));
+      stub->ConfigureVoltageLevels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -701,7 +734,8 @@ create_capture_waveform_from_file_digicapture(const StubPtr& stub, const nidevic
   auto response = CreateCaptureWaveformFromFileDigicaptureResponse{};
 
   raise_if_error(
-      stub->CreateCaptureWaveformFromFileDigicapture(&context, request, &response));
+      stub->CreateCaptureWaveformFromFileDigicapture(&context, request, &response),
+      context);
 
   return response;
 }
@@ -719,7 +753,8 @@ create_capture_waveform_parallel(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = CreateCaptureWaveformParallelResponse{};
 
   raise_if_error(
-      stub->CreateCaptureWaveformParallel(&context, request, &response));
+      stub->CreateCaptureWaveformParallel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -746,7 +781,8 @@ create_capture_waveform_serial(const StubPtr& stub, const nidevice_grpc::Session
   auto response = CreateCaptureWaveformSerialResponse{};
 
   raise_if_error(
-      stub->CreateCaptureWaveformSerial(&context, request, &response));
+      stub->CreateCaptureWaveformSerial(&context, request, &response),
+      context);
 
   return response;
 }
@@ -763,7 +799,8 @@ create_channel_map(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = CreateChannelMapResponse{};
 
   raise_if_error(
-      stub->CreateChannelMap(&context, request, &response));
+      stub->CreateChannelMap(&context, request, &response),
+      context);
 
   return response;
 }
@@ -782,7 +819,8 @@ create_source_waveform_from_file_tdms(const StubPtr& stub, const nidevice_grpc::
   auto response = CreateSourceWaveformFromFileTDMSResponse{};
 
   raise_if_error(
-      stub->CreateSourceWaveformFromFileTDMS(&context, request, &response));
+      stub->CreateSourceWaveformFromFileTDMS(&context, request, &response),
+      context);
 
   return response;
 }
@@ -800,7 +838,8 @@ create_pin_map(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::
   auto response = CreatePinMapResponse{};
 
   raise_if_error(
-      stub->CreatePinMap(&context, request, &response));
+      stub->CreatePinMap(&context, request, &response),
+      context);
 
   return response;
 }
@@ -818,7 +857,8 @@ create_pin_group(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb
   auto response = CreatePinGroupResponse{};
 
   raise_if_error(
-      stub->CreatePinGroup(&context, request, &response));
+      stub->CreatePinGroup(&context, request, &response),
+      context);
 
   return response;
 }
@@ -844,7 +884,8 @@ create_source_waveform_parallel(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = CreateSourceWaveformParallelResponse{};
 
   raise_if_error(
-      stub->CreateSourceWaveformParallel(&context, request, &response));
+      stub->CreateSourceWaveformParallel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -879,7 +920,8 @@ create_source_waveform_serial(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = CreateSourceWaveformSerialResponse{};
 
   raise_if_error(
-      stub->CreateSourceWaveformSerial(&context, request, &response));
+      stub->CreateSourceWaveformSerial(&context, request, &response),
+      context);
 
   return response;
 }
@@ -896,7 +938,8 @@ create_time_set(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb:
   auto response = CreateTimeSetResponse{};
 
   raise_if_error(
-      stub->CreateTimeSet(&context, request, &response));
+      stub->CreateTimeSet(&context, request, &response),
+      context);
 
   return response;
 }
@@ -912,7 +955,8 @@ delete_all_time_sets(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DeleteAllTimeSetsResponse{};
 
   raise_if_error(
-      stub->DeleteAllTimeSets(&context, request, &response));
+      stub->DeleteAllTimeSets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -929,7 +973,8 @@ disable_conditional_jump_trigger(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = DisableConditionalJumpTriggerResponse{};
 
   raise_if_error(
-      stub->DisableConditionalJumpTrigger(&context, request, &response));
+      stub->DisableConditionalJumpTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -946,7 +991,8 @@ disable_sites(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::s
   auto response = DisableSitesResponse{};
 
   raise_if_error(
-      stub->DisableSites(&context, request, &response));
+      stub->DisableSites(&context, request, &response),
+      context);
 
   return response;
 }
@@ -962,7 +1008,8 @@ disable_start_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisableStartTriggerResponse{};
 
   raise_if_error(
-      stub->DisableStartTrigger(&context, request, &response));
+      stub->DisableStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -980,7 +1027,8 @@ enable_match_fail_combination(const StubPtr& stub, const pb::uint32& session_cou
   auto response = EnableMatchFailCombinationResponse{};
 
   raise_if_error(
-      stub->EnableMatchFailCombination(&context, request, &response));
+      stub->EnableMatchFailCombination(&context, request, &response),
+      context);
 
   return response;
 }
@@ -997,7 +1045,8 @@ enable_sites(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::st
   auto response = EnableSitesResponse{};
 
   raise_if_error(
-      stub->EnableSites(&context, request, &response));
+      stub->EnableSites(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1013,7 +1062,8 @@ end_channel_map(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = EndChannelMapResponse{};
 
   raise_if_error(
-      stub->EndChannelMap(&context, request, &response));
+      stub->EndChannelMap(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1030,7 +1080,8 @@ error_message(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::i
   auto response = ErrorMessageResponse{};
 
   raise_if_error(
-      stub->ErrorMessage(&context, request, &response));
+      stub->ErrorMessage(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1056,7 +1107,8 @@ export_signal(const StubPtr& stub, const nidevice_grpc::Session& vi, const simpl
   auto response = ExportSignalResponse{};
 
   raise_if_error(
-      stub->ExportSignal(&context, request, &response));
+      stub->ExportSignal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1076,7 +1128,8 @@ fetch_capture_waveform_u32(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = FetchCaptureWaveformU32Response{};
 
   raise_if_error(
-      stub->FetchCaptureWaveformU32(&context, request, &response));
+      stub->FetchCaptureWaveformU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1094,7 +1147,8 @@ fetch_history_ram_cycle_information(const StubPtr& stub, const nidevice_grpc::Se
   auto response = FetchHistoryRAMCycleInformationResponse{};
 
   raise_if_error(
-      stub->FetchHistoryRAMCycleInformation(&context, request, &response));
+      stub->FetchHistoryRAMCycleInformation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1114,7 +1168,8 @@ fetch_history_ram_cycle_pin_data(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = FetchHistoryRAMCyclePinDataResponse{};
 
   raise_if_error(
-      stub->FetchHistoryRAMCyclePinData(&context, request, &response));
+      stub->FetchHistoryRAMCyclePinData(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1132,7 +1187,8 @@ fetch_history_ram_scan_cycle_number(const StubPtr& stub, const nidevice_grpc::Se
   auto response = FetchHistoryRAMScanCycleNumberResponse{};
 
   raise_if_error(
-      stub->FetchHistoryRAMScanCycleNumber(&context, request, &response));
+      stub->FetchHistoryRAMScanCycleNumber(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1156,7 +1212,8 @@ frequency_counter_configure_measurement_mode(const StubPtr& stub, const nidevice
   auto response = FrequencyCounterConfigureMeasurementModeResponse{};
 
   raise_if_error(
-      stub->FrequencyCounterConfigureMeasurementMode(&context, request, &response));
+      stub->FrequencyCounterConfigureMeasurementMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1174,7 +1231,8 @@ frequency_counter_configure_measurement_time(const StubPtr& stub, const nidevice
   auto response = FrequencyCounterConfigureMeasurementTimeResponse{};
 
   raise_if_error(
-      stub->FrequencyCounterConfigureMeasurementTime(&context, request, &response));
+      stub->FrequencyCounterConfigureMeasurementTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1191,7 +1249,8 @@ frequency_counter_measure_frequency(const StubPtr& stub, const nidevice_grpc::Se
   auto response = FrequencyCounterMeasureFrequencyResponse{};
 
   raise_if_error(
-      stub->FrequencyCounterMeasureFrequency(&context, request, &response));
+      stub->FrequencyCounterMeasureFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1209,7 +1268,8 @@ get_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->GetAttributeViBoolean(&context, request, &response));
+      stub->GetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1227,7 +1287,8 @@ get_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->GetAttributeViInt32(&context, request, &response));
+      stub->GetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1245,7 +1306,8 @@ get_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetAttributeViInt64Response{};
 
   raise_if_error(
-      stub->GetAttributeViInt64(&context, request, &response));
+      stub->GetAttributeViInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1263,7 +1325,8 @@ get_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->GetAttributeViReal64(&context, request, &response));
+      stub->GetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1281,7 +1344,8 @@ get_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->GetAttributeViSession(&context, request, &response));
+      stub->GetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1299,7 +1363,8 @@ get_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeViString(&context, request, &response));
+      stub->GetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1316,7 +1381,8 @@ get_channel_name(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb
   auto response = GetChannelNameResponse{};
 
   raise_if_error(
-      stub->GetChannelName(&context, request, &response));
+      stub->GetChannelName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1333,7 +1399,8 @@ get_channel_name_from_string(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetChannelNameFromStringResponse{};
 
   raise_if_error(
-      stub->GetChannelNameFromString(&context, request, &response));
+      stub->GetChannelNameFromString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1349,7 +1416,8 @@ get_error(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetErrorResponse{};
 
   raise_if_error(
-      stub->GetError(&context, request, &response));
+      stub->GetError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1366,7 +1434,8 @@ get_fail_count(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::
   auto response = GetFailCountResponse{};
 
   raise_if_error(
-      stub->GetFailCount(&context, request, &response));
+      stub->GetFailCount(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1383,7 +1452,8 @@ get_history_ram_sample_count(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetHistoryRAMSampleCountResponse{};
 
   raise_if_error(
-      stub->GetHistoryRAMSampleCount(&context, request, &response));
+      stub->GetHistoryRAMSampleCount(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1400,7 +1470,8 @@ get_pattern_pin_indexes(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetPatternPinIndexesResponse{};
 
   raise_if_error(
-      stub->GetPatternPinIndexes(&context, request, &response));
+      stub->GetPatternPinIndexes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1417,7 +1488,8 @@ get_pattern_name(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb
   auto response = GetPatternNameResponse{};
 
   raise_if_error(
-      stub->GetPatternName(&context, request, &response));
+      stub->GetPatternName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1434,7 +1506,8 @@ get_pattern_pin_list(const StubPtr& stub, const nidevice_grpc::Session& vi, cons
   auto response = GetPatternPinListResponse{};
 
   raise_if_error(
-      stub->GetPatternPinList(&context, request, &response));
+      stub->GetPatternPinList(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1451,7 +1524,8 @@ get_pin_name(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::in
   auto response = GetPinNameResponse{};
 
   raise_if_error(
-      stub->GetPinName(&context, request, &response));
+      stub->GetPinName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1468,7 +1542,8 @@ get_pin_results_pin_information(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = GetPinResultsPinInformationResponse{};
 
   raise_if_error(
-      stub->GetPinResultsPinInformation(&context, request, &response));
+      stub->GetPinResultsPinInformation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1485,7 +1560,8 @@ get_site_pass_fail(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = GetSitePassFailResponse{};
 
   raise_if_error(
-      stub->GetSitePassFail(&context, request, &response));
+      stub->GetSitePassFail(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1510,7 +1586,8 @@ get_site_results_site_numbers(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = GetSiteResultsSiteNumbersResponse{};
 
   raise_if_error(
-      stub->GetSiteResultsSiteNumbers(&context, request, &response));
+      stub->GetSiteResultsSiteNumbers(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1528,7 +1605,8 @@ get_time_set_drive_format(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = GetTimeSetDriveFormatResponse{};
 
   raise_if_error(
-      stub->GetTimeSetDriveFormat(&context, request, &response));
+      stub->GetTimeSetDriveFormat(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1554,7 +1632,8 @@ get_time_set_edge(const StubPtr& stub, const nidevice_grpc::Session& vi, const p
   auto response = GetTimeSetEdgeResponse{};
 
   raise_if_error(
-      stub->GetTimeSetEdge(&context, request, &response));
+      stub->GetTimeSetEdge(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1572,7 +1651,8 @@ get_time_set_edge_multiplier(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetTimeSetEdgeMultiplierResponse{};
 
   raise_if_error(
-      stub->GetTimeSetEdgeMultiplier(&context, request, &response));
+      stub->GetTimeSetEdgeMultiplier(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1589,7 +1669,8 @@ get_time_set_name(const StubPtr& stub, const nidevice_grpc::Session& vi, const p
   auto response = GetTimeSetNameResponse{};
 
   raise_if_error(
-      stub->GetTimeSetName(&context, request, &response));
+      stub->GetTimeSetName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1606,7 +1687,8 @@ get_time_set_period(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = GetTimeSetPeriodResponse{};
 
   raise_if_error(
-      stub->GetTimeSetPeriod(&context, request, &response));
+      stub->GetTimeSetPeriod(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1624,7 +1706,8 @@ init(const StubPtr& stub, const pb::string& resource_name, const bool& id_query,
   auto response = InitResponse{};
 
   raise_if_error(
-      stub->Init(&context, request, &response));
+      stub->Init(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1643,7 +1726,8 @@ init_with_options(const StubPtr& stub, const pb::string& resource_name, const bo
   auto response = InitWithOptionsResponse{};
 
   raise_if_error(
-      stub->InitWithOptions(&context, request, &response));
+      stub->InitWithOptions(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1659,7 +1743,8 @@ initiate(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = InitiateResponse{};
 
   raise_if_error(
-      stub->Initiate(&context, request, &response));
+      stub->Initiate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1675,7 +1760,8 @@ is_done(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = IsDoneResponse{};
 
   raise_if_error(
-      stub->IsDone(&context, request, &response));
+      stub->IsDone(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1692,7 +1778,8 @@ is_site_enabled(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb:
   auto response = IsSiteEnabledResponse{};
 
   raise_if_error(
-      stub->IsSiteEnabled(&context, request, &response));
+      stub->IsSiteEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1709,7 +1796,8 @@ load_levels(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::str
   auto response = LoadLevelsResponse{};
 
   raise_if_error(
-      stub->LoadLevels(&context, request, &response));
+      stub->LoadLevels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1726,7 +1814,8 @@ load_pattern(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::st
   auto response = LoadPatternResponse{};
 
   raise_if_error(
-      stub->LoadPattern(&context, request, &response));
+      stub->LoadPattern(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1743,7 +1832,8 @@ load_pin_map(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::st
   auto response = LoadPinMapResponse{};
 
   raise_if_error(
-      stub->LoadPinMap(&context, request, &response));
+      stub->LoadPinMap(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1760,7 +1850,8 @@ load_specifications(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = LoadSpecificationsResponse{};
 
   raise_if_error(
-      stub->LoadSpecifications(&context, request, &response));
+      stub->LoadSpecifications(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1777,7 +1868,8 @@ load_timing(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::str
   auto response = LoadTimingResponse{};
 
   raise_if_error(
-      stub->LoadTiming(&context, request, &response));
+      stub->LoadTiming(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1796,7 +1888,8 @@ map_pin_to_channel(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = MapPinToChannelResponse{};
 
   raise_if_error(
-      stub->MapPinToChannel(&context, request, &response));
+      stub->MapPinToChannel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1822,7 +1915,8 @@ ppmu_configure_aperture_time(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = PPMUConfigureApertureTimeResponse{};
 
   raise_if_error(
-      stub->PPMUConfigureApertureTime(&context, request, &response));
+      stub->PPMUConfigureApertureTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1840,7 +1934,8 @@ ppmu_configure_current_level(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = PPMUConfigureCurrentLevelResponse{};
 
   raise_if_error(
-      stub->PPMUConfigureCurrentLevel(&context, request, &response));
+      stub->PPMUConfigureCurrentLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1858,7 +1953,8 @@ ppmu_configure_current_level_range(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = PPMUConfigureCurrentLevelRangeResponse{};
 
   raise_if_error(
-      stub->PPMUConfigureCurrentLevelRange(&context, request, &response));
+      stub->PPMUConfigureCurrentLevelRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1884,7 +1980,8 @@ ppmu_configure_current_limit(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = PPMUConfigureCurrentLimitResponse{};
 
   raise_if_error(
-      stub->PPMUConfigureCurrentLimit(&context, request, &response));
+      stub->PPMUConfigureCurrentLimit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1902,7 +1999,8 @@ ppmu_configure_current_limit_range(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = PPMUConfigureCurrentLimitRangeResponse{};
 
   raise_if_error(
-      stub->PPMUConfigureCurrentLimitRange(&context, request, &response));
+      stub->PPMUConfigureCurrentLimitRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1927,7 +2025,8 @@ ppmu_configure_output_function(const StubPtr& stub, const nidevice_grpc::Session
   auto response = PPMUConfigureOutputFunctionResponse{};
 
   raise_if_error(
-      stub->PPMUConfigureOutputFunction(&context, request, &response));
+      stub->PPMUConfigureOutputFunction(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1945,7 +2044,8 @@ ppmu_configure_voltage_level(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = PPMUConfigureVoltageLevelResponse{};
 
   raise_if_error(
-      stub->PPMUConfigureVoltageLevel(&context, request, &response));
+      stub->PPMUConfigureVoltageLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1964,7 +2064,8 @@ ppmu_configure_voltage_limits(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = PPMUConfigureVoltageLimitsResponse{};
 
   raise_if_error(
-      stub->PPMUConfigureVoltageLimits(&context, request, &response));
+      stub->PPMUConfigureVoltageLimits(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1989,7 +2090,8 @@ ppmu_measure(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::st
   auto response = PPMUMeasureResponse{};
 
   raise_if_error(
-      stub->PPMUMeasure(&context, request, &response));
+      stub->PPMUMeasure(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2006,7 +2108,8 @@ ppmu_source(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::str
   auto response = PPMUSourceResponse{};
 
   raise_if_error(
-      stub->PPMUSource(&context, request, &response));
+      stub->PPMUSource(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2023,7 +2126,8 @@ read_sequencer_flag(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = ReadSequencerFlagResponse{};
 
   raise_if_error(
-      stub->ReadSequencerFlag(&context, request, &response));
+      stub->ReadSequencerFlag(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2040,7 +2144,8 @@ read_sequencer_register(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = ReadSequencerRegisterResponse{};
 
   raise_if_error(
-      stub->ReadSequencerRegister(&context, request, &response));
+      stub->ReadSequencerRegister(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2057,7 +2162,8 @@ read_static(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::str
   auto response = ReadStaticResponse{};
 
   raise_if_error(
-      stub->ReadStatic(&context, request, &response));
+      stub->ReadStatic(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2073,7 +2179,8 @@ reset(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetResponse{};
 
   raise_if_error(
-      stub->Reset(&context, request, &response));
+      stub->Reset(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2091,7 +2198,8 @@ reset_attribute(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb:
   auto response = ResetAttributeResponse{};
 
   raise_if_error(
-      stub->ResetAttribute(&context, request, &response));
+      stub->ResetAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2107,7 +2215,8 @@ reset_device(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetDeviceResponse{};
 
   raise_if_error(
-      stub->ResetDevice(&context, request, &response));
+      stub->ResetDevice(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2132,7 +2241,8 @@ select_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb:
   auto response = SelectFunctionResponse{};
 
   raise_if_error(
-      stub->SelectFunction(&context, request, &response));
+      stub->SelectFunction(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2148,7 +2258,8 @@ self_calibrate(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SelfCalibrateResponse{};
 
   raise_if_error(
-      stub->SelfCalibrate(&context, request, &response));
+      stub->SelfCalibrate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2164,7 +2275,8 @@ self_test(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SelfTestResponse{};
 
   raise_if_error(
-      stub->SelfTest(&context, request, &response));
+      stub->SelfTest(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2189,7 +2301,8 @@ send_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = SendSoftwareEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->SendSoftwareEdgeTrigger(&context, request, &response));
+      stub->SendSoftwareEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2208,7 +2321,8 @@ set_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = SetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->SetAttributeViBoolean(&context, request, &response));
+      stub->SetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2234,7 +2348,8 @@ set_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = SetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->SetAttributeViInt32(&context, request, &response));
+      stub->SetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2253,7 +2368,8 @@ set_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = SetAttributeViInt64Response{};
 
   raise_if_error(
-      stub->SetAttributeViInt64(&context, request, &response));
+      stub->SetAttributeViInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2272,7 +2388,8 @@ set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->SetAttributeViReal64(&context, request, &response));
+      stub->SetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2291,7 +2408,8 @@ set_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = SetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->SetAttributeViSession(&context, request, &response));
+      stub->SetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2310,7 +2428,8 @@ set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->SetAttributeViString(&context, request, &response));
+      stub->SetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2328,7 +2447,8 @@ tdr(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& cha
   auto response = TDRResponse{};
 
   raise_if_error(
-      stub->TDR(&context, request, &response));
+      stub->TDR(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2345,7 +2465,8 @@ unload_all_patterns(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = UnloadAllPatternsResponse{};
 
   raise_if_error(
-      stub->UnloadAllPatterns(&context, request, &response));
+      stub->UnloadAllPatterns(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2362,7 +2483,8 @@ unload_specifications(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = UnloadSpecificationsResponse{};
 
   raise_if_error(
-      stub->UnloadSpecifications(&context, request, &response));
+      stub->UnloadSpecifications(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2379,7 +2501,8 @@ wait_until_done(const StubPtr& stub, const nidevice_grpc::Session& vi, const dou
   auto response = WaitUntilDoneResponse{};
 
   raise_if_error(
-      stub->WaitUntilDone(&context, request, &response));
+      stub->WaitUntilDone(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2397,7 +2520,8 @@ write_sequencer_flag(const StubPtr& stub, const nidevice_grpc::Session& vi, cons
   auto response = WriteSequencerFlagResponse{};
 
   raise_if_error(
-      stub->WriteSequencerFlag(&context, request, &response));
+      stub->WriteSequencerFlag(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2416,7 +2540,8 @@ write_sequencer_flag_synchronized(const StubPtr& stub, const pb::uint32& session
   auto response = WriteSequencerFlagSynchronizedResponse{};
 
   raise_if_error(
-      stub->WriteSequencerFlagSynchronized(&context, request, &response));
+      stub->WriteSequencerFlagSynchronized(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2434,7 +2559,8 @@ write_sequencer_register(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = WriteSequencerRegisterResponse{};
 
   raise_if_error(
-      stub->WriteSequencerRegister(&context, request, &response));
+      stub->WriteSequencerRegister(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2452,7 +2578,8 @@ write_source_waveform_broadcast_u32(const StubPtr& stub, const nidevice_grpc::Se
   auto response = WriteSourceWaveformBroadcastU32Response{};
 
   raise_if_error(
-      stub->WriteSourceWaveformBroadcastU32(&context, request, &response));
+      stub->WriteSourceWaveformBroadcastU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2470,7 +2597,8 @@ write_source_waveform_data_from_file_tdms(const StubPtr& stub, const nidevice_gr
   auto response = WriteSourceWaveformDataFromFileTDMSResponse{};
 
   raise_if_error(
-      stub->WriteSourceWaveformDataFromFileTDMS(&context, request, &response));
+      stub->WriteSourceWaveformDataFromFileTDMS(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2495,7 +2623,8 @@ write_static(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::st
   auto response = WriteStaticResponse{};
 
   raise_if_error(
-      stub->WriteStatic(&context, request, &response));
+      stub->WriteStatic(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2516,7 +2645,8 @@ write_source_waveform_site_unique_u32(const StubPtr& stub, const nidevice_grpc::
   auto response = WriteSourceWaveformSiteUniqueU32Response{};
 
   raise_if_error(
-      stub->WriteSourceWaveformSiteUniqueU32(&context, request, &response));
+      stub->WriteSourceWaveformSiteUniqueU32(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nidmm/nidmm_client.cpp
+++ b/generated/nidmm/nidmm_client.cpp
@@ -36,7 +36,8 @@ control4022(const StubPtr& stub, const pb::string& resource_name, const simple_v
   auto response = Control4022Response{};
 
   raise_if_error(
-      stub->Control4022(&context, request, &response));
+      stub->Control4022(&context, request, &response),
+      context);
 
   return response;
 }
@@ -52,7 +53,8 @@ abort(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = AbortResponse{};
 
   raise_if_error(
-      stub->Abort(&context, request, &response));
+      stub->Abort(&context, request, &response),
+      context);
 
   return response;
 }
@@ -71,7 +73,8 @@ check_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = CheckAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->CheckAttributeViBoolean(&context, request, &response));
+      stub->CheckAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -97,7 +100,8 @@ check_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = CheckAttributeViInt32Response{};
 
   raise_if_error(
-      stub->CheckAttributeViInt32(&context, request, &response));
+      stub->CheckAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -123,7 +127,8 @@ check_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = CheckAttributeViReal64Response{};
 
   raise_if_error(
-      stub->CheckAttributeViReal64(&context, request, &response));
+      stub->CheckAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -142,7 +147,8 @@ check_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = CheckAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->CheckAttributeViSession(&context, request, &response));
+      stub->CheckAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -161,7 +167,8 @@ check_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = CheckAttributeViStringResponse{};
 
   raise_if_error(
-      stub->CheckAttributeViString(&context, request, &response));
+      stub->CheckAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -177,7 +184,8 @@ clear_error(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ClearErrorResponse{};
 
   raise_if_error(
-      stub->ClearError(&context, request, &response));
+      stub->ClearError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -193,7 +201,8 @@ clear_interchange_warnings(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = ClearInterchangeWarningsResponse{};
 
   raise_if_error(
-      stub->ClearInterchangeWarnings(&context, request, &response));
+      stub->ClearInterchangeWarnings(&context, request, &response),
+      context);
 
   return response;
 }
@@ -209,7 +218,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }
@@ -227,7 +237,8 @@ configure_ac_bandwidth(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = ConfigureACBandwidthResponse{};
 
   raise_if_error(
-      stub->ConfigureACBandwidth(&context, request, &response));
+      stub->ConfigureACBandwidth(&context, request, &response),
+      context);
 
   return response;
 }
@@ -244,7 +255,8 @@ configure_adc_calibration(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = ConfigureADCCalibrationResponse{};
 
   raise_if_error(
-      stub->ConfigureADCCalibration(&context, request, &response));
+      stub->ConfigureADCCalibration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -261,7 +273,8 @@ configure_auto_zero_mode(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = ConfigureAutoZeroModeResponse{};
 
   raise_if_error(
-      stub->ConfigureAutoZeroMode(&context, request, &response));
+      stub->ConfigureAutoZeroMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -278,7 +291,8 @@ configure_cable_comp_type(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = ConfigureCableCompTypeResponse{};
 
   raise_if_error(
-      stub->ConfigureCableCompType(&context, request, &response));
+      stub->ConfigureCableCompType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -295,7 +309,8 @@ configure_current_source(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = ConfigureCurrentSourceResponse{};
 
   raise_if_error(
-      stub->ConfigureCurrentSource(&context, request, &response));
+      stub->ConfigureCurrentSource(&context, request, &response),
+      context);
 
   return response;
 }
@@ -312,7 +327,8 @@ configure_fixed_ref_junction(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ConfigureFixedRefJunctionResponse{};
 
   raise_if_error(
-      stub->ConfigureFixedRefJunction(&context, request, &response));
+      stub->ConfigureFixedRefJunction(&context, request, &response),
+      context);
 
   return response;
 }
@@ -336,7 +352,8 @@ configure_frequency_voltage_range(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = ConfigureFrequencyVoltageRangeResponse{};
 
   raise_if_error(
-      stub->ConfigureFrequencyVoltageRange(&context, request, &response));
+      stub->ConfigureFrequencyVoltageRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -353,7 +370,8 @@ configure_meas_complete_dest(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ConfigureMeasCompleteDestResponse{};
 
   raise_if_error(
-      stub->ConfigureMeasCompleteDest(&context, request, &response));
+      stub->ConfigureMeasCompleteDest(&context, request, &response),
+      context);
 
   return response;
 }
@@ -379,7 +397,8 @@ configure_measurement_absolute(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ConfigureMeasurementAbsoluteResponse{};
 
   raise_if_error(
-      stub->ConfigureMeasurementAbsolute(&context, request, &response));
+      stub->ConfigureMeasurementAbsolute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -396,7 +415,8 @@ configure_meas_complete_slope(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ConfigureMeasCompleteSlopeResponse{};
 
   raise_if_error(
-      stub->ConfigureMeasCompleteSlope(&context, request, &response));
+      stub->ConfigureMeasCompleteSlope(&context, request, &response),
+      context);
 
   return response;
 }
@@ -422,7 +442,8 @@ configure_measurement_digits(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ConfigureMeasurementDigitsResponse{};
 
   raise_if_error(
-      stub->ConfigureMeasurementDigits(&context, request, &response));
+      stub->ConfigureMeasurementDigits(&context, request, &response),
+      context);
 
   return response;
 }
@@ -470,7 +491,8 @@ configure_multi_point(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = ConfigureMultiPointResponse{};
 
   raise_if_error(
-      stub->ConfigureMultiPoint(&context, request, &response));
+      stub->ConfigureMultiPoint(&context, request, &response),
+      context);
 
   return response;
 }
@@ -494,7 +516,8 @@ configure_offset_comp_ohms(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = ConfigureOffsetCompOhmsResponse{};
 
   raise_if_error(
-      stub->ConfigureOffsetCompOhms(&context, request, &response));
+      stub->ConfigureOffsetCompOhms(&context, request, &response),
+      context);
 
   return response;
 }
@@ -512,7 +535,8 @@ configure_open_cable_comp_values(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ConfigureOpenCableCompValuesResponse{};
 
   raise_if_error(
-      stub->ConfigureOpenCableCompValues(&context, request, &response));
+      stub->ConfigureOpenCableCompValues(&context, request, &response),
+      context);
 
   return response;
 }
@@ -536,7 +560,8 @@ configure_power_line_frequency(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ConfigurePowerLineFrequencyResponse{};
 
   raise_if_error(
-      stub->ConfigurePowerLineFrequency(&context, request, &response));
+      stub->ConfigurePowerLineFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -554,7 +579,8 @@ configure_short_cable_comp_values(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = ConfigureShortCableCompValuesResponse{};
 
   raise_if_error(
-      stub->ConfigureShortCableCompValues(&context, request, &response));
+      stub->ConfigureShortCableCompValues(&context, request, &response),
+      context);
 
   return response;
 }
@@ -573,7 +599,8 @@ configure_rtd_custom(const StubPtr& stub, const nidevice_grpc::Session& vi, cons
   auto response = ConfigureRTDCustomResponse{};
 
   raise_if_error(
-      stub->ConfigureRTDCustom(&context, request, &response));
+      stub->ConfigureRTDCustom(&context, request, &response),
+      context);
 
   return response;
 }
@@ -598,7 +625,8 @@ configure_rtd_type(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = ConfigureRTDTypeResponse{};
 
   raise_if_error(
-      stub->ConfigureRTDType(&context, request, &response));
+      stub->ConfigureRTDType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -622,7 +650,8 @@ configure_sample_trigger_slope(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ConfigureSampleTriggerSlopeResponse{};
 
   raise_if_error(
-      stub->ConfigureSampleTriggerSlope(&context, request, &response));
+      stub->ConfigureSampleTriggerSlope(&context, request, &response),
+      context);
 
   return response;
 }
@@ -641,7 +670,8 @@ configure_thermistor_custom(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = ConfigureThermistorCustomResponse{};
 
   raise_if_error(
-      stub->ConfigureThermistorCustom(&context, request, &response));
+      stub->ConfigureThermistorCustom(&context, request, &response),
+      context);
 
   return response;
 }
@@ -673,7 +703,8 @@ configure_thermocouple(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = ConfigureThermocoupleResponse{};
 
   raise_if_error(
-      stub->ConfigureThermocouple(&context, request, &response));
+      stub->ConfigureThermocouple(&context, request, &response),
+      context);
 
   return response;
 }
@@ -690,7 +721,8 @@ configure_thermistor_type(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = ConfigureThermistorTypeResponse{};
 
   raise_if_error(
-      stub->ConfigureThermistorType(&context, request, &response));
+      stub->ConfigureThermistorType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -707,7 +739,8 @@ configure_transducer_type(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = ConfigureTransducerTypeResponse{};
 
   raise_if_error(
-      stub->ConfigureTransducerType(&context, request, &response));
+      stub->ConfigureTransducerType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -739,7 +772,8 @@ configure_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, const s
   auto response = ConfigureTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureTrigger(&context, request, &response));
+      stub->ConfigureTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -763,7 +797,8 @@ configure_trigger_slope(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = ConfigureTriggerSlopeResponse{};
 
   raise_if_error(
-      stub->ConfigureTriggerSlope(&context, request, &response));
+      stub->ConfigureTriggerSlope(&context, request, &response),
+      context);
 
   return response;
 }
@@ -790,7 +825,8 @@ configure_waveform_acquisition(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ConfigureWaveformAcquisitionResponse{};
 
   raise_if_error(
-      stub->ConfigureWaveformAcquisition(&context, request, &response));
+      stub->ConfigureWaveformAcquisition(&context, request, &response),
+      context);
 
   return response;
 }
@@ -807,7 +843,8 @@ configure_waveform_coupling(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = ConfigureWaveformCouplingResponse{};
 
   raise_if_error(
-      stub->ConfigureWaveformCoupling(&context, request, &response));
+      stub->ConfigureWaveformCoupling(&context, request, &response),
+      context);
 
   return response;
 }
@@ -831,7 +868,8 @@ control(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_vari
   auto response = ControlResponse{};
 
   raise_if_error(
-      stub->Control(&context, request, &response));
+      stub->Control(&context, request, &response),
+      context);
 
   return response;
 }
@@ -847,7 +885,8 @@ disable(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisableResponse{};
 
   raise_if_error(
-      stub->Disable(&context, request, &response));
+      stub->Disable(&context, request, &response),
+      context);
 
   return response;
 }
@@ -863,7 +902,8 @@ export_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::
   auto response = ExportAttributeConfigurationBufferResponse{};
 
   raise_if_error(
-      stub->ExportAttributeConfigurationBuffer(&context, request, &response));
+      stub->ExportAttributeConfigurationBuffer(&context, request, &response),
+      context);
 
   return response;
 }
@@ -880,7 +920,8 @@ export_attribute_configuration_file(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ExportAttributeConfigurationFileResponse{};
 
   raise_if_error(
-      stub->ExportAttributeConfigurationFile(&context, request, &response));
+      stub->ExportAttributeConfigurationFile(&context, request, &response),
+      context);
 
   return response;
 }
@@ -904,7 +945,8 @@ fetch(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_varian
   auto response = FetchResponse{};
 
   raise_if_error(
-      stub->Fetch(&context, request, &response));
+      stub->Fetch(&context, request, &response),
+      context);
 
   return response;
 }
@@ -929,7 +971,8 @@ fetch_multi_point(const StubPtr& stub, const nidevice_grpc::Session& vi, const s
   auto response = FetchMultiPointResponse{};
 
   raise_if_error(
-      stub->FetchMultiPoint(&context, request, &response));
+      stub->FetchMultiPoint(&context, request, &response),
+      context);
 
   return response;
 }
@@ -954,7 +997,8 @@ fetch_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const simp
   auto response = FetchWaveformResponse{};
 
   raise_if_error(
-      stub->FetchWaveform(&context, request, &response));
+      stub->FetchWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -970,7 +1014,8 @@ get_aperture_time_info(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetApertureTimeInfoResponse{};
 
   raise_if_error(
-      stub->GetApertureTimeInfo(&context, request, &response));
+      stub->GetApertureTimeInfo(&context, request, &response),
+      context);
 
   return response;
 }
@@ -988,7 +1033,8 @@ get_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->GetAttributeViBoolean(&context, request, &response));
+      stub->GetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1006,7 +1052,8 @@ get_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->GetAttributeViInt32(&context, request, &response));
+      stub->GetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1024,7 +1071,8 @@ get_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->GetAttributeViReal64(&context, request, &response));
+      stub->GetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1042,7 +1090,8 @@ get_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->GetAttributeViSession(&context, request, &response));
+      stub->GetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1060,7 +1109,8 @@ get_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeViString(&context, request, &response));
+      stub->GetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1076,7 +1126,8 @@ get_auto_range_value(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetAutoRangeValueResponse{};
 
   raise_if_error(
-      stub->GetAutoRangeValue(&context, request, &response));
+      stub->GetAutoRangeValue(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1100,7 +1151,8 @@ get_cal_date_and_time(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = GetCalDateAndTimeResponse{};
 
   raise_if_error(
-      stub->GetCalDateAndTime(&context, request, &response));
+      stub->GetCalDateAndTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1117,7 +1169,8 @@ get_channel_name(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb
   auto response = GetChannelNameResponse{};
 
   raise_if_error(
-      stub->GetChannelName(&context, request, &response));
+      stub->GetChannelName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1134,7 +1187,8 @@ get_dev_temp(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::st
   auto response = GetDevTempResponse{};
 
   raise_if_error(
-      stub->GetDevTemp(&context, request, &response));
+      stub->GetDevTemp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1150,7 +1204,8 @@ get_error(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetErrorResponse{};
 
   raise_if_error(
-      stub->GetError(&context, request, &response));
+      stub->GetError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1167,7 +1222,8 @@ get_error_message(const StubPtr& stub, const nidevice_grpc::Session& vi, const p
   auto response = GetErrorMessageResponse{};
 
   raise_if_error(
-      stub->GetErrorMessage(&context, request, &response));
+      stub->GetErrorMessage(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1183,7 +1239,8 @@ get_ext_cal_recommended_interval(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = GetExtCalRecommendedIntervalResponse{};
 
   raise_if_error(
-      stub->GetExtCalRecommendedInterval(&context, request, &response));
+      stub->GetExtCalRecommendedInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1207,7 +1264,8 @@ get_last_cal_temp(const StubPtr& stub, const nidevice_grpc::Session& vi, const s
   auto response = GetLastCalTempResponse{};
 
   raise_if_error(
-      stub->GetLastCalTemp(&context, request, &response));
+      stub->GetLastCalTemp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1223,7 +1281,8 @@ get_measurement_period(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetMeasurementPeriodResponse{};
 
   raise_if_error(
-      stub->GetMeasurementPeriod(&context, request, &response));
+      stub->GetMeasurementPeriod(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1239,7 +1298,8 @@ get_next_coercion_record(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetNextCoercionRecordResponse{};
 
   raise_if_error(
-      stub->GetNextCoercionRecord(&context, request, &response));
+      stub->GetNextCoercionRecord(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1255,7 +1315,8 @@ get_next_interchange_warning(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetNextInterchangeWarningResponse{};
 
   raise_if_error(
-      stub->GetNextInterchangeWarning(&context, request, &response));
+      stub->GetNextInterchangeWarning(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1271,7 +1332,8 @@ get_self_cal_supported(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetSelfCalSupportedResponse{};
 
   raise_if_error(
-      stub->GetSelfCalSupported(&context, request, &response));
+      stub->GetSelfCalSupported(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1288,7 +1350,8 @@ import_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::
   auto response = ImportAttributeConfigurationBufferResponse{};
 
   raise_if_error(
-      stub->ImportAttributeConfigurationBuffer(&context, request, &response));
+      stub->ImportAttributeConfigurationBuffer(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1305,7 +1368,8 @@ import_attribute_configuration_file(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ImportAttributeConfigurationFileResponse{};
 
   raise_if_error(
-      stub->ImportAttributeConfigurationFile(&context, request, &response));
+      stub->ImportAttributeConfigurationFile(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1323,7 +1387,8 @@ init(const StubPtr& stub, const pb::string& resource_name, const bool& id_query,
   auto response = InitResponse{};
 
   raise_if_error(
-      stub->Init(&context, request, &response));
+      stub->Init(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1342,7 +1407,8 @@ init_with_options(const StubPtr& stub, const pb::string& resource_name, const bo
   auto response = InitWithOptionsResponse{};
 
   raise_if_error(
-      stub->InitWithOptions(&context, request, &response));
+      stub->InitWithOptions(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1358,7 +1424,8 @@ initiate(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = InitiateResponse{};
 
   raise_if_error(
-      stub->Initiate(&context, request, &response));
+      stub->Initiate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1374,7 +1441,8 @@ invalidate_all_attributes(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = InvalidateAllAttributesResponse{};
 
   raise_if_error(
-      stub->InvalidateAllAttributes(&context, request, &response));
+      stub->InvalidateAllAttributes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1391,7 +1459,8 @@ is_over_range(const StubPtr& stub, const nidevice_grpc::Session& vi, const doubl
   auto response = IsOverRangeResponse{};
 
   raise_if_error(
-      stub->IsOverRange(&context, request, &response));
+      stub->IsOverRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1408,7 +1477,8 @@ is_under_range(const StubPtr& stub, const nidevice_grpc::Session& vi, const doub
   auto response = IsUnderRangeResponse{};
 
   raise_if_error(
-      stub->IsUnderRange(&context, request, &response));
+      stub->IsUnderRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1424,7 +1494,8 @@ perform_open_cable_comp(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = PerformOpenCableCompResponse{};
 
   raise_if_error(
-      stub->PerformOpenCableComp(&context, request, &response));
+      stub->PerformOpenCableComp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1440,7 +1511,8 @@ perform_short_cable_comp(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = PerformShortCableCompResponse{};
 
   raise_if_error(
-      stub->PerformShortCableComp(&context, request, &response));
+      stub->PerformShortCableComp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1464,7 +1536,8 @@ read(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant
   auto response = ReadResponse{};
 
   raise_if_error(
-      stub->Read(&context, request, &response));
+      stub->Read(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1489,7 +1562,8 @@ read_multi_point(const StubPtr& stub, const nidevice_grpc::Session& vi, const si
   auto response = ReadMultiPointResponse{};
 
   raise_if_error(
-      stub->ReadMultiPoint(&context, request, &response));
+      stub->ReadMultiPoint(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1505,7 +1579,8 @@ read_status(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ReadStatusResponse{};
 
   raise_if_error(
-      stub->ReadStatus(&context, request, &response));
+      stub->ReadStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1530,7 +1605,8 @@ read_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const simpl
   auto response = ReadWaveformResponse{};
 
   raise_if_error(
-      stub->ReadWaveform(&context, request, &response));
+      stub->ReadWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1546,7 +1622,8 @@ reset(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetResponse{};
 
   raise_if_error(
-      stub->Reset(&context, request, &response));
+      stub->Reset(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1562,7 +1639,8 @@ reset_interchange_check(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetInterchangeCheckResponse{};
 
   raise_if_error(
-      stub->ResetInterchangeCheck(&context, request, &response));
+      stub->ResetInterchangeCheck(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1578,7 +1656,8 @@ reset_with_defaults(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetWithDefaultsResponse{};
 
   raise_if_error(
-      stub->ResetWithDefaults(&context, request, &response));
+      stub->ResetWithDefaults(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1594,7 +1673,8 @@ revision_query(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = RevisionQueryResponse{};
 
   raise_if_error(
-      stub->RevisionQuery(&context, request, &response));
+      stub->RevisionQuery(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1610,7 +1690,8 @@ self_cal(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SelfCalResponse{};
 
   raise_if_error(
-      stub->SelfCal(&context, request, &response));
+      stub->SelfCal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1626,7 +1707,8 @@ self_test(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SelfTestResponse{};
 
   raise_if_error(
-      stub->SelfTest(&context, request, &response));
+      stub->SelfTest(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1642,7 +1724,8 @@ send_software_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SendSoftwareTriggerResponse{};
 
   raise_if_error(
-      stub->SendSoftwareTrigger(&context, request, &response));
+      stub->SendSoftwareTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1661,7 +1744,8 @@ set_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = SetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->SetAttributeViBoolean(&context, request, &response));
+      stub->SetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1687,7 +1771,8 @@ set_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = SetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->SetAttributeViInt32(&context, request, &response));
+      stub->SetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1713,7 +1798,8 @@ set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->SetAttributeViReal64(&context, request, &response));
+      stub->SetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1732,7 +1818,8 @@ set_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = SetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->SetAttributeViSession(&context, request, &response));
+      stub->SetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1751,7 +1838,8 @@ set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->SetAttributeViString(&context, request, &response));
+      stub->SetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nifake/nifake_client.cpp
+++ b/generated/nifake/nifake_client.cpp
@@ -28,7 +28,8 @@ abort(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = AbortResponse{};
 
   raise_if_error(
-      stub->Abort(&context, request, &response));
+      stub->Abort(&context, request, &response),
+      context);
 
   return response;
 }
@@ -45,7 +46,8 @@ accept_list_of_durations_in_seconds(const StubPtr& stub, const nidevice_grpc::Se
   auto response = AcceptListOfDurationsInSecondsResponse{};
 
   raise_if_error(
-      stub->AcceptListOfDurationsInSeconds(&context, request, &response));
+      stub->AcceptListOfDurationsInSeconds(&context, request, &response),
+      context);
 
   return response;
 }
@@ -62,7 +64,8 @@ accept_vi_session_array(const StubPtr& stub, const pb::uint32& session_count, co
   auto response = AcceptViSessionArrayResponse{};
 
   raise_if_error(
-      stub->AcceptViSessionArray(&context, request, &response));
+      stub->AcceptViSessionArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -79,7 +82,8 @@ accept_vi_uint32_array(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = AcceptViUInt32ArrayResponse{};
 
   raise_if_error(
-      stub->AcceptViUInt32Array(&context, request, &response));
+      stub->AcceptViUInt32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -97,7 +101,8 @@ bool_array_input_function(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = BoolArrayInputFunctionResponse{};
 
   raise_if_error(
-      stub->BoolArrayInputFunction(&context, request, &response));
+      stub->BoolArrayInputFunction(&context, request, &response),
+      context);
 
   return response;
 }
@@ -114,7 +119,8 @@ bool_array_output_function(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = BoolArrayOutputFunctionResponse{};
 
   raise_if_error(
-      stub->BoolArrayOutputFunction(&context, request, &response));
+      stub->BoolArrayOutputFunction(&context, request, &response),
+      context);
 
   return response;
 }
@@ -131,7 +137,8 @@ close_ext_cal(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::i
   auto response = CloseExtCalResponse{};
 
   raise_if_error(
-      stub->CloseExtCal(&context, request, &response));
+      stub->CloseExtCal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -147,7 +154,8 @@ command_with_reserved_param(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = CommandWithReservedParamResponse{};
 
   raise_if_error(
-      stub->CommandWithReservedParam(&context, request, &response));
+      stub->CommandWithReservedParam(&context, request, &response),
+      context);
 
   return response;
 }
@@ -163,7 +171,8 @@ create_configuration_list(const StubPtr& stub, const std::vector<NiFakeAttribute
   auto response = CreateConfigurationListResponse{};
 
   raise_if_error(
-      stub->CreateConfigurationList(&context, request, &response));
+      stub->CreateConfigurationList(&context, request, &response),
+      context);
 
   return response;
 }
@@ -180,7 +189,8 @@ double_all_the_nums(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = DoubleAllTheNumsResponse{};
 
   raise_if_error(
-      stub->DoubleAllTheNums(&context, request, &response));
+      stub->DoubleAllTheNums(&context, request, &response),
+      context);
 
   return response;
 }
@@ -197,7 +207,8 @@ enum_array_output_function(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = EnumArrayOutputFunctionResponse{};
 
   raise_if_error(
-      stub->EnumArrayOutputFunction(&context, request, &response));
+      stub->EnumArrayOutputFunction(&context, request, &response),
+      context);
 
   return response;
 }
@@ -221,7 +232,8 @@ enum_input_function_with_defaults(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = EnumInputFunctionWithDefaultsResponse{};
 
   raise_if_error(
-      stub->EnumInputFunctionWithDefaults(&context, request, &response));
+      stub->EnumInputFunctionWithDefaults(&context, request, &response),
+      context);
 
   return response;
 }
@@ -237,7 +249,8 @@ export_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::
   auto response = ExportAttributeConfigurationBufferResponse{};
 
   raise_if_error(
-      stub->ExportAttributeConfigurationBuffer(&context, request, &response));
+      stub->ExportAttributeConfigurationBuffer(&context, request, &response),
+      context);
 
   return response;
 }
@@ -254,7 +267,8 @@ fetch_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::
   auto response = FetchWaveformResponse{};
 
   raise_if_error(
-      stub->FetchWaveform(&context, request, &response));
+      stub->FetchWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -270,7 +284,8 @@ get_a_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetABooleanResponse{};
 
   raise_if_error(
-      stub->GetABoolean(&context, request, &response));
+      stub->GetABoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -286,7 +301,8 @@ get_a_number(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetANumberResponse{};
 
   raise_if_error(
-      stub->GetANumber(&context, request, &response));
+      stub->GetANumber(&context, request, &response),
+      context);
 
   return response;
 }
@@ -302,7 +318,8 @@ get_a_string_of_fixed_maximum_size(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = GetAStringOfFixedMaximumSizeResponse{};
 
   raise_if_error(
-      stub->GetAStringOfFixedMaximumSize(&context, request, &response));
+      stub->GetAStringOfFixedMaximumSize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -318,7 +335,8 @@ get_an_ivi_dance_string(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetAnIviDanceStringResponse{};
 
   raise_if_error(
-      stub->GetAnIviDanceString(&context, request, &response));
+      stub->GetAnIviDanceString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -335,7 +353,8 @@ get_an_ivi_dance_with_a_twist_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = GetAnIviDanceWithATwistArrayResponse{};
 
   raise_if_error(
-      stub->GetAnIviDanceWithATwistArray(&context, request, &response));
+      stub->GetAnIviDanceWithATwistArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -351,7 +370,8 @@ get_an_ivi_dance_with_a_twist_array_of_custom_type(const StubPtr& stub, const ni
   auto response = GetAnIviDanceWithATwistArrayOfCustomTypeResponse{};
 
   raise_if_error(
-      stub->GetAnIviDanceWithATwistArrayOfCustomType(&context, request, &response));
+      stub->GetAnIviDanceWithATwistArrayOfCustomType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -367,7 +387,8 @@ get_an_ivi_dance_with_a_twist_array_with_input_array(const StubPtr& stub, const 
   auto response = GetAnIviDanceWithATwistArrayWithInputArrayResponse{};
 
   raise_if_error(
-      stub->GetAnIviDanceWithATwistArrayWithInputArray(&context, request, &response));
+      stub->GetAnIviDanceWithATwistArrayWithInputArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -382,7 +403,8 @@ get_an_ivi_dance_with_a_twist_byte_array(const StubPtr& stub)
   auto response = GetAnIviDanceWithATwistByteArrayResponse{};
 
   raise_if_error(
-      stub->GetAnIviDanceWithATwistByteArray(&context, request, &response));
+      stub->GetAnIviDanceWithATwistByteArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -397,7 +419,8 @@ get_an_ivi_dance_with_a_twist_string(const StubPtr& stub)
   auto response = GetAnIviDanceWithATwistStringResponse{};
 
   raise_if_error(
-      stub->GetAnIviDanceWithATwistString(&context, request, &response));
+      stub->GetAnIviDanceWithATwistString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -412,7 +435,8 @@ get_an_ivi_dance_with_a_twist_string_strlen_bug(const StubPtr& stub)
   auto response = GetAnIviDanceWithATwistStringStrlenBugResponse{};
 
   raise_if_error(
-      stub->GetAnIviDanceWithATwistStringStrlenBug(&context, request, &response));
+      stub->GetAnIviDanceWithATwistStringStrlenBug(&context, request, &response),
+      context);
 
   return response;
 }
@@ -428,7 +452,8 @@ get_array_size_for_custom_code(const StubPtr& stub, const nidevice_grpc::Session
   auto response = GetArraySizeForCustomCodeResponse{};
 
   raise_if_error(
-      stub->GetArraySizeForCustomCode(&context, request, &response));
+      stub->GetArraySizeForCustomCode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -444,7 +469,8 @@ get_array_using_ivi_dance(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetArrayUsingIviDanceResponse{};
 
   raise_if_error(
-      stub->GetArrayUsingIviDance(&context, request, &response));
+      stub->GetArrayUsingIviDance(&context, request, &response),
+      context);
 
   return response;
 }
@@ -461,7 +487,8 @@ get_array_vi_uint8_with_enum(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetArrayViUInt8WithEnumResponse{};
 
   raise_if_error(
-      stub->GetArrayViUInt8WithEnum(&context, request, &response));
+      stub->GetArrayViUInt8WithEnum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -479,7 +506,8 @@ get_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->GetAttributeViBoolean(&context, request, &response));
+      stub->GetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -497,7 +525,8 @@ get_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->GetAttributeViInt32(&context, request, &response));
+      stub->GetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -515,7 +544,8 @@ get_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetAttributeViInt64Response{};
 
   raise_if_error(
-      stub->GetAttributeViInt64(&context, request, &response));
+      stub->GetAttributeViInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -533,7 +563,8 @@ get_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->GetAttributeViReal64(&context, request, &response));
+      stub->GetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -550,7 +581,8 @@ get_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->GetAttributeViSession(&context, request, &response));
+      stub->GetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -568,7 +600,8 @@ get_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeViString(&context, request, &response));
+      stub->GetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -583,7 +616,8 @@ get_bitfield_as_enum_array(const StubPtr& stub)
   auto response = GetBitfieldAsEnumArrayResponse{};
 
   raise_if_error(
-      stub->GetBitfieldAsEnumArray(&context, request, &response));
+      stub->GetBitfieldAsEnumArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -600,7 +634,8 @@ get_cal_date_and_time(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = GetCalDateAndTimeResponse{};
 
   raise_if_error(
-      stub->GetCalDateAndTime(&context, request, &response));
+      stub->GetCalDateAndTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -616,7 +651,8 @@ get_cal_interval(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetCalIntervalResponse{};
 
   raise_if_error(
-      stub->GetCalInterval(&context, request, &response));
+      stub->GetCalInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -632,7 +668,8 @@ get_custom_type(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetCustomTypeResponse{};
 
   raise_if_error(
-      stub->GetCustomType(&context, request, &response));
+      stub->GetCustomType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -649,7 +686,8 @@ get_custom_type_array(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = GetCustomTypeArrayResponse{};
 
   raise_if_error(
-      stub->GetCustomTypeArray(&context, request, &response));
+      stub->GetCustomTypeArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -665,7 +703,8 @@ get_enum_value(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetEnumValueResponse{};
 
   raise_if_error(
-      stub->GetEnumValue(&context, request, &response));
+      stub->GetEnumValue(&context, request, &response),
+      context);
 
   return response;
 }
@@ -682,7 +721,8 @@ get_vi_int32_array(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = GetViInt32ArrayResponse{};
 
   raise_if_error(
-      stub->GetViInt32Array(&context, request, &response));
+      stub->GetViInt32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -699,7 +739,8 @@ get_vi_uint32_array(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = GetViUInt32ArrayResponse{};
 
   raise_if_error(
-      stub->GetViUInt32Array(&context, request, &response));
+      stub->GetViUInt32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -715,7 +756,8 @@ get_vi_uint8(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetViUInt8Response{};
 
   raise_if_error(
-      stub->GetViUInt8(&context, request, &response));
+      stub->GetViUInt8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -732,7 +774,8 @@ import_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::
   auto response = ImportAttributeConfigurationBufferResponse{};
 
   raise_if_error(
-      stub->ImportAttributeConfigurationBuffer(&context, request, &response));
+      stub->ImportAttributeConfigurationBuffer(&context, request, &response),
+      context);
 
   return response;
 }
@@ -749,7 +792,8 @@ init_ext_cal(const StubPtr& stub, const pb::string& resource_name, const pb::str
   auto response = InitExtCalResponse{};
 
   raise_if_error(
-      stub->InitExtCal(&context, request, &response));
+      stub->InitExtCal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -768,7 +812,8 @@ init_with_options(const StubPtr& stub, const pb::string& resource_name, const bo
   auto response = InitWithOptionsResponse{};
 
   raise_if_error(
-      stub->InitWithOptions(&context, request, &response));
+      stub->InitWithOptions(&context, request, &response),
+      context);
 
   return response;
 }
@@ -785,7 +830,8 @@ init_with_var_args(const StubPtr& stub, const pb::string& resource_name, const s
   auto response = InitWithVarArgsResponse{};
 
   raise_if_error(
-      stub->InitWithVarArgs(&context, request, &response));
+      stub->InitWithVarArgs(&context, request, &response),
+      context);
 
   return response;
 }
@@ -804,7 +850,8 @@ multiple_array_types(const StubPtr& stub, const nidevice_grpc::Session& vi, cons
   auto response = MultipleArrayTypesResponse{};
 
   raise_if_error(
-      stub->MultipleArrayTypes(&context, request, &response));
+      stub->MultipleArrayTypes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -824,7 +871,8 @@ multiple_arrays_same_size(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = MultipleArraysSameSizeResponse{};
 
   raise_if_error(
-      stub->MultipleArraysSameSize(&context, request, &response));
+      stub->MultipleArraysSameSize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -845,7 +893,8 @@ multiple_arrays_same_size_with_optional(const StubPtr& stub, const nidevice_grpc
   auto response = MultipleArraysSameSizeWithOptionalResponse{};
 
   raise_if_error(
-      stub->MultipleArraysSameSizeWithOptional(&context, request, &response));
+      stub->MultipleArraysSameSizeWithOptional(&context, request, &response),
+      context);
 
   return response;
 }
@@ -862,7 +911,8 @@ one_input_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = OneInputFunctionResponse{};
 
   raise_if_error(
-      stub->OneInputFunction(&context, request, &response));
+      stub->OneInputFunction(&context, request, &response),
+      context);
 
   return response;
 }
@@ -899,7 +949,8 @@ parameters_are_multiple_types(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ParametersAreMultipleTypesResponse{};
 
   raise_if_error(
-      stub->ParametersAreMultipleTypes(&context, request, &response));
+      stub->ParametersAreMultipleTypes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -915,7 +966,8 @@ poorly_named_simple_function(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = PoorlyNamedSimpleFunctionResponse{};
 
   raise_if_error(
-      stub->PoorlyNamedSimpleFunction(&context, request, &response));
+      stub->PoorlyNamedSimpleFunction(&context, request, &response),
+      context);
 
   return response;
 }
@@ -932,7 +984,8 @@ read(const StubPtr& stub, const nidevice_grpc::Session& vi, const double& maximu
   auto response = ReadResponse{};
 
   raise_if_error(
-      stub->Read(&context, request, &response));
+      stub->Read(&context, request, &response),
+      context);
 
   return response;
 }
@@ -947,7 +1000,8 @@ read_data_with_in_out_ivi_twist(const StubPtr& stub)
   auto response = ReadDataWithInOutIviTwistResponse{};
 
   raise_if_error(
-      stub->ReadDataWithInOutIviTwist(&context, request, &response));
+      stub->ReadDataWithInOutIviTwist(&context, request, &response),
+      context);
 
   return response;
 }
@@ -962,7 +1016,8 @@ read_data_with_multiple_ivi_twist_param_sets(const StubPtr& stub)
   auto response = ReadDataWithMultipleIviTwistParamSetsResponse{};
 
   raise_if_error(
-      stub->ReadDataWithMultipleIviTwistParamSets(&context, request, &response));
+      stub->ReadDataWithMultipleIviTwistParamSets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -980,7 +1035,8 @@ read_from_channel(const StubPtr& stub, const nidevice_grpc::Session& vi, const p
   auto response = ReadFromChannelResponse{};
 
   raise_if_error(
-      stub->ReadFromChannel(&context, request, &response));
+      stub->ReadFromChannel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -996,7 +1052,8 @@ return_a_number_and_a_string(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ReturnANumberAndAStringResponse{};
 
   raise_if_error(
-      stub->ReturnANumberAndAString(&context, request, &response));
+      stub->ReturnANumberAndAString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1012,7 +1069,8 @@ return_duration_in_seconds(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = ReturnDurationInSecondsResponse{};
 
   raise_if_error(
-      stub->ReturnDurationInSeconds(&context, request, &response));
+      stub->ReturnDurationInSeconds(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1029,7 +1087,8 @@ return_list_of_durations_in_seconds(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ReturnListOfDurationsInSecondsResponse{};
 
   raise_if_error(
-      stub->ReturnListOfDurationsInSeconds(&context, request, &response));
+      stub->ReturnListOfDurationsInSeconds(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1046,7 +1105,8 @@ return_multiple_types(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = ReturnMultipleTypesResponse{};
 
   raise_if_error(
-      stub->ReturnMultipleTypes(&context, request, &response));
+      stub->ReturnMultipleTypes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1063,7 +1123,8 @@ set_custom_type(const StubPtr& stub, const nidevice_grpc::Session& vi, const Fak
   auto response = SetCustomTypeResponse{};
 
   raise_if_error(
-      stub->SetCustomType(&context, request, &response));
+      stub->SetCustomType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1080,7 +1141,8 @@ set_custom_type_array(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = SetCustomTypeArrayResponse{};
 
   raise_if_error(
-      stub->SetCustomTypeArray(&context, request, &response));
+      stub->SetCustomTypeArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1104,7 +1166,8 @@ string_valued_enum_input_function_with_defaults(const StubPtr& stub, const nidev
   auto response = StringValuedEnumInputFunctionWithDefaultsResponse{};
 
   raise_if_error(
-      stub->StringValuedEnumInputFunctionWithDefaults(&context, request, &response));
+      stub->StringValuedEnumInputFunctionWithDefaults(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1122,7 +1185,8 @@ two_input_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = TwoInputFunctionResponse{};
 
   raise_if_error(
-      stub->TwoInputFunction(&context, request, &response));
+      stub->TwoInputFunction(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1139,7 +1203,8 @@ use64_bit_number(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb
   auto response = Use64BitNumberResponse{};
 
   raise_if_error(
-      stub->Use64BitNumber(&context, request, &response));
+      stub->Use64BitNumber(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1157,7 +1222,8 @@ use_a_two_dimension_parameter(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = UseATwoDimensionParameterResponse{};
 
   raise_if_error(
-      stub->UseATwoDimensionParameter(&context, request, &response));
+      stub->UseATwoDimensionParameter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1174,7 +1240,8 @@ vi_int16_array_input_function(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ViInt16ArrayInputFunctionResponse{};
 
   raise_if_error(
-      stub->ViInt16ArrayInputFunction(&context, request, &response));
+      stub->ViInt16ArrayInputFunction(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1192,7 +1259,8 @@ vi_uint8_array_input_function(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ViUInt8ArrayInputFunctionResponse{};
 
   raise_if_error(
-      stub->ViUInt8ArrayInputFunction(&context, request, &response));
+      stub->ViUInt8ArrayInputFunction(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1209,7 +1277,8 @@ vi_uint8_array_output_function(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ViUInt8ArrayOutputFunctionResponse{};
 
   raise_if_error(
-      stub->ViUInt8ArrayOutputFunction(&context, request, &response));
+      stub->ViUInt8ArrayOutputFunction(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1226,7 +1295,8 @@ write_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const std:
   auto response = WriteWaveformResponse{};
 
   raise_if_error(
-      stub->WriteWaveform(&context, request, &response));
+      stub->WriteWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1242,7 +1312,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nifake_extension/nifake_extension_client.cpp
+++ b/generated/nifake_extension/nifake_extension_client.cpp
@@ -29,7 +29,8 @@ add_cool_functionality(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = AddCoolFunctionalityResponse{};
 
   raise_if_error(
-      stub->AddCoolFunctionality(&context, request, &response));
+      stub->AddCoolFunctionality(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nifake_non_ivi/nifake_non_ivi_client.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_client.cpp
@@ -28,7 +28,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& handle)
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }
@@ -44,7 +45,8 @@ close_secondary_session(const StubPtr& stub, const nidevice_grpc::Session& secon
   auto response = CloseSecondarySessionResponse{};
 
   raise_if_error(
-      stub->CloseSecondarySession(&context, request, &response));
+      stub->CloseSecondarySession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -60,7 +62,8 @@ get_cross_driver_session(const StubPtr& stub, const nidevice_grpc::Session& hand
   auto response = GetCrossDriverSessionResponse{};
 
   raise_if_error(
-      stub->GetCrossDriverSession(&context, request, &response));
+      stub->GetCrossDriverSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -75,7 +78,8 @@ get_latest_error_message(const StubPtr& stub)
   auto response = GetLatestErrorMessageResponse{};
 
   raise_if_error(
-      stub->GetLatestErrorMessage(&context, request, &response));
+      stub->GetLatestErrorMessage(&context, request, &response),
+      context);
 
   return response;
 }
@@ -90,7 +94,8 @@ get_string_as_returned_value(const StubPtr& stub)
   auto response = GetStringAsReturnedValueResponse{};
 
   raise_if_error(
-      stub->GetStringAsReturnedValue(&context, request, &response));
+      stub->GetStringAsReturnedValue(&context, request, &response),
+      context);
 
   return response;
 }
@@ -114,7 +119,8 @@ get_marble_attribute_double(const StubPtr& stub, const nidevice_grpc::Session& h
   auto response = GetMarbleAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->GetMarbleAttributeDouble(&context, request, &response));
+      stub->GetMarbleAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -138,7 +144,8 @@ get_marble_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session& ha
   auto response = GetMarbleAttributeInt32Response{};
 
   raise_if_error(
-      stub->GetMarbleAttributeInt32(&context, request, &response));
+      stub->GetMarbleAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -162,7 +169,8 @@ get_marble_attribute_int32_array(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = GetMarbleAttributeInt32ArrayResponse{};
 
   raise_if_error(
-      stub->GetMarbleAttributeInt32Array(&context, request, &response));
+      stub->GetMarbleAttributeInt32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -178,7 +186,8 @@ init(const StubPtr& stub, const pb::string& session_name)
   auto response = InitResponse{};
 
   raise_if_error(
-      stub->Init(&context, request, &response));
+      stub->Init(&context, request, &response),
+      context);
 
   return response;
 }
@@ -194,7 +203,8 @@ init_from_cross_driver_session(const StubPtr& stub, const nidevice_grpc::Session
   auto response = InitFromCrossDriverSessionResponse{};
 
   raise_if_error(
-      stub->InitFromCrossDriverSession(&context, request, &response));
+      stub->InitFromCrossDriverSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -210,7 +220,8 @@ init_from_cross_driver_session_array(const StubPtr& stub, const std::vector<nide
   auto response = InitFromCrossDriverSessionArrayResponse{};
 
   raise_if_error(
-      stub->InitFromCrossDriverSessionArray(&context, request, &response));
+      stub->InitFromCrossDriverSessionArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -225,7 +236,8 @@ init_secondary_session(const StubPtr& stub)
   auto response = InitSecondarySessionResponse{};
 
   raise_if_error(
-      stub->InitSecondarySession(&context, request, &response));
+      stub->InitSecondarySession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -241,7 +253,8 @@ init_with_handle_name_as_session_name(const StubPtr& stub, const pb::string& han
   auto response = InitWithHandleNameAsSessionNameResponse{};
 
   raise_if_error(
-      stub->InitWithHandleNameAsSessionName(&context, request, &response));
+      stub->InitWithHandleNameAsSessionName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -257,7 +270,8 @@ init_with_returned_session(const StubPtr& stub, const pb::string& handle_name)
   auto response = InitWithReturnedSessionResponse{};
 
   raise_if_error(
-      stub->InitWithReturnedSession(&context, request, &response));
+      stub->InitWithReturnedSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -275,7 +289,8 @@ input_arrays_with_narrow_integer_types(const StubPtr& stub, const std::vector<pb
   auto response = InputArraysWithNarrowIntegerTypesResponse{};
 
   raise_if_error(
-      stub->InputArraysWithNarrowIntegerTypes(&context, request, &response));
+      stub->InputArraysWithNarrowIntegerTypes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -292,7 +307,8 @@ iota_with_custom_size(const StubPtr& stub, const pb::int32& size_one, const pb::
   auto response = IotaWithCustomSizeResponse{};
 
   raise_if_error(
-      stub->IotaWithCustomSize(&context, request, &response));
+      stub->IotaWithCustomSize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -310,7 +326,8 @@ output_arrays_with_narrow_integer_types(const StubPtr& stub, const pb::int32& nu
   auto response = OutputArraysWithNarrowIntegerTypesResponse{};
 
   raise_if_error(
-      stub->OutputArraysWithNarrowIntegerTypes(&context, request, &response));
+      stub->OutputArraysWithNarrowIntegerTypes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -326,7 +343,8 @@ input_array_of_bytes(const StubPtr& stub, const pb::string& u8_array)
   auto response = InputArrayOfBytesResponse{};
 
   raise_if_error(
-      stub->InputArrayOfBytes(&context, request, &response));
+      stub->InputArrayOfBytes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -342,7 +360,8 @@ output_array_of_bytes(const StubPtr& stub, const pb::int32& number_of_u8_samples
   auto response = OutputArrayOfBytesResponse{};
 
   raise_if_error(
-      stub->OutputArrayOfBytes(&context, request, &response));
+      stub->OutputArrayOfBytes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -358,7 +377,8 @@ output_arrays_with_passed_in_by_ptr_mechanism(const StubPtr& stub, const pb::int
   auto response = OutputArraysWithPassedInByPtrMechanismResponse{};
 
   raise_if_error(
-      stub->OutputArraysWithPassedInByPtrMechanism(&context, request, &response));
+      stub->OutputArraysWithPassedInByPtrMechanism(&context, request, &response),
+      context);
 
   return response;
 }
@@ -393,7 +413,8 @@ input_timestamp(const StubPtr& stub, const google::protobuf::Timestamp& when)
   auto response = InputTimestampResponse{};
 
   raise_if_error(
-      stub->InputTimestamp(&context, request, &response));
+      stub->InputTimestamp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -408,7 +429,8 @@ output_timestamp(const StubPtr& stub)
   auto response = OutputTimestampResponse{};
 
   raise_if_error(
-      stub->OutputTimestamp(&context, request, &response));
+      stub->OutputTimestamp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -425,7 +447,8 @@ input_var_args(const StubPtr& stub, const pb::string& input_name, const std::vec
   auto response = InputVarArgsResponse{};
 
   raise_if_error(
-      stub->InputVarArgs(&context, request, &response));
+      stub->InputVarArgs(&context, request, &response),
+      context);
 
   return response;
 }
@@ -442,7 +465,8 @@ output_var_args(const StubPtr& stub, const pb::string& input_name, const std::ve
   auto response = OutputVarArgsResponse{};
 
   raise_if_error(
-      stub->OutputVarArgs(&context, request, &response));
+      stub->OutputVarArgs(&context, request, &response),
+      context);
 
   return response;
 }
@@ -466,7 +490,8 @@ reset_marble_attribute(const StubPtr& stub, const nidevice_grpc::Session& handle
   auto response = ResetMarbleAttributeResponse{};
 
   raise_if_error(
-      stub->ResetMarbleAttribute(&context, request, &response));
+      stub->ResetMarbleAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -484,7 +509,8 @@ scalars_with_narrow_integer_types(const StubPtr& stub, const pb::uint32& u16, co
   auto response = ScalarsWithNarrowIntegerTypesResponse{};
 
   raise_if_error(
-      stub->ScalarsWithNarrowIntegerTypes(&context, request, &response));
+      stub->ScalarsWithNarrowIntegerTypes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -509,7 +535,8 @@ set_marble_attribute_double(const StubPtr& stub, const nidevice_grpc::Session& h
   auto response = SetMarbleAttributeDoubleResponse{};
 
   raise_if_error(
-      stub->SetMarbleAttributeDouble(&context, request, &response));
+      stub->SetMarbleAttributeDouble(&context, request, &response),
+      context);
 
   return response;
 }
@@ -541,7 +568,8 @@ set_marble_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session& ha
   auto response = SetMarbleAttributeInt32Response{};
 
   raise_if_error(
-      stub->SetMarbleAttributeInt32(&context, request, &response));
+      stub->SetMarbleAttributeInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -558,7 +586,8 @@ set_colors(const StubPtr& stub, const std::vector<pb::int32>& colors, const pb::
   auto response = SetColorsResponse{};
 
   raise_if_error(
-      stub->SetColors(&context, request, &response));
+      stub->SetColors(&context, request, &response),
+      context);
 
   return response;
 }
@@ -574,7 +603,8 @@ get_structs_with_coercion(const StubPtr& stub, const pb::int32& number_of_struct
   auto response = GetStructsWithCoercionResponse{};
 
   raise_if_error(
-      stub->GetStructsWithCoercion(&context, request, &response));
+      stub->GetStructsWithCoercion(&context, request, &response),
+      context);
 
   return response;
 }
@@ -590,7 +620,8 @@ set_structs_with_coercion(const StubPtr& stub, const std::vector<StructWithCoerc
   auto response = SetStructsWithCoercionResponse{};
 
   raise_if_error(
-      stub->SetStructsWithCoercion(&context, request, &response));
+      stub->SetStructsWithCoercion(&context, request, &response),
+      context);
 
   return response;
 }
@@ -613,7 +644,8 @@ input_string_valued_enum(const StubPtr& stub, const simple_variant<MobileOSNames
   auto response = InputStringValuedEnumResponse{};
 
   raise_if_error(
-      stub->InputStringValuedEnum(&context, request, &response));
+      stub->InputStringValuedEnum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -629,7 +661,8 @@ write_boolean_array(const StubPtr& stub, const std::vector<bool>& bools)
   auto response = WriteBooleanArrayResponse{};
 
   raise_if_error(
-      stub->WriteBooleanArray(&context, request, &response));
+      stub->WriteBooleanArray(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nifgen/nifgen_client.cpp
+++ b/generated/nifgen/nifgen_client.cpp
@@ -28,7 +28,8 @@ abort_generation(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = AbortGenerationResponse{};
 
   raise_if_error(
-      stub->AbortGeneration(&context, request, &response));
+      stub->AbortGeneration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -45,7 +46,8 @@ adjust_sample_clock_relative_delay(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = AdjustSampleClockRelativeDelayResponse{};
 
   raise_if_error(
-      stub->AdjustSampleClockRelativeDelay(&context, request, &response));
+      stub->AdjustSampleClockRelativeDelay(&context, request, &response),
+      context);
 
   return response;
 }
@@ -64,7 +66,8 @@ allocate_named_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = AllocateNamedWaveformResponse{};
 
   raise_if_error(
-      stub->AllocateNamedWaveform(&context, request, &response));
+      stub->AllocateNamedWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -82,7 +85,8 @@ allocate_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const p
   auto response = AllocateWaveformResponse{};
 
   raise_if_error(
-      stub->AllocateWaveform(&context, request, &response));
+      stub->AllocateWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -101,7 +105,8 @@ check_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = CheckAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->CheckAttributeViBoolean(&context, request, &response));
+      stub->CheckAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -127,7 +132,8 @@ check_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = CheckAttributeViInt32Response{};
 
   raise_if_error(
-      stub->CheckAttributeViInt32(&context, request, &response));
+      stub->CheckAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -146,7 +152,8 @@ check_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = CheckAttributeViInt64Response{};
 
   raise_if_error(
-      stub->CheckAttributeViInt64(&context, request, &response));
+      stub->CheckAttributeViInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -172,7 +179,8 @@ check_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = CheckAttributeViReal64Response{};
 
   raise_if_error(
-      stub->CheckAttributeViReal64(&context, request, &response));
+      stub->CheckAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -191,7 +199,8 @@ check_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = CheckAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->CheckAttributeViSession(&context, request, &response));
+      stub->CheckAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -210,7 +219,8 @@ check_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = CheckAttributeViStringResponse{};
 
   raise_if_error(
-      stub->CheckAttributeViString(&context, request, &response));
+      stub->CheckAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -226,7 +236,8 @@ clear_arb_memory(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ClearArbMemoryResponse{};
 
   raise_if_error(
-      stub->ClearArbMemory(&context, request, &response));
+      stub->ClearArbMemory(&context, request, &response),
+      context);
 
   return response;
 }
@@ -250,7 +261,8 @@ clear_arb_sequence(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = ClearArbSequenceResponse{};
 
   raise_if_error(
-      stub->ClearArbSequence(&context, request, &response));
+      stub->ClearArbSequence(&context, request, &response),
+      context);
 
   return response;
 }
@@ -274,7 +286,8 @@ clear_arb_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = ClearArbWaveformResponse{};
 
   raise_if_error(
-      stub->ClearArbWaveform(&context, request, &response));
+      stub->ClearArbWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -290,7 +303,8 @@ clear_error(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ClearErrorResponse{};
 
   raise_if_error(
-      stub->ClearError(&context, request, &response));
+      stub->ClearError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -314,7 +328,8 @@ clear_freq_list(const StubPtr& stub, const nidevice_grpc::Session& vi, const sim
   auto response = ClearFreqListResponse{};
 
   raise_if_error(
-      stub->ClearFreqList(&context, request, &response));
+      stub->ClearFreqList(&context, request, &response),
+      context);
 
   return response;
 }
@@ -330,7 +345,8 @@ clear_interchange_warnings(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = ClearInterchangeWarningsResponse{};
 
   raise_if_error(
-      stub->ClearInterchangeWarnings(&context, request, &response));
+      stub->ClearInterchangeWarnings(&context, request, &response),
+      context);
 
   return response;
 }
@@ -347,7 +363,8 @@ clear_user_standard_waveform(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ClearUserStandardWaveformResponse{};
 
   raise_if_error(
-      stub->ClearUserStandardWaveform(&context, request, &response));
+      stub->ClearUserStandardWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -363,7 +380,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }
@@ -379,7 +397,8 @@ commit(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CommitResponse{};
 
   raise_if_error(
-      stub->Commit(&context, request, &response));
+      stub->Commit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -397,7 +416,8 @@ configure_amplitude(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = ConfigureAmplitudeResponse{};
 
   raise_if_error(
-      stub->ConfigureAmplitude(&context, request, &response));
+      stub->ConfigureAmplitude(&context, request, &response),
+      context);
 
   return response;
 }
@@ -417,7 +437,8 @@ configure_arb_sequence(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = ConfigureArbSequenceResponse{};
 
   raise_if_error(
-      stub->ConfigureArbSequence(&context, request, &response));
+      stub->ConfigureArbSequence(&context, request, &response),
+      context);
 
   return response;
 }
@@ -437,7 +458,8 @@ configure_arb_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = ConfigureArbWaveformResponse{};
 
   raise_if_error(
-      stub->ConfigureArbWaveform(&context, request, &response));
+      stub->ConfigureArbWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -454,7 +476,8 @@ configure_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = ConfigureChannelsResponse{};
 
   raise_if_error(
-      stub->ConfigureChannels(&context, request, &response));
+      stub->ConfigureChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -478,7 +501,8 @@ configure_clock_mode(const StubPtr& stub, const nidevice_grpc::Session& vi, cons
   auto response = ConfigureClockModeResponse{};
 
   raise_if_error(
-      stub->ConfigureClockMode(&context, request, &response));
+      stub->ConfigureClockMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -496,7 +520,8 @@ configure_custom_fir_filter_coefficients(const StubPtr& stub, const nidevice_grp
   auto response = ConfigureCustomFIRFilterCoefficientsResponse{};
 
   raise_if_error(
-      stub->ConfigureCustomFIRFilterCoefficients(&context, request, &response));
+      stub->ConfigureCustomFIRFilterCoefficients(&context, request, &response),
+      context);
 
   return response;
 }
@@ -515,7 +540,8 @@ configure_digital_edge_script_trigger(const StubPtr& stub, const nidevice_grpc::
   auto response = ConfigureDigitalEdgeScriptTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeScriptTrigger(&context, request, &response));
+      stub->ConfigureDigitalEdgeScriptTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -533,7 +559,8 @@ configure_digital_edge_start_trigger(const StubPtr& stub, const nidevice_grpc::S
   auto response = ConfigureDigitalEdgeStartTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeStartTrigger(&context, request, &response));
+      stub->ConfigureDigitalEdgeStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -559,7 +586,8 @@ configure_digital_level_script_trigger(const StubPtr& stub, const nidevice_grpc:
   auto response = ConfigureDigitalLevelScriptTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalLevelScriptTrigger(&context, request, &response));
+      stub->ConfigureDigitalLevelScriptTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -580,7 +608,8 @@ configure_freq_list(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = ConfigureFreqListResponse{};
 
   raise_if_error(
-      stub->ConfigureFreqList(&context, request, &response));
+      stub->ConfigureFreqList(&context, request, &response),
+      context);
 
   return response;
 }
@@ -598,7 +627,8 @@ configure_frequency(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = ConfigureFrequencyResponse{};
 
   raise_if_error(
-      stub->ConfigureFrequency(&context, request, &response));
+      stub->ConfigureFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -616,7 +646,8 @@ configure_operation_mode(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = ConfigureOperationModeResponse{};
 
   raise_if_error(
-      stub->ConfigureOperationMode(&context, request, &response));
+      stub->ConfigureOperationMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -634,7 +665,8 @@ configure_output_enabled(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = ConfigureOutputEnabledResponse{};
 
   raise_if_error(
-      stub->ConfigureOutputEnabled(&context, request, &response));
+      stub->ConfigureOutputEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -652,7 +684,8 @@ configure_output_impedance(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = ConfigureOutputImpedanceResponse{};
 
   raise_if_error(
-      stub->ConfigureOutputImpedance(&context, request, &response));
+      stub->ConfigureOutputImpedance(&context, request, &response),
+      context);
 
   return response;
 }
@@ -676,7 +709,8 @@ configure_output_mode(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = ConfigureOutputModeResponse{};
 
   raise_if_error(
-      stub->ConfigureOutputMode(&context, request, &response));
+      stub->ConfigureOutputMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -693,7 +727,8 @@ configure_p2p_endpoint_fullness_start_trigger(const StubPtr& stub, const nidevic
   auto response = ConfigureP2PEndpointFullnessStartTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureP2PEndpointFullnessStartTrigger(&context, request, &response));
+      stub->ConfigureP2PEndpointFullnessStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -711,7 +746,8 @@ configure_reference_clock(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = ConfigureReferenceClockResponse{};
 
   raise_if_error(
-      stub->ConfigureReferenceClock(&context, request, &response));
+      stub->ConfigureReferenceClock(&context, request, &response),
+      context);
 
   return response;
 }
@@ -728,7 +764,8 @@ configure_sample_clock_source(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ConfigureSampleClockSourceResponse{};
 
   raise_if_error(
-      stub->ConfigureSampleClockSource(&context, request, &response));
+      stub->ConfigureSampleClockSource(&context, request, &response),
+      context);
 
   return response;
 }
@@ -745,7 +782,8 @@ configure_sample_rate(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = ConfigureSampleRateResponse{};
 
   raise_if_error(
-      stub->ConfigureSampleRate(&context, request, &response));
+      stub->ConfigureSampleRate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -762,7 +800,8 @@ configure_software_edge_script_trigger(const StubPtr& stub, const nidevice_grpc:
   auto response = ConfigureSoftwareEdgeScriptTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgeScriptTrigger(&context, request, &response));
+      stub->ConfigureSoftwareEdgeScriptTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -778,7 +817,8 @@ configure_software_edge_start_trigger(const StubPtr& stub, const nidevice_grpc::
   auto response = ConfigureSoftwareEdgeStartTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgeStartTrigger(&context, request, &response));
+      stub->ConfigureSoftwareEdgeStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -807,7 +847,8 @@ configure_standard_waveform(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = ConfigureStandardWaveformResponse{};
 
   raise_if_error(
-      stub->ConfigureStandardWaveform(&context, request, &response));
+      stub->ConfigureStandardWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -825,7 +866,8 @@ configure_synchronization(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = ConfigureSynchronizationResponse{};
 
   raise_if_error(
-      stub->ConfigureSynchronization(&context, request, &response));
+      stub->ConfigureSynchronization(&context, request, &response),
+      context);
 
   return response;
 }
@@ -850,7 +892,8 @@ configure_trigger_mode(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = ConfigureTriggerModeResponse{};
 
   raise_if_error(
-      stub->ConfigureTriggerMode(&context, request, &response));
+      stub->ConfigureTriggerMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -870,7 +913,8 @@ create_advanced_arb_sequence(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = CreateAdvancedArbSequenceResponse{};
 
   raise_if_error(
-      stub->CreateAdvancedArbSequence(&context, request, &response));
+      stub->CreateAdvancedArbSequence(&context, request, &response),
+      context);
 
   return response;
 }
@@ -888,7 +932,8 @@ create_arb_sequence(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = CreateArbSequenceResponse{};
 
   raise_if_error(
-      stub->CreateArbSequence(&context, request, &response));
+      stub->CreateArbSequence(&context, request, &response),
+      context);
 
   return response;
 }
@@ -914,7 +959,8 @@ create_freq_list(const StubPtr& stub, const nidevice_grpc::Session& vi, const si
   auto response = CreateFreqListResponse{};
 
   raise_if_error(
-      stub->CreateFreqList(&context, request, &response));
+      stub->CreateFreqList(&context, request, &response),
+      context);
 
   return response;
 }
@@ -932,7 +978,8 @@ create_waveform_complex_f64(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = CreateWaveformComplexF64Response{};
 
   raise_if_error(
-      stub->CreateWaveformComplexF64(&context, request, &response));
+      stub->CreateWaveformComplexF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -950,7 +997,8 @@ create_waveform_f64(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = CreateWaveformF64Response{};
 
   raise_if_error(
-      stub->CreateWaveformF64(&context, request, &response));
+      stub->CreateWaveformF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -976,7 +1024,8 @@ create_waveform_from_file_f64(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = CreateWaveformFromFileF64Response{};
 
   raise_if_error(
-      stub->CreateWaveformFromFileF64(&context, request, &response));
+      stub->CreateWaveformFromFileF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -996,7 +1045,8 @@ create_waveform_from_file_hws(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = CreateWaveformFromFileHWSResponse{};
 
   raise_if_error(
-      stub->CreateWaveformFromFileHWS(&context, request, &response));
+      stub->CreateWaveformFromFileHWS(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1014,7 +1064,8 @@ create_waveform_i16(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = CreateWaveformI16Response{};
 
   raise_if_error(
-      stub->CreateWaveformI16(&context, request, &response));
+      stub->CreateWaveformI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1040,7 +1091,8 @@ create_waveform_from_file_i16(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = CreateWaveformFromFileI16Response{};
 
   raise_if_error(
-      stub->CreateWaveformFromFileI16(&context, request, &response));
+      stub->CreateWaveformFromFileI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1058,7 +1110,8 @@ define_user_standard_waveform(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = DefineUserStandardWaveformResponse{};
 
   raise_if_error(
-      stub->DefineUserStandardWaveform(&context, request, &response));
+      stub->DefineUserStandardWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1076,7 +1129,8 @@ delete_named_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = DeleteNamedWaveformResponse{};
 
   raise_if_error(
-      stub->DeleteNamedWaveform(&context, request, &response));
+      stub->DeleteNamedWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1094,7 +1148,8 @@ delete_script(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::s
   auto response = DeleteScriptResponse{};
 
   raise_if_error(
-      stub->DeleteScript(&context, request, &response));
+      stub->DeleteScript(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1110,7 +1165,8 @@ disable(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisableResponse{};
 
   raise_if_error(
-      stub->Disable(&context, request, &response));
+      stub->Disable(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1127,7 +1183,8 @@ disable_analog_filter(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = DisableAnalogFilterResponse{};
 
   raise_if_error(
-      stub->DisableAnalogFilter(&context, request, &response));
+      stub->DisableAnalogFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1144,7 +1201,8 @@ disable_digital_filter(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = DisableDigitalFilterResponse{};
 
   raise_if_error(
-      stub->DisableDigitalFilter(&context, request, &response));
+      stub->DisableDigitalFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1161,7 +1219,8 @@ disable_digital_patterning(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = DisableDigitalPatterningResponse{};
 
   raise_if_error(
-      stub->DisableDigitalPatterning(&context, request, &response));
+      stub->DisableDigitalPatterning(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1178,7 +1237,8 @@ disable_script_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = DisableScriptTriggerResponse{};
 
   raise_if_error(
-      stub->DisableScriptTrigger(&context, request, &response));
+      stub->DisableScriptTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1194,7 +1254,8 @@ disable_start_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisableStartTriggerResponse{};
 
   raise_if_error(
-      stub->DisableStartTrigger(&context, request, &response));
+      stub->DisableStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1212,7 +1273,8 @@ enable_analog_filter(const StubPtr& stub, const nidevice_grpc::Session& vi, cons
   auto response = EnableAnalogFilterResponse{};
 
   raise_if_error(
-      stub->EnableAnalogFilter(&context, request, &response));
+      stub->EnableAnalogFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1229,7 +1291,8 @@ enable_digital_filter(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = EnableDigitalFilterResponse{};
 
   raise_if_error(
-      stub->EnableDigitalFilter(&context, request, &response));
+      stub->EnableDigitalFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1246,7 +1309,8 @@ enable_digital_patterning(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = EnableDigitalPatterningResponse{};
 
   raise_if_error(
-      stub->EnableDigitalPatterning(&context, request, &response));
+      stub->EnableDigitalPatterning(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1263,7 +1327,8 @@ error_handler(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::i
   auto response = ErrorHandlerResponse{};
 
   raise_if_error(
-      stub->ErrorHandler(&context, request, &response));
+      stub->ErrorHandler(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1280,7 +1345,8 @@ error_message(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::i
   auto response = ErrorMessageResponse{};
 
   raise_if_error(
-      stub->ErrorMessage(&context, request, &response));
+      stub->ErrorMessage(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1296,7 +1362,8 @@ error_query(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ErrorQueryResponse{};
 
   raise_if_error(
-      stub->ErrorQuery(&context, request, &response));
+      stub->ErrorQuery(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1312,7 +1379,8 @@ export_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::
   auto response = ExportAttributeConfigurationBufferResponse{};
 
   raise_if_error(
-      stub->ExportAttributeConfigurationBuffer(&context, request, &response));
+      stub->ExportAttributeConfigurationBuffer(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1329,7 +1397,8 @@ export_attribute_configuration_file(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ExportAttributeConfigurationFileResponse{};
 
   raise_if_error(
-      stub->ExportAttributeConfigurationFile(&context, request, &response));
+      stub->ExportAttributeConfigurationFile(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1355,7 +1424,8 @@ export_signal(const StubPtr& stub, const nidevice_grpc::Session& vi, const simpl
   auto response = ExportSignalResponse{};
 
   raise_if_error(
-      stub->ExportSignal(&context, request, &response));
+      stub->ExportSignal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1373,7 +1443,8 @@ get_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->GetAttributeViBoolean(&context, request, &response));
+      stub->GetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1391,7 +1462,8 @@ get_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->GetAttributeViInt32(&context, request, &response));
+      stub->GetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1409,7 +1481,8 @@ get_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetAttributeViInt64Response{};
 
   raise_if_error(
-      stub->GetAttributeViInt64(&context, request, &response));
+      stub->GetAttributeViInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1427,7 +1500,8 @@ get_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->GetAttributeViReal64(&context, request, &response));
+      stub->GetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1445,7 +1519,8 @@ get_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->GetAttributeViSession(&context, request, &response));
+      stub->GetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1463,7 +1538,8 @@ get_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeViString(&context, request, &response));
+      stub->GetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1480,7 +1556,8 @@ get_channel_name(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb
   auto response = GetChannelNameResponse{};
 
   raise_if_error(
-      stub->GetChannelName(&context, request, &response));
+      stub->GetChannelName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1496,7 +1573,8 @@ get_error(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetErrorResponse{};
 
   raise_if_error(
-      stub->GetError(&context, request, &response));
+      stub->GetError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1512,7 +1590,8 @@ get_ext_cal_last_date_and_time(const StubPtr& stub, const nidevice_grpc::Session
   auto response = GetExtCalLastDateAndTimeResponse{};
 
   raise_if_error(
-      stub->GetExtCalLastDateAndTime(&context, request, &response));
+      stub->GetExtCalLastDateAndTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1528,7 +1607,8 @@ get_ext_cal_last_temp(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetExtCalLastTempResponse{};
 
   raise_if_error(
-      stub->GetExtCalLastTemp(&context, request, &response));
+      stub->GetExtCalLastTemp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1544,7 +1624,8 @@ get_ext_cal_recommended_interval(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = GetExtCalRecommendedIntervalResponse{};
 
   raise_if_error(
-      stub->GetExtCalRecommendedInterval(&context, request, &response));
+      stub->GetExtCalRecommendedInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1561,7 +1642,8 @@ get_fir_filter_coefficients(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = GetFIRFilterCoefficientsResponse{};
 
   raise_if_error(
-      stub->GetFIRFilterCoefficients(&context, request, &response));
+      stub->GetFIRFilterCoefficients(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1577,7 +1659,8 @@ get_hardware_state(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetHardwareStateResponse{};
 
   raise_if_error(
-      stub->GetHardwareState(&context, request, &response));
+      stub->GetHardwareState(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1593,7 +1676,8 @@ get_next_coercion_record(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetNextCoercionRecordResponse{};
 
   raise_if_error(
-      stub->GetNextCoercionRecord(&context, request, &response));
+      stub->GetNextCoercionRecord(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1609,7 +1693,8 @@ get_next_interchange_warning(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetNextInterchangeWarningResponse{};
 
   raise_if_error(
-      stub->GetNextInterchangeWarning(&context, request, &response));
+      stub->GetNextInterchangeWarning(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1625,7 +1710,8 @@ get_self_cal_last_date_and_time(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = GetSelfCalLastDateAndTimeResponse{};
 
   raise_if_error(
-      stub->GetSelfCalLastDateAndTime(&context, request, &response));
+      stub->GetSelfCalLastDateAndTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1641,7 +1727,8 @@ get_self_cal_last_temp(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetSelfCalLastTempResponse{};
 
   raise_if_error(
-      stub->GetSelfCalLastTemp(&context, request, &response));
+      stub->GetSelfCalLastTemp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1657,7 +1744,8 @@ get_self_cal_supported(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetSelfCalSupportedResponse{};
 
   raise_if_error(
-      stub->GetSelfCalSupported(&context, request, &response));
+      stub->GetSelfCalSupported(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1674,7 +1762,8 @@ get_stream_endpoint_handle(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = GetStreamEndpointHandleResponse{};
 
   raise_if_error(
-      stub->GetStreamEndpointHandle(&context, request, &response));
+      stub->GetStreamEndpointHandle(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1691,7 +1780,8 @@ import_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::
   auto response = ImportAttributeConfigurationBufferResponse{};
 
   raise_if_error(
-      stub->ImportAttributeConfigurationBuffer(&context, request, &response));
+      stub->ImportAttributeConfigurationBuffer(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1708,7 +1798,8 @@ import_attribute_configuration_file(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ImportAttributeConfigurationFileResponse{};
 
   raise_if_error(
-      stub->ImportAttributeConfigurationFile(&context, request, &response));
+      stub->ImportAttributeConfigurationFile(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1726,7 +1817,8 @@ init(const StubPtr& stub, const pb::string& resource_name, const bool& id_query,
   auto response = InitResponse{};
 
   raise_if_error(
-      stub->Init(&context, request, &response));
+      stub->Init(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1745,7 +1837,8 @@ init_with_options(const StubPtr& stub, const pb::string& resource_name, const bo
   auto response = InitWithOptionsResponse{};
 
   raise_if_error(
-      stub->InitWithOptions(&context, request, &response));
+      stub->InitWithOptions(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1764,7 +1857,8 @@ initialize_with_channels(const StubPtr& stub, const pb::string& resource_name, c
   auto response = InitializeWithChannelsResponse{};
 
   raise_if_error(
-      stub->InitializeWithChannels(&context, request, &response));
+      stub->InitializeWithChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1780,7 +1874,8 @@ initiate_generation(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = InitiateGenerationResponse{};
 
   raise_if_error(
-      stub->InitiateGeneration(&context, request, &response));
+      stub->InitiateGeneration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1796,7 +1891,8 @@ invalidate_all_attributes(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = InvalidateAllAttributesResponse{};
 
   raise_if_error(
-      stub->InvalidateAllAttributes(&context, request, &response));
+      stub->InvalidateAllAttributes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1812,7 +1908,8 @@ is_done(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = IsDoneResponse{};
 
   raise_if_error(
-      stub->IsDone(&context, request, &response));
+      stub->IsDone(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1829,7 +1926,8 @@ manual_enable_p2p_stream(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = ManualEnableP2PStreamResponse{};
 
   raise_if_error(
-      stub->ManualEnableP2PStream(&context, request, &response));
+      stub->ManualEnableP2PStream(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1845,7 +1943,8 @@ query_arb_seq_capabilities(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = QueryArbSeqCapabilitiesResponse{};
 
   raise_if_error(
-      stub->QueryArbSeqCapabilities(&context, request, &response));
+      stub->QueryArbSeqCapabilities(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1861,7 +1960,8 @@ query_arb_wfm_capabilities(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = QueryArbWfmCapabilitiesResponse{};
 
   raise_if_error(
-      stub->QueryArbWfmCapabilities(&context, request, &response));
+      stub->QueryArbWfmCapabilities(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1877,7 +1977,8 @@ query_freq_list_capabilities(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = QueryFreqListCapabilitiesResponse{};
 
   raise_if_error(
-      stub->QueryFreqListCapabilities(&context, request, &response));
+      stub->QueryFreqListCapabilities(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1893,7 +1994,8 @@ read_current_temperature(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ReadCurrentTemperatureResponse{};
 
   raise_if_error(
-      stub->ReadCurrentTemperature(&context, request, &response));
+      stub->ReadCurrentTemperature(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1909,7 +2011,8 @@ reset(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetResponse{};
 
   raise_if_error(
-      stub->Reset(&context, request, &response));
+      stub->Reset(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1927,7 +2030,8 @@ reset_attribute(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb:
   auto response = ResetAttributeResponse{};
 
   raise_if_error(
-      stub->ResetAttribute(&context, request, &response));
+      stub->ResetAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1943,7 +2047,8 @@ reset_device(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetDeviceResponse{};
 
   raise_if_error(
-      stub->ResetDevice(&context, request, &response));
+      stub->ResetDevice(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1959,7 +2064,8 @@ reset_interchange_check(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetInterchangeCheckResponse{};
 
   raise_if_error(
-      stub->ResetInterchangeCheck(&context, request, &response));
+      stub->ResetInterchangeCheck(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1975,7 +2081,8 @@ reset_with_defaults(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetWithDefaultsResponse{};
 
   raise_if_error(
-      stub->ResetWithDefaults(&context, request, &response));
+      stub->ResetWithDefaults(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1991,7 +2098,8 @@ revision_query(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = RevisionQueryResponse{};
 
   raise_if_error(
-      stub->RevisionQuery(&context, request, &response));
+      stub->RevisionQuery(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2024,7 +2132,8 @@ route_signal_out(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb
   auto response = RouteSignalOutResponse{};
 
   raise_if_error(
-      stub->RouteSignalOut(&context, request, &response));
+      stub->RouteSignalOut(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2040,7 +2149,8 @@ self_cal(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SelfCalResponse{};
 
   raise_if_error(
-      stub->SelfCal(&context, request, &response));
+      stub->SelfCal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2056,7 +2166,8 @@ self_test(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SelfTestResponse{};
 
   raise_if_error(
-      stub->SelfTest(&context, request, &response));
+      stub->SelfTest(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2081,7 +2192,8 @@ send_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = SendSoftwareEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->SendSoftwareEdgeTrigger(&context, request, &response));
+      stub->SendSoftwareEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2100,7 +2212,8 @@ set_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = SetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->SetAttributeViBoolean(&context, request, &response));
+      stub->SetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2126,7 +2239,8 @@ set_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = SetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->SetAttributeViInt32(&context, request, &response));
+      stub->SetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2145,7 +2259,8 @@ set_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = SetAttributeViInt64Response{};
 
   raise_if_error(
-      stub->SetAttributeViInt64(&context, request, &response));
+      stub->SetAttributeViInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2171,7 +2286,8 @@ set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->SetAttributeViReal64(&context, request, &response));
+      stub->SetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2190,7 +2306,8 @@ set_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = SetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->SetAttributeViSession(&context, request, &response));
+      stub->SetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2209,7 +2326,8 @@ set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->SetAttributeViString(&context, request, &response));
+      stub->SetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2236,7 +2354,8 @@ set_named_waveform_next_write_position(const StubPtr& stub, const nidevice_grpc:
   auto response = SetNamedWaveformNextWritePositionResponse{};
 
   raise_if_error(
-      stub->SetNamedWaveformNextWritePosition(&context, request, &response));
+      stub->SetNamedWaveformNextWritePosition(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2263,7 +2382,8 @@ set_waveform_next_write_position(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = SetWaveformNextWritePositionResponse{};
 
   raise_if_error(
-      stub->SetWaveformNextWritePosition(&context, request, &response));
+      stub->SetWaveformNextWritePosition(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2280,7 +2400,8 @@ wait_until_done(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb:
   auto response = WaitUntilDoneResponse{};
 
   raise_if_error(
-      stub->WaitUntilDone(&context, request, &response));
+      stub->WaitUntilDone(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2299,7 +2420,8 @@ write_binary16_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = WriteBinary16WaveformResponse{};
 
   raise_if_error(
-      stub->WriteBinary16Waveform(&context, request, &response));
+      stub->WriteBinary16Waveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2318,7 +2440,8 @@ write_complex_binary16_waveform(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = WriteComplexBinary16WaveformResponse{};
 
   raise_if_error(
-      stub->WriteComplexBinary16Waveform(&context, request, &response));
+      stub->WriteComplexBinary16Waveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2337,7 +2460,8 @@ write_named_waveform_f64(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = WriteNamedWaveformF64Response{};
 
   raise_if_error(
-      stub->WriteNamedWaveformF64(&context, request, &response));
+      stub->WriteNamedWaveformF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2356,7 +2480,8 @@ write_named_waveform_i16(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = WriteNamedWaveformI16Response{};
 
   raise_if_error(
-      stub->WriteNamedWaveformI16(&context, request, &response));
+      stub->WriteNamedWaveformI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2374,7 +2499,8 @@ write_p2p_endpoint_i16(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = WriteP2PEndpointI16Response{};
 
   raise_if_error(
-      stub->WriteP2PEndpointI16(&context, request, &response));
+      stub->WriteP2PEndpointI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2392,7 +2518,8 @@ write_script(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::st
   auto response = WriteScriptResponse{};
 
   raise_if_error(
-      stub->WriteScript(&context, request, &response));
+      stub->WriteScript(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2411,7 +2538,8 @@ write_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::
   auto response = WriteWaveformResponse{};
 
   raise_if_error(
-      stub->WriteWaveform(&context, request, &response));
+      stub->WriteWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2430,7 +2558,8 @@ write_waveform_complex_f64(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = WriteWaveformComplexF64Response{};
 
   raise_if_error(
-      stub->WriteWaveformComplexF64(&context, request, &response));
+      stub->WriteWaveformComplexF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2449,7 +2578,8 @@ write_named_waveform_complex_f64(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = WriteNamedWaveformComplexF64Response{};
 
   raise_if_error(
-      stub->WriteNamedWaveformComplexF64(&context, request, &response));
+      stub->WriteNamedWaveformComplexF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2468,7 +2598,8 @@ write_named_waveform_complex_i16(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = WriteNamedWaveformComplexI16Response{};
 
   raise_if_error(
-      stub->WriteNamedWaveformComplexI16(&context, request, &response));
+      stub->WriteNamedWaveformComplexI16(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_client.cpp
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_client.cpp
@@ -38,7 +38,8 @@ acp_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = ACPCfgAveragingResponse{};
 
   raise_if_error(
-      stub->ACPCfgAveraging(&context, request, &response));
+      stub->ACPCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -63,7 +64,8 @@ acp_cfg_burst_synchronization_type(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ACPCfgBurstSynchronizationTypeResponse{};
 
   raise_if_error(
-      stub->ACPCfgBurstSynchronizationType(&context, request, &response));
+      stub->ACPCfgBurstSynchronizationType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -81,7 +83,8 @@ acp_cfg_number_of_offsets(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = ACPCfgNumberOfOffsetsResponse{};
 
   raise_if_error(
-      stub->ACPCfgNumberOfOffsets(&context, request, &response));
+      stub->ACPCfgNumberOfOffsets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -106,7 +109,8 @@ acp_cfg_offset_channel_mode(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = ACPCfgOffsetChannelModeResponse{};
 
   raise_if_error(
-      stub->ACPCfgOffsetChannelMode(&context, request, &response));
+      stub->ACPCfgOffsetChannelMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -124,7 +128,8 @@ acp_fetch_absolute_power_trace(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ACPFetchAbsolutePowerTraceResponse{};
 
   raise_if_error(
-      stub->ACPFetchAbsolutePowerTrace(&context, request, &response));
+      stub->ACPFetchAbsolutePowerTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -142,7 +147,8 @@ acp_fetch_mask_trace(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = ACPFetchMaskTraceResponse{};
 
   raise_if_error(
-      stub->ACPFetchMaskTrace(&context, request, &response));
+      stub->ACPFetchMaskTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -160,7 +166,8 @@ acp_fetch_measurement_status(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ACPFetchMeasurementStatusResponse{};
 
   raise_if_error(
-      stub->ACPFetchMeasurementStatus(&context, request, &response));
+      stub->ACPFetchMeasurementStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -178,7 +185,8 @@ acp_fetch_offset_measurement(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ACPFetchOffsetMeasurementResponse{};
 
   raise_if_error(
-      stub->ACPFetchOffsetMeasurement(&context, request, &response));
+      stub->ACPFetchOffsetMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -196,7 +204,8 @@ acp_fetch_offset_measurement_array(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ACPFetchOffsetMeasurementArrayResponse{};
 
   raise_if_error(
-      stub->ACPFetchOffsetMeasurementArray(&context, request, &response));
+      stub->ACPFetchOffsetMeasurementArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -214,7 +223,8 @@ acp_fetch_reference_channel_power(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = ACPFetchReferenceChannelPowerResponse{};
 
   raise_if_error(
-      stub->ACPFetchReferenceChannelPower(&context, request, &response));
+      stub->ACPFetchReferenceChannelPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -232,7 +242,8 @@ acp_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = ACPFetchSpectrumResponse{};
 
   raise_if_error(
-      stub->ACPFetchSpectrum(&context, request, &response));
+      stub->ACPFetchSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -249,7 +260,8 @@ abort_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = AbortMeasurementsResponse{};
 
   raise_if_error(
-      stub->AbortMeasurements(&context, request, &response));
+      stub->AbortMeasurements(&context, request, &response),
+      context);
 
   return response;
 }
@@ -271,7 +283,8 @@ analyze_iq1_waveform(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = AnalyzeIQ1WaveformResponse{};
 
   raise_if_error(
-      stub->AnalyzeIQ1Waveform(&context, request, &response));
+      stub->AnalyzeIQ1Waveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -289,7 +302,8 @@ auto_detect_signal(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = AutoDetectSignalResponse{};
 
   raise_if_error(
-      stub->AutoDetectSignal(&context, request, &response));
+      stub->AutoDetectSignal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -307,7 +321,8 @@ auto_level(const StubPtr& stub, const nidevice_grpc::Session& instrument, const 
   auto response = AutoLevelResponse{};
 
   raise_if_error(
-      stub->AutoLevel(&context, request, &response));
+      stub->AutoLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -324,7 +339,8 @@ build_offset_string(const StubPtr& stub, const pb::string& selector_string, cons
   auto response = BuildOffsetStringResponse{};
 
   raise_if_error(
-      stub->BuildOffsetString(&context, request, &response));
+      stub->BuildOffsetString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -341,7 +357,8 @@ build_signal_string(const StubPtr& stub, const pb::string& signal_name, const pb
   auto response = BuildSignalStringResponse{};
 
   raise_if_error(
-      stub->BuildSignalString(&context, request, &response));
+      stub->BuildSignalString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -358,7 +375,8 @@ build_slot_string(const StubPtr& stub, const pb::string& selector_string, const 
   auto response = BuildSlotStringResponse{};
 
   raise_if_error(
-      stub->BuildSlotString(&context, request, &response));
+      stub->BuildSlotString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -376,7 +394,8 @@ cfg_channel_number(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CfgChannelNumberResponse{};
 
   raise_if_error(
-      stub->CfgChannelNumber(&context, request, &response));
+      stub->CfgChannelNumber(&context, request, &response),
+      context);
 
   return response;
 }
@@ -394,7 +413,8 @@ cfg_data_rate(const StubPtr& stub, const nidevice_grpc::Session& instrument, con
   auto response = CfgDataRateResponse{};
 
   raise_if_error(
-      stub->CfgDataRate(&context, request, &response));
+      stub->CfgDataRate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -422,7 +442,8 @@ cfg_digital_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CfgDigitalEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->CfgDigitalEdgeTrigger(&context, request, &response));
+      stub->CfgDigitalEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -440,7 +461,8 @@ cfg_external_attenuation(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CfgExternalAttenuationResponse{};
 
   raise_if_error(
-      stub->CfgExternalAttenuation(&context, request, &response));
+      stub->CfgExternalAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -458,7 +480,8 @@ cfg_frequency(const StubPtr& stub, const nidevice_grpc::Session& instrument, con
   auto response = CfgFrequencyResponse{};
 
   raise_if_error(
-      stub->CfgFrequency(&context, request, &response));
+      stub->CfgFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -484,7 +507,8 @@ cfg_frequency_channel_number(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = CfgFrequencyChannelNumberResponse{};
 
   raise_if_error(
-      stub->CfgFrequencyChannelNumber(&context, request, &response));
+      stub->CfgFrequencyChannelNumber(&context, request, &response),
+      context);
 
   return response;
 }
@@ -510,7 +534,8 @@ cfg_frequency_reference(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = CfgFrequencyReferenceResponse{};
 
   raise_if_error(
-      stub->CfgFrequencyReference(&context, request, &response));
+      stub->CfgFrequencyReference(&context, request, &response),
+      context);
 
   return response;
 }
@@ -556,7 +581,8 @@ cfg_iq_power_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = CfgIQPowerEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->CfgIQPowerEdgeTrigger(&context, request, &response));
+      stub->CfgIQPowerEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -583,7 +609,8 @@ cfg_le_direction_finding(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CfgLEDirectionFindingResponse{};
 
   raise_if_error(
-      stub->CfgLEDirectionFinding(&context, request, &response));
+      stub->CfgLEDirectionFinding(&context, request, &response),
+      context);
 
   return response;
 }
@@ -609,7 +636,8 @@ cfg_mechanical_attenuation(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = CfgMechanicalAttenuationResponse{};
 
   raise_if_error(
-      stub->CfgMechanicalAttenuation(&context, request, &response));
+      stub->CfgMechanicalAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -634,7 +662,8 @@ cfg_packet_type(const StubPtr& stub, const nidevice_grpc::Session& instrument, c
   auto response = CfgPacketTypeResponse{};
 
   raise_if_error(
-      stub->CfgPacketType(&context, request, &response));
+      stub->CfgPacketType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -659,7 +688,8 @@ cfg_payload_bit_pattern(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = CfgPayloadBitPatternResponse{};
 
   raise_if_error(
-      stub->CfgPayloadBitPattern(&context, request, &response));
+      stub->CfgPayloadBitPattern(&context, request, &response),
+      context);
 
   return response;
 }
@@ -685,7 +715,8 @@ cfg_payload_length(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CfgPayloadLengthResponse{};
 
   raise_if_error(
-      stub->CfgPayloadLength(&context, request, &response));
+      stub->CfgPayloadLength(&context, request, &response),
+      context);
 
   return response;
 }
@@ -705,7 +736,8 @@ cfg_rf(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::
   auto response = CfgRFResponse{};
 
   raise_if_error(
-      stub->CfgRF(&context, request, &response));
+      stub->CfgRF(&context, request, &response),
+      context);
 
   return response;
 }
@@ -731,7 +763,8 @@ cfg_rf_attenuation(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CfgRFAttenuationResponse{};
 
   raise_if_error(
-      stub->CfgRFAttenuation(&context, request, &response));
+      stub->CfgRFAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -749,7 +782,8 @@ cfg_reference_level(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = CfgReferenceLevelResponse{};
 
   raise_if_error(
-      stub->CfgReferenceLevel(&context, request, &response));
+      stub->CfgReferenceLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -768,7 +802,8 @@ cfg_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = CfgSoftwareEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->CfgSoftwareEdgeTrigger(&context, request, &response));
+      stub->CfgSoftwareEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -785,7 +820,8 @@ check_measurement_status(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CheckMeasurementStatusResponse{};
 
   raise_if_error(
-      stub->CheckMeasurementStatus(&context, request, &response));
+      stub->CheckMeasurementStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -802,7 +838,8 @@ clear_all_named_results(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = ClearAllNamedResultsResponse{};
 
   raise_if_error(
-      stub->ClearAllNamedResults(&context, request, &response));
+      stub->ClearAllNamedResults(&context, request, &response),
+      context);
 
   return response;
 }
@@ -819,7 +856,8 @@ clear_named_result(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = ClearNamedResultResponse{};
 
   raise_if_error(
-      stub->ClearNamedResult(&context, request, &response));
+      stub->ClearNamedResult(&context, request, &response),
+      context);
 
   return response;
 }
@@ -837,7 +875,8 @@ clone_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = CloneSignalConfigurationResponse{};
 
   raise_if_error(
-      stub->CloneSignalConfiguration(&context, request, &response));
+      stub->CloneSignalConfiguration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -854,7 +893,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const bool&
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }
@@ -871,7 +911,8 @@ commit(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::
   auto response = CommitResponse{};
 
   raise_if_error(
-      stub->Commit(&context, request, &response));
+      stub->Commit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -888,7 +929,8 @@ create_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = CreateSignalConfigurationResponse{};
 
   raise_if_error(
-      stub->CreateSignalConfiguration(&context, request, &response));
+      stub->CreateSignalConfiguration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -905,7 +947,8 @@ delete_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = DeleteSignalConfigurationResponse{};
 
   raise_if_error(
-      stub->DeleteSignalConfiguration(&context, request, &response));
+      stub->DeleteSignalConfiguration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -922,7 +965,8 @@ disable_trigger(const StubPtr& stub, const nidevice_grpc::Session& instrument, c
   auto response = DisableTriggerResponse{};
 
   raise_if_error(
-      stub->DisableTrigger(&context, request, &response));
+      stub->DisableTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -948,7 +992,8 @@ frequency_range_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = FrequencyRangeCfgAveragingResponse{};
 
   raise_if_error(
-      stub->FrequencyRangeCfgAveraging(&context, request, &response));
+      stub->FrequencyRangeCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -966,7 +1011,8 @@ frequency_range_cfg_span(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = FrequencyRangeCfgSpanResponse{};
 
   raise_if_error(
-      stub->FrequencyRangeCfgSpan(&context, request, &response));
+      stub->FrequencyRangeCfgSpan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -984,7 +1030,8 @@ frequency_range_fetch_measurement(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = FrequencyRangeFetchMeasurementResponse{};
 
   raise_if_error(
-      stub->FrequencyRangeFetchMeasurement(&context, request, &response));
+      stub->FrequencyRangeFetchMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1002,7 +1049,8 @@ frequency_range_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session
   auto response = FrequencyRangeFetchSpectrumResponse{};
 
   raise_if_error(
-      stub->FrequencyRangeFetchSpectrum(&context, request, &response));
+      stub->FrequencyRangeFetchSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1019,7 +1067,8 @@ get_all_named_result_names(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = GetAllNamedResultNamesResponse{};
 
   raise_if_error(
-      stub->GetAllNamedResultNames(&context, request, &response));
+      stub->GetAllNamedResultNames(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1037,7 +1086,8 @@ get_attribute_f32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeF32Response{};
 
   raise_if_error(
-      stub->GetAttributeF32(&context, request, &response));
+      stub->GetAttributeF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1055,7 +1105,8 @@ get_attribute_f32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeF32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeF32Array(&context, request, &response));
+      stub->GetAttributeF32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1073,7 +1124,8 @@ get_attribute_f64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeF64Response{};
 
   raise_if_error(
-      stub->GetAttributeF64(&context, request, &response));
+      stub->GetAttributeF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1091,7 +1143,8 @@ get_attribute_f64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeF64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeF64Array(&context, request, &response));
+      stub->GetAttributeF64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1109,7 +1162,8 @@ get_attribute_i16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI16Response{};
 
   raise_if_error(
-      stub->GetAttributeI16(&context, request, &response));
+      stub->GetAttributeI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1127,7 +1181,8 @@ get_attribute_i32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI32Response{};
 
   raise_if_error(
-      stub->GetAttributeI32(&context, request, &response));
+      stub->GetAttributeI32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1145,7 +1200,8 @@ get_attribute_i32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeI32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI32Array(&context, request, &response));
+      stub->GetAttributeI32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1163,7 +1219,8 @@ get_attribute_i64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI64Response{};
 
   raise_if_error(
-      stub->GetAttributeI64(&context, request, &response));
+      stub->GetAttributeI64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1181,7 +1238,8 @@ get_attribute_i64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeI64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI64Array(&context, request, &response));
+      stub->GetAttributeI64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1199,7 +1257,8 @@ get_attribute_i8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetAttributeI8Response{};
 
   raise_if_error(
-      stub->GetAttributeI8(&context, request, &response));
+      stub->GetAttributeI8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1217,7 +1276,8 @@ get_attribute_i8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = GetAttributeI8ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI8Array(&context, request, &response));
+      stub->GetAttributeI8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1235,7 +1295,8 @@ get_attribute_ni_complex_double_array(const StubPtr& stub, const nidevice_grpc::
   auto response = GetAttributeNIComplexDoubleArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeNIComplexDoubleArray(&context, request, &response));
+      stub->GetAttributeNIComplexDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1253,7 +1314,8 @@ get_attribute_ni_complex_single_array(const StubPtr& stub, const nidevice_grpc::
   auto response = GetAttributeNIComplexSingleArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeNIComplexSingleArray(&context, request, &response));
+      stub->GetAttributeNIComplexSingleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1271,7 +1333,8 @@ get_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = GetAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeString(&context, request, &response));
+      stub->GetAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1289,7 +1352,8 @@ get_attribute_u16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeU16Response{};
 
   raise_if_error(
-      stub->GetAttributeU16(&context, request, &response));
+      stub->GetAttributeU16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1307,7 +1371,8 @@ get_attribute_u32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeU32Response{};
 
   raise_if_error(
-      stub->GetAttributeU32(&context, request, &response));
+      stub->GetAttributeU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1325,7 +1390,8 @@ get_attribute_u32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeU32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU32Array(&context, request, &response));
+      stub->GetAttributeU32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1343,7 +1409,8 @@ get_attribute_u64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeU64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU64Array(&context, request, &response));
+      stub->GetAttributeU64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1361,7 +1428,8 @@ get_attribute_u8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetAttributeU8Response{};
 
   raise_if_error(
-      stub->GetAttributeU8(&context, request, &response));
+      stub->GetAttributeU8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1379,7 +1447,8 @@ get_attribute_u8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = GetAttributeU8ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU8Array(&context, request, &response));
+      stub->GetAttributeU8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1395,7 +1464,8 @@ get_error(const StubPtr& stub, const nidevice_grpc::Session& instrument)
   auto response = GetErrorResponse{};
 
   raise_if_error(
-      stub->GetError(&context, request, &response));
+      stub->GetError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1412,7 +1482,8 @@ get_error_string(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetErrorStringResponse{};
 
   raise_if_error(
-      stub->GetErrorString(&context, request, &response));
+      stub->GetErrorString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1429,7 +1500,8 @@ initialize(const StubPtr& stub, const pb::string& resource_name, const pb::strin
   auto response = InitializeResponse{};
 
   raise_if_error(
-      stub->Initialize(&context, request, &response));
+      stub->Initialize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1445,7 +1517,8 @@ initialize_from_nirfsa_session(const StubPtr& stub, const nidevice_grpc::Session
   auto response = InitializeFromNIRFSASessionResponse{};
 
   raise_if_error(
-      stub->InitializeFromNIRFSASession(&context, request, &response));
+      stub->InitializeFromNIRFSASession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1463,7 +1536,8 @@ initiate(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb
   auto response = InitiateResponse{};
 
   raise_if_error(
-      stub->Initiate(&context, request, &response));
+      stub->Initiate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1489,7 +1563,8 @@ mod_acc_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = ModAccCfgAveragingResponse{};
 
   raise_if_error(
-      stub->ModAccCfgAveraging(&context, request, &response));
+      stub->ModAccCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1514,7 +1589,8 @@ mod_acc_cfg_burst_synchronization_type(const StubPtr& stub, const nidevice_grpc:
   auto response = ModAccCfgBurstSynchronizationTypeResponse{};
 
   raise_if_error(
-      stub->ModAccCfgBurstSynchronizationType(&context, request, &response));
+      stub->ModAccCfgBurstSynchronizationType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1532,7 +1608,8 @@ mod_acc_fetch_constellation_trace(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = ModAccFetchConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchConstellationTrace(&context, request, &response));
+      stub->ModAccFetchConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1550,7 +1627,8 @@ mod_acc_fetch_devm(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = ModAccFetchDEVMResponse{};
 
   raise_if_error(
-      stub->ModAccFetchDEVM(&context, request, &response));
+      stub->ModAccFetchDEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1568,7 +1646,8 @@ mod_acc_fetch_devm_magnitude_error(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ModAccFetchDEVMMagnitudeErrorResponse{};
 
   raise_if_error(
-      stub->ModAccFetchDEVMMagnitudeError(&context, request, &response));
+      stub->ModAccFetchDEVMMagnitudeError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1586,7 +1665,8 @@ mod_acc_fetch_devm_per_symbol_trace(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ModAccFetchDEVMPerSymbolTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchDEVMPerSymbolTrace(&context, request, &response));
+      stub->ModAccFetchDEVMPerSymbolTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1604,7 +1684,8 @@ mod_acc_fetch_devm_phase_error(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ModAccFetchDEVMPhaseErrorResponse{};
 
   raise_if_error(
-      stub->ModAccFetchDEVMPhaseError(&context, request, &response));
+      stub->ModAccFetchDEVMPhaseError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1622,7 +1703,8 @@ mod_acc_fetch_demodulated_bit_trace(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ModAccFetchDemodulatedBitTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchDemodulatedBitTrace(&context, request, &response));
+      stub->ModAccFetchDemodulatedBitTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1640,7 +1722,8 @@ mod_acc_fetch_df1(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = ModAccFetchDf1Response{};
 
   raise_if_error(
-      stub->ModAccFetchDf1(&context, request, &response));
+      stub->ModAccFetchDf1(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1658,7 +1741,8 @@ mod_acc_fetch_df1max_trace(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = ModAccFetchDf1maxTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchDf1maxTrace(&context, request, &response));
+      stub->ModAccFetchDf1maxTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1676,7 +1760,8 @@ mod_acc_fetch_df2(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = ModAccFetchDf2Response{};
 
   raise_if_error(
-      stub->ModAccFetchDf2(&context, request, &response));
+      stub->ModAccFetchDf2(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1694,7 +1779,8 @@ mod_acc_fetch_df2max_trace(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = ModAccFetchDf2maxTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchDf2maxTrace(&context, request, &response));
+      stub->ModAccFetchDf2maxTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1712,7 +1798,8 @@ mod_acc_fetch_frequency_error_br(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ModAccFetchFrequencyErrorBRResponse{};
 
   raise_if_error(
-      stub->ModAccFetchFrequencyErrorBR(&context, request, &response));
+      stub->ModAccFetchFrequencyErrorBR(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1730,7 +1817,8 @@ mod_acc_fetch_frequency_error_edr(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = ModAccFetchFrequencyErrorEDRResponse{};
 
   raise_if_error(
-      stub->ModAccFetchFrequencyErrorEDR(&context, request, &response));
+      stub->ModAccFetchFrequencyErrorEDR(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1748,7 +1836,8 @@ mod_acc_fetch_frequency_error_le(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ModAccFetchFrequencyErrorLEResponse{};
 
   raise_if_error(
-      stub->ModAccFetchFrequencyErrorLE(&context, request, &response));
+      stub->ModAccFetchFrequencyErrorLE(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1766,7 +1855,8 @@ mod_acc_fetch_frequency_error_trace_br(const StubPtr& stub, const nidevice_grpc:
   auto response = ModAccFetchFrequencyErrorTraceBRResponse{};
 
   raise_if_error(
-      stub->ModAccFetchFrequencyErrorTraceBR(&context, request, &response));
+      stub->ModAccFetchFrequencyErrorTraceBR(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1784,7 +1874,8 @@ mod_acc_fetch_frequency_error_trace_le(const StubPtr& stub, const nidevice_grpc:
   auto response = ModAccFetchFrequencyErrorTraceLEResponse{};
 
   raise_if_error(
-      stub->ModAccFetchFrequencyErrorTraceLE(&context, request, &response));
+      stub->ModAccFetchFrequencyErrorTraceLE(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1802,7 +1893,8 @@ mod_acc_fetch_frequency_error_wi_plus_w0_trace_edr(const StubPtr& stub, const ni
   auto response = ModAccFetchFrequencyErrorWiPlusW0TraceEDRResponse{};
 
   raise_if_error(
-      stub->ModAccFetchFrequencyErrorWiPlusW0TraceEDR(&context, request, &response));
+      stub->ModAccFetchFrequencyErrorWiPlusW0TraceEDR(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1820,7 +1912,8 @@ mod_acc_fetch_frequency_trace(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ModAccFetchFrequencyTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchFrequencyTrace(&context, request, &response));
+      stub->ModAccFetchFrequencyTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1838,7 +1931,8 @@ mod_acc_fetch_rmsdevm_trace(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = ModAccFetchRMSDEVMTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchRMSDEVMTrace(&context, request, &response));
+      stub->ModAccFetchRMSDEVMTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1856,7 +1950,8 @@ reset_attribute(const StubPtr& stub, const nidevice_grpc::Session& instrument, c
   auto response = ResetAttributeResponse{};
 
   raise_if_error(
-      stub->ResetAttribute(&context, request, &response));
+      stub->ResetAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1873,7 +1968,8 @@ reset_to_default(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = ResetToDefaultResponse{};
 
   raise_if_error(
-      stub->ResetToDefault(&context, request, &response));
+      stub->ResetToDefault(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1899,7 +1995,8 @@ select_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = SelectMeasurementsResponse{};
 
   raise_if_error(
-      stub->SelectMeasurements(&context, request, &response));
+      stub->SelectMeasurements(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1915,7 +2012,8 @@ send_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = SendSoftwareEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->SendSoftwareEdgeTrigger(&context, request, &response));
+      stub->SendSoftwareEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1934,7 +2032,8 @@ set_attribute_f32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeF32Response{};
 
   raise_if_error(
-      stub->SetAttributeF32(&context, request, &response));
+      stub->SetAttributeF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1953,7 +2052,8 @@ set_attribute_f32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeF32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeF32Array(&context, request, &response));
+      stub->SetAttributeF32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1972,7 +2072,8 @@ set_attribute_f64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeF64Response{};
 
   raise_if_error(
-      stub->SetAttributeF64(&context, request, &response));
+      stub->SetAttributeF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1991,7 +2092,8 @@ set_attribute_f64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeF64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeF64Array(&context, request, &response));
+      stub->SetAttributeF64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2010,7 +2112,8 @@ set_attribute_i16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI16Response{};
 
   raise_if_error(
-      stub->SetAttributeI16(&context, request, &response));
+      stub->SetAttributeI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2036,7 +2139,8 @@ set_attribute_i32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI32Response{};
 
   raise_if_error(
-      stub->SetAttributeI32(&context, request, &response));
+      stub->SetAttributeI32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2055,7 +2159,8 @@ set_attribute_i32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeI32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI32Array(&context, request, &response));
+      stub->SetAttributeI32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2074,7 +2179,8 @@ set_attribute_i64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI64Response{};
 
   raise_if_error(
-      stub->SetAttributeI64(&context, request, &response));
+      stub->SetAttributeI64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2093,7 +2199,8 @@ set_attribute_i64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeI64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI64Array(&context, request, &response));
+      stub->SetAttributeI64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2112,7 +2219,8 @@ set_attribute_i8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = SetAttributeI8Response{};
 
   raise_if_error(
-      stub->SetAttributeI8(&context, request, &response));
+      stub->SetAttributeI8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2131,7 +2239,8 @@ set_attribute_i8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = SetAttributeI8ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI8Array(&context, request, &response));
+      stub->SetAttributeI8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2150,7 +2259,8 @@ set_attribute_ni_complex_double_array(const StubPtr& stub, const nidevice_grpc::
   auto response = SetAttributeNIComplexDoubleArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeNIComplexDoubleArray(&context, request, &response));
+      stub->SetAttributeNIComplexDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2169,7 +2279,8 @@ set_attribute_ni_complex_single_array(const StubPtr& stub, const nidevice_grpc::
   auto response = SetAttributeNIComplexSingleArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeNIComplexSingleArray(&context, request, &response));
+      stub->SetAttributeNIComplexSingleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2195,7 +2306,8 @@ set_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = SetAttributeStringResponse{};
 
   raise_if_error(
-      stub->SetAttributeString(&context, request, &response));
+      stub->SetAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2214,7 +2326,8 @@ set_attribute_u16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeU16Response{};
 
   raise_if_error(
-      stub->SetAttributeU16(&context, request, &response));
+      stub->SetAttributeU16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2233,7 +2346,8 @@ set_attribute_u32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeU32Response{};
 
   raise_if_error(
-      stub->SetAttributeU32(&context, request, &response));
+      stub->SetAttributeU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2252,7 +2366,8 @@ set_attribute_u32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeU32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU32Array(&context, request, &response));
+      stub->SetAttributeU32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2271,7 +2386,8 @@ set_attribute_u64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeU64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU64Array(&context, request, &response));
+      stub->SetAttributeU64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2290,7 +2406,8 @@ set_attribute_u8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = SetAttributeU8Response{};
 
   raise_if_error(
-      stub->SetAttributeU8(&context, request, &response));
+      stub->SetAttributeU8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2309,7 +2426,8 @@ set_attribute_u8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = SetAttributeU8ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU8Array(&context, request, &response));
+      stub->SetAttributeU8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2335,7 +2453,8 @@ txp_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = TXPCfgAveragingResponse{};
 
   raise_if_error(
-      stub->TXPCfgAveraging(&context, request, &response));
+      stub->TXPCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2360,7 +2479,8 @@ txp_cfg_burst_synchronization_type(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = TXPCfgBurstSynchronizationTypeResponse{};
 
   raise_if_error(
-      stub->TXPCfgBurstSynchronizationType(&context, request, &response));
+      stub->TXPCfgBurstSynchronizationType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2378,7 +2498,8 @@ txp_fetch_edr_powers(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = TXPFetchEDRPowersResponse{};
 
   raise_if_error(
-      stub->TXPFetchEDRPowers(&context, request, &response));
+      stub->TXPFetchEDRPowers(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2396,7 +2517,8 @@ txp_fetch_lecte_reference_period_powers(const StubPtr& stub, const nidevice_grpc
   auto response = TXPFetchLECTEReferencePeriodPowersResponse{};
 
   raise_if_error(
-      stub->TXPFetchLECTEReferencePeriodPowers(&context, request, &response));
+      stub->TXPFetchLECTEReferencePeriodPowers(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2414,7 +2536,8 @@ txp_fetch_lecte_transmit_slot_powers(const StubPtr& stub, const nidevice_grpc::S
   auto response = TXPFetchLECTETransmitSlotPowersResponse{};
 
   raise_if_error(
-      stub->TXPFetchLECTETransmitSlotPowers(&context, request, &response));
+      stub->TXPFetchLECTETransmitSlotPowers(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2432,7 +2555,8 @@ txp_fetch_lecte_transmit_slot_powers_array(const StubPtr& stub, const nidevice_g
   auto response = TXPFetchLECTETransmitSlotPowersArrayResponse{};
 
   raise_if_error(
-      stub->TXPFetchLECTETransmitSlotPowersArray(&context, request, &response));
+      stub->TXPFetchLECTETransmitSlotPowersArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2450,7 +2574,8 @@ txp_fetch_power_trace(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = TXPFetchPowerTraceResponse{};
 
   raise_if_error(
-      stub->TXPFetchPowerTrace(&context, request, &response));
+      stub->TXPFetchPowerTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2468,7 +2593,8 @@ txp_fetch_powers(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = TXPFetchPowersResponse{};
 
   raise_if_error(
-      stub->TXPFetchPowers(&context, request, &response));
+      stub->TXPFetchPowers(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2494,7 +2620,8 @@ twentyd_b_bandwidth_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = TwentydBBandwidthCfgAveragingResponse{};
 
   raise_if_error(
-      stub->TwentydBBandwidthCfgAveraging(&context, request, &response));
+      stub->TwentydBBandwidthCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2512,7 +2639,8 @@ twentyd_b_bandwidth_fetch_measurement(const StubPtr& stub, const nidevice_grpc::
   auto response = TwentydBBandwidthFetchMeasurementResponse{};
 
   raise_if_error(
-      stub->TwentydBBandwidthFetchMeasurement(&context, request, &response));
+      stub->TwentydBBandwidthFetchMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2530,7 +2658,8 @@ twentyd_b_bandwidth_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = TwentydBBandwidthFetchSpectrumResponse{};
 
   raise_if_error(
-      stub->TwentydBBandwidthFetchSpectrum(&context, request, &response));
+      stub->TwentydBBandwidthFetchSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2547,7 +2676,8 @@ wait_for_acquisition_complete(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = WaitForAcquisitionCompleteResponse{};
 
   raise_if_error(
-      stub->WaitForAcquisitionComplete(&context, request, &response));
+      stub->WaitForAcquisitionComplete(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2565,7 +2695,8 @@ wait_for_measurement_complete(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = WaitForMeasurementCompleteResponse{};
 
   raise_if_error(
-      stub->WaitForMeasurementComplete(&context, request, &response));
+      stub->WaitForMeasurementComplete(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nirfmxinstr/nirfmxinstr_client.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_client.cpp
@@ -28,7 +28,8 @@ build_calibration_plane_string(const StubPtr& stub, const pb::string& calibratio
   auto response = BuildCalibrationPlaneStringResponse{};
 
   raise_if_error(
-      stub->BuildCalibrationPlaneString(&context, request, &response));
+      stub->BuildCalibrationPlaneString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -45,7 +46,8 @@ build_instrument_string(const StubPtr& stub, const pb::string& selector_string, 
   auto response = BuildInstrumentStringResponse{};
 
   raise_if_error(
-      stub->BuildInstrumentString(&context, request, &response));
+      stub->BuildInstrumentString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -62,7 +64,8 @@ build_lo_string(const StubPtr& stub, const pb::string& selector_string, const pb
   auto response = BuildLOStringResponse{};
 
   raise_if_error(
-      stub->BuildLOString(&context, request, &response));
+      stub->BuildLOString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -79,7 +82,8 @@ build_module_string(const StubPtr& stub, const pb::string& selector_string, cons
   auto response = BuildModuleStringResponse{};
 
   raise_if_error(
-      stub->BuildModuleString(&context, request, &response));
+      stub->BuildModuleString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -98,7 +102,8 @@ build_port_string(const StubPtr& stub, const pb::string& selector_string, const 
   auto response = BuildPortStringResponse{};
 
   raise_if_error(
-      stub->BuildPortString(&context, request, &response));
+      stub->BuildPortString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -124,7 +129,8 @@ cfg_external_attenuation_interpolation_linear(const StubPtr& stub, const nidevic
   auto response = CfgExternalAttenuationInterpolationLinearResponse{};
 
   raise_if_error(
-      stub->CfgExternalAttenuationInterpolationLinear(&context, request, &response));
+      stub->CfgExternalAttenuationInterpolationLinear(&context, request, &response),
+      context);
 
   return response;
 }
@@ -142,7 +148,8 @@ cfg_external_attenuation_interpolation_nearest(const StubPtr& stub, const nidevi
   auto response = CfgExternalAttenuationInterpolationNearestResponse{};
 
   raise_if_error(
-      stub->CfgExternalAttenuationInterpolationNearest(&context, request, &response));
+      stub->CfgExternalAttenuationInterpolationNearest(&context, request, &response),
+      context);
 
   return response;
 }
@@ -160,7 +167,8 @@ cfg_external_attenuation_interpolation_spline(const StubPtr& stub, const nidevic
   auto response = CfgExternalAttenuationInterpolationSplineResponse{};
 
   raise_if_error(
-      stub->CfgExternalAttenuationInterpolationSpline(&context, request, &response));
+      stub->CfgExternalAttenuationInterpolationSpline(&context, request, &response),
+      context);
 
   return response;
 }
@@ -180,7 +188,8 @@ cfg_external_attenuation_table(const StubPtr& stub, const nidevice_grpc::Session
   auto response = CfgExternalAttenuationTableResponse{};
 
   raise_if_error(
-      stub->CfgExternalAttenuationTable(&context, request, &response));
+      stub->CfgExternalAttenuationTable(&context, request, &response),
+      context);
 
   return response;
 }
@@ -206,7 +215,8 @@ cfg_frequency_reference(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = CfgFrequencyReferenceResponse{};
 
   raise_if_error(
-      stub->CfgFrequencyReference(&context, request, &response));
+      stub->CfgFrequencyReference(&context, request, &response),
+      context);
 
   return response;
 }
@@ -232,7 +242,8 @@ cfg_mechanical_attenuation(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = CfgMechanicalAttenuationResponse{};
 
   raise_if_error(
-      stub->CfgMechanicalAttenuation(&context, request, &response));
+      stub->CfgMechanicalAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -258,7 +269,8 @@ cfg_rf_attenuation(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CfgRFAttenuationResponse{};
 
   raise_if_error(
-      stub->CfgRFAttenuation(&context, request, &response));
+      stub->CfgRFAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -287,7 +299,8 @@ cfg_s_parameter_external_attenuation_table(const StubPtr& stub, const nidevice_g
   auto response = CfgSParameterExternalAttenuationTableResponse{};
 
   raise_if_error(
-      stub->CfgSParameterExternalAttenuationTable(&context, request, &response));
+      stub->CfgSParameterExternalAttenuationTable(&context, request, &response),
+      context);
 
   return response;
 }
@@ -312,7 +325,8 @@ cfg_s_parameter_external_attenuation_type(const StubPtr& stub, const nidevice_gr
   auto response = CfgSParameterExternalAttenuationTypeResponse{};
 
   raise_if_error(
-      stub->CfgSParameterExternalAttenuationType(&context, request, &response));
+      stub->CfgSParameterExternalAttenuationType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -328,7 +342,8 @@ check_acquisition_status(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CheckAcquisitionStatusResponse{};
 
   raise_if_error(
-      stub->CheckAcquisitionStatus(&context, request, &response));
+      stub->CheckAcquisitionStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -345,7 +360,8 @@ check_if_list_exists(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = CheckIfListExistsResponse{};
 
   raise_if_error(
-      stub->CheckIfListExists(&context, request, &response));
+      stub->CheckIfListExists(&context, request, &response),
+      context);
 
   return response;
 }
@@ -362,7 +378,8 @@ check_if_signal_configuration_exists(const StubPtr& stub, const nidevice_grpc::S
   auto response = CheckIfSignalConfigurationExistsResponse{};
 
   raise_if_error(
-      stub->CheckIfSignalConfigurationExists(&context, request, &response));
+      stub->CheckIfSignalConfigurationExists(&context, request, &response),
+      context);
 
   return response;
 }
@@ -379,7 +396,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const bool&
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }
@@ -396,7 +414,8 @@ delete_all_external_attenuation_tables(const StubPtr& stub, const nidevice_grpc:
   auto response = DeleteAllExternalAttenuationTablesResponse{};
 
   raise_if_error(
-      stub->DeleteAllExternalAttenuationTables(&context, request, &response));
+      stub->DeleteAllExternalAttenuationTables(&context, request, &response),
+      context);
 
   return response;
 }
@@ -414,7 +433,8 @@ delete_external_attenuation_table(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = DeleteExternalAttenuationTableResponse{};
 
   raise_if_error(
-      stub->DeleteExternalAttenuationTable(&context, request, &response));
+      stub->DeleteExternalAttenuationTable(&context, request, &response),
+      context);
 
   return response;
 }
@@ -431,7 +451,8 @@ disable_calibration_plane(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = DisableCalibrationPlaneResponse{};
 
   raise_if_error(
-      stub->DisableCalibrationPlane(&context, request, &response));
+      stub->DisableCalibrationPlane(&context, request, &response),
+      context);
 
   return response;
 }
@@ -448,7 +469,8 @@ enable_calibration_plane(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = EnableCalibrationPlaneResponse{};
 
   raise_if_error(
-      stub->EnableCalibrationPlane(&context, request, &response));
+      stub->EnableCalibrationPlane(&context, request, &response),
+      context);
 
   return response;
 }
@@ -480,7 +502,8 @@ export_signal(const StubPtr& stub, const nidevice_grpc::Session& instrument, con
   auto response = ExportSignalResponse{};
 
   raise_if_error(
-      stub->ExportSignal(&context, request, &response));
+      stub->ExportSignal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -498,7 +521,8 @@ get_attribute_f32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeF32Response{};
 
   raise_if_error(
-      stub->GetAttributeF32(&context, request, &response));
+      stub->GetAttributeF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -516,7 +540,8 @@ get_attribute_f32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeF32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeF32Array(&context, request, &response));
+      stub->GetAttributeF32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -534,7 +559,8 @@ get_attribute_f64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeF64Response{};
 
   raise_if_error(
-      stub->GetAttributeF64(&context, request, &response));
+      stub->GetAttributeF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -552,7 +578,8 @@ get_attribute_f64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeF64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeF64Array(&context, request, &response));
+      stub->GetAttributeF64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -570,7 +597,8 @@ get_attribute_i16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI16Response{};
 
   raise_if_error(
-      stub->GetAttributeI16(&context, request, &response));
+      stub->GetAttributeI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -588,7 +616,8 @@ get_attribute_i32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI32Response{};
 
   raise_if_error(
-      stub->GetAttributeI32(&context, request, &response));
+      stub->GetAttributeI32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -606,7 +635,8 @@ get_attribute_i32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeI32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI32Array(&context, request, &response));
+      stub->GetAttributeI32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -624,7 +654,8 @@ get_attribute_i64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI64Response{};
 
   raise_if_error(
-      stub->GetAttributeI64(&context, request, &response));
+      stub->GetAttributeI64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -642,7 +673,8 @@ get_attribute_i64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeI64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI64Array(&context, request, &response));
+      stub->GetAttributeI64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -660,7 +692,8 @@ get_attribute_i8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetAttributeI8Response{};
 
   raise_if_error(
-      stub->GetAttributeI8(&context, request, &response));
+      stub->GetAttributeI8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -678,7 +711,8 @@ get_attribute_i8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = GetAttributeI8ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI8Array(&context, request, &response));
+      stub->GetAttributeI8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -696,7 +730,8 @@ get_attribute_ni_complex_double_array(const StubPtr& stub, const nidevice_grpc::
   auto response = GetAttributeNIComplexDoubleArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeNIComplexDoubleArray(&context, request, &response));
+      stub->GetAttributeNIComplexDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -714,7 +749,8 @@ get_attribute_ni_complex_single_array(const StubPtr& stub, const nidevice_grpc::
   auto response = GetAttributeNIComplexSingleArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeNIComplexSingleArray(&context, request, &response));
+      stub->GetAttributeNIComplexSingleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -732,7 +768,8 @@ get_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = GetAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeString(&context, request, &response));
+      stub->GetAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -750,7 +787,8 @@ get_attribute_u16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeU16Response{};
 
   raise_if_error(
-      stub->GetAttributeU16(&context, request, &response));
+      stub->GetAttributeU16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -768,7 +806,8 @@ get_attribute_u32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeU32Response{};
 
   raise_if_error(
-      stub->GetAttributeU32(&context, request, &response));
+      stub->GetAttributeU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -786,7 +825,8 @@ get_attribute_u32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeU32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU32Array(&context, request, &response));
+      stub->GetAttributeU32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -804,7 +844,8 @@ get_attribute_u64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeU64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU64Array(&context, request, &response));
+      stub->GetAttributeU64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -822,7 +863,8 @@ get_attribute_u8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetAttributeU8Response{};
 
   raise_if_error(
-      stub->GetAttributeU8(&context, request, &response));
+      stub->GetAttributeU8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -840,7 +882,8 @@ get_attribute_u8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = GetAttributeU8ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU8Array(&context, request, &response));
+      stub->GetAttributeU8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -857,7 +900,8 @@ get_available_ports(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = GetAvailablePortsResponse{};
 
   raise_if_error(
-      stub->GetAvailablePorts(&context, request, &response));
+      stub->GetAvailablePorts(&context, request, &response),
+      context);
 
   return response;
 }
@@ -873,7 +917,8 @@ get_error(const StubPtr& stub, const nidevice_grpc::Session& instrument)
   auto response = GetErrorResponse{};
 
   raise_if_error(
-      stub->GetError(&context, request, &response));
+      stub->GetError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -890,7 +935,8 @@ get_error_string(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetErrorStringResponse{};
 
   raise_if_error(
-      stub->GetErrorString(&context, request, &response));
+      stub->GetErrorString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -907,7 +953,8 @@ get_external_attenuation_table_actual_value(const StubPtr& stub, const nidevice_
   auto response = GetExternalAttenuationTableActualValueResponse{};
 
   raise_if_error(
-      stub->GetExternalAttenuationTableActualValue(&context, request, &response));
+      stub->GetExternalAttenuationTableActualValue(&context, request, &response),
+      context);
 
   return response;
 }
@@ -932,7 +979,8 @@ get_list_names(const StubPtr& stub, const nidevice_grpc::Session& instrument, co
   auto response = GetListNamesResponse{};
 
   raise_if_error(
-      stub->GetListNames(&context, request, &response));
+      stub->GetListNames(&context, request, &response),
+      context);
 
   return response;
 }
@@ -948,7 +996,8 @@ get_nirfsa_session(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = GetNIRFSASessionResponse{};
 
   raise_if_error(
-      stub->GetNIRFSASession(&context, request, &response));
+      stub->GetNIRFSASession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -964,7 +1013,8 @@ get_nirfsa_session_array(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = GetNIRFSASessionArrayResponse{};
 
   raise_if_error(
-      stub->GetNIRFSASessionArray(&context, request, &response));
+      stub->GetNIRFSASessionArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -981,7 +1031,8 @@ get_s_parameter_external_attenuation_type(const StubPtr& stub, const nidevice_gr
   auto response = GetSParameterExternalAttenuationTypeResponse{};
 
   raise_if_error(
-      stub->GetSParameterExternalAttenuationType(&context, request, &response));
+      stub->GetSParameterExternalAttenuationType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1006,7 +1057,8 @@ get_self_calibrate_last_date_and_time(const StubPtr& stub, const nidevice_grpc::
   auto response = GetSelfCalibrateLastDateAndTimeResponse{};
 
   raise_if_error(
-      stub->GetSelfCalibrateLastDateAndTime(&context, request, &response));
+      stub->GetSelfCalibrateLastDateAndTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1031,7 +1083,8 @@ get_self_calibrate_last_temperature(const StubPtr& stub, const nidevice_grpc::Se
   auto response = GetSelfCalibrateLastTemperatureResponse{};
 
   raise_if_error(
-      stub->GetSelfCalibrateLastTemperature(&context, request, &response));
+      stub->GetSelfCalibrateLastTemperature(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1056,7 +1109,8 @@ get_signal_configuration_names(const StubPtr& stub, const nidevice_grpc::Session
   auto response = GetSignalConfigurationNamesResponse{};
 
   raise_if_error(
-      stub->GetSignalConfigurationNames(&context, request, &response));
+      stub->GetSignalConfigurationNames(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1073,7 +1127,8 @@ initialize(const StubPtr& stub, const pb::string& resource_name, const pb::strin
   auto response = InitializeResponse{};
 
   raise_if_error(
-      stub->Initialize(&context, request, &response));
+      stub->Initialize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1089,7 +1144,8 @@ initialize_from_nirfsa_session(const StubPtr& stub, const nidevice_grpc::Session
   auto response = InitializeFromNIRFSASessionResponse{};
 
   raise_if_error(
-      stub->InitializeFromNIRFSASession(&context, request, &response));
+      stub->InitializeFromNIRFSASession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1105,7 +1161,8 @@ initialize_from_nirfsa_session_array(const StubPtr& stub, const std::vector<nide
   auto response = InitializeFromNIRFSASessionArrayResponse{};
 
   raise_if_error(
-      stub->InitializeFromNIRFSASessionArray(&context, request, &response));
+      stub->InitializeFromNIRFSASessionArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1122,7 +1179,8 @@ is_self_calibrate_valid(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = IsSelfCalibrateValidResponse{};
 
   raise_if_error(
-      stub->IsSelfCalibrateValid(&context, request, &response));
+      stub->IsSelfCalibrateValid(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1140,7 +1198,8 @@ load_all_configurations(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = LoadAllConfigurationsResponse{};
 
   raise_if_error(
-      stub->LoadAllConfigurations(&context, request, &response));
+      stub->LoadAllConfigurations(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1167,7 +1226,8 @@ load_s_parameter_external_attenuation_table_from_s2p_file(const StubPtr& stub, c
   auto response = LoadSParameterExternalAttenuationTableFromS2PFileResponse{};
 
   raise_if_error(
-      stub->LoadSParameterExternalAttenuationTableFromS2PFile(&context, request, &response));
+      stub->LoadSParameterExternalAttenuationTableFromS2PFile(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1185,7 +1245,8 @@ reset_attribute(const StubPtr& stub, const nidevice_grpc::Session& instrument, c
   auto response = ResetAttributeResponse{};
 
   raise_if_error(
-      stub->ResetAttribute(&context, request, &response));
+      stub->ResetAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1201,7 +1262,8 @@ reset_driver(const StubPtr& stub, const nidevice_grpc::Session& instrument)
   auto response = ResetDriverResponse{};
 
   raise_if_error(
-      stub->ResetDriver(&context, request, &response));
+      stub->ResetDriver(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1217,7 +1279,8 @@ reset_entire_session(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = ResetEntireSessionResponse{};
 
   raise_if_error(
-      stub->ResetEntireSession(&context, request, &response));
+      stub->ResetEntireSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1233,7 +1296,8 @@ reset_to_default(const StubPtr& stub, const nidevice_grpc::Session& instrument)
   auto response = ResetToDefaultResponse{};
 
   raise_if_error(
-      stub->ResetToDefault(&context, request, &response));
+      stub->ResetToDefault(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1250,7 +1314,8 @@ save_all_configurations(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SaveAllConfigurationsResponse{};
 
   raise_if_error(
-      stub->SaveAllConfigurations(&context, request, &response));
+      stub->SaveAllConfigurations(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1268,7 +1333,8 @@ select_active_external_attenuation_table(const StubPtr& stub, const nidevice_grp
   auto response = SelectActiveExternalAttenuationTableResponse{};
 
   raise_if_error(
-      stub->SelectActiveExternalAttenuationTable(&context, request, &response));
+      stub->SelectActiveExternalAttenuationTable(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1293,7 +1359,8 @@ self_calibrate(const StubPtr& stub, const nidevice_grpc::Session& instrument, co
   auto response = SelfCalibrateResponse{};
 
   raise_if_error(
-      stub->SelfCalibrate(&context, request, &response));
+      stub->SelfCalibrate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1322,7 +1389,8 @@ self_calibrate_range(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = SelfCalibrateRangeResponse{};
 
   raise_if_error(
-      stub->SelfCalibrateRange(&context, request, &response));
+      stub->SelfCalibrateRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1338,7 +1406,8 @@ send_software_edge_advance_trigger(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = SendSoftwareEdgeAdvanceTriggerResponse{};
 
   raise_if_error(
-      stub->SendSoftwareEdgeAdvanceTrigger(&context, request, &response));
+      stub->SendSoftwareEdgeAdvanceTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1354,7 +1423,8 @@ send_software_edge_start_trigger(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = SendSoftwareEdgeStartTriggerResponse{};
 
   raise_if_error(
-      stub->SendSoftwareEdgeStartTrigger(&context, request, &response));
+      stub->SendSoftwareEdgeStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1373,7 +1443,8 @@ set_attribute_f32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeF32Response{};
 
   raise_if_error(
-      stub->SetAttributeF32(&context, request, &response));
+      stub->SetAttributeF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1392,7 +1463,8 @@ set_attribute_f32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeF32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeF32Array(&context, request, &response));
+      stub->SetAttributeF32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1411,7 +1483,8 @@ set_attribute_f64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeF64Response{};
 
   raise_if_error(
-      stub->SetAttributeF64(&context, request, &response));
+      stub->SetAttributeF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1430,7 +1503,8 @@ set_attribute_f64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeF64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeF64Array(&context, request, &response));
+      stub->SetAttributeF64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1449,7 +1523,8 @@ set_attribute_i16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI16Response{};
 
   raise_if_error(
-      stub->SetAttributeI16(&context, request, &response));
+      stub->SetAttributeI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1475,7 +1550,8 @@ set_attribute_i32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI32Response{};
 
   raise_if_error(
-      stub->SetAttributeI32(&context, request, &response));
+      stub->SetAttributeI32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1494,7 +1570,8 @@ set_attribute_i32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeI32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI32Array(&context, request, &response));
+      stub->SetAttributeI32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1513,7 +1590,8 @@ set_attribute_i64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI64Response{};
 
   raise_if_error(
-      stub->SetAttributeI64(&context, request, &response));
+      stub->SetAttributeI64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1532,7 +1610,8 @@ set_attribute_i64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeI64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI64Array(&context, request, &response));
+      stub->SetAttributeI64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1551,7 +1630,8 @@ set_attribute_i8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = SetAttributeI8Response{};
 
   raise_if_error(
-      stub->SetAttributeI8(&context, request, &response));
+      stub->SetAttributeI8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1570,7 +1650,8 @@ set_attribute_i8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = SetAttributeI8ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI8Array(&context, request, &response));
+      stub->SetAttributeI8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1589,7 +1670,8 @@ set_attribute_ni_complex_double_array(const StubPtr& stub, const nidevice_grpc::
   auto response = SetAttributeNIComplexDoubleArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeNIComplexDoubleArray(&context, request, &response));
+      stub->SetAttributeNIComplexDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1608,7 +1690,8 @@ set_attribute_ni_complex_single_array(const StubPtr& stub, const nidevice_grpc::
   auto response = SetAttributeNIComplexSingleArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeNIComplexSingleArray(&context, request, &response));
+      stub->SetAttributeNIComplexSingleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1634,7 +1717,8 @@ set_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = SetAttributeStringResponse{};
 
   raise_if_error(
-      stub->SetAttributeString(&context, request, &response));
+      stub->SetAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1653,7 +1737,8 @@ set_attribute_u16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeU16Response{};
 
   raise_if_error(
-      stub->SetAttributeU16(&context, request, &response));
+      stub->SetAttributeU16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1672,7 +1757,8 @@ set_attribute_u32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeU32Response{};
 
   raise_if_error(
-      stub->SetAttributeU32(&context, request, &response));
+      stub->SetAttributeU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1691,7 +1777,8 @@ set_attribute_u32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeU32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU32Array(&context, request, &response));
+      stub->SetAttributeU32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1710,7 +1797,8 @@ set_attribute_u64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeU64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU64Array(&context, request, &response));
+      stub->SetAttributeU64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1729,7 +1817,8 @@ set_attribute_u8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = SetAttributeU8Response{};
 
   raise_if_error(
-      stub->SetAttributeU8(&context, request, &response));
+      stub->SetAttributeU8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1748,7 +1837,8 @@ set_attribute_u8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = SetAttributeU8ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU8Array(&context, request, &response));
+      stub->SetAttributeU8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1765,7 +1855,8 @@ timestamp_from_values(const StubPtr& stub, const pb::int64& seconds_since_1970, 
   auto response = TimestampFromValuesResponse{};
 
   raise_if_error(
-      stub->TimestampFromValues(&context, request, &response));
+      stub->TimestampFromValues(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1781,7 +1872,8 @@ values_from_timestamp(const StubPtr& stub, const google::protobuf::Timestamp& ti
   auto response = ValuesFromTimestampResponse{};
 
   raise_if_error(
-      stub->ValuesFromTimestamp(&context, request, &response));
+      stub->ValuesFromTimestamp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1798,7 +1890,8 @@ wait_for_acquisition_complete(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = WaitForAcquisitionCompleteResponse{};
 
   raise_if_error(
-      stub->WaitForAcquisitionComplete(&context, request, &response));
+      stub->WaitForAcquisitionComplete(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.cpp
@@ -33,7 +33,8 @@ convert_for_power_units_utility(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = ConvertForPowerUnitsUtilityResponse{};
 
   raise_if_error(
-      stub->ConvertForPowerUnitsUtility(&context, request, &response));
+      stub->ConvertForPowerUnitsUtility(&context, request, &response),
+      context);
 
   return response;
 }
@@ -51,7 +52,8 @@ delete_snapshot(const StubPtr& stub, const nidevice_grpc::Session& instrument, c
   auto response = DeleteSnapshotResponse{};
 
   raise_if_error(
-      stub->DeleteSnapshot(&context, request, &response));
+      stub->DeleteSnapshot(&context, request, &response),
+      context);
 
   return response;
 }
@@ -69,7 +71,8 @@ get_active_result_name(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = GetActiveResultNameResponse{};
 
   raise_if_error(
-      stub->GetActiveResultName(&context, request, &response));
+      stub->GetActiveResultName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -86,7 +89,8 @@ get_active_table_name(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = GetActiveTableNameResponse{};
 
   raise_if_error(
-      stub->GetActiveTableName(&context, request, &response));
+      stub->GetActiveTableName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -104,7 +108,8 @@ get_attribute_author(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = GetAttributeAuthorResponse{};
 
   raise_if_error(
-      stub->GetAttributeAuthor(&context, request, &response));
+      stub->GetAttributeAuthor(&context, request, &response),
+      context);
 
   return response;
 }
@@ -122,7 +127,8 @@ get_attribute_desired_f32(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = GetAttributeDesiredF32Response{};
 
   raise_if_error(
-      stub->GetAttributeDesiredF32(&context, request, &response));
+      stub->GetAttributeDesiredF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -140,7 +146,8 @@ get_attribute_desired_f32_array(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = GetAttributeDesiredF32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeDesiredF32Array(&context, request, &response));
+      stub->GetAttributeDesiredF32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -158,7 +165,8 @@ get_attribute_desired_f64(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = GetAttributeDesiredF64Response{};
 
   raise_if_error(
-      stub->GetAttributeDesiredF64(&context, request, &response));
+      stub->GetAttributeDesiredF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -176,7 +184,8 @@ get_attribute_desired_f64_array(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = GetAttributeDesiredF64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeDesiredF64Array(&context, request, &response));
+      stub->GetAttributeDesiredF64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -194,7 +203,8 @@ get_attribute_desired_i32(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = GetAttributeDesiredI32Response{};
 
   raise_if_error(
-      stub->GetAttributeDesiredI32(&context, request, &response));
+      stub->GetAttributeDesiredI32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -212,7 +222,8 @@ get_attribute_desired_i64(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = GetAttributeDesiredI64Response{};
 
   raise_if_error(
-      stub->GetAttributeDesiredI64(&context, request, &response));
+      stub->GetAttributeDesiredI64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -230,7 +241,8 @@ get_attribute_desired_string(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetAttributeDesiredStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeDesiredString(&context, request, &response));
+      stub->GetAttributeDesiredString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -247,7 +259,8 @@ get_calibration_plane_enabled(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = GetCalibrationPlaneEnabledResponse{};
 
   raise_if_error(
-      stub->GetCalibrationPlaneEnabled(&context, request, &response));
+      stub->GetCalibrationPlaneEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -264,7 +277,8 @@ get_calibration_plane_names(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = GetCalibrationPlaneNamesResponse{};
 
   raise_if_error(
-      stub->GetCalibrationPlaneNames(&context, request, &response));
+      stub->GetCalibrationPlaneNames(&context, request, &response),
+      context);
 
   return response;
 }
@@ -281,7 +295,8 @@ get_external_attenuation_table_names(const StubPtr& stub, const nidevice_grpc::S
   auto response = GetExternalAttenuationTableNamesResponse{};
 
   raise_if_error(
-      stub->GetExternalAttenuationTableNames(&context, request, &response));
+      stub->GetExternalAttenuationTableNames(&context, request, &response),
+      context);
 
   return response;
 }
@@ -298,7 +313,8 @@ get_force_all_traces_enabled(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetForceAllTracesEnabledResponse{};
 
   raise_if_error(
-      stub->GetForceAllTracesEnabled(&context, request, &response));
+      stub->GetForceAllTracesEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -314,7 +330,8 @@ get_initiaited_snapshot_strings(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = GetInitiaitedSnapshotStringsResponse{};
 
   raise_if_error(
-      stub->GetInitiaitedSnapshotStrings(&context, request, &response));
+      stub->GetInitiaitedSnapshotStrings(&context, request, &response),
+      context);
 
   return response;
 }
@@ -330,7 +347,8 @@ get_latest_configuration_snapshot(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = GetLatestConfigurationSnapshotResponse{};
 
   raise_if_error(
-      stub->GetLatestConfigurationSnapshot(&context, request, &response));
+      stub->GetLatestConfigurationSnapshot(&context, request, &response),
+      context);
 
   return response;
 }
@@ -346,7 +364,8 @@ get_open_sessions_information(const StubPtr& stub, const pb::string& resource_na
   auto response = GetOpenSessionsInformationResponse{};
 
   raise_if_error(
-      stub->GetOpenSessionsInformation(&context, request, &response));
+      stub->GetOpenSessionsInformation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -362,7 +381,8 @@ get_privilege_level(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = GetPrivilegeLevelResponse{};
 
   raise_if_error(
-      stub->GetPrivilegeLevel(&context, request, &response));
+      stub->GetPrivilegeLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -378,7 +398,8 @@ get_r_fmx_version(const StubPtr& stub, const nidevice_grpc::Session& instrument)
   auto response = GetRFmxVersionResponse{};
 
   raise_if_error(
-      stub->GetRFmxVersion(&context, request, &response));
+      stub->GetRFmxVersion(&context, request, &response),
+      context);
 
   return response;
 }
@@ -396,7 +417,8 @@ get_signal_configuration_state64(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = GetSignalConfigurationState64Response{};
 
   raise_if_error(
-      stub->GetSignalConfigurationState64(&context, request, &response));
+      stub->GetSignalConfigurationState64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -414,7 +436,8 @@ get_snapshot_state(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = GetSnapshotStateResponse{};
 
   raise_if_error(
-      stub->GetSnapshotState(&context, request, &response));
+      stub->GetSnapshotState(&context, request, &response),
+      context);
 
   return response;
 }
@@ -431,7 +454,8 @@ get_traces_info_for_monitor_snapshot(const StubPtr& stub, const nidevice_grpc::S
   auto response = GetTracesInfoForMonitorSnapshotResponse{};
 
   raise_if_error(
-      stub->GetTracesInfoForMonitorSnapshot(&context, request, &response));
+      stub->GetTracesInfoForMonitorSnapshot(&context, request, &response),
+      context);
 
   return response;
 }
@@ -448,7 +472,8 @@ load_all_for_revert(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = LoadAllForRevertResponse{};
 
   raise_if_error(
-      stub->LoadAllForRevert(&context, request, &response));
+      stub->LoadAllForRevert(&context, request, &response),
+      context);
 
   return response;
 }
@@ -465,7 +490,8 @@ load_configurations_from_json(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = LoadConfigurationsFromJSONResponse{};
 
   raise_if_error(
-      stub->LoadConfigurationsFromJSON(&context, request, &response));
+      stub->LoadConfigurationsFromJSON(&context, request, &response),
+      context);
 
   return response;
 }
@@ -481,7 +507,8 @@ register_special_client_snapshot_interest(const StubPtr& stub, const pb::string&
   auto response = RegisterSpecialClientSnapshotInterestResponse{};
 
   raise_if_error(
-      stub->RegisterSpecialClientSnapshotInterest(&context, request, &response));
+      stub->RegisterSpecialClientSnapshotInterest(&context, request, &response),
+      context);
 
   return response;
 }
@@ -498,7 +525,8 @@ request_privilege(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = RequestPrivilegeResponse{};
 
   raise_if_error(
-      stub->RequestPrivilege(&context, request, &response));
+      stub->RequestPrivilege(&context, request, &response),
+      context);
 
   return response;
 }
@@ -515,7 +543,8 @@ save_all_for_revert(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = SaveAllForRevertResponse{};
 
   raise_if_error(
-      stub->SaveAllForRevert(&context, request, &response));
+      stub->SaveAllForRevert(&context, request, &response),
+      context);
 
   return response;
 }
@@ -532,7 +561,8 @@ save_configurations_to_json(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = SaveConfigurationsToJSONResponse{};
 
   raise_if_error(
-      stub->SaveConfigurationsToJSON(&context, request, &response));
+      stub->SaveConfigurationsToJSON(&context, request, &response),
+      context);
 
   return response;
 }
@@ -550,7 +580,8 @@ set_force_all_traces_enabled(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SetForceAllTracesEnabledResponse{};
 
   raise_if_error(
-      stub->SetForceAllTracesEnabled(&context, request, &response));
+      stub->SetForceAllTracesEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -567,7 +598,8 @@ set_io_trace_status(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = SetIOTraceStatusResponse{};
 
   raise_if_error(
-      stub->SetIOTraceStatus(&context, request, &response));
+      stub->SetIOTraceStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -583,7 +615,8 @@ unregister_special_client_snapshot_interest(const StubPtr& stub, const pb::strin
   auto response = UnregisterSpecialClientSnapshotInterestResponse{};
 
   raise_if_error(
-      stub->UnregisterSpecialClientSnapshotInterest(&context, request, &response));
+      stub->UnregisterSpecialClientSnapshotInterest(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nirfmxlte/nirfmxlte_client.cpp
+++ b/generated/nirfmxlte/nirfmxlte_client.cpp
@@ -46,7 +46,8 @@ acp_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = ACPCfgAveragingResponse{};
 
   raise_if_error(
-      stub->ACPCfgAveraging(&context, request, &response));
+      stub->ACPCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -71,7 +72,8 @@ acp_cfg_configurable_number_of_offsets_enabled(const StubPtr& stub, const nidevi
   auto response = ACPCfgConfigurableNumberOfOffsetsEnabledResponse{};
 
   raise_if_error(
-      stub->ACPCfgConfigurableNumberOfOffsetsEnabled(&context, request, &response));
+      stub->ACPCfgConfigurableNumberOfOffsetsEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -96,7 +98,8 @@ acp_cfg_measurement_method(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = ACPCfgMeasurementMethodResponse{};
 
   raise_if_error(
-      stub->ACPCfgMeasurementMethod(&context, request, &response));
+      stub->ACPCfgMeasurementMethod(&context, request, &response),
+      context);
 
   return response;
 }
@@ -121,7 +124,8 @@ acp_cfg_noise_compensation_enabled(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ACPCfgNoiseCompensationEnabledResponse{};
 
   raise_if_error(
-      stub->ACPCfgNoiseCompensationEnabled(&context, request, &response));
+      stub->ACPCfgNoiseCompensationEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -139,7 +143,8 @@ acp_cfg_number_of_eutra_offsets(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = ACPCfgNumberOfEUTRAOffsetsResponse{};
 
   raise_if_error(
-      stub->ACPCfgNumberOfEUTRAOffsets(&context, request, &response));
+      stub->ACPCfgNumberOfEUTRAOffsets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -157,7 +162,8 @@ acp_cfg_number_of_gsm_offsets(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ACPCfgNumberOfGSMOffsetsResponse{};
 
   raise_if_error(
-      stub->ACPCfgNumberOfGSMOffsets(&context, request, &response));
+      stub->ACPCfgNumberOfGSMOffsets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -175,7 +181,8 @@ acp_cfg_number_of_utra_offsets(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ACPCfgNumberOfUTRAOffsetsResponse{};
 
   raise_if_error(
-      stub->ACPCfgNumberOfUTRAOffsets(&context, request, &response));
+      stub->ACPCfgNumberOfUTRAOffsets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -200,7 +207,8 @@ acp_cfg_power_units(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = ACPCfgPowerUnitsResponse{};
 
   raise_if_error(
-      stub->ACPCfgPowerUnits(&context, request, &response));
+      stub->ACPCfgPowerUnits(&context, request, &response),
+      context);
 
   return response;
 }
@@ -234,7 +242,8 @@ acp_cfg_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = ACPCfgRBWFilterResponse{};
 
   raise_if_error(
-      stub->ACPCfgRBWFilter(&context, request, &response));
+      stub->ACPCfgRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -260,7 +269,8 @@ acp_cfg_sweep_time(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = ACPCfgSweepTimeResponse{};
 
   raise_if_error(
-      stub->ACPCfgSweepTime(&context, request, &response));
+      stub->ACPCfgSweepTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -279,7 +289,8 @@ acp_cfg_utra_and_eutra_offsets(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ACPCfgUTRAAndEUTRAOffsetsResponse{};
 
   raise_if_error(
-      stub->ACPCfgUTRAAndEUTRAOffsets(&context, request, &response));
+      stub->ACPCfgUTRAAndEUTRAOffsets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -298,7 +309,8 @@ acp_fetch_absolute_powers_trace(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = ACPFetchAbsolutePowersTraceResponse{};
 
   raise_if_error(
-      stub->ACPFetchAbsolutePowersTrace(&context, request, &response));
+      stub->ACPFetchAbsolutePowersTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -316,7 +328,8 @@ acp_fetch_component_carrier_measurement(const StubPtr& stub, const nidevice_grpc
   auto response = ACPFetchComponentCarrierMeasurementResponse{};
 
   raise_if_error(
-      stub->ACPFetchComponentCarrierMeasurement(&context, request, &response));
+      stub->ACPFetchComponentCarrierMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -334,7 +347,8 @@ acp_fetch_component_carrier_measurement_array(const StubPtr& stub, const nidevic
   auto response = ACPFetchComponentCarrierMeasurementArrayResponse{};
 
   raise_if_error(
-      stub->ACPFetchComponentCarrierMeasurementArray(&context, request, &response));
+      stub->ACPFetchComponentCarrierMeasurementArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -352,7 +366,8 @@ acp_fetch_offset_measurement(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ACPFetchOffsetMeasurementResponse{};
 
   raise_if_error(
-      stub->ACPFetchOffsetMeasurement(&context, request, &response));
+      stub->ACPFetchOffsetMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -370,7 +385,8 @@ acp_fetch_offset_measurement_array(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ACPFetchOffsetMeasurementArrayResponse{};
 
   raise_if_error(
-      stub->ACPFetchOffsetMeasurementArray(&context, request, &response));
+      stub->ACPFetchOffsetMeasurementArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -389,7 +405,8 @@ acp_fetch_relative_powers_trace(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = ACPFetchRelativePowersTraceResponse{};
 
   raise_if_error(
-      stub->ACPFetchRelativePowersTrace(&context, request, &response));
+      stub->ACPFetchRelativePowersTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -407,7 +424,8 @@ acp_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = ACPFetchSpectrumResponse{};
 
   raise_if_error(
-      stub->ACPFetchSpectrum(&context, request, &response));
+      stub->ACPFetchSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -425,7 +443,8 @@ acp_fetch_subblock_measurement(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ACPFetchSubblockMeasurementResponse{};
 
   raise_if_error(
-      stub->ACPFetchSubblockMeasurement(&context, request, &response));
+      stub->ACPFetchSubblockMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -443,7 +462,8 @@ acp_fetch_total_aggregated_power(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ACPFetchTotalAggregatedPowerResponse{};
 
   raise_if_error(
-      stub->ACPFetchTotalAggregatedPower(&context, request, &response));
+      stub->ACPFetchTotalAggregatedPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -460,7 +480,8 @@ acp_validate_noise_calibration_data(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ACPValidateNoiseCalibrationDataResponse{};
 
   raise_if_error(
-      stub->ACPValidateNoiseCalibrationData(&context, request, &response));
+      stub->ACPValidateNoiseCalibrationData(&context, request, &response),
+      context);
 
   return response;
 }
@@ -477,7 +498,8 @@ abort_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = AbortMeasurementsResponse{};
 
   raise_if_error(
-      stub->AbortMeasurements(&context, request, &response));
+      stub->AbortMeasurements(&context, request, &response),
+      context);
 
   return response;
 }
@@ -499,7 +521,8 @@ analyze_iq1_waveform(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = AnalyzeIQ1WaveformResponse{};
 
   raise_if_error(
-      stub->AnalyzeIQ1Waveform(&context, request, &response));
+      stub->AnalyzeIQ1Waveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -521,7 +544,8 @@ analyze_spectrum1_waveform(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = AnalyzeSpectrum1WaveformResponse{};
 
   raise_if_error(
-      stub->AnalyzeSpectrum1Waveform(&context, request, &response));
+      stub->AnalyzeSpectrum1Waveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -539,7 +563,8 @@ auto_level(const StubPtr& stub, const nidevice_grpc::Session& instrument, const 
   auto response = AutoLevelResponse{};
 
   raise_if_error(
-      stub->AutoLevel(&context, request, &response));
+      stub->AutoLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -556,7 +581,8 @@ build_carrier_string(const StubPtr& stub, const pb::string& selector_string, con
   auto response = BuildCarrierStringResponse{};
 
   raise_if_error(
-      stub->BuildCarrierString(&context, request, &response));
+      stub->BuildCarrierString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -573,7 +599,8 @@ build_cluster_string(const StubPtr& stub, const pb::string& selector_string, con
   auto response = BuildClusterStringResponse{};
 
   raise_if_error(
-      stub->BuildClusterString(&context, request, &response));
+      stub->BuildClusterString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -590,7 +617,8 @@ build_offset_string(const StubPtr& stub, const pb::string& selector_string, cons
   auto response = BuildOffsetStringResponse{};
 
   raise_if_error(
-      stub->BuildOffsetString(&context, request, &response));
+      stub->BuildOffsetString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -607,7 +635,8 @@ build_pdsch_string(const StubPtr& stub, const pb::string& selector_string, const
   auto response = BuildPDSCHStringResponse{};
 
   raise_if_error(
-      stub->BuildPDSCHString(&context, request, &response));
+      stub->BuildPDSCHString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -624,7 +653,8 @@ build_signal_string(const StubPtr& stub, const pb::string& signal_name, const pb
   auto response = BuildSignalStringResponse{};
 
   raise_if_error(
-      stub->BuildSignalString(&context, request, &response));
+      stub->BuildSignalString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -641,7 +671,8 @@ build_subblock_string(const StubPtr& stub, const pb::string& selector_string, co
   auto response = BuildSubblockStringResponse{};
 
   raise_if_error(
-      stub->BuildSubblockString(&context, request, &response));
+      stub->BuildSubblockString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -658,7 +689,8 @@ build_subframe_string(const StubPtr& stub, const pb::string& selector_string, co
   auto response = BuildSubframeStringResponse{};
 
   raise_if_error(
-      stub->BuildSubframeString(&context, request, &response));
+      stub->BuildSubframeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -692,7 +724,8 @@ chp_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = CHPCfgAveragingResponse{};
 
   raise_if_error(
-      stub->CHPCfgAveraging(&context, request, &response));
+      stub->CHPCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -717,7 +750,8 @@ chp_cfg_integration_bandwidth_type(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = CHPCfgIntegrationBandwidthTypeResponse{};
 
   raise_if_error(
-      stub->CHPCfgIntegrationBandwidthType(&context, request, &response));
+      stub->CHPCfgIntegrationBandwidthType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -751,7 +785,8 @@ chp_cfg_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CHPCfgRBWFilterResponse{};
 
   raise_if_error(
-      stub->CHPCfgRBWFilter(&context, request, &response));
+      stub->CHPCfgRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -777,7 +812,8 @@ chp_cfg_sweep_time(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CHPCfgSweepTimeResponse{};
 
   raise_if_error(
-      stub->CHPCfgSweepTime(&context, request, &response));
+      stub->CHPCfgSweepTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -795,7 +831,8 @@ chp_fetch_component_carrier_measurement(const StubPtr& stub, const nidevice_grpc
   auto response = CHPFetchComponentCarrierMeasurementResponse{};
 
   raise_if_error(
-      stub->CHPFetchComponentCarrierMeasurement(&context, request, &response));
+      stub->CHPFetchComponentCarrierMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -813,7 +850,8 @@ chp_fetch_component_carrier_measurement_array(const StubPtr& stub, const nidevic
   auto response = CHPFetchComponentCarrierMeasurementArrayResponse{};
 
   raise_if_error(
-      stub->CHPFetchComponentCarrierMeasurementArray(&context, request, &response));
+      stub->CHPFetchComponentCarrierMeasurementArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -831,7 +869,8 @@ chp_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CHPFetchSpectrumResponse{};
 
   raise_if_error(
-      stub->CHPFetchSpectrum(&context, request, &response));
+      stub->CHPFetchSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -849,7 +888,8 @@ chp_fetch_subblock_measurement(const StubPtr& stub, const nidevice_grpc::Session
   auto response = CHPFetchSubblockMeasurementResponse{};
 
   raise_if_error(
-      stub->CHPFetchSubblockMeasurement(&context, request, &response));
+      stub->CHPFetchSubblockMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -867,7 +907,8 @@ chp_fetch_total_aggregated_power(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = CHPFetchTotalAggregatedPowerResponse{};
 
   raise_if_error(
-      stub->CHPFetchTotalAggregatedPower(&context, request, &response));
+      stub->CHPFetchTotalAggregatedPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -884,7 +925,8 @@ chp_validate_noise_calibration_data(const StubPtr& stub, const nidevice_grpc::Se
   auto response = CHPValidateNoiseCalibrationDataResponse{};
 
   raise_if_error(
-      stub->CHPValidateNoiseCalibrationData(&context, request, &response));
+      stub->CHPValidateNoiseCalibrationData(&context, request, &response),
+      context);
 
   return response;
 }
@@ -909,7 +951,8 @@ cfg_auto_dmrs_detection_enabled(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = CfgAutoDMRSDetectionEnabledResponse{};
 
   raise_if_error(
-      stub->CfgAutoDMRSDetectionEnabled(&context, request, &response));
+      stub->CfgAutoDMRSDetectionEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -934,7 +977,8 @@ cfg_auto_npusch_channel_detection_enabled(const StubPtr& stub, const nidevice_gr
   auto response = CfgAutoNPUSCHChannelDetectionEnabledResponse{};
 
   raise_if_error(
-      stub->CfgAutoNPUSCHChannelDetectionEnabled(&context, request, &response));
+      stub->CfgAutoNPUSCHChannelDetectionEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -959,7 +1003,8 @@ cfg_auto_resource_block_detection_enabled(const StubPtr& stub, const nidevice_gr
   auto response = CfgAutoResourceBlockDetectionEnabledResponse{};
 
   raise_if_error(
-      stub->CfgAutoResourceBlockDetectionEnabled(&context, request, &response));
+      stub->CfgAutoResourceBlockDetectionEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -977,7 +1022,8 @@ cfg_band(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb
   auto response = CfgBandResponse{};
 
   raise_if_error(
-      stub->CfgBand(&context, request, &response));
+      stub->CfgBand(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1002,7 +1048,8 @@ cfg_cell_specific_ratio(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = CfgCellSpecificRatioResponse{};
 
   raise_if_error(
-      stub->CfgCellSpecificRatio(&context, request, &response));
+      stub->CfgCellSpecificRatio(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1022,7 +1069,8 @@ cfg_component_carrier(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = CfgComponentCarrierResponse{};
 
   raise_if_error(
-      stub->CfgComponentCarrier(&context, request, &response));
+      stub->CfgComponentCarrier(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1042,7 +1090,8 @@ cfg_component_carrier_array(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = CfgComponentCarrierArrayResponse{};
 
   raise_if_error(
-      stub->CfgComponentCarrierArray(&context, request, &response));
+      stub->CfgComponentCarrierArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1068,7 +1117,8 @@ cfg_component_carrier_spacing(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = CfgComponentCarrierSpacingResponse{};
 
   raise_if_error(
-      stub->CfgComponentCarrierSpacing(&context, request, &response));
+      stub->CfgComponentCarrierSpacing(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1103,7 +1153,8 @@ cfg_digital_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CfgDigitalEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->CfgDigitalEdgeTrigger(&context, request, &response));
+      stub->CfgDigitalEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1128,7 +1179,8 @@ cfg_downlink_auto_cell_id_detection_enabled(const StubPtr& stub, const nidevice_
   auto response = CfgDownlinkAutoCellIDDetectionEnabledResponse{};
 
   raise_if_error(
-      stub->CfgDownlinkAutoCellIDDetectionEnabled(&context, request, &response));
+      stub->CfgDownlinkAutoCellIDDetectionEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1169,7 +1221,8 @@ cfg_downlink_auto_channel_detection(const StubPtr& stub, const nidevice_grpc::Se
   auto response = CfgDownlinkAutoChannelDetectionResponse{};
 
   raise_if_error(
-      stub->CfgDownlinkAutoChannelDetection(&context, request, &response));
+      stub->CfgDownlinkAutoChannelDetection(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1194,7 +1247,8 @@ cfg_downlink_channel_configuration_mode(const StubPtr& stub, const nidevice_grpc
   auto response = CfgDownlinkChannelConfigurationModeResponse{};
 
   raise_if_error(
-      stub->CfgDownlinkChannelConfigurationMode(&context, request, &response));
+      stub->CfgDownlinkChannelConfigurationMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1212,7 +1266,8 @@ cfg_downlink_number_of_subframes(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = CfgDownlinkNumberOfSubframesResponse{};
 
   raise_if_error(
-      stub->CfgDownlinkNumberOfSubframes(&context, request, &response));
+      stub->CfgDownlinkNumberOfSubframes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1231,7 +1286,8 @@ cfg_downlink_synchronization_signal(const StubPtr& stub, const nidevice_grpc::Se
   auto response = CfgDownlinkSynchronizationSignalResponse{};
 
   raise_if_error(
-      stub->CfgDownlinkSynchronizationSignal(&context, request, &response));
+      stub->CfgDownlinkSynchronizationSignal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1256,7 +1312,8 @@ cfg_downlink_test_model(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = CfgDownlinkTestModelResponse{};
 
   raise_if_error(
-      stub->CfgDownlinkTestModel(&context, request, &response));
+      stub->CfgDownlinkTestModel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1274,7 +1331,8 @@ cfg_downlink_test_model_array(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = CfgDownlinkTestModelArrayResponse{};
 
   raise_if_error(
-      stub->CfgDownlinkTestModelArray(&context, request, &response));
+      stub->CfgDownlinkTestModelArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1307,7 +1365,8 @@ cfg_duplex_scheme(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = CfgDuplexSchemeResponse{};
 
   raise_if_error(
-      stub->CfgDuplexScheme(&context, request, &response));
+      stub->CfgDuplexScheme(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1332,7 +1391,8 @@ cfg_emtc_analysis_enabled(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = CfgEMTCAnalysisEnabledResponse{};
 
   raise_if_error(
-      stub->CfgEMTCAnalysisEnabled(&context, request, &response));
+      stub->CfgEMTCAnalysisEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1350,7 +1410,8 @@ cfg_external_attenuation(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CfgExternalAttenuationResponse{};
 
   raise_if_error(
-      stub->CfgExternalAttenuation(&context, request, &response));
+      stub->CfgExternalAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1368,7 +1429,8 @@ cfg_frequency(const StubPtr& stub, const nidevice_grpc::Session& instrument, con
   auto response = CfgFrequencyResponse{};
 
   raise_if_error(
-      stub->CfgFrequency(&context, request, &response));
+      stub->CfgFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1395,7 +1457,8 @@ cfg_frequency_earfcn(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = CfgFrequencyEARFCNResponse{};
 
   raise_if_error(
-      stub->CfgFrequencyEARFCN(&context, request, &response));
+      stub->CfgFrequencyEARFCN(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1421,7 +1484,8 @@ cfg_frequency_reference(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = CfgFrequencyReferenceResponse{};
 
   raise_if_error(
-      stub->CfgFrequencyReference(&context, request, &response));
+      stub->CfgFrequencyReference(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1467,7 +1531,8 @@ cfg_iq_power_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = CfgIQPowerEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->CfgIQPowerEdgeTrigger(&context, request, &response));
+      stub->CfgIQPowerEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1492,7 +1557,8 @@ cfg_link_direction(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CfgLinkDirectionResponse{};
 
   raise_if_error(
-      stub->CfgLinkDirection(&context, request, &response));
+      stub->CfgLinkDirection(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1518,7 +1584,8 @@ cfg_mechanical_attenuation(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = CfgMechanicalAttenuationResponse{};
 
   raise_if_error(
-      stub->CfgMechanicalAttenuation(&context, request, &response));
+      stub->CfgMechanicalAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1544,7 +1611,8 @@ cfg_nb_io_t_component_carrier(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = CfgNBIoTComponentCarrierResponse{};
 
   raise_if_error(
-      stub->CfgNBIoTComponentCarrier(&context, request, &response));
+      stub->CfgNBIoTComponentCarrier(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1580,7 +1648,8 @@ cfg_npuschdmrs(const StubPtr& stub, const nidevice_grpc::Session& instrument, co
   auto response = CfgNPUSCHDMRSResponse{};
 
   raise_if_error(
-      stub->CfgNPUSCHDMRS(&context, request, &response));
+      stub->CfgNPUSCHDMRS(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1598,7 +1667,8 @@ cfg_npusch_format(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = CfgNPUSCHFormatResponse{};
 
   raise_if_error(
-      stub->CfgNPUSCHFormat(&context, request, &response));
+      stub->CfgNPUSCHFormat(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1616,7 +1686,8 @@ cfg_npusch_starting_slot(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CfgNPUSCHStartingSlotResponse{};
 
   raise_if_error(
-      stub->CfgNPUSCHStartingSlot(&context, request, &response));
+      stub->CfgNPUSCHStartingSlot(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1643,7 +1714,8 @@ cfg_npusch_tones(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = CfgNPUSCHTonesResponse{};
 
   raise_if_error(
-      stub->CfgNPUSCHTones(&context, request, &response));
+      stub->CfgNPUSCHTones(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1661,7 +1733,8 @@ cfg_number_of_component_carriers(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = CfgNumberOfComponentCarriersResponse{};
 
   raise_if_error(
-      stub->CfgNumberOfComponentCarriers(&context, request, &response));
+      stub->CfgNumberOfComponentCarriers(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1679,7 +1752,8 @@ cfg_number_of_dut_antennas(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = CfgNumberOfDUTAntennasResponse{};
 
   raise_if_error(
-      stub->CfgNumberOfDUTAntennas(&context, request, &response));
+      stub->CfgNumberOfDUTAntennas(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1697,7 +1771,8 @@ cfg_number_of_pdsch_channels(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = CfgNumberOfPDSCHChannelsResponse{};
 
   raise_if_error(
-      stub->CfgNumberOfPDSCHChannels(&context, request, &response));
+      stub->CfgNumberOfPDSCHChannels(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1715,7 +1790,8 @@ cfg_number_of_pusch_resource_block_clusters(const StubPtr& stub, const nidevice_
   auto response = CfgNumberOfPUSCHResourceBlockClustersResponse{};
 
   raise_if_error(
-      stub->CfgNumberOfPUSCHResourceBlockClusters(&context, request, &response));
+      stub->CfgNumberOfPUSCHResourceBlockClusters(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1733,7 +1809,8 @@ cfg_number_of_subblocks(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = CfgNumberOfSubblocksResponse{};
 
   raise_if_error(
-      stub->CfgNumberOfSubblocks(&context, request, &response));
+      stub->CfgNumberOfSubblocks(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1751,7 +1828,8 @@ cfg_pbch(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb
   auto response = CfgPBCHResponse{};
 
   raise_if_error(
-      stub->CfgPBCH(&context, request, &response));
+      stub->CfgPBCH(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1770,7 +1848,8 @@ cfg_pcfich(const StubPtr& stub, const nidevice_grpc::Session& instrument, const 
   auto response = CfgPCFICHResponse{};
 
   raise_if_error(
-      stub->CfgPCFICH(&context, request, &response));
+      stub->CfgPCFICH(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1788,7 +1867,8 @@ cfg_pdcch(const StubPtr& stub, const nidevice_grpc::Session& instrument, const p
   auto response = CfgPDCCHResponse{};
 
   raise_if_error(
-      stub->CfgPDCCH(&context, request, &response));
+      stub->CfgPDCCH(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1815,7 +1895,8 @@ cfg_pdsch(const StubPtr& stub, const nidevice_grpc::Session& instrument, const p
   auto response = CfgPDSCHResponse{};
 
   raise_if_error(
-      stub->CfgPDSCH(&context, request, &response));
+      stub->CfgPDSCH(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1849,7 +1930,8 @@ cfg_phich(const StubPtr& stub, const nidevice_grpc::Session& instrument, const p
   auto response = CfgPHICHResponse{};
 
   raise_if_error(
-      stub->CfgPHICH(&context, request, &response));
+      stub->CfgPHICH(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1867,7 +1949,8 @@ cfg_pssch_modulation_type(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = CfgPSSCHModulationTypeResponse{};
 
   raise_if_error(
-      stub->CfgPSSCHModulationType(&context, request, &response));
+      stub->CfgPSSCHModulationType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1886,7 +1969,8 @@ cfg_pssch_resource_blocks(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = CfgPSSCHResourceBlocksResponse{};
 
   raise_if_error(
-      stub->CfgPSSCHResourceBlocks(&context, request, &response));
+      stub->CfgPSSCHResourceBlocks(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1911,7 +1995,8 @@ cfg_pusch_modulation_type(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = CfgPUSCHModulationTypeResponse{};
 
   raise_if_error(
-      stub->CfgPUSCHModulationType(&context, request, &response));
+      stub->CfgPUSCHModulationType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1930,7 +2015,8 @@ cfg_pusch_resource_blocks(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = CfgPUSCHResourceBlocksResponse{};
 
   raise_if_error(
-      stub->CfgPUSCHResourceBlocks(&context, request, &response));
+      stub->CfgPUSCHResourceBlocks(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1950,7 +2036,8 @@ cfg_rf(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::
   auto response = CfgRFResponse{};
 
   raise_if_error(
-      stub->CfgRF(&context, request, &response));
+      stub->CfgRF(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1976,7 +2063,8 @@ cfg_rf_attenuation(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CfgRFAttenuationResponse{};
 
   raise_if_error(
-      stub->CfgRFAttenuation(&context, request, &response));
+      stub->CfgRFAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1994,7 +2082,8 @@ cfg_reference_level(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = CfgReferenceLevelResponse{};
 
   raise_if_error(
-      stub->CfgReferenceLevel(&context, request, &response));
+      stub->CfgReferenceLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2013,7 +2102,8 @@ cfg_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = CfgSoftwareEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->CfgSoftwareEdgeTrigger(&context, request, &response));
+      stub->CfgSoftwareEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2031,7 +2121,8 @@ cfg_transmit_antenna_to_analyze(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = CfgTransmitAntennaToAnalyzeResponse{};
 
   raise_if_error(
-      stub->CfgTransmitAntennaToAnalyze(&context, request, &response));
+      stub->CfgTransmitAntennaToAnalyze(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2056,7 +2147,8 @@ cfge_node_b_category(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = CfgeNodeBCategoryResponse{};
 
   raise_if_error(
-      stub->CfgeNodeBCategory(&context, request, &response));
+      stub->CfgeNodeBCategory(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2073,7 +2165,8 @@ check_measurement_status(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CheckMeasurementStatusResponse{};
 
   raise_if_error(
-      stub->CheckMeasurementStatus(&context, request, &response));
+      stub->CheckMeasurementStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2090,7 +2183,8 @@ clear_all_named_results(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = ClearAllNamedResultsResponse{};
 
   raise_if_error(
-      stub->ClearAllNamedResults(&context, request, &response));
+      stub->ClearAllNamedResults(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2107,7 +2201,8 @@ clear_named_result(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = ClearNamedResultResponse{};
 
   raise_if_error(
-      stub->ClearNamedResult(&context, request, &response));
+      stub->ClearNamedResult(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2124,7 +2219,8 @@ clear_noise_calibration_database(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ClearNoiseCalibrationDatabaseResponse{};
 
   raise_if_error(
-      stub->ClearNoiseCalibrationDatabase(&context, request, &response));
+      stub->ClearNoiseCalibrationDatabase(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2142,7 +2238,8 @@ clone_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = CloneSignalConfigurationResponse{};
 
   raise_if_error(
-      stub->CloneSignalConfiguration(&context, request, &response));
+      stub->CloneSignalConfiguration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2159,7 +2256,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const bool&
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2176,7 +2274,8 @@ commit(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::
   auto response = CommitResponse{};
 
   raise_if_error(
-      stub->Commit(&context, request, &response));
+      stub->Commit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2193,7 +2292,8 @@ create_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = CreateSignalConfigurationResponse{};
 
   raise_if_error(
-      stub->CreateSignalConfiguration(&context, request, &response));
+      stub->CreateSignalConfiguration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2210,7 +2310,8 @@ delete_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = DeleteSignalConfigurationResponse{};
 
   raise_if_error(
-      stub->DeleteSignalConfiguration(&context, request, &response));
+      stub->DeleteSignalConfiguration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2227,7 +2328,8 @@ disable_trigger(const StubPtr& stub, const nidevice_grpc::Session& instrument, c
   auto response = DisableTriggerResponse{};
 
   raise_if_error(
-      stub->DisableTrigger(&context, request, &response));
+      stub->DisableTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2244,7 +2346,8 @@ get_all_named_result_names(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = GetAllNamedResultNamesResponse{};
 
   raise_if_error(
-      stub->GetAllNamedResultNames(&context, request, &response));
+      stub->GetAllNamedResultNames(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2262,7 +2365,8 @@ get_attribute_f32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeF32Response{};
 
   raise_if_error(
-      stub->GetAttributeF32(&context, request, &response));
+      stub->GetAttributeF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2280,7 +2384,8 @@ get_attribute_f32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeF32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeF32Array(&context, request, &response));
+      stub->GetAttributeF32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2298,7 +2403,8 @@ get_attribute_f64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeF64Response{};
 
   raise_if_error(
-      stub->GetAttributeF64(&context, request, &response));
+      stub->GetAttributeF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2316,7 +2422,8 @@ get_attribute_f64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeF64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeF64Array(&context, request, &response));
+      stub->GetAttributeF64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2334,7 +2441,8 @@ get_attribute_i16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI16Response{};
 
   raise_if_error(
-      stub->GetAttributeI16(&context, request, &response));
+      stub->GetAttributeI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2352,7 +2460,8 @@ get_attribute_i32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI32Response{};
 
   raise_if_error(
-      stub->GetAttributeI32(&context, request, &response));
+      stub->GetAttributeI32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2370,7 +2479,8 @@ get_attribute_i32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeI32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI32Array(&context, request, &response));
+      stub->GetAttributeI32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2388,7 +2498,8 @@ get_attribute_i64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI64Response{};
 
   raise_if_error(
-      stub->GetAttributeI64(&context, request, &response));
+      stub->GetAttributeI64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2406,7 +2517,8 @@ get_attribute_i64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeI64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI64Array(&context, request, &response));
+      stub->GetAttributeI64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2424,7 +2536,8 @@ get_attribute_i8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetAttributeI8Response{};
 
   raise_if_error(
-      stub->GetAttributeI8(&context, request, &response));
+      stub->GetAttributeI8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2442,7 +2555,8 @@ get_attribute_i8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = GetAttributeI8ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI8Array(&context, request, &response));
+      stub->GetAttributeI8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2460,7 +2574,8 @@ get_attribute_ni_complex_double_array(const StubPtr& stub, const nidevice_grpc::
   auto response = GetAttributeNIComplexDoubleArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeNIComplexDoubleArray(&context, request, &response));
+      stub->GetAttributeNIComplexDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2478,7 +2593,8 @@ get_attribute_ni_complex_single_array(const StubPtr& stub, const nidevice_grpc::
   auto response = GetAttributeNIComplexSingleArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeNIComplexSingleArray(&context, request, &response));
+      stub->GetAttributeNIComplexSingleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2496,7 +2612,8 @@ get_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = GetAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeString(&context, request, &response));
+      stub->GetAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2514,7 +2631,8 @@ get_attribute_u16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeU16Response{};
 
   raise_if_error(
-      stub->GetAttributeU16(&context, request, &response));
+      stub->GetAttributeU16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2532,7 +2650,8 @@ get_attribute_u32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeU32Response{};
 
   raise_if_error(
-      stub->GetAttributeU32(&context, request, &response));
+      stub->GetAttributeU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2550,7 +2669,8 @@ get_attribute_u32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeU32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU32Array(&context, request, &response));
+      stub->GetAttributeU32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2568,7 +2688,8 @@ get_attribute_u64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeU64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU64Array(&context, request, &response));
+      stub->GetAttributeU64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2586,7 +2707,8 @@ get_attribute_u8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetAttributeU8Response{};
 
   raise_if_error(
-      stub->GetAttributeU8(&context, request, &response));
+      stub->GetAttributeU8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2604,7 +2726,8 @@ get_attribute_u8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = GetAttributeU8ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU8Array(&context, request, &response));
+      stub->GetAttributeU8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2620,7 +2743,8 @@ get_error(const StubPtr& stub, const nidevice_grpc::Session& instrument)
   auto response = GetErrorResponse{};
 
   raise_if_error(
-      stub->GetError(&context, request, &response));
+      stub->GetError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2637,7 +2761,8 @@ get_error_string(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetErrorStringResponse{};
 
   raise_if_error(
-      stub->GetErrorString(&context, request, &response));
+      stub->GetErrorString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2654,7 +2779,8 @@ initialize(const StubPtr& stub, const pb::string& resource_name, const pb::strin
   auto response = InitializeResponse{};
 
   raise_if_error(
-      stub->Initialize(&context, request, &response));
+      stub->Initialize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2670,7 +2796,8 @@ initialize_from_nirfsa_session(const StubPtr& stub, const nidevice_grpc::Session
   auto response = InitializeFromNIRFSASessionResponse{};
 
   raise_if_error(
-      stub->InitializeFromNIRFSASession(&context, request, &response));
+      stub->InitializeFromNIRFSASession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2688,7 +2815,8 @@ initiate(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb
   auto response = InitiateResponse{};
 
   raise_if_error(
-      stub->Initiate(&context, request, &response));
+      stub->Initiate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2714,7 +2842,8 @@ mod_acc_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = ModAccCfgAveragingResponse{};
 
   raise_if_error(
-      stub->ModAccCfgAveraging(&context, request, &response));
+      stub->ModAccCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2739,7 +2868,8 @@ mod_acc_cfg_common_clock_source_enabled(const StubPtr& stub, const nidevice_grpc
   auto response = ModAccCfgCommonClockSourceEnabledResponse{};
 
   raise_if_error(
-      stub->ModAccCfgCommonClockSourceEnabled(&context, request, &response));
+      stub->ModAccCfgCommonClockSourceEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2764,7 +2894,8 @@ mod_acc_cfg_evm_unit(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = ModAccCfgEVMUnitResponse{};
 
   raise_if_error(
-      stub->ModAccCfgEVMUnit(&context, request, &response));
+      stub->ModAccCfgEVMUnit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2782,7 +2913,8 @@ mod_acc_cfg_fft_window_offset(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ModAccCfgFFTWindowOffsetResponse{};
 
   raise_if_error(
-      stub->ModAccCfgFFTWindowOffset(&context, request, &response));
+      stub->ModAccCfgFFTWindowOffset(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2809,7 +2941,8 @@ mod_acc_cfg_fft_window_position(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = ModAccCfgFFTWindowPositionResponse{};
 
   raise_if_error(
-      stub->ModAccCfgFFTWindowPosition(&context, request, &response));
+      stub->ModAccCfgFFTWindowPosition(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2834,7 +2967,8 @@ mod_acc_cfg_in_band_emission_mask_type(const StubPtr& stub, const nidevice_grpc:
   auto response = ModAccCfgInBandEmissionMaskTypeResponse{};
 
   raise_if_error(
-      stub->ModAccCfgInBandEmissionMaskType(&context, request, &response));
+      stub->ModAccCfgInBandEmissionMaskType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2861,7 +2995,8 @@ mod_acc_cfg_synchronization_mode_and_interval(const StubPtr& stub, const nidevic
   auto response = ModAccCfgSynchronizationModeAndIntervalResponse{};
 
   raise_if_error(
-      stub->ModAccCfgSynchronizationModeAndInterval(&context, request, &response));
+      stub->ModAccCfgSynchronizationModeAndInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2879,7 +3014,8 @@ mod_acc_fetch_csrs_constellation(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ModAccFetchCSRSConstellationResponse{};
 
   raise_if_error(
-      stub->ModAccFetchCSRSConstellation(&context, request, &response));
+      stub->ModAccFetchCSRSConstellation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2897,7 +3033,8 @@ mod_acc_fetch_csrsevm(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = ModAccFetchCSRSEVMResponse{};
 
   raise_if_error(
-      stub->ModAccFetchCSRSEVM(&context, request, &response));
+      stub->ModAccFetchCSRSEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2915,7 +3052,8 @@ mod_acc_fetch_csrsevm_array(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = ModAccFetchCSRSEVMArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchCSRSEVMArray(&context, request, &response));
+      stub->ModAccFetchCSRSEVMArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2933,7 +3071,8 @@ mod_acc_fetch_composite_evm(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = ModAccFetchCompositeEVMResponse{};
 
   raise_if_error(
-      stub->ModAccFetchCompositeEVM(&context, request, &response));
+      stub->ModAccFetchCompositeEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2951,7 +3090,8 @@ mod_acc_fetch_composite_evm_array(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = ModAccFetchCompositeEVMArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchCompositeEVMArray(&context, request, &response));
+      stub->ModAccFetchCompositeEVMArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2969,7 +3109,8 @@ mod_acc_fetch_composite_magnitude_and_phase_error(const StubPtr& stub, const nid
   auto response = ModAccFetchCompositeMagnitudeAndPhaseErrorResponse{};
 
   raise_if_error(
-      stub->ModAccFetchCompositeMagnitudeAndPhaseError(&context, request, &response));
+      stub->ModAccFetchCompositeMagnitudeAndPhaseError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2987,7 +3128,8 @@ mod_acc_fetch_composite_magnitude_and_phase_error_array(const StubPtr& stub, con
   auto response = ModAccFetchCompositeMagnitudeAndPhaseErrorArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchCompositeMagnitudeAndPhaseErrorArray(&context, request, &response));
+      stub->ModAccFetchCompositeMagnitudeAndPhaseErrorArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3005,7 +3147,8 @@ mod_acc_fetch_downlink_detected_cell_id(const StubPtr& stub, const nidevice_grpc
   auto response = ModAccFetchDownlinkDetectedCellIDResponse{};
 
   raise_if_error(
-      stub->ModAccFetchDownlinkDetectedCellID(&context, request, &response));
+      stub->ModAccFetchDownlinkDetectedCellID(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3023,7 +3166,8 @@ mod_acc_fetch_downlink_detected_cell_id_array(const StubPtr& stub, const nidevic
   auto response = ModAccFetchDownlinkDetectedCellIDArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchDownlinkDetectedCellIDArray(&context, request, &response));
+      stub->ModAccFetchDownlinkDetectedCellIDArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3041,7 +3185,8 @@ mod_acc_fetch_downlink_pbch_constellation(const StubPtr& stub, const nidevice_gr
   auto response = ModAccFetchDownlinkPBCHConstellationResponse{};
 
   raise_if_error(
-      stub->ModAccFetchDownlinkPBCHConstellation(&context, request, &response));
+      stub->ModAccFetchDownlinkPBCHConstellation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3059,7 +3204,8 @@ mod_acc_fetch_downlink_pcfich_constellation(const StubPtr& stub, const nidevice_
   auto response = ModAccFetchDownlinkPCFICHConstellationResponse{};
 
   raise_if_error(
-      stub->ModAccFetchDownlinkPCFICHConstellation(&context, request, &response));
+      stub->ModAccFetchDownlinkPCFICHConstellation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3077,7 +3223,8 @@ mod_acc_fetch_downlink_pdcch_constellation(const StubPtr& stub, const nidevice_g
   auto response = ModAccFetchDownlinkPDCCHConstellationResponse{};
 
   raise_if_error(
-      stub->ModAccFetchDownlinkPDCCHConstellation(&context, request, &response));
+      stub->ModAccFetchDownlinkPDCCHConstellation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3095,7 +3242,8 @@ mod_acc_fetch_downlink_phich_constellation(const StubPtr& stub, const nidevice_g
   auto response = ModAccFetchDownlinkPHICHConstellationResponse{};
 
   raise_if_error(
-      stub->ModAccFetchDownlinkPHICHConstellation(&context, request, &response));
+      stub->ModAccFetchDownlinkPHICHConstellation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3113,7 +3261,8 @@ mod_acc_fetch_downlink_transmit_power(const StubPtr& stub, const nidevice_grpc::
   auto response = ModAccFetchDownlinkTransmitPowerResponse{};
 
   raise_if_error(
-      stub->ModAccFetchDownlinkTransmitPower(&context, request, &response));
+      stub->ModAccFetchDownlinkTransmitPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3131,7 +3280,8 @@ mod_acc_fetch_downlink_transmit_power_array(const StubPtr& stub, const nidevice_
   auto response = ModAccFetchDownlinkTransmitPowerArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchDownlinkTransmitPowerArray(&context, request, &response));
+      stub->ModAccFetchDownlinkTransmitPowerArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3149,7 +3299,8 @@ mod_acc_fetch_evm_high_per_symbol_trace(const StubPtr& stub, const nidevice_grpc
   auto response = ModAccFetchEVMHighPerSymbolTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchEVMHighPerSymbolTrace(&context, request, &response));
+      stub->ModAccFetchEVMHighPerSymbolTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3167,7 +3318,8 @@ mod_acc_fetch_evm_low_per_symbol_trace(const StubPtr& stub, const nidevice_grpc:
   auto response = ModAccFetchEVMLowPerSymbolTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchEVMLowPerSymbolTrace(&context, request, &response));
+      stub->ModAccFetchEVMLowPerSymbolTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3185,7 +3337,8 @@ mod_acc_fetch_evm_per_slot_trace(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ModAccFetchEVMPerSlotTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchEVMPerSlotTrace(&context, request, &response));
+      stub->ModAccFetchEVMPerSlotTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3203,7 +3356,8 @@ mod_acc_fetch_evm_per_subcarrier_trace(const StubPtr& stub, const nidevice_grpc:
   auto response = ModAccFetchEVMPerSubcarrierTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchEVMPerSubcarrierTrace(&context, request, &response));
+      stub->ModAccFetchEVMPerSubcarrierTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3221,7 +3375,8 @@ mod_acc_fetch_evm_per_symbol_trace(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ModAccFetchEVMPerSymbolTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchEVMPerSymbolTrace(&context, request, &response));
+      stub->ModAccFetchEVMPerSymbolTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3239,7 +3394,8 @@ mod_acc_fetch_iq_impairments(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ModAccFetchIQImpairmentsResponse{};
 
   raise_if_error(
-      stub->ModAccFetchIQImpairments(&context, request, &response));
+      stub->ModAccFetchIQImpairments(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3257,7 +3413,8 @@ mod_acc_fetch_iq_impairments_array(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ModAccFetchIQImpairmentsArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchIQImpairmentsArray(&context, request, &response));
+      stub->ModAccFetchIQImpairmentsArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3275,7 +3432,8 @@ mod_acc_fetch_in_band_emission_margin(const StubPtr& stub, const nidevice_grpc::
   auto response = ModAccFetchInBandEmissionMarginResponse{};
 
   raise_if_error(
-      stub->ModAccFetchInBandEmissionMargin(&context, request, &response));
+      stub->ModAccFetchInBandEmissionMargin(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3293,7 +3451,8 @@ mod_acc_fetch_in_band_emission_margin_array(const StubPtr& stub, const nidevice_
   auto response = ModAccFetchInBandEmissionMarginArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchInBandEmissionMarginArray(&context, request, &response));
+      stub->ModAccFetchInBandEmissionMarginArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3311,7 +3470,8 @@ mod_acc_fetch_in_band_emission_trace(const StubPtr& stub, const nidevice_grpc::S
   auto response = ModAccFetchInBandEmissionTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchInBandEmissionTrace(&context, request, &response));
+      stub->ModAccFetchInBandEmissionTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3329,7 +3489,8 @@ mod_acc_fetch_maximum_evm_per_slot_trace(const StubPtr& stub, const nidevice_grp
   auto response = ModAccFetchMaximumEVMPerSlotTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchMaximumEVMPerSlotTrace(&context, request, &response));
+      stub->ModAccFetchMaximumEVMPerSlotTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3347,7 +3508,8 @@ mod_acc_fetch_maximum_evm_per_subcarrier_trace(const StubPtr& stub, const nidevi
   auto response = ModAccFetchMaximumEVMPerSubcarrierTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchMaximumEVMPerSubcarrierTrace(&context, request, &response));
+      stub->ModAccFetchMaximumEVMPerSubcarrierTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3365,7 +3527,8 @@ mod_acc_fetch_maximum_evm_per_symbol_trace(const StubPtr& stub, const nidevice_g
   auto response = ModAccFetchMaximumEVMPerSymbolTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchMaximumEVMPerSymbolTrace(&context, request, &response));
+      stub->ModAccFetchMaximumEVMPerSymbolTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3383,7 +3546,8 @@ mod_acc_fetch_maximum_magnitude_error_per_symbol_trace(const StubPtr& stub, cons
   auto response = ModAccFetchMaximumMagnitudeErrorPerSymbolTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchMaximumMagnitudeErrorPerSymbolTrace(&context, request, &response));
+      stub->ModAccFetchMaximumMagnitudeErrorPerSymbolTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3401,7 +3565,8 @@ mod_acc_fetch_maximum_phase_error_per_symbol_trace(const StubPtr& stub, const ni
   auto response = ModAccFetchMaximumPhaseErrorPerSymbolTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchMaximumPhaseErrorPerSymbolTrace(&context, request, &response));
+      stub->ModAccFetchMaximumPhaseErrorPerSymbolTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3419,7 +3584,8 @@ mod_acc_fetch_npusch_constellation_trace(const StubPtr& stub, const nidevice_grp
   auto response = ModAccFetchNPUSCHConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchNPUSCHConstellationTrace(&context, request, &response));
+      stub->ModAccFetchNPUSCHConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3437,7 +3603,8 @@ mod_acc_fetch_npuschdmrsevm(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = ModAccFetchNPUSCHDMRSEVMResponse{};
 
   raise_if_error(
-      stub->ModAccFetchNPUSCHDMRSEVM(&context, request, &response));
+      stub->ModAccFetchNPUSCHDMRSEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3455,7 +3622,8 @@ mod_acc_fetch_npusch_data_evm(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ModAccFetchNPUSCHDataEVMResponse{};
 
   raise_if_error(
-      stub->ModAccFetchNPUSCHDataEVM(&context, request, &response));
+      stub->ModAccFetchNPUSCHDataEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3473,7 +3641,8 @@ mod_acc_fetch_npusch_symbol_power(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = ModAccFetchNPUSCHSymbolPowerResponse{};
 
   raise_if_error(
-      stub->ModAccFetchNPUSCHSymbolPower(&context, request, &response));
+      stub->ModAccFetchNPUSCHSymbolPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3491,7 +3660,8 @@ mod_acc_fetch_pdsch1024q_am_constellation(const StubPtr& stub, const nidevice_gr
   auto response = ModAccFetchPDSCH1024QAMConstellationResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCH1024QAMConstellation(&context, request, &response));
+      stub->ModAccFetchPDSCH1024QAMConstellation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3509,7 +3679,8 @@ mod_acc_fetch_pdsch1024q_amevm(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ModAccFetchPDSCH1024QAMEVMResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCH1024QAMEVM(&context, request, &response));
+      stub->ModAccFetchPDSCH1024QAMEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3527,7 +3698,8 @@ mod_acc_fetch_pdsch1024q_amevm_array(const StubPtr& stub, const nidevice_grpc::S
   auto response = ModAccFetchPDSCH1024QAMEVMArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCH1024QAMEVMArray(&context, request, &response));
+      stub->ModAccFetchPDSCH1024QAMEVMArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3545,7 +3717,8 @@ mod_acc_fetch_pdsch16q_am_constellation(const StubPtr& stub, const nidevice_grpc
   auto response = ModAccFetchPDSCH16QAMConstellationResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCH16QAMConstellation(&context, request, &response));
+      stub->ModAccFetchPDSCH16QAMConstellation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3563,7 +3736,8 @@ mod_acc_fetch_pdsch256q_am_constellation(const StubPtr& stub, const nidevice_grp
   auto response = ModAccFetchPDSCH256QAMConstellationResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCH256QAMConstellation(&context, request, &response));
+      stub->ModAccFetchPDSCH256QAMConstellation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3581,7 +3755,8 @@ mod_acc_fetch_pdsch64q_am_constellation(const StubPtr& stub, const nidevice_grpc
   auto response = ModAccFetchPDSCH64QAMConstellationResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCH64QAMConstellation(&context, request, &response));
+      stub->ModAccFetchPDSCH64QAMConstellation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3599,7 +3774,8 @@ mod_acc_fetch_pdschevm(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = ModAccFetchPDSCHEVMResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCHEVM(&context, request, &response));
+      stub->ModAccFetchPDSCHEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3617,7 +3793,8 @@ mod_acc_fetch_pdschevm_array(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ModAccFetchPDSCHEVMArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCHEVMArray(&context, request, &response));
+      stub->ModAccFetchPDSCHEVMArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3635,7 +3812,8 @@ mod_acc_fetch_pdschqpsk_constellation(const StubPtr& stub, const nidevice_grpc::
   auto response = ModAccFetchPDSCHQPSKConstellationResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCHQPSKConstellation(&context, request, &response));
+      stub->ModAccFetchPDSCHQPSKConstellation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3653,7 +3831,8 @@ mod_acc_fetch_pssch_constellation_trace(const StubPtr& stub, const nidevice_grpc
   auto response = ModAccFetchPSSCHConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPSSCHConstellationTrace(&context, request, &response));
+      stub->ModAccFetchPSSCHConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3671,7 +3850,8 @@ mod_acc_fetch_psschdmrsevm(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = ModAccFetchPSSCHDMRSEVMResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPSSCHDMRSEVM(&context, request, &response));
+      stub->ModAccFetchPSSCHDMRSEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3689,7 +3869,8 @@ mod_acc_fetch_psschdmrsevm_array(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ModAccFetchPSSCHDMRSEVMArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPSSCHDMRSEVMArray(&context, request, &response));
+      stub->ModAccFetchPSSCHDMRSEVMArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3707,7 +3888,8 @@ mod_acc_fetch_pssch_data_evm(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ModAccFetchPSSCHDataEVMResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPSSCHDataEVM(&context, request, &response));
+      stub->ModAccFetchPSSCHDataEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3725,7 +3907,8 @@ mod_acc_fetch_pssch_data_evm_array(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ModAccFetchPSSCHDataEVMArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPSSCHDataEVMArray(&context, request, &response));
+      stub->ModAccFetchPSSCHDataEVMArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3743,7 +3926,8 @@ mod_acc_fetch_pssch_symbol_power(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ModAccFetchPSSCHSymbolPowerResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPSSCHSymbolPower(&context, request, &response));
+      stub->ModAccFetchPSSCHSymbolPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3761,7 +3945,8 @@ mod_acc_fetch_pssch_symbol_power_array(const StubPtr& stub, const nidevice_grpc:
   auto response = ModAccFetchPSSCHSymbolPowerArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPSSCHSymbolPowerArray(&context, request, &response));
+      stub->ModAccFetchPSSCHSymbolPowerArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3779,7 +3964,8 @@ mod_acc_fetch_pusch_constellation_trace(const StubPtr& stub, const nidevice_grpc
   auto response = ModAccFetchPUSCHConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPUSCHConstellationTrace(&context, request, &response));
+      stub->ModAccFetchPUSCHConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3797,7 +3983,8 @@ mod_acc_fetch_puschdmrsevm(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = ModAccFetchPUSCHDMRSEVMResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPUSCHDMRSEVM(&context, request, &response));
+      stub->ModAccFetchPUSCHDMRSEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3815,7 +4002,8 @@ mod_acc_fetch_puschdmrsevm_array(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ModAccFetchPUSCHDMRSEVMArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPUSCHDMRSEVMArray(&context, request, &response));
+      stub->ModAccFetchPUSCHDMRSEVMArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3833,7 +4021,8 @@ mod_acc_fetch_pusch_data_evm(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ModAccFetchPUSCHDataEVMResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPUSCHDataEVM(&context, request, &response));
+      stub->ModAccFetchPUSCHDataEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3851,7 +4040,8 @@ mod_acc_fetch_pusch_data_evm_array(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ModAccFetchPUSCHDataEVMArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPUSCHDataEVMArray(&context, request, &response));
+      stub->ModAccFetchPUSCHDataEVMArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3869,7 +4059,8 @@ mod_acc_fetch_pusch_demodulated_bits(const StubPtr& stub, const nidevice_grpc::S
   auto response = ModAccFetchPUSCHDemodulatedBitsResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPUSCHDemodulatedBits(&context, request, &response));
+      stub->ModAccFetchPUSCHDemodulatedBits(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3887,7 +4078,8 @@ mod_acc_fetch_pusch_symbol_power(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ModAccFetchPUSCHSymbolPowerResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPUSCHSymbolPower(&context, request, &response));
+      stub->ModAccFetchPUSCHSymbolPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3905,7 +4097,8 @@ mod_acc_fetch_pusch_symbol_power_array(const StubPtr& stub, const nidevice_grpc:
   auto response = ModAccFetchPUSCHSymbolPowerArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPUSCHSymbolPowerArray(&context, request, &response));
+      stub->ModAccFetchPUSCHSymbolPowerArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3923,7 +4116,8 @@ mod_acc_fetch_rms_magnitude_error_per_symbol_trace(const StubPtr& stub, const ni
   auto response = ModAccFetchRMSMagnitudeErrorPerSymbolTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchRMSMagnitudeErrorPerSymbolTrace(&context, request, &response));
+      stub->ModAccFetchRMSMagnitudeErrorPerSymbolTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3941,7 +4135,8 @@ mod_acc_fetch_rms_phase_error_per_symbol_trace(const StubPtr& stub, const nidevi
   auto response = ModAccFetchRMSPhaseErrorPerSymbolTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchRMSPhaseErrorPerSymbolTrace(&context, request, &response));
+      stub->ModAccFetchRMSPhaseErrorPerSymbolTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3959,7 +4154,8 @@ mod_acc_fetch_srs_constellation(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = ModAccFetchSRSConstellationResponse{};
 
   raise_if_error(
-      stub->ModAccFetchSRSConstellation(&context, request, &response));
+      stub->ModAccFetchSRSConstellation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3977,7 +4173,8 @@ mod_acc_fetch_srsevm(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = ModAccFetchSRSEVMResponse{};
 
   raise_if_error(
-      stub->ModAccFetchSRSEVM(&context, request, &response));
+      stub->ModAccFetchSRSEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3995,7 +4192,8 @@ mod_acc_fetch_srsevm_array(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = ModAccFetchSRSEVMArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchSRSEVMArray(&context, request, &response));
+      stub->ModAccFetchSRSEVMArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4013,7 +4211,8 @@ mod_acc_fetch_spectral_flatness(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = ModAccFetchSpectralFlatnessResponse{};
 
   raise_if_error(
-      stub->ModAccFetchSpectralFlatness(&context, request, &response));
+      stub->ModAccFetchSpectralFlatness(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4031,7 +4230,8 @@ mod_acc_fetch_spectral_flatness_array(const StubPtr& stub, const nidevice_grpc::
   auto response = ModAccFetchSpectralFlatnessArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchSpectralFlatnessArray(&context, request, &response));
+      stub->ModAccFetchSpectralFlatnessArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4049,7 +4249,8 @@ mod_acc_fetch_spectral_flatness_trace(const StubPtr& stub, const nidevice_grpc::
   auto response = ModAccFetchSpectralFlatnessTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchSpectralFlatnessTrace(&context, request, &response));
+      stub->ModAccFetchSpectralFlatnessTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4067,7 +4268,8 @@ mod_acc_fetch_subblock_iq_impairments(const StubPtr& stub, const nidevice_grpc::
   auto response = ModAccFetchSubblockIQImpairmentsResponse{};
 
   raise_if_error(
-      stub->ModAccFetchSubblockIQImpairments(&context, request, &response));
+      stub->ModAccFetchSubblockIQImpairments(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4085,7 +4287,8 @@ mod_acc_fetch_subblock_in_band_emission_margin(const StubPtr& stub, const nidevi
   auto response = ModAccFetchSubblockInBandEmissionMarginResponse{};
 
   raise_if_error(
-      stub->ModAccFetchSubblockInBandEmissionMargin(&context, request, &response));
+      stub->ModAccFetchSubblockInBandEmissionMargin(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4103,7 +4306,8 @@ mod_acc_fetch_subblock_in_band_emission_trace(const StubPtr& stub, const nidevic
   auto response = ModAccFetchSubblockInBandEmissionTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchSubblockInBandEmissionTrace(&context, request, &response));
+      stub->ModAccFetchSubblockInBandEmissionTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4121,7 +4325,8 @@ mod_acc_fetch_synchronization_signal_constellation(const StubPtr& stub, const ni
   auto response = ModAccFetchSynchronizationSignalConstellationResponse{};
 
   raise_if_error(
-      stub->ModAccFetchSynchronizationSignalConstellation(&context, request, &response));
+      stub->ModAccFetchSynchronizationSignalConstellation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4139,7 +4344,8 @@ mod_acc_fetch_synchronization_signal_evm(const StubPtr& stub, const nidevice_grp
   auto response = ModAccFetchSynchronizationSignalEVMResponse{};
 
   raise_if_error(
-      stub->ModAccFetchSynchronizationSignalEVM(&context, request, &response));
+      stub->ModAccFetchSynchronizationSignalEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4157,7 +4363,8 @@ mod_acc_fetch_synchronization_signal_evm_array(const StubPtr& stub, const nidevi
   auto response = ModAccFetchSynchronizationSignalEVMArrayResponse{};
 
   raise_if_error(
-      stub->ModAccFetchSynchronizationSignalEVMArray(&context, request, &response));
+      stub->ModAccFetchSynchronizationSignalEVMArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4191,7 +4398,8 @@ obw_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = OBWCfgAveragingResponse{};
 
   raise_if_error(
-      stub->OBWCfgAveraging(&context, request, &response));
+      stub->OBWCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4225,7 +4433,8 @@ obw_cfg_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = OBWCfgRBWFilterResponse{};
 
   raise_if_error(
-      stub->OBWCfgRBWFilter(&context, request, &response));
+      stub->OBWCfgRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4251,7 +4460,8 @@ obw_cfg_sweep_time(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = OBWCfgSweepTimeResponse{};
 
   raise_if_error(
-      stub->OBWCfgSweepTime(&context, request, &response));
+      stub->OBWCfgSweepTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4269,7 +4479,8 @@ obw_fetch_measurement(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = OBWFetchMeasurementResponse{};
 
   raise_if_error(
-      stub->OBWFetchMeasurement(&context, request, &response));
+      stub->OBWFetchMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4287,7 +4498,8 @@ obw_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = OBWFetchSpectrumResponse{};
 
   raise_if_error(
-      stub->OBWFetchSpectrum(&context, request, &response));
+      stub->OBWFetchSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4321,7 +4533,8 @@ pvt_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = PVTCfgAveragingResponse{};
 
   raise_if_error(
-      stub->PVTCfgAveraging(&context, request, &response));
+      stub->PVTCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4346,7 +4559,8 @@ pvt_cfg_measurement_method(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = PVTCfgMeasurementMethodResponse{};
 
   raise_if_error(
-      stub->PVTCfgMeasurementMethod(&context, request, &response));
+      stub->PVTCfgMeasurementMethod(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4365,7 +4579,8 @@ pvt_cfg_off_power_exclusion_periods(const StubPtr& stub, const nidevice_grpc::Se
   auto response = PVTCfgOFFPowerExclusionPeriodsResponse{};
 
   raise_if_error(
-      stub->PVTCfgOFFPowerExclusionPeriods(&context, request, &response));
+      stub->PVTCfgOFFPowerExclusionPeriods(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4383,7 +4598,8 @@ pvt_fetch_measurement(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = PVTFetchMeasurementResponse{};
 
   raise_if_error(
-      stub->PVTFetchMeasurement(&context, request, &response));
+      stub->PVTFetchMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4401,7 +4617,8 @@ pvt_fetch_measurement_array(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = PVTFetchMeasurementArrayResponse{};
 
   raise_if_error(
-      stub->PVTFetchMeasurementArray(&context, request, &response));
+      stub->PVTFetchMeasurementArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4419,7 +4636,8 @@ pvt_fetch_signal_power_trace(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = PVTFetchSignalPowerTraceResponse{};
 
   raise_if_error(
-      stub->PVTFetchSignalPowerTrace(&context, request, &response));
+      stub->PVTFetchSignalPowerTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4437,7 +4655,8 @@ reset_attribute(const StubPtr& stub, const nidevice_grpc::Session& instrument, c
   auto response = ResetAttributeResponse{};
 
   raise_if_error(
-      stub->ResetAttribute(&context, request, &response));
+      stub->ResetAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4454,7 +4673,8 @@ reset_to_default(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = ResetToDefaultResponse{};
 
   raise_if_error(
-      stub->ResetToDefault(&context, request, &response));
+      stub->ResetToDefault(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4488,7 +4708,8 @@ sem_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SEMCfgAveragingResponse{};
 
   raise_if_error(
-      stub->SEMCfgAveraging(&context, request, &response));
+      stub->SEMCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4506,7 +4727,8 @@ sem_cfg_component_carrier_maximum_output_power(const StubPtr& stub, const nidevi
   auto response = SEMCfgComponentCarrierMaximumOutputPowerResponse{};
 
   raise_if_error(
-      stub->SEMCfgComponentCarrierMaximumOutputPower(&context, request, &response));
+      stub->SEMCfgComponentCarrierMaximumOutputPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4524,7 +4746,8 @@ sem_cfg_component_carrier_maximum_output_power_array(const StubPtr& stub, const 
   auto response = SEMCfgComponentCarrierMaximumOutputPowerArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgComponentCarrierMaximumOutputPowerArray(&context, request, &response));
+      stub->SEMCfgComponentCarrierMaximumOutputPowerArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4551,7 +4774,8 @@ sem_cfg_downlink_mask(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = SEMCfgDownlinkMaskResponse{};
 
   raise_if_error(
-      stub->SEMCfgDownlinkMask(&context, request, &response));
+      stub->SEMCfgDownlinkMask(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4569,7 +4793,8 @@ sem_cfg_number_of_offsets(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = SEMCfgNumberOfOffsetsResponse{};
 
   raise_if_error(
-      stub->SEMCfgNumberOfOffsets(&context, request, &response));
+      stub->SEMCfgNumberOfOffsets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4588,7 +4813,8 @@ sem_cfg_offset_absolute_limit(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMCfgOffsetAbsoluteLimitResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetAbsoluteLimit(&context, request, &response));
+      stub->SEMCfgOffsetAbsoluteLimit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4607,7 +4833,8 @@ sem_cfg_offset_absolute_limit_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SEMCfgOffsetAbsoluteLimitArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetAbsoluteLimitArray(&context, request, &response));
+      stub->SEMCfgOffsetAbsoluteLimitArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4625,7 +4852,8 @@ sem_cfg_offset_bandwidth_integral(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = SEMCfgOffsetBandwidthIntegralResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetBandwidthIntegral(&context, request, &response));
+      stub->SEMCfgOffsetBandwidthIntegral(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4643,7 +4871,8 @@ sem_cfg_offset_bandwidth_integral_array(const StubPtr& stub, const nidevice_grpc
   auto response = SEMCfgOffsetBandwidthIntegralArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetBandwidthIntegralArray(&context, request, &response));
+      stub->SEMCfgOffsetBandwidthIntegralArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4670,7 +4899,8 @@ sem_cfg_offset_frequency(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = SEMCfgOffsetFrequencyResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetFrequency(&context, request, &response));
+      stub->SEMCfgOffsetFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4690,7 +4920,8 @@ sem_cfg_offset_frequency_array(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SEMCfgOffsetFrequencyArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetFrequencyArray(&context, request, &response));
+      stub->SEMCfgOffsetFrequencyArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4715,7 +4946,8 @@ sem_cfg_offset_limit_fail_mask(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SEMCfgOffsetLimitFailMaskResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetLimitFailMask(&context, request, &response));
+      stub->SEMCfgOffsetLimitFailMask(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4733,7 +4965,8 @@ sem_cfg_offset_limit_fail_mask_array(const StubPtr& stub, const nidevice_grpc::S
   auto response = SEMCfgOffsetLimitFailMaskArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetLimitFailMaskArray(&context, request, &response));
+      stub->SEMCfgOffsetLimitFailMaskArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4759,7 +4992,8 @@ sem_cfg_offset_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = SEMCfgOffsetRBWFilterResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetRBWFilter(&context, request, &response));
+      stub->SEMCfgOffsetRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4778,7 +5012,8 @@ sem_cfg_offset_rbw_filter_array(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = SEMCfgOffsetRBWFilterArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetRBWFilterArray(&context, request, &response));
+      stub->SEMCfgOffsetRBWFilterArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4797,7 +5032,8 @@ sem_cfg_offset_relative_limit(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMCfgOffsetRelativeLimitResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetRelativeLimit(&context, request, &response));
+      stub->SEMCfgOffsetRelativeLimit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4816,7 +5052,8 @@ sem_cfg_offset_relative_limit_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SEMCfgOffsetRelativeLimitArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetRelativeLimitArray(&context, request, &response));
+      stub->SEMCfgOffsetRelativeLimitArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4842,7 +5079,8 @@ sem_cfg_sweep_time(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = SEMCfgSweepTimeResponse{};
 
   raise_if_error(
-      stub->SEMCfgSweepTime(&context, request, &response));
+      stub->SEMCfgSweepTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4867,7 +5105,8 @@ sem_cfg_uplink_mask_type(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = SEMCfgUplinkMaskTypeResponse{};
 
   raise_if_error(
-      stub->SEMCfgUplinkMaskType(&context, request, &response));
+      stub->SEMCfgUplinkMaskType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4885,7 +5124,8 @@ sem_fetch_component_carrier_measurement(const StubPtr& stub, const nidevice_grpc
   auto response = SEMFetchComponentCarrierMeasurementResponse{};
 
   raise_if_error(
-      stub->SEMFetchComponentCarrierMeasurement(&context, request, &response));
+      stub->SEMFetchComponentCarrierMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4903,7 +5143,8 @@ sem_fetch_component_carrier_measurement_array(const StubPtr& stub, const nidevic
   auto response = SEMFetchComponentCarrierMeasurementArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchComponentCarrierMeasurementArray(&context, request, &response));
+      stub->SEMFetchComponentCarrierMeasurementArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4921,7 +5162,8 @@ sem_fetch_lower_offset_margin(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMFetchLowerOffsetMarginResponse{};
 
   raise_if_error(
-      stub->SEMFetchLowerOffsetMargin(&context, request, &response));
+      stub->SEMFetchLowerOffsetMargin(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4939,7 +5181,8 @@ sem_fetch_lower_offset_margin_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SEMFetchLowerOffsetMarginArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchLowerOffsetMarginArray(&context, request, &response));
+      stub->SEMFetchLowerOffsetMarginArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4957,7 +5200,8 @@ sem_fetch_lower_offset_power(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SEMFetchLowerOffsetPowerResponse{};
 
   raise_if_error(
-      stub->SEMFetchLowerOffsetPower(&context, request, &response));
+      stub->SEMFetchLowerOffsetPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4975,7 +5219,8 @@ sem_fetch_lower_offset_power_array(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = SEMFetchLowerOffsetPowerArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchLowerOffsetPowerArray(&context, request, &response));
+      stub->SEMFetchLowerOffsetPowerArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4993,7 +5238,8 @@ sem_fetch_measurement_status(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SEMFetchMeasurementStatusResponse{};
 
   raise_if_error(
-      stub->SEMFetchMeasurementStatus(&context, request, &response));
+      stub->SEMFetchMeasurementStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5011,7 +5257,8 @@ sem_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = SEMFetchSpectrumResponse{};
 
   raise_if_error(
-      stub->SEMFetchSpectrum(&context, request, &response));
+      stub->SEMFetchSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5029,7 +5276,8 @@ sem_fetch_subblock_measurement(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SEMFetchSubblockMeasurementResponse{};
 
   raise_if_error(
-      stub->SEMFetchSubblockMeasurement(&context, request, &response));
+      stub->SEMFetchSubblockMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5047,7 +5295,8 @@ sem_fetch_total_aggregated_power(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = SEMFetchTotalAggregatedPowerResponse{};
 
   raise_if_error(
-      stub->SEMFetchTotalAggregatedPower(&context, request, &response));
+      stub->SEMFetchTotalAggregatedPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5065,7 +5314,8 @@ sem_fetch_upper_offset_margin(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMFetchUpperOffsetMarginResponse{};
 
   raise_if_error(
-      stub->SEMFetchUpperOffsetMargin(&context, request, &response));
+      stub->SEMFetchUpperOffsetMargin(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5083,7 +5333,8 @@ sem_fetch_upper_offset_margin_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SEMFetchUpperOffsetMarginArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchUpperOffsetMarginArray(&context, request, &response));
+      stub->SEMFetchUpperOffsetMarginArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5101,7 +5352,8 @@ sem_fetch_upper_offset_power(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SEMFetchUpperOffsetPowerResponse{};
 
   raise_if_error(
-      stub->SEMFetchUpperOffsetPower(&context, request, &response));
+      stub->SEMFetchUpperOffsetPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5119,7 +5371,8 @@ sem_fetch_upper_offset_power_array(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = SEMFetchUpperOffsetPowerArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchUpperOffsetPowerArray(&context, request, &response));
+      stub->SEMFetchUpperOffsetPowerArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5145,7 +5398,8 @@ select_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = SelectMeasurementsResponse{};
 
   raise_if_error(
-      stub->SelectMeasurements(&context, request, &response));
+      stub->SelectMeasurements(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5161,7 +5415,8 @@ send_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = SendSoftwareEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->SendSoftwareEdgeTrigger(&context, request, &response));
+      stub->SendSoftwareEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5180,7 +5435,8 @@ set_attribute_f32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeF32Response{};
 
   raise_if_error(
-      stub->SetAttributeF32(&context, request, &response));
+      stub->SetAttributeF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5199,7 +5455,8 @@ set_attribute_f32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeF32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeF32Array(&context, request, &response));
+      stub->SetAttributeF32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5218,7 +5475,8 @@ set_attribute_f64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeF64Response{};
 
   raise_if_error(
-      stub->SetAttributeF64(&context, request, &response));
+      stub->SetAttributeF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5237,7 +5495,8 @@ set_attribute_f64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeF64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeF64Array(&context, request, &response));
+      stub->SetAttributeF64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5256,7 +5515,8 @@ set_attribute_i16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI16Response{};
 
   raise_if_error(
-      stub->SetAttributeI16(&context, request, &response));
+      stub->SetAttributeI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5282,7 +5542,8 @@ set_attribute_i32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI32Response{};
 
   raise_if_error(
-      stub->SetAttributeI32(&context, request, &response));
+      stub->SetAttributeI32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5301,7 +5562,8 @@ set_attribute_i32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeI32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI32Array(&context, request, &response));
+      stub->SetAttributeI32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5320,7 +5582,8 @@ set_attribute_i64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI64Response{};
 
   raise_if_error(
-      stub->SetAttributeI64(&context, request, &response));
+      stub->SetAttributeI64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5339,7 +5602,8 @@ set_attribute_i64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeI64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI64Array(&context, request, &response));
+      stub->SetAttributeI64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5358,7 +5622,8 @@ set_attribute_i8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = SetAttributeI8Response{};
 
   raise_if_error(
-      stub->SetAttributeI8(&context, request, &response));
+      stub->SetAttributeI8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5377,7 +5642,8 @@ set_attribute_i8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = SetAttributeI8ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI8Array(&context, request, &response));
+      stub->SetAttributeI8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5396,7 +5662,8 @@ set_attribute_ni_complex_double_array(const StubPtr& stub, const nidevice_grpc::
   auto response = SetAttributeNIComplexDoubleArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeNIComplexDoubleArray(&context, request, &response));
+      stub->SetAttributeNIComplexDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5415,7 +5682,8 @@ set_attribute_ni_complex_single_array(const StubPtr& stub, const nidevice_grpc::
   auto response = SetAttributeNIComplexSingleArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeNIComplexSingleArray(&context, request, &response));
+      stub->SetAttributeNIComplexSingleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5441,7 +5709,8 @@ set_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = SetAttributeStringResponse{};
 
   raise_if_error(
-      stub->SetAttributeString(&context, request, &response));
+      stub->SetAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5460,7 +5729,8 @@ set_attribute_u16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeU16Response{};
 
   raise_if_error(
-      stub->SetAttributeU16(&context, request, &response));
+      stub->SetAttributeU16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5479,7 +5749,8 @@ set_attribute_u32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeU32Response{};
 
   raise_if_error(
-      stub->SetAttributeU32(&context, request, &response));
+      stub->SetAttributeU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5498,7 +5769,8 @@ set_attribute_u32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeU32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU32Array(&context, request, &response));
+      stub->SetAttributeU32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5517,7 +5789,8 @@ set_attribute_u64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeU64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU64Array(&context, request, &response));
+      stub->SetAttributeU64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5536,7 +5809,8 @@ set_attribute_u8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = SetAttributeU8Response{};
 
   raise_if_error(
-      stub->SetAttributeU8(&context, request, &response));
+      stub->SetAttributeU8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5555,7 +5829,8 @@ set_attribute_u8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = SetAttributeU8ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU8Array(&context, request, &response));
+      stub->SetAttributeU8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5582,7 +5857,8 @@ slot_phase_cfg_synchronization_mode_and_interval(const StubPtr& stub, const nide
   auto response = SlotPhaseCfgSynchronizationModeAndIntervalResponse{};
 
   raise_if_error(
-      stub->SlotPhaseCfgSynchronizationModeAndInterval(&context, request, &response));
+      stub->SlotPhaseCfgSynchronizationModeAndInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5600,7 +5876,8 @@ slot_phase_fetch_maximum_phase_discontinuity(const StubPtr& stub, const nidevice
   auto response = SlotPhaseFetchMaximumPhaseDiscontinuityResponse{};
 
   raise_if_error(
-      stub->SlotPhaseFetchMaximumPhaseDiscontinuity(&context, request, &response));
+      stub->SlotPhaseFetchMaximumPhaseDiscontinuity(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5618,7 +5895,8 @@ slot_phase_fetch_maximum_phase_discontinuity_array(const StubPtr& stub, const ni
   auto response = SlotPhaseFetchMaximumPhaseDiscontinuityArrayResponse{};
 
   raise_if_error(
-      stub->SlotPhaseFetchMaximumPhaseDiscontinuityArray(&context, request, &response));
+      stub->SlotPhaseFetchMaximumPhaseDiscontinuityArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5636,7 +5914,8 @@ slot_phase_fetch_phase_discontinuities(const StubPtr& stub, const nidevice_grpc:
   auto response = SlotPhaseFetchPhaseDiscontinuitiesResponse{};
 
   raise_if_error(
-      stub->SlotPhaseFetchPhaseDiscontinuities(&context, request, &response));
+      stub->SlotPhaseFetchPhaseDiscontinuities(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5654,7 +5933,8 @@ slot_phase_fetch_sample_phase_error(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SlotPhaseFetchSamplePhaseErrorResponse{};
 
   raise_if_error(
-      stub->SlotPhaseFetchSamplePhaseError(&context, request, &response));
+      stub->SlotPhaseFetchSamplePhaseError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5672,7 +5952,8 @@ slot_phase_fetch_sample_phase_error_linear_fit_trace(const StubPtr& stub, const 
   auto response = SlotPhaseFetchSamplePhaseErrorLinearFitTraceResponse{};
 
   raise_if_error(
-      stub->SlotPhaseFetchSamplePhaseErrorLinearFitTrace(&context, request, &response));
+      stub->SlotPhaseFetchSamplePhaseErrorLinearFitTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5691,7 +5972,8 @@ slot_power_cfg_measurement_interval(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SlotPowerCfgMeasurementIntervalResponse{};
 
   raise_if_error(
-      stub->SlotPowerCfgMeasurementInterval(&context, request, &response));
+      stub->SlotPowerCfgMeasurementInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5709,7 +5991,8 @@ slot_power_fetch_powers(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SlotPowerFetchPowersResponse{};
 
   raise_if_error(
-      stub->SlotPowerFetchPowers(&context, request, &response));
+      stub->SlotPowerFetchPowers(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5726,7 +6009,8 @@ wait_for_acquisition_complete(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = WaitForAcquisitionCompleteResponse{};
 
   raise_if_error(
-      stub->WaitForAcquisitionComplete(&context, request, &response));
+      stub->WaitForAcquisitionComplete(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5744,7 +6028,8 @@ wait_for_measurement_complete(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = WaitForMeasurementCompleteResponse{};
 
   raise_if_error(
-      stub->WaitForMeasurementComplete(&context, request, &response));
+      stub->WaitForMeasurementComplete(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nirfmxnr/nirfmxnr_client.cpp
+++ b/generated/nirfmxnr/nirfmxnr_client.cpp
@@ -46,7 +46,8 @@ acp_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = ACPCfgAveragingResponse{};
 
   raise_if_error(
-      stub->ACPCfgAveraging(&context, request, &response));
+      stub->ACPCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -71,7 +72,8 @@ acp_cfg_measurement_method(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = ACPCfgMeasurementMethodResponse{};
 
   raise_if_error(
-      stub->ACPCfgMeasurementMethod(&context, request, &response));
+      stub->ACPCfgMeasurementMethod(&context, request, &response),
+      context);
 
   return response;
 }
@@ -96,7 +98,8 @@ acp_cfg_noise_compensation_enabled(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ACPCfgNoiseCompensationEnabledResponse{};
 
   raise_if_error(
-      stub->ACPCfgNoiseCompensationEnabled(&context, request, &response));
+      stub->ACPCfgNoiseCompensationEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -114,7 +117,8 @@ acp_cfg_number_of_endc_offsets(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ACPCfgNumberOfENDCOffsetsResponse{};
 
   raise_if_error(
-      stub->ACPCfgNumberOfENDCOffsets(&context, request, &response));
+      stub->ACPCfgNumberOfENDCOffsets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -132,7 +136,8 @@ acp_cfg_number_of_eutra_offsets(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = ACPCfgNumberOfEUTRAOffsetsResponse{};
 
   raise_if_error(
-      stub->ACPCfgNumberOfEUTRAOffsets(&context, request, &response));
+      stub->ACPCfgNumberOfEUTRAOffsets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -150,7 +155,8 @@ acp_cfg_number_of_nr_offsets(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ACPCfgNumberOfNROffsetsResponse{};
 
   raise_if_error(
-      stub->ACPCfgNumberOfNROffsets(&context, request, &response));
+      stub->ACPCfgNumberOfNROffsets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -168,7 +174,8 @@ acp_cfg_number_of_utra_offsets(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ACPCfgNumberOfUTRAOffsetsResponse{};
 
   raise_if_error(
-      stub->ACPCfgNumberOfUTRAOffsets(&context, request, &response));
+      stub->ACPCfgNumberOfUTRAOffsets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -193,7 +200,8 @@ acp_cfg_power_units(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = ACPCfgPowerUnitsResponse{};
 
   raise_if_error(
-      stub->ACPCfgPowerUnits(&context, request, &response));
+      stub->ACPCfgPowerUnits(&context, request, &response),
+      context);
 
   return response;
 }
@@ -227,7 +235,8 @@ acp_cfg_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = ACPCfgRBWFilterResponse{};
 
   raise_if_error(
-      stub->ACPCfgRBWFilter(&context, request, &response));
+      stub->ACPCfgRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -253,7 +262,8 @@ acp_cfg_sweep_time(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = ACPCfgSweepTimeResponse{};
 
   raise_if_error(
-      stub->ACPCfgSweepTime(&context, request, &response));
+      stub->ACPCfgSweepTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -272,7 +282,8 @@ acp_fetch_absolute_powers_trace(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = ACPFetchAbsolutePowersTraceResponse{};
 
   raise_if_error(
-      stub->ACPFetchAbsolutePowersTrace(&context, request, &response));
+      stub->ACPFetchAbsolutePowersTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -290,7 +301,8 @@ acp_fetch_component_carrier_measurement(const StubPtr& stub, const nidevice_grpc
   auto response = ACPFetchComponentCarrierMeasurementResponse{};
 
   raise_if_error(
-      stub->ACPFetchComponentCarrierMeasurement(&context, request, &response));
+      stub->ACPFetchComponentCarrierMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -308,7 +320,8 @@ acp_fetch_component_carrier_measurement_array(const StubPtr& stub, const nidevic
   auto response = ACPFetchComponentCarrierMeasurementArrayResponse{};
 
   raise_if_error(
-      stub->ACPFetchComponentCarrierMeasurementArray(&context, request, &response));
+      stub->ACPFetchComponentCarrierMeasurementArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -326,7 +339,8 @@ acp_fetch_offset_measurement(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ACPFetchOffsetMeasurementResponse{};
 
   raise_if_error(
-      stub->ACPFetchOffsetMeasurement(&context, request, &response));
+      stub->ACPFetchOffsetMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -344,7 +358,8 @@ acp_fetch_offset_measurement_array(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ACPFetchOffsetMeasurementArrayResponse{};
 
   raise_if_error(
-      stub->ACPFetchOffsetMeasurementArray(&context, request, &response));
+      stub->ACPFetchOffsetMeasurementArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -363,7 +378,8 @@ acp_fetch_relative_powers_trace(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = ACPFetchRelativePowersTraceResponse{};
 
   raise_if_error(
-      stub->ACPFetchRelativePowersTrace(&context, request, &response));
+      stub->ACPFetchRelativePowersTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -381,7 +397,8 @@ acp_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = ACPFetchSpectrumResponse{};
 
   raise_if_error(
-      stub->ACPFetchSpectrum(&context, request, &response));
+      stub->ACPFetchSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -399,7 +416,8 @@ acp_fetch_subblock_measurement(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ACPFetchSubblockMeasurementResponse{};
 
   raise_if_error(
-      stub->ACPFetchSubblockMeasurement(&context, request, &response));
+      stub->ACPFetchSubblockMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -417,7 +435,8 @@ acp_fetch_total_aggregated_power(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ACPFetchTotalAggregatedPowerResponse{};
 
   raise_if_error(
-      stub->ACPFetchTotalAggregatedPower(&context, request, &response));
+      stub->ACPFetchTotalAggregatedPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -434,7 +453,8 @@ acp_validate_noise_calibration_data(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ACPValidateNoiseCalibrationDataResponse{};
 
   raise_if_error(
-      stub->ACPValidateNoiseCalibrationData(&context, request, &response));
+      stub->ACPValidateNoiseCalibrationData(&context, request, &response),
+      context);
 
   return response;
 }
@@ -451,7 +471,8 @@ abort_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = AbortMeasurementsResponse{};
 
   raise_if_error(
-      stub->AbortMeasurements(&context, request, &response));
+      stub->AbortMeasurements(&context, request, &response),
+      context);
 
   return response;
 }
@@ -473,7 +494,8 @@ analyze_iq1_waveform(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = AnalyzeIQ1WaveformResponse{};
 
   raise_if_error(
-      stub->AnalyzeIQ1Waveform(&context, request, &response));
+      stub->AnalyzeIQ1Waveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -495,7 +517,8 @@ analyze_spectrum1_waveform(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = AnalyzeSpectrum1WaveformResponse{};
 
   raise_if_error(
-      stub->AnalyzeSpectrum1Waveform(&context, request, &response));
+      stub->AnalyzeSpectrum1Waveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -513,7 +536,8 @@ auto_level(const StubPtr& stub, const nidevice_grpc::Session& instrument, const 
   auto response = AutoLevelResponse{};
 
   raise_if_error(
-      stub->AutoLevel(&context, request, &response));
+      stub->AutoLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -530,7 +554,8 @@ build_bandwidth_part_string(const StubPtr& stub, const pb::string& selector_stri
   auto response = BuildBandwidthPartStringResponse{};
 
   raise_if_error(
-      stub->BuildBandwidthPartString(&context, request, &response));
+      stub->BuildBandwidthPartString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -547,7 +572,8 @@ build_coreset_cluster_string(const StubPtr& stub, const pb::string& selector_str
   auto response = BuildCORESETClusterStringResponse{};
 
   raise_if_error(
-      stub->BuildCORESETClusterString(&context, request, &response));
+      stub->BuildCORESETClusterString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -564,7 +590,8 @@ build_coreset_string(const StubPtr& stub, const pb::string& selector_string, con
   auto response = BuildCORESETStringResponse{};
 
   raise_if_error(
-      stub->BuildCORESETString(&context, request, &response));
+      stub->BuildCORESETString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -581,7 +608,8 @@ build_carrier_string(const StubPtr& stub, const pb::string& selector_string, con
   auto response = BuildCarrierStringResponse{};
 
   raise_if_error(
-      stub->BuildCarrierString(&context, request, &response));
+      stub->BuildCarrierString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -599,7 +627,8 @@ build_list_step_string(const StubPtr& stub, const pb::string& list_name, const p
   auto response = BuildListStepStringResponse{};
 
   raise_if_error(
-      stub->BuildListStepString(&context, request, &response));
+      stub->BuildListStepString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -616,7 +645,8 @@ build_list_string(const StubPtr& stub, const pb::string& list_name, const pb::st
   auto response = BuildListStringResponse{};
 
   raise_if_error(
-      stub->BuildListString(&context, request, &response));
+      stub->BuildListString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -633,7 +663,8 @@ build_offset_string(const StubPtr& stub, const pb::string& selector_string, cons
   auto response = BuildOffsetStringResponse{};
 
   raise_if_error(
-      stub->BuildOffsetString(&context, request, &response));
+      stub->BuildOffsetString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -650,7 +681,8 @@ build_pdcch_string(const StubPtr& stub, const pb::string& selector_string, const
   auto response = BuildPDCCHStringResponse{};
 
   raise_if_error(
-      stub->BuildPDCCHString(&context, request, &response));
+      stub->BuildPDCCHString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -667,7 +699,8 @@ build_pdsch_cluster_string(const StubPtr& stub, const pb::string& selector_strin
   auto response = BuildPDSCHClusterStringResponse{};
 
   raise_if_error(
-      stub->BuildPDSCHClusterString(&context, request, &response));
+      stub->BuildPDSCHClusterString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -684,7 +717,8 @@ build_pdsch_string(const StubPtr& stub, const pb::string& selector_string, const
   auto response = BuildPDSCHStringResponse{};
 
   raise_if_error(
-      stub->BuildPDSCHString(&context, request, &response));
+      stub->BuildPDSCHString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -701,7 +735,8 @@ build_pusch_cluster_string(const StubPtr& stub, const pb::string& selector_strin
   auto response = BuildPUSCHClusterStringResponse{};
 
   raise_if_error(
-      stub->BuildPUSCHClusterString(&context, request, &response));
+      stub->BuildPUSCHClusterString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -718,7 +753,8 @@ build_pusch_string(const StubPtr& stub, const pb::string& selector_string, const
   auto response = BuildPUSCHStringResponse{};
 
   raise_if_error(
-      stub->BuildPUSCHString(&context, request, &response));
+      stub->BuildPUSCHString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -735,7 +771,8 @@ build_signal_string(const StubPtr& stub, const pb::string& signal_name, const pb
   auto response = BuildSignalStringResponse{};
 
   raise_if_error(
-      stub->BuildSignalString(&context, request, &response));
+      stub->BuildSignalString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -752,7 +789,8 @@ build_subblock_string(const StubPtr& stub, const pb::string& selector_string, co
   auto response = BuildSubblockStringResponse{};
 
   raise_if_error(
-      stub->BuildSubblockString(&context, request, &response));
+      stub->BuildSubblockString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -769,7 +807,8 @@ build_user_string(const StubPtr& stub, const pb::string& selector_string, const 
   auto response = BuildUserStringResponse{};
 
   raise_if_error(
-      stub->BuildUserString(&context, request, &response));
+      stub->BuildUserString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -803,7 +842,8 @@ chp_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = CHPCfgAveragingResponse{};
 
   raise_if_error(
-      stub->CHPCfgAveraging(&context, request, &response));
+      stub->CHPCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -837,7 +877,8 @@ chp_cfg_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CHPCfgRBWFilterResponse{};
 
   raise_if_error(
-      stub->CHPCfgRBWFilter(&context, request, &response));
+      stub->CHPCfgRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -863,7 +904,8 @@ chp_cfg_sweep_time(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CHPCfgSweepTimeResponse{};
 
   raise_if_error(
-      stub->CHPCfgSweepTime(&context, request, &response));
+      stub->CHPCfgSweepTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -881,7 +923,8 @@ chp_fetch_component_carrier_measurement(const StubPtr& stub, const nidevice_grpc
   auto response = CHPFetchComponentCarrierMeasurementResponse{};
 
   raise_if_error(
-      stub->CHPFetchComponentCarrierMeasurement(&context, request, &response));
+      stub->CHPFetchComponentCarrierMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -899,7 +942,8 @@ chp_fetch_component_carrier_measurement_array(const StubPtr& stub, const nidevic
   auto response = CHPFetchComponentCarrierMeasurementArrayResponse{};
 
   raise_if_error(
-      stub->CHPFetchComponentCarrierMeasurementArray(&context, request, &response));
+      stub->CHPFetchComponentCarrierMeasurementArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -917,7 +961,8 @@ chp_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CHPFetchSpectrumResponse{};
 
   raise_if_error(
-      stub->CHPFetchSpectrum(&context, request, &response));
+      stub->CHPFetchSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -935,7 +980,8 @@ chp_fetch_subblock_power(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CHPFetchSubblockPowerResponse{};
 
   raise_if_error(
-      stub->CHPFetchSubblockPower(&context, request, &response));
+      stub->CHPFetchSubblockPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -953,7 +999,8 @@ chp_fetch_total_aggregated_power(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = CHPFetchTotalAggregatedPowerResponse{};
 
   raise_if_error(
-      stub->CHPFetchTotalAggregatedPower(&context, request, &response));
+      stub->CHPFetchTotalAggregatedPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -970,7 +1017,8 @@ chp_validate_noise_calibration_data(const StubPtr& stub, const nidevice_grpc::Se
   auto response = CHPValidateNoiseCalibrationDataResponse{};
 
   raise_if_error(
-      stub->CHPValidateNoiseCalibrationData(&context, request, &response));
+      stub->CHPValidateNoiseCalibrationData(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1005,7 +1053,8 @@ cfg_digital_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CfgDigitalEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->CfgDigitalEdgeTrigger(&context, request, &response));
+      stub->CfgDigitalEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1023,7 +1072,8 @@ cfg_external_attenuation(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CfgExternalAttenuationResponse{};
 
   raise_if_error(
-      stub->CfgExternalAttenuation(&context, request, &response));
+      stub->CfgExternalAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1041,7 +1091,8 @@ cfg_frequency(const StubPtr& stub, const nidevice_grpc::Session& instrument, con
   auto response = CfgFrequencyResponse{};
 
   raise_if_error(
-      stub->CfgFrequency(&context, request, &response));
+      stub->CfgFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1067,7 +1118,8 @@ cfg_frequency_reference(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = CfgFrequencyReferenceResponse{};
 
   raise_if_error(
-      stub->CfgFrequencyReference(&context, request, &response));
+      stub->CfgFrequencyReference(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1113,7 +1165,8 @@ cfg_iq_power_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = CfgIQPowerEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->CfgIQPowerEdgeTrigger(&context, request, &response));
+      stub->CfgIQPowerEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1139,7 +1192,8 @@ cfg_mechanical_attenuation(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = CfgMechanicalAttenuationResponse{};
 
   raise_if_error(
-      stub->CfgMechanicalAttenuation(&context, request, &response));
+      stub->CfgMechanicalAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1159,7 +1213,8 @@ cfg_rf(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::
   auto response = CfgRFResponse{};
 
   raise_if_error(
-      stub->CfgRF(&context, request, &response));
+      stub->CfgRF(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1185,7 +1240,8 @@ cfg_rf_attenuation(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CfgRFAttenuationResponse{};
 
   raise_if_error(
-      stub->CfgRFAttenuation(&context, request, &response));
+      stub->CfgRFAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1203,7 +1259,8 @@ cfg_reference_level(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = CfgReferenceLevelResponse{};
 
   raise_if_error(
-      stub->CfgReferenceLevel(&context, request, &response));
+      stub->CfgReferenceLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1222,7 +1279,8 @@ cfg_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = CfgSoftwareEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->CfgSoftwareEdgeTrigger(&context, request, &response));
+      stub->CfgSoftwareEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1247,7 +1305,8 @@ cfgg_node_b_category(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = CfggNodeBCategoryResponse{};
 
   raise_if_error(
-      stub->CfggNodeBCategory(&context, request, &response));
+      stub->CfggNodeBCategory(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1264,7 +1323,8 @@ check_measurement_status(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CheckMeasurementStatusResponse{};
 
   raise_if_error(
-      stub->CheckMeasurementStatus(&context, request, &response));
+      stub->CheckMeasurementStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1281,7 +1341,8 @@ clear_all_named_results(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = ClearAllNamedResultsResponse{};
 
   raise_if_error(
-      stub->ClearAllNamedResults(&context, request, &response));
+      stub->ClearAllNamedResults(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1298,7 +1359,8 @@ clear_named_result(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = ClearNamedResultResponse{};
 
   raise_if_error(
-      stub->ClearNamedResult(&context, request, &response));
+      stub->ClearNamedResult(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1315,7 +1377,8 @@ clear_noise_calibration_database(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ClearNoiseCalibrationDatabaseResponse{};
 
   raise_if_error(
-      stub->ClearNoiseCalibrationDatabase(&context, request, &response));
+      stub->ClearNoiseCalibrationDatabase(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1333,7 +1396,8 @@ clone_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = CloneSignalConfigurationResponse{};
 
   raise_if_error(
-      stub->CloneSignalConfiguration(&context, request, &response));
+      stub->CloneSignalConfiguration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1350,7 +1414,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const bool&
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1367,7 +1432,8 @@ commit(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::
   auto response = CommitResponse{};
 
   raise_if_error(
-      stub->Commit(&context, request, &response));
+      stub->Commit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1384,7 +1450,8 @@ create_list(const StubPtr& stub, const nidevice_grpc::Session& instrument, const
   auto response = CreateListResponse{};
 
   raise_if_error(
-      stub->CreateList(&context, request, &response));
+      stub->CreateList(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1401,7 +1468,8 @@ create_list_step(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = CreateListStepResponse{};
 
   raise_if_error(
-      stub->CreateListStep(&context, request, &response));
+      stub->CreateListStep(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1418,7 +1486,8 @@ create_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = CreateSignalConfigurationResponse{};
 
   raise_if_error(
-      stub->CreateSignalConfiguration(&context, request, &response));
+      stub->CreateSignalConfiguration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1435,7 +1504,8 @@ delete_list(const StubPtr& stub, const nidevice_grpc::Session& instrument, const
   auto response = DeleteListResponse{};
 
   raise_if_error(
-      stub->DeleteList(&context, request, &response));
+      stub->DeleteList(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1452,7 +1522,8 @@ delete_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = DeleteSignalConfigurationResponse{};
 
   raise_if_error(
-      stub->DeleteSignalConfiguration(&context, request, &response));
+      stub->DeleteSignalConfiguration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1469,7 +1540,8 @@ disable_trigger(const StubPtr& stub, const nidevice_grpc::Session& instrument, c
   auto response = DisableTriggerResponse{};
 
   raise_if_error(
-      stub->DisableTrigger(&context, request, &response));
+      stub->DisableTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1486,7 +1558,8 @@ get_all_named_result_names(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = GetAllNamedResultNamesResponse{};
 
   raise_if_error(
-      stub->GetAllNamedResultNames(&context, request, &response));
+      stub->GetAllNamedResultNames(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1504,7 +1577,8 @@ get_attribute_f32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeF32Response{};
 
   raise_if_error(
-      stub->GetAttributeF32(&context, request, &response));
+      stub->GetAttributeF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1522,7 +1596,8 @@ get_attribute_f32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeF32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeF32Array(&context, request, &response));
+      stub->GetAttributeF32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1540,7 +1615,8 @@ get_attribute_f64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeF64Response{};
 
   raise_if_error(
-      stub->GetAttributeF64(&context, request, &response));
+      stub->GetAttributeF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1558,7 +1634,8 @@ get_attribute_f64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeF64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeF64Array(&context, request, &response));
+      stub->GetAttributeF64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1576,7 +1653,8 @@ get_attribute_i16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI16Response{};
 
   raise_if_error(
-      stub->GetAttributeI16(&context, request, &response));
+      stub->GetAttributeI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1594,7 +1672,8 @@ get_attribute_i32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI32Response{};
 
   raise_if_error(
-      stub->GetAttributeI32(&context, request, &response));
+      stub->GetAttributeI32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1612,7 +1691,8 @@ get_attribute_i32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeI32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI32Array(&context, request, &response));
+      stub->GetAttributeI32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1630,7 +1710,8 @@ get_attribute_i64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI64Response{};
 
   raise_if_error(
-      stub->GetAttributeI64(&context, request, &response));
+      stub->GetAttributeI64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1648,7 +1729,8 @@ get_attribute_i64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeI64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI64Array(&context, request, &response));
+      stub->GetAttributeI64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1666,7 +1748,8 @@ get_attribute_i8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetAttributeI8Response{};
 
   raise_if_error(
-      stub->GetAttributeI8(&context, request, &response));
+      stub->GetAttributeI8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1684,7 +1767,8 @@ get_attribute_i8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = GetAttributeI8ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI8Array(&context, request, &response));
+      stub->GetAttributeI8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1702,7 +1786,8 @@ get_attribute_ni_complex_double_array(const StubPtr& stub, const nidevice_grpc::
   auto response = GetAttributeNIComplexDoubleArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeNIComplexDoubleArray(&context, request, &response));
+      stub->GetAttributeNIComplexDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1720,7 +1805,8 @@ get_attribute_ni_complex_single_array(const StubPtr& stub, const nidevice_grpc::
   auto response = GetAttributeNIComplexSingleArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeNIComplexSingleArray(&context, request, &response));
+      stub->GetAttributeNIComplexSingleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1738,7 +1824,8 @@ get_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = GetAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeString(&context, request, &response));
+      stub->GetAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1756,7 +1843,8 @@ get_attribute_u16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeU16Response{};
 
   raise_if_error(
-      stub->GetAttributeU16(&context, request, &response));
+      stub->GetAttributeU16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1774,7 +1862,8 @@ get_attribute_u32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeU32Response{};
 
   raise_if_error(
-      stub->GetAttributeU32(&context, request, &response));
+      stub->GetAttributeU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1792,7 +1881,8 @@ get_attribute_u32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeU32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU32Array(&context, request, &response));
+      stub->GetAttributeU32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1810,7 +1900,8 @@ get_attribute_u64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeU64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU64Array(&context, request, &response));
+      stub->GetAttributeU64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1828,7 +1919,8 @@ get_attribute_u8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetAttributeU8Response{};
 
   raise_if_error(
-      stub->GetAttributeU8(&context, request, &response));
+      stub->GetAttributeU8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1846,7 +1938,8 @@ get_attribute_u8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = GetAttributeU8ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU8Array(&context, request, &response));
+      stub->GetAttributeU8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1862,7 +1955,8 @@ get_error(const StubPtr& stub, const nidevice_grpc::Session& instrument)
   auto response = GetErrorResponse{};
 
   raise_if_error(
-      stub->GetError(&context, request, &response));
+      stub->GetError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1879,7 +1973,8 @@ get_error_string(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetErrorStringResponse{};
 
   raise_if_error(
-      stub->GetErrorString(&context, request, &response));
+      stub->GetErrorString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1896,7 +1991,8 @@ initialize(const StubPtr& stub, const pb::string& resource_name, const pb::strin
   auto response = InitializeResponse{};
 
   raise_if_error(
-      stub->Initialize(&context, request, &response));
+      stub->Initialize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1912,7 +2008,8 @@ initialize_from_nirfsa_session(const StubPtr& stub, const nidevice_grpc::Session
   auto response = InitializeFromNIRFSASessionResponse{};
 
   raise_if_error(
-      stub->InitializeFromNIRFSASession(&context, request, &response));
+      stub->InitializeFromNIRFSASession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1930,7 +2027,8 @@ initiate(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb
   auto response = InitiateResponse{};
 
   raise_if_error(
-      stub->Initiate(&context, request, &response));
+      stub->Initiate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1948,7 +2046,8 @@ mod_acc_auto_level(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = ModAccAutoLevelResponse{};
 
   raise_if_error(
-      stub->ModAccAutoLevel(&context, request, &response));
+      stub->ModAccAutoLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1973,7 +2072,8 @@ mod_acc_cfg_measurement_mode(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ModAccCfgMeasurementModeResponse{};
 
   raise_if_error(
-      stub->ModAccCfgMeasurementMode(&context, request, &response));
+      stub->ModAccCfgMeasurementMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1998,7 +2098,8 @@ mod_acc_cfg_noise_compensation_enabled(const StubPtr& stub, const nidevice_grpc:
   auto response = ModAccCfgNoiseCompensationEnabledResponse{};
 
   raise_if_error(
-      stub->ModAccCfgNoiseCompensationEnabled(&context, request, &response));
+      stub->ModAccCfgNoiseCompensationEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2018,7 +2119,8 @@ mod_acc_cfg_reference_waveform(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ModAccCfgReferenceWaveformResponse{};
 
   raise_if_error(
-      stub->ModAccCfgReferenceWaveform(&context, request, &response));
+      stub->ModAccCfgReferenceWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2034,7 +2136,8 @@ mod_acc_clear_noise_calibration_database(const StubPtr& stub, const nidevice_grp
   auto response = ModAccClearNoiseCalibrationDatabaseResponse{};
 
   raise_if_error(
-      stub->ModAccClearNoiseCalibrationDatabase(&context, request, &response));
+      stub->ModAccClearNoiseCalibrationDatabase(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2052,7 +2155,8 @@ mod_acc_fetch_composite_evm(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = ModAccFetchCompositeEVMResponse{};
 
   raise_if_error(
-      stub->ModAccFetchCompositeEVM(&context, request, &response));
+      stub->ModAccFetchCompositeEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2070,7 +2174,8 @@ mod_acc_fetch_frequency_error_mean(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ModAccFetchFrequencyErrorMeanResponse{};
 
   raise_if_error(
-      stub->ModAccFetchFrequencyErrorMean(&context, request, &response));
+      stub->ModAccFetchFrequencyErrorMean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2088,7 +2193,8 @@ mod_acc_fetch_frequency_error_per_slot_maximum_trace(const StubPtr& stub, const 
   auto response = ModAccFetchFrequencyErrorPerSlotMaximumTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchFrequencyErrorPerSlotMaximumTrace(&context, request, &response));
+      stub->ModAccFetchFrequencyErrorPerSlotMaximumTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2106,7 +2212,8 @@ mod_acc_fetch_iq_gain_imbalance_per_subcarrier_mean_trace(const StubPtr& stub, c
   auto response = ModAccFetchIQGainImbalancePerSubcarrierMeanTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchIQGainImbalancePerSubcarrierMeanTrace(&context, request, &response));
+      stub->ModAccFetchIQGainImbalancePerSubcarrierMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2124,7 +2231,8 @@ mod_acc_fetch_iq_quadrature_error_per_subcarrier_mean_trace(const StubPtr& stub,
   auto response = ModAccFetchIQQuadratureErrorPerSubcarrierMeanTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchIQQuadratureErrorPerSubcarrierMeanTrace(&context, request, &response));
+      stub->ModAccFetchIQQuadratureErrorPerSubcarrierMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2142,7 +2250,8 @@ mod_acc_fetch_in_band_emission_trace(const StubPtr& stub, const nidevice_grpc::S
   auto response = ModAccFetchInBandEmissionTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchInBandEmissionTrace(&context, request, &response));
+      stub->ModAccFetchInBandEmissionTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2160,7 +2269,8 @@ mod_acc_fetch_pbchdmrs_constellation_trace(const StubPtr& stub, const nidevice_g
   auto response = ModAccFetchPBCHDMRSConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPBCHDMRSConstellationTrace(&context, request, &response));
+      stub->ModAccFetchPBCHDMRSConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2178,7 +2288,8 @@ mod_acc_fetch_pbchdmrsrmsevm_per_subcarrier_mean_trace(const StubPtr& stub, cons
   auto response = ModAccFetchPBCHDMRSRMSEVMPerSubcarrierMeanTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPBCHDMRSRMSEVMPerSubcarrierMeanTrace(&context, request, &response));
+      stub->ModAccFetchPBCHDMRSRMSEVMPerSubcarrierMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2196,7 +2307,8 @@ mod_acc_fetch_pbchdmrsrmsevm_per_symbol_mean_trace(const StubPtr& stub, const ni
   auto response = ModAccFetchPBCHDMRSRMSEVMPerSymbolMeanTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPBCHDMRSRMSEVMPerSymbolMeanTrace(&context, request, &response));
+      stub->ModAccFetchPBCHDMRSRMSEVMPerSymbolMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2214,7 +2326,8 @@ mod_acc_fetch_pbch_data_constellation_trace(const StubPtr& stub, const nidevice_
   auto response = ModAccFetchPBCHDataConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPBCHDataConstellationTrace(&context, request, &response));
+      stub->ModAccFetchPBCHDataConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2232,7 +2345,8 @@ mod_acc_fetch_pbch_data_rmsevm_per_subcarrier_mean_trace(const StubPtr& stub, co
   auto response = ModAccFetchPBCHDataRMSEVMPerSubcarrierMeanTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPBCHDataRMSEVMPerSubcarrierMeanTrace(&context, request, &response));
+      stub->ModAccFetchPBCHDataRMSEVMPerSubcarrierMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2250,7 +2364,8 @@ mod_acc_fetch_pbch_data_rmsevm_per_symbol_mean_trace(const StubPtr& stub, const 
   auto response = ModAccFetchPBCHDataRMSEVMPerSymbolMeanTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPBCHDataRMSEVMPerSymbolMeanTrace(&context, request, &response));
+      stub->ModAccFetchPBCHDataRMSEVMPerSymbolMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2268,7 +2383,8 @@ mod_acc_fetch_pdsch1024q_am_constellation_trace(const StubPtr& stub, const nidev
   auto response = ModAccFetchPDSCH1024QAMConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCH1024QAMConstellationTrace(&context, request, &response));
+      stub->ModAccFetchPDSCH1024QAMConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2286,7 +2402,8 @@ mod_acc_fetch_pdsch16q_am_constellation_trace(const StubPtr& stub, const nidevic
   auto response = ModAccFetchPDSCH16QAMConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCH16QAMConstellationTrace(&context, request, &response));
+      stub->ModAccFetchPDSCH16QAMConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2304,7 +2421,8 @@ mod_acc_fetch_pdsch256q_am_constellation_trace(const StubPtr& stub, const nidevi
   auto response = ModAccFetchPDSCH256QAMConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCH256QAMConstellationTrace(&context, request, &response));
+      stub->ModAccFetchPDSCH256QAMConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2322,7 +2440,8 @@ mod_acc_fetch_pdsch64q_am_constellation_trace(const StubPtr& stub, const nidevic
   auto response = ModAccFetchPDSCH64QAMConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCH64QAMConstellationTrace(&context, request, &response));
+      stub->ModAccFetchPDSCH64QAMConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2340,7 +2459,8 @@ mod_acc_fetch_pdsch8p_sk_constellation_trace(const StubPtr& stub, const nidevice
   auto response = ModAccFetchPDSCH8PSKConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCH8PSKConstellationTrace(&context, request, &response));
+      stub->ModAccFetchPDSCH8PSKConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2358,7 +2478,8 @@ mod_acc_fetch_pdschdmrs_constellation_trace(const StubPtr& stub, const nidevice_
   auto response = ModAccFetchPDSCHDMRSConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCHDMRSConstellationTrace(&context, request, &response));
+      stub->ModAccFetchPDSCHDMRSConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2376,7 +2497,8 @@ mod_acc_fetch_pdsch_data_constellation_trace(const StubPtr& stub, const nidevice
   auto response = ModAccFetchPDSCHDataConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCHDataConstellationTrace(&context, request, &response));
+      stub->ModAccFetchPDSCHDataConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2394,7 +2516,8 @@ mod_acc_fetch_pdsch_demodulated_bits(const StubPtr& stub, const nidevice_grpc::S
   auto response = ModAccFetchPDSCHDemodulatedBitsResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCHDemodulatedBits(&context, request, &response));
+      stub->ModAccFetchPDSCHDemodulatedBits(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2412,7 +2535,8 @@ mod_acc_fetch_pdschptrs_constellation_trace(const StubPtr& stub, const nidevice_
   auto response = ModAccFetchPDSCHPTRSConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCHPTRSConstellationTrace(&context, request, &response));
+      stub->ModAccFetchPDSCHPTRSConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2430,7 +2554,8 @@ mod_acc_fetch_pdschqpsk_constellation_trace(const StubPtr& stub, const nidevice_
   auto response = ModAccFetchPDSCHQPSKConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPDSCHQPSKConstellationTrace(&context, request, &response));
+      stub->ModAccFetchPDSCHQPSKConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2448,7 +2573,8 @@ mod_acc_fetch_pss_constellation_trace(const StubPtr& stub, const nidevice_grpc::
   auto response = ModAccFetchPSSConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPSSConstellationTrace(&context, request, &response));
+      stub->ModAccFetchPSSConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2466,7 +2592,8 @@ mod_acc_fetch_pssrmsevm_per_subcarrier_mean_trace(const StubPtr& stub, const nid
   auto response = ModAccFetchPSSRMSEVMPerSubcarrierMeanTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPSSRMSEVMPerSubcarrierMeanTrace(&context, request, &response));
+      stub->ModAccFetchPSSRMSEVMPerSubcarrierMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2484,7 +2611,8 @@ mod_acc_fetch_pssrmsevm_per_symbol_mean_trace(const StubPtr& stub, const nidevic
   auto response = ModAccFetchPSSRMSEVMPerSymbolMeanTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPSSRMSEVMPerSymbolMeanTrace(&context, request, &response));
+      stub->ModAccFetchPSSRMSEVMPerSymbolMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2502,7 +2630,8 @@ mod_acc_fetch_puschdmrs_constellation_trace(const StubPtr& stub, const nidevice_
   auto response = ModAccFetchPUSCHDMRSConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPUSCHDMRSConstellationTrace(&context, request, &response));
+      stub->ModAccFetchPUSCHDMRSConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2520,7 +2649,8 @@ mod_acc_fetch_pusch_data_constellation_trace(const StubPtr& stub, const nidevice
   auto response = ModAccFetchPUSCHDataConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPUSCHDataConstellationTrace(&context, request, &response));
+      stub->ModAccFetchPUSCHDataConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2538,7 +2668,8 @@ mod_acc_fetch_pusch_demodulated_bits(const StubPtr& stub, const nidevice_grpc::S
   auto response = ModAccFetchPUSCHDemodulatedBitsResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPUSCHDemodulatedBits(&context, request, &response));
+      stub->ModAccFetchPUSCHDemodulatedBits(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2556,7 +2687,8 @@ mod_acc_fetch_puschptrs_constellation_trace(const StubPtr& stub, const nidevice_
   auto response = ModAccFetchPUSCHPTRSConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPUSCHPTRSConstellationTrace(&context, request, &response));
+      stub->ModAccFetchPUSCHPTRSConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2574,7 +2706,8 @@ mod_acc_fetch_peak_evm_per_slot_maximum_trace(const StubPtr& stub, const nidevic
   auto response = ModAccFetchPeakEVMPerSlotMaximumTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPeakEVMPerSlotMaximumTrace(&context, request, &response));
+      stub->ModAccFetchPeakEVMPerSlotMaximumTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2592,7 +2725,8 @@ mod_acc_fetch_peak_evm_per_subcarrier_maximum_trace(const StubPtr& stub, const n
   auto response = ModAccFetchPeakEVMPerSubcarrierMaximumTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPeakEVMPerSubcarrierMaximumTrace(&context, request, &response));
+      stub->ModAccFetchPeakEVMPerSubcarrierMaximumTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2610,7 +2744,8 @@ mod_acc_fetch_peak_evm_per_symbol_maximum_trace(const StubPtr& stub, const nidev
   auto response = ModAccFetchPeakEVMPerSymbolMaximumTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchPeakEVMPerSymbolMaximumTrace(&context, request, &response));
+      stub->ModAccFetchPeakEVMPerSymbolMaximumTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2628,7 +2763,8 @@ mod_acc_fetch_rmsevm_high_per_symbol_mean_trace(const StubPtr& stub, const nidev
   auto response = ModAccFetchRMSEVMHighPerSymbolMeanTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchRMSEVMHighPerSymbolMeanTrace(&context, request, &response));
+      stub->ModAccFetchRMSEVMHighPerSymbolMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2646,7 +2782,8 @@ mod_acc_fetch_rmsevm_low_per_symbol_mean_trace(const StubPtr& stub, const nidevi
   auto response = ModAccFetchRMSEVMLowPerSymbolMeanTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchRMSEVMLowPerSymbolMeanTrace(&context, request, &response));
+      stub->ModAccFetchRMSEVMLowPerSymbolMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2664,7 +2801,8 @@ mod_acc_fetch_rmsevm_per_slot_mean_trace(const StubPtr& stub, const nidevice_grp
   auto response = ModAccFetchRMSEVMPerSlotMeanTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchRMSEVMPerSlotMeanTrace(&context, request, &response));
+      stub->ModAccFetchRMSEVMPerSlotMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2682,7 +2820,8 @@ mod_acc_fetch_rmsevm_per_subcarrier_mean_trace(const StubPtr& stub, const nidevi
   auto response = ModAccFetchRMSEVMPerSubcarrierMeanTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchRMSEVMPerSubcarrierMeanTrace(&context, request, &response));
+      stub->ModAccFetchRMSEVMPerSubcarrierMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2700,7 +2839,8 @@ mod_acc_fetch_rmsevm_per_symbol_mean_trace(const StubPtr& stub, const nidevice_g
   auto response = ModAccFetchRMSEVMPerSymbolMeanTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchRMSEVMPerSymbolMeanTrace(&context, request, &response));
+      stub->ModAccFetchRMSEVMPerSymbolMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2718,7 +2858,8 @@ mod_acc_fetch_sss_constellation_trace(const StubPtr& stub, const nidevice_grpc::
   auto response = ModAccFetchSSSConstellationTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchSSSConstellationTrace(&context, request, &response));
+      stub->ModAccFetchSSSConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2736,7 +2877,8 @@ mod_acc_fetch_sssrmsevm_per_subcarrier_mean_trace(const StubPtr& stub, const nid
   auto response = ModAccFetchSSSRMSEVMPerSubcarrierMeanTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchSSSRMSEVMPerSubcarrierMeanTrace(&context, request, &response));
+      stub->ModAccFetchSSSRMSEVMPerSubcarrierMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2754,7 +2896,8 @@ mod_acc_fetch_sssrmsevm_per_symbol_mean_trace(const StubPtr& stub, const nidevic
   auto response = ModAccFetchSSSRMSEVMPerSymbolMeanTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchSSSRMSEVMPerSymbolMeanTrace(&context, request, &response));
+      stub->ModAccFetchSSSRMSEVMPerSymbolMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2772,7 +2915,8 @@ mod_acc_fetch_spectral_flatness_trace(const StubPtr& stub, const nidevice_grpc::
   auto response = ModAccFetchSpectralFlatnessTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchSpectralFlatnessTrace(&context, request, &response));
+      stub->ModAccFetchSpectralFlatnessTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2790,7 +2934,8 @@ mod_acc_fetch_subblock_in_band_emission_trace(const StubPtr& stub, const nidevic
   auto response = ModAccFetchSubblockInBandEmissionTraceResponse{};
 
   raise_if_error(
-      stub->ModAccFetchSubblockInBandEmissionTrace(&context, request, &response));
+      stub->ModAccFetchSubblockInBandEmissionTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2807,7 +2952,8 @@ mod_acc_validate_calibration_data(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = ModAccValidateCalibrationDataResponse{};
 
   raise_if_error(
-      stub->ModAccValidateCalibrationData(&context, request, &response));
+      stub->ModAccValidateCalibrationData(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2841,7 +2987,8 @@ obw_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = OBWCfgAveragingResponse{};
 
   raise_if_error(
-      stub->OBWCfgAveraging(&context, request, &response));
+      stub->OBWCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2875,7 +3022,8 @@ obw_cfg_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = OBWCfgRBWFilterResponse{};
 
   raise_if_error(
-      stub->OBWCfgRBWFilter(&context, request, &response));
+      stub->OBWCfgRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2901,7 +3049,8 @@ obw_cfg_sweep_time(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = OBWCfgSweepTimeResponse{};
 
   raise_if_error(
-      stub->OBWCfgSweepTime(&context, request, &response));
+      stub->OBWCfgSweepTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2919,7 +3068,8 @@ obw_fetch_measurement(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = OBWFetchMeasurementResponse{};
 
   raise_if_error(
-      stub->OBWFetchMeasurement(&context, request, &response));
+      stub->OBWFetchMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2937,7 +3087,8 @@ obw_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = OBWFetchSpectrumResponse{};
 
   raise_if_error(
-      stub->OBWFetchSpectrum(&context, request, &response));
+      stub->OBWFetchSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2971,7 +3122,8 @@ pvt_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = PVTCfgAveragingResponse{};
 
   raise_if_error(
-      stub->PVTCfgAveraging(&context, request, &response));
+      stub->PVTCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2996,7 +3148,8 @@ pvt_cfg_measurement_method(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = PVTCfgMeasurementMethodResponse{};
 
   raise_if_error(
-      stub->PVTCfgMeasurementMethod(&context, request, &response));
+      stub->PVTCfgMeasurementMethod(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3015,7 +3168,8 @@ pvt_cfg_off_power_exclusion_periods(const StubPtr& stub, const nidevice_grpc::Se
   auto response = PVTCfgOFFPowerExclusionPeriodsResponse{};
 
   raise_if_error(
-      stub->PVTCfgOFFPowerExclusionPeriods(&context, request, &response));
+      stub->PVTCfgOFFPowerExclusionPeriods(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3033,7 +3187,8 @@ pvt_fetch_measurement(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = PVTFetchMeasurementResponse{};
 
   raise_if_error(
-      stub->PVTFetchMeasurement(&context, request, &response));
+      stub->PVTFetchMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3051,7 +3206,8 @@ pvt_fetch_measurement_array(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = PVTFetchMeasurementArrayResponse{};
 
   raise_if_error(
-      stub->PVTFetchMeasurementArray(&context, request, &response));
+      stub->PVTFetchMeasurementArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3069,7 +3225,8 @@ pvt_fetch_signal_power_trace(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = PVTFetchSignalPowerTraceResponse{};
 
   raise_if_error(
-      stub->PVTFetchSignalPowerTrace(&context, request, &response));
+      stub->PVTFetchSignalPowerTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3087,7 +3244,8 @@ pvt_fetch_windowed_signal_power_trace(const StubPtr& stub, const nidevice_grpc::
   auto response = PVTFetchWindowedSignalPowerTraceResponse{};
 
   raise_if_error(
-      stub->PVTFetchWindowedSignalPowerTrace(&context, request, &response));
+      stub->PVTFetchWindowedSignalPowerTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3105,7 +3263,8 @@ reset_attribute(const StubPtr& stub, const nidevice_grpc::Session& instrument, c
   auto response = ResetAttributeResponse{};
 
   raise_if_error(
-      stub->ResetAttribute(&context, request, &response));
+      stub->ResetAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3122,7 +3281,8 @@ reset_to_default(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = ResetToDefaultResponse{};
 
   raise_if_error(
-      stub->ResetToDefault(&context, request, &response));
+      stub->ResetToDefault(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3156,7 +3316,8 @@ sem_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SEMCfgAveragingResponse{};
 
   raise_if_error(
-      stub->SEMCfgAveraging(&context, request, &response));
+      stub->SEMCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3174,7 +3335,8 @@ sem_cfg_component_carrier_rated_output_power(const StubPtr& stub, const nidevice
   auto response = SEMCfgComponentCarrierRatedOutputPowerResponse{};
 
   raise_if_error(
-      stub->SEMCfgComponentCarrierRatedOutputPower(&context, request, &response));
+      stub->SEMCfgComponentCarrierRatedOutputPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3192,7 +3354,8 @@ sem_cfg_component_carrier_rated_output_power_array(const StubPtr& stub, const ni
   auto response = SEMCfgComponentCarrierRatedOutputPowerArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgComponentCarrierRatedOutputPowerArray(&context, request, &response));
+      stub->SEMCfgComponentCarrierRatedOutputPowerArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3210,7 +3373,8 @@ sem_cfg_number_of_offsets(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = SEMCfgNumberOfOffsetsResponse{};
 
   raise_if_error(
-      stub->SEMCfgNumberOfOffsets(&context, request, &response));
+      stub->SEMCfgNumberOfOffsets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3229,7 +3393,8 @@ sem_cfg_offset_absolute_limit(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMCfgOffsetAbsoluteLimitResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetAbsoluteLimit(&context, request, &response));
+      stub->SEMCfgOffsetAbsoluteLimit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3248,7 +3413,8 @@ sem_cfg_offset_absolute_limit_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SEMCfgOffsetAbsoluteLimitArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetAbsoluteLimitArray(&context, request, &response));
+      stub->SEMCfgOffsetAbsoluteLimitArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3266,7 +3432,8 @@ sem_cfg_offset_bandwidth_integral(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = SEMCfgOffsetBandwidthIntegralResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetBandwidthIntegral(&context, request, &response));
+      stub->SEMCfgOffsetBandwidthIntegral(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3284,7 +3451,8 @@ sem_cfg_offset_bandwidth_integral_array(const StubPtr& stub, const nidevice_grpc
   auto response = SEMCfgOffsetBandwidthIntegralArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetBandwidthIntegralArray(&context, request, &response));
+      stub->SEMCfgOffsetBandwidthIntegralArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3311,7 +3479,8 @@ sem_cfg_offset_frequency(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = SEMCfgOffsetFrequencyResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetFrequency(&context, request, &response));
+      stub->SEMCfgOffsetFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3331,7 +3500,8 @@ sem_cfg_offset_frequency_array(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SEMCfgOffsetFrequencyArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetFrequencyArray(&context, request, &response));
+      stub->SEMCfgOffsetFrequencyArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3356,7 +3526,8 @@ sem_cfg_offset_limit_fail_mask(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SEMCfgOffsetLimitFailMaskResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetLimitFailMask(&context, request, &response));
+      stub->SEMCfgOffsetLimitFailMask(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3374,7 +3545,8 @@ sem_cfg_offset_limit_fail_mask_array(const StubPtr& stub, const nidevice_grpc::S
   auto response = SEMCfgOffsetLimitFailMaskArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetLimitFailMaskArray(&context, request, &response));
+      stub->SEMCfgOffsetLimitFailMaskArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3400,7 +3572,8 @@ sem_cfg_offset_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = SEMCfgOffsetRBWFilterResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetRBWFilter(&context, request, &response));
+      stub->SEMCfgOffsetRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3419,7 +3592,8 @@ sem_cfg_offset_rbw_filter_array(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = SEMCfgOffsetRBWFilterArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetRBWFilterArray(&context, request, &response));
+      stub->SEMCfgOffsetRBWFilterArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3438,7 +3612,8 @@ sem_cfg_offset_relative_limit(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMCfgOffsetRelativeLimitResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetRelativeLimit(&context, request, &response));
+      stub->SEMCfgOffsetRelativeLimit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3457,7 +3632,8 @@ sem_cfg_offset_relative_limit_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SEMCfgOffsetRelativeLimitArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetRelativeLimitArray(&context, request, &response));
+      stub->SEMCfgOffsetRelativeLimitArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3483,7 +3659,8 @@ sem_cfg_sweep_time(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = SEMCfgSweepTimeResponse{};
 
   raise_if_error(
-      stub->SEMCfgSweepTime(&context, request, &response));
+      stub->SEMCfgSweepTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3508,7 +3685,8 @@ sem_cfg_uplink_mask_type(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = SEMCfgUplinkMaskTypeResponse{};
 
   raise_if_error(
-      stub->SEMCfgUplinkMaskType(&context, request, &response));
+      stub->SEMCfgUplinkMaskType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3526,7 +3704,8 @@ sem_fetch_component_carrier_measurement(const StubPtr& stub, const nidevice_grpc
   auto response = SEMFetchComponentCarrierMeasurementResponse{};
 
   raise_if_error(
-      stub->SEMFetchComponentCarrierMeasurement(&context, request, &response));
+      stub->SEMFetchComponentCarrierMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3544,7 +3723,8 @@ sem_fetch_component_carrier_measurement_array(const StubPtr& stub, const nidevic
   auto response = SEMFetchComponentCarrierMeasurementArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchComponentCarrierMeasurementArray(&context, request, &response));
+      stub->SEMFetchComponentCarrierMeasurementArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3562,7 +3742,8 @@ sem_fetch_lower_offset_margin(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMFetchLowerOffsetMarginResponse{};
 
   raise_if_error(
-      stub->SEMFetchLowerOffsetMargin(&context, request, &response));
+      stub->SEMFetchLowerOffsetMargin(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3580,7 +3761,8 @@ sem_fetch_lower_offset_margin_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SEMFetchLowerOffsetMarginArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchLowerOffsetMarginArray(&context, request, &response));
+      stub->SEMFetchLowerOffsetMarginArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3598,7 +3780,8 @@ sem_fetch_lower_offset_power(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SEMFetchLowerOffsetPowerResponse{};
 
   raise_if_error(
-      stub->SEMFetchLowerOffsetPower(&context, request, &response));
+      stub->SEMFetchLowerOffsetPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3616,7 +3799,8 @@ sem_fetch_lower_offset_power_array(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = SEMFetchLowerOffsetPowerArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchLowerOffsetPowerArray(&context, request, &response));
+      stub->SEMFetchLowerOffsetPowerArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3634,7 +3818,8 @@ sem_fetch_measurement_status(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SEMFetchMeasurementStatusResponse{};
 
   raise_if_error(
-      stub->SEMFetchMeasurementStatus(&context, request, &response));
+      stub->SEMFetchMeasurementStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3652,7 +3837,8 @@ sem_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = SEMFetchSpectrumResponse{};
 
   raise_if_error(
-      stub->SEMFetchSpectrum(&context, request, &response));
+      stub->SEMFetchSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3670,7 +3856,8 @@ sem_fetch_subblock_measurement(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SEMFetchSubblockMeasurementResponse{};
 
   raise_if_error(
-      stub->SEMFetchSubblockMeasurement(&context, request, &response));
+      stub->SEMFetchSubblockMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3688,7 +3875,8 @@ sem_fetch_total_aggregated_power(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = SEMFetchTotalAggregatedPowerResponse{};
 
   raise_if_error(
-      stub->SEMFetchTotalAggregatedPower(&context, request, &response));
+      stub->SEMFetchTotalAggregatedPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3706,7 +3894,8 @@ sem_fetch_upper_offset_margin(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMFetchUpperOffsetMarginResponse{};
 
   raise_if_error(
-      stub->SEMFetchUpperOffsetMargin(&context, request, &response));
+      stub->SEMFetchUpperOffsetMargin(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3724,7 +3913,8 @@ sem_fetch_upper_offset_margin_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SEMFetchUpperOffsetMarginArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchUpperOffsetMarginArray(&context, request, &response));
+      stub->SEMFetchUpperOffsetMarginArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3742,7 +3932,8 @@ sem_fetch_upper_offset_power(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SEMFetchUpperOffsetPowerResponse{};
 
   raise_if_error(
-      stub->SEMFetchUpperOffsetPower(&context, request, &response));
+      stub->SEMFetchUpperOffsetPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3760,7 +3951,8 @@ sem_fetch_upper_offset_power_array(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = SEMFetchUpperOffsetPowerArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchUpperOffsetPowerArray(&context, request, &response));
+      stub->SEMFetchUpperOffsetPowerArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3786,7 +3978,8 @@ select_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = SelectMeasurementsResponse{};
 
   raise_if_error(
-      stub->SelectMeasurements(&context, request, &response));
+      stub->SelectMeasurements(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3802,7 +3995,8 @@ send_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = SendSoftwareEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->SendSoftwareEdgeTrigger(&context, request, &response));
+      stub->SendSoftwareEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3821,7 +4015,8 @@ set_attribute_f32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeF32Response{};
 
   raise_if_error(
-      stub->SetAttributeF32(&context, request, &response));
+      stub->SetAttributeF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3840,7 +4035,8 @@ set_attribute_f32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeF32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeF32Array(&context, request, &response));
+      stub->SetAttributeF32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3859,7 +4055,8 @@ set_attribute_f64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeF64Response{};
 
   raise_if_error(
-      stub->SetAttributeF64(&context, request, &response));
+      stub->SetAttributeF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3878,7 +4075,8 @@ set_attribute_f64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeF64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeF64Array(&context, request, &response));
+      stub->SetAttributeF64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3897,7 +4095,8 @@ set_attribute_i16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI16Response{};
 
   raise_if_error(
-      stub->SetAttributeI16(&context, request, &response));
+      stub->SetAttributeI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3923,7 +4122,8 @@ set_attribute_i32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI32Response{};
 
   raise_if_error(
-      stub->SetAttributeI32(&context, request, &response));
+      stub->SetAttributeI32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3942,7 +4142,8 @@ set_attribute_i32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeI32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI32Array(&context, request, &response));
+      stub->SetAttributeI32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3961,7 +4162,8 @@ set_attribute_i64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI64Response{};
 
   raise_if_error(
-      stub->SetAttributeI64(&context, request, &response));
+      stub->SetAttributeI64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3980,7 +4182,8 @@ set_attribute_i64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeI64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI64Array(&context, request, &response));
+      stub->SetAttributeI64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3999,7 +4202,8 @@ set_attribute_i8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = SetAttributeI8Response{};
 
   raise_if_error(
-      stub->SetAttributeI8(&context, request, &response));
+      stub->SetAttributeI8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4018,7 +4222,8 @@ set_attribute_i8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = SetAttributeI8ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI8Array(&context, request, &response));
+      stub->SetAttributeI8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4037,7 +4242,8 @@ set_attribute_ni_complex_double_array(const StubPtr& stub, const nidevice_grpc::
   auto response = SetAttributeNIComplexDoubleArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeNIComplexDoubleArray(&context, request, &response));
+      stub->SetAttributeNIComplexDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4056,7 +4262,8 @@ set_attribute_ni_complex_single_array(const StubPtr& stub, const nidevice_grpc::
   auto response = SetAttributeNIComplexSingleArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeNIComplexSingleArray(&context, request, &response));
+      stub->SetAttributeNIComplexSingleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4082,7 +4289,8 @@ set_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = SetAttributeStringResponse{};
 
   raise_if_error(
-      stub->SetAttributeString(&context, request, &response));
+      stub->SetAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4101,7 +4309,8 @@ set_attribute_u16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeU16Response{};
 
   raise_if_error(
-      stub->SetAttributeU16(&context, request, &response));
+      stub->SetAttributeU16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4120,7 +4329,8 @@ set_attribute_u32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeU32Response{};
 
   raise_if_error(
-      stub->SetAttributeU32(&context, request, &response));
+      stub->SetAttributeU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4139,7 +4349,8 @@ set_attribute_u32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeU32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU32Array(&context, request, &response));
+      stub->SetAttributeU32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4158,7 +4369,8 @@ set_attribute_u64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeU64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU64Array(&context, request, &response));
+      stub->SetAttributeU64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4177,7 +4389,8 @@ set_attribute_u8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = SetAttributeU8Response{};
 
   raise_if_error(
-      stub->SetAttributeU8(&context, request, &response));
+      stub->SetAttributeU8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4196,7 +4409,8 @@ set_attribute_u8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = SetAttributeU8ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU8Array(&context, request, &response));
+      stub->SetAttributeU8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4214,7 +4428,8 @@ txp_fetch_measurement(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = TXPFetchMeasurementResponse{};
 
   raise_if_error(
-      stub->TXPFetchMeasurement(&context, request, &response));
+      stub->TXPFetchMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4232,7 +4447,8 @@ txp_fetch_power_trace(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = TXPFetchPowerTraceResponse{};
 
   raise_if_error(
-      stub->TXPFetchPowerTrace(&context, request, &response));
+      stub->TXPFetchPowerTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4249,7 +4465,8 @@ wait_for_acquisition_complete(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = WaitForAcquisitionCompleteResponse{};
 
   raise_if_error(
-      stub->WaitForAcquisitionComplete(&context, request, &response));
+      stub->WaitForAcquisitionComplete(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4267,7 +4484,8 @@ wait_for_measurement_complete(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = WaitForMeasurementCompleteResponse{};
 
   raise_if_error(
-      stub->WaitForMeasurementComplete(&context, request, &response));
+      stub->WaitForMeasurementComplete(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nirfmxspecan/nirfmxspecan_client.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_client.cpp
@@ -46,7 +46,8 @@ acp_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = ACPCfgAveragingResponse{};
 
   raise_if_error(
-      stub->ACPCfgAveraging(&context, request, &response));
+      stub->ACPCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -66,7 +67,8 @@ acp_cfg_carrier_and_offsets(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = ACPCfgCarrierAndOffsetsResponse{};
 
   raise_if_error(
-      stub->ACPCfgCarrierAndOffsets(&context, request, &response));
+      stub->ACPCfgCarrierAndOffsets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -84,7 +86,8 @@ acp_cfg_carrier_frequency(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = ACPCfgCarrierFrequencyResponse{};
 
   raise_if_error(
-      stub->ACPCfgCarrierFrequency(&context, request, &response));
+      stub->ACPCfgCarrierFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -102,7 +105,8 @@ acp_cfg_carrier_integration_bandwidth(const StubPtr& stub, const nidevice_grpc::
   auto response = ACPCfgCarrierIntegrationBandwidthResponse{};
 
   raise_if_error(
-      stub->ACPCfgCarrierIntegrationBandwidth(&context, request, &response));
+      stub->ACPCfgCarrierIntegrationBandwidth(&context, request, &response),
+      context);
 
   return response;
 }
@@ -127,7 +131,8 @@ acp_cfg_carrier_mode(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = ACPCfgCarrierModeResponse{};
 
   raise_if_error(
-      stub->ACPCfgCarrierMode(&context, request, &response));
+      stub->ACPCfgCarrierMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -153,7 +158,8 @@ acp_cfg_carrier_rrc_filter(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = ACPCfgCarrierRRCFilterResponse{};
 
   raise_if_error(
-      stub->ACPCfgCarrierRRCFilter(&context, request, &response));
+      stub->ACPCfgCarrierRRCFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -179,7 +185,8 @@ acp_cfg_fft(const StubPtr& stub, const nidevice_grpc::Session& instrument, const
   auto response = ACPCfgFFTResponse{};
 
   raise_if_error(
-      stub->ACPCfgFFT(&context, request, &response));
+      stub->ACPCfgFFT(&context, request, &response),
+      context);
 
   return response;
 }
@@ -204,7 +211,8 @@ acp_cfg_measurement_method(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = ACPCfgMeasurementMethodResponse{};
 
   raise_if_error(
-      stub->ACPCfgMeasurementMethod(&context, request, &response));
+      stub->ACPCfgMeasurementMethod(&context, request, &response),
+      context);
 
   return response;
 }
@@ -229,7 +237,8 @@ acp_cfg_noise_compensation_enabled(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ACPCfgNoiseCompensationEnabledResponse{};
 
   raise_if_error(
-      stub->ACPCfgNoiseCompensationEnabled(&context, request, &response));
+      stub->ACPCfgNoiseCompensationEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -247,7 +256,8 @@ acp_cfg_number_of_carriers(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = ACPCfgNumberOfCarriersResponse{};
 
   raise_if_error(
-      stub->ACPCfgNumberOfCarriers(&context, request, &response));
+      stub->ACPCfgNumberOfCarriers(&context, request, &response),
+      context);
 
   return response;
 }
@@ -265,7 +275,8 @@ acp_cfg_number_of_offsets(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = ACPCfgNumberOfOffsetsResponse{};
 
   raise_if_error(
-      stub->ACPCfgNumberOfOffsets(&context, request, &response));
+      stub->ACPCfgNumberOfOffsets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -299,7 +310,8 @@ acp_cfg_offset(const StubPtr& stub, const nidevice_grpc::Session& instrument, co
   auto response = ACPCfgOffsetResponse{};
 
   raise_if_error(
-      stub->ACPCfgOffset(&context, request, &response));
+      stub->ACPCfgOffset(&context, request, &response),
+      context);
 
   return response;
 }
@@ -319,7 +331,8 @@ acp_cfg_offset_array(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = ACPCfgOffsetArrayResponse{};
 
   raise_if_error(
-      stub->ACPCfgOffsetArray(&context, request, &response));
+      stub->ACPCfgOffsetArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -344,7 +357,8 @@ acp_cfg_offset_frequency_definition(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ACPCfgOffsetFrequencyDefinitionResponse{};
 
   raise_if_error(
-      stub->ACPCfgOffsetFrequencyDefinition(&context, request, &response));
+      stub->ACPCfgOffsetFrequencyDefinition(&context, request, &response),
+      context);
 
   return response;
 }
@@ -362,7 +376,8 @@ acp_cfg_offset_integration_bandwidth(const StubPtr& stub, const nidevice_grpc::S
   auto response = ACPCfgOffsetIntegrationBandwidthResponse{};
 
   raise_if_error(
-      stub->ACPCfgOffsetIntegrationBandwidth(&context, request, &response));
+      stub->ACPCfgOffsetIntegrationBandwidth(&context, request, &response),
+      context);
 
   return response;
 }
@@ -380,7 +395,8 @@ acp_cfg_offset_integration_bandwidth_array(const StubPtr& stub, const nidevice_g
   auto response = ACPCfgOffsetIntegrationBandwidthArrayResponse{};
 
   raise_if_error(
-      stub->ACPCfgOffsetIntegrationBandwidthArray(&context, request, &response));
+      stub->ACPCfgOffsetIntegrationBandwidthArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -406,7 +422,8 @@ acp_cfg_offset_power_reference(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ACPCfgOffsetPowerReferenceResponse{};
 
   raise_if_error(
-      stub->ACPCfgOffsetPowerReference(&context, request, &response));
+      stub->ACPCfgOffsetPowerReference(&context, request, &response),
+      context);
 
   return response;
 }
@@ -425,7 +442,8 @@ acp_cfg_offset_power_reference_array(const StubPtr& stub, const nidevice_grpc::S
   auto response = ACPCfgOffsetPowerReferenceArrayResponse{};
 
   raise_if_error(
-      stub->ACPCfgOffsetPowerReferenceArray(&context, request, &response));
+      stub->ACPCfgOffsetPowerReferenceArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -451,7 +469,8 @@ acp_cfg_offset_rrc_filter(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = ACPCfgOffsetRRCFilterResponse{};
 
   raise_if_error(
-      stub->ACPCfgOffsetRRCFilter(&context, request, &response));
+      stub->ACPCfgOffsetRRCFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -470,7 +489,8 @@ acp_cfg_offset_rrc_filter_array(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = ACPCfgOffsetRRCFilterArrayResponse{};
 
   raise_if_error(
-      stub->ACPCfgOffsetRRCFilterArray(&context, request, &response));
+      stub->ACPCfgOffsetRRCFilterArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -488,7 +508,8 @@ acp_cfg_offset_relative_attenuation(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ACPCfgOffsetRelativeAttenuationResponse{};
 
   raise_if_error(
-      stub->ACPCfgOffsetRelativeAttenuation(&context, request, &response));
+      stub->ACPCfgOffsetRelativeAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -506,7 +527,8 @@ acp_cfg_offset_relative_attenuation_array(const StubPtr& stub, const nidevice_gr
   auto response = ACPCfgOffsetRelativeAttenuationArrayResponse{};
 
   raise_if_error(
-      stub->ACPCfgOffsetRelativeAttenuationArray(&context, request, &response));
+      stub->ACPCfgOffsetRelativeAttenuationArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -531,7 +553,8 @@ acp_cfg_power_units(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = ACPCfgPowerUnitsResponse{};
 
   raise_if_error(
-      stub->ACPCfgPowerUnits(&context, request, &response));
+      stub->ACPCfgPowerUnits(&context, request, &response),
+      context);
 
   return response;
 }
@@ -565,7 +588,8 @@ acp_cfg_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = ACPCfgRBWFilterResponse{};
 
   raise_if_error(
-      stub->ACPCfgRBWFilter(&context, request, &response));
+      stub->ACPCfgRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -591,7 +615,8 @@ acp_cfg_sweep_time(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = ACPCfgSweepTimeResponse{};
 
   raise_if_error(
-      stub->ACPCfgSweepTime(&context, request, &response));
+      stub->ACPCfgSweepTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -610,7 +635,8 @@ acp_fetch_absolute_powers_trace(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = ACPFetchAbsolutePowersTraceResponse{};
 
   raise_if_error(
-      stub->ACPFetchAbsolutePowersTrace(&context, request, &response));
+      stub->ACPFetchAbsolutePowersTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -628,7 +654,8 @@ acp_fetch_carrier_measurement(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ACPFetchCarrierMeasurementResponse{};
 
   raise_if_error(
-      stub->ACPFetchCarrierMeasurement(&context, request, &response));
+      stub->ACPFetchCarrierMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -646,7 +673,8 @@ acp_fetch_frequency_resolution(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ACPFetchFrequencyResolutionResponse{};
 
   raise_if_error(
-      stub->ACPFetchFrequencyResolution(&context, request, &response));
+      stub->ACPFetchFrequencyResolution(&context, request, &response),
+      context);
 
   return response;
 }
@@ -664,7 +692,8 @@ acp_fetch_offset_measurement(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ACPFetchOffsetMeasurementResponse{};
 
   raise_if_error(
-      stub->ACPFetchOffsetMeasurement(&context, request, &response));
+      stub->ACPFetchOffsetMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -682,7 +711,8 @@ acp_fetch_offset_measurement_array(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ACPFetchOffsetMeasurementArrayResponse{};
 
   raise_if_error(
-      stub->ACPFetchOffsetMeasurementArray(&context, request, &response));
+      stub->ACPFetchOffsetMeasurementArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -701,7 +731,8 @@ acp_fetch_relative_powers_trace(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = ACPFetchRelativePowersTraceResponse{};
 
   raise_if_error(
-      stub->ACPFetchRelativePowersTrace(&context, request, &response));
+      stub->ACPFetchRelativePowersTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -719,7 +750,8 @@ acp_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = ACPFetchSpectrumResponse{};
 
   raise_if_error(
-      stub->ACPFetchSpectrum(&context, request, &response));
+      stub->ACPFetchSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -737,7 +769,8 @@ acp_fetch_total_carrier_power(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = ACPFetchTotalCarrierPowerResponse{};
 
   raise_if_error(
-      stub->ACPFetchTotalCarrierPower(&context, request, &response));
+      stub->ACPFetchTotalCarrierPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -755,7 +788,8 @@ acp_read(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb
   auto response = ACPReadResponse{};
 
   raise_if_error(
-      stub->ACPRead(&context, request, &response));
+      stub->ACPRead(&context, request, &response),
+      context);
 
   return response;
 }
@@ -772,7 +806,8 @@ acp_validate_noise_calibration_data(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ACPValidateNoiseCalibrationDataResponse{};
 
   raise_if_error(
-      stub->ACPValidateNoiseCalibrationData(&context, request, &response));
+      stub->ACPValidateNoiseCalibrationData(&context, request, &response),
+      context);
 
   return response;
 }
@@ -798,7 +833,8 @@ ampm_cfg_am_to_am_curve_fit(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = AMPMCfgAMToAMCurveFitResponse{};
 
   raise_if_error(
-      stub->AMPMCfgAMToAMCurveFit(&context, request, &response));
+      stub->AMPMCfgAMToAMCurveFit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -824,7 +860,8 @@ ampm_cfg_am_to_pm_curve_fit(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = AMPMCfgAMToPMCurveFitResponse{};
 
   raise_if_error(
-      stub->AMPMCfgAMToPMCurveFit(&context, request, &response));
+      stub->AMPMCfgAMToPMCurveFit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -850,7 +887,8 @@ ampm_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = AMPMCfgAveragingResponse{};
 
   raise_if_error(
-      stub->AMPMCfgAveraging(&context, request, &response));
+      stub->AMPMCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -876,7 +914,8 @@ ampm_cfg_compression_points(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = AMPMCfgCompressionPointsResponse{};
 
   raise_if_error(
-      stub->AMPMCfgCompressionPoints(&context, request, &response));
+      stub->AMPMCfgCompressionPoints(&context, request, &response),
+      context);
 
   return response;
 }
@@ -894,7 +933,8 @@ ampm_cfg_dut_average_input_power(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = AMPMCfgDUTAverageInputPowerResponse{};
 
   raise_if_error(
-      stub->AMPMCfgDUTAverageInputPower(&context, request, &response));
+      stub->AMPMCfgDUTAverageInputPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -912,7 +952,8 @@ ampm_cfg_measurement_interval(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = AMPMCfgMeasurementIntervalResponse{};
 
   raise_if_error(
-      stub->AMPMCfgMeasurementInterval(&context, request, &response));
+      stub->AMPMCfgMeasurementInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -938,7 +979,8 @@ ampm_cfg_measurement_sample_rate(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = AMPMCfgMeasurementSampleRateResponse{};
 
   raise_if_error(
-      stub->AMPMCfgMeasurementSampleRate(&context, request, &response));
+      stub->AMPMCfgMeasurementSampleRate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -963,7 +1005,8 @@ ampm_cfg_reference_power_type(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = AMPMCfgReferencePowerTypeResponse{};
 
   raise_if_error(
-      stub->AMPMCfgReferencePowerType(&context, request, &response));
+      stub->AMPMCfgReferencePowerType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -999,7 +1042,8 @@ ampm_cfg_reference_waveform(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = AMPMCfgReferenceWaveformResponse{};
 
   raise_if_error(
-      stub->AMPMCfgReferenceWaveform(&context, request, &response));
+      stub->AMPMCfgReferenceWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1024,7 +1068,8 @@ ampm_cfg_synchronization_method(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = AMPMCfgSynchronizationMethodResponse{};
 
   raise_if_error(
-      stub->AMPMCfgSynchronizationMethod(&context, request, &response));
+      stub->AMPMCfgSynchronizationMethod(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1058,7 +1103,8 @@ ampm_cfg_threshold(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = AMPMCfgThresholdResponse{};
 
   raise_if_error(
-      stub->AMPMCfgThreshold(&context, request, &response));
+      stub->AMPMCfgThreshold(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1076,7 +1122,8 @@ ampm_fetch_am_to_am_trace(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = AMPMFetchAMToAMTraceResponse{};
 
   raise_if_error(
-      stub->AMPMFetchAMToAMTrace(&context, request, &response));
+      stub->AMPMFetchAMToAMTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1094,7 +1141,8 @@ ampm_fetch_am_to_pm_trace(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = AMPMFetchAMToPMTraceResponse{};
 
   raise_if_error(
-      stub->AMPMFetchAMToPMTrace(&context, request, &response));
+      stub->AMPMFetchAMToPMTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1112,7 +1160,8 @@ ampm_fetch_compression_points(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = AMPMFetchCompressionPointsResponse{};
 
   raise_if_error(
-      stub->AMPMFetchCompressionPoints(&context, request, &response));
+      stub->AMPMFetchCompressionPoints(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1130,7 +1179,8 @@ ampm_fetch_curve_fit_coefficients(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = AMPMFetchCurveFitCoefficientsResponse{};
 
   raise_if_error(
-      stub->AMPMFetchCurveFitCoefficients(&context, request, &response));
+      stub->AMPMFetchCurveFitCoefficients(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1148,7 +1198,8 @@ ampm_fetch_curve_fit_residual(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = AMPMFetchCurveFitResidualResponse{};
 
   raise_if_error(
-      stub->AMPMFetchCurveFitResidual(&context, request, &response));
+      stub->AMPMFetchCurveFitResidual(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1166,7 +1217,8 @@ ampm_fetch_dut_characteristics(const StubPtr& stub, const nidevice_grpc::Session
   auto response = AMPMFetchDUTCharacteristicsResponse{};
 
   raise_if_error(
-      stub->AMPMFetchDUTCharacteristics(&context, request, &response));
+      stub->AMPMFetchDUTCharacteristics(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1184,7 +1236,8 @@ ampm_fetch_error(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = AMPMFetchErrorResponse{};
 
   raise_if_error(
-      stub->AMPMFetchError(&context, request, &response));
+      stub->AMPMFetchError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1202,7 +1255,8 @@ ampm_fetch_processed_mean_acquired_waveform(const StubPtr& stub, const nidevice_
   auto response = AMPMFetchProcessedMeanAcquiredWaveformResponse{};
 
   raise_if_error(
-      stub->AMPMFetchProcessedMeanAcquiredWaveform(&context, request, &response));
+      stub->AMPMFetchProcessedMeanAcquiredWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1220,7 +1274,8 @@ ampm_fetch_processed_reference_waveform(const StubPtr& stub, const nidevice_grpc
   auto response = AMPMFetchProcessedReferenceWaveformResponse{};
 
   raise_if_error(
-      stub->AMPMFetchProcessedReferenceWaveform(&context, request, &response));
+      stub->AMPMFetchProcessedReferenceWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1238,7 +1293,8 @@ ampm_fetch_relative_phase_trace(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = AMPMFetchRelativePhaseTraceResponse{};
 
   raise_if_error(
-      stub->AMPMFetchRelativePhaseTrace(&context, request, &response));
+      stub->AMPMFetchRelativePhaseTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1256,7 +1312,8 @@ ampm_fetch_relative_power_trace(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = AMPMFetchRelativePowerTraceResponse{};
 
   raise_if_error(
-      stub->AMPMFetchRelativePowerTrace(&context, request, &response));
+      stub->AMPMFetchRelativePowerTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1273,7 +1330,8 @@ abort_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = AbortMeasurementsResponse{};
 
   raise_if_error(
-      stub->AbortMeasurements(&context, request, &response));
+      stub->AbortMeasurements(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1295,7 +1353,8 @@ analyze_iq1_waveform(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = AnalyzeIQ1WaveformResponse{};
 
   raise_if_error(
-      stub->AnalyzeIQ1Waveform(&context, request, &response));
+      stub->AnalyzeIQ1Waveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1317,7 +1376,8 @@ analyze_spectrum1_waveform(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = AnalyzeSpectrum1WaveformResponse{};
 
   raise_if_error(
-      stub->AnalyzeSpectrum1Waveform(&context, request, &response));
+      stub->AnalyzeSpectrum1Waveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1336,7 +1396,8 @@ auto_level(const StubPtr& stub, const nidevice_grpc::Session& instrument, const 
   auto response = AutoLevelResponse{};
 
   raise_if_error(
-      stub->AutoLevel(&context, request, &response));
+      stub->AutoLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1353,7 +1414,8 @@ build_carrier_string(const StubPtr& stub, const pb::string& selector_string, con
   auto response = BuildCarrierStringResponse{};
 
   raise_if_error(
-      stub->BuildCarrierString(&context, request, &response));
+      stub->BuildCarrierString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1370,7 +1432,8 @@ build_harmonic_string(const StubPtr& stub, const pb::string& selector_string, co
   auto response = BuildHarmonicStringResponse{};
 
   raise_if_error(
-      stub->BuildHarmonicString(&context, request, &response));
+      stub->BuildHarmonicString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1387,7 +1450,8 @@ build_intermod_string(const StubPtr& stub, const pb::string& selector_string, co
   auto response = BuildIntermodStringResponse{};
 
   raise_if_error(
-      stub->BuildIntermodString(&context, request, &response));
+      stub->BuildIntermodString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1405,7 +1469,8 @@ build_list_step_string(const StubPtr& stub, const pb::string& list_name, const p
   auto response = BuildListStepStringResponse{};
 
   raise_if_error(
-      stub->BuildListStepString(&context, request, &response));
+      stub->BuildListStepString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1422,7 +1487,8 @@ build_list_string(const StubPtr& stub, const pb::string& list_name, const pb::st
   auto response = BuildListStringResponse{};
 
   raise_if_error(
-      stub->BuildListString(&context, request, &response));
+      stub->BuildListString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1439,7 +1505,8 @@ build_marker_string(const StubPtr& stub, const pb::string& selector_string, cons
   auto response = BuildMarkerStringResponse{};
 
   raise_if_error(
-      stub->BuildMarkerString(&context, request, &response));
+      stub->BuildMarkerString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1456,7 +1523,8 @@ build_offset_string(const StubPtr& stub, const pb::string& selector_string, cons
   auto response = BuildOffsetStringResponse{};
 
   raise_if_error(
-      stub->BuildOffsetString(&context, request, &response));
+      stub->BuildOffsetString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1475,7 +1543,8 @@ build_range_spur_string(const StubPtr& stub, const pb::string& signal_name, cons
   auto response = BuildRangeSpurStringResponse{};
 
   raise_if_error(
-      stub->BuildRangeSpurString(&context, request, &response));
+      stub->BuildRangeSpurString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1492,7 +1561,8 @@ build_range_string(const StubPtr& stub, const pb::string& selector_string, const
   auto response = BuildRangeStringResponse{};
 
   raise_if_error(
-      stub->BuildRangeString(&context, request, &response));
+      stub->BuildRangeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1509,7 +1579,8 @@ build_segment_string(const StubPtr& stub, const pb::string& selector_string, con
   auto response = BuildSegmentStringResponse{};
 
   raise_if_error(
-      stub->BuildSegmentString(&context, request, &response));
+      stub->BuildSegmentString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1526,7 +1597,8 @@ build_signal_string(const StubPtr& stub, const pb::string& signal_name, const pb
   auto response = BuildSignalStringResponse{};
 
   raise_if_error(
-      stub->BuildSignalString(&context, request, &response));
+      stub->BuildSignalString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1543,7 +1615,8 @@ build_spur_string(const StubPtr& stub, const pb::string& selector_string, const 
   auto response = BuildSpurStringResponse{};
 
   raise_if_error(
-      stub->BuildSpurString(&context, request, &response));
+      stub->BuildSpurString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1561,7 +1634,8 @@ ccdf_cfg_measurement_interval(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = CCDFCfgMeasurementIntervalResponse{};
 
   raise_if_error(
-      stub->CCDFCfgMeasurementInterval(&context, request, &response));
+      stub->CCDFCfgMeasurementInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1579,7 +1653,8 @@ ccdf_cfg_number_of_records(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = CCDFCfgNumberOfRecordsResponse{};
 
   raise_if_error(
-      stub->CCDFCfgNumberOfRecords(&context, request, &response));
+      stub->CCDFCfgNumberOfRecords(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1606,7 +1681,8 @@ ccdf_cfg_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = CCDFCfgRBWFilterResponse{};
 
   raise_if_error(
-      stub->CCDFCfgRBWFilter(&context, request, &response));
+      stub->CCDFCfgRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1640,7 +1716,8 @@ ccdf_cfg_threshold(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CCDFCfgThresholdResponse{};
 
   raise_if_error(
-      stub->CCDFCfgThreshold(&context, request, &response));
+      stub->CCDFCfgThreshold(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1658,7 +1735,8 @@ ccdf_fetch_basic_power_probabilities(const StubPtr& stub, const nidevice_grpc::S
   auto response = CCDFFetchBasicPowerProbabilitiesResponse{};
 
   raise_if_error(
-      stub->CCDFFetchBasicPowerProbabilities(&context, request, &response));
+      stub->CCDFFetchBasicPowerProbabilities(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1676,7 +1754,8 @@ ccdf_fetch_gaussian_probabilities_trace(const StubPtr& stub, const nidevice_grpc
   auto response = CCDFFetchGaussianProbabilitiesTraceResponse{};
 
   raise_if_error(
-      stub->CCDFFetchGaussianProbabilitiesTrace(&context, request, &response));
+      stub->CCDFFetchGaussianProbabilitiesTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1694,7 +1773,8 @@ ccdf_fetch_power(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = CCDFFetchPowerResponse{};
 
   raise_if_error(
-      stub->CCDFFetchPower(&context, request, &response));
+      stub->CCDFFetchPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1712,7 +1792,8 @@ ccdf_fetch_probabilities_trace(const StubPtr& stub, const nidevice_grpc::Session
   auto response = CCDFFetchProbabilitiesTraceResponse{};
 
   raise_if_error(
-      stub->CCDFFetchProbabilitiesTrace(&context, request, &response));
+      stub->CCDFFetchProbabilitiesTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1730,7 +1811,8 @@ ccdf_read(const StubPtr& stub, const nidevice_grpc::Session& instrument, const p
   auto response = CCDFReadResponse{};
 
   raise_if_error(
-      stub->CCDFRead(&context, request, &response));
+      stub->CCDFRead(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1764,7 +1846,8 @@ chp_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = CHPCfgAveragingResponse{};
 
   raise_if_error(
-      stub->CHPCfgAveraging(&context, request, &response));
+      stub->CHPCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1782,7 +1865,8 @@ chp_cfg_carrier_offset(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = CHPCfgCarrierOffsetResponse{};
 
   raise_if_error(
-      stub->CHPCfgCarrierOffset(&context, request, &response));
+      stub->CHPCfgCarrierOffset(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1808,7 +1892,8 @@ chp_cfg_fft(const StubPtr& stub, const nidevice_grpc::Session& instrument, const
   auto response = CHPCfgFFTResponse{};
 
   raise_if_error(
-      stub->CHPCfgFFT(&context, request, &response));
+      stub->CHPCfgFFT(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1826,7 +1911,8 @@ chp_cfg_integration_bandwidth(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = CHPCfgIntegrationBandwidthResponse{};
 
   raise_if_error(
-      stub->CHPCfgIntegrationBandwidth(&context, request, &response));
+      stub->CHPCfgIntegrationBandwidth(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1844,7 +1930,8 @@ chp_cfg_number_of_carriers(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = CHPCfgNumberOfCarriersResponse{};
 
   raise_if_error(
-      stub->CHPCfgNumberOfCarriers(&context, request, &response));
+      stub->CHPCfgNumberOfCarriers(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1878,7 +1965,8 @@ chp_cfg_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CHPCfgRBWFilterResponse{};
 
   raise_if_error(
-      stub->CHPCfgRBWFilter(&context, request, &response));
+      stub->CHPCfgRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1904,7 +1992,8 @@ chp_cfg_rrc_filter(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CHPCfgRRCFilterResponse{};
 
   raise_if_error(
-      stub->CHPCfgRRCFilter(&context, request, &response));
+      stub->CHPCfgRRCFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1922,7 +2011,8 @@ chp_cfg_span(const StubPtr& stub, const nidevice_grpc::Session& instrument, cons
   auto response = CHPCfgSpanResponse{};
 
   raise_if_error(
-      stub->CHPCfgSpan(&context, request, &response));
+      stub->CHPCfgSpan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1948,7 +2038,8 @@ chp_cfg_sweep_time(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CHPCfgSweepTimeResponse{};
 
   raise_if_error(
-      stub->CHPCfgSweepTime(&context, request, &response));
+      stub->CHPCfgSweepTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1966,7 +2057,8 @@ chp_fetch_carrier_measurement(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = CHPFetchCarrierMeasurementResponse{};
 
   raise_if_error(
-      stub->CHPFetchCarrierMeasurement(&context, request, &response));
+      stub->CHPFetchCarrierMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1984,7 +2076,8 @@ chp_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CHPFetchSpectrumResponse{};
 
   raise_if_error(
-      stub->CHPFetchSpectrum(&context, request, &response));
+      stub->CHPFetchSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2002,7 +2095,8 @@ chp_fetch_total_carrier_power(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = CHPFetchTotalCarrierPowerResponse{};
 
   raise_if_error(
-      stub->CHPFetchTotalCarrierPower(&context, request, &response));
+      stub->CHPFetchTotalCarrierPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2020,7 +2114,8 @@ chp_read(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb
   auto response = CHPReadResponse{};
 
   raise_if_error(
-      stub->CHPRead(&context, request, &response));
+      stub->CHPRead(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2037,7 +2132,8 @@ chp_validate_noise_calibration_data(const StubPtr& stub, const nidevice_grpc::Se
   auto response = CHPValidateNoiseCalibrationDataResponse{};
 
   raise_if_error(
-      stub->CHPValidateNoiseCalibrationData(&context, request, &response));
+      stub->CHPValidateNoiseCalibrationData(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2072,7 +2168,8 @@ cfg_digital_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CfgDigitalEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->CfgDigitalEdgeTrigger(&context, request, &response));
+      stub->CfgDigitalEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2090,7 +2187,8 @@ cfg_external_attenuation(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CfgExternalAttenuationResponse{};
 
   raise_if_error(
-      stub->CfgExternalAttenuation(&context, request, &response));
+      stub->CfgExternalAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2108,7 +2206,8 @@ cfg_frequency(const StubPtr& stub, const nidevice_grpc::Session& instrument, con
   auto response = CfgFrequencyResponse{};
 
   raise_if_error(
-      stub->CfgFrequency(&context, request, &response));
+      stub->CfgFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2134,7 +2233,8 @@ cfg_frequency_reference(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = CfgFrequencyReferenceResponse{};
 
   raise_if_error(
-      stub->CfgFrequencyReference(&context, request, &response));
+      stub->CfgFrequencyReference(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2172,7 +2272,8 @@ cfg_iq_power_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = CfgIQPowerEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->CfgIQPowerEdgeTrigger(&context, request, &response));
+      stub->CfgIQPowerEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2198,7 +2299,8 @@ cfg_mechanical_attenuation(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = CfgMechanicalAttenuationResponse{};
 
   raise_if_error(
-      stub->CfgMechanicalAttenuation(&context, request, &response));
+      stub->CfgMechanicalAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2218,7 +2320,8 @@ cfg_rf(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::
   auto response = CfgRFResponse{};
 
   raise_if_error(
-      stub->CfgRF(&context, request, &response));
+      stub->CfgRF(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2244,7 +2347,8 @@ cfg_rf_attenuation(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CfgRFAttenuationResponse{};
 
   raise_if_error(
-      stub->CfgRFAttenuation(&context, request, &response));
+      stub->CfgRFAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2262,7 +2366,8 @@ cfg_reference_level(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = CfgReferenceLevelResponse{};
 
   raise_if_error(
-      stub->CfgReferenceLevel(&context, request, &response));
+      stub->CfgReferenceLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2281,7 +2386,8 @@ cfg_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = CfgSoftwareEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->CfgSoftwareEdgeTrigger(&context, request, &response));
+      stub->CfgSoftwareEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2298,7 +2404,8 @@ check_measurement_status(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CheckMeasurementStatusResponse{};
 
   raise_if_error(
-      stub->CheckMeasurementStatus(&context, request, &response));
+      stub->CheckMeasurementStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2315,7 +2422,8 @@ clear_all_named_results(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = ClearAllNamedResultsResponse{};
 
   raise_if_error(
-      stub->ClearAllNamedResults(&context, request, &response));
+      stub->ClearAllNamedResults(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2332,7 +2440,8 @@ clear_named_result(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = ClearNamedResultResponse{};
 
   raise_if_error(
-      stub->ClearNamedResult(&context, request, &response));
+      stub->ClearNamedResult(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2349,7 +2458,8 @@ clear_noise_calibration_database(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ClearNoiseCalibrationDatabaseResponse{};
 
   raise_if_error(
-      stub->ClearNoiseCalibrationDatabase(&context, request, &response));
+      stub->ClearNoiseCalibrationDatabase(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2367,7 +2477,8 @@ clone_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = CloneSignalConfigurationResponse{};
 
   raise_if_error(
-      stub->CloneSignalConfiguration(&context, request, &response));
+      stub->CloneSignalConfiguration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2384,7 +2495,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const bool&
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2401,7 +2513,8 @@ commit(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::
   auto response = CommitResponse{};
 
   raise_if_error(
-      stub->Commit(&context, request, &response));
+      stub->Commit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2418,7 +2531,8 @@ create_list(const StubPtr& stub, const nidevice_grpc::Session& instrument, const
   auto response = CreateListResponse{};
 
   raise_if_error(
-      stub->CreateList(&context, request, &response));
+      stub->CreateList(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2435,7 +2549,8 @@ create_list_step(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = CreateListStepResponse{};
 
   raise_if_error(
-      stub->CreateListStep(&context, request, &response));
+      stub->CreateListStep(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2452,7 +2567,8 @@ create_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = CreateSignalConfigurationResponse{};
 
   raise_if_error(
-      stub->CreateSignalConfiguration(&context, request, &response));
+      stub->CreateSignalConfiguration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2481,7 +2597,8 @@ dpd_apply_digital_predistortion(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = DPDApplyDigitalPredistortionResponse{};
 
   raise_if_error(
-      stub->DPDApplyDigitalPredistortion(&context, request, &response));
+      stub->DPDApplyDigitalPredistortion(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2509,7 +2626,8 @@ dpd_apply_pre_dpd_signal_conditioning(const StubPtr& stub, const nidevice_grpc::
   auto response = DPDApplyPreDPDSignalConditioningResponse{};
 
   raise_if_error(
-      stub->DPDApplyPreDPDSignalConditioning(&context, request, &response));
+      stub->DPDApplyPreDPDSignalConditioning(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2534,7 +2652,8 @@ dpd_cfg_apply_dpd_configuration_input(const StubPtr& stub, const nidevice_grpc::
   auto response = DPDCfgApplyDPDConfigurationInputResponse{};
 
   raise_if_error(
-      stub->DPDCfgApplyDPDConfigurationInput(&context, request, &response));
+      stub->DPDCfgApplyDPDConfigurationInput(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2559,7 +2678,8 @@ dpd_cfg_apply_dpd_lookup_table_correction_type(const StubPtr& stub, const nidevi
   auto response = DPDCfgApplyDPDLookupTableCorrectionTypeResponse{};
 
   raise_if_error(
-      stub->DPDCfgApplyDPDLookupTableCorrectionType(&context, request, &response));
+      stub->DPDCfgApplyDPDLookupTableCorrectionType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2584,7 +2704,8 @@ dpd_cfg_apply_dpd_memory_model_correction_type(const StubPtr& stub, const nidevi
   auto response = DPDCfgApplyDPDMemoryModelCorrectionTypeResponse{};
 
   raise_if_error(
-      stub->DPDCfgApplyDPDMemoryModelCorrectionType(&context, request, &response));
+      stub->DPDCfgApplyDPDMemoryModelCorrectionType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2602,7 +2723,8 @@ dpd_cfg_apply_dpd_user_dpd_polynomial(const StubPtr& stub, const nidevice_grpc::
   auto response = DPDCfgApplyDPDUserDPDPolynomialResponse{};
 
   raise_if_error(
-      stub->DPDCfgApplyDPDUserDPDPolynomial(&context, request, &response));
+      stub->DPDCfgApplyDPDUserDPDPolynomial(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2621,7 +2743,8 @@ dpd_cfg_apply_dpd_user_lookup_table(const StubPtr& stub, const nidevice_grpc::Se
   auto response = DPDCfgApplyDPDUserLookupTableResponse{};
 
   raise_if_error(
-      stub->DPDCfgApplyDPDUserLookupTable(&context, request, &response));
+      stub->DPDCfgApplyDPDUserLookupTable(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2647,7 +2770,8 @@ dpd_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = DPDCfgAveragingResponse{};
 
   raise_if_error(
-      stub->DPDCfgAveraging(&context, request, &response));
+      stub->DPDCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2672,7 +2796,8 @@ dpd_cfg_dpd_model(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = DPDCfgDPDModelResponse{};
 
   raise_if_error(
-      stub->DPDCfgDPDModel(&context, request, &response));
+      stub->DPDCfgDPDModel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2690,7 +2815,8 @@ dpd_cfg_dut_average_input_power(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = DPDCfgDUTAverageInputPowerResponse{};
 
   raise_if_error(
-      stub->DPDCfgDUTAverageInputPower(&context, request, &response));
+      stub->DPDCfgDUTAverageInputPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2713,7 +2839,8 @@ dpd_cfg_generalized_memory_polynomial_cross_terms(const StubPtr& stub, const nid
   auto response = DPDCfgGeneralizedMemoryPolynomialCrossTermsResponse{};
 
   raise_if_error(
-      stub->DPDCfgGeneralizedMemoryPolynomialCrossTerms(&context, request, &response));
+      stub->DPDCfgGeneralizedMemoryPolynomialCrossTerms(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2738,7 +2865,8 @@ dpd_cfg_iterative_dpd_enabled(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = DPDCfgIterativeDPDEnabledResponse{};
 
   raise_if_error(
-      stub->DPDCfgIterativeDPDEnabled(&context, request, &response));
+      stub->DPDCfgIterativeDPDEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2764,7 +2892,8 @@ dpd_cfg_lookup_table_am_to_am_curve_fit(const StubPtr& stub, const nidevice_grpc
   auto response = DPDCfgLookupTableAMToAMCurveFitResponse{};
 
   raise_if_error(
-      stub->DPDCfgLookupTableAMToAMCurveFit(&context, request, &response));
+      stub->DPDCfgLookupTableAMToAMCurveFit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2790,7 +2919,8 @@ dpd_cfg_lookup_table_am_to_pm_curve_fit(const StubPtr& stub, const nidevice_grpc
   auto response = DPDCfgLookupTableAMToPMCurveFitResponse{};
 
   raise_if_error(
-      stub->DPDCfgLookupTableAMToPMCurveFit(&context, request, &response));
+      stub->DPDCfgLookupTableAMToPMCurveFit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2808,7 +2938,8 @@ dpd_cfg_lookup_table_step_size(const StubPtr& stub, const nidevice_grpc::Session
   auto response = DPDCfgLookupTableStepSizeResponse{};
 
   raise_if_error(
-      stub->DPDCfgLookupTableStepSize(&context, request, &response));
+      stub->DPDCfgLookupTableStepSize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2842,7 +2973,8 @@ dpd_cfg_lookup_table_threshold(const StubPtr& stub, const nidevice_grpc::Session
   auto response = DPDCfgLookupTableThresholdResponse{};
 
   raise_if_error(
-      stub->DPDCfgLookupTableThreshold(&context, request, &response));
+      stub->DPDCfgLookupTableThreshold(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2867,7 +2999,8 @@ dpd_cfg_lookup_table_type(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = DPDCfgLookupTableTypeResponse{};
 
   raise_if_error(
-      stub->DPDCfgLookupTableType(&context, request, &response));
+      stub->DPDCfgLookupTableType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2885,7 +3018,8 @@ dpd_cfg_measurement_interval(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = DPDCfgMeasurementIntervalResponse{};
 
   raise_if_error(
-      stub->DPDCfgMeasurementInterval(&context, request, &response));
+      stub->DPDCfgMeasurementInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2911,7 +3045,8 @@ dpd_cfg_measurement_sample_rate(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = DPDCfgMeasurementSampleRateResponse{};
 
   raise_if_error(
-      stub->DPDCfgMeasurementSampleRate(&context, request, &response));
+      stub->DPDCfgMeasurementSampleRate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2930,7 +3065,8 @@ dpd_cfg_memory_polynomial(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = DPDCfgMemoryPolynomialResponse{};
 
   raise_if_error(
-      stub->DPDCfgMemoryPolynomial(&context, request, &response));
+      stub->DPDCfgMemoryPolynomial(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2948,7 +3084,8 @@ dpd_cfg_previous_dpd_polynomial(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = DPDCfgPreviousDPDPolynomialResponse{};
 
   raise_if_error(
-      stub->DPDCfgPreviousDPDPolynomial(&context, request, &response));
+      stub->DPDCfgPreviousDPDPolynomial(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2984,7 +3121,8 @@ dpd_cfg_reference_waveform(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = DPDCfgReferenceWaveformResponse{};
 
   raise_if_error(
-      stub->DPDCfgReferenceWaveform(&context, request, &response));
+      stub->DPDCfgReferenceWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3009,7 +3147,8 @@ dpd_cfg_synchronization_method(const StubPtr& stub, const nidevice_grpc::Session
   auto response = DPDCfgSynchronizationMethodResponse{};
 
   raise_if_error(
-      stub->DPDCfgSynchronizationMethod(&context, request, &response));
+      stub->DPDCfgSynchronizationMethod(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3027,7 +3166,8 @@ dpd_fetch_apply_dpd_pre_cfrpapr(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = DPDFetchApplyDPDPreCFRPAPRResponse{};
 
   raise_if_error(
-      stub->DPDFetchApplyDPDPreCFRPAPR(&context, request, &response));
+      stub->DPDFetchApplyDPDPreCFRPAPR(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3045,7 +3185,8 @@ dpd_fetch_average_gain(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = DPDFetchAverageGainResponse{};
 
   raise_if_error(
-      stub->DPDFetchAverageGain(&context, request, &response));
+      stub->DPDFetchAverageGain(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3063,7 +3204,8 @@ dpd_fetch_dpd_polynomial(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = DPDFetchDPDPolynomialResponse{};
 
   raise_if_error(
-      stub->DPDFetchDPDPolynomial(&context, request, &response));
+      stub->DPDFetchDPDPolynomial(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3081,7 +3223,8 @@ dpd_fetch_lookup_table(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = DPDFetchLookupTableResponse{};
 
   raise_if_error(
-      stub->DPDFetchLookupTable(&context, request, &response));
+      stub->DPDFetchLookupTable(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3099,7 +3242,8 @@ dpd_fetch_nmse(const StubPtr& stub, const nidevice_grpc::Session& instrument, co
   auto response = DPDFetchNMSEResponse{};
 
   raise_if_error(
-      stub->DPDFetchNMSE(&context, request, &response));
+      stub->DPDFetchNMSE(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3117,7 +3261,8 @@ dpd_fetch_processed_mean_acquired_waveform(const StubPtr& stub, const nidevice_g
   auto response = DPDFetchProcessedMeanAcquiredWaveformResponse{};
 
   raise_if_error(
-      stub->DPDFetchProcessedMeanAcquiredWaveform(&context, request, &response));
+      stub->DPDFetchProcessedMeanAcquiredWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3135,7 +3280,8 @@ dpd_fetch_processed_reference_waveform(const StubPtr& stub, const nidevice_grpc:
   auto response = DPDFetchProcessedReferenceWaveformResponse{};
 
   raise_if_error(
-      stub->DPDFetchProcessedReferenceWaveform(&context, request, &response));
+      stub->DPDFetchProcessedReferenceWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3152,7 +3298,8 @@ delete_list(const StubPtr& stub, const nidevice_grpc::Session& instrument, const
   auto response = DeleteListResponse{};
 
   raise_if_error(
-      stub->DeleteList(&context, request, &response));
+      stub->DeleteList(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3169,7 +3316,8 @@ delete_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = DeleteSignalConfigurationResponse{};
 
   raise_if_error(
-      stub->DeleteSignalConfiguration(&context, request, &response));
+      stub->DeleteSignalConfiguration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3186,7 +3334,8 @@ disable_trigger(const StubPtr& stub, const nidevice_grpc::Session& instrument, c
   auto response = DisableTriggerResponse{};
 
   raise_if_error(
-      stub->DisableTrigger(&context, request, &response));
+      stub->DisableTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3220,7 +3369,8 @@ f_cnt_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = FCntCfgAveragingResponse{};
 
   raise_if_error(
-      stub->FCntCfgAveraging(&context, request, &response));
+      stub->FCntCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3238,7 +3388,8 @@ f_cnt_cfg_measurement_interval(const StubPtr& stub, const nidevice_grpc::Session
   auto response = FCntCfgMeasurementIntervalResponse{};
 
   raise_if_error(
-      stub->FCntCfgMeasurementInterval(&context, request, &response));
+      stub->FCntCfgMeasurementInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3265,7 +3416,8 @@ f_cnt_cfg_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = FCntCfgRBWFilterResponse{};
 
   raise_if_error(
-      stub->FCntCfgRBWFilter(&context, request, &response));
+      stub->FCntCfgRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3299,7 +3451,8 @@ f_cnt_cfg_threshold(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = FCntCfgThresholdResponse{};
 
   raise_if_error(
-      stub->FCntCfgThreshold(&context, request, &response));
+      stub->FCntCfgThreshold(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3317,7 +3470,8 @@ f_cnt_fetch_allan_deviation(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = FCntFetchAllanDeviationResponse{};
 
   raise_if_error(
-      stub->FCntFetchAllanDeviation(&context, request, &response));
+      stub->FCntFetchAllanDeviation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3335,7 +3489,8 @@ f_cnt_fetch_frequency_trace(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = FCntFetchFrequencyTraceResponse{};
 
   raise_if_error(
-      stub->FCntFetchFrequencyTrace(&context, request, &response));
+      stub->FCntFetchFrequencyTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3353,7 +3508,8 @@ f_cnt_fetch_measurement(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = FCntFetchMeasurementResponse{};
 
   raise_if_error(
-      stub->FCntFetchMeasurement(&context, request, &response));
+      stub->FCntFetchMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3371,7 +3527,8 @@ f_cnt_fetch_phase_trace(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = FCntFetchPhaseTraceResponse{};
 
   raise_if_error(
-      stub->FCntFetchPhaseTrace(&context, request, &response));
+      stub->FCntFetchPhaseTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3389,7 +3546,8 @@ f_cnt_fetch_power_trace(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = FCntFetchPowerTraceResponse{};
 
   raise_if_error(
-      stub->FCntFetchPowerTrace(&context, request, &response));
+      stub->FCntFetchPowerTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3407,7 +3565,8 @@ f_cnt_read(const StubPtr& stub, const nidevice_grpc::Session& instrument, const 
   auto response = FCntReadResponse{};
 
   raise_if_error(
-      stub->FCntRead(&context, request, &response));
+      stub->FCntRead(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3424,7 +3583,8 @@ get_all_named_result_names(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = GetAllNamedResultNamesResponse{};
 
   raise_if_error(
-      stub->GetAllNamedResultNames(&context, request, &response));
+      stub->GetAllNamedResultNames(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3442,7 +3602,8 @@ get_attribute_f32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeF32Response{};
 
   raise_if_error(
-      stub->GetAttributeF32(&context, request, &response));
+      stub->GetAttributeF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3460,7 +3621,8 @@ get_attribute_f32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeF32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeF32Array(&context, request, &response));
+      stub->GetAttributeF32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3478,7 +3640,8 @@ get_attribute_f64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeF64Response{};
 
   raise_if_error(
-      stub->GetAttributeF64(&context, request, &response));
+      stub->GetAttributeF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3496,7 +3659,8 @@ get_attribute_f64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeF64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeF64Array(&context, request, &response));
+      stub->GetAttributeF64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3514,7 +3678,8 @@ get_attribute_i16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI16Response{};
 
   raise_if_error(
-      stub->GetAttributeI16(&context, request, &response));
+      stub->GetAttributeI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3532,7 +3697,8 @@ get_attribute_i32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI32Response{};
 
   raise_if_error(
-      stub->GetAttributeI32(&context, request, &response));
+      stub->GetAttributeI32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3550,7 +3716,8 @@ get_attribute_i32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeI32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI32Array(&context, request, &response));
+      stub->GetAttributeI32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3568,7 +3735,8 @@ get_attribute_i64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI64Response{};
 
   raise_if_error(
-      stub->GetAttributeI64(&context, request, &response));
+      stub->GetAttributeI64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3586,7 +3754,8 @@ get_attribute_i64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeI64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI64Array(&context, request, &response));
+      stub->GetAttributeI64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3604,7 +3773,8 @@ get_attribute_i8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetAttributeI8Response{};
 
   raise_if_error(
-      stub->GetAttributeI8(&context, request, &response));
+      stub->GetAttributeI8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3622,7 +3792,8 @@ get_attribute_i8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = GetAttributeI8ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI8Array(&context, request, &response));
+      stub->GetAttributeI8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3640,7 +3811,8 @@ get_attribute_ni_complex_double_array(const StubPtr& stub, const nidevice_grpc::
   auto response = GetAttributeNIComplexDoubleArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeNIComplexDoubleArray(&context, request, &response));
+      stub->GetAttributeNIComplexDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3658,7 +3830,8 @@ get_attribute_ni_complex_single_array(const StubPtr& stub, const nidevice_grpc::
   auto response = GetAttributeNIComplexSingleArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeNIComplexSingleArray(&context, request, &response));
+      stub->GetAttributeNIComplexSingleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3676,7 +3849,8 @@ get_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = GetAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeString(&context, request, &response));
+      stub->GetAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3694,7 +3868,8 @@ get_attribute_u16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeU16Response{};
 
   raise_if_error(
-      stub->GetAttributeU16(&context, request, &response));
+      stub->GetAttributeU16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3712,7 +3887,8 @@ get_attribute_u32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeU32Response{};
 
   raise_if_error(
-      stub->GetAttributeU32(&context, request, &response));
+      stub->GetAttributeU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3730,7 +3906,8 @@ get_attribute_u32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeU32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU32Array(&context, request, &response));
+      stub->GetAttributeU32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3748,7 +3925,8 @@ get_attribute_u64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeU64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU64Array(&context, request, &response));
+      stub->GetAttributeU64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3766,7 +3944,8 @@ get_attribute_u8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetAttributeU8Response{};
 
   raise_if_error(
-      stub->GetAttributeU8(&context, request, &response));
+      stub->GetAttributeU8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3784,7 +3963,8 @@ get_attribute_u8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = GetAttributeU8ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU8Array(&context, request, &response));
+      stub->GetAttributeU8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3800,7 +3980,8 @@ get_error(const StubPtr& stub, const nidevice_grpc::Session& instrument)
   auto response = GetErrorResponse{};
 
   raise_if_error(
-      stub->GetError(&context, request, &response));
+      stub->GetError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3817,7 +3998,8 @@ get_error_string(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetErrorStringResponse{};
 
   raise_if_error(
-      stub->GetErrorString(&context, request, &response));
+      stub->GetErrorString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3842,7 +4024,8 @@ harm_cfg_auto_harmonics(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = HarmCfgAutoHarmonicsResponse{};
 
   raise_if_error(
-      stub->HarmCfgAutoHarmonics(&context, request, &response));
+      stub->HarmCfgAutoHarmonics(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3876,7 +4059,8 @@ harm_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = HarmCfgAveragingResponse{};
 
   raise_if_error(
-      stub->HarmCfgAveraging(&context, request, &response));
+      stub->HarmCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3894,7 +4078,8 @@ harm_cfg_fundamental_measurement_interval(const StubPtr& stub, const nidevice_gr
   auto response = HarmCfgFundamentalMeasurementIntervalResponse{};
 
   raise_if_error(
-      stub->HarmCfgFundamentalMeasurementInterval(&context, request, &response));
+      stub->HarmCfgFundamentalMeasurementInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3921,7 +4106,8 @@ harm_cfg_fundamental_rbw(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = HarmCfgFundamentalRBWResponse{};
 
   raise_if_error(
-      stub->HarmCfgFundamentalRBW(&context, request, &response));
+      stub->HarmCfgFundamentalRBW(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3949,7 +4135,8 @@ harm_cfg_harmonic(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = HarmCfgHarmonicResponse{};
 
   raise_if_error(
-      stub->HarmCfgHarmonic(&context, request, &response));
+      stub->HarmCfgHarmonic(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3970,7 +4157,8 @@ harm_cfg_harmonic_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = HarmCfgHarmonicArrayResponse{};
 
   raise_if_error(
-      stub->HarmCfgHarmonicArray(&context, request, &response));
+      stub->HarmCfgHarmonicArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3988,7 +4176,8 @@ harm_cfg_number_of_harmonics(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = HarmCfgNumberOfHarmonicsResponse{};
 
   raise_if_error(
-      stub->HarmCfgNumberOfHarmonics(&context, request, &response));
+      stub->HarmCfgNumberOfHarmonics(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4006,7 +4195,8 @@ harm_fetch_harmonic_measurement(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = HarmFetchHarmonicMeasurementResponse{};
 
   raise_if_error(
-      stub->HarmFetchHarmonicMeasurement(&context, request, &response));
+      stub->HarmFetchHarmonicMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4024,7 +4214,8 @@ harm_fetch_harmonic_measurement_array(const StubPtr& stub, const nidevice_grpc::
   auto response = HarmFetchHarmonicMeasurementArrayResponse{};
 
   raise_if_error(
-      stub->HarmFetchHarmonicMeasurementArray(&context, request, &response));
+      stub->HarmFetchHarmonicMeasurementArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4042,7 +4233,8 @@ harm_fetch_harmonic_power_trace(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = HarmFetchHarmonicPowerTraceResponse{};
 
   raise_if_error(
-      stub->HarmFetchHarmonicPowerTrace(&context, request, &response));
+      stub->HarmFetchHarmonicPowerTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4060,7 +4252,8 @@ harm_fetch_thd(const StubPtr& stub, const nidevice_grpc::Session& instrument, co
   auto response = HarmFetchTHDResponse{};
 
   raise_if_error(
-      stub->HarmFetchTHD(&context, request, &response));
+      stub->HarmFetchTHD(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4078,7 +4271,8 @@ harm_read(const StubPtr& stub, const nidevice_grpc::Session& instrument, const p
   auto response = HarmReadResponse{};
 
   raise_if_error(
-      stub->HarmRead(&context, request, &response));
+      stub->HarmRead(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4104,7 +4298,8 @@ im_cfg_auto_intermods_setup(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = IMCfgAutoIntermodsSetupResponse{};
 
   raise_if_error(
-      stub->IMCfgAutoIntermodsSetup(&context, request, &response));
+      stub->IMCfgAutoIntermodsSetup(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4138,7 +4333,8 @@ im_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = IMCfgAveragingResponse{};
 
   raise_if_error(
-      stub->IMCfgAveraging(&context, request, &response));
+      stub->IMCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4164,7 +4360,8 @@ im_cfg_fft(const StubPtr& stub, const nidevice_grpc::Session& instrument, const 
   auto response = IMCfgFFTResponse{};
 
   raise_if_error(
-      stub->IMCfgFFT(&context, request, &response));
+      stub->IMCfgFFT(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4189,7 +4386,8 @@ im_cfg_frequency_definition(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = IMCfgFrequencyDefinitionResponse{};
 
   raise_if_error(
-      stub->IMCfgFrequencyDefinition(&context, request, &response));
+      stub->IMCfgFrequencyDefinition(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4208,7 +4406,8 @@ im_cfg_fundamental_tones(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = IMCfgFundamentalTonesResponse{};
 
   raise_if_error(
-      stub->IMCfgFundamentalTones(&context, request, &response));
+      stub->IMCfgFundamentalTones(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4244,7 +4443,8 @@ im_cfg_intermod(const StubPtr& stub, const nidevice_grpc::Session& instrument, c
   auto response = IMCfgIntermodResponse{};
 
   raise_if_error(
-      stub->IMCfgIntermod(&context, request, &response));
+      stub->IMCfgIntermod(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4266,7 +4466,8 @@ im_cfg_intermod_array(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = IMCfgIntermodArrayResponse{};
 
   raise_if_error(
-      stub->IMCfgIntermodArray(&context, request, &response));
+      stub->IMCfgIntermodArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4291,7 +4492,8 @@ im_cfg_measurement_method(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = IMCfgMeasurementMethodResponse{};
 
   raise_if_error(
-      stub->IMCfgMeasurementMethod(&context, request, &response));
+      stub->IMCfgMeasurementMethod(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4309,7 +4511,8 @@ im_cfg_number_of_intermods(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = IMCfgNumberOfIntermodsResponse{};
 
   raise_if_error(
-      stub->IMCfgNumberOfIntermods(&context, request, &response));
+      stub->IMCfgNumberOfIntermods(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4343,7 +4546,8 @@ im_cfg_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = IMCfgRBWFilterResponse{};
 
   raise_if_error(
-      stub->IMCfgRBWFilter(&context, request, &response));
+      stub->IMCfgRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4369,7 +4573,8 @@ im_cfg_sweep_time(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = IMCfgSweepTimeResponse{};
 
   raise_if_error(
-      stub->IMCfgSweepTime(&context, request, &response));
+      stub->IMCfgSweepTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4387,7 +4592,8 @@ im_fetch_fundamental_measurement(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = IMFetchFundamentalMeasurementResponse{};
 
   raise_if_error(
-      stub->IMFetchFundamentalMeasurement(&context, request, &response));
+      stub->IMFetchFundamentalMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4405,7 +4611,8 @@ im_fetch_intercept_power(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = IMFetchInterceptPowerResponse{};
 
   raise_if_error(
-      stub->IMFetchInterceptPower(&context, request, &response));
+      stub->IMFetchInterceptPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4423,7 +4630,8 @@ im_fetch_intercept_power_array(const StubPtr& stub, const nidevice_grpc::Session
   auto response = IMFetchInterceptPowerArrayResponse{};
 
   raise_if_error(
-      stub->IMFetchInterceptPowerArray(&context, request, &response));
+      stub->IMFetchInterceptPowerArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4441,7 +4649,8 @@ im_fetch_intermod_measurement(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = IMFetchIntermodMeasurementResponse{};
 
   raise_if_error(
-      stub->IMFetchIntermodMeasurement(&context, request, &response));
+      stub->IMFetchIntermodMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4459,7 +4668,8 @@ im_fetch_intermod_measurement_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = IMFetchIntermodMeasurementArrayResponse{};
 
   raise_if_error(
-      stub->IMFetchIntermodMeasurementArray(&context, request, &response));
+      stub->IMFetchIntermodMeasurementArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4478,7 +4688,8 @@ im_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = IMFetchSpectrumResponse{};
 
   raise_if_error(
-      stub->IMFetchSpectrum(&context, request, &response));
+      stub->IMFetchSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4499,7 +4710,8 @@ iq_cfg_acquisition(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = IQCfgAcquisitionResponse{};
 
   raise_if_error(
-      stub->IQCfgAcquisition(&context, request, &response));
+      stub->IQCfgAcquisition(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4525,7 +4737,8 @@ iq_cfg_bandwidth(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = IQCfgBandwidthResponse{};
 
   raise_if_error(
-      stub->IQCfgBandwidth(&context, request, &response));
+      stub->IQCfgBandwidth(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4545,7 +4758,8 @@ iq_fetch_data(const StubPtr& stub, const nidevice_grpc::Session& instrument, con
   auto response = IQFetchDataResponse{};
 
   raise_if_error(
-      stub->IQFetchData(&context, request, &response));
+      stub->IQFetchData(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4562,7 +4776,8 @@ iq_get_records_done(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = IQGetRecordsDoneResponse{};
 
   raise_if_error(
-      stub->IQGetRecordsDone(&context, request, &response));
+      stub->IQGetRecordsDone(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4579,7 +4794,8 @@ initialize(const StubPtr& stub, const pb::string& resource_name, const pb::strin
   auto response = InitializeResponse{};
 
   raise_if_error(
-      stub->Initialize(&context, request, &response));
+      stub->Initialize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4595,7 +4811,8 @@ initialize_from_nirfsa_session(const StubPtr& stub, const nidevice_grpc::Session
   auto response = InitializeFromNIRFSASessionResponse{};
 
   raise_if_error(
-      stub->InitializeFromNIRFSASession(&context, request, &response));
+      stub->InitializeFromNIRFSASession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4613,7 +4830,8 @@ initiate(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb
   auto response = InitiateResponse{};
 
   raise_if_error(
-      stub->Initiate(&context, request, &response));
+      stub->Initiate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4631,7 +4849,8 @@ marker_cfg_number_of_markers(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = MarkerCfgNumberOfMarkersResponse{};
 
   raise_if_error(
-      stub->MarkerCfgNumberOfMarkers(&context, request, &response));
+      stub->MarkerCfgNumberOfMarkers(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4657,7 +4876,8 @@ marker_cfg_peak_excursion(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = MarkerCfgPeakExcursionResponse{};
 
   raise_if_error(
-      stub->MarkerCfgPeakExcursion(&context, request, &response));
+      stub->MarkerCfgPeakExcursion(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4675,7 +4895,8 @@ marker_cfg_reference_marker(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = MarkerCfgReferenceMarkerResponse{};
 
   raise_if_error(
-      stub->MarkerCfgReferenceMarker(&context, request, &response));
+      stub->MarkerCfgReferenceMarker(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4701,7 +4922,8 @@ marker_cfg_threshold(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = MarkerCfgThresholdResponse{};
 
   raise_if_error(
-      stub->MarkerCfgThreshold(&context, request, &response));
+      stub->MarkerCfgThreshold(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4726,7 +4948,8 @@ marker_cfg_trace(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = MarkerCfgTraceResponse{};
 
   raise_if_error(
-      stub->MarkerCfgTrace(&context, request, &response));
+      stub->MarkerCfgTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4751,7 +4974,8 @@ marker_cfg_type(const StubPtr& stub, const nidevice_grpc::Session& instrument, c
   auto response = MarkerCfgTypeResponse{};
 
   raise_if_error(
-      stub->MarkerCfgType(&context, request, &response));
+      stub->MarkerCfgType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4769,7 +4993,8 @@ marker_cfg_x_location(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = MarkerCfgXLocationResponse{};
 
   raise_if_error(
-      stub->MarkerCfgXLocation(&context, request, &response));
+      stub->MarkerCfgXLocation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4786,7 +5011,8 @@ marker_fetch_xy(const StubPtr& stub, const nidevice_grpc::Session& instrument, c
   auto response = MarkerFetchXYResponse{};
 
   raise_if_error(
-      stub->MarkerFetchXY(&context, request, &response));
+      stub->MarkerFetchXY(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4811,7 +5037,8 @@ marker_next_peak(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = MarkerNextPeakResponse{};
 
   raise_if_error(
-      stub->MarkerNextPeak(&context, request, &response));
+      stub->MarkerNextPeak(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4828,7 +5055,8 @@ marker_peak_search(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = MarkerPeakSearchResponse{};
 
   raise_if_error(
-      stub->MarkerPeakSearch(&context, request, &response));
+      stub->MarkerPeakSearch(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4854,7 +5082,8 @@ nf_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = NFCfgAveragingResponse{};
 
   raise_if_error(
-      stub->NFCfgAveraging(&context, request, &response));
+      stub->NFCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4882,7 +5111,8 @@ nf_cfg_calibration_loss(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = NFCfgCalibrationLossResponse{};
 
   raise_if_error(
-      stub->NFCfgCalibrationLoss(&context, request, &response));
+      stub->NFCfgCalibrationLoss(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4904,7 +5134,8 @@ nf_cfg_cold_source_duts_parameters(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = NFCfgColdSourceDUTSParametersResponse{};
 
   raise_if_error(
-      stub->NFCfgColdSourceDUTSParameters(&context, request, &response));
+      stub->NFCfgColdSourceDUTSParameters(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4924,7 +5155,8 @@ nf_cfg_cold_source_input_termination(const StubPtr& stub, const nidevice_grpc::S
   auto response = NFCfgColdSourceInputTerminationResponse{};
 
   raise_if_error(
-      stub->NFCfgColdSourceInputTermination(&context, request, &response));
+      stub->NFCfgColdSourceInputTermination(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4949,7 +5181,8 @@ nf_cfg_cold_source_mode(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = NFCfgColdSourceModeResponse{};
 
   raise_if_error(
-      stub->NFCfgColdSourceMode(&context, request, &response));
+      stub->NFCfgColdSourceMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4977,7 +5210,8 @@ nf_cfg_dut_input_loss(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = NFCfgDUTInputLossResponse{};
 
   raise_if_error(
-      stub->NFCfgDUTInputLoss(&context, request, &response));
+      stub->NFCfgDUTInputLoss(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5005,7 +5239,8 @@ nf_cfg_dut_output_loss(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = NFCfgDUTOutputLossResponse{};
 
   raise_if_error(
-      stub->NFCfgDUTOutputLoss(&context, request, &response));
+      stub->NFCfgDUTOutputLoss(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5023,7 +5258,8 @@ nf_cfg_frequency_list(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = NFCfgFrequencyListResponse{};
 
   raise_if_error(
-      stub->NFCfgFrequencyList(&context, request, &response));
+      stub->NFCfgFrequencyList(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5043,7 +5279,8 @@ nf_cfg_frequency_list_start_stop_points(const StubPtr& stub, const nidevice_grpc
   auto response = NFCfgFrequencyListStartStopPointsResponse{};
 
   raise_if_error(
-      stub->NFCfgFrequencyListStartStopPoints(&context, request, &response));
+      stub->NFCfgFrequencyListStartStopPoints(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5063,7 +5300,8 @@ nf_cfg_frequency_list_start_stop_step(const StubPtr& stub, const nidevice_grpc::
   auto response = NFCfgFrequencyListStartStopStepResponse{};
 
   raise_if_error(
-      stub->NFCfgFrequencyListStartStopStep(&context, request, &response));
+      stub->NFCfgFrequencyListStartStopStep(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5081,7 +5319,8 @@ nf_cfg_measurement_bandwidth(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = NFCfgMeasurementBandwidthResponse{};
 
   raise_if_error(
-      stub->NFCfgMeasurementBandwidth(&context, request, &response));
+      stub->NFCfgMeasurementBandwidth(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5099,7 +5338,8 @@ nf_cfg_measurement_interval(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = NFCfgMeasurementIntervalResponse{};
 
   raise_if_error(
-      stub->NFCfgMeasurementInterval(&context, request, &response));
+      stub->NFCfgMeasurementInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5124,7 +5364,8 @@ nf_cfg_measurement_method(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = NFCfgMeasurementMethodResponse{};
 
   raise_if_error(
-      stub->NFCfgMeasurementMethod(&context, request, &response));
+      stub->NFCfgMeasurementMethod(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5149,7 +5390,8 @@ nf_cfg_y_factor_mode(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = NFCfgYFactorModeResponse{};
 
   raise_if_error(
-      stub->NFCfgYFactorMode(&context, request, &response));
+      stub->NFCfgYFactorMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5170,7 +5412,8 @@ nf_cfg_y_factor_noise_source_enr(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = NFCfgYFactorNoiseSourceENRResponse{};
 
   raise_if_error(
-      stub->NFCfgYFactorNoiseSourceENR(&context, request, &response));
+      stub->NFCfgYFactorNoiseSourceENR(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5198,7 +5441,8 @@ nf_cfg_y_factor_noise_source_loss(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = NFCfgYFactorNoiseSourceLossResponse{};
 
   raise_if_error(
-      stub->NFCfgYFactorNoiseSourceLoss(&context, request, &response));
+      stub->NFCfgYFactorNoiseSourceLoss(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5216,7 +5460,8 @@ nf_cfg_y_factor_noise_source_settling_time(const StubPtr& stub, const nidevice_g
   auto response = NFCfgYFactorNoiseSourceSettlingTimeResponse{};
 
   raise_if_error(
-      stub->NFCfgYFactorNoiseSourceSettlingTime(&context, request, &response));
+      stub->NFCfgYFactorNoiseSourceSettlingTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5233,7 +5478,8 @@ nf_clear_calibration_database(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = NFClearCalibrationDatabaseResponse{};
 
   raise_if_error(
-      stub->NFClearCalibrationDatabase(&context, request, &response));
+      stub->NFClearCalibrationDatabase(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5251,7 +5497,8 @@ nf_fetch_analyzer_noise_figure(const StubPtr& stub, const nidevice_grpc::Session
   auto response = NFFetchAnalyzerNoiseFigureResponse{};
 
   raise_if_error(
-      stub->NFFetchAnalyzerNoiseFigure(&context, request, &response));
+      stub->NFFetchAnalyzerNoiseFigure(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5269,7 +5516,8 @@ nf_fetch_cold_source_power(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = NFFetchColdSourcePowerResponse{};
 
   raise_if_error(
-      stub->NFFetchColdSourcePower(&context, request, &response));
+      stub->NFFetchColdSourcePower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5287,7 +5535,8 @@ nf_fetch_dut_noise_figure_and_gain(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = NFFetchDUTNoiseFigureAndGainResponse{};
 
   raise_if_error(
-      stub->NFFetchDUTNoiseFigureAndGain(&context, request, &response));
+      stub->NFFetchDUTNoiseFigureAndGain(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5305,7 +5554,8 @@ nf_fetch_y_factor_powers(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = NFFetchYFactorPowersResponse{};
 
   raise_if_error(
-      stub->NFFetchYFactorPowers(&context, request, &response));
+      stub->NFFetchYFactorPowers(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5323,7 +5573,8 @@ nf_fetch_y_factors(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = NFFetchYFactorsResponse{};
 
   raise_if_error(
-      stub->NFFetchYFactors(&context, request, &response));
+      stub->NFFetchYFactors(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5342,7 +5593,8 @@ nf_recommend_reference_level(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = NFRecommendReferenceLevelResponse{};
 
   raise_if_error(
-      stub->NFRecommendReferenceLevel(&context, request, &response));
+      stub->NFRecommendReferenceLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5359,7 +5611,8 @@ nf_validate_calibration_data(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = NFValidateCalibrationDataResponse{};
 
   raise_if_error(
-      stub->NFValidateCalibrationData(&context, request, &response));
+      stub->NFValidateCalibrationData(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5393,7 +5646,8 @@ obw_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = OBWCfgAveragingResponse{};
 
   raise_if_error(
-      stub->OBWCfgAveraging(&context, request, &response));
+      stub->OBWCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5411,7 +5665,8 @@ obw_cfg_bandwidth_percentage(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = OBWCfgBandwidthPercentageResponse{};
 
   raise_if_error(
-      stub->OBWCfgBandwidthPercentage(&context, request, &response));
+      stub->OBWCfgBandwidthPercentage(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5437,7 +5692,8 @@ obw_cfg_fft(const StubPtr& stub, const nidevice_grpc::Session& instrument, const
   auto response = OBWCfgFFTResponse{};
 
   raise_if_error(
-      stub->OBWCfgFFT(&context, request, &response));
+      stub->OBWCfgFFT(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5462,7 +5718,8 @@ obw_cfg_power_units(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = OBWCfgPowerUnitsResponse{};
 
   raise_if_error(
-      stub->OBWCfgPowerUnits(&context, request, &response));
+      stub->OBWCfgPowerUnits(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5496,7 +5753,8 @@ obw_cfg_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = OBWCfgRBWFilterResponse{};
 
   raise_if_error(
-      stub->OBWCfgRBWFilter(&context, request, &response));
+      stub->OBWCfgRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5514,7 +5772,8 @@ obw_cfg_span(const StubPtr& stub, const nidevice_grpc::Session& instrument, cons
   auto response = OBWCfgSpanResponse{};
 
   raise_if_error(
-      stub->OBWCfgSpan(&context, request, &response));
+      stub->OBWCfgSpan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5540,7 +5799,8 @@ obw_cfg_sweep_time(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = OBWCfgSweepTimeResponse{};
 
   raise_if_error(
-      stub->OBWCfgSweepTime(&context, request, &response));
+      stub->OBWCfgSweepTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5558,7 +5818,8 @@ obw_fetch_measurement(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = OBWFetchMeasurementResponse{};
 
   raise_if_error(
-      stub->OBWFetchMeasurement(&context, request, &response));
+      stub->OBWFetchMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5576,7 +5837,8 @@ obw_fetch_spectrum_trace(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = OBWFetchSpectrumTraceResponse{};
 
   raise_if_error(
-      stub->OBWFetchSpectrumTrace(&context, request, &response));
+      stub->OBWFetchSpectrumTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5594,7 +5856,8 @@ obw_read(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb
   auto response = OBWReadResponse{};
 
   raise_if_error(
-      stub->OBWRead(&context, request, &response));
+      stub->OBWRead(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5612,7 +5875,8 @@ pavt_cfg_measurement_bandwidth(const StubPtr& stub, const nidevice_grpc::Session
   auto response = PAVTCfgMeasurementBandwidthResponse{};
 
   raise_if_error(
-      stub->PAVTCfgMeasurementBandwidth(&context, request, &response));
+      stub->PAVTCfgMeasurementBandwidth(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5631,7 +5895,8 @@ pavt_cfg_measurement_interval(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = PAVTCfgMeasurementIntervalResponse{};
 
   raise_if_error(
-      stub->PAVTCfgMeasurementInterval(&context, request, &response));
+      stub->PAVTCfgMeasurementInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5656,7 +5921,8 @@ pavt_cfg_measurement_interval_mode(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = PAVTCfgMeasurementIntervalModeResponse{};
 
   raise_if_error(
-      stub->PAVTCfgMeasurementIntervalMode(&context, request, &response));
+      stub->PAVTCfgMeasurementIntervalMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5681,7 +5947,8 @@ pavt_cfg_measurement_location_type(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = PAVTCfgMeasurementLocationTypeResponse{};
 
   raise_if_error(
-      stub->PAVTCfgMeasurementLocationType(&context, request, &response));
+      stub->PAVTCfgMeasurementLocationType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5699,7 +5966,8 @@ pavt_cfg_number_of_segments(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = PAVTCfgNumberOfSegmentsResponse{};
 
   raise_if_error(
-      stub->PAVTCfgNumberOfSegments(&context, request, &response));
+      stub->PAVTCfgNumberOfSegments(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5718,7 +5986,8 @@ pavt_cfg_segment_measurement_interval(const StubPtr& stub, const nidevice_grpc::
   auto response = PAVTCfgSegmentMeasurementIntervalResponse{};
 
   raise_if_error(
-      stub->PAVTCfgSegmentMeasurementInterval(&context, request, &response));
+      stub->PAVTCfgSegmentMeasurementInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5737,7 +6006,8 @@ pavt_cfg_segment_measurement_interval_array(const StubPtr& stub, const nidevice_
   auto response = PAVTCfgSegmentMeasurementIntervalArrayResponse{};
 
   raise_if_error(
-      stub->PAVTCfgSegmentMeasurementIntervalArray(&context, request, &response));
+      stub->PAVTCfgSegmentMeasurementIntervalArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5755,7 +6025,8 @@ pavt_cfg_segment_start_time_list(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = PAVTCfgSegmentStartTimeListResponse{};
 
   raise_if_error(
-      stub->PAVTCfgSegmentStartTimeList(&context, request, &response));
+      stub->PAVTCfgSegmentStartTimeList(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5775,7 +6046,8 @@ pavt_cfg_segment_start_time_step(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = PAVTCfgSegmentStartTimeStepResponse{};
 
   raise_if_error(
-      stub->PAVTCfgSegmentStartTimeStep(&context, request, &response));
+      stub->PAVTCfgSegmentStartTimeStep(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5800,7 +6072,8 @@ pavt_cfg_segment_type(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = PAVTCfgSegmentTypeResponse{};
 
   raise_if_error(
-      stub->PAVTCfgSegmentType(&context, request, &response));
+      stub->PAVTCfgSegmentType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5818,7 +6091,8 @@ pavt_cfg_segment_type_array(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = PAVTCfgSegmentTypeArrayResponse{};
 
   raise_if_error(
-      stub->PAVTCfgSegmentTypeArray(&context, request, &response));
+      stub->PAVTCfgSegmentTypeArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5837,7 +6111,8 @@ pavt_fetch_amplitude_trace(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = PAVTFetchAmplitudeTraceResponse{};
 
   raise_if_error(
-      stub->PAVTFetchAmplitudeTrace(&context, request, &response));
+      stub->PAVTFetchAmplitudeTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5855,7 +6130,8 @@ pavt_fetch_phase_and_amplitude(const StubPtr& stub, const nidevice_grpc::Session
   auto response = PAVTFetchPhaseAndAmplitudeResponse{};
 
   raise_if_error(
-      stub->PAVTFetchPhaseAndAmplitude(&context, request, &response));
+      stub->PAVTFetchPhaseAndAmplitude(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5873,7 +6149,8 @@ pavt_fetch_phase_and_amplitude_array(const StubPtr& stub, const nidevice_grpc::S
   auto response = PAVTFetchPhaseAndAmplitudeArrayResponse{};
 
   raise_if_error(
-      stub->PAVTFetchPhaseAndAmplitudeArray(&context, request, &response));
+      stub->PAVTFetchPhaseAndAmplitudeArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5892,7 +6169,8 @@ pavt_fetch_phase_trace(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = PAVTFetchPhaseTraceResponse{};
 
   raise_if_error(
-      stub->PAVTFetchPhaseTrace(&context, request, &response));
+      stub->PAVTFetchPhaseTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5912,7 +6190,8 @@ phase_noise_cfg_auto_range(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = PhaseNoiseCfgAutoRangeResponse{};
 
   raise_if_error(
-      stub->PhaseNoiseCfgAutoRange(&context, request, &response));
+      stub->PhaseNoiseCfgAutoRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5930,7 +6209,8 @@ phase_noise_cfg_averaging_multiplier(const StubPtr& stub, const nidevice_grpc::S
   auto response = PhaseNoiseCfgAveragingMultiplierResponse{};
 
   raise_if_error(
-      stub->PhaseNoiseCfgAveragingMultiplier(&context, request, &response));
+      stub->PhaseNoiseCfgAveragingMultiplier(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5958,7 +6238,8 @@ phase_noise_cfg_cancellation(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = PhaseNoiseCfgCancellationResponse{};
 
   raise_if_error(
-      stub->PhaseNoiseCfgCancellation(&context, request, &response));
+      stub->PhaseNoiseCfgCancellation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -5985,7 +6266,8 @@ phase_noise_cfg_integrated_noise(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = PhaseNoiseCfgIntegratedNoiseResponse{};
 
   raise_if_error(
-      stub->PhaseNoiseCfgIntegratedNoise(&context, request, &response));
+      stub->PhaseNoiseCfgIntegratedNoise(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6003,7 +6285,8 @@ phase_noise_cfg_number_of_ranges(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = PhaseNoiseCfgNumberOfRangesResponse{};
 
   raise_if_error(
-      stub->PhaseNoiseCfgNumberOfRanges(&context, request, &response));
+      stub->PhaseNoiseCfgNumberOfRanges(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6024,7 +6307,8 @@ phase_noise_cfg_range_array(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = PhaseNoiseCfgRangeArrayResponse{};
 
   raise_if_error(
-      stub->PhaseNoiseCfgRangeArray(&context, request, &response));
+      stub->PhaseNoiseCfgRangeArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6049,7 +6333,8 @@ phase_noise_cfg_range_definition(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = PhaseNoiseCfgRangeDefinitionResponse{};
 
   raise_if_error(
-      stub->PhaseNoiseCfgRangeDefinition(&context, request, &response));
+      stub->PhaseNoiseCfgRangeDefinition(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6075,7 +6360,8 @@ phase_noise_cfg_smoothing(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = PhaseNoiseCfgSmoothingResponse{};
 
   raise_if_error(
-      stub->PhaseNoiseCfgSmoothing(&context, request, &response));
+      stub->PhaseNoiseCfgSmoothing(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6093,7 +6379,8 @@ phase_noise_cfg_spot_noise_frequency_list(const StubPtr& stub, const nidevice_gr
   auto response = PhaseNoiseCfgSpotNoiseFrequencyListResponse{};
 
   raise_if_error(
-      stub->PhaseNoiseCfgSpotNoiseFrequencyList(&context, request, &response));
+      stub->PhaseNoiseCfgSpotNoiseFrequencyList(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6119,7 +6406,8 @@ phase_noise_cfg_spur_removal(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = PhaseNoiseCfgSpurRemovalResponse{};
 
   raise_if_error(
-      stub->PhaseNoiseCfgSpurRemoval(&context, request, &response));
+      stub->PhaseNoiseCfgSpurRemoval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6137,7 +6425,8 @@ phase_noise_fetch_carrier_measurement(const StubPtr& stub, const nidevice_grpc::
   auto response = PhaseNoiseFetchCarrierMeasurementResponse{};
 
   raise_if_error(
-      stub->PhaseNoiseFetchCarrierMeasurement(&context, request, &response));
+      stub->PhaseNoiseFetchCarrierMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6155,7 +6444,8 @@ phase_noise_fetch_integrated_noise(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = PhaseNoiseFetchIntegratedNoiseResponse{};
 
   raise_if_error(
-      stub->PhaseNoiseFetchIntegratedNoise(&context, request, &response));
+      stub->PhaseNoiseFetchIntegratedNoise(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6173,7 +6463,8 @@ phase_noise_fetch_measured_log_plot_trace(const StubPtr& stub, const nidevice_gr
   auto response = PhaseNoiseFetchMeasuredLogPlotTraceResponse{};
 
   raise_if_error(
-      stub->PhaseNoiseFetchMeasuredLogPlotTrace(&context, request, &response));
+      stub->PhaseNoiseFetchMeasuredLogPlotTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6191,7 +6482,8 @@ phase_noise_fetch_smoothed_log_plot_trace(const StubPtr& stub, const nidevice_gr
   auto response = PhaseNoiseFetchSmoothedLogPlotTraceResponse{};
 
   raise_if_error(
-      stub->PhaseNoiseFetchSmoothedLogPlotTrace(&context, request, &response));
+      stub->PhaseNoiseFetchSmoothedLogPlotTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6209,7 +6501,8 @@ phase_noise_fetch_spot_noise(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = PhaseNoiseFetchSpotNoiseResponse{};
 
   raise_if_error(
-      stub->PhaseNoiseFetchSpotNoise(&context, request, &response));
+      stub->PhaseNoiseFetchSpotNoise(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6227,7 +6520,8 @@ reset_attribute(const StubPtr& stub, const nidevice_grpc::Session& instrument, c
   auto response = ResetAttributeResponse{};
 
   raise_if_error(
-      stub->ResetAttribute(&context, request, &response));
+      stub->ResetAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6244,7 +6538,8 @@ reset_to_default(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = ResetToDefaultResponse{};
 
   raise_if_error(
-      stub->ResetToDefault(&context, request, &response));
+      stub->ResetToDefault(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6278,7 +6573,8 @@ sem_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SEMCfgAveragingResponse{};
 
   raise_if_error(
-      stub->SEMCfgAveraging(&context, request, &response));
+      stub->SEMCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6296,7 +6592,8 @@ sem_cfg_carrier_channel_bandwidth(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = SEMCfgCarrierChannelBandwidthResponse{};
 
   raise_if_error(
-      stub->SEMCfgCarrierChannelBandwidth(&context, request, &response));
+      stub->SEMCfgCarrierChannelBandwidth(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6321,7 +6618,8 @@ sem_cfg_carrier_enabled(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SEMCfgCarrierEnabledResponse{};
 
   raise_if_error(
-      stub->SEMCfgCarrierEnabled(&context, request, &response));
+      stub->SEMCfgCarrierEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6339,7 +6637,8 @@ sem_cfg_carrier_frequency(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = SEMCfgCarrierFrequencyResponse{};
 
   raise_if_error(
-      stub->SEMCfgCarrierFrequency(&context, request, &response));
+      stub->SEMCfgCarrierFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6357,7 +6656,8 @@ sem_cfg_carrier_integration_bandwidth(const StubPtr& stub, const nidevice_grpc::
   auto response = SEMCfgCarrierIntegrationBandwidthResponse{};
 
   raise_if_error(
-      stub->SEMCfgCarrierIntegrationBandwidth(&context, request, &response));
+      stub->SEMCfgCarrierIntegrationBandwidth(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6391,7 +6691,8 @@ sem_cfg_carrier_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = SEMCfgCarrierRBWFilterResponse{};
 
   raise_if_error(
-      stub->SEMCfgCarrierRBWFilter(&context, request, &response));
+      stub->SEMCfgCarrierRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6417,7 +6718,8 @@ sem_cfg_carrier_rrc_filter(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = SEMCfgCarrierRRCFilterResponse{};
 
   raise_if_error(
-      stub->SEMCfgCarrierRRCFilter(&context, request, &response));
+      stub->SEMCfgCarrierRRCFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6443,7 +6745,8 @@ sem_cfg_fft(const StubPtr& stub, const nidevice_grpc::Session& instrument, const
   auto response = SEMCfgFFTResponse{};
 
   raise_if_error(
-      stub->SEMCfgFFT(&context, request, &response));
+      stub->SEMCfgFFT(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6461,7 +6764,8 @@ sem_cfg_number_of_carriers(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = SEMCfgNumberOfCarriersResponse{};
 
   raise_if_error(
-      stub->SEMCfgNumberOfCarriers(&context, request, &response));
+      stub->SEMCfgNumberOfCarriers(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6479,7 +6783,8 @@ sem_cfg_number_of_offsets(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = SEMCfgNumberOfOffsetsResponse{};
 
   raise_if_error(
-      stub->SEMCfgNumberOfOffsets(&context, request, &response));
+      stub->SEMCfgNumberOfOffsets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6506,7 +6811,8 @@ sem_cfg_offset_absolute_limit(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMCfgOffsetAbsoluteLimitResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetAbsoluteLimit(&context, request, &response));
+      stub->SEMCfgOffsetAbsoluteLimit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6526,7 +6832,8 @@ sem_cfg_offset_absolute_limit_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SEMCfgOffsetAbsoluteLimitArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetAbsoluteLimitArray(&context, request, &response));
+      stub->SEMCfgOffsetAbsoluteLimitArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6544,7 +6851,8 @@ sem_cfg_offset_bandwidth_integral(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = SEMCfgOffsetBandwidthIntegralResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetBandwidthIntegral(&context, request, &response));
+      stub->SEMCfgOffsetBandwidthIntegral(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6579,7 +6887,8 @@ sem_cfg_offset_frequency(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = SEMCfgOffsetFrequencyResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetFrequency(&context, request, &response));
+      stub->SEMCfgOffsetFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6600,7 +6909,8 @@ sem_cfg_offset_frequency_array(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SEMCfgOffsetFrequencyArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetFrequencyArray(&context, request, &response));
+      stub->SEMCfgOffsetFrequencyArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6625,7 +6935,8 @@ sem_cfg_offset_frequency_definition(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SEMCfgOffsetFrequencyDefinitionResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetFrequencyDefinition(&context, request, &response));
+      stub->SEMCfgOffsetFrequencyDefinition(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6650,7 +6961,8 @@ sem_cfg_offset_limit_fail_mask(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SEMCfgOffsetLimitFailMaskResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetLimitFailMask(&context, request, &response));
+      stub->SEMCfgOffsetLimitFailMask(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6684,7 +6996,8 @@ sem_cfg_offset_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = SEMCfgOffsetRBWFilterResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetRBWFilter(&context, request, &response));
+      stub->SEMCfgOffsetRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6704,7 +7017,8 @@ sem_cfg_offset_rbw_filter_array(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = SEMCfgOffsetRBWFilterArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetRBWFilterArray(&context, request, &response));
+      stub->SEMCfgOffsetRBWFilterArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6722,7 +7036,8 @@ sem_cfg_offset_relative_attenuation(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SEMCfgOffsetRelativeAttenuationResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetRelativeAttenuation(&context, request, &response));
+      stub->SEMCfgOffsetRelativeAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6740,7 +7055,8 @@ sem_cfg_offset_relative_attenuation_array(const StubPtr& stub, const nidevice_gr
   auto response = SEMCfgOffsetRelativeAttenuationArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetRelativeAttenuationArray(&context, request, &response));
+      stub->SEMCfgOffsetRelativeAttenuationArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6767,7 +7083,8 @@ sem_cfg_offset_relative_limit(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMCfgOffsetRelativeLimitResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetRelativeLimit(&context, request, &response));
+      stub->SEMCfgOffsetRelativeLimit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6787,7 +7104,8 @@ sem_cfg_offset_relative_limit_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SEMCfgOffsetRelativeLimitArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetRelativeLimitArray(&context, request, &response));
+      stub->SEMCfgOffsetRelativeLimitArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6812,7 +7130,8 @@ sem_cfg_power_units(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = SEMCfgPowerUnitsResponse{};
 
   raise_if_error(
-      stub->SEMCfgPowerUnits(&context, request, &response));
+      stub->SEMCfgPowerUnits(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6837,7 +7156,8 @@ sem_cfg_reference_type(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = SEMCfgReferenceTypeResponse{};
 
   raise_if_error(
-      stub->SEMCfgReferenceType(&context, request, &response));
+      stub->SEMCfgReferenceType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6863,7 +7183,8 @@ sem_cfg_sweep_time(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = SEMCfgSweepTimeResponse{};
 
   raise_if_error(
-      stub->SEMCfgSweepTime(&context, request, &response));
+      stub->SEMCfgSweepTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6881,7 +7202,8 @@ sem_fetch_absolute_mask_trace(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMFetchAbsoluteMaskTraceResponse{};
 
   raise_if_error(
-      stub->SEMFetchAbsoluteMaskTrace(&context, request, &response));
+      stub->SEMFetchAbsoluteMaskTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6899,7 +7221,8 @@ sem_fetch_carrier_measurement(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMFetchCarrierMeasurementResponse{};
 
   raise_if_error(
-      stub->SEMFetchCarrierMeasurement(&context, request, &response));
+      stub->SEMFetchCarrierMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6917,7 +7240,8 @@ sem_fetch_composite_measurement_status(const StubPtr& stub, const nidevice_grpc:
   auto response = SEMFetchCompositeMeasurementStatusResponse{};
 
   raise_if_error(
-      stub->SEMFetchCompositeMeasurementStatus(&context, request, &response));
+      stub->SEMFetchCompositeMeasurementStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6935,7 +7259,8 @@ sem_fetch_frequency_resolution(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SEMFetchFrequencyResolutionResponse{};
 
   raise_if_error(
-      stub->SEMFetchFrequencyResolution(&context, request, &response));
+      stub->SEMFetchFrequencyResolution(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6953,7 +7278,8 @@ sem_fetch_lower_offset_margin(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMFetchLowerOffsetMarginResponse{};
 
   raise_if_error(
-      stub->SEMFetchLowerOffsetMargin(&context, request, &response));
+      stub->SEMFetchLowerOffsetMargin(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6971,7 +7297,8 @@ sem_fetch_lower_offset_margin_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SEMFetchLowerOffsetMarginArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchLowerOffsetMarginArray(&context, request, &response));
+      stub->SEMFetchLowerOffsetMarginArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -6989,7 +7316,8 @@ sem_fetch_lower_offset_power(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SEMFetchLowerOffsetPowerResponse{};
 
   raise_if_error(
-      stub->SEMFetchLowerOffsetPower(&context, request, &response));
+      stub->SEMFetchLowerOffsetPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7007,7 +7335,8 @@ sem_fetch_lower_offset_power_array(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = SEMFetchLowerOffsetPowerArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchLowerOffsetPowerArray(&context, request, &response));
+      stub->SEMFetchLowerOffsetPowerArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7025,7 +7354,8 @@ sem_fetch_relative_mask_trace(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMFetchRelativeMaskTraceResponse{};
 
   raise_if_error(
-      stub->SEMFetchRelativeMaskTrace(&context, request, &response));
+      stub->SEMFetchRelativeMaskTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7043,7 +7373,8 @@ sem_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = SEMFetchSpectrumResponse{};
 
   raise_if_error(
-      stub->SEMFetchSpectrum(&context, request, &response));
+      stub->SEMFetchSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7061,7 +7392,8 @@ sem_fetch_total_carrier_power(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMFetchTotalCarrierPowerResponse{};
 
   raise_if_error(
-      stub->SEMFetchTotalCarrierPower(&context, request, &response));
+      stub->SEMFetchTotalCarrierPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7079,7 +7411,8 @@ sem_fetch_upper_offset_margin(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMFetchUpperOffsetMarginResponse{};
 
   raise_if_error(
-      stub->SEMFetchUpperOffsetMargin(&context, request, &response));
+      stub->SEMFetchUpperOffsetMargin(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7097,7 +7430,8 @@ sem_fetch_upper_offset_margin_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SEMFetchUpperOffsetMarginArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchUpperOffsetMarginArray(&context, request, &response));
+      stub->SEMFetchUpperOffsetMarginArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7115,7 +7449,8 @@ sem_fetch_upper_offset_power(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SEMFetchUpperOffsetPowerResponse{};
 
   raise_if_error(
-      stub->SEMFetchUpperOffsetPower(&context, request, &response));
+      stub->SEMFetchUpperOffsetPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7133,7 +7468,8 @@ sem_fetch_upper_offset_power_array(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = SEMFetchUpperOffsetPowerArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchUpperOffsetPowerArray(&context, request, &response));
+      stub->SEMFetchUpperOffsetPowerArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7159,7 +7495,8 @@ select_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = SelectMeasurementsResponse{};
 
   raise_if_error(
-      stub->SelectMeasurements(&context, request, &response));
+      stub->SelectMeasurements(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7175,7 +7512,8 @@ send_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = SendSoftwareEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->SendSoftwareEdgeTrigger(&context, request, &response));
+      stub->SendSoftwareEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7194,7 +7532,8 @@ set_attribute_f32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeF32Response{};
 
   raise_if_error(
-      stub->SetAttributeF32(&context, request, &response));
+      stub->SetAttributeF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7213,7 +7552,8 @@ set_attribute_f32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeF32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeF32Array(&context, request, &response));
+      stub->SetAttributeF32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7232,7 +7572,8 @@ set_attribute_f64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeF64Response{};
 
   raise_if_error(
-      stub->SetAttributeF64(&context, request, &response));
+      stub->SetAttributeF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7251,7 +7592,8 @@ set_attribute_f64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeF64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeF64Array(&context, request, &response));
+      stub->SetAttributeF64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7270,7 +7612,8 @@ set_attribute_i16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI16Response{};
 
   raise_if_error(
-      stub->SetAttributeI16(&context, request, &response));
+      stub->SetAttributeI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7296,7 +7639,8 @@ set_attribute_i32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI32Response{};
 
   raise_if_error(
-      stub->SetAttributeI32(&context, request, &response));
+      stub->SetAttributeI32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7315,7 +7659,8 @@ set_attribute_i32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeI32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI32Array(&context, request, &response));
+      stub->SetAttributeI32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7334,7 +7679,8 @@ set_attribute_i64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI64Response{};
 
   raise_if_error(
-      stub->SetAttributeI64(&context, request, &response));
+      stub->SetAttributeI64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7353,7 +7699,8 @@ set_attribute_i64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeI64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI64Array(&context, request, &response));
+      stub->SetAttributeI64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7372,7 +7719,8 @@ set_attribute_i8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = SetAttributeI8Response{};
 
   raise_if_error(
-      stub->SetAttributeI8(&context, request, &response));
+      stub->SetAttributeI8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7391,7 +7739,8 @@ set_attribute_i8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = SetAttributeI8ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI8Array(&context, request, &response));
+      stub->SetAttributeI8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7410,7 +7759,8 @@ set_attribute_ni_complex_double_array(const StubPtr& stub, const nidevice_grpc::
   auto response = SetAttributeNIComplexDoubleArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeNIComplexDoubleArray(&context, request, &response));
+      stub->SetAttributeNIComplexDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7429,7 +7779,8 @@ set_attribute_ni_complex_single_array(const StubPtr& stub, const nidevice_grpc::
   auto response = SetAttributeNIComplexSingleArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeNIComplexSingleArray(&context, request, &response));
+      stub->SetAttributeNIComplexSingleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7455,7 +7806,8 @@ set_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = SetAttributeStringResponse{};
 
   raise_if_error(
-      stub->SetAttributeString(&context, request, &response));
+      stub->SetAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7474,7 +7826,8 @@ set_attribute_u16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeU16Response{};
 
   raise_if_error(
-      stub->SetAttributeU16(&context, request, &response));
+      stub->SetAttributeU16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7493,7 +7846,8 @@ set_attribute_u32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeU32Response{};
 
   raise_if_error(
-      stub->SetAttributeU32(&context, request, &response));
+      stub->SetAttributeU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7512,7 +7866,8 @@ set_attribute_u32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeU32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU32Array(&context, request, &response));
+      stub->SetAttributeU32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7531,7 +7886,8 @@ set_attribute_u64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeU64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU64Array(&context, request, &response));
+      stub->SetAttributeU64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7550,7 +7906,8 @@ set_attribute_u8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = SetAttributeU8Response{};
 
   raise_if_error(
-      stub->SetAttributeU8(&context, request, &response));
+      stub->SetAttributeU8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7569,7 +7926,8 @@ set_attribute_u8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = SetAttributeU8ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU8Array(&context, request, &response));
+      stub->SetAttributeU8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7603,7 +7961,8 @@ spectrum_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = SpectrumCfgAveragingResponse{};
 
   raise_if_error(
-      stub->SpectrumCfgAveraging(&context, request, &response));
+      stub->SpectrumCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7629,7 +7988,8 @@ spectrum_cfg_detector(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = SpectrumCfgDetectorResponse{};
 
   raise_if_error(
-      stub->SpectrumCfgDetector(&context, request, &response));
+      stub->SpectrumCfgDetector(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7655,7 +8015,8 @@ spectrum_cfg_fft(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = SpectrumCfgFFTResponse{};
 
   raise_if_error(
-      stub->SpectrumCfgFFT(&context, request, &response));
+      stub->SpectrumCfgFFT(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7674,7 +8035,8 @@ spectrum_cfg_frequency_start_stop(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = SpectrumCfgFrequencyStartStopResponse{};
 
   raise_if_error(
-      stub->SpectrumCfgFrequencyStartStop(&context, request, &response));
+      stub->SpectrumCfgFrequencyStartStop(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7699,7 +8061,8 @@ spectrum_cfg_noise_compensation_enabled(const StubPtr& stub, const nidevice_grpc
   auto response = SpectrumCfgNoiseCompensationEnabledResponse{};
 
   raise_if_error(
-      stub->SpectrumCfgNoiseCompensationEnabled(&context, request, &response));
+      stub->SpectrumCfgNoiseCompensationEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7724,7 +8087,8 @@ spectrum_cfg_power_units(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = SpectrumCfgPowerUnitsResponse{};
 
   raise_if_error(
-      stub->SpectrumCfgPowerUnits(&context, request, &response));
+      stub->SpectrumCfgPowerUnits(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7758,7 +8122,8 @@ spectrum_cfg_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SpectrumCfgRBWFilterResponse{};
 
   raise_if_error(
-      stub->SpectrumCfgRBWFilter(&context, request, &response));
+      stub->SpectrumCfgRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7776,7 +8141,8 @@ spectrum_cfg_span(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SpectrumCfgSpanResponse{};
 
   raise_if_error(
-      stub->SpectrumCfgSpan(&context, request, &response));
+      stub->SpectrumCfgSpan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7802,7 +8168,8 @@ spectrum_cfg_sweep_time(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SpectrumCfgSweepTimeResponse{};
 
   raise_if_error(
-      stub->SpectrumCfgSweepTime(&context, request, &response));
+      stub->SpectrumCfgSweepTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7829,7 +8196,8 @@ spectrum_cfg_vbw_filter(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SpectrumCfgVBWFilterResponse{};
 
   raise_if_error(
-      stub->SpectrumCfgVBWFilter(&context, request, &response));
+      stub->SpectrumCfgVBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7847,7 +8215,8 @@ spectrum_fetch_measurement(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = SpectrumFetchMeasurementResponse{};
 
   raise_if_error(
-      stub->SpectrumFetchMeasurement(&context, request, &response));
+      stub->SpectrumFetchMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7865,7 +8234,8 @@ spectrum_fetch_power_trace(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = SpectrumFetchPowerTraceResponse{};
 
   raise_if_error(
-      stub->SpectrumFetchPowerTrace(&context, request, &response));
+      stub->SpectrumFetchPowerTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7883,7 +8253,8 @@ spectrum_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SpectrumFetchSpectrumResponse{};
 
   raise_if_error(
-      stub->SpectrumFetchSpectrum(&context, request, &response));
+      stub->SpectrumFetchSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7901,7 +8272,8 @@ spectrum_read(const StubPtr& stub, const nidevice_grpc::Session& instrument, con
   auto response = SpectrumReadResponse{};
 
   raise_if_error(
-      stub->SpectrumRead(&context, request, &response));
+      stub->SpectrumRead(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7918,7 +8290,8 @@ spectrum_validate_noise_calibration_data(const StubPtr& stub, const nidevice_grp
   auto response = SpectrumValidateNoiseCalibrationDataResponse{};
 
   raise_if_error(
-      stub->SpectrumValidateNoiseCalibrationData(&context, request, &response));
+      stub->SpectrumValidateNoiseCalibrationData(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7952,7 +8325,8 @@ spur_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = SpurCfgAveragingResponse{};
 
   raise_if_error(
-      stub->SpurCfgAveraging(&context, request, &response));
+      stub->SpurCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7977,7 +8351,8 @@ spur_cfg_fft_window_type(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = SpurCfgFFTWindowTypeResponse{};
 
   raise_if_error(
-      stub->SpurCfgFFTWindowType(&context, request, &response));
+      stub->SpurCfgFFTWindowType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -7995,7 +8370,8 @@ spur_cfg_number_of_ranges(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = SpurCfgNumberOfRangesResponse{};
 
   raise_if_error(
-      stub->SpurCfgNumberOfRanges(&context, request, &response));
+      stub->SpurCfgNumberOfRanges(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8022,7 +8398,8 @@ spur_cfg_range_absolute_limit(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SpurCfgRangeAbsoluteLimitResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangeAbsoluteLimit(&context, request, &response));
+      stub->SpurCfgRangeAbsoluteLimit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8042,7 +8419,8 @@ spur_cfg_range_absolute_limit_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SpurCfgRangeAbsoluteLimitArrayResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangeAbsoluteLimitArray(&context, request, &response));
+      stub->SpurCfgRangeAbsoluteLimitArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8068,7 +8446,8 @@ spur_cfg_range_detector(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SpurCfgRangeDetectorResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangeDetector(&context, request, &response));
+      stub->SpurCfgRangeDetector(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8087,7 +8466,8 @@ spur_cfg_range_detector_array(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SpurCfgRangeDetectorArrayResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangeDetectorArray(&context, request, &response));
+      stub->SpurCfgRangeDetectorArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8114,7 +8494,8 @@ spur_cfg_range_frequency(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = SpurCfgRangeFrequencyResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangeFrequency(&context, request, &response));
+      stub->SpurCfgRangeFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8134,7 +8515,8 @@ spur_cfg_range_frequency_array(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SpurCfgRangeFrequencyArrayResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangeFrequencyArray(&context, request, &response));
+      stub->SpurCfgRangeFrequencyArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8152,7 +8534,8 @@ spur_cfg_range_number_of_spurs_to_report(const StubPtr& stub, const nidevice_grp
   auto response = SpurCfgRangeNumberOfSpursToReportResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangeNumberOfSpursToReport(&context, request, &response));
+      stub->SpurCfgRangeNumberOfSpursToReport(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8170,7 +8553,8 @@ spur_cfg_range_number_of_spurs_to_report_array(const StubPtr& stub, const nidevi
   auto response = SpurCfgRangeNumberOfSpursToReportArrayResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangeNumberOfSpursToReportArray(&context, request, &response));
+      stub->SpurCfgRangeNumberOfSpursToReportArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8189,7 +8573,8 @@ spur_cfg_range_peak_criteria(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SpurCfgRangePeakCriteriaResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangePeakCriteria(&context, request, &response));
+      stub->SpurCfgRangePeakCriteria(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8208,7 +8593,8 @@ spur_cfg_range_peak_criteria_array(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = SpurCfgRangePeakCriteriaArrayResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangePeakCriteriaArray(&context, request, &response));
+      stub->SpurCfgRangePeakCriteriaArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8228,7 +8614,8 @@ spur_cfg_range_rbw_array(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = SpurCfgRangeRBWArrayResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangeRBWArray(&context, request, &response));
+      stub->SpurCfgRangeRBWArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8262,7 +8649,8 @@ spur_cfg_range_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = SpurCfgRangeRBWFilterResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangeRBWFilter(&context, request, &response));
+      stub->SpurCfgRangeRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8280,7 +8668,8 @@ spur_cfg_range_relative_attenuation(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SpurCfgRangeRelativeAttenuationResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangeRelativeAttenuation(&context, request, &response));
+      stub->SpurCfgRangeRelativeAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8298,7 +8687,8 @@ spur_cfg_range_relative_attenuation_array(const StubPtr& stub, const nidevice_gr
   auto response = SpurCfgRangeRelativeAttenuationArrayResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangeRelativeAttenuationArray(&context, request, &response));
+      stub->SpurCfgRangeRelativeAttenuationArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8324,7 +8714,8 @@ spur_cfg_range_sweep_time(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = SpurCfgRangeSweepTimeResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangeSweepTime(&context, request, &response));
+      stub->SpurCfgRangeSweepTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8343,7 +8734,8 @@ spur_cfg_range_sweep_time_array(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = SpurCfgRangeSweepTimeArrayResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangeSweepTimeArray(&context, request, &response));
+      stub->SpurCfgRangeSweepTimeArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8370,7 +8762,8 @@ spur_cfg_range_vbw_filter(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = SpurCfgRangeVBWFilterResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangeVBWFilter(&context, request, &response));
+      stub->SpurCfgRangeVBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8390,7 +8783,8 @@ spur_cfg_range_vbw_filter_array(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = SpurCfgRangeVBWFilterArrayResponse{};
 
   raise_if_error(
-      stub->SpurCfgRangeVBWFilterArray(&context, request, &response));
+      stub->SpurCfgRangeVBWFilterArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8408,7 +8802,8 @@ spur_cfg_trace_range_index(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = SpurCfgTraceRangeIndexResponse{};
 
   raise_if_error(
-      stub->SpurCfgTraceRangeIndex(&context, request, &response));
+      stub->SpurCfgTraceRangeIndex(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8426,7 +8821,8 @@ spur_fetch_all_spurs(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = SpurFetchAllSpursResponse{};
 
   raise_if_error(
-      stub->SpurFetchAllSpurs(&context, request, &response));
+      stub->SpurFetchAllSpurs(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8444,7 +8840,8 @@ spur_fetch_measurement_status(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SpurFetchMeasurementStatusResponse{};
 
   raise_if_error(
-      stub->SpurFetchMeasurementStatus(&context, request, &response));
+      stub->SpurFetchMeasurementStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8462,7 +8859,8 @@ spur_fetch_range_absolute_limit_trace(const StubPtr& stub, const nidevice_grpc::
   auto response = SpurFetchRangeAbsoluteLimitTraceResponse{};
 
   raise_if_error(
-      stub->SpurFetchRangeAbsoluteLimitTrace(&context, request, &response));
+      stub->SpurFetchRangeAbsoluteLimitTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8480,7 +8878,8 @@ spur_fetch_range_spectrum_trace(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = SpurFetchRangeSpectrumTraceResponse{};
 
   raise_if_error(
-      stub->SpurFetchRangeSpectrumTrace(&context, request, &response));
+      stub->SpurFetchRangeSpectrumTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8498,7 +8897,8 @@ spur_fetch_range_status(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SpurFetchRangeStatusResponse{};
 
   raise_if_error(
-      stub->SpurFetchRangeStatus(&context, request, &response));
+      stub->SpurFetchRangeStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8516,7 +8916,8 @@ spur_fetch_range_status_array(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SpurFetchRangeStatusArrayResponse{};
 
   raise_if_error(
-      stub->SpurFetchRangeStatusArray(&context, request, &response));
+      stub->SpurFetchRangeStatusArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8534,7 +8935,8 @@ spur_fetch_spur_measurement(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = SpurFetchSpurMeasurementResponse{};
 
   raise_if_error(
-      stub->SpurFetchSpurMeasurement(&context, request, &response));
+      stub->SpurFetchSpurMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8552,7 +8954,8 @@ spur_fetch_spur_measurement_array(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = SpurFetchSpurMeasurementArrayResponse{};
 
   raise_if_error(
-      stub->SpurFetchSpurMeasurementArray(&context, request, &response));
+      stub->SpurFetchSpurMeasurementArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8586,7 +8989,8 @@ txp_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = TXPCfgAveragingResponse{};
 
   raise_if_error(
-      stub->TXPCfgAveraging(&context, request, &response));
+      stub->TXPCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8604,7 +9008,8 @@ txp_cfg_measurement_interval(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = TXPCfgMeasurementIntervalResponse{};
 
   raise_if_error(
-      stub->TXPCfgMeasurementInterval(&context, request, &response));
+      stub->TXPCfgMeasurementInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8631,7 +9036,8 @@ txp_cfg_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = TXPCfgRBWFilterResponse{};
 
   raise_if_error(
-      stub->TXPCfgRBWFilter(&context, request, &response));
+      stub->TXPCfgRBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8665,7 +9071,8 @@ txp_cfg_threshold(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = TXPCfgThresholdResponse{};
 
   raise_if_error(
-      stub->TXPCfgThreshold(&context, request, &response));
+      stub->TXPCfgThreshold(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8692,7 +9099,8 @@ txp_cfg_vbw_filter(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = TXPCfgVBWFilterResponse{};
 
   raise_if_error(
-      stub->TXPCfgVBWFilter(&context, request, &response));
+      stub->TXPCfgVBWFilter(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8710,7 +9118,8 @@ txp_fetch_measurement(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = TXPFetchMeasurementResponse{};
 
   raise_if_error(
-      stub->TXPFetchMeasurement(&context, request, &response));
+      stub->TXPFetchMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8728,7 +9137,8 @@ txp_fetch_power_trace(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = TXPFetchPowerTraceResponse{};
 
   raise_if_error(
-      stub->TXPFetchPowerTrace(&context, request, &response));
+      stub->TXPFetchPowerTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8746,7 +9156,8 @@ txp_read(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb
   auto response = TXPReadResponse{};
 
   raise_if_error(
-      stub->TXPRead(&context, request, &response));
+      stub->TXPRead(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8763,7 +9174,8 @@ wait_for_acquisition_complete(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = WaitForAcquisitionCompleteResponse{};
 
   raise_if_error(
-      stub->WaitForAcquisitionComplete(&context, request, &response));
+      stub->WaitForAcquisitionComplete(&context, request, &response),
+      context);
 
   return response;
 }
@@ -8781,7 +9193,8 @@ wait_for_measurement_complete(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = WaitForMeasurementCompleteResponse{};
 
   raise_if_error(
-      stub->WaitForMeasurementComplete(&context, request, &response));
+      stub->WaitForMeasurementComplete(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.cpp
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.cpp
@@ -30,7 +30,8 @@ cache_result(const StubPtr& stub, const nidevice_grpc::Session& instrument, cons
   auto response = CacheResultResponse{};
 
   raise_if_error(
-      stub->CacheResult(&context, request, &response));
+      stub->CacheResult(&context, request, &response),
+      context);
 
   return response;
 }
@@ -51,7 +52,8 @@ iq_fetch_data_override_behavior(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = IQFetchDataOverrideBehaviorResponse{};
 
   raise_if_error(
-      stub->IQFetchDataOverrideBehavior(&context, request, &response));
+      stub->IQFetchDataOverrideBehavior(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nirfmxwlan/nirfmxwlan_client.cpp
+++ b/generated/nirfmxwlan/nirfmxwlan_client.cpp
@@ -29,7 +29,8 @@ abort_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = AbortMeasurementsResponse{};
 
   raise_if_error(
-      stub->AbortMeasurements(&context, request, &response));
+      stub->AbortMeasurements(&context, request, &response),
+      context);
 
   return response;
 }
@@ -51,7 +52,8 @@ analyze_iq1_waveform(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = AnalyzeIQ1WaveformResponse{};
 
   raise_if_error(
-      stub->AnalyzeIQ1Waveform(&context, request, &response));
+      stub->AnalyzeIQ1Waveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -74,7 +76,8 @@ analyze_n_waveforms_iq(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = AnalyzeNWaveformsIQResponse{};
 
   raise_if_error(
-      stub->AnalyzeNWaveformsIQ(&context, request, &response));
+      stub->AnalyzeNWaveformsIQ(&context, request, &response),
+      context);
 
   return response;
 }
@@ -97,7 +100,8 @@ analyze_n_waveforms_spectrum(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = AnalyzeNWaveformsSpectrumResponse{};
 
   raise_if_error(
-      stub->AnalyzeNWaveformsSpectrum(&context, request, &response));
+      stub->AnalyzeNWaveformsSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -119,7 +123,8 @@ analyze_spectrum1_waveform(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = AnalyzeSpectrum1WaveformResponse{};
 
   raise_if_error(
-      stub->AnalyzeSpectrum1Waveform(&context, request, &response));
+      stub->AnalyzeSpectrum1Waveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -137,7 +142,8 @@ auto_detect_signal(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = AutoDetectSignalResponse{};
 
   raise_if_error(
-      stub->AutoDetectSignal(&context, request, &response));
+      stub->AutoDetectSignal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -155,7 +161,8 @@ auto_level(const StubPtr& stub, const nidevice_grpc::Session& instrument, const 
   auto response = AutoLevelResponse{};
 
   raise_if_error(
-      stub->AutoLevel(&context, request, &response));
+      stub->AutoLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -172,7 +179,8 @@ build_chain_string(const StubPtr& stub, const pb::string& selector_string, const
   auto response = BuildChainStringResponse{};
 
   raise_if_error(
-      stub->BuildChainString(&context, request, &response));
+      stub->BuildChainString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -189,7 +197,8 @@ build_gate_string(const StubPtr& stub, const pb::string& selector_string, const 
   auto response = BuildGateStringResponse{};
 
   raise_if_error(
-      stub->BuildGateString(&context, request, &response));
+      stub->BuildGateString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -206,7 +215,8 @@ build_offset_string(const StubPtr& stub, const pb::string& selector_string, cons
   auto response = BuildOffsetStringResponse{};
 
   raise_if_error(
-      stub->BuildOffsetString(&context, request, &response));
+      stub->BuildOffsetString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -223,7 +233,8 @@ build_segment_string(const StubPtr& stub, const pb::string& selector_string, con
   auto response = BuildSegmentStringResponse{};
 
   raise_if_error(
-      stub->BuildSegmentString(&context, request, &response));
+      stub->BuildSegmentString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -240,7 +251,8 @@ build_signal_string(const StubPtr& stub, const pb::string& signal_name, const pb
   auto response = BuildSignalStringResponse{};
 
   raise_if_error(
-      stub->BuildSignalString(&context, request, &response));
+      stub->BuildSignalString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -257,7 +269,8 @@ build_stream_string(const StubPtr& stub, const pb::string& selector_string, cons
   auto response = BuildStreamStringResponse{};
 
   raise_if_error(
-      stub->BuildStreamString(&context, request, &response));
+      stub->BuildStreamString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -274,7 +287,8 @@ build_user_string(const StubPtr& stub, const pb::string& selector_string, const 
   auto response = BuildUserStringResponse{};
 
   raise_if_error(
-      stub->BuildUserString(&context, request, &response));
+      stub->BuildUserString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -292,7 +306,8 @@ cfg_channel_bandwidth(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = CfgChannelBandwidthResponse{};
 
   raise_if_error(
-      stub->CfgChannelBandwidth(&context, request, &response));
+      stub->CfgChannelBandwidth(&context, request, &response),
+      context);
 
   return response;
 }
@@ -320,7 +335,8 @@ cfg_digital_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CfgDigitalEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->CfgDigitalEdgeTrigger(&context, request, &response));
+      stub->CfgDigitalEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -338,7 +354,8 @@ cfg_external_attenuation(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CfgExternalAttenuationResponse{};
 
   raise_if_error(
-      stub->CfgExternalAttenuation(&context, request, &response));
+      stub->CfgExternalAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -356,7 +373,8 @@ cfg_frequency(const StubPtr& stub, const nidevice_grpc::Session& instrument, con
   auto response = CfgFrequencyResponse{};
 
   raise_if_error(
-      stub->CfgFrequency(&context, request, &response));
+      stub->CfgFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -374,7 +392,8 @@ cfg_frequency_array(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = CfgFrequencyArrayResponse{};
 
   raise_if_error(
-      stub->CfgFrequencyArray(&context, request, &response));
+      stub->CfgFrequencyArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -400,7 +419,8 @@ cfg_frequency_reference(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = CfgFrequencyReferenceResponse{};
 
   raise_if_error(
-      stub->CfgFrequencyReference(&context, request, &response));
+      stub->CfgFrequencyReference(&context, request, &response),
+      context);
 
   return response;
 }
@@ -446,7 +466,8 @@ cfg_iq_power_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = CfgIQPowerEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->CfgIQPowerEdgeTrigger(&context, request, &response));
+      stub->CfgIQPowerEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -472,7 +493,8 @@ cfg_mechanical_attenuation(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = CfgMechanicalAttenuationResponse{};
 
   raise_if_error(
-      stub->CfgMechanicalAttenuation(&context, request, &response));
+      stub->CfgMechanicalAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -491,7 +513,8 @@ cfg_number_of_frequency_segments_and_receive_chains(const StubPtr& stub, const n
   auto response = CfgNumberOfFrequencySegmentsAndReceiveChainsResponse{};
 
   raise_if_error(
-      stub->CfgNumberOfFrequencySegmentsAndReceiveChains(&context, request, &response));
+      stub->CfgNumberOfFrequencySegmentsAndReceiveChains(&context, request, &response),
+      context);
 
   return response;
 }
@@ -517,7 +540,8 @@ cfg_rf_attenuation(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = CfgRFAttenuationResponse{};
 
   raise_if_error(
-      stub->CfgRFAttenuation(&context, request, &response));
+      stub->CfgRFAttenuation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -535,7 +559,8 @@ cfg_reference_level(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = CfgReferenceLevelResponse{};
 
   raise_if_error(
-      stub->CfgReferenceLevel(&context, request, &response));
+      stub->CfgReferenceLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -553,7 +578,8 @@ cfg_selected_ports_multiple(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = CfgSelectedPortsMultipleResponse{};
 
   raise_if_error(
-      stub->CfgSelectedPortsMultiple(&context, request, &response));
+      stub->CfgSelectedPortsMultiple(&context, request, &response),
+      context);
 
   return response;
 }
@@ -572,7 +598,8 @@ cfg_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = CfgSoftwareEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->CfgSoftwareEdgeTrigger(&context, request, &response));
+      stub->CfgSoftwareEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -597,7 +624,8 @@ cfg_standard(const StubPtr& stub, const nidevice_grpc::Session& instrument, cons
   auto response = CfgStandardResponse{};
 
   raise_if_error(
-      stub->CfgStandard(&context, request, &response));
+      stub->CfgStandard(&context, request, &response),
+      context);
 
   return response;
 }
@@ -614,7 +642,8 @@ check_measurement_status(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = CheckMeasurementStatusResponse{};
 
   raise_if_error(
-      stub->CheckMeasurementStatus(&context, request, &response));
+      stub->CheckMeasurementStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -631,7 +660,8 @@ clear_all_named_results(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = ClearAllNamedResultsResponse{};
 
   raise_if_error(
-      stub->ClearAllNamedResults(&context, request, &response));
+      stub->ClearAllNamedResults(&context, request, &response),
+      context);
 
   return response;
 }
@@ -648,7 +678,8 @@ clear_named_result(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = ClearNamedResultResponse{};
 
   raise_if_error(
-      stub->ClearNamedResult(&context, request, &response));
+      stub->ClearNamedResult(&context, request, &response),
+      context);
 
   return response;
 }
@@ -666,7 +697,8 @@ clone_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = CloneSignalConfigurationResponse{};
 
   raise_if_error(
-      stub->CloneSignalConfiguration(&context, request, &response));
+      stub->CloneSignalConfiguration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -683,7 +715,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& instrument, const bool&
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }
@@ -700,7 +733,8 @@ commit(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::
   auto response = CommitResponse{};
 
   raise_if_error(
-      stub->Commit(&context, request, &response));
+      stub->Commit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -717,7 +751,8 @@ create_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = CreateSignalConfigurationResponse{};
 
   raise_if_error(
-      stub->CreateSignalConfiguration(&context, request, &response));
+      stub->CreateSignalConfiguration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -743,7 +778,8 @@ dsss_mod_acc_cfg_acquisition_length(const StubPtr& stub, const nidevice_grpc::Se
   auto response = DSSSModAccCfgAcquisitionLengthResponse{};
 
   raise_if_error(
-      stub->DSSSModAccCfgAcquisitionLength(&context, request, &response));
+      stub->DSSSModAccCfgAcquisitionLength(&context, request, &response),
+      context);
 
   return response;
 }
@@ -769,7 +805,8 @@ dsss_mod_acc_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = DSSSModAccCfgAveragingResponse{};
 
   raise_if_error(
-      stub->DSSSModAccCfgAveraging(&context, request, &response));
+      stub->DSSSModAccCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -794,7 +831,8 @@ dsss_mod_acc_cfg_evm_unit(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = DSSSModAccCfgEVMUnitResponse{};
 
   raise_if_error(
-      stub->DSSSModAccCfgEVMUnit(&context, request, &response));
+      stub->DSSSModAccCfgEVMUnit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -813,7 +851,8 @@ dsss_mod_acc_cfg_measurement_length(const StubPtr& stub, const nidevice_grpc::Se
   auto response = DSSSModAccCfgMeasurementLengthResponse{};
 
   raise_if_error(
-      stub->DSSSModAccCfgMeasurementLength(&context, request, &response));
+      stub->DSSSModAccCfgMeasurementLength(&context, request, &response),
+      context);
 
   return response;
 }
@@ -832,7 +871,8 @@ dsss_mod_acc_cfg_power_measurement_custom_gate_array(const StubPtr& stub, const 
   auto response = DSSSModAccCfgPowerMeasurementCustomGateArrayResponse{};
 
   raise_if_error(
-      stub->DSSSModAccCfgPowerMeasurementCustomGateArray(&context, request, &response));
+      stub->DSSSModAccCfgPowerMeasurementCustomGateArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -857,7 +897,8 @@ dsss_mod_acc_cfg_power_measurement_enabled(const StubPtr& stub, const nidevice_g
   auto response = DSSSModAccCfgPowerMeasurementEnabledResponse{};
 
   raise_if_error(
-      stub->DSSSModAccCfgPowerMeasurementEnabled(&context, request, &response));
+      stub->DSSSModAccCfgPowerMeasurementEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -875,7 +916,8 @@ dsss_mod_acc_cfg_power_measurement_number_of_custom_gates(const StubPtr& stub, c
   auto response = DSSSModAccCfgPowerMeasurementNumberOfCustomGatesResponse{};
 
   raise_if_error(
-      stub->DSSSModAccCfgPowerMeasurementNumberOfCustomGates(&context, request, &response));
+      stub->DSSSModAccCfgPowerMeasurementNumberOfCustomGates(&context, request, &response),
+      context);
 
   return response;
 }
@@ -893,7 +935,8 @@ dsss_mod_acc_fetch_average_powers(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = DSSSModAccFetchAveragePowersResponse{};
 
   raise_if_error(
-      stub->DSSSModAccFetchAveragePowers(&context, request, &response));
+      stub->DSSSModAccFetchAveragePowers(&context, request, &response),
+      context);
 
   return response;
 }
@@ -911,7 +954,8 @@ dsss_mod_acc_fetch_constellation_trace(const StubPtr& stub, const nidevice_grpc:
   auto response = DSSSModAccFetchConstellationTraceResponse{};
 
   raise_if_error(
-      stub->DSSSModAccFetchConstellationTrace(&context, request, &response));
+      stub->DSSSModAccFetchConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -929,7 +973,8 @@ dsss_mod_acc_fetch_custom_gate_powers_array(const StubPtr& stub, const nidevice_
   auto response = DSSSModAccFetchCustomGatePowersArrayResponse{};
 
   raise_if_error(
-      stub->DSSSModAccFetchCustomGatePowersArray(&context, request, &response));
+      stub->DSSSModAccFetchCustomGatePowersArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -947,7 +992,8 @@ dsss_mod_acc_fetch_decoded_header_bits_trace(const StubPtr& stub, const nidevice
   auto response = DSSSModAccFetchDecodedHeaderBitsTraceResponse{};
 
   raise_if_error(
-      stub->DSSSModAccFetchDecodedHeaderBitsTrace(&context, request, &response));
+      stub->DSSSModAccFetchDecodedHeaderBitsTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -965,7 +1011,8 @@ dsss_mod_acc_fetch_decoded_psdu_bits_trace(const StubPtr& stub, const nidevice_g
   auto response = DSSSModAccFetchDecodedPSDUBitsTraceResponse{};
 
   raise_if_error(
-      stub->DSSSModAccFetchDecodedPSDUBitsTrace(&context, request, &response));
+      stub->DSSSModAccFetchDecodedPSDUBitsTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -983,7 +1030,8 @@ dsss_mod_acc_fetch_evm(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = DSSSModAccFetchEVMResponse{};
 
   raise_if_error(
-      stub->DSSSModAccFetchEVM(&context, request, &response));
+      stub->DSSSModAccFetchEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1001,7 +1049,8 @@ dsss_mod_acc_fetch_evm_per_chip_mean_trace(const StubPtr& stub, const nidevice_g
   auto response = DSSSModAccFetchEVMPerChipMeanTraceResponse{};
 
   raise_if_error(
-      stub->DSSSModAccFetchEVMPerChipMeanTrace(&context, request, &response));
+      stub->DSSSModAccFetchEVMPerChipMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1019,7 +1068,8 @@ dsss_mod_acc_fetch_iq_impairments(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = DSSSModAccFetchIQImpairmentsResponse{};
 
   raise_if_error(
-      stub->DSSSModAccFetchIQImpairments(&context, request, &response));
+      stub->DSSSModAccFetchIQImpairments(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1037,7 +1087,8 @@ dsss_mod_acc_fetch_ppdu_information(const StubPtr& stub, const nidevice_grpc::Se
   auto response = DSSSModAccFetchPPDUInformationResponse{};
 
   raise_if_error(
-      stub->DSSSModAccFetchPPDUInformation(&context, request, &response));
+      stub->DSSSModAccFetchPPDUInformation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1055,7 +1106,8 @@ dsss_mod_acc_fetch_peak_powers(const StubPtr& stub, const nidevice_grpc::Session
   auto response = DSSSModAccFetchPeakPowersResponse{};
 
   raise_if_error(
-      stub->DSSSModAccFetchPeakPowers(&context, request, &response));
+      stub->DSSSModAccFetchPeakPowers(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1072,7 +1124,8 @@ delete_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = DeleteSignalConfigurationResponse{};
 
   raise_if_error(
-      stub->DeleteSignalConfiguration(&context, request, &response));
+      stub->DeleteSignalConfiguration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1089,7 +1142,8 @@ disable_trigger(const StubPtr& stub, const nidevice_grpc::Session& instrument, c
   auto response = DisableTriggerResponse{};
 
   raise_if_error(
-      stub->DisableTrigger(&context, request, &response));
+      stub->DisableTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1106,7 +1160,8 @@ get_all_named_result_names(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = GetAllNamedResultNamesResponse{};
 
   raise_if_error(
-      stub->GetAllNamedResultNames(&context, request, &response));
+      stub->GetAllNamedResultNames(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1124,7 +1179,8 @@ get_attribute_f32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeF32Response{};
 
   raise_if_error(
-      stub->GetAttributeF32(&context, request, &response));
+      stub->GetAttributeF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1142,7 +1198,8 @@ get_attribute_f32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeF32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeF32Array(&context, request, &response));
+      stub->GetAttributeF32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1160,7 +1217,8 @@ get_attribute_f64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeF64Response{};
 
   raise_if_error(
-      stub->GetAttributeF64(&context, request, &response));
+      stub->GetAttributeF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1178,7 +1236,8 @@ get_attribute_f64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeF64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeF64Array(&context, request, &response));
+      stub->GetAttributeF64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1196,7 +1255,8 @@ get_attribute_i16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI16Response{};
 
   raise_if_error(
-      stub->GetAttributeI16(&context, request, &response));
+      stub->GetAttributeI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1214,7 +1274,8 @@ get_attribute_i32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI32Response{};
 
   raise_if_error(
-      stub->GetAttributeI32(&context, request, &response));
+      stub->GetAttributeI32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1232,7 +1293,8 @@ get_attribute_i32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeI32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI32Array(&context, request, &response));
+      stub->GetAttributeI32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1250,7 +1312,8 @@ get_attribute_i64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeI64Response{};
 
   raise_if_error(
-      stub->GetAttributeI64(&context, request, &response));
+      stub->GetAttributeI64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1268,7 +1331,8 @@ get_attribute_i64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeI64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI64Array(&context, request, &response));
+      stub->GetAttributeI64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1286,7 +1350,8 @@ get_attribute_i8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetAttributeI8Response{};
 
   raise_if_error(
-      stub->GetAttributeI8(&context, request, &response));
+      stub->GetAttributeI8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1304,7 +1369,8 @@ get_attribute_i8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = GetAttributeI8ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeI8Array(&context, request, &response));
+      stub->GetAttributeI8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1322,7 +1388,8 @@ get_attribute_ni_complex_double_array(const StubPtr& stub, const nidevice_grpc::
   auto response = GetAttributeNIComplexDoubleArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeNIComplexDoubleArray(&context, request, &response));
+      stub->GetAttributeNIComplexDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1340,7 +1407,8 @@ get_attribute_ni_complex_single_array(const StubPtr& stub, const nidevice_grpc::
   auto response = GetAttributeNIComplexSingleArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeNIComplexSingleArray(&context, request, &response));
+      stub->GetAttributeNIComplexSingleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1358,7 +1426,8 @@ get_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = GetAttributeStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeString(&context, request, &response));
+      stub->GetAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1376,7 +1445,8 @@ get_attribute_u16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeU16Response{};
 
   raise_if_error(
-      stub->GetAttributeU16(&context, request, &response));
+      stub->GetAttributeU16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1394,7 +1464,8 @@ get_attribute_u32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = GetAttributeU32Response{};
 
   raise_if_error(
-      stub->GetAttributeU32(&context, request, &response));
+      stub->GetAttributeU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1412,7 +1483,8 @@ get_attribute_u32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeU32ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU32Array(&context, request, &response));
+      stub->GetAttributeU32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1430,7 +1502,8 @@ get_attribute_u64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = GetAttributeU64ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU64Array(&context, request, &response));
+      stub->GetAttributeU64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1448,7 +1521,8 @@ get_attribute_u8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetAttributeU8Response{};
 
   raise_if_error(
-      stub->GetAttributeU8(&context, request, &response));
+      stub->GetAttributeU8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1466,7 +1540,8 @@ get_attribute_u8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = GetAttributeU8ArrayResponse{};
 
   raise_if_error(
-      stub->GetAttributeU8Array(&context, request, &response));
+      stub->GetAttributeU8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1482,7 +1557,8 @@ get_error(const StubPtr& stub, const nidevice_grpc::Session& instrument)
   auto response = GetErrorResponse{};
 
   raise_if_error(
-      stub->GetError(&context, request, &response));
+      stub->GetError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1499,7 +1575,8 @@ get_error_string(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = GetErrorStringResponse{};
 
   raise_if_error(
-      stub->GetErrorString(&context, request, &response));
+      stub->GetErrorString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1516,7 +1593,8 @@ initialize(const StubPtr& stub, const pb::string& resource_name, const pb::strin
   auto response = InitializeResponse{};
 
   raise_if_error(
-      stub->Initialize(&context, request, &response));
+      stub->Initialize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1532,7 +1610,8 @@ initialize_from_nirfsa_session(const StubPtr& stub, const nidevice_grpc::Session
   auto response = InitializeFromNIRFSASessionResponse{};
 
   raise_if_error(
-      stub->InitializeFromNIRFSASession(&context, request, &response));
+      stub->InitializeFromNIRFSASession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1550,7 +1629,8 @@ initiate(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb
   auto response = InitiateResponse{};
 
   raise_if_error(
-      stub->Initiate(&context, request, &response));
+      stub->Initiate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1568,7 +1648,8 @@ ofdm_mod_acc_auto_level(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = OFDMModAccAutoLevelResponse{};
 
   raise_if_error(
-      stub->OFDMModAccAutoLevel(&context, request, &response));
+      stub->OFDMModAccAutoLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1588,7 +1669,8 @@ ofdm_mod_acc_cfg1_reference_waveform(const StubPtr& stub, const nidevice_grpc::S
   auto response = OFDMModAccCfg1ReferenceWaveformResponse{};
 
   raise_if_error(
-      stub->OFDMModAccCfg1ReferenceWaveform(&context, request, &response));
+      stub->OFDMModAccCfg1ReferenceWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1614,7 +1696,8 @@ ofdm_mod_acc_cfg_acquisition_length(const StubPtr& stub, const nidevice_grpc::Se
   auto response = OFDMModAccCfgAcquisitionLengthResponse{};
 
   raise_if_error(
-      stub->OFDMModAccCfgAcquisitionLength(&context, request, &response));
+      stub->OFDMModAccCfgAcquisitionLength(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1639,7 +1722,8 @@ ofdm_mod_acc_cfg_amplitude_tracking_enabled(const StubPtr& stub, const nidevice_
   auto response = OFDMModAccCfgAmplitudeTrackingEnabledResponse{};
 
   raise_if_error(
-      stub->OFDMModAccCfgAmplitudeTrackingEnabled(&context, request, &response));
+      stub->OFDMModAccCfgAmplitudeTrackingEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1665,7 +1749,8 @@ ofdm_mod_acc_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = OFDMModAccCfgAveragingResponse{};
 
   raise_if_error(
-      stub->OFDMModAccCfgAveraging(&context, request, &response));
+      stub->OFDMModAccCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1690,7 +1775,8 @@ ofdm_mod_acc_cfg_channel_estimation_type(const StubPtr& stub, const nidevice_grp
   auto response = OFDMModAccCfgChannelEstimationTypeResponse{};
 
   raise_if_error(
-      stub->OFDMModAccCfgChannelEstimationType(&context, request, &response));
+      stub->OFDMModAccCfgChannelEstimationType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1715,7 +1801,8 @@ ofdm_mod_acc_cfg_common_clock_source_enabled(const StubPtr& stub, const nidevice
   auto response = OFDMModAccCfgCommonClockSourceEnabledResponse{};
 
   raise_if_error(
-      stub->OFDMModAccCfgCommonClockSourceEnabled(&context, request, &response));
+      stub->OFDMModAccCfgCommonClockSourceEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1740,7 +1827,8 @@ ofdm_mod_acc_cfg_evm_unit(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = OFDMModAccCfgEVMUnitResponse{};
 
   raise_if_error(
-      stub->OFDMModAccCfgEVMUnit(&context, request, &response));
+      stub->OFDMModAccCfgEVMUnit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1765,7 +1853,8 @@ ofdm_mod_acc_cfg_frequency_error_estimation_method(const StubPtr& stub, const ni
   auto response = OFDMModAccCfgFrequencyErrorEstimationMethodResponse{};
 
   raise_if_error(
-      stub->OFDMModAccCfgFrequencyErrorEstimationMethod(&context, request, &response));
+      stub->OFDMModAccCfgFrequencyErrorEstimationMethod(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1784,7 +1873,8 @@ ofdm_mod_acc_cfg_measurement_length(const StubPtr& stub, const nidevice_grpc::Se
   auto response = OFDMModAccCfgMeasurementLengthResponse{};
 
   raise_if_error(
-      stub->OFDMModAccCfgMeasurementLength(&context, request, &response));
+      stub->OFDMModAccCfgMeasurementLength(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1809,7 +1899,8 @@ ofdm_mod_acc_cfg_measurement_mode(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = OFDMModAccCfgMeasurementModeResponse{};
 
   raise_if_error(
-      stub->OFDMModAccCfgMeasurementMode(&context, request, &response));
+      stub->OFDMModAccCfgMeasurementMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1830,7 +1921,8 @@ ofdm_mod_acc_cfg_n_reference_waveforms(const StubPtr& stub, const nidevice_grpc:
   auto response = OFDMModAccCfgNReferenceWaveformsResponse{};
 
   raise_if_error(
-      stub->OFDMModAccCfgNReferenceWaveforms(&context, request, &response));
+      stub->OFDMModAccCfgNReferenceWaveforms(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1855,7 +1947,8 @@ ofdm_mod_acc_cfg_noise_compensation_enabled(const StubPtr& stub, const nidevice_
   auto response = OFDMModAccCfgNoiseCompensationEnabledResponse{};
 
   raise_if_error(
-      stub->OFDMModAccCfgNoiseCompensationEnabled(&context, request, &response));
+      stub->OFDMModAccCfgNoiseCompensationEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1881,7 +1974,8 @@ ofdm_mod_acc_cfg_optimize_dynamic_range_for_evm(const StubPtr& stub, const nidev
   auto response = OFDMModAccCfgOptimizeDynamicRangeForEVMResponse{};
 
   raise_if_error(
-      stub->OFDMModAccCfgOptimizeDynamicRangeForEVM(&context, request, &response));
+      stub->OFDMModAccCfgOptimizeDynamicRangeForEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1906,7 +2000,8 @@ ofdm_mod_acc_cfg_phase_tracking_enabled(const StubPtr& stub, const nidevice_grpc
   auto response = OFDMModAccCfgPhaseTrackingEnabledResponse{};
 
   raise_if_error(
-      stub->OFDMModAccCfgPhaseTrackingEnabled(&context, request, &response));
+      stub->OFDMModAccCfgPhaseTrackingEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1931,7 +2026,8 @@ ofdm_mod_acc_cfg_symbol_clock_error_correction_enabled(const StubPtr& stub, cons
   auto response = OFDMModAccCfgSymbolClockErrorCorrectionEnabledResponse{};
 
   raise_if_error(
-      stub->OFDMModAccCfgSymbolClockErrorCorrectionEnabled(&context, request, &response));
+      stub->OFDMModAccCfgSymbolClockErrorCorrectionEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1947,7 +2043,8 @@ ofdm_mod_acc_clear_noise_calibration_database(const StubPtr& stub, const nidevic
   auto response = OFDMModAccClearNoiseCalibrationDatabaseResponse{};
 
   raise_if_error(
-      stub->OFDMModAccClearNoiseCalibrationDatabase(&context, request, &response));
+      stub->OFDMModAccClearNoiseCalibrationDatabase(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1965,7 +2062,8 @@ ofdm_mod_acc_fetch_chain_data_rmsevm_per_symbol_mean_trace(const StubPtr& stub, 
   auto response = OFDMModAccFetchChainDataRMSEVMPerSymbolMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchChainDataRMSEVMPerSymbolMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchChainDataRMSEVMPerSymbolMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1983,7 +2081,8 @@ ofdm_mod_acc_fetch_chain_pilot_rmsevm_per_symbol_mean_trace(const StubPtr& stub,
   auto response = OFDMModAccFetchChainPilotRMSEVMPerSymbolMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchChainPilotRMSEVMPerSymbolMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchChainPilotRMSEVMPerSymbolMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2001,7 +2100,8 @@ ofdm_mod_acc_fetch_chain_rmsevm(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = OFDMModAccFetchChainRMSEVMResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchChainRMSEVM(&context, request, &response));
+      stub->OFDMModAccFetchChainRMSEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2019,7 +2119,8 @@ ofdm_mod_acc_fetch_chain_rmsevm_per_subcarrier_mean_trace(const StubPtr& stub, c
   auto response = OFDMModAccFetchChainRMSEVMPerSubcarrierMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchChainRMSEVMPerSubcarrierMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchChainRMSEVMPerSubcarrierMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2037,7 +2138,8 @@ ofdm_mod_acc_fetch_chain_rmsevm_per_symbol_mean_trace(const StubPtr& stub, const
   auto response = OFDMModAccFetchChainRMSEVMPerSymbolMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchChainRMSEVMPerSymbolMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchChainRMSEVMPerSymbolMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2055,7 +2157,8 @@ ofdm_mod_acc_fetch_channel_frequency_response_mean_trace(const StubPtr& stub, co
   auto response = OFDMModAccFetchChannelFrequencyResponseMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchChannelFrequencyResponseMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchChannelFrequencyResponseMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2073,7 +2176,8 @@ ofdm_mod_acc_fetch_common_pilot_error_trace(const StubPtr& stub, const nidevice_
   auto response = OFDMModAccFetchCommonPilotErrorTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchCommonPilotErrorTrace(&context, request, &response));
+      stub->OFDMModAccFetchCommonPilotErrorTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2091,7 +2195,8 @@ ofdm_mod_acc_fetch_composite_rmsevm(const StubPtr& stub, const nidevice_grpc::Se
   auto response = OFDMModAccFetchCompositeRMSEVMResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchCompositeRMSEVM(&context, request, &response));
+      stub->OFDMModAccFetchCompositeRMSEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2109,7 +2214,8 @@ ofdm_mod_acc_fetch_cross_power(const StubPtr& stub, const nidevice_grpc::Session
   auto response = OFDMModAccFetchCrossPowerResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchCrossPower(&context, request, &response));
+      stub->OFDMModAccFetchCrossPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2127,7 +2233,8 @@ ofdm_mod_acc_fetch_custom_gate_powers_array(const StubPtr& stub, const nidevice_
   auto response = OFDMModAccFetchCustomGatePowersArrayResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchCustomGatePowersArray(&context, request, &response));
+      stub->OFDMModAccFetchCustomGatePowersArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2145,7 +2252,8 @@ ofdm_mod_acc_fetch_data_average_power(const StubPtr& stub, const nidevice_grpc::
   auto response = OFDMModAccFetchDataAveragePowerResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchDataAveragePower(&context, request, &response));
+      stub->OFDMModAccFetchDataAveragePower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2163,7 +2271,8 @@ ofdm_mod_acc_fetch_data_constellation_trace(const StubPtr& stub, const nidevice_
   auto response = OFDMModAccFetchDataConstellationTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchDataConstellationTrace(&context, request, &response));
+      stub->OFDMModAccFetchDataConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2181,7 +2290,8 @@ ofdm_mod_acc_fetch_data_peak_power(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = OFDMModAccFetchDataPeakPowerResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchDataPeakPower(&context, request, &response));
+      stub->OFDMModAccFetchDataPeakPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2199,7 +2309,8 @@ ofdm_mod_acc_fetch_decoded_ehtsig_bits_trace(const StubPtr& stub, const nidevice
   auto response = OFDMModAccFetchDecodedEHTSIGBitsTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchDecodedEHTSIGBitsTrace(&context, request, &response));
+      stub->OFDMModAccFetchDecodedEHTSIGBitsTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2217,7 +2328,8 @@ ofdm_mod_acc_fetch_decoded_lsig_bits_trace(const StubPtr& stub, const nidevice_g
   auto response = OFDMModAccFetchDecodedLSIGBitsTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchDecodedLSIGBitsTrace(&context, request, &response));
+      stub->OFDMModAccFetchDecodedLSIGBitsTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2235,7 +2347,8 @@ ofdm_mod_acc_fetch_decoded_psdu_bits_trace(const StubPtr& stub, const nidevice_g
   auto response = OFDMModAccFetchDecodedPSDUBitsTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchDecodedPSDUBitsTrace(&context, request, &response));
+      stub->OFDMModAccFetchDecodedPSDUBitsTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2253,7 +2366,8 @@ ofdm_mod_acc_fetch_decoded_sigb_bits_trace(const StubPtr& stub, const nidevice_g
   auto response = OFDMModAccFetchDecodedSIGBBitsTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchDecodedSIGBBitsTrace(&context, request, &response));
+      stub->OFDMModAccFetchDecodedSIGBBitsTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2271,7 +2385,8 @@ ofdm_mod_acc_fetch_decoded_sig_bits_trace(const StubPtr& stub, const nidevice_gr
   auto response = OFDMModAccFetchDecodedSIGBitsTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchDecodedSIGBitsTrace(&context, request, &response));
+      stub->OFDMModAccFetchDecodedSIGBitsTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2289,7 +2404,8 @@ ofdm_mod_acc_fetch_decoded_service_bits_trace(const StubPtr& stub, const nidevic
   auto response = OFDMModAccFetchDecodedServiceBitsTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchDecodedServiceBitsTrace(&context, request, &response));
+      stub->OFDMModAccFetchDecodedServiceBitsTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2307,7 +2423,8 @@ ofdm_mod_acc_fetch_decoded_usig_bits_trace(const StubPtr& stub, const nidevice_g
   auto response = OFDMModAccFetchDecodedUSIGBitsTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchDecodedUSIGBitsTrace(&context, request, &response));
+      stub->OFDMModAccFetchDecodedUSIGBitsTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2325,7 +2442,8 @@ ofdm_mod_acc_fetch_evm_subcarrier_indices(const StubPtr& stub, const nidevice_gr
   auto response = OFDMModAccFetchEVMSubcarrierIndicesResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchEVMSubcarrierIndices(&context, request, &response));
+      stub->OFDMModAccFetchEVMSubcarrierIndices(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2343,7 +2461,8 @@ ofdm_mod_acc_fetch_frequency_error_ccdf10_percent(const StubPtr& stub, const nid
   auto response = OFDMModAccFetchFrequencyErrorCCDF10PercentResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchFrequencyErrorCCDF10Percent(&context, request, &response));
+      stub->OFDMModAccFetchFrequencyErrorCCDF10Percent(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2361,7 +2480,8 @@ ofdm_mod_acc_fetch_frequency_error_mean(const StubPtr& stub, const nidevice_grpc
   auto response = OFDMModAccFetchFrequencyErrorMeanResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchFrequencyErrorMean(&context, request, &response));
+      stub->OFDMModAccFetchFrequencyErrorMean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2379,7 +2499,8 @@ ofdm_mod_acc_fetch_group_delay_mean_trace(const StubPtr& stub, const nidevice_gr
   auto response = OFDMModAccFetchGroupDelayMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchGroupDelayMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchGroupDelayMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2397,7 +2518,8 @@ ofdm_mod_acc_fetch_guard_interval_type(const StubPtr& stub, const nidevice_grpc:
   auto response = OFDMModAccFetchGuardIntervalTypeResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchGuardIntervalType(&context, request, &response));
+      stub->OFDMModAccFetchGuardIntervalType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2415,7 +2537,8 @@ ofdm_mod_acc_fetch_iq_gain_imbalance_per_subcarrier_mean_trace(const StubPtr& st
   auto response = OFDMModAccFetchIQGainImbalancePerSubcarrierMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchIQGainImbalancePerSubcarrierMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchIQGainImbalancePerSubcarrierMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2433,7 +2556,8 @@ ofdm_mod_acc_fetch_iq_impairments(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = OFDMModAccFetchIQImpairmentsResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchIQImpairments(&context, request, &response));
+      stub->OFDMModAccFetchIQImpairments(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2451,7 +2575,8 @@ ofdm_mod_acc_fetch_iq_quadrature_error_per_subcarrier_mean_trace(const StubPtr& 
   auto response = OFDMModAccFetchIQQuadratureErrorPerSubcarrierMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchIQQuadratureErrorPerSubcarrierMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchIQQuadratureErrorPerSubcarrierMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2469,7 +2594,8 @@ ofdm_mod_acc_fetch_lsig_parity_check_status(const StubPtr& stub, const nidevice_
   auto response = OFDMModAccFetchLSIGParityCheckStatusResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchLSIGParityCheckStatus(&context, request, &response));
+      stub->OFDMModAccFetchLSIGParityCheckStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2487,7 +2613,8 @@ ofdm_mod_acc_fetch_ltf_size(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = OFDMModAccFetchLTFSizeResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchLTFSize(&context, request, &response));
+      stub->OFDMModAccFetchLTFSize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2505,7 +2632,8 @@ ofdm_mod_acc_fetch_mcs_index(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = OFDMModAccFetchMCSIndexResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchMCSIndex(&context, request, &response));
+      stub->OFDMModAccFetchMCSIndex(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2523,7 +2651,8 @@ ofdm_mod_acc_fetch_number_of_hesigb_symbols(const StubPtr& stub, const nidevice_
   auto response = OFDMModAccFetchNumberOfHESIGBSymbolsResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchNumberOfHESIGBSymbols(&context, request, &response));
+      stub->OFDMModAccFetchNumberOfHESIGBSymbols(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2541,7 +2670,8 @@ ofdm_mod_acc_fetch_number_of_space_time_streams(const StubPtr& stub, const nidev
   auto response = OFDMModAccFetchNumberOfSpaceTimeStreamsResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchNumberOfSpaceTimeStreams(&context, request, &response));
+      stub->OFDMModAccFetchNumberOfSpaceTimeStreams(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2559,7 +2689,8 @@ ofdm_mod_acc_fetch_number_of_users(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = OFDMModAccFetchNumberOfUsersResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchNumberOfUsers(&context, request, &response));
+      stub->OFDMModAccFetchNumberOfUsers(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2577,7 +2708,8 @@ ofdm_mod_acc_fetch_numberof_symbols_used(const StubPtr& stub, const nidevice_grp
   auto response = OFDMModAccFetchNumberofSymbolsUsedResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchNumberofSymbolsUsed(&context, request, &response));
+      stub->OFDMModAccFetchNumberofSymbolsUsed(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2595,7 +2727,8 @@ ofdm_mod_acc_fetch_pe_average_power(const StubPtr& stub, const nidevice_grpc::Se
   auto response = OFDMModAccFetchPEAveragePowerResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPEAveragePower(&context, request, &response));
+      stub->OFDMModAccFetchPEAveragePower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2613,7 +2746,8 @@ ofdm_mod_acc_fetch_pe_duration(const StubPtr& stub, const nidevice_grpc::Session
   auto response = OFDMModAccFetchPEDurationResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPEDuration(&context, request, &response));
+      stub->OFDMModAccFetchPEDuration(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2631,7 +2765,8 @@ ofdm_mod_acc_fetch_pe_peak_power(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = OFDMModAccFetchPEPeakPowerResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPEPeakPower(&context, request, &response));
+      stub->OFDMModAccFetchPEPeakPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2649,7 +2784,8 @@ ofdm_mod_acc_fetch_ppdu_average_power(const StubPtr& stub, const nidevice_grpc::
   auto response = OFDMModAccFetchPPDUAveragePowerResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPPDUAveragePower(&context, request, &response));
+      stub->OFDMModAccFetchPPDUAveragePower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2667,7 +2803,8 @@ ofdm_mod_acc_fetch_ppdu_peak_power(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = OFDMModAccFetchPPDUPeakPowerResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPPDUPeakPower(&context, request, &response));
+      stub->OFDMModAccFetchPPDUPeakPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2685,7 +2822,8 @@ ofdm_mod_acc_fetch_ppdu_type(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = OFDMModAccFetchPPDUTypeResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPPDUType(&context, request, &response));
+      stub->OFDMModAccFetchPPDUType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2703,7 +2841,8 @@ ofdm_mod_acc_fetch_psducrc_status(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = OFDMModAccFetchPSDUCRCStatusResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPSDUCRCStatus(&context, request, &response));
+      stub->OFDMModAccFetchPSDUCRCStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2721,7 +2860,8 @@ ofdm_mod_acc_fetch_phase_noise_psd_mean_trace(const StubPtr& stub, const nidevic
   auto response = OFDMModAccFetchPhaseNoisePSDMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPhaseNoisePSDMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchPhaseNoisePSDMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2739,7 +2879,8 @@ ofdm_mod_acc_fetch_pilot_constellation_trace(const StubPtr& stub, const nidevice
   auto response = OFDMModAccFetchPilotConstellationTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPilotConstellationTrace(&context, request, &response));
+      stub->OFDMModAccFetchPilotConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2757,7 +2898,8 @@ ofdm_mod_acc_fetch_preamble_average_powers80211ac(const StubPtr& stub, const nid
   auto response = OFDMModAccFetchPreambleAveragePowers80211acResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPreambleAveragePowers80211ac(&context, request, &response));
+      stub->OFDMModAccFetchPreambleAveragePowers80211ac(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2775,7 +2917,8 @@ ofdm_mod_acc_fetch_preamble_average_powers80211ax(const StubPtr& stub, const nid
   auto response = OFDMModAccFetchPreambleAveragePowers80211axResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPreambleAveragePowers80211ax(&context, request, &response));
+      stub->OFDMModAccFetchPreambleAveragePowers80211ax(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2793,7 +2936,8 @@ ofdm_mod_acc_fetch_preamble_average_powers80211n(const StubPtr& stub, const nide
   auto response = OFDMModAccFetchPreambleAveragePowers80211nResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPreambleAveragePowers80211n(&context, request, &response));
+      stub->OFDMModAccFetchPreambleAveragePowers80211n(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2811,7 +2955,8 @@ ofdm_mod_acc_fetch_preamble_average_powers_common(const StubPtr& stub, const nid
   auto response = OFDMModAccFetchPreambleAveragePowersCommonResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPreambleAveragePowersCommon(&context, request, &response));
+      stub->OFDMModAccFetchPreambleAveragePowersCommon(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2829,7 +2974,8 @@ ofdm_mod_acc_fetch_preamble_frequency_error_trace(const StubPtr& stub, const nid
   auto response = OFDMModAccFetchPreambleFrequencyErrorTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPreambleFrequencyErrorTrace(&context, request, &response));
+      stub->OFDMModAccFetchPreambleFrequencyErrorTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2847,7 +2993,8 @@ ofdm_mod_acc_fetch_preamble_peak_powers80211ac(const StubPtr& stub, const nidevi
   auto response = OFDMModAccFetchPreamblePeakPowers80211acResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPreamblePeakPowers80211ac(&context, request, &response));
+      stub->OFDMModAccFetchPreamblePeakPowers80211ac(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2865,7 +3012,8 @@ ofdm_mod_acc_fetch_preamble_peak_powers80211ax(const StubPtr& stub, const nidevi
   auto response = OFDMModAccFetchPreamblePeakPowers80211axResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPreamblePeakPowers80211ax(&context, request, &response));
+      stub->OFDMModAccFetchPreamblePeakPowers80211ax(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2883,7 +3031,8 @@ ofdm_mod_acc_fetch_preamble_peak_powers80211n(const StubPtr& stub, const nidevic
   auto response = OFDMModAccFetchPreamblePeakPowers80211nResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPreamblePeakPowers80211n(&context, request, &response));
+      stub->OFDMModAccFetchPreamblePeakPowers80211n(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2901,7 +3050,8 @@ ofdm_mod_acc_fetch_preamble_peak_powers_common(const StubPtr& stub, const nidevi
   auto response = OFDMModAccFetchPreamblePeakPowersCommonResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchPreamblePeakPowersCommon(&context, request, &response));
+      stub->OFDMModAccFetchPreamblePeakPowersCommon(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2919,7 +3069,8 @@ ofdm_mod_acc_fetch_ru_offset_and_size(const StubPtr& stub, const nidevice_grpc::
   auto response = OFDMModAccFetchRUOffsetAndSizeResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchRUOffsetAndSize(&context, request, &response));
+      stub->OFDMModAccFetchRUOffsetAndSize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2937,7 +3088,8 @@ ofdm_mod_acc_fetch_sigbcrc_status(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = OFDMModAccFetchSIGBCRCStatusResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchSIGBCRCStatus(&context, request, &response));
+      stub->OFDMModAccFetchSIGBCRCStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2955,7 +3107,8 @@ ofdm_mod_acc_fetch_sigcrc_status(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = OFDMModAccFetchSIGCRCStatusResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchSIGCRCStatus(&context, request, &response));
+      stub->OFDMModAccFetchSIGCRCStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2973,7 +3126,8 @@ ofdm_mod_acc_fetch_spectral_flatness(const StubPtr& stub, const nidevice_grpc::S
   auto response = OFDMModAccFetchSpectralFlatnessResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchSpectralFlatness(&context, request, &response));
+      stub->OFDMModAccFetchSpectralFlatness(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2991,7 +3145,8 @@ ofdm_mod_acc_fetch_spectral_flatness_mean_trace(const StubPtr& stub, const nidev
   auto response = OFDMModAccFetchSpectralFlatnessMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchSpectralFlatnessMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchSpectralFlatnessMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3009,7 +3164,8 @@ ofdm_mod_acc_fetch_stream_data_rmsevm_per_symbol_mean_trace(const StubPtr& stub,
   auto response = OFDMModAccFetchStreamDataRMSEVMPerSymbolMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchStreamDataRMSEVMPerSymbolMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchStreamDataRMSEVMPerSymbolMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3027,7 +3183,8 @@ ofdm_mod_acc_fetch_stream_pilot_rmsevm_per_symbol_mean_trace(const StubPtr& stub
   auto response = OFDMModAccFetchStreamPilotRMSEVMPerSymbolMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchStreamPilotRMSEVMPerSymbolMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchStreamPilotRMSEVMPerSymbolMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3045,7 +3202,8 @@ ofdm_mod_acc_fetch_stream_rmsevm(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = OFDMModAccFetchStreamRMSEVMResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchStreamRMSEVM(&context, request, &response));
+      stub->OFDMModAccFetchStreamRMSEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3063,7 +3221,8 @@ ofdm_mod_acc_fetch_stream_rmsevm_per_subcarrier_mean_trace(const StubPtr& stub, 
   auto response = OFDMModAccFetchStreamRMSEVMPerSubcarrierMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchStreamRMSEVMPerSubcarrierMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchStreamRMSEVMPerSubcarrierMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3081,7 +3240,8 @@ ofdm_mod_acc_fetch_stream_rmsevm_per_symbol_mean_trace(const StubPtr& stub, cons
   auto response = OFDMModAccFetchStreamRMSEVMPerSymbolMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchStreamRMSEVMPerSymbolMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchStreamRMSEVMPerSymbolMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3100,7 +3260,8 @@ ofdm_mod_acc_fetch_subcarrier_chain_evm_per_symbol_trace(const StubPtr& stub, co
   auto response = OFDMModAccFetchSubcarrierChainEVMPerSymbolTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchSubcarrierChainEVMPerSymbolTrace(&context, request, &response));
+      stub->OFDMModAccFetchSubcarrierChainEVMPerSymbolTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3119,7 +3280,8 @@ ofdm_mod_acc_fetch_subcarrier_stream_evm_per_symbol_trace(const StubPtr& stub, c
   auto response = OFDMModAccFetchSubcarrierStreamEVMPerSymbolTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchSubcarrierStreamEVMPerSymbolTrace(&context, request, &response));
+      stub->OFDMModAccFetchSubcarrierStreamEVMPerSymbolTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3138,7 +3300,8 @@ ofdm_mod_acc_fetch_symbol_chain_evm_per_subcarrier_trace(const StubPtr& stub, co
   auto response = OFDMModAccFetchSymbolChainEVMPerSubcarrierTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchSymbolChainEVMPerSubcarrierTrace(&context, request, &response));
+      stub->OFDMModAccFetchSymbolChainEVMPerSubcarrierTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3156,7 +3319,8 @@ ofdm_mod_acc_fetch_symbol_clock_error_mean(const StubPtr& stub, const nidevice_g
   auto response = OFDMModAccFetchSymbolClockErrorMeanResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchSymbolClockErrorMean(&context, request, &response));
+      stub->OFDMModAccFetchSymbolClockErrorMean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3175,7 +3339,8 @@ ofdm_mod_acc_fetch_symbol_stream_evm_per_subcarrier_trace(const StubPtr& stub, c
   auto response = OFDMModAccFetchSymbolStreamEVMPerSubcarrierTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchSymbolStreamEVMPerSubcarrierTrace(&context, request, &response));
+      stub->OFDMModAccFetchSymbolStreamEVMPerSubcarrierTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3193,7 +3358,8 @@ ofdm_mod_acc_fetch_unused_tone_error(const StubPtr& stub, const nidevice_grpc::S
   auto response = OFDMModAccFetchUnusedToneErrorResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchUnusedToneError(&context, request, &response));
+      stub->OFDMModAccFetchUnusedToneError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3211,7 +3377,8 @@ ofdm_mod_acc_fetch_unused_tone_error_margin_per_ru(const StubPtr& stub, const ni
   auto response = OFDMModAccFetchUnusedToneErrorMarginPerRUResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchUnusedToneErrorMarginPerRU(&context, request, &response));
+      stub->OFDMModAccFetchUnusedToneErrorMarginPerRU(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3229,7 +3396,8 @@ ofdm_mod_acc_fetch_unused_tone_error_mean_trace(const StubPtr& stub, const nidev
   auto response = OFDMModAccFetchUnusedToneErrorMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchUnusedToneErrorMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchUnusedToneErrorMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3247,7 +3415,8 @@ ofdm_mod_acc_fetch_user_data_constellation_trace(const StubPtr& stub, const nide
   auto response = OFDMModAccFetchUserDataConstellationTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchUserDataConstellationTrace(&context, request, &response));
+      stub->OFDMModAccFetchUserDataConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3265,7 +3434,8 @@ ofdm_mod_acc_fetch_user_pilot_constellation_trace(const StubPtr& stub, const nid
   auto response = OFDMModAccFetchUserPilotConstellationTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchUserPilotConstellationTrace(&context, request, &response));
+      stub->OFDMModAccFetchUserPilotConstellationTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3283,7 +3453,8 @@ ofdm_mod_acc_fetch_user_power(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = OFDMModAccFetchUserPowerResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchUserPower(&context, request, &response));
+      stub->OFDMModAccFetchUserPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3301,7 +3472,8 @@ ofdm_mod_acc_fetch_user_stream_data_rmsevm_per_symbol_mean_trace(const StubPtr& 
   auto response = OFDMModAccFetchUserStreamDataRMSEVMPerSymbolMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchUserStreamDataRMSEVMPerSymbolMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchUserStreamDataRMSEVMPerSymbolMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3319,7 +3491,8 @@ ofdm_mod_acc_fetch_user_stream_pilot_rmsevm_per_symbol_mean_trace(const StubPtr&
   auto response = OFDMModAccFetchUserStreamPilotRMSEVMPerSymbolMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchUserStreamPilotRMSEVMPerSymbolMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchUserStreamPilotRMSEVMPerSymbolMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3337,7 +3510,8 @@ ofdm_mod_acc_fetch_user_stream_rmsevm(const StubPtr& stub, const nidevice_grpc::
   auto response = OFDMModAccFetchUserStreamRMSEVMResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchUserStreamRMSEVM(&context, request, &response));
+      stub->OFDMModAccFetchUserStreamRMSEVM(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3355,7 +3529,8 @@ ofdm_mod_acc_fetch_user_stream_rmsevm_per_subcarrier_mean_trace(const StubPtr& s
   auto response = OFDMModAccFetchUserStreamRMSEVMPerSubcarrierMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchUserStreamRMSEVMPerSubcarrierMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchUserStreamRMSEVMPerSubcarrierMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3373,7 +3548,8 @@ ofdm_mod_acc_fetch_user_stream_rmsevm_per_symbol_mean_trace(const StubPtr& stub,
   auto response = OFDMModAccFetchUserStreamRMSEVMPerSymbolMeanTraceResponse{};
 
   raise_if_error(
-      stub->OFDMModAccFetchUserStreamRMSEVMPerSymbolMeanTrace(&context, request, &response));
+      stub->OFDMModAccFetchUserStreamRMSEVMPerSymbolMeanTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3390,7 +3566,8 @@ ofdm_mod_acc_validate_calibration_data(const StubPtr& stub, const nidevice_grpc:
   auto response = OFDMModAccValidateCalibrationDataResponse{};
 
   raise_if_error(
-      stub->OFDMModAccValidateCalibrationData(&context, request, &response));
+      stub->OFDMModAccValidateCalibrationData(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3408,7 +3585,8 @@ power_ramp_cfg_acquisition_length(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = PowerRampCfgAcquisitionLengthResponse{};
 
   raise_if_error(
-      stub->PowerRampCfgAcquisitionLength(&context, request, &response));
+      stub->PowerRampCfgAcquisitionLength(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3434,7 +3612,8 @@ power_ramp_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& inst
   auto response = PowerRampCfgAveragingResponse{};
 
   raise_if_error(
-      stub->PowerRampCfgAveraging(&context, request, &response));
+      stub->PowerRampCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3452,7 +3631,8 @@ power_ramp_fetch_fall_trace(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = PowerRampFetchFallTraceResponse{};
 
   raise_if_error(
-      stub->PowerRampFetchFallTrace(&context, request, &response));
+      stub->PowerRampFetchFallTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3470,7 +3650,8 @@ power_ramp_fetch_measurement(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = PowerRampFetchMeasurementResponse{};
 
   raise_if_error(
-      stub->PowerRampFetchMeasurement(&context, request, &response));
+      stub->PowerRampFetchMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3488,7 +3669,8 @@ power_ramp_fetch_rise_trace(const StubPtr& stub, const nidevice_grpc::Session& i
   auto response = PowerRampFetchRiseTraceResponse{};
 
   raise_if_error(
-      stub->PowerRampFetchRiseTrace(&context, request, &response));
+      stub->PowerRampFetchRiseTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3506,7 +3688,8 @@ reset_attribute(const StubPtr& stub, const nidevice_grpc::Session& instrument, c
   auto response = ResetAttributeResponse{};
 
   raise_if_error(
-      stub->ResetAttribute(&context, request, &response));
+      stub->ResetAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3523,7 +3706,8 @@ reset_to_default(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = ResetToDefaultResponse{};
 
   raise_if_error(
-      stub->ResetToDefault(&context, request, &response));
+      stub->ResetToDefault(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3557,7 +3741,8 @@ sem_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SEMCfgAveragingResponse{};
 
   raise_if_error(
-      stub->SEMCfgAveraging(&context, request, &response));
+      stub->SEMCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3582,7 +3767,8 @@ sem_cfg_mask_type(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SEMCfgMaskTypeResponse{};
 
   raise_if_error(
-      stub->SEMCfgMaskType(&context, request, &response));
+      stub->SEMCfgMaskType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3600,7 +3786,8 @@ sem_cfg_number_of_offsets(const StubPtr& stub, const nidevice_grpc::Session& ins
   auto response = SEMCfgNumberOfOffsetsResponse{};
 
   raise_if_error(
-      stub->SEMCfgNumberOfOffsets(&context, request, &response));
+      stub->SEMCfgNumberOfOffsets(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3620,7 +3807,8 @@ sem_cfg_offset_frequency_array(const StubPtr& stub, const nidevice_grpc::Session
   auto response = SEMCfgOffsetFrequencyArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetFrequencyArray(&context, request, &response));
+      stub->SEMCfgOffsetFrequencyArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3639,7 +3827,8 @@ sem_cfg_offset_relative_limit_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SEMCfgOffsetRelativeLimitArrayResponse{};
 
   raise_if_error(
-      stub->SEMCfgOffsetRelativeLimitArray(&context, request, &response));
+      stub->SEMCfgOffsetRelativeLimitArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3665,7 +3854,8 @@ sem_cfg_span(const StubPtr& stub, const nidevice_grpc::Session& instrument, cons
   auto response = SEMCfgSpanResponse{};
 
   raise_if_error(
-      stub->SEMCfgSpan(&context, request, &response));
+      stub->SEMCfgSpan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3691,7 +3881,8 @@ sem_cfg_sweep_time(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = SEMCfgSweepTimeResponse{};
 
   raise_if_error(
-      stub->SEMCfgSweepTime(&context, request, &response));
+      stub->SEMCfgSweepTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3709,7 +3900,8 @@ sem_fetch_carrier_measurement(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMFetchCarrierMeasurementResponse{};
 
   raise_if_error(
-      stub->SEMFetchCarrierMeasurement(&context, request, &response));
+      stub->SEMFetchCarrierMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3727,7 +3919,8 @@ sem_fetch_lower_offset_margin(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMFetchLowerOffsetMarginResponse{};
 
   raise_if_error(
-      stub->SEMFetchLowerOffsetMargin(&context, request, &response));
+      stub->SEMFetchLowerOffsetMargin(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3745,7 +3938,8 @@ sem_fetch_lower_offset_margin_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SEMFetchLowerOffsetMarginArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchLowerOffsetMarginArray(&context, request, &response));
+      stub->SEMFetchLowerOffsetMarginArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3763,7 +3957,8 @@ sem_fetch_lower_offset_power(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SEMFetchLowerOffsetPowerResponse{};
 
   raise_if_error(
-      stub->SEMFetchLowerOffsetPower(&context, request, &response));
+      stub->SEMFetchLowerOffsetPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3781,7 +3976,8 @@ sem_fetch_lower_offset_power_array(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = SEMFetchLowerOffsetPowerArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchLowerOffsetPowerArray(&context, request, &response));
+      stub->SEMFetchLowerOffsetPowerArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3799,7 +3995,8 @@ sem_fetch_measurement_status(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SEMFetchMeasurementStatusResponse{};
 
   raise_if_error(
-      stub->SEMFetchMeasurementStatus(&context, request, &response));
+      stub->SEMFetchMeasurementStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3817,7 +4014,8 @@ sem_fetch_spectrum(const StubPtr& stub, const nidevice_grpc::Session& instrument
   auto response = SEMFetchSpectrumResponse{};
 
   raise_if_error(
-      stub->SEMFetchSpectrum(&context, request, &response));
+      stub->SEMFetchSpectrum(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3835,7 +4033,8 @@ sem_fetch_upper_offset_margin(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = SEMFetchUpperOffsetMarginResponse{};
 
   raise_if_error(
-      stub->SEMFetchUpperOffsetMargin(&context, request, &response));
+      stub->SEMFetchUpperOffsetMargin(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3853,7 +4052,8 @@ sem_fetch_upper_offset_margin_array(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SEMFetchUpperOffsetMarginArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchUpperOffsetMarginArray(&context, request, &response));
+      stub->SEMFetchUpperOffsetMarginArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3871,7 +4071,8 @@ sem_fetch_upper_offset_power(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = SEMFetchUpperOffsetPowerResponse{};
 
   raise_if_error(
-      stub->SEMFetchUpperOffsetPower(&context, request, &response));
+      stub->SEMFetchUpperOffsetPower(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3889,7 +4090,8 @@ sem_fetch_upper_offset_power_array(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = SEMFetchUpperOffsetPowerArrayResponse{};
 
   raise_if_error(
-      stub->SEMFetchUpperOffsetPowerArray(&context, request, &response));
+      stub->SEMFetchUpperOffsetPowerArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3915,7 +4117,8 @@ select_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrumen
   auto response = SelectMeasurementsResponse{};
 
   raise_if_error(
-      stub->SelectMeasurements(&context, request, &response));
+      stub->SelectMeasurements(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3931,7 +4134,8 @@ send_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& in
   auto response = SendSoftwareEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->SendSoftwareEdgeTrigger(&context, request, &response));
+      stub->SendSoftwareEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3950,7 +4154,8 @@ set_attribute_f32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeF32Response{};
 
   raise_if_error(
-      stub->SetAttributeF32(&context, request, &response));
+      stub->SetAttributeF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3969,7 +4174,8 @@ set_attribute_f32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeF32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeF32Array(&context, request, &response));
+      stub->SetAttributeF32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -3988,7 +4194,8 @@ set_attribute_f64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeF64Response{};
 
   raise_if_error(
-      stub->SetAttributeF64(&context, request, &response));
+      stub->SetAttributeF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4007,7 +4214,8 @@ set_attribute_f64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeF64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeF64Array(&context, request, &response));
+      stub->SetAttributeF64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4026,7 +4234,8 @@ set_attribute_i16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI16Response{};
 
   raise_if_error(
-      stub->SetAttributeI16(&context, request, &response));
+      stub->SetAttributeI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4052,7 +4261,8 @@ set_attribute_i32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI32Response{};
 
   raise_if_error(
-      stub->SetAttributeI32(&context, request, &response));
+      stub->SetAttributeI32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4071,7 +4281,8 @@ set_attribute_i32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeI32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI32Array(&context, request, &response));
+      stub->SetAttributeI32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4090,7 +4301,8 @@ set_attribute_i64(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeI64Response{};
 
   raise_if_error(
-      stub->SetAttributeI64(&context, request, &response));
+      stub->SetAttributeI64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4109,7 +4321,8 @@ set_attribute_i64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeI64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI64Array(&context, request, &response));
+      stub->SetAttributeI64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4128,7 +4341,8 @@ set_attribute_i8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = SetAttributeI8Response{};
 
   raise_if_error(
-      stub->SetAttributeI8(&context, request, &response));
+      stub->SetAttributeI8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4147,7 +4361,8 @@ set_attribute_i8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = SetAttributeI8ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeI8Array(&context, request, &response));
+      stub->SetAttributeI8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4166,7 +4381,8 @@ set_attribute_ni_complex_double_array(const StubPtr& stub, const nidevice_grpc::
   auto response = SetAttributeNIComplexDoubleArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeNIComplexDoubleArray(&context, request, &response));
+      stub->SetAttributeNIComplexDoubleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4185,7 +4401,8 @@ set_attribute_ni_complex_single_array(const StubPtr& stub, const nidevice_grpc::
   auto response = SetAttributeNIComplexSingleArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeNIComplexSingleArray(&context, request, &response));
+      stub->SetAttributeNIComplexSingleArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4211,7 +4428,8 @@ set_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& instrume
   auto response = SetAttributeStringResponse{};
 
   raise_if_error(
-      stub->SetAttributeString(&context, request, &response));
+      stub->SetAttributeString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4230,7 +4448,8 @@ set_attribute_u16(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeU16Response{};
 
   raise_if_error(
-      stub->SetAttributeU16(&context, request, &response));
+      stub->SetAttributeU16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4249,7 +4468,8 @@ set_attribute_u32(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = SetAttributeU32Response{};
 
   raise_if_error(
-      stub->SetAttributeU32(&context, request, &response));
+      stub->SetAttributeU32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4268,7 +4488,8 @@ set_attribute_u32_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeU32ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU32Array(&context, request, &response));
+      stub->SetAttributeU32Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4287,7 +4508,8 @@ set_attribute_u64_array(const StubPtr& stub, const nidevice_grpc::Session& instr
   auto response = SetAttributeU64ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU64Array(&context, request, &response));
+      stub->SetAttributeU64Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4306,7 +4528,8 @@ set_attribute_u8(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
   auto response = SetAttributeU8Response{};
 
   raise_if_error(
-      stub->SetAttributeU8(&context, request, &response));
+      stub->SetAttributeU8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4325,7 +4548,8 @@ set_attribute_u8_array(const StubPtr& stub, const nidevice_grpc::Session& instru
   auto response = SetAttributeU8ArrayResponse{};
 
   raise_if_error(
-      stub->SetAttributeU8Array(&context, request, &response));
+      stub->SetAttributeU8Array(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4351,7 +4575,8 @@ txp_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument,
   auto response = TXPCfgAveragingResponse{};
 
   raise_if_error(
-      stub->TXPCfgAveraging(&context, request, &response));
+      stub->TXPCfgAveraging(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4376,7 +4601,8 @@ txp_cfg_burst_detection_enabled(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = TXPCfgBurstDetectionEnabledResponse{};
 
   raise_if_error(
-      stub->TXPCfgBurstDetectionEnabled(&context, request, &response));
+      stub->TXPCfgBurstDetectionEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4394,7 +4620,8 @@ txp_cfg_maximum_measurement_interval(const StubPtr& stub, const nidevice_grpc::S
   auto response = TXPCfgMaximumMeasurementIntervalResponse{};
 
   raise_if_error(
-      stub->TXPCfgMaximumMeasurementInterval(&context, request, &response));
+      stub->TXPCfgMaximumMeasurementInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4412,7 +4639,8 @@ txp_fetch_measurement(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = TXPFetchMeasurementResponse{};
 
   raise_if_error(
-      stub->TXPFetchMeasurement(&context, request, &response));
+      stub->TXPFetchMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4430,7 +4658,8 @@ txp_fetch_power_trace(const StubPtr& stub, const nidevice_grpc::Session& instrum
   auto response = TXPFetchPowerTraceResponse{};
 
   raise_if_error(
-      stub->TXPFetchPowerTrace(&context, request, &response));
+      stub->TXPFetchPowerTrace(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4447,7 +4676,8 @@ wait_for_acquisition_complete(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = WaitForAcquisitionCompleteResponse{};
 
   raise_if_error(
-      stub->WaitForAcquisitionComplete(&context, request, &response));
+      stub->WaitForAcquisitionComplete(&context, request, &response),
+      context);
 
   return response;
 }
@@ -4465,7 +4695,8 @@ wait_for_measurement_complete(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = WaitForMeasurementCompleteResponse{};
 
   raise_if_error(
-      stub->WaitForMeasurementComplete(&context, request, &response));
+      stub->WaitForMeasurementComplete(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nirfsa/nirfsa_client.cpp
+++ b/generated/nirfsa/nirfsa_client.cpp
@@ -28,7 +28,8 @@ abort(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = AbortResponse{};
 
   raise_if_error(
-      stub->Abort(&context, request, &response));
+      stub->Abort(&context, request, &response),
+      context);
 
   return response;
 }
@@ -44,7 +45,8 @@ check_acquisition_status(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CheckAcquisitionStatusResponse{};
 
   raise_if_error(
-      stub->CheckAcquisitionStatus(&context, request, &response));
+      stub->CheckAcquisitionStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -60,7 +62,8 @@ clear_error(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ClearErrorResponse{};
 
   raise_if_error(
-      stub->ClearError(&context, request, &response));
+      stub->ClearError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -76,7 +79,8 @@ clear_self_calibrate_range(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = ClearSelfCalibrateRangeResponse{};
 
   raise_if_error(
-      stub->ClearSelfCalibrateRange(&context, request, &response));
+      stub->ClearSelfCalibrateRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -92,7 +96,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }
@@ -108,7 +113,8 @@ commit(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CommitResponse{};
 
   raise_if_error(
-      stub->Commit(&context, request, &response));
+      stub->Commit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -132,7 +138,8 @@ configure_acquisition_type(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = ConfigureAcquisitionTypeResponse{};
 
   raise_if_error(
-      stub->ConfigureAcquisitionType(&context, request, &response));
+      stub->ConfigureAcquisitionType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -158,7 +165,8 @@ configure_deembedding_table_interpolation_linear(const StubPtr& stub, const nide
   auto response = ConfigureDeembeddingTableInterpolationLinearResponse{};
 
   raise_if_error(
-      stub->ConfigureDeembeddingTableInterpolationLinear(&context, request, &response));
+      stub->ConfigureDeembeddingTableInterpolationLinear(&context, request, &response),
+      context);
 
   return response;
 }
@@ -176,7 +184,8 @@ configure_deembedding_table_interpolation_nearest(const StubPtr& stub, const nid
   auto response = ConfigureDeembeddingTableInterpolationNearestResponse{};
 
   raise_if_error(
-      stub->ConfigureDeembeddingTableInterpolationNearest(&context, request, &response));
+      stub->ConfigureDeembeddingTableInterpolationNearest(&context, request, &response),
+      context);
 
   return response;
 }
@@ -194,7 +203,8 @@ configure_deembedding_table_interpolation_spline(const StubPtr& stub, const nide
   auto response = ConfigureDeembeddingTableInterpolationSplineResponse{};
 
   raise_if_error(
-      stub->ConfigureDeembeddingTableInterpolationSpline(&context, request, &response));
+      stub->ConfigureDeembeddingTableInterpolationSpline(&context, request, &response),
+      context);
 
   return response;
 }
@@ -226,7 +236,8 @@ configure_digital_edge_advance_trigger(const StubPtr& stub, const nidevice_grpc:
   auto response = ConfigureDigitalEdgeAdvanceTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeAdvanceTrigger(&context, request, &response));
+      stub->ConfigureDigitalEdgeAdvanceTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -259,7 +270,8 @@ configure_digital_edge_ref_trigger(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = ConfigureDigitalEdgeRefTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeRefTrigger(&context, request, &response));
+      stub->ConfigureDigitalEdgeRefTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -291,7 +303,8 @@ configure_digital_edge_start_trigger(const StubPtr& stub, const nidevice_grpc::S
   auto response = ConfigureDigitalEdgeStartTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeStartTrigger(&context, request, &response));
+      stub->ConfigureDigitalEdgeStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -309,7 +322,8 @@ configure_iq_carrier_frequency(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ConfigureIQCarrierFrequencyResponse{};
 
   raise_if_error(
-      stub->ConfigureIQCarrierFrequency(&context, request, &response));
+      stub->ConfigureIQCarrierFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -335,7 +349,8 @@ configure_iq_power_edge_ref_trigger(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ConfigureIQPowerEdgeRefTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureIQPowerEdgeRefTrigger(&context, request, &response));
+      stub->ConfigureIQPowerEdgeRefTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -353,7 +368,8 @@ configure_iq_rate(const StubPtr& stub, const nidevice_grpc::Session& vi, const p
   auto response = ConfigureIQRateResponse{};
 
   raise_if_error(
-      stub->ConfigureIQRate(&context, request, &response));
+      stub->ConfigureIQRate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -372,7 +388,8 @@ configure_number_of_records(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = ConfigureNumberOfRecordsResponse{};
 
   raise_if_error(
-      stub->ConfigureNumberOfRecords(&context, request, &response));
+      stub->ConfigureNumberOfRecords(&context, request, &response),
+      context);
 
   return response;
 }
@@ -391,7 +408,8 @@ configure_number_of_samples(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = ConfigureNumberOfSamplesResponse{};
 
   raise_if_error(
-      stub->ConfigureNumberOfSamples(&context, request, &response));
+      stub->ConfigureNumberOfSamples(&context, request, &response),
+      context);
 
   return response;
 }
@@ -415,7 +433,8 @@ configure_pxi_chassis_clk10(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = ConfigurePXIChassisClk10Response{};
 
   raise_if_error(
-      stub->ConfigurePXIChassisClk10(&context, request, &response));
+      stub->ConfigurePXIChassisClk10(&context, request, &response),
+      context);
 
   return response;
 }
@@ -440,7 +459,8 @@ configure_ref_clock(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = ConfigureRefClockResponse{};
 
   raise_if_error(
-      stub->ConfigureRefClock(&context, request, &response));
+      stub->ConfigureRefClock(&context, request, &response),
+      context);
 
   return response;
 }
@@ -458,7 +478,8 @@ configure_reference_level(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = ConfigureReferenceLevelResponse{};
 
   raise_if_error(
-      stub->ConfigureReferenceLevel(&context, request, &response));
+      stub->ConfigureReferenceLevel(&context, request, &response),
+      context);
 
   return response;
 }
@@ -476,7 +497,8 @@ configure_resolution_bandwidth(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ConfigureResolutionBandwidthResponse{};
 
   raise_if_error(
-      stub->ConfigureResolutionBandwidth(&context, request, &response));
+      stub->ConfigureResolutionBandwidth(&context, request, &response),
+      context);
 
   return response;
 }
@@ -492,7 +514,8 @@ configure_software_edge_advance_trigger(const StubPtr& stub, const nidevice_grpc
   auto response = ConfigureSoftwareEdgeAdvanceTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgeAdvanceTrigger(&context, request, &response));
+      stub->ConfigureSoftwareEdgeAdvanceTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -509,7 +532,8 @@ configure_software_edge_ref_trigger(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ConfigureSoftwareEdgeRefTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgeRefTrigger(&context, request, &response));
+      stub->ConfigureSoftwareEdgeRefTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -525,7 +549,8 @@ configure_software_edge_start_trigger(const StubPtr& stub, const nidevice_grpc::
   auto response = ConfigureSoftwareEdgeStartTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareEdgeStartTrigger(&context, request, &response));
+      stub->ConfigureSoftwareEdgeStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -544,7 +569,8 @@ configure_spectrum_frequency_center_span(const StubPtr& stub, const nidevice_grp
   auto response = ConfigureSpectrumFrequencyCenterSpanResponse{};
 
   raise_if_error(
-      stub->ConfigureSpectrumFrequencyCenterSpan(&context, request, &response));
+      stub->ConfigureSpectrumFrequencyCenterSpan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -563,7 +589,8 @@ configure_spectrum_frequency_start_stop(const StubPtr& stub, const nidevice_grpc
   auto response = ConfigureSpectrumFrequencyStartStopResponse{};
 
   raise_if_error(
-      stub->ConfigureSpectrumFrequencyStartStop(&context, request, &response));
+      stub->ConfigureSpectrumFrequencyStartStop(&context, request, &response),
+      context);
 
   return response;
 }
@@ -582,7 +609,8 @@ create_configuration_list(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = CreateConfigurationListResponse{};
 
   raise_if_error(
-      stub->CreateConfigurationList(&context, request, &response));
+      stub->CreateConfigurationList(&context, request, &response),
+      context);
 
   return response;
 }
@@ -599,7 +627,8 @@ create_configuration_list_step(const StubPtr& stub, const nidevice_grpc::Session
   auto response = CreateConfigurationListStepResponse{};
 
   raise_if_error(
-      stub->CreateConfigurationListStep(&context, request, &response));
+      stub->CreateConfigurationListStep(&context, request, &response),
+      context);
 
   return response;
 }
@@ -628,7 +657,8 @@ create_deembedding_sparameter_table_array(const StubPtr& stub, const nidevice_gr
   auto response = CreateDeembeddingSparameterTableArrayResponse{};
 
   raise_if_error(
-      stub->CreateDeembeddingSparameterTableArray(&context, request, &response));
+      stub->CreateDeembeddingSparameterTableArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -655,7 +685,8 @@ create_deembedding_sparameter_table_s2p_file(const StubPtr& stub, const nidevice
   auto response = CreateDeembeddingSparameterTableS2PFileResponse{};
 
   raise_if_error(
-      stub->CreateDeembeddingSparameterTableS2PFile(&context, request, &response));
+      stub->CreateDeembeddingSparameterTableS2PFile(&context, request, &response),
+      context);
 
   return response;
 }
@@ -671,7 +702,8 @@ delete_all_deembedding_tables(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = DeleteAllDeembeddingTablesResponse{};
 
   raise_if_error(
-      stub->DeleteAllDeembeddingTables(&context, request, &response));
+      stub->DeleteAllDeembeddingTables(&context, request, &response),
+      context);
 
   return response;
 }
@@ -688,7 +720,8 @@ delete_configuration_list(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = DeleteConfigurationListResponse{};
 
   raise_if_error(
-      stub->DeleteConfigurationList(&context, request, &response));
+      stub->DeleteConfigurationList(&context, request, &response),
+      context);
 
   return response;
 }
@@ -706,7 +739,8 @@ delete_deembedding_table(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = DeleteDeembeddingTableResponse{};
 
   raise_if_error(
-      stub->DeleteDeembeddingTable(&context, request, &response));
+      stub->DeleteDeembeddingTable(&context, request, &response),
+      context);
 
   return response;
 }
@@ -722,7 +756,8 @@ disable(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisableResponse{};
 
   raise_if_error(
-      stub->Disable(&context, request, &response));
+      stub->Disable(&context, request, &response),
+      context);
 
   return response;
 }
@@ -738,7 +773,8 @@ disable_advance_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisableAdvanceTriggerResponse{};
 
   raise_if_error(
-      stub->DisableAdvanceTrigger(&context, request, &response));
+      stub->DisableAdvanceTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -754,7 +790,8 @@ disable_ref_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisableRefTriggerResponse{};
 
   raise_if_error(
-      stub->DisableRefTrigger(&context, request, &response));
+      stub->DisableRefTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -770,7 +807,8 @@ disable_start_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisableStartTriggerResponse{};
 
   raise_if_error(
-      stub->DisableStartTrigger(&context, request, &response));
+      stub->DisableStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -787,7 +825,8 @@ enable_session_access(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = EnableSessionAccessResponse{};
 
   raise_if_error(
-      stub->EnableSessionAccess(&context, request, &response));
+      stub->EnableSessionAccess(&context, request, &response),
+      context);
 
   return response;
 }
@@ -804,7 +843,8 @@ error_message(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::i
   auto response = ErrorMessageResponse{};
 
   raise_if_error(
-      stub->ErrorMessage(&context, request, &response));
+      stub->ErrorMessage(&context, request, &response),
+      context);
 
   return response;
 }
@@ -820,7 +860,8 @@ error_query(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ErrorQueryResponse{};
 
   raise_if_error(
-      stub->ErrorQuery(&context, request, &response));
+      stub->ErrorQuery(&context, request, &response),
+      context);
 
   return response;
 }
@@ -853,7 +894,8 @@ export_signal(const StubPtr& stub, const nidevice_grpc::Session& vi, const simpl
   auto response = ExportSignalResponse{};
 
   raise_if_error(
-      stub->ExportSignal(&context, request, &response));
+      stub->ExportSignal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -874,7 +916,8 @@ fetch_iq_multi_record_complex_f32(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = FetchIQMultiRecordComplexF32Response{};
 
   raise_if_error(
-      stub->FetchIQMultiRecordComplexF32(&context, request, &response));
+      stub->FetchIQMultiRecordComplexF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -895,7 +938,8 @@ fetch_iq_multi_record_complex_f64(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = FetchIQMultiRecordComplexF64Response{};
 
   raise_if_error(
-      stub->FetchIQMultiRecordComplexF64(&context, request, &response));
+      stub->FetchIQMultiRecordComplexF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -916,7 +960,8 @@ fetch_iq_multi_record_complex_i16(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = FetchIQMultiRecordComplexI16Response{};
 
   raise_if_error(
-      stub->FetchIQMultiRecordComplexI16(&context, request, &response));
+      stub->FetchIQMultiRecordComplexI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -936,7 +981,8 @@ fetch_iq_single_record_complex_f32(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = FetchIQSingleRecordComplexF32Response{};
 
   raise_if_error(
-      stub->FetchIQSingleRecordComplexF32(&context, request, &response));
+      stub->FetchIQSingleRecordComplexF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -956,7 +1002,8 @@ fetch_iq_single_record_complex_f64(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = FetchIQSingleRecordComplexF64Response{};
 
   raise_if_error(
-      stub->FetchIQSingleRecordComplexF64(&context, request, &response));
+      stub->FetchIQSingleRecordComplexF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -976,7 +1023,8 @@ fetch_iq_single_record_complex_i16(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = FetchIQSingleRecordComplexI16Response{};
 
   raise_if_error(
-      stub->FetchIQSingleRecordComplexI16(&context, request, &response));
+      stub->FetchIQSingleRecordComplexI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -994,7 +1042,8 @@ get_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->GetAttributeViBoolean(&context, request, &response));
+      stub->GetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1012,7 +1061,8 @@ get_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->GetAttributeViInt32(&context, request, &response));
+      stub->GetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1030,7 +1080,8 @@ get_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetAttributeViInt64Response{};
 
   raise_if_error(
-      stub->GetAttributeViInt64(&context, request, &response));
+      stub->GetAttributeViInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1048,7 +1099,8 @@ get_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->GetAttributeViReal64(&context, request, &response));
+      stub->GetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1066,7 +1118,8 @@ get_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->GetAttributeViSession(&context, request, &response));
+      stub->GetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1084,7 +1137,8 @@ get_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeViString(&context, request, &response));
+      stub->GetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1100,7 +1154,8 @@ get_cal_user_defined_info(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetCalUserDefinedInfoResponse{};
 
   raise_if_error(
-      stub->GetCalUserDefinedInfo(&context, request, &response));
+      stub->GetCalUserDefinedInfo(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1116,7 +1171,8 @@ get_cal_user_defined_info_max_size(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = GetCalUserDefinedInfoMaxSizeResponse{};
 
   raise_if_error(
-      stub->GetCalUserDefinedInfoMaxSize(&context, request, &response));
+      stub->GetCalUserDefinedInfoMaxSize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1132,7 +1188,8 @@ get_deembedding_sparameters(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = GetDeembeddingSparametersResponse{};
 
   raise_if_error(
-      stub->GetDeembeddingSparameters(&context, request, &response));
+      stub->GetDeembeddingSparameters(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1157,7 +1214,8 @@ get_device_response(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = GetDeviceResponseResponse{};
 
   raise_if_error(
-      stub->GetDeviceResponse(&context, request, &response));
+      stub->GetDeviceResponse(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1173,7 +1231,8 @@ get_error(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetErrorResponse{};
 
   raise_if_error(
-      stub->GetError(&context, request, &response));
+      stub->GetError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1189,7 +1248,8 @@ get_ext_cal_last_date_and_time(const StubPtr& stub, const nidevice_grpc::Session
   auto response = GetExtCalLastDateAndTimeResponse{};
 
   raise_if_error(
-      stub->GetExtCalLastDateAndTime(&context, request, &response));
+      stub->GetExtCalLastDateAndTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1205,7 +1265,8 @@ get_ext_cal_last_temp(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetExtCalLastTempResponse{};
 
   raise_if_error(
-      stub->GetExtCalLastTemp(&context, request, &response));
+      stub->GetExtCalLastTemp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1221,7 +1282,8 @@ get_ext_cal_recommended_interval(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = GetExtCalRecommendedIntervalResponse{};
 
   raise_if_error(
-      stub->GetExtCalRecommendedInterval(&context, request, &response));
+      stub->GetExtCalRecommendedInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1239,7 +1301,8 @@ get_fetch_backlog(const StubPtr& stub, const nidevice_grpc::Session& vi, const p
   auto response = GetFetchBacklogResponse{};
 
   raise_if_error(
-      stub->GetFetchBacklog(&context, request, &response));
+      stub->GetFetchBacklog(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1256,7 +1319,8 @@ get_frequency_response(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetFrequencyResponseResponse{};
 
   raise_if_error(
-      stub->GetFrequencyResponse(&context, request, &response));
+      stub->GetFrequencyResponse(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1273,7 +1337,8 @@ get_normalization_coefficients(const StubPtr& stub, const nidevice_grpc::Session
   auto response = GetNormalizationCoefficientsResponse{};
 
   raise_if_error(
-      stub->GetNormalizationCoefficients(&context, request, &response));
+      stub->GetNormalizationCoefficients(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1290,7 +1355,8 @@ get_number_of_spectral_lines(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetNumberOfSpectralLinesResponse{};
 
   raise_if_error(
-      stub->GetNumberOfSpectralLines(&context, request, &response));
+      stub->GetNumberOfSpectralLines(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1308,7 +1374,8 @@ get_relay_name(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::
   auto response = GetRelayNameResponse{};
 
   raise_if_error(
-      stub->GetRelayName(&context, request, &response));
+      stub->GetRelayName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1325,7 +1392,8 @@ get_relay_operations_count(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = GetRelayOperationsCountResponse{};
 
   raise_if_error(
-      stub->GetRelayOperationsCount(&context, request, &response));
+      stub->GetRelayOperationsCount(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1342,7 +1410,8 @@ get_scaling_coefficients(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetScalingCoefficientsResponse{};
 
   raise_if_error(
-      stub->GetScalingCoefficients(&context, request, &response));
+      stub->GetScalingCoefficients(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1359,7 +1428,8 @@ get_self_cal_last_date_and_time(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = GetSelfCalLastDateAndTimeResponse{};
 
   raise_if_error(
-      stub->GetSelfCalLastDateAndTime(&context, request, &response));
+      stub->GetSelfCalLastDateAndTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1376,7 +1446,8 @@ get_self_cal_last_temp(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetSelfCalLastTempResponse{};
 
   raise_if_error(
-      stub->GetSelfCalLastTemp(&context, request, &response));
+      stub->GetSelfCalLastTemp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1392,7 +1463,8 @@ get_spectral_info_for_smt(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetSpectralInfoForSMTResponse{};
 
   raise_if_error(
-      stub->GetSpectralInfoForSMT(&context, request, &response));
+      stub->GetSpectralInfoForSMT(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1409,7 +1481,8 @@ get_stream_endpoint_handle(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = GetStreamEndpointHandleResponse{};
 
   raise_if_error(
-      stub->GetStreamEndpointHandle(&context, request, &response));
+      stub->GetStreamEndpointHandle(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1435,7 +1508,8 @@ get_terminal_name(const StubPtr& stub, const nidevice_grpc::Session& vi, const s
   auto response = GetTerminalNameResponse{};
 
   raise_if_error(
-      stub->GetTerminalName(&context, request, &response));
+      stub->GetTerminalName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1452,7 +1526,8 @@ get_user_data(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::s
   auto response = GetUserDataResponse{};
 
   raise_if_error(
-      stub->GetUserData(&context, request, &response));
+      stub->GetUserData(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1470,7 +1545,8 @@ init(const StubPtr& stub, const pb::string& resource_name, const bool& id_query,
   auto response = InitResponse{};
 
   raise_if_error(
-      stub->Init(&context, request, &response));
+      stub->Init(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1489,7 +1565,8 @@ init_with_options(const StubPtr& stub, const pb::string& resource_name, const bo
   auto response = InitWithOptionsResponse{};
 
   raise_if_error(
-      stub->InitWithOptions(&context, request, &response));
+      stub->InitWithOptions(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1505,7 +1582,8 @@ initiate(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = InitiateResponse{};
 
   raise_if_error(
-      stub->Initiate(&context, request, &response));
+      stub->Initiate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1521,7 +1599,8 @@ invalidate_all_attributes(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = InvalidateAllAttributesResponse{};
 
   raise_if_error(
-      stub->InvalidateAllAttributes(&context, request, &response));
+      stub->InvalidateAllAttributes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1537,7 +1616,8 @@ is_self_cal_valid(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = IsSelfCalValidResponse{};
 
   raise_if_error(
-      stub->IsSelfCalValid(&context, request, &response));
+      stub->IsSelfCalValid(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1553,7 +1633,8 @@ perform_thermal_correction(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = PerformThermalCorrectionResponse{};
 
   raise_if_error(
-      stub->PerformThermalCorrection(&context, request, &response));
+      stub->PerformThermalCorrection(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1572,7 +1653,8 @@ read_iq_single_record_complex_f64(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = ReadIQSingleRecordComplexF64Response{};
 
   raise_if_error(
-      stub->ReadIQSingleRecordComplexF64(&context, request, &response));
+      stub->ReadIQSingleRecordComplexF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1591,7 +1673,8 @@ read_power_spectrum_f32(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = ReadPowerSpectrumF32Response{};
 
   raise_if_error(
-      stub->ReadPowerSpectrumF32(&context, request, &response));
+      stub->ReadPowerSpectrumF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1610,7 +1693,8 @@ read_power_spectrum_f64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = ReadPowerSpectrumF64Response{};
 
   raise_if_error(
-      stub->ReadPowerSpectrumF64(&context, request, &response));
+      stub->ReadPowerSpectrumF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1626,7 +1710,8 @@ reset(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetResponse{};
 
   raise_if_error(
-      stub->Reset(&context, request, &response));
+      stub->Reset(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1644,7 +1729,8 @@ reset_attribute(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb:
   auto response = ResetAttributeResponse{};
 
   raise_if_error(
-      stub->ResetAttribute(&context, request, &response));
+      stub->ResetAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1660,7 +1746,8 @@ reset_device(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetDeviceResponse{};
 
   raise_if_error(
-      stub->ResetDevice(&context, request, &response));
+      stub->ResetDevice(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1676,7 +1763,8 @@ reset_with_defaults(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetWithDefaultsResponse{};
 
   raise_if_error(
-      stub->ResetWithDefaults(&context, request, &response));
+      stub->ResetWithDefaults(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1700,7 +1788,8 @@ reset_with_options(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = ResetWithOptionsResponse{};
 
   raise_if_error(
-      stub->ResetWithOptions(&context, request, &response));
+      stub->ResetWithOptions(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1716,7 +1805,8 @@ revision_query(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = RevisionQueryResponse{};
 
   raise_if_error(
-      stub->RevisionQuery(&context, request, &response));
+      stub->RevisionQuery(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1732,7 +1822,8 @@ self_cal(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SelfCalResponse{};
 
   raise_if_error(
-      stub->SelfCal(&context, request, &response));
+      stub->SelfCal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1756,7 +1847,8 @@ self_calibrate(const StubPtr& stub, const nidevice_grpc::Session& vi, const simp
   auto response = SelfCalibrateResponse{};
 
   raise_if_error(
-      stub->SelfCalibrate(&context, request, &response));
+      stub->SelfCalibrate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1784,7 +1876,8 @@ self_calibrate_range(const StubPtr& stub, const nidevice_grpc::Session& vi, cons
   auto response = SelfCalibrateRangeResponse{};
 
   raise_if_error(
-      stub->SelfCalibrateRange(&context, request, &response));
+      stub->SelfCalibrateRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1800,7 +1893,8 @@ self_test(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SelfTestResponse{};
 
   raise_if_error(
-      stub->SelfTest(&context, request, &response));
+      stub->SelfTest(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1825,7 +1919,8 @@ send_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = SendSoftwareEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->SendSoftwareEdgeTrigger(&context, request, &response));
+      stub->SendSoftwareEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1844,7 +1939,8 @@ set_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = SetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->SetAttributeViBoolean(&context, request, &response));
+      stub->SetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1870,7 +1966,8 @@ set_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = SetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->SetAttributeViInt32(&context, request, &response));
+      stub->SetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1889,7 +1986,8 @@ set_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = SetAttributeViInt64Response{};
 
   raise_if_error(
-      stub->SetAttributeViInt64(&context, request, &response));
+      stub->SetAttributeViInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1908,7 +2006,8 @@ set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->SetAttributeViReal64(&context, request, &response));
+      stub->SetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1927,7 +2026,8 @@ set_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = SetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->SetAttributeViSession(&context, request, &response));
+      stub->SetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1953,7 +2053,8 @@ set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->SetAttributeViString(&context, request, &response));
+      stub->SetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1970,7 +2071,8 @@ set_cal_user_defined_info(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = SetCalUserDefinedInfoResponse{};
 
   raise_if_error(
-      stub->SetCalUserDefinedInfo(&context, request, &response));
+      stub->SetCalUserDefinedInfo(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1988,7 +2090,8 @@ set_user_data(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::s
   auto response = SetUserDataResponse{};
 
   raise_if_error(
-      stub->SetUserData(&context, request, &response));
+      stub->SetUserData(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nirfsg/nirfsg_client.cpp
+++ b/generated/nirfsg/nirfsg_client.cpp
@@ -28,7 +28,8 @@ abort(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = AbortResponse{};
 
   raise_if_error(
-      stub->Abort(&context, request, &response));
+      stub->Abort(&context, request, &response),
+      context);
 
   return response;
 }
@@ -46,7 +47,8 @@ allocate_arb_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = AllocateArbWaveformResponse{};
 
   raise_if_error(
-      stub->AllocateArbWaveform(&context, request, &response));
+      stub->AllocateArbWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -65,7 +67,8 @@ check_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = CheckAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->CheckAttributeViBoolean(&context, request, &response));
+      stub->CheckAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -91,7 +94,8 @@ check_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = CheckAttributeViInt32Response{};
 
   raise_if_error(
-      stub->CheckAttributeViInt32(&context, request, &response));
+      stub->CheckAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -110,7 +114,8 @@ check_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = CheckAttributeViInt64Response{};
 
   raise_if_error(
-      stub->CheckAttributeViInt64(&context, request, &response));
+      stub->CheckAttributeViInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -136,7 +141,8 @@ check_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = CheckAttributeViReal64Response{};
 
   raise_if_error(
-      stub->CheckAttributeViReal64(&context, request, &response));
+      stub->CheckAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -155,7 +161,8 @@ check_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = CheckAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->CheckAttributeViSession(&context, request, &response));
+      stub->CheckAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -181,7 +188,8 @@ check_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = CheckAttributeViStringResponse{};
 
   raise_if_error(
-      stub->CheckAttributeViString(&context, request, &response));
+      stub->CheckAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -197,7 +205,8 @@ check_generation_status(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CheckGenerationStatusResponse{};
 
   raise_if_error(
-      stub->CheckGenerationStatus(&context, request, &response));
+      stub->CheckGenerationStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -214,7 +223,8 @@ check_if_configuration_list_exists(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = CheckIfConfigurationListExistsResponse{};
 
   raise_if_error(
-      stub->CheckIfConfigurationListExists(&context, request, &response));
+      stub->CheckIfConfigurationListExists(&context, request, &response),
+      context);
 
   return response;
 }
@@ -231,7 +241,8 @@ check_if_script_exists(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = CheckIfScriptExistsResponse{};
 
   raise_if_error(
-      stub->CheckIfScriptExists(&context, request, &response));
+      stub->CheckIfScriptExists(&context, request, &response),
+      context);
 
   return response;
 }
@@ -248,7 +259,8 @@ check_if_waveform_exists(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = CheckIfWaveformExistsResponse{};
 
   raise_if_error(
-      stub->CheckIfWaveformExists(&context, request, &response));
+      stub->CheckIfWaveformExists(&context, request, &response),
+      context);
 
   return response;
 }
@@ -264,7 +276,8 @@ clear_all_arb_waveforms(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ClearAllArbWaveformsResponse{};
 
   raise_if_error(
-      stub->ClearAllArbWaveforms(&context, request, &response));
+      stub->ClearAllArbWaveforms(&context, request, &response),
+      context);
 
   return response;
 }
@@ -281,7 +294,8 @@ clear_arb_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = ClearArbWaveformResponse{};
 
   raise_if_error(
-      stub->ClearArbWaveform(&context, request, &response));
+      stub->ClearArbWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -297,7 +311,8 @@ clear_error(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ClearErrorResponse{};
 
   raise_if_error(
-      stub->ClearError(&context, request, &response));
+      stub->ClearError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -313,7 +328,8 @@ clear_self_calibrate_range(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = ClearSelfCalibrateRangeResponse{};
 
   raise_if_error(
-      stub->ClearSelfCalibrateRange(&context, request, &response));
+      stub->ClearSelfCalibrateRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -329,7 +345,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }
@@ -345,7 +362,8 @@ commit(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CommitResponse{};
 
   raise_if_error(
-      stub->Commit(&context, request, &response));
+      stub->Commit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -371,7 +389,8 @@ configure_deembedding_table_interpolation_linear(const StubPtr& stub, const nide
   auto response = ConfigureDeembeddingTableInterpolationLinearResponse{};
 
   raise_if_error(
-      stub->ConfigureDeembeddingTableInterpolationLinear(&context, request, &response));
+      stub->ConfigureDeembeddingTableInterpolationLinear(&context, request, &response),
+      context);
 
   return response;
 }
@@ -389,7 +408,8 @@ configure_deembedding_table_interpolation_nearest(const StubPtr& stub, const nid
   auto response = ConfigureDeembeddingTableInterpolationNearestResponse{};
 
   raise_if_error(
-      stub->ConfigureDeembeddingTableInterpolationNearest(&context, request, &response));
+      stub->ConfigureDeembeddingTableInterpolationNearest(&context, request, &response),
+      context);
 
   return response;
 }
@@ -407,7 +427,8 @@ configure_deembedding_table_interpolation_spline(const StubPtr& stub, const nide
   auto response = ConfigureDeembeddingTableInterpolationSplineResponse{};
 
   raise_if_error(
-      stub->ConfigureDeembeddingTableInterpolationSpline(&context, request, &response));
+      stub->ConfigureDeembeddingTableInterpolationSpline(&context, request, &response),
+      context);
 
   return response;
 }
@@ -439,7 +460,8 @@ configure_digital_edge_configuration_list_step_trigger(const StubPtr& stub, cons
   auto response = ConfigureDigitalEdgeConfigurationListStepTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeConfigurationListStepTrigger(&context, request, &response));
+      stub->ConfigureDigitalEdgeConfigurationListStepTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -479,7 +501,8 @@ configure_digital_edge_script_trigger(const StubPtr& stub, const nidevice_grpc::
   auto response = ConfigureDigitalEdgeScriptTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeScriptTrigger(&context, request, &response));
+      stub->ConfigureDigitalEdgeScriptTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -511,7 +534,8 @@ configure_digital_edge_start_trigger(const StubPtr& stub, const nidevice_grpc::S
   auto response = ConfigureDigitalEdgeStartTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalEdgeStartTrigger(&context, request, &response));
+      stub->ConfigureDigitalEdgeStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -551,7 +575,8 @@ configure_digital_level_script_trigger(const StubPtr& stub, const nidevice_grpc:
   auto response = ConfigureDigitalLevelScriptTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalLevelScriptTrigger(&context, request, &response));
+      stub->ConfigureDigitalLevelScriptTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -568,7 +593,8 @@ configure_digital_modulation_user_defined_waveform(const StubPtr& stub, const ni
   auto response = ConfigureDigitalModulationUserDefinedWaveformResponse{};
 
   raise_if_error(
-      stub->ConfigureDigitalModulationUserDefinedWaveform(&context, request, &response));
+      stub->ConfigureDigitalModulationUserDefinedWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -592,7 +618,8 @@ configure_generation_mode(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = ConfigureGenerationModeResponse{};
 
   raise_if_error(
-      stub->ConfigureGenerationMode(&context, request, &response));
+      stub->ConfigureGenerationMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -609,7 +636,8 @@ configure_output_enabled(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = ConfigureOutputEnabledResponse{};
 
   raise_if_error(
-      stub->ConfigureOutputEnabled(&context, request, &response));
+      stub->ConfigureOutputEnabled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -626,7 +654,8 @@ configure_p2p_endpoint_fullness_start_trigger(const StubPtr& stub, const nidevic
   auto response = ConfigureP2PEndpointFullnessStartTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureP2PEndpointFullnessStartTrigger(&context, request, &response));
+      stub->ConfigureP2PEndpointFullnessStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -650,7 +679,8 @@ configure_pxi_chassis_clk10(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = ConfigurePXIChassisClk10Response{};
 
   raise_if_error(
-      stub->ConfigurePXIChassisClk10(&context, request, &response));
+      stub->ConfigurePXIChassisClk10(&context, request, &response),
+      context);
 
   return response;
 }
@@ -674,7 +704,8 @@ configure_power_level_type(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = ConfigurePowerLevelTypeResponse{};
 
   raise_if_error(
-      stub->ConfigurePowerLevelType(&context, request, &response));
+      stub->ConfigurePowerLevelType(&context, request, &response),
+      context);
 
   return response;
 }
@@ -692,7 +723,8 @@ configure_rf(const StubPtr& stub, const nidevice_grpc::Session& vi, const double
   auto response = ConfigureRFResponse{};
 
   raise_if_error(
-      stub->ConfigureRF(&context, request, &response));
+      stub->ConfigureRF(&context, request, &response),
+      context);
 
   return response;
 }
@@ -717,7 +749,8 @@ configure_ref_clock(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = ConfigureRefClockResponse{};
 
   raise_if_error(
-      stub->ConfigureRefClock(&context, request, &response));
+      stub->ConfigureRefClock(&context, request, &response),
+      context);
 
   return response;
 }
@@ -734,7 +767,8 @@ configure_signal_bandwidth(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = ConfigureSignalBandwidthResponse{};
 
   raise_if_error(
-      stub->ConfigureSignalBandwidth(&context, request, &response));
+      stub->ConfigureSignalBandwidth(&context, request, &response),
+      context);
 
   return response;
 }
@@ -758,7 +792,8 @@ configure_software_script_trigger(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = ConfigureSoftwareScriptTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareScriptTrigger(&context, request, &response));
+      stub->ConfigureSoftwareScriptTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -774,7 +809,8 @@ configure_software_start_trigger(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ConfigureSoftwareStartTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureSoftwareStartTrigger(&context, request, &response));
+      stub->ConfigureSoftwareStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -792,7 +828,8 @@ configure_upconverter_pll_settling_time(const StubPtr& stub, const nidevice_grpc
   auto response = ConfigureUpconverterPLLSettlingTimeResponse{};
 
   raise_if_error(
-      stub->ConfigureUpconverterPLLSettlingTime(&context, request, &response));
+      stub->ConfigureUpconverterPLLSettlingTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -811,7 +848,8 @@ create_configuration_list(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = CreateConfigurationListResponse{};
 
   raise_if_error(
-      stub->CreateConfigurationList(&context, request, &response));
+      stub->CreateConfigurationList(&context, request, &response),
+      context);
 
   return response;
 }
@@ -828,7 +866,8 @@ create_configuration_list_step(const StubPtr& stub, const nidevice_grpc::Session
   auto response = CreateConfigurationListStepResponse{};
 
   raise_if_error(
-      stub->CreateConfigurationListStep(&context, request, &response));
+      stub->CreateConfigurationListStep(&context, request, &response),
+      context);
 
   return response;
 }
@@ -857,7 +896,8 @@ create_deembedding_sparameter_table_array(const StubPtr& stub, const nidevice_gr
   auto response = CreateDeembeddingSparameterTableArrayResponse{};
 
   raise_if_error(
-      stub->CreateDeembeddingSparameterTableArray(&context, request, &response));
+      stub->CreateDeembeddingSparameterTableArray(&context, request, &response),
+      context);
 
   return response;
 }
@@ -884,7 +924,8 @@ create_deembedding_sparameter_table_s2p_file(const StubPtr& stub, const nidevice
   auto response = CreateDeembeddingSparameterTableS2PFileResponse{};
 
   raise_if_error(
-      stub->CreateDeembeddingSparameterTableS2PFile(&context, request, &response));
+      stub->CreateDeembeddingSparameterTableS2PFile(&context, request, &response),
+      context);
 
   return response;
 }
@@ -900,7 +941,8 @@ delete_all_deembedding_tables(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = DeleteAllDeembeddingTablesResponse{};
 
   raise_if_error(
-      stub->DeleteAllDeembeddingTables(&context, request, &response));
+      stub->DeleteAllDeembeddingTables(&context, request, &response),
+      context);
 
   return response;
 }
@@ -917,7 +959,8 @@ delete_configuration_list(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = DeleteConfigurationListResponse{};
 
   raise_if_error(
-      stub->DeleteConfigurationList(&context, request, &response));
+      stub->DeleteConfigurationList(&context, request, &response),
+      context);
 
   return response;
 }
@@ -935,7 +978,8 @@ delete_deembedding_table(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = DeleteDeembeddingTableResponse{};
 
   raise_if_error(
-      stub->DeleteDeembeddingTable(&context, request, &response));
+      stub->DeleteDeembeddingTable(&context, request, &response),
+      context);
 
   return response;
 }
@@ -952,7 +996,8 @@ delete_script(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::s
   auto response = DeleteScriptResponse{};
 
   raise_if_error(
-      stub->DeleteScript(&context, request, &response));
+      stub->DeleteScript(&context, request, &response),
+      context);
 
   return response;
 }
@@ -968,7 +1013,8 @@ disable(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisableResponse{};
 
   raise_if_error(
-      stub->Disable(&context, request, &response));
+      stub->Disable(&context, request, &response),
+      context);
 
   return response;
 }
@@ -984,7 +1030,8 @@ disable_all_modulation(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisableAllModulationResponse{};
 
   raise_if_error(
-      stub->DisableAllModulation(&context, request, &response));
+      stub->DisableAllModulation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1000,7 +1047,8 @@ disable_configuration_list_step_trigger(const StubPtr& stub, const nidevice_grpc
   auto response = DisableConfigurationListStepTriggerResponse{};
 
   raise_if_error(
-      stub->DisableConfigurationListStepTrigger(&context, request, &response));
+      stub->DisableConfigurationListStepTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1024,7 +1072,8 @@ disable_script_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = DisableScriptTriggerResponse{};
 
   raise_if_error(
-      stub->DisableScriptTrigger(&context, request, &response));
+      stub->DisableScriptTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1040,7 +1089,8 @@ disable_start_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisableStartTriggerResponse{};
 
   raise_if_error(
-      stub->DisableStartTrigger(&context, request, &response));
+      stub->DisableStartTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1057,7 +1107,8 @@ error_message(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::i
   auto response = ErrorMessageResponse{};
 
   raise_if_error(
-      stub->ErrorMessage(&context, request, &response));
+      stub->ErrorMessage(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1073,7 +1124,8 @@ error_query(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ErrorQueryResponse{};
 
   raise_if_error(
-      stub->ErrorQuery(&context, request, &response));
+      stub->ErrorQuery(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1113,7 +1165,8 @@ export_signal(const StubPtr& stub, const nidevice_grpc::Session& vi, const simpl
   auto response = ExportSignalResponse{};
 
   raise_if_error(
-      stub->ExportSignal(&context, request, &response));
+      stub->ExportSignal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1131,7 +1184,8 @@ get_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->GetAttributeViBoolean(&context, request, &response));
+      stub->GetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1149,7 +1203,8 @@ get_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->GetAttributeViInt32(&context, request, &response));
+      stub->GetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1167,7 +1222,8 @@ get_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetAttributeViInt64Response{};
 
   raise_if_error(
-      stub->GetAttributeViInt64(&context, request, &response));
+      stub->GetAttributeViInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1185,7 +1241,8 @@ get_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->GetAttributeViReal64(&context, request, &response));
+      stub->GetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1203,7 +1260,8 @@ get_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->GetAttributeViSession(&context, request, &response));
+      stub->GetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1221,7 +1279,8 @@ get_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeViString(&context, request, &response));
+      stub->GetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1238,7 +1297,8 @@ get_channel_name(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb
   auto response = GetChannelNameResponse{};
 
   raise_if_error(
-      stub->GetChannelName(&context, request, &response));
+      stub->GetChannelName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1254,7 +1314,8 @@ get_deembedding_sparameters(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = GetDeembeddingSparametersResponse{};
 
   raise_if_error(
-      stub->GetDeembeddingSparameters(&context, request, &response));
+      stub->GetDeembeddingSparameters(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1270,7 +1331,8 @@ get_error(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetErrorResponse{};
 
   raise_if_error(
-      stub->GetError(&context, request, &response));
+      stub->GetError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1286,7 +1348,8 @@ get_external_calibration_last_date_and_time(const StubPtr& stub, const nidevice_
   auto response = GetExternalCalibrationLastDateAndTimeResponse{};
 
   raise_if_error(
-      stub->GetExternalCalibrationLastDateAndTime(&context, request, &response));
+      stub->GetExternalCalibrationLastDateAndTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1310,7 +1373,8 @@ get_self_calibration_date_and_time(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = GetSelfCalibrationDateAndTimeResponse{};
 
   raise_if_error(
-      stub->GetSelfCalibrationDateAndTime(&context, request, &response));
+      stub->GetSelfCalibrationDateAndTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1334,7 +1398,8 @@ get_self_calibration_temperature(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = GetSelfCalibrationTemperatureResponse{};
 
   raise_if_error(
-      stub->GetSelfCalibrationTemperature(&context, request, &response));
+      stub->GetSelfCalibrationTemperature(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1366,7 +1431,8 @@ get_terminal_name(const StubPtr& stub, const nidevice_grpc::Session& vi, const s
   auto response = GetTerminalNameResponse{};
 
   raise_if_error(
-      stub->GetTerminalName(&context, request, &response));
+      stub->GetTerminalName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1383,7 +1449,8 @@ get_user_data(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::s
   auto response = GetUserDataResponse{};
 
   raise_if_error(
-      stub->GetUserData(&context, request, &response));
+      stub->GetUserData(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1400,7 +1467,8 @@ get_waveform_burst_start_locations(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = GetWaveformBurstStartLocationsResponse{};
 
   raise_if_error(
-      stub->GetWaveformBurstStartLocations(&context, request, &response));
+      stub->GetWaveformBurstStartLocations(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1417,7 +1485,8 @@ get_waveform_burst_stop_locations(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = GetWaveformBurstStopLocationsResponse{};
 
   raise_if_error(
-      stub->GetWaveformBurstStopLocations(&context, request, &response));
+      stub->GetWaveformBurstStopLocations(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1434,7 +1503,8 @@ get_waveform_marker_event_locations(const StubPtr& stub, const nidevice_grpc::Se
   auto response = GetWaveformMarkerEventLocationsResponse{};
 
   raise_if_error(
-      stub->GetWaveformMarkerEventLocations(&context, request, &response));
+      stub->GetWaveformMarkerEventLocations(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1452,7 +1522,8 @@ init(const StubPtr& stub, const pb::string& resource_name, const bool& id_query,
   auto response = InitResponse{};
 
   raise_if_error(
-      stub->Init(&context, request, &response));
+      stub->Init(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1471,7 +1542,8 @@ init_with_options(const StubPtr& stub, const pb::string& resource_name, const bo
   auto response = InitWithOptionsResponse{};
 
   raise_if_error(
-      stub->InitWithOptions(&context, request, &response));
+      stub->InitWithOptions(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1487,7 +1559,8 @@ initiate(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = InitiateResponse{};
 
   raise_if_error(
-      stub->Initiate(&context, request, &response));
+      stub->Initiate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1503,7 +1576,8 @@ invalidate_all_attributes(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = InvalidateAllAttributesResponse{};
 
   raise_if_error(
-      stub->InvalidateAllAttributes(&context, request, &response));
+      stub->InvalidateAllAttributes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1521,7 +1595,8 @@ load_configurations_from_file(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = LoadConfigurationsFromFileResponse{};
 
   raise_if_error(
-      stub->LoadConfigurationsFromFile(&context, request, &response));
+      stub->LoadConfigurationsFromFile(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1537,7 +1612,8 @@ perform_power_search(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = PerformPowerSearchResponse{};
 
   raise_if_error(
-      stub->PerformPowerSearch(&context, request, &response));
+      stub->PerformPowerSearch(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1553,7 +1629,8 @@ perform_thermal_correction(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = PerformThermalCorrectionResponse{};
 
   raise_if_error(
-      stub->PerformThermalCorrection(&context, request, &response));
+      stub->PerformThermalCorrection(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1569,7 +1646,8 @@ query_arb_waveform_capabilities(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = QueryArbWaveformCapabilitiesResponse{};
 
   raise_if_error(
-      stub->QueryArbWaveformCapabilities(&context, request, &response));
+      stub->QueryArbWaveformCapabilities(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1588,7 +1666,8 @@ read_and_download_waveform_from_file_tdms(const StubPtr& stub, const nidevice_gr
   auto response = ReadAndDownloadWaveformFromFileTDMSResponse{};
 
   raise_if_error(
-      stub->ReadAndDownloadWaveformFromFileTDMS(&context, request, &response));
+      stub->ReadAndDownloadWaveformFromFileTDMS(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1604,7 +1683,8 @@ reset(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetResponse{};
 
   raise_if_error(
-      stub->Reset(&context, request, &response));
+      stub->Reset(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1622,7 +1702,8 @@ reset_attribute(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb:
   auto response = ResetAttributeResponse{};
 
   raise_if_error(
-      stub->ResetAttribute(&context, request, &response));
+      stub->ResetAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1638,7 +1719,8 @@ reset_device(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetDeviceResponse{};
 
   raise_if_error(
-      stub->ResetDevice(&context, request, &response));
+      stub->ResetDevice(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1654,7 +1736,8 @@ reset_with_defaults(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetWithDefaultsResponse{};
 
   raise_if_error(
-      stub->ResetWithDefaults(&context, request, &response));
+      stub->ResetWithDefaults(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1678,7 +1761,8 @@ reset_with_options(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = ResetWithOptionsResponse{};
 
   raise_if_error(
-      stub->ResetWithOptions(&context, request, &response));
+      stub->ResetWithOptions(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1694,7 +1778,8 @@ revision_query(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = RevisionQueryResponse{};
 
   raise_if_error(
-      stub->RevisionQuery(&context, request, &response));
+      stub->RevisionQuery(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1712,7 +1797,8 @@ save_configurations_to_file(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = SaveConfigurationsToFileResponse{};
 
   raise_if_error(
-      stub->SaveConfigurationsToFile(&context, request, &response));
+      stub->SaveConfigurationsToFile(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1729,7 +1815,8 @@ select_arb_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = SelectArbWaveformResponse{};
 
   raise_if_error(
-      stub->SelectArbWaveform(&context, request, &response));
+      stub->SelectArbWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1745,7 +1832,8 @@ self_cal(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SelfCalResponse{};
 
   raise_if_error(
-      stub->SelfCal(&context, request, &response));
+      stub->SelfCal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1773,7 +1861,8 @@ self_calibrate_range(const StubPtr& stub, const nidevice_grpc::Session& vi, cons
   auto response = SelfCalibrateRangeResponse{};
 
   raise_if_error(
-      stub->SelfCalibrateRange(&context, request, &response));
+      stub->SelfCalibrateRange(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1789,7 +1878,8 @@ self_test(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SelfTestResponse{};
 
   raise_if_error(
-      stub->SelfTest(&context, request, &response));
+      stub->SelfTest(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1821,7 +1911,8 @@ send_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = SendSoftwareEdgeTriggerResponse{};
 
   raise_if_error(
-      stub->SendSoftwareEdgeTrigger(&context, request, &response));
+      stub->SendSoftwareEdgeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1847,7 +1938,8 @@ set_arb_waveform_next_write_position(const StubPtr& stub, const nidevice_grpc::S
   auto response = SetArbWaveformNextWritePositionResponse{};
 
   raise_if_error(
-      stub->SetArbWaveformNextWritePosition(&context, request, &response));
+      stub->SetArbWaveformNextWritePosition(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1866,7 +1958,8 @@ set_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = SetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->SetAttributeViBoolean(&context, request, &response));
+      stub->SetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1892,7 +1985,8 @@ set_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = SetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->SetAttributeViInt32(&context, request, &response));
+      stub->SetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1911,7 +2005,8 @@ set_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = SetAttributeViInt64Response{};
 
   raise_if_error(
-      stub->SetAttributeViInt64(&context, request, &response));
+      stub->SetAttributeViInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1937,7 +2032,8 @@ set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->SetAttributeViReal64(&context, request, &response));
+      stub->SetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1956,7 +2052,8 @@ set_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = SetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->SetAttributeViSession(&context, request, &response));
+      stub->SetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1982,7 +2079,8 @@ set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->SetAttributeViString(&context, request, &response));
+      stub->SetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2000,7 +2098,8 @@ set_user_data(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::s
   auto response = SetUserDataResponse{};
 
   raise_if_error(
-      stub->SetUserData(&context, request, &response));
+      stub->SetUserData(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2018,7 +2117,8 @@ set_waveform_burst_start_locations(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = SetWaveformBurstStartLocationsResponse{};
 
   raise_if_error(
-      stub->SetWaveformBurstStartLocations(&context, request, &response));
+      stub->SetWaveformBurstStartLocations(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2036,7 +2136,8 @@ set_waveform_burst_stop_locations(const StubPtr& stub, const nidevice_grpc::Sess
   auto response = SetWaveformBurstStopLocationsResponse{};
 
   raise_if_error(
-      stub->SetWaveformBurstStopLocations(&context, request, &response));
+      stub->SetWaveformBurstStopLocations(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2054,7 +2155,8 @@ set_waveform_marker_event_locations(const StubPtr& stub, const nidevice_grpc::Se
   auto response = SetWaveformMarkerEventLocationsResponse{};
 
   raise_if_error(
-      stub->SetWaveformMarkerEventLocations(&context, request, &response));
+      stub->SetWaveformMarkerEventLocations(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2071,7 +2173,8 @@ wait_until_settled(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = WaitUntilSettledResponse{};
 
   raise_if_error(
-      stub->WaitUntilSettled(&context, request, &response));
+      stub->WaitUntilSettled(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2091,7 +2194,8 @@ write_arb_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = WriteArbWaveformResponse{};
 
   raise_if_error(
-      stub->WriteArbWaveform(&context, request, &response));
+      stub->WriteArbWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2110,7 +2214,8 @@ write_arb_waveform_complex_f32(const StubPtr& stub, const nidevice_grpc::Session
   auto response = WriteArbWaveformComplexF32Response{};
 
   raise_if_error(
-      stub->WriteArbWaveformComplexF32(&context, request, &response));
+      stub->WriteArbWaveformComplexF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2129,7 +2234,8 @@ write_arb_waveform_complex_f64(const StubPtr& stub, const nidevice_grpc::Session
   auto response = WriteArbWaveformComplexF64Response{};
 
   raise_if_error(
-      stub->WriteArbWaveformComplexF64(&context, request, &response));
+      stub->WriteArbWaveformComplexF64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2147,7 +2253,8 @@ write_arb_waveform_complex_i16(const StubPtr& stub, const nidevice_grpc::Session
   auto response = WriteArbWaveformComplexI16Response{};
 
   raise_if_error(
-      stub->WriteArbWaveformComplexI16(&context, request, &response));
+      stub->WriteArbWaveformComplexI16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2167,7 +2274,8 @@ write_arb_waveform_f32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = WriteArbWaveformF32Response{};
 
   raise_if_error(
-      stub->WriteArbWaveformF32(&context, request, &response));
+      stub->WriteArbWaveformF32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -2184,7 +2292,8 @@ write_script(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::st
   auto response = WriteScriptResponse{};
 
   raise_if_error(
-      stub->WriteScript(&context, request, &response));
+      stub->WriteScript(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/niscope/niscope_client.cpp
+++ b/generated/niscope/niscope_client.cpp
@@ -28,7 +28,8 @@ abort(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = AbortResponse{};
 
   raise_if_error(
-      stub->Abort(&context, request, &response));
+      stub->Abort(&context, request, &response),
+      context);
 
   return response;
 }
@@ -44,7 +45,8 @@ acquisition_status(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = AcquisitionStatusResponse{};
 
   raise_if_error(
-      stub->AcquisitionStatus(&context, request, &response));
+      stub->AcquisitionStatus(&context, request, &response),
+      context);
 
   return response;
 }
@@ -68,7 +70,8 @@ actual_meas_wfm_size(const StubPtr& stub, const nidevice_grpc::Session& vi, cons
   auto response = ActualMeasWfmSizeResponse{};
 
   raise_if_error(
-      stub->ActualMeasWfmSize(&context, request, &response));
+      stub->ActualMeasWfmSize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -85,7 +88,8 @@ actual_num_wfms(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb:
   auto response = ActualNumWfmsResponse{};
 
   raise_if_error(
-      stub->ActualNumWfms(&context, request, &response));
+      stub->ActualNumWfms(&context, request, &response),
+      context);
 
   return response;
 }
@@ -101,7 +105,8 @@ actual_record_length(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ActualRecordLengthResponse{};
 
   raise_if_error(
-      stub->ActualRecordLength(&context, request, &response));
+      stub->ActualRecordLength(&context, request, &response),
+      context);
 
   return response;
 }
@@ -126,7 +131,8 @@ add_waveform_processing(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = AddWaveformProcessingResponse{};
 
   raise_if_error(
-      stub->AddWaveformProcessing(&context, request, &response));
+      stub->AddWaveformProcessing(&context, request, &response),
+      context);
 
   return response;
 }
@@ -143,7 +149,8 @@ adjust_sample_clock_relative_delay(const StubPtr& stub, const nidevice_grpc::Ses
   auto response = AdjustSampleClockRelativeDelayResponse{};
 
   raise_if_error(
-      stub->AdjustSampleClockRelativeDelay(&context, request, &response));
+      stub->AdjustSampleClockRelativeDelay(&context, request, &response),
+      context);
 
   return response;
 }
@@ -159,7 +166,8 @@ auto_setup(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = AutoSetupResponse{};
 
   raise_if_error(
-      stub->AutoSetup(&context, request, &response));
+      stub->AutoSetup(&context, request, &response),
+      context);
 
   return response;
 }
@@ -175,7 +183,8 @@ cable_sense_signal_start(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CableSenseSignalStartResponse{};
 
   raise_if_error(
-      stub->CableSenseSignalStart(&context, request, &response));
+      stub->CableSenseSignalStart(&context, request, &response),
+      context);
 
   return response;
 }
@@ -191,7 +200,8 @@ cable_sense_signal_stop(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CableSenseSignalStopResponse{};
 
   raise_if_error(
-      stub->CableSenseSignalStop(&context, request, &response));
+      stub->CableSenseSignalStop(&context, request, &response),
+      context);
 
   return response;
 }
@@ -216,7 +226,8 @@ cal_self_calibrate(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = CalSelfCalibrateResponse{};
 
   raise_if_error(
-      stub->CalSelfCalibrate(&context, request, &response));
+      stub->CalSelfCalibrate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -235,7 +246,8 @@ check_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = CheckAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->CheckAttributeViBoolean(&context, request, &response));
+      stub->CheckAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -261,7 +273,8 @@ check_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = CheckAttributeViInt32Response{};
 
   raise_if_error(
-      stub->CheckAttributeViInt32(&context, request, &response));
+      stub->CheckAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -287,7 +300,8 @@ check_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = CheckAttributeViInt64Response{};
 
   raise_if_error(
-      stub->CheckAttributeViInt64(&context, request, &response));
+      stub->CheckAttributeViInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -313,7 +327,8 @@ check_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = CheckAttributeViReal64Response{};
 
   raise_if_error(
-      stub->CheckAttributeViReal64(&context, request, &response));
+      stub->CheckAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -332,7 +347,8 @@ check_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = CheckAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->CheckAttributeViSession(&context, request, &response));
+      stub->CheckAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -358,7 +374,8 @@ check_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = CheckAttributeViStringResponse{};
 
   raise_if_error(
-      stub->CheckAttributeViString(&context, request, &response));
+      stub->CheckAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -383,7 +400,8 @@ clear_waveform_measurement_stats(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ClearWaveformMeasurementStatsResponse{};
 
   raise_if_error(
-      stub->ClearWaveformMeasurementStats(&context, request, &response));
+      stub->ClearWaveformMeasurementStats(&context, request, &response),
+      context);
 
   return response;
 }
@@ -400,7 +418,8 @@ clear_waveform_processing(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = ClearWaveformProcessingResponse{};
 
   raise_if_error(
-      stub->ClearWaveformProcessing(&context, request, &response));
+      stub->ClearWaveformProcessing(&context, request, &response),
+      context);
 
   return response;
 }
@@ -416,7 +435,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }
@@ -432,7 +452,8 @@ commit(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CommitResponse{};
 
   raise_if_error(
-      stub->Commit(&context, request, &response));
+      stub->Commit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -449,7 +470,8 @@ configure_acquisition(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = ConfigureAcquisitionResponse{};
 
   raise_if_error(
-      stub->ConfigureAcquisition(&context, request, &response));
+      stub->ConfigureAcquisition(&context, request, &response),
+      context);
 
   return response;
 }
@@ -468,7 +490,8 @@ configure_chan_characteristics(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ConfigureChanCharacteristicsResponse{};
 
   raise_if_error(
-      stub->ConfigureChanCharacteristics(&context, request, &response));
+      stub->ConfigureChanCharacteristics(&context, request, &response),
+      context);
 
   return response;
 }
@@ -509,7 +532,8 @@ configure_clock(const StubPtr& stub, const nidevice_grpc::Session& vi, const sim
   auto response = ConfigureClockResponse{};
 
   raise_if_error(
-      stub->ConfigureClock(&context, request, &response));
+      stub->ConfigureClock(&context, request, &response),
+      context);
 
   return response;
 }
@@ -527,7 +551,8 @@ configure_equalization_filter_coefficients(const StubPtr& stub, const nidevice_g
   auto response = ConfigureEqualizationFilterCoefficientsResponse{};
 
   raise_if_error(
-      stub->ConfigureEqualizationFilterCoefficients(&context, request, &response));
+      stub->ConfigureEqualizationFilterCoefficients(&context, request, &response),
+      context);
 
   return response;
 }
@@ -548,7 +573,8 @@ configure_horizontal_timing(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = ConfigureHorizontalTimingResponse{};
 
   raise_if_error(
-      stub->ConfigureHorizontalTiming(&context, request, &response));
+      stub->ConfigureHorizontalTiming(&context, request, &response),
+      context);
 
   return response;
 }
@@ -575,7 +601,8 @@ configure_trigger_digital(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = ConfigureTriggerDigitalResponse{};
 
   raise_if_error(
-      stub->ConfigureTriggerDigital(&context, request, &response));
+      stub->ConfigureTriggerDigital(&context, request, &response),
+      context);
 
   return response;
 }
@@ -611,7 +638,8 @@ configure_trigger_edge(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = ConfigureTriggerEdgeResponse{};
 
   raise_if_error(
-      stub->ConfigureTriggerEdge(&context, request, &response));
+      stub->ConfigureTriggerEdge(&context, request, &response),
+      context);
 
   return response;
 }
@@ -656,7 +684,8 @@ configure_trigger_glitch(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = ConfigureTriggerGlitchResponse{};
 
   raise_if_error(
-      stub->ConfigureTriggerGlitch(&context, request, &response));
+      stub->ConfigureTriggerGlitch(&context, request, &response),
+      context);
 
   return response;
 }
@@ -693,7 +722,8 @@ configure_trigger_hysteresis(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = ConfigureTriggerHysteresisResponse{};
 
   raise_if_error(
-      stub->ConfigureTriggerHysteresis(&context, request, &response));
+      stub->ConfigureTriggerHysteresis(&context, request, &response),
+      context);
 
   return response;
 }
@@ -709,7 +739,8 @@ configure_trigger_immediate(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = ConfigureTriggerImmediateResponse{};
 
   raise_if_error(
-      stub->ConfigureTriggerImmediate(&context, request, &response));
+      stub->ConfigureTriggerImmediate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -746,7 +777,8 @@ configure_trigger_runt(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = ConfigureTriggerRuntResponse{};
 
   raise_if_error(
-      stub->ConfigureTriggerRunt(&context, request, &response));
+      stub->ConfigureTriggerRunt(&context, request, &response),
+      context);
 
   return response;
 }
@@ -764,7 +796,8 @@ configure_trigger_software(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = ConfigureTriggerSoftwareResponse{};
 
   raise_if_error(
-      stub->ConfigureTriggerSoftware(&context, request, &response));
+      stub->ConfigureTriggerSoftware(&context, request, &response),
+      context);
 
   return response;
 }
@@ -817,7 +850,8 @@ configure_trigger_video(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = ConfigureTriggerVideoResponse{};
 
   raise_if_error(
-      stub->ConfigureTriggerVideo(&context, request, &response));
+      stub->ConfigureTriggerVideo(&context, request, &response),
+      context);
 
   return response;
 }
@@ -863,7 +897,8 @@ configure_trigger_width(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = ConfigureTriggerWidthResponse{};
 
   raise_if_error(
-      stub->ConfigureTriggerWidth(&context, request, &response));
+      stub->ConfigureTriggerWidth(&context, request, &response),
+      context);
 
   return response;
 }
@@ -900,7 +935,8 @@ configure_trigger_window(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = ConfigureTriggerWindowResponse{};
 
   raise_if_error(
-      stub->ConfigureTriggerWindow(&context, request, &response));
+      stub->ConfigureTriggerWindow(&context, request, &response),
+      context);
 
   return response;
 }
@@ -929,7 +965,8 @@ configure_vertical(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = ConfigureVerticalResponse{};
 
   raise_if_error(
-      stub->ConfigureVertical(&context, request, &response));
+      stub->ConfigureVertical(&context, request, &response),
+      context);
 
   return response;
 }
@@ -945,7 +982,8 @@ disable(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisableResponse{};
 
   raise_if_error(
-      stub->Disable(&context, request, &response));
+      stub->Disable(&context, request, &response),
+      context);
 
   return response;
 }
@@ -963,7 +1001,8 @@ error_handler(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::i
   auto response = ErrorHandlerResponse{};
 
   raise_if_error(
-      stub->ErrorHandler(&context, request, &response));
+      stub->ErrorHandler(&context, request, &response),
+      context);
 
   return response;
 }
@@ -979,7 +1018,8 @@ export_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::
   auto response = ExportAttributeConfigurationBufferResponse{};
 
   raise_if_error(
-      stub->ExportAttributeConfigurationBuffer(&context, request, &response));
+      stub->ExportAttributeConfigurationBuffer(&context, request, &response),
+      context);
 
   return response;
 }
@@ -996,7 +1036,8 @@ export_attribute_configuration_file(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ExportAttributeConfigurationFileResponse{};
 
   raise_if_error(
-      stub->ExportAttributeConfigurationFile(&context, request, &response));
+      stub->ExportAttributeConfigurationFile(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1029,7 +1070,8 @@ export_signal(const StubPtr& stub, const nidevice_grpc::Session& vi, const simpl
   auto response = ExportSignalResponse{};
 
   raise_if_error(
-      stub->ExportSignal(&context, request, &response));
+      stub->ExportSignal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1048,7 +1090,8 @@ fetch(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& c
   auto response = FetchResponse{};
 
   raise_if_error(
-      stub->Fetch(&context, request, &response));
+      stub->Fetch(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1074,7 +1117,8 @@ fetch_array_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = FetchArrayMeasurementResponse{};
 
   raise_if_error(
-      stub->FetchArrayMeasurement(&context, request, &response));
+      stub->FetchArrayMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1093,7 +1137,8 @@ fetch_binary16(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::
   auto response = FetchBinary16Response{};
 
   raise_if_error(
-      stub->FetchBinary16(&context, request, &response));
+      stub->FetchBinary16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1112,7 +1157,8 @@ fetch_binary32(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::
   auto response = FetchBinary32Response{};
 
   raise_if_error(
-      stub->FetchBinary32(&context, request, &response));
+      stub->FetchBinary32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1131,7 +1177,8 @@ fetch_binary8(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::s
   auto response = FetchBinary8Response{};
 
   raise_if_error(
-      stub->FetchBinary8(&context, request, &response));
+      stub->FetchBinary8(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1150,7 +1197,8 @@ fetch_complex(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::s
   auto response = FetchComplexResponse{};
 
   raise_if_error(
-      stub->FetchComplex(&context, request, &response));
+      stub->FetchComplex(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1169,7 +1217,8 @@ fetch_complex_binary16(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = FetchComplexBinary16Response{};
 
   raise_if_error(
-      stub->FetchComplexBinary16(&context, request, &response));
+      stub->FetchComplexBinary16(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1195,7 +1244,8 @@ fetch_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, const p
   auto response = FetchMeasurementResponse{};
 
   raise_if_error(
-      stub->FetchMeasurement(&context, request, &response));
+      stub->FetchMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1221,7 +1271,8 @@ fetch_measurement_stats(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = FetchMeasurementStatsResponse{};
 
   raise_if_error(
-      stub->FetchMeasurementStats(&context, request, &response));
+      stub->FetchMeasurementStats(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1239,7 +1290,8 @@ get_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->GetAttributeViBoolean(&context, request, &response));
+      stub->GetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1257,7 +1309,8 @@ get_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->GetAttributeViInt32(&context, request, &response));
+      stub->GetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1275,7 +1328,8 @@ get_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetAttributeViInt64Response{};
 
   raise_if_error(
-      stub->GetAttributeViInt64(&context, request, &response));
+      stub->GetAttributeViInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1293,7 +1347,8 @@ get_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->GetAttributeViReal64(&context, request, &response));
+      stub->GetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1311,7 +1366,8 @@ get_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->GetAttributeViSession(&context, request, &response));
+      stub->GetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1329,7 +1385,8 @@ get_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeViString(&context, request, &response));
+      stub->GetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1346,7 +1403,8 @@ get_channel_name(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb
   auto response = GetChannelNameResponse{};
 
   raise_if_error(
-      stub->GetChannelName(&context, request, &response));
+      stub->GetChannelName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1363,7 +1421,8 @@ get_channel_name_from_string(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetChannelNameFromStringResponse{};
 
   raise_if_error(
-      stub->GetChannelNameFromString(&context, request, &response));
+      stub->GetChannelNameFromString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1381,7 +1440,8 @@ get_equalization_filter_coefficients(const StubPtr& stub, const nidevice_grpc::S
   auto response = GetEqualizationFilterCoefficientsResponse{};
 
   raise_if_error(
-      stub->GetEqualizationFilterCoefficients(&context, request, &response));
+      stub->GetEqualizationFilterCoefficients(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1397,7 +1457,8 @@ get_error(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetErrorResponse{};
 
   raise_if_error(
-      stub->GetError(&context, request, &response));
+      stub->GetError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1414,7 +1475,8 @@ get_error_message(const StubPtr& stub, const nidevice_grpc::Session& vi, const p
   auto response = GetErrorMessageResponse{};
 
   raise_if_error(
-      stub->GetErrorMessage(&context, request, &response));
+      stub->GetErrorMessage(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1432,7 +1494,8 @@ get_frequency_response(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetFrequencyResponseResponse{};
 
   raise_if_error(
-      stub->GetFrequencyResponse(&context, request, &response));
+      stub->GetFrequencyResponse(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1449,7 +1512,8 @@ get_normalization_coefficients(const StubPtr& stub, const nidevice_grpc::Session
   auto response = GetNormalizationCoefficientsResponse{};
 
   raise_if_error(
-      stub->GetNormalizationCoefficients(&context, request, &response));
+      stub->GetNormalizationCoefficients(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1466,7 +1530,8 @@ get_scaling_coefficients(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetScalingCoefficientsResponse{};
 
   raise_if_error(
-      stub->GetScalingCoefficients(&context, request, &response));
+      stub->GetScalingCoefficients(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1483,7 +1548,8 @@ get_stream_endpoint_handle(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = GetStreamEndpointHandleResponse{};
 
   raise_if_error(
-      stub->GetStreamEndpointHandle(&context, request, &response));
+      stub->GetStreamEndpointHandle(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1500,7 +1566,8 @@ import_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::
   auto response = ImportAttributeConfigurationBufferResponse{};
 
   raise_if_error(
-      stub->ImportAttributeConfigurationBuffer(&context, request, &response));
+      stub->ImportAttributeConfigurationBuffer(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1517,7 +1584,8 @@ import_attribute_configuration_file(const StubPtr& stub, const nidevice_grpc::Se
   auto response = ImportAttributeConfigurationFileResponse{};
 
   raise_if_error(
-      stub->ImportAttributeConfigurationFile(&context, request, &response));
+      stub->ImportAttributeConfigurationFile(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1535,7 +1603,8 @@ init(const StubPtr& stub, const pb::string& resource_name, const bool& id_query,
   auto response = InitResponse{};
 
   raise_if_error(
-      stub->Init(&context, request, &response));
+      stub->Init(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1554,7 +1623,8 @@ init_with_options(const StubPtr& stub, const pb::string& resource_name, const bo
   auto response = InitWithOptionsResponse{};
 
   raise_if_error(
-      stub->InitWithOptions(&context, request, &response));
+      stub->InitWithOptions(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1570,7 +1640,8 @@ initiate_acquisition(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = InitiateAcquisitionResponse{};
 
   raise_if_error(
-      stub->InitiateAcquisition(&context, request, &response));
+      stub->InitiateAcquisition(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1586,7 +1657,8 @@ probe_compensation_signal_start(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = ProbeCompensationSignalStartResponse{};
 
   raise_if_error(
-      stub->ProbeCompensationSignalStart(&context, request, &response));
+      stub->ProbeCompensationSignalStart(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1602,7 +1674,8 @@ probe_compensation_signal_stop(const StubPtr& stub, const nidevice_grpc::Session
   auto response = ProbeCompensationSignalStopResponse{};
 
   raise_if_error(
-      stub->ProbeCompensationSignalStop(&context, request, &response));
+      stub->ProbeCompensationSignalStop(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1621,7 +1694,8 @@ read(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& ch
   auto response = ReadResponse{};
 
   raise_if_error(
-      stub->Read(&context, request, &response));
+      stub->Read(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1647,7 +1721,8 @@ read_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb
   auto response = ReadMeasurementResponse{};
 
   raise_if_error(
-      stub->ReadMeasurement(&context, request, &response));
+      stub->ReadMeasurement(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1663,7 +1738,8 @@ reset(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetResponse{};
 
   raise_if_error(
-      stub->Reset(&context, request, &response));
+      stub->Reset(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1679,7 +1755,8 @@ reset_device(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetDeviceResponse{};
 
   raise_if_error(
-      stub->ResetDevice(&context, request, &response));
+      stub->ResetDevice(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1695,7 +1772,8 @@ revision_query(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = RevisionQueryResponse{};
 
   raise_if_error(
-      stub->RevisionQuery(&context, request, &response));
+      stub->RevisionQuery(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1711,7 +1789,8 @@ sample_mode(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SampleModeResponse{};
 
   raise_if_error(
-      stub->SampleMode(&context, request, &response));
+      stub->SampleMode(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1727,7 +1806,8 @@ sample_rate(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SampleRateResponse{};
 
   raise_if_error(
-      stub->SampleRate(&context, request, &response));
+      stub->SampleRate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1743,7 +1823,8 @@ self_test(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SelfTestResponse{};
 
   raise_if_error(
-      stub->SelfTest(&context, request, &response));
+      stub->SelfTest(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1767,7 +1848,8 @@ send_software_trigger_edge(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = SendSoftwareTriggerEdgeResponse{};
 
   raise_if_error(
-      stub->SendSoftwareTriggerEdge(&context, request, &response));
+      stub->SendSoftwareTriggerEdge(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1786,7 +1868,8 @@ set_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = SetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->SetAttributeViBoolean(&context, request, &response));
+      stub->SetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1812,7 +1895,8 @@ set_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = SetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->SetAttributeViInt32(&context, request, &response));
+      stub->SetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1838,7 +1922,8 @@ set_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = SetAttributeViInt64Response{};
 
   raise_if_error(
-      stub->SetAttributeViInt64(&context, request, &response));
+      stub->SetAttributeViInt64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1864,7 +1949,8 @@ set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->SetAttributeViReal64(&context, request, &response));
+      stub->SetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1883,7 +1969,8 @@ set_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = SetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->SetAttributeViSession(&context, request, &response));
+      stub->SetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1909,7 +1996,8 @@ set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->SetAttributeViString(&context, request, &response));
+      stub->SetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/niswitch/niswitch_client.cpp
+++ b/generated/niswitch/niswitch_client.cpp
@@ -28,7 +28,8 @@ abort_scan(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = AbortScanResponse{};
 
   raise_if_error(
-      stub->AbortScan(&context, request, &response));
+      stub->AbortScan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -46,7 +47,8 @@ can_connect(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::str
   auto response = CanConnectResponse{};
 
   raise_if_error(
-      stub->CanConnect(&context, request, &response));
+      stub->CanConnect(&context, request, &response),
+      context);
 
   return response;
 }
@@ -65,7 +67,8 @@ check_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = CheckAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->CheckAttributeViBoolean(&context, request, &response));
+      stub->CheckAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -91,7 +94,8 @@ check_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = CheckAttributeViInt32Response{};
 
   raise_if_error(
-      stub->CheckAttributeViInt32(&context, request, &response));
+      stub->CheckAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -110,7 +114,8 @@ check_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = CheckAttributeViReal64Response{};
 
   raise_if_error(
-      stub->CheckAttributeViReal64(&context, request, &response));
+      stub->CheckAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -129,7 +134,8 @@ check_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = CheckAttributeViStringResponse{};
 
   raise_if_error(
-      stub->CheckAttributeViString(&context, request, &response));
+      stub->CheckAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -148,7 +154,8 @@ check_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = CheckAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->CheckAttributeViSession(&context, request, &response));
+      stub->CheckAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -164,7 +171,8 @@ clear_error(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ClearErrorResponse{};
 
   raise_if_error(
-      stub->ClearError(&context, request, &response));
+      stub->ClearError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -180,7 +188,8 @@ clear_interchange_warnings(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = ClearInterchangeWarningsResponse{};
 
   raise_if_error(
-      stub->ClearInterchangeWarnings(&context, request, &response));
+      stub->ClearInterchangeWarnings(&context, request, &response),
+      context);
 
   return response;
 }
@@ -196,7 +205,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }
@@ -212,7 +222,8 @@ commit(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CommitResponse{};
 
   raise_if_error(
-      stub->Commit(&context, request, &response));
+      stub->Commit(&context, request, &response),
+      context);
 
   return response;
 }
@@ -237,7 +248,8 @@ configure_scan_list(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = ConfigureScanListResponse{};
 
   raise_if_error(
-      stub->ConfigureScanList(&context, request, &response));
+      stub->ConfigureScanList(&context, request, &response),
+      context);
 
   return response;
 }
@@ -270,7 +282,8 @@ configure_scan_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = ConfigureScanTriggerResponse{};
 
   raise_if_error(
-      stub->ConfigureScanTrigger(&context, request, &response));
+      stub->ConfigureScanTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -288,7 +301,8 @@ connect(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string&
   auto response = ConnectResponse{};
 
   raise_if_error(
-      stub->Connect(&context, request, &response));
+      stub->Connect(&context, request, &response),
+      context);
 
   return response;
 }
@@ -305,7 +319,8 @@ connect_multiple(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb
   auto response = ConnectMultipleResponse{};
 
   raise_if_error(
-      stub->ConnectMultiple(&context, request, &response));
+      stub->ConnectMultiple(&context, request, &response),
+      context);
 
   return response;
 }
@@ -321,7 +336,8 @@ disable(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisableResponse{};
 
   raise_if_error(
-      stub->Disable(&context, request, &response));
+      stub->Disable(&context, request, &response),
+      context);
 
   return response;
 }
@@ -339,7 +355,8 @@ disconnect(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::stri
   auto response = DisconnectResponse{};
 
   raise_if_error(
-      stub->Disconnect(&context, request, &response));
+      stub->Disconnect(&context, request, &response),
+      context);
 
   return response;
 }
@@ -355,7 +372,8 @@ disconnect_all(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisconnectAllResponse{};
 
   raise_if_error(
-      stub->DisconnectAll(&context, request, &response));
+      stub->DisconnectAll(&context, request, &response),
+      context);
 
   return response;
 }
@@ -372,7 +390,8 @@ disconnect_multiple(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = DisconnectMultipleResponse{};
 
   raise_if_error(
-      stub->DisconnectMultiple(&context, request, &response));
+      stub->DisconnectMultiple(&context, request, &response),
+      context);
 
   return response;
 }
@@ -389,7 +408,8 @@ error_message(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::i
   auto response = ErrorMessageResponse{};
 
   raise_if_error(
-      stub->ErrorMessage(&context, request, &response));
+      stub->ErrorMessage(&context, request, &response),
+      context);
 
   return response;
 }
@@ -405,7 +425,8 @@ error_query(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ErrorQueryResponse{};
 
   raise_if_error(
-      stub->ErrorQuery(&context, request, &response));
+      stub->ErrorQuery(&context, request, &response),
+      context);
 
   return response;
 }
@@ -423,7 +444,8 @@ get_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->GetAttributeViBoolean(&context, request, &response));
+      stub->GetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -441,7 +463,8 @@ get_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->GetAttributeViInt32(&context, request, &response));
+      stub->GetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -459,7 +482,8 @@ get_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->GetAttributeViReal64(&context, request, &response));
+      stub->GetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -477,7 +501,8 @@ get_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeViString(&context, request, &response));
+      stub->GetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -495,7 +520,8 @@ get_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->GetAttributeViSession(&context, request, &response));
+      stub->GetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -512,7 +538,8 @@ get_channel_name(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb
   auto response = GetChannelNameResponse{};
 
   raise_if_error(
-      stub->GetChannelName(&context, request, &response));
+      stub->GetChannelName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -528,7 +555,8 @@ get_error(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetErrorResponse{};
 
   raise_if_error(
-      stub->GetError(&context, request, &response));
+      stub->GetError(&context, request, &response),
+      context);
 
   return response;
 }
@@ -544,7 +572,8 @@ get_next_coercion_record(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetNextCoercionRecordResponse{};
 
   raise_if_error(
-      stub->GetNextCoercionRecord(&context, request, &response));
+      stub->GetNextCoercionRecord(&context, request, &response),
+      context);
 
   return response;
 }
@@ -560,7 +589,8 @@ get_next_interchange_warning(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = GetNextInterchangeWarningResponse{};
 
   raise_if_error(
-      stub->GetNextInterchangeWarning(&context, request, &response));
+      stub->GetNextInterchangeWarning(&context, request, &response),
+      context);
 
   return response;
 }
@@ -578,7 +608,8 @@ get_path(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string
   auto response = GetPathResponse{};
 
   raise_if_error(
-      stub->GetPath(&context, request, &response));
+      stub->GetPath(&context, request, &response),
+      context);
 
   return response;
 }
@@ -595,7 +626,8 @@ get_relay_count(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb:
   auto response = GetRelayCountResponse{};
 
   raise_if_error(
-      stub->GetRelayCount(&context, request, &response));
+      stub->GetRelayCount(&context, request, &response),
+      context);
 
   return response;
 }
@@ -612,7 +644,8 @@ get_relay_name(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::
   auto response = GetRelayNameResponse{};
 
   raise_if_error(
-      stub->GetRelayName(&context, request, &response));
+      stub->GetRelayName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -629,7 +662,8 @@ get_relay_position(const StubPtr& stub, const nidevice_grpc::Session& vi, const 
   auto response = GetRelayPositionResponse{};
 
   raise_if_error(
-      stub->GetRelayPosition(&context, request, &response));
+      stub->GetRelayPosition(&context, request, &response),
+      context);
 
   return response;
 }
@@ -647,7 +681,8 @@ init(const StubPtr& stub, const pb::string& resource_name, const bool& id_query,
   auto response = InitResponse{};
 
   raise_if_error(
-      stub->Init(&context, request, &response));
+      stub->Init(&context, request, &response),
+      context);
 
   return response;
 }
@@ -666,7 +701,8 @@ init_with_options(const StubPtr& stub, const pb::string& resource_name, const bo
   auto response = InitWithOptionsResponse{};
 
   raise_if_error(
-      stub->InitWithOptions(&context, request, &response));
+      stub->InitWithOptions(&context, request, &response),
+      context);
 
   return response;
 }
@@ -685,7 +721,8 @@ init_with_topology(const StubPtr& stub, const pb::string& resource_name, const p
   auto response = InitWithTopologyResponse{};
 
   raise_if_error(
-      stub->InitWithTopology(&context, request, &response));
+      stub->InitWithTopology(&context, request, &response),
+      context);
 
   return response;
 }
@@ -701,7 +738,8 @@ initiate_scan(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = InitiateScanResponse{};
 
   raise_if_error(
-      stub->InitiateScan(&context, request, &response));
+      stub->InitiateScan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -717,7 +755,8 @@ invalidate_all_attributes(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = InvalidateAllAttributesResponse{};
 
   raise_if_error(
-      stub->InvalidateAllAttributes(&context, request, &response));
+      stub->InvalidateAllAttributes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -733,7 +772,8 @@ is_debounced(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = IsDebouncedResponse{};
 
   raise_if_error(
-      stub->IsDebounced(&context, request, &response));
+      stub->IsDebounced(&context, request, &response),
+      context);
 
   return response;
 }
@@ -749,7 +789,8 @@ is_scanning(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = IsScanningResponse{};
 
   raise_if_error(
-      stub->IsScanning(&context, request, &response));
+      stub->IsScanning(&context, request, &response),
+      context);
 
   return response;
 }
@@ -774,7 +815,8 @@ relay_control(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::s
   auto response = RelayControlResponse{};
 
   raise_if_error(
-      stub->RelayControl(&context, request, &response));
+      stub->RelayControl(&context, request, &response),
+      context);
 
   return response;
 }
@@ -790,7 +832,8 @@ reset(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetResponse{};
 
   raise_if_error(
-      stub->Reset(&context, request, &response));
+      stub->Reset(&context, request, &response),
+      context);
 
   return response;
 }
@@ -806,7 +849,8 @@ reset_interchange_check(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetInterchangeCheckResponse{};
 
   raise_if_error(
-      stub->ResetInterchangeCheck(&context, request, &response));
+      stub->ResetInterchangeCheck(&context, request, &response),
+      context);
 
   return response;
 }
@@ -822,7 +866,8 @@ reset_with_defaults(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetWithDefaultsResponse{};
 
   raise_if_error(
-      stub->ResetWithDefaults(&context, request, &response));
+      stub->ResetWithDefaults(&context, request, &response),
+      context);
 
   return response;
 }
@@ -838,7 +883,8 @@ revision_query(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = RevisionQueryResponse{};
 
   raise_if_error(
-      stub->RevisionQuery(&context, request, &response));
+      stub->RevisionQuery(&context, request, &response),
+      context);
 
   return response;
 }
@@ -871,7 +917,8 @@ route_scan_advanced_output(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = RouteScanAdvancedOutputResponse{};
 
   raise_if_error(
-      stub->RouteScanAdvancedOutput(&context, request, &response));
+      stub->RouteScanAdvancedOutput(&context, request, &response),
+      context);
 
   return response;
 }
@@ -904,7 +951,8 @@ route_trigger_input(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = RouteTriggerInputResponse{};
 
   raise_if_error(
-      stub->RouteTriggerInput(&context, request, &response));
+      stub->RouteTriggerInput(&context, request, &response),
+      context);
 
   return response;
 }
@@ -929,7 +977,8 @@ scan(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& sc
   auto response = ScanResponse{};
 
   raise_if_error(
-      stub->Scan(&context, request, &response));
+      stub->Scan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -945,7 +994,8 @@ self_test(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SelfTestResponse{};
 
   raise_if_error(
-      stub->SelfTest(&context, request, &response));
+      stub->SelfTest(&context, request, &response),
+      context);
 
   return response;
 }
@@ -961,7 +1011,8 @@ send_software_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SendSoftwareTriggerResponse{};
 
   raise_if_error(
-      stub->SendSoftwareTrigger(&context, request, &response));
+      stub->SendSoftwareTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -980,7 +1031,8 @@ set_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = SetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->SetAttributeViBoolean(&context, request, &response));
+      stub->SetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1006,7 +1058,8 @@ set_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = SetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->SetAttributeViInt32(&context, request, &response));
+      stub->SetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1025,7 +1078,8 @@ set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->SetAttributeViReal64(&context, request, &response));
+      stub->SetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1044,7 +1098,8 @@ set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->SetAttributeViString(&context, request, &response));
+      stub->SetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1063,7 +1118,8 @@ set_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = SetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->SetAttributeViSession(&context, request, &response));
+      stub->SetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1080,7 +1136,8 @@ set_continuous_scan(const StubPtr& stub, const nidevice_grpc::Session& vi, const
   auto response = SetContinuousScanResponse{};
 
   raise_if_error(
-      stub->SetContinuousScan(&context, request, &response));
+      stub->SetContinuousScan(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1097,7 +1154,8 @@ set_path(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string
   auto response = SetPathResponse{};
 
   raise_if_error(
-      stub->SetPath(&context, request, &response));
+      stub->SetPath(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1114,7 +1172,8 @@ wait_for_debounce(const StubPtr& stub, const nidevice_grpc::Session& vi, const p
   auto response = WaitForDebounceResponse{};
 
   raise_if_error(
-      stub->WaitForDebounce(&context, request, &response));
+      stub->WaitForDebounce(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1131,7 +1190,8 @@ wait_for_scan_complete(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = WaitForScanCompleteResponse{};
 
   raise_if_error(
-      stub->WaitForScanComplete(&context, request, &response));
+      stub->WaitForScanComplete(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nisync/nisync_client.cpp
+++ b/generated/nisync/nisync_client.cpp
@@ -30,7 +30,8 @@ init(const StubPtr& stub, const pb::string& resource_name, const bool& id_query,
   auto response = InitResponse{};
 
   raise_if_error(
-      stub->Init(&context, request, &response));
+      stub->Init(&context, request, &response),
+      context);
 
   return response;
 }
@@ -46,7 +47,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }
@@ -63,7 +65,8 @@ error_message(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::i
   auto response = ErrorMessageResponse{};
 
   raise_if_error(
-      stub->ErrorMessage(&context, request, &response));
+      stub->ErrorMessage(&context, request, &response),
+      context);
 
   return response;
 }
@@ -79,7 +82,8 @@ reset(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetResponse{};
 
   raise_if_error(
-      stub->Reset(&context, request, &response));
+      stub->Reset(&context, request, &response),
+      context);
 
   return response;
 }
@@ -95,7 +99,8 @@ persist_config(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = PersistConfigResponse{};
 
   raise_if_error(
-      stub->PersistConfig(&context, request, &response));
+      stub->PersistConfig(&context, request, &response),
+      context);
 
   return response;
 }
@@ -111,7 +116,8 @@ self_test(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SelfTestResponse{};
 
   raise_if_error(
-      stub->SelfTest(&context, request, &response));
+      stub->SelfTest(&context, request, &response),
+      context);
 
   return response;
 }
@@ -127,7 +133,8 @@ revision_query(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = RevisionQueryResponse{};
 
   raise_if_error(
-      stub->RevisionQuery(&context, request, &response));
+      stub->RevisionQuery(&context, request, &response),
+      context);
 
   return response;
 }
@@ -148,7 +155,8 @@ connect_trig_terminals(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = ConnectTrigTerminalsResponse{};
 
   raise_if_error(
-      stub->ConnectTrigTerminals(&context, request, &response));
+      stub->ConnectTrigTerminals(&context, request, &response),
+      context);
 
   return response;
 }
@@ -166,7 +174,8 @@ disconnect_trig_terminals(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = DisconnectTrigTerminalsResponse{};
 
   raise_if_error(
-      stub->DisconnectTrigTerminals(&context, request, &response));
+      stub->DisconnectTrigTerminals(&context, request, &response),
+      context);
 
   return response;
 }
@@ -188,7 +197,8 @@ connect_sw_trig_to_terminal(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = ConnectSWTrigToTerminalResponse{};
 
   raise_if_error(
-      stub->ConnectSWTrigToTerminal(&context, request, &response));
+      stub->ConnectSWTrigToTerminal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -206,7 +216,8 @@ disconnect_sw_trig_from_terminal(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = DisconnectSWTrigFromTerminalResponse{};
 
   raise_if_error(
-      stub->DisconnectSWTrigFromTerminal(&context, request, &response));
+      stub->DisconnectSWTrigFromTerminal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -223,7 +234,8 @@ send_software_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = SendSoftwareTriggerResponse{};
 
   raise_if_error(
-      stub->SendSoftwareTrigger(&context, request, &response));
+      stub->SendSoftwareTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -241,7 +253,8 @@ connect_clk_terminals(const StubPtr& stub, const nidevice_grpc::Session& vi, con
   auto response = ConnectClkTerminalsResponse{};
 
   raise_if_error(
-      stub->ConnectClkTerminals(&context, request, &response));
+      stub->ConnectClkTerminals(&context, request, &response),
+      context);
 
   return response;
 }
@@ -259,7 +272,8 @@ disconnect_clk_terminals(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = DisconnectClkTerminalsResponse{};
 
   raise_if_error(
-      stub->DisconnectClkTerminals(&context, request, &response));
+      stub->DisconnectClkTerminals(&context, request, &response),
+      context);
 
   return response;
 }
@@ -277,7 +291,8 @@ measure_frequency(const StubPtr& stub, const nidevice_grpc::Session& vi, const p
   auto response = MeasureFrequencyResponse{};
 
   raise_if_error(
-      stub->MeasureFrequency(&context, request, &response));
+      stub->MeasureFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -296,7 +311,8 @@ measure_frequency_ex(const StubPtr& stub, const nidevice_grpc::Session& vi, cons
   auto response = MeasureFrequencyExResponse{};
 
   raise_if_error(
-      stub->MeasureFrequencyEx(&context, request, &response));
+      stub->MeasureFrequencyEx(&context, request, &response),
+      context);
 
   return response;
 }
@@ -312,7 +328,8 @@ start1588(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = Start1588Response{};
 
   raise_if_error(
-      stub->Start1588(&context, request, &response));
+      stub->Start1588(&context, request, &response),
+      context);
 
   return response;
 }
@@ -328,7 +345,8 @@ stop1588(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = Stop1588Response{};
 
   raise_if_error(
-      stub->Stop1588(&context, request, &response));
+      stub->Stop1588(&context, request, &response),
+      context);
 
   return response;
 }
@@ -344,7 +362,8 @@ start8021_as(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = Start8021ASResponse{};
 
   raise_if_error(
-      stub->Start8021AS(&context, request, &response));
+      stub->Start8021AS(&context, request, &response),
+      context);
 
   return response;
 }
@@ -360,7 +379,8 @@ stop8021_as(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = Stop8021ASResponse{};
 
   raise_if_error(
-      stub->Stop8021AS(&context, request, &response));
+      stub->Stop8021AS(&context, request, &response),
+      context);
 
   return response;
 }
@@ -380,7 +400,8 @@ set_time(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32&
   auto response = SetTimeResponse{};
 
   raise_if_error(
-      stub->SetTime(&context, request, &response));
+      stub->SetTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -396,7 +417,8 @@ get_time(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetTimeResponse{};
 
   raise_if_error(
-      stub->GetTime(&context, request, &response));
+      stub->GetTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -412,7 +434,8 @@ reset_frequency(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ResetFrequencyResponse{};
 
   raise_if_error(
-      stub->ResetFrequency(&context, request, &response));
+      stub->ResetFrequency(&context, request, &response),
+      context);
 
   return response;
 }
@@ -433,7 +456,8 @@ create_future_time_event(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = CreateFutureTimeEventResponse{};
 
   raise_if_error(
-      stub->CreateFutureTimeEvent(&context, request, &response));
+      stub->CreateFutureTimeEvent(&context, request, &response),
+      context);
 
   return response;
 }
@@ -450,7 +474,8 @@ clear_future_time_events(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = ClearFutureTimeEventsResponse{};
 
   raise_if_error(
-      stub->ClearFutureTimeEvents(&context, request, &response));
+      stub->ClearFutureTimeEvents(&context, request, &response),
+      context);
 
   return response;
 }
@@ -468,7 +493,8 @@ enable_time_stamp_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = EnableTimeStampTriggerResponse{};
 
   raise_if_error(
-      stub->EnableTimeStampTrigger(&context, request, &response));
+      stub->EnableTimeStampTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -487,7 +513,8 @@ enable_time_stamp_trigger_with_decimation(const StubPtr& stub, const nidevice_gr
   auto response = EnableTimeStampTriggerWithDecimationResponse{};
 
   raise_if_error(
-      stub->EnableTimeStampTriggerWithDecimation(&context, request, &response));
+      stub->EnableTimeStampTriggerWithDecimation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -505,7 +532,8 @@ read_trigger_time_stamp(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = ReadTriggerTimeStampResponse{};
 
   raise_if_error(
-      stub->ReadTriggerTimeStamp(&context, request, &response));
+      stub->ReadTriggerTimeStamp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -524,7 +552,8 @@ read_multiple_trigger_time_stamp(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = ReadMultipleTriggerTimeStampResponse{};
 
   raise_if_error(
-      stub->ReadMultipleTriggerTimeStamp(&context, request, &response));
+      stub->ReadMultipleTriggerTimeStamp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -541,7 +570,8 @@ disable_time_stamp_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = DisableTimeStampTriggerResponse{};
 
   raise_if_error(
-      stub->DisableTimeStampTrigger(&context, request, &response));
+      stub->DisableTimeStampTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -566,7 +596,8 @@ create_clock(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::st
   auto response = CreateClockResponse{};
 
   raise_if_error(
-      stub->CreateClock(&context, request, &response));
+      stub->CreateClock(&context, request, &response),
+      context);
 
   return response;
 }
@@ -583,7 +614,8 @@ clear_clock(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::str
   auto response = ClearClockResponse{};
 
   raise_if_error(
-      stub->ClearClock(&context, request, &response));
+      stub->ClearClock(&context, request, &response),
+      context);
 
   return response;
 }
@@ -599,7 +631,8 @@ set_time_reference_free_running(const StubPtr& stub, const nidevice_grpc::Sessio
   auto response = SetTimeReferenceFreeRunningResponse{};
 
   raise_if_error(
-      stub->SetTimeReferenceFreeRunning(&context, request, &response));
+      stub->SetTimeReferenceFreeRunning(&context, request, &response),
+      context);
 
   return response;
 }
@@ -615,7 +648,8 @@ set_time_reference_gps(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SetTimeReferenceGPSResponse{};
 
   raise_if_error(
-      stub->SetTimeReferenceGPS(&context, request, &response));
+      stub->SetTimeReferenceGPS(&context, request, &response),
+      context);
 
   return response;
 }
@@ -633,7 +667,8 @@ set_time_reference_irig(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetTimeReferenceIRIGResponse{};
 
   raise_if_error(
-      stub->SetTimeReferenceIRIG(&context, request, &response));
+      stub->SetTimeReferenceIRIG(&context, request, &response),
+      context);
 
   return response;
 }
@@ -654,7 +689,8 @@ set_time_reference_pps(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = SetTimeReferencePPSResponse{};
 
   raise_if_error(
-      stub->SetTimeReferencePPS(&context, request, &response));
+      stub->SetTimeReferencePPS(&context, request, &response),
+      context);
 
   return response;
 }
@@ -670,7 +706,8 @@ set_time_reference1588_ordinary_clock(const StubPtr& stub, const nidevice_grpc::
   auto response = SetTimeReference1588OrdinaryClockResponse{};
 
   raise_if_error(
-      stub->SetTimeReference1588OrdinaryClock(&context, request, &response));
+      stub->SetTimeReference1588OrdinaryClock(&context, request, &response),
+      context);
 
   return response;
 }
@@ -686,7 +723,8 @@ set_time_reference8021_as(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = SetTimeReference8021ASResponse{};
 
   raise_if_error(
-      stub->SetTimeReference8021AS(&context, request, &response));
+      stub->SetTimeReference8021AS(&context, request, &response),
+      context);
 
   return response;
 }
@@ -702,7 +740,8 @@ enable_gps_timestamping(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = EnableGPSTimestampingResponse{};
 
   raise_if_error(
-      stub->EnableGPSTimestamping(&context, request, &response));
+      stub->EnableGPSTimestamping(&context, request, &response),
+      context);
 
   return response;
 }
@@ -720,7 +759,8 @@ enable_irig_timestamping(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = EnableIRIGTimestampingResponse{};
 
   raise_if_error(
-      stub->EnableIRIGTimestamping(&context, request, &response));
+      stub->EnableIRIGTimestamping(&context, request, &response),
+      context);
 
   return response;
 }
@@ -736,7 +776,8 @@ read_last_gps_timestamp(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ReadLastGPSTimestampResponse{};
 
   raise_if_error(
-      stub->ReadLastGPSTimestamp(&context, request, &response));
+      stub->ReadLastGPSTimestamp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -753,7 +794,8 @@ read_last_irig_timestamp(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = ReadLastIRIGTimestampResponse{};
 
   raise_if_error(
-      stub->ReadLastIRIGTimestamp(&context, request, &response));
+      stub->ReadLastIRIGTimestamp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -769,7 +811,8 @@ disable_gps_timestamping(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = DisableGPSTimestampingResponse{};
 
   raise_if_error(
-      stub->DisableGPSTimestamping(&context, request, &response));
+      stub->DisableGPSTimestamping(&context, request, &response),
+      context);
 
   return response;
 }
@@ -786,7 +829,8 @@ disable_irig_timestamping(const StubPtr& stub, const nidevice_grpc::Session& vi,
   auto response = DisableIRIGTimestampingResponse{};
 
   raise_if_error(
-      stub->DisableIRIGTimestamping(&context, request, &response));
+      stub->DisableIRIGTimestamping(&context, request, &response),
+      context);
 
   return response;
 }
@@ -802,7 +846,8 @@ get_velocity(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetVelocityResponse{};
 
   raise_if_error(
-      stub->GetVelocity(&context, request, &response));
+      stub->GetVelocity(&context, request, &response),
+      context);
 
   return response;
 }
@@ -818,7 +863,8 @@ get_location(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetLocationResponse{};
 
   raise_if_error(
-      stub->GetLocation(&context, request, &response));
+      stub->GetLocation(&context, request, &response),
+      context);
 
   return response;
 }
@@ -834,7 +880,8 @@ get_time_reference_names(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetTimeReferenceNamesResponse{};
 
   raise_if_error(
-      stub->GetTimeReferenceNames(&context, request, &response));
+      stub->GetTimeReferenceNames(&context, request, &response),
+      context);
 
   return response;
 }
@@ -852,7 +899,8 @@ get_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = GetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->GetAttributeViInt32(&context, request, &response));
+      stub->GetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -870,7 +918,8 @@ get_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->GetAttributeViReal64(&context, request, &response));
+      stub->GetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -888,7 +937,8 @@ get_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = GetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->GetAttributeViBoolean(&context, request, &response));
+      stub->GetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -906,7 +956,8 @@ get_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = GetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeViString(&context, request, &response));
+      stub->GetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -925,7 +976,8 @@ set_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, co
   auto response = SetAttributeViInt32Response{};
 
   raise_if_error(
-      stub->SetAttributeViInt32(&context, request, &response));
+      stub->SetAttributeViInt32(&context, request, &response),
+      context);
 
   return response;
 }
@@ -944,7 +996,8 @@ set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->SetAttributeViReal64(&context, request, &response));
+      stub->SetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -963,7 +1016,8 @@ set_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   auto response = SetAttributeViBooleanResponse{};
 
   raise_if_error(
-      stub->SetAttributeViBoolean(&context, request, &response));
+      stub->SetAttributeViBoolean(&context, request, &response),
+      context);
 
   return response;
 }
@@ -982,7 +1036,8 @@ set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = SetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->SetAttributeViString(&context, request, &response));
+      stub->SetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -998,7 +1053,8 @@ get_ext_cal_last_date_and_time(const StubPtr& stub, const nidevice_grpc::Session
   auto response = GetExtCalLastDateAndTimeResponse{};
 
   raise_if_error(
-      stub->GetExtCalLastDateAndTime(&context, request, &response));
+      stub->GetExtCalLastDateAndTime(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1014,7 +1070,8 @@ get_ext_cal_last_temp(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = GetExtCalLastTempResponse{};
 
   raise_if_error(
-      stub->GetExtCalLastTemp(&context, request, &response));
+      stub->GetExtCalLastTemp(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1030,7 +1087,8 @@ get_ext_cal_recommended_interval(const StubPtr& stub, const nidevice_grpc::Sessi
   auto response = GetExtCalRecommendedIntervalResponse{};
 
   raise_if_error(
-      stub->GetExtCalRecommendedInterval(&context, request, &response));
+      stub->GetExtCalRecommendedInterval(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1048,7 +1106,8 @@ change_ext_cal_password(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   auto response = ChangeExtCalPasswordResponse{};
 
   raise_if_error(
-      stub->ChangeExtCalPassword(&context, request, &response));
+      stub->ChangeExtCalPassword(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1064,7 +1123,8 @@ read_current_temperature(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = ReadCurrentTemperatureResponse{};
 
   raise_if_error(
-      stub->ReadCurrentTemperature(&context, request, &response));
+      stub->ReadCurrentTemperature(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1080,7 +1140,8 @@ cal_get_oscillator_voltage(const StubPtr& stub, const nidevice_grpc::Session& vi
   auto response = CalGetOscillatorVoltageResponse{};
 
   raise_if_error(
-      stub->CalGetOscillatorVoltage(&context, request, &response));
+      stub->CalGetOscillatorVoltage(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1096,7 +1157,8 @@ cal_get_clk10_phase_voltage(const StubPtr& stub, const nidevice_grpc::Session& v
   auto response = CalGetClk10PhaseVoltageResponse{};
 
   raise_if_error(
-      stub->CalGetClk10PhaseVoltage(&context, request, &response));
+      stub->CalGetClk10PhaseVoltage(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1112,7 +1174,8 @@ cal_get_dds_start_pulse_phase_voltage(const StubPtr& stub, const nidevice_grpc::
   auto response = CalGetDDSStartPulsePhaseVoltageResponse{};
 
   raise_if_error(
-      stub->CalGetDDSStartPulsePhaseVoltage(&context, request, &response));
+      stub->CalGetDDSStartPulsePhaseVoltage(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1128,7 +1191,8 @@ cal_get_dds_initial_phase(const StubPtr& stub, const nidevice_grpc::Session& vi)
   auto response = CalGetDDSInitialPhaseResponse{};
 
   raise_if_error(
-      stub->CalGetDDSInitialPhase(&context, request, &response));
+      stub->CalGetDDSInitialPhase(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1145,7 +1209,8 @@ init_ext_cal(const StubPtr& stub, const pb::string& resource_name, const pb::str
   auto response = InitExtCalResponse{};
 
   raise_if_error(
-      stub->InitExtCal(&context, request, &response));
+      stub->InitExtCal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1162,7 +1227,8 @@ close_ext_cal(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::i
   auto response = CloseExtCalResponse{};
 
   raise_if_error(
-      stub->CloseExtCal(&context, request, &response));
+      stub->CloseExtCal(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1179,7 +1245,8 @@ cal_adjust_oscillator_voltage(const StubPtr& stub, const nidevice_grpc::Session&
   auto response = CalAdjustOscillatorVoltageResponse{};
 
   raise_if_error(
-      stub->CalAdjustOscillatorVoltage(&context, request, &response));
+      stub->CalAdjustOscillatorVoltage(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1196,7 +1263,8 @@ cal_adjust_clk10_phase_voltage(const StubPtr& stub, const nidevice_grpc::Session
   auto response = CalAdjustClk10PhaseVoltageResponse{};
 
   raise_if_error(
-      stub->CalAdjustClk10PhaseVoltage(&context, request, &response));
+      stub->CalAdjustClk10PhaseVoltage(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1213,7 +1281,8 @@ cal_adjust_dds_start_pulse_phase_voltage(const StubPtr& stub, const nidevice_grp
   auto response = CalAdjustDDSStartPulsePhaseVoltageResponse{};
 
   raise_if_error(
-      stub->CalAdjustDDSStartPulsePhaseVoltage(&context, request, &response));
+      stub->CalAdjustDDSStartPulsePhaseVoltage(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1230,7 +1299,8 @@ cal_adjust_dds_initial_phase(const StubPtr& stub, const nidevice_grpc::Session& 
   auto response = CalAdjustDDSInitialPhaseResponse{};
 
   raise_if_error(
-      stub->CalAdjustDDSInitialPhase(&context, request, &response));
+      stub->CalAdjustDDSInitialPhase(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nitclk/nitclk_client.cpp
+++ b/generated/nitclk/nitclk_client.cpp
@@ -28,7 +28,8 @@ configure_for_homogeneous_triggers(const StubPtr& stub, const std::vector<nidevi
   auto response = ConfigureForHomogeneousTriggersResponse{};
 
   raise_if_error(
-      stub->ConfigureForHomogeneousTriggers(&context, request, &response));
+      stub->ConfigureForHomogeneousTriggers(&context, request, &response),
+      context);
 
   return response;
 }
@@ -45,7 +46,8 @@ finish_sync_pulse_sender_synchronize(const StubPtr& stub, const std::vector<nide
   auto response = FinishSyncPulseSenderSynchronizeResponse{};
 
   raise_if_error(
-      stub->FinishSyncPulseSenderSynchronize(&context, request, &response));
+      stub->FinishSyncPulseSenderSynchronize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -63,7 +65,8 @@ get_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& sessi
   auto response = GetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->GetAttributeViReal64(&context, request, &response));
+      stub->GetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -81,7 +84,8 @@ get_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& sess
   auto response = GetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->GetAttributeViSession(&context, request, &response));
+      stub->GetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -99,7 +103,8 @@ get_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& sessi
   auto response = GetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->GetAttributeViString(&context, request, &response));
+      stub->GetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -114,7 +119,8 @@ get_extended_error_info(const StubPtr& stub)
   auto response = GetExtendedErrorInfoResponse{};
 
   raise_if_error(
-      stub->GetExtendedErrorInfo(&context, request, &response));
+      stub->GetExtendedErrorInfo(&context, request, &response),
+      context);
 
   return response;
 }
@@ -130,7 +136,8 @@ initiate(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& session
   auto response = InitiateResponse{};
 
   raise_if_error(
-      stub->Initiate(&context, request, &response));
+      stub->Initiate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -146,7 +153,8 @@ is_done(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& sessions
   auto response = IsDoneResponse{};
 
   raise_if_error(
-      stub->IsDone(&context, request, &response));
+      stub->IsDone(&context, request, &response),
+      context);
 
   return response;
 }
@@ -165,7 +173,8 @@ set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& sessi
   auto response = SetAttributeViReal64Response{};
 
   raise_if_error(
-      stub->SetAttributeViReal64(&context, request, &response));
+      stub->SetAttributeViReal64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -184,7 +193,8 @@ set_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& sess
   auto response = SetAttributeViSessionResponse{};
 
   raise_if_error(
-      stub->SetAttributeViSession(&context, request, &response));
+      stub->SetAttributeViSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -203,7 +213,8 @@ set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& sessi
   auto response = SetAttributeViStringResponse{};
 
   raise_if_error(
-      stub->SetAttributeViString(&context, request, &response));
+      stub->SetAttributeViString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -220,7 +231,8 @@ setup_for_sync_pulse_sender_synchronize(const StubPtr& stub, const std::vector<n
   auto response = SetupForSyncPulseSenderSynchronizeResponse{};
 
   raise_if_error(
-      stub->SetupForSyncPulseSenderSynchronize(&context, request, &response));
+      stub->SetupForSyncPulseSenderSynchronize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -237,7 +249,8 @@ synchronize(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& sess
   auto response = SynchronizeResponse{};
 
   raise_if_error(
-      stub->Synchronize(&context, request, &response));
+      stub->Synchronize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -254,7 +267,8 @@ synchronize_to_sync_pulse_sender(const StubPtr& stub, const std::vector<nidevice
   auto response = SynchronizeToSyncPulseSenderResponse{};
 
   raise_if_error(
-      stub->SynchronizeToSyncPulseSender(&context, request, &response));
+      stub->SynchronizeToSyncPulseSender(&context, request, &response),
+      context);
 
   return response;
 }
@@ -271,7 +285,8 @@ wait_until_done(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& 
   auto response = WaitUntilDoneResponse{};
 
   raise_if_error(
-      stub->WaitUntilDone(&context, request, &response));
+      stub->WaitUntilDone(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nixnet/nixnet_client.cpp
+++ b/generated/nixnet/nixnet_client.cpp
@@ -36,7 +36,8 @@ blink(const StubPtr& stub, const nidevice_grpc::Session& interface_ref, const si
   auto response = BlinkResponse{};
 
   raise_if_error(
-      stub->Blink(&context, request, &response));
+      stub->Blink(&context, request, &response),
+      context);
 
   return response;
 }
@@ -52,7 +53,8 @@ clear(const StubPtr& stub, const nidevice_grpc::Session& session)
   auto response = ClearResponse{};
 
   raise_if_error(
-      stub->Clear(&context, request, &response));
+      stub->Clear(&context, request, &response),
+      context);
 
   return response;
 }
@@ -84,7 +86,8 @@ connect_terminals(const StubPtr& stub, const nidevice_grpc::Session& session, co
   auto response = ConnectTerminalsResponse{};
 
   raise_if_error(
-      stub->ConnectTerminals(&context, request, &response));
+      stub->ConnectTerminals(&context, request, &response),
+      context);
 
   return response;
 }
@@ -111,7 +114,8 @@ convert_byte_array_to_frames_single_point(const StubPtr& stub, const nidevice_gr
   auto response = ConvertByteArrayToFramesSinglePointResponse{};
 
   raise_if_error(
-      stub->ConvertByteArrayToFramesSinglePoint(&context, request, &response));
+      stub->ConvertByteArrayToFramesSinglePoint(&context, request, &response),
+      context);
 
   return response;
 }
@@ -129,7 +133,8 @@ convert_frames_to_byte_array_single_point(const StubPtr& stub, const nidevice_gr
   auto response = ConvertFramesToByteArraySinglePointResponse{};
 
   raise_if_error(
-      stub->ConvertFramesToByteArraySinglePoint(&context, request, &response));
+      stub->ConvertFramesToByteArraySinglePoint(&context, request, &response),
+      context);
 
   return response;
 }
@@ -147,7 +152,8 @@ convert_frames_to_signals_single_point(const StubPtr& stub, const nidevice_grpc:
   auto response = ConvertFramesToSignalsSinglePointResponse{};
 
   raise_if_error(
-      stub->ConvertFramesToSignalsSinglePoint(&context, request, &response));
+      stub->ConvertFramesToSignalsSinglePoint(&context, request, &response),
+      context);
 
   return response;
 }
@@ -174,7 +180,8 @@ convert_signals_to_frames_single_point(const StubPtr& stub, const nidevice_grpc:
   auto response = ConvertSignalsToFramesSinglePointResponse{};
 
   raise_if_error(
-      stub->ConvertSignalsToFramesSinglePoint(&context, request, &response));
+      stub->ConvertSignalsToFramesSinglePoint(&context, request, &response),
+      context);
 
   return response;
 }
@@ -190,7 +197,8 @@ convert_timestamp100ns_to1ns(const StubPtr& stub, const pb::uint64& from_timesta
   auto response = ConvertTimestamp100nsTo1nsResponse{};
 
   raise_if_error(
-      stub->ConvertTimestamp100nsTo1ns(&context, request, &response));
+      stub->ConvertTimestamp100nsTo1ns(&context, request, &response),
+      context);
 
   return response;
 }
@@ -206,7 +214,8 @@ convert_timestamp1ns_to100ns(const StubPtr& stub, const pb::uint64& from_timesta
   auto response = ConvertTimestamp1nsTo100nsResponse{};
 
   raise_if_error(
-      stub->ConvertTimestamp1nsTo100ns(&context, request, &response));
+      stub->ConvertTimestamp1nsTo100ns(&context, request, &response),
+      context);
 
   return response;
 }
@@ -233,7 +242,8 @@ create_session(const StubPtr& stub, const pb::string& database_name, const pb::s
   auto response = CreateSessionResponse{};
 
   raise_if_error(
-      stub->CreateSession(&context, request, &response));
+      stub->CreateSession(&context, request, &response),
+      context);
 
   return response;
 }
@@ -258,7 +268,8 @@ create_session_by_ref(const StubPtr& stub, const std::vector<nidevice_grpc::Sess
   auto response = CreateSessionByRefResponse{};
 
   raise_if_error(
-      stub->CreateSessionByRef(&context, request, &response));
+      stub->CreateSessionByRef(&context, request, &response),
+      context);
 
   return response;
 }
@@ -276,7 +287,8 @@ db_add_alias(const StubPtr& stub, const pb::string& database_alias, const pb::st
   auto response = DbAddAliasResponse{};
 
   raise_if_error(
-      stub->DbAddAlias(&context, request, &response));
+      stub->DbAddAlias(&context, request, &response),
+      context);
 
   return response;
 }
@@ -294,7 +306,8 @@ db_add_alias64(const StubPtr& stub, const pb::string& database_alias, const pb::
   auto response = DbAddAlias64Response{};
 
   raise_if_error(
-      stub->DbAddAlias64(&context, request, &response));
+      stub->DbAddAlias64(&context, request, &response),
+      context);
 
   return response;
 }
@@ -311,7 +324,8 @@ db_close_database(const StubPtr& stub, const nidevice_grpc::Session& database, c
   auto response = DbCloseDatabaseResponse{};
 
   raise_if_error(
-      stub->DbCloseDatabase(&context, request, &response));
+      stub->DbCloseDatabase(&context, request, &response),
+      context);
 
   return response;
 }
@@ -329,7 +343,8 @@ db_create_object(const StubPtr& stub, const nidevice_grpc::Session& parent_objec
   auto response = DbCreateObjectResponse{};
 
   raise_if_error(
-      stub->DbCreateObject(&context, request, &response));
+      stub->DbCreateObject(&context, request, &response),
+      context);
 
   return response;
 }
@@ -345,7 +360,8 @@ db_delete_object(const StubPtr& stub, const nidevice_grpc::Session& db_object)
   auto response = DbDeleteObjectResponse{};
 
   raise_if_error(
-      stub->DbDeleteObject(&context, request, &response));
+      stub->DbDeleteObject(&context, request, &response),
+      context);
 
   return response;
 }
@@ -363,7 +379,8 @@ db_deploy(const StubPtr& stub, const pb::string& ip_address, const pb::string& d
   auto response = DbDeployResponse{};
 
   raise_if_error(
-      stub->DbDeploy(&context, request, &response));
+      stub->DbDeploy(&context, request, &response),
+      context);
 
   return response;
 }
@@ -381,7 +398,8 @@ db_find_object(const StubPtr& stub, const nidevice_grpc::Session& parent_object,
   auto response = DbFindObjectResponse{};
 
   raise_if_error(
-      stub->DbFindObject(&context, request, &response));
+      stub->DbFindObject(&context, request, &response),
+      context);
 
   return response;
 }
@@ -406,7 +424,8 @@ db_get_dbc_attribute(const StubPtr& stub, const nidevice_grpc::Session& db_objec
   auto response = DbGetDBCAttributeResponse{};
 
   raise_if_error(
-      stub->DbGetDBCAttribute(&context, request, &response));
+      stub->DbGetDBCAttribute(&context, request, &response),
+      context);
 
   return response;
 }
@@ -431,7 +450,8 @@ db_get_dbc_attribute_size(const StubPtr& stub, const nidevice_grpc::Session& db_
   auto response = DbGetDBCAttributeSizeResponse{};
 
   raise_if_error(
-      stub->DbGetDBCAttributeSize(&context, request, &response));
+      stub->DbGetDBCAttributeSize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -447,7 +467,8 @@ db_get_database_list_sizes(const StubPtr& stub, const pb::string& ip_address)
   auto response = DbGetDatabaseListSizesResponse{};
 
   raise_if_error(
-      stub->DbGetDatabaseListSizes(&context, request, &response));
+      stub->DbGetDatabaseListSizes(&context, request, &response),
+      context);
 
   return response;
 }
@@ -471,7 +492,8 @@ db_get_property_size(const StubPtr& stub, const nidevice_grpc::Session& db_objec
   auto response = DbGetPropertySizeResponse{};
 
   raise_if_error(
-      stub->DbGetPropertySize(&context, request, &response));
+      stub->DbGetPropertySize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -498,7 +520,8 @@ db_merge(const StubPtr& stub, const nidevice_grpc::Session& target_cluster, cons
   auto response = DbMergeResponse{};
 
   raise_if_error(
-      stub->DbMerge(&context, request, &response));
+      stub->DbMerge(&context, request, &response),
+      context);
 
   return response;
 }
@@ -514,7 +537,8 @@ db_open_database(const StubPtr& stub, const pb::string& database_name)
   auto response = DbOpenDatabaseResponse{};
 
   raise_if_error(
-      stub->DbOpenDatabase(&context, request, &response));
+      stub->DbOpenDatabase(&context, request, &response),
+      context);
 
   return response;
 }
@@ -530,7 +554,8 @@ db_remove_alias(const StubPtr& stub, const pb::string& database_alias)
   auto response = DbRemoveAliasResponse{};
 
   raise_if_error(
-      stub->DbRemoveAlias(&context, request, &response));
+      stub->DbRemoveAlias(&context, request, &response),
+      context);
 
   return response;
 }
@@ -547,7 +572,8 @@ db_save_database(const StubPtr& stub, const nidevice_grpc::Session& database, co
   auto response = DbSaveDatabaseResponse{};
 
   raise_if_error(
-      stub->DbSaveDatabase(&context, request, &response));
+      stub->DbSaveDatabase(&context, request, &response),
+      context);
 
   return response;
 }
@@ -564,7 +590,8 @@ db_undeploy(const StubPtr& stub, const pb::string& ip_address, const pb::string&
   auto response = DbUndeployResponse{};
 
   raise_if_error(
-      stub->DbUndeploy(&context, request, &response));
+      stub->DbUndeploy(&context, request, &response),
+      context);
 
   return response;
 }
@@ -596,7 +623,8 @@ disconnect_terminals(const StubPtr& stub, const nidevice_grpc::Session& session,
   auto response = DisconnectTerminalsResponse{};
 
   raise_if_error(
-      stub->DisconnectTerminals(&context, request, &response));
+      stub->DisconnectTerminals(&context, request, &response),
+      context);
 
   return response;
 }
@@ -612,7 +640,8 @@ flush(const StubPtr& stub, const nidevice_grpc::Session& session)
   auto response = FlushResponse{};
 
   raise_if_error(
-      stub->Flush(&context, request, &response));
+      stub->Flush(&context, request, &response),
+      context);
 
   return response;
 }
@@ -637,7 +666,8 @@ future_time_trigger(const StubPtr& stub, const nidevice_grpc::Session& session, 
   auto response = FutureTimeTriggerResponse{};
 
   raise_if_error(
-      stub->FutureTimeTrigger(&context, request, &response));
+      stub->FutureTimeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -661,7 +691,8 @@ get_property_size(const StubPtr& stub, const nidevice_grpc::Session& session, co
   auto response = GetPropertySizeResponse{};
 
   raise_if_error(
-      stub->GetPropertySize(&context, request, &response));
+      stub->GetPropertySize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -686,7 +717,8 @@ get_sub_property_size(const StubPtr& stub, const nidevice_grpc::Session& session
   auto response = GetSubPropertySizeResponse{};
 
   raise_if_error(
-      stub->GetSubPropertySize(&context, request, &response));
+      stub->GetSubPropertySize(&context, request, &response),
+      context);
 
   return response;
 }
@@ -720,7 +752,8 @@ read_frame(const StubPtr& stub, const nidevice_grpc::Session& session, const pb:
   auto response = ReadFrameResponse{};
 
   raise_if_error(
-      stub->ReadFrame(&context, request, &response));
+      stub->ReadFrame(&context, request, &response),
+      context);
 
   return response;
 }
@@ -737,7 +770,8 @@ read_signal_single_point(const StubPtr& stub, const nidevice_grpc::Session& sess
   auto response = ReadSignalSinglePointResponse{};
 
   raise_if_error(
-      stub->ReadSignalSinglePoint(&context, request, &response));
+      stub->ReadSignalSinglePoint(&context, request, &response),
+      context);
 
   return response;
 }
@@ -763,7 +797,8 @@ read_signal_waveform(const StubPtr& stub, const nidevice_grpc::Session& session,
   auto response = ReadSignalWaveformResponse{};
 
   raise_if_error(
-      stub->ReadSignalWaveform(&context, request, &response));
+      stub->ReadSignalWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -782,7 +817,8 @@ read_signal_xy(const StubPtr& stub, const nidevice_grpc::Session& session, const
   auto response = ReadSignalXYResponse{};
 
   raise_if_error(
-      stub->ReadSignalXY(&context, request, &response));
+      stub->ReadSignalXY(&context, request, &response),
+      context);
 
   return response;
 }
@@ -806,7 +842,8 @@ read_state(const StubPtr& stub, const nidevice_grpc::Session& session, const sim
   auto response = ReadStateResponse{};
 
   raise_if_error(
-      stub->ReadState(&context, request, &response));
+      stub->ReadState(&context, request, &response),
+      context);
 
   return response;
 }
@@ -830,7 +867,8 @@ read_state_time_trigger(const StubPtr& stub, const nidevice_grpc::Session& sessi
   auto response = ReadStateTimeTriggerResponse{};
 
   raise_if_error(
-      stub->ReadStateTimeTrigger(&context, request, &response));
+      stub->ReadStateTimeTrigger(&context, request, &response),
+      context);
 
   return response;
 }
@@ -854,7 +892,8 @@ start(const StubPtr& stub, const nidevice_grpc::Session& session, const simple_v
   auto response = StartResponse{};
 
   raise_if_error(
-      stub->Start(&context, request, &response));
+      stub->Start(&context, request, &response),
+      context);
 
   return response;
 }
@@ -870,7 +909,8 @@ status_to_string(const StubPtr& stub, const pb::int32& status_id)
   auto response = StatusToStringResponse{};
 
   raise_if_error(
-      stub->StatusToString(&context, request, &response));
+      stub->StatusToString(&context, request, &response),
+      context);
 
   return response;
 }
@@ -894,7 +934,8 @@ stop(const StubPtr& stub, const nidevice_grpc::Session& session, const simple_va
   auto response = StopResponse{};
 
   raise_if_error(
-      stub->Stop(&context, request, &response));
+      stub->Stop(&context, request, &response),
+      context);
 
   return response;
 }
@@ -910,7 +951,8 @@ system_close(const StubPtr& stub, const nidevice_grpc::Session& system)
   auto response = SystemCloseResponse{};
 
   raise_if_error(
-      stub->SystemClose(&context, request, &response));
+      stub->SystemClose(&context, request, &response),
+      context);
 
   return response;
 }
@@ -925,7 +967,8 @@ system_open(const StubPtr& stub)
   auto response = SystemOpenResponse{};
 
   raise_if_error(
-      stub->SystemOpen(&context, request, &response));
+      stub->SystemOpen(&context, request, &response),
+      context);
 
   return response;
 }
@@ -951,7 +994,8 @@ wait(const StubPtr& stub, const nidevice_grpc::Session& session, const simple_va
   auto response = WaitResponse{};
 
   raise_if_error(
-      stub->Wait(&context, request, &response));
+      stub->Wait(&context, request, &response),
+      context);
 
   return response;
 }
@@ -976,7 +1020,8 @@ write_frame(const StubPtr& stub, const nidevice_grpc::Session& session, const st
   auto response = WriteFrameResponse{};
 
   raise_if_error(
-      stub->WriteFrame(&context, request, &response));
+      stub->WriteFrame(&context, request, &response),
+      context);
 
   return response;
 }
@@ -993,7 +1038,8 @@ write_signal_single_point(const StubPtr& stub, const nidevice_grpc::Session& ses
   auto response = WriteSignalSinglePointResponse{};
 
   raise_if_error(
-      stub->WriteSignalSinglePoint(&context, request, &response));
+      stub->WriteSignalSinglePoint(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1018,7 +1064,8 @@ write_signal_waveform(const StubPtr& stub, const nidevice_grpc::Session& session
   auto response = WriteSignalWaveformResponse{};
 
   raise_if_error(
-      stub->WriteSignalWaveform(&context, request, &response));
+      stub->WriteSignalWaveform(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1045,7 +1092,8 @@ write_signal_xy(const StubPtr& stub, const nidevice_grpc::Session& session, cons
   auto response = WriteSignalXYResponse{};
 
   raise_if_error(
-      stub->WriteSignalXY(&context, request, &response));
+      stub->WriteSignalXY(&context, request, &response),
+      context);
 
   return response;
 }
@@ -1070,7 +1118,8 @@ write_state(const StubPtr& stub, const nidevice_grpc::Session& session, const si
   auto response = WriteStateResponse{};
 
   raise_if_error(
-      stub->WriteState(&context, request, &response));
+      stub->WriteState(&context, request, &response),
+      context);
 
   return response;
 }

--- a/generated/nixnetsocket/nixnetsocket_client.cpp
+++ b/generated/nixnetsocket/nixnetsocket_client.cpp
@@ -28,7 +28,8 @@ accept(const StubPtr& stub, const nidevice_grpc::Session& socket)
   auto response = AcceptResponse{};
 
   raise_if_error(
-      stub->Accept(&context, request, &response));
+      stub->Accept(&context, request, &response),
+      context);
 
   return response;
 }
@@ -45,7 +46,8 @@ bind(const StubPtr& stub, const nidevice_grpc::Session& socket, const SockAddr& 
   auto response = BindResponse{};
 
   raise_if_error(
-      stub->Bind(&context, request, &response));
+      stub->Bind(&context, request, &response),
+      context);
 
   return response;
 }
@@ -61,7 +63,8 @@ close(const StubPtr& stub, const nidevice_grpc::Session& socket)
   auto response = CloseResponse{};
 
   raise_if_error(
-      stub->Close(&context, request, &response));
+      stub->Close(&context, request, &response),
+      context);
 
   return response;
 }
@@ -78,7 +81,8 @@ connect(const StubPtr& stub, const nidevice_grpc::Session& socket, const SockAdd
   auto response = ConnectResponse{};
 
   raise_if_error(
-      stub->Connect(&context, request, &response));
+      stub->Connect(&context, request, &response),
+      context);
 
   return response;
 }
@@ -95,7 +99,8 @@ fd_is_set(const StubPtr& stub, const nidevice_grpc::Session& fd, const std::vect
   auto response = FdIsSetResponse{};
 
   raise_if_error(
-      stub->FdIsSet(&context, request, &response));
+      stub->FdIsSet(&context, request, &response),
+      context);
 
   return response;
 }
@@ -114,7 +119,8 @@ get_addr_info(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, cons
   auto response = GetAddrInfoResponse{};
 
   raise_if_error(
-      stub->GetAddrInfo(&context, request, &response));
+      stub->GetAddrInfo(&context, request, &response),
+      context);
 
   return response;
 }
@@ -134,7 +140,8 @@ get_name_info(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, cons
   auto response = GetNameInfoResponse{};
 
   raise_if_error(
-      stub->GetNameInfo(&context, request, &response));
+      stub->GetNameInfo(&context, request, &response),
+      context);
 
   return response;
 }
@@ -150,7 +157,8 @@ get_peer_name(const StubPtr& stub, const nidevice_grpc::Session& socket)
   auto response = GetPeerNameResponse{};
 
   raise_if_error(
-      stub->GetPeerName(&context, request, &response));
+      stub->GetPeerName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -166,7 +174,8 @@ get_sock_name(const StubPtr& stub, const nidevice_grpc::Session& socket)
   auto response = GetSockNameResponse{};
 
   raise_if_error(
-      stub->GetSockName(&context, request, &response));
+      stub->GetSockName(&context, request, &response),
+      context);
 
   return response;
 }
@@ -198,7 +207,8 @@ get_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const si
   auto response = GetSockOptResponse{};
 
   raise_if_error(
-      stub->GetSockOpt(&context, request, &response));
+      stub->GetSockOpt(&context, request, &response),
+      context);
 
   return response;
 }
@@ -215,7 +225,8 @@ inet_addr(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const pb
   auto response = InetAddrResponse{};
 
   raise_if_error(
-      stub->InetAddr(&context, request, &response));
+      stub->InetAddr(&context, request, &response),
+      context);
 
   return response;
 }
@@ -232,7 +243,8 @@ inet_a_to_n(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const 
   auto response = InetAToNResponse{};
 
   raise_if_error(
-      stub->InetAToN(&context, request, &response));
+      stub->InetAToN(&context, request, &response),
+      context);
 
   return response;
 }
@@ -249,7 +261,8 @@ inet_n_to_a(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const 
   auto response = InetNToAResponse{};
 
   raise_if_error(
-      stub->InetNToA(&context, request, &response));
+      stub->InetNToA(&context, request, &response),
+      context);
 
   return response;
 }
@@ -266,7 +279,8 @@ inet_n_to_p(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const 
   auto response = InetNToPResponse{};
 
   raise_if_error(
-      stub->InetNToP(&context, request, &response));
+      stub->InetNToP(&context, request, &response),
+      context);
 
   return response;
 }
@@ -291,7 +305,8 @@ inet_p_to_n(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const 
   auto response = InetPToNResponse{};
 
   raise_if_error(
-      stub->InetPToN(&context, request, &response));
+      stub->InetPToN(&context, request, &response),
+      context);
 
   return response;
 }
@@ -307,7 +322,8 @@ ip_stack_clear(const StubPtr& stub, const nidevice_grpc::Session& stack_ref)
   auto response = IpStackClearResponse{};
 
   raise_if_error(
-      stub->IpStackClear(&context, request, &response));
+      stub->IpStackClear(&context, request, &response),
+      context);
 
   return response;
 }
@@ -324,7 +340,8 @@ ip_stack_create(const StubPtr& stub, const pb::string& stack_name, const pb::str
   auto response = IpStackCreateResponse{};
 
   raise_if_error(
-      stub->IpStackCreate(&context, request, &response));
+      stub->IpStackCreate(&context, request, &response),
+      context);
 
   return response;
 }
@@ -347,7 +364,8 @@ ip_stack_get_all_stacks_info_str(const StubPtr& stub, const simple_variant<IPSta
   auto response = IpStackGetAllStacksInfoStrResponse{};
 
   raise_if_error(
-      stub->IpStackGetAllStacksInfoStr(&context, request, &response));
+      stub->IpStackGetAllStacksInfoStr(&context, request, &response),
+      context);
 
   return response;
 }
@@ -363,7 +381,8 @@ ip_stack_get_info(const StubPtr& stub, const nidevice_grpc::Session& stack_ref)
   auto response = IpStackGetInfoResponse{};
 
   raise_if_error(
-      stub->IpStackGetInfo(&context, request, &response));
+      stub->IpStackGetInfo(&context, request, &response),
+      context);
 
   return response;
 }
@@ -379,7 +398,8 @@ ip_stack_open(const StubPtr& stub, const pb::string& stack_name)
   auto response = IpStackOpenResponse{};
 
   raise_if_error(
-      stub->IpStackOpen(&context, request, &response));
+      stub->IpStackOpen(&context, request, &response),
+      context);
 
   return response;
 }
@@ -397,7 +417,8 @@ ip_stack_wait_for_interface(const StubPtr& stub, const nidevice_grpc::Session& s
   auto response = IpStackWaitForInterfaceResponse{};
 
   raise_if_error(
-      stub->IpStackWaitForInterface(&context, request, &response));
+      stub->IpStackWaitForInterface(&context, request, &response),
+      context);
 
   return response;
 }
@@ -414,7 +435,8 @@ listen(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int3
   auto response = ListenResponse{};
 
   raise_if_error(
-      stub->Listen(&context, request, &response));
+      stub->Listen(&context, request, &response),
+      context);
 
   return response;
 }
@@ -432,7 +454,8 @@ recv(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::int32&
   auto response = RecvResponse{};
 
   raise_if_error(
-      stub->Recv(&context, request, &response));
+      stub->Recv(&context, request, &response),
+      context);
 
   return response;
 }
@@ -450,7 +473,8 @@ recv_from(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::i
   auto response = RecvFromResponse{};
 
   raise_if_error(
-      stub->RecvFrom(&context, request, &response));
+      stub->RecvFrom(&context, request, &response),
+      context);
 
   return response;
 }
@@ -469,7 +493,8 @@ select(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& readfds, 
   auto response = SelectResponse{};
 
   raise_if_error(
-      stub->Select(&context, request, &response));
+      stub->Select(&context, request, &response),
+      context);
 
   return response;
 }
@@ -487,7 +512,8 @@ send(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::string
   auto response = SendResponse{};
 
   raise_if_error(
-      stub->Send(&context, request, &response));
+      stub->Send(&context, request, &response),
+      context);
 
   return response;
 }
@@ -506,7 +532,8 @@ send_to(const StubPtr& stub, const nidevice_grpc::Session& socket, const pb::str
   auto response = SendToResponse{};
 
   raise_if_error(
-      stub->SendTo(&context, request, &response));
+      stub->SendTo(&context, request, &response),
+      context);
 
   return response;
 }
@@ -539,7 +566,8 @@ set_sock_opt(const StubPtr& stub, const nidevice_grpc::Session& socket, const si
   auto response = SetSockOptResponse{};
 
   raise_if_error(
-      stub->SetSockOpt(&context, request, &response));
+      stub->SetSockOpt(&context, request, &response),
+      context);
 
   return response;
 }
@@ -563,7 +591,8 @@ shutdown(const StubPtr& stub, const nidevice_grpc::Session& socket, const simple
   auto response = ShutdownResponse{};
 
   raise_if_error(
-      stub->Shutdown(&context, request, &response));
+      stub->Shutdown(&context, request, &response),
+      context);
 
   return response;
 }
@@ -603,7 +632,8 @@ socket(const StubPtr& stub, const nidevice_grpc::Session& stack_ref, const simpl
   auto response = SocketResponse{};
 
   raise_if_error(
-      stub->Socket(&context, request, &response));
+      stub->Socket(&context, request, &response),
+      context);
 
   return response;
 }
@@ -620,7 +650,8 @@ str_err_r(const StubPtr& stub, const pb::int32& errnum, const pb::uint64& buf_le
   auto response = StrErrRResponse{};
 
   raise_if_error(
-      stub->StrErrR(&context, request, &response));
+      stub->StrErrR(&context, request, &response),
+      context);
 
   return response;
 }

--- a/source/codegen/templates/client.cpp.mako
+++ b/source/codegen/templates/client.cpp.mako
@@ -69,7 +69,8 @@ ${mako_helper.build_request(client_params)}\
   auto response = ${response_type}{};
 
   raise_if_error(
-      stub->${stub_method_name}(&context, request, &response));
+      stub->${stub_method_name}(&context, request, &response),
+      context);
 
   return response;
 }

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -675,13 +675,6 @@ class NiDAQmxDriverApiTests : public Test {
     return stub()->CfgWatchdogDOExpirStates(&context, request, &response);
   }
 
-  // void raise_if_error(::grpc::Status status)
-  // {
-  //   if (!status.ok()) {
-  //     throw new std::runtime_error(status.error_message());
-  //   }
-  // }
-
   std::unique_ptr<NiDAQmx::Stub>& stub()
   {
     return nidaqmx_stub_;

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -1,10 +1,10 @@
 #include <gmock/gmock.h>
 #include <google/protobuf/util/time_util.h>
 #include <gtest/gtest.h>  // For EXPECT matchers.
-#include <nlohmann/json.hpp>
 
 #include <algorithm>
 #include <cstring>
+#include <nlohmann/json.hpp>
 #include <random>
 #include <stdexcept>
 #include <vector>
@@ -675,12 +675,12 @@ class NiDAQmxDriverApiTests : public Test {
     return stub()->CfgWatchdogDOExpirStates(&context, request, &response);
   }
 
-  void raise_if_error(::grpc::Status status)
-  {
-    if (!status.ok()) {
-      throw new std::runtime_error(status.error_message());
-    }
-  }
+  // void raise_if_error(::grpc::Status status)
+  // {
+  //   if (!status.ok()) {
+  //     throw new std::runtime_error(status.error_message());
+  //   }
+  // }
 
   std::unique_ptr<NiDAQmx::Stub>& stub()
   {
@@ -1003,12 +1003,12 @@ TEST_F(NiDAQmxDriverApiTests, GetScaledUnitsAsDouble_Fails)
 
   try {
     client::get_scale_attribute_double(
-      stub(),
-      SCALE_NAME,
-      (ScaleDoubleAttribute)ScaleStringAttribute::SCALE_ATTRIBUTE_SCALED_UNITS);
+        stub(),
+        SCALE_NAME,
+        (ScaleDoubleAttribute)ScaleStringAttribute::SCALE_ATTRIBUTE_SCALED_UNITS);
     EXPECT_FALSE(true);
   }
-  catch (const std::runtime_error& ex) {
+  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
     EXPECT_DAQ_ERROR(SPECIFIED_ATTRIBUTE_NOT_VALID_ERROR, ex.what());
   }
 }
@@ -1429,7 +1429,7 @@ TEST_F(NiDAQmxDriverApiTests, ConfigureTEDSOnNonTEDSChannel_ErrorTEDSSensorNotDe
     client::configure_teds(stub(), AI_CHANNEL, "");
     EXPECT_FALSE(true);
   }
-  catch (const std::runtime_error& ex) {
+  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
     EXPECT_DAQ_ERROR(TEDS_SENSOR_NOT_DETECTED_ERROR, ex.what());
   }
 }
@@ -1492,7 +1492,7 @@ TEST_F(NiDAQmxDriverApiTests, AutoConfigureCDAQSyncConnections_ReturnsNotSupport
     client::auto_configure_cdaq_sync_connections(stub(), DEVICE_NAME, 1.0);
     EXPECT_FALSE(true);
   }
-  catch (const std::runtime_error& ex) {
+  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
     EXPECT_DAQ_ERROR(DEVICE_DOES_NOT_SUPPORT_CDAQ_SYNC_CONNECTIONS_ERROR, ex.what());
   }
 }
@@ -1715,7 +1715,7 @@ TEST_F(NiDAQmxDriverApiTests, SetWrongCategoryAttribute_ReturnsNotValidError)
     client::get_device_attribute_bool(stub(), DEVICE_NAME, ScaleDoubleAttribute::SCALE_ATTRIBUTE_LIN_SLOPE);
     EXPECT_FALSE(true);
   }
-  catch (const std::runtime_error& ex) {
+  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
     EXPECT_DAQ_ERROR(SPECIFIED_ATTRIBUTE_NOT_VALID_ERROR, ex.what());
   }
 }
@@ -1726,7 +1726,7 @@ TEST_F(NiDAQmxDriverApiTests, SetWrongDataTypeAttribute_ReturnsNotValidError)
     client::get_device_attribute_bool(stub(), DEVICE_NAME, DeviceStringAttribute::DEVICE_ATTRIBUTE_AO_PHYSICAL_CHANS);
     EXPECT_FALSE(true);
   }
-  catch (const std::runtime_error& ex) {
+  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
     EXPECT_DAQ_ERROR(SPECIFIED_ATTRIBUTE_NOT_VALID_ERROR, ex.what());
   }
 }

--- a/source/tests/system/nirfmxlte_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxlte_driver_api_tests.cpp
@@ -366,7 +366,7 @@ TEST_F(NiRFmxLTEDriverApiTests, NBIoTModAccFromExample_FetchData_DataLooksReason
       mod_acc_fetch_composite_evm_response = client::mod_acc_fetch_composite_evm(stub(), session, "", 10.0);
       actualStatus = mod_acc_fetch_composite_evm_response.status();
     }
-    catch (const std::runtime_error& ex) {
+    catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
       auto error = json::parse(ex.what());
       actualStatus = error.value("code", -1);
     }
@@ -446,7 +446,7 @@ TEST_F(NiRFmxLTEDriverApiTests, NBIoTModAccAcpChpObwSemCompositeSingleCarrierFro
       mod_acc_fetch_composite_evm_response = client::mod_acc_fetch_composite_evm(stub(), session, "", 10.0);
       actualStatus = mod_acc_fetch_composite_evm_response.status();
     }
-    catch (const std::runtime_error& ex) {
+    catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
       auto error = json::parse(ex.what());
       actualStatus = error.value("code", -1);
     }

--- a/source/tests/system/nirfmxspecan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxspecan_driver_api_tests.cpp
@@ -1,7 +1,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
-#include <nlohmann/json.hpp>
 
+#include <nlohmann/json.hpp>
 #include <thread>
 #include <tuple>
 
@@ -68,7 +68,7 @@ class NiRFmxSpecAnDriverApiTests : public ::testing::Test {
       EXPECT_EQ(0, response.status());
       return true;
     }
-    catch (const std::runtime_error& ex) {
+    catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
       auto error = json::parse(ex.what());
       return error.value("code", 0) != INVALID_SESSION_HANDLE_ERROR;
     }
@@ -652,7 +652,7 @@ TEST_P(NiRFmxSpecAnDriverApiConflictingResourceInitTests, InitializeResource_Ini
     init(stub(), PXI_5663, std::get<1>(GetParam()));
     EXPECT_FALSE(true);
   }
-  catch (const std::runtime_error& ex) {
+  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
     EXPECT_STATUS_ERROR(DEVICE_IN_USE_ERROR, ex.what());
   }
 }

--- a/source/tests/system/nirfsa_driver_api_tests.cpp
+++ b/source/tests/system/nirfsa_driver_api_tests.cpp
@@ -1,8 +1,8 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>  // For EXPECT matchers.
-#include <nlohmann/json.hpp>
 
 #include <algorithm>
+#include <nlohmann/json.hpp>
 
 #include "device_server.h"
 #include "niRFSAErrors.h"
@@ -133,7 +133,7 @@ TEST_F(NiRFSADriverApiTests, InitWithErrorFromDriver_ReturnsUserErrorMessage)
     client::init_with_options(stub(), "", false, false, "");
     EXPECT_FALSE(true);
   }
-  catch (const std::runtime_error& ex) {
+  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
     auto message = EXPECT_RFSA_ERROR(-200220, ex.what());
     EXPECT_STREQ("Device identifier is invalid.", message.c_str());
   }
@@ -506,14 +506,14 @@ TEST_F(NiRFSADriverApiTests, CreateConfigurationListWithInvalidAttribute_Reports
 
   try {
     client::create_configuration_list(
-      stub(),
-      session,
-      LIST_NAME,
-      {NiRFSAAttribute::NIRFSA_ATTRIBUTE_EXTERNAL_GAIN, NiRFSAAttribute::NIRFSA_ATTRIBUTE_NOTCH_FILTER_ENABLED},
-      true);
+        stub(),
+        session,
+        LIST_NAME,
+        {NiRFSAAttribute::NIRFSA_ATTRIBUTE_EXTERNAL_GAIN, NiRFSAAttribute::NIRFSA_ATTRIBUTE_NOTCH_FILTER_ENABLED},
+        true);
     EXPECT_FALSE(true);
   }
-  catch (const std::runtime_error& ex) {
+  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
     EXPECT_RFSA_ERROR(IVI_ATTRIBUTE_NOT_SUPPORTED_ERROR, "Attribute or property not supported.", ex.what(), session);
   }
 }

--- a/source/tests/system/nixnet_utilities.h
+++ b/source/tests/system/nixnet_utilities.h
@@ -63,7 +63,8 @@ inline GetPropertyResponse get_property(const client::StubPtr& stub, const nidev
   auto response = GetPropertyResponse{};
 
   client::raise_if_error(
-      stub->GetProperty(&context, request, &response));
+      stub->GetProperty(&context, request, &response),
+      context);
 
   return response;
 }
@@ -151,7 +152,8 @@ inline SetPropertyResponse set_property(
   auto response = SetPropertyResponse{};
 
   client::raise_if_error(
-      stub->SetProperty(&context, request, &response));
+      stub->SetProperty(&context, request, &response),
+      context);
 
   return response;
 }
@@ -174,7 +176,8 @@ inline DbGetPropertyResponse db_get_property(const client::StubPtr& stub, const 
   auto response = DbGetPropertyResponse{};
 
   client::raise_if_error(
-      stub->DbGetProperty(&context, request, &response));
+      stub->DbGetProperty(&context, request, &response),
+      context);
 
   return response;
 }

--- a/source/tests/system/nixnetsocket_driver_api_tests.cpp
+++ b/source/tests/system/nixnetsocket_driver_api_tests.cpp
@@ -293,7 +293,7 @@ TEST_F(NiXnetSocketNoHardwareTests, InitWithInvalidIpStack_Close_ReturnsAndSetsE
     client::close(stub(), invalid_socket.socket());
     EXPECT_FALSE(true);
   }
-  catch (const std::runtime_error& ex) {
+  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
     auto error = json::parse(ex.what());
     EXPECT_XNET_ERROR_CODE(GENERIC_NXSOCKET_ERROR, error);
     EXPECT_XNET_ERROR_NUMBER(INVALID_SOCKET_ERROR, error);
@@ -313,7 +313,7 @@ TEST_F(NiXnetSocketNoHardwareTests, InitWithInvalidIpStack_Bind_ReturnsAndSetsEx
     client::bind(stub(), invalid_socket.socket(), sock_addr);
     EXPECT_FALSE(true);
   }
-  catch (const std::runtime_error& ex) {
+  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
     auto error = json::parse(ex.what());
     EXPECT_XNET_ERROR_CODE(GENERIC_NXSOCKET_ERROR, error);
     EXPECT_XNET_ERROR_NUMBER(INVALID_SOCKET_ERROR, error);
@@ -355,7 +355,7 @@ TEST_F(NiXnetSocketNoHardwareTests, InvalidSocket_Select_ReturnsAndSetsExpectedE
     client::select(stub(), {invalid_socket.socket()}, {invalid_socket.socket()}, {}, duration);
     EXPECT_FALSE(true);
   }
-  catch (const std::runtime_error& ex) {
+  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
     auto error = json::parse(ex.what());
     EXPECT_XNET_ERROR_CODE(GENERIC_NXSOCKET_ERROR, error);
     EXPECT_XNET_ERROR_NUMBER(INVALID_SOCKET_ERROR, error);
@@ -372,7 +372,7 @@ TEST_F(NiXnetSocketNoHardwareTests, InvalidEmptyConfigJson_IpStackCreate_Returns
     client::ip_stack_create(stub(), "", "{}");
     EXPECT_FALSE(true);
   }
-  catch (const std::runtime_error& ex) {
+  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
     auto error = json::parse(ex.what());
     EXPECT_XNET_ERROR_CODE(JSON_OBJECT_MISSING_VALUE, error);
   }
@@ -387,7 +387,7 @@ TEST_F(NiXnetSocketNoHardwareTests, ValidConfigJsonForMissingDevice_IpStackCreat
     client::ip_stack_create(stub(), "", TEST_CONFIG);
     EXPECT_FALSE(true);
   }
-  catch (const std::runtime_error& ex) {
+  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
     auto error = json::parse(ex.what());
     EXPECT_XNET_ERROR_CODE(INVALID_INTERFACE_NAME, error);
   }
@@ -411,7 +411,7 @@ TEST_F(NiXnetSocketNoHardwareTests, StackAlreadyExistsError_StrErrRWithZeroBuffe
     client::str_err_r(stub(), STACK_ALREADY_EXISTS, 0);
     EXPECT_FALSE(true);
   }
-  catch (const std::runtime_error& ex) {
+  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
     auto error = json::parse(ex.what());
     EXPECT_XNET_ERROR_CODE(GENERIC_NXSOCKET_ERROR, error);
     EXPECT_EQ(std::string("Unknown"), error.value("message", "default"));

--- a/source/tests/system/rfmx_macros.h
+++ b/source/tests/system/rfmx_macros.h
@@ -3,6 +3,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+
 #include <nlohmann/json.hpp>
 
 #define EXPECT_NO_ERROR_MESSAGE(session, response)                                                  \
@@ -49,7 +50,7 @@
     response_call_;                                                                 \
     EXPECT_FALSE(true);                                                             \
   }                                                                                 \
-  catch (const std::runtime_error& ex) {                                            \
+  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {        \
     EXPECT_STATUS_ERROR(expected_error_, ex.what());                                \
     EXPECT_THAT(error.value("message", ""), HasSubstr(message_substring_));         \
   }

--- a/source/tests/utilities/client_helpers.h
+++ b/source/tests/utilities/client_helpers.h
@@ -64,8 +64,10 @@ class grpc_driver_error : public std::runtime_error {
   grpc_driver_error(const std::string& message, ::grpc::StatusCode code, const std::multimap<grpc::string_ref, grpc::string_ref>& trailers)
       : std::runtime_error(message), code_(code)
   {
-    for (auto trailer : trailers) {
-      trailers_.emplace(trailer.first.data(), trailer.second.data());
+    for (const auto& trailer : trailers) {
+      trailers_.emplace(
+          std::string(trailer.first.data(), trailer.first.length()),
+          std::string(trailer.second.data(), trailer.second.length()));
     }
   }
   ::grpc::StatusCode StatusCode() const

--- a/source/tests/utilities/client_helpers.h
+++ b/source/tests/utilities/client_helpers.h
@@ -55,10 +55,34 @@ class simple_variant {
   int8_t slot_{-1};
 };
 
-inline void raise_if_error(const ::grpc::Status& status)
+class grpc_driver_error : public std::runtime_error {
+ private:
+  ::grpc::StatusCode code_;
+  std::multimap<std::string, std::string> trailers_;
+
+ public:
+  grpc_driver_error(const std::string& message, ::grpc::StatusCode code, const std::multimap<grpc::string_ref, grpc::string_ref>& trailers)
+      : std::runtime_error(message), code_(code)
+  {
+    for (auto trailer : trailers) {
+      trailers_.emplace(trailer.first.data(), trailer.second.data());
+    }
+  }
+  ::grpc::StatusCode StatusCode() const
+  {
+    return code_;
+  }
+  const std::multimap<std::string, std::string>& Trailers() const
+  {
+    return trailers_;
+  }
+};
+
+inline void
+raise_if_error(const ::grpc::Status& status, const ::grpc::ClientContext& context)
 {
   if (!status.ok()) {
-    throw std::runtime_error(status.error_message());
+    throw grpc_driver_error(status.error_message(), status.error_code(), context.GetServerTrailingMetadata());
   }
 }
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

The exception that the experimental client currently raises has only the message and nothing else. That makes it hard to glean other information about the error. This change makes it fairly similar to the C# exception, exposing the gRPC status code and trailer metadata as well.

This PR has no functional changes.

### Why should this Pull Request be merged?

I will likely make a follow-on change that returns the gRPC error number in the trailer rather than as JSON.

### What testing has been done?

Built locally and ensured unit tests still pass.