### PR TITLE
[Owners] Make IQFetchDataOverrideBehavior function's deleteOnFetch parameter an enum

### DIFF
--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted.proto
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted.proto
@@ -21,10 +21,10 @@ service NiRFmxSpecAnRestricted {
   rpc IQFetchDataOverrideBehavior(IQFetchDataOverrideBehaviorRequest) returns (IQFetchDataOverrideBehaviorResponse);
 }
 
-enum MXIQDeleteOnFetch {
-  MXIQ_DELETE_ON_FETCH_DEFAULT = 0;
-  MXIQ_DELETE_ON_FETCH_TRUE = 1;
-  MXIQ_DELETE_ON_FETCH_FALSE = 2;
+enum IQDeleteOnFetch {
+  IQ_DELETE_ON_FETCH_DEFAULT = 0;
+  IQ_DELETE_ON_FETCH_TRUE = 1;
+  IQ_DELETE_ON_FETCH_FALSE = 2;
 }
 
 message CacheResultRequest {
@@ -45,7 +45,7 @@ message IQFetchDataOverrideBehaviorRequest {
   int32 record_to_fetch = 4;
   int64 samples_to_read = 5;
   oneof delete_on_fetch_enum {
-    MXIQDeleteOnFetch delete_on_fetch = 6;
+    IQDeleteOnFetch delete_on_fetch = 6;
     int32 delete_on_fetch_raw = 7;
   }
 }

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted.proto
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted.proto
@@ -21,6 +21,12 @@ service NiRFmxSpecAnRestricted {
   rpc IQFetchDataOverrideBehavior(IQFetchDataOverrideBehaviorRequest) returns (IQFetchDataOverrideBehaviorResponse);
 }
 
+enum MXIQDeleteOnFetch {
+  MXIQ_DELETE_ON_FETCH_DEFAULT = 0;
+  MXIQ_DELETE_ON_FETCH_TRUE = 1;
+  MXIQ_DELETE_ON_FETCH_FALSE = 2;
+}
+
 message CacheResultRequest {
   nidevice_grpc.Session instrument = 1;
   string selector_string = 2;
@@ -38,7 +44,10 @@ message IQFetchDataOverrideBehaviorRequest {
   double timeout = 3;
   int32 record_to_fetch = 4;
   int64 samples_to_read = 5;
-  int32 delete_on_fetch = 6;
+  oneof delete_on_fetch_enum {
+    MXIQDeleteOnFetch delete_on_fetch = 6;
+    int32 delete_on_fetch_raw = 7;
+  }
 }
 
 message IQFetchDataOverrideBehaviorResponse {

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.cpp
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.cpp
@@ -37,7 +37,7 @@ cache_result(const StubPtr& stub, const nidevice_grpc::Session& instrument, cons
 }
 
 IQFetchDataOverrideBehaviorResponse
-iq_fetch_data_override_behavior(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const double& timeout, const pb::int32& record_to_fetch, const pb::int64& samples_to_read, const pb::int32& delete_on_fetch)
+iq_fetch_data_override_behavior(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const double& timeout, const pb::int32& record_to_fetch, const pb::int64& samples_to_read, const simple_variant<MXIQDeleteOnFetch, pb::int32>& delete_on_fetch)
 {
   ::grpc::ClientContext context;
 
@@ -47,7 +47,14 @@ iq_fetch_data_override_behavior(const StubPtr& stub, const nidevice_grpc::Sessio
   request.set_timeout(timeout);
   request.set_record_to_fetch(record_to_fetch);
   request.set_samples_to_read(samples_to_read);
-  request.set_delete_on_fetch(delete_on_fetch);
+  const auto delete_on_fetch_ptr = delete_on_fetch.get_if<MXIQDeleteOnFetch>();
+  const auto delete_on_fetch_raw_ptr = delete_on_fetch.get_if<pb::int32>();
+  if (delete_on_fetch_ptr) {
+    request.set_delete_on_fetch(*delete_on_fetch_ptr);
+  }
+  else if (delete_on_fetch_raw_ptr) {
+    request.set_delete_on_fetch_raw(*delete_on_fetch_raw_ptr);
+  }
 
   auto response = IQFetchDataOverrideBehaviorResponse{};
 

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.cpp
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.cpp
@@ -37,7 +37,7 @@ cache_result(const StubPtr& stub, const nidevice_grpc::Session& instrument, cons
 }
 
 IQFetchDataOverrideBehaviorResponse
-iq_fetch_data_override_behavior(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const double& timeout, const pb::int32& record_to_fetch, const pb::int64& samples_to_read, const simple_variant<MXIQDeleteOnFetch, pb::int32>& delete_on_fetch)
+iq_fetch_data_override_behavior(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const double& timeout, const pb::int32& record_to_fetch, const pb::int64& samples_to_read, const simple_variant<IQDeleteOnFetch, pb::int32>& delete_on_fetch)
 {
   ::grpc::ClientContext context;
 
@@ -47,7 +47,7 @@ iq_fetch_data_override_behavior(const StubPtr& stub, const nidevice_grpc::Sessio
   request.set_timeout(timeout);
   request.set_record_to_fetch(record_to_fetch);
   request.set_samples_to_read(samples_to_read);
-  const auto delete_on_fetch_ptr = delete_on_fetch.get_if<MXIQDeleteOnFetch>();
+  const auto delete_on_fetch_ptr = delete_on_fetch.get_if<IQDeleteOnFetch>();
   const auto delete_on_fetch_raw_ptr = delete_on_fetch.get_if<pb::int32>();
   if (delete_on_fetch_ptr) {
     request.set_delete_on_fetch(*delete_on_fetch_ptr);

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.h
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.h
@@ -23,7 +23,7 @@ using namespace nidevice_grpc::experimental::client;
 
 
 CacheResultResponse cache_result(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const pb::int32& selector_string_out_size);
-IQFetchDataOverrideBehaviorResponse iq_fetch_data_override_behavior(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const double& timeout, const pb::int32& record_to_fetch, const pb::int64& samples_to_read, const simple_variant<MXIQDeleteOnFetch, pb::int32>& delete_on_fetch);
+IQFetchDataOverrideBehaviorResponse iq_fetch_data_override_behavior(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const double& timeout, const pb::int32& record_to_fetch, const pb::int64& samples_to_read, const simple_variant<IQDeleteOnFetch, pb::int32>& delete_on_fetch);
 
 } // namespace nirfmxspecan_restricted_grpc::experimental::client
 

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.h
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.h
@@ -23,7 +23,7 @@ using namespace nidevice_grpc::experimental::client;
 
 
 CacheResultResponse cache_result(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const pb::int32& selector_string_out_size);
-IQFetchDataOverrideBehaviorResponse iq_fetch_data_override_behavior(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const double& timeout, const pb::int32& record_to_fetch, const pb::int64& samples_to_read, const pb::int32& delete_on_fetch);
+IQFetchDataOverrideBehaviorResponse iq_fetch_data_override_behavior(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string, const double& timeout, const pb::int32& record_to_fetch, const pb::int64& samples_to_read, const simple_variant<MXIQDeleteOnFetch, pb::int32>& delete_on_fetch);
 
 } // namespace nirfmxspecan_restricted_grpc::experimental::client
 

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_service.cpp
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_service.cpp
@@ -88,7 +88,22 @@ namespace nirfmxspecan_restricted_grpc {
       float64 timeout = request->timeout();
       int32 record_to_fetch = request->record_to_fetch();
       int64 samples_to_read = request->samples_to_read();
-      int32 delete_on_fetch = request->delete_on_fetch();
+      int32 delete_on_fetch;
+      switch (request->delete_on_fetch_enum_case()) {
+        case nirfmxspecan_restricted_grpc::IQFetchDataOverrideBehaviorRequest::DeleteOnFetchEnumCase::kDeleteOnFetch: {
+          delete_on_fetch = static_cast<int32>(request->delete_on_fetch());
+          break;
+        }
+        case nirfmxspecan_restricted_grpc::IQFetchDataOverrideBehaviorRequest::DeleteOnFetchEnumCase::kDeleteOnFetchRaw: {
+          delete_on_fetch = static_cast<int32>(request->delete_on_fetch_raw());
+          break;
+        }
+        case nirfmxspecan_restricted_grpc::IQFetchDataOverrideBehaviorRequest::DeleteOnFetchEnumCase::DELETE_ON_FETCH_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for delete_on_fetch was not specified or out of range");
+          break;
+        }
+      }
+
       float64 t0 {};
       float64 dt {};
       int32 actual_array_size {};

--- a/source/codegen/metadata/nirfmxspecan_restricted/enums.py
+++ b/source/codegen/metadata/nirfmxspecan_restricted/enums.py
@@ -1,5 +1,5 @@
 enums = {
-    'MXIQDeleteOnFetch': {
+    'IQDeleteOnFetch': {
         'values': [
             {
                 'name': 'DEFAULT',

--- a/source/codegen/metadata/nirfmxspecan_restricted/enums.py
+++ b/source/codegen/metadata/nirfmxspecan_restricted/enums.py
@@ -1,2 +1,18 @@
 enums = {
+    'MXIQDeleteOnFetch': {
+        'values': [
+            {
+                'name': 'DEFAULT',
+                'value': 0
+            },
+            {
+                'name': 'TRUE',
+                'value': 1
+            },
+            {
+                'name': 'FALSE',
+                'value': 2
+            }
+        ]
+    }
 }

--- a/source/codegen/metadata/nirfmxspecan_restricted/functions.py
+++ b/source/codegen/metadata/nirfmxspecan_restricted/functions.py
@@ -121,7 +121,7 @@ functions = {
             },
             {
                 'direction': 'in',
-                'enum': 'MXIQDeleteOnFetch',
+                'enum': 'IQDeleteOnFetch',
                 'name': 'deleteOnFetch',
                 'type': 'int32'
             },

--- a/source/codegen/metadata/nirfmxspecan_restricted/functions.py
+++ b/source/codegen/metadata/nirfmxspecan_restricted/functions.py
@@ -121,6 +121,7 @@ functions = {
             },
             {
                 'direction': 'in',
+                'enum': 'MXIQDeleteOnFetch',
                 'name': 'deleteOnFetch',
                 'type': 'int32'
             },


### PR DESCRIPTION
### What does this Pull Request accomplish?

Makes the `deleteOnFetch` parameter of `IQFetchDataOverrideBehavior` function an enumeration. This is based on the corresponding .NET API here:
https://p4.natinst.com/browser/perforce/RfProtocols/RFmx/SpecAn/DotNetSupport/Assembly/mx/trunk/19.0.1/source/Internal/RFmxSpecAnMXImpl.cs?revision_at=67619223#line_969
The enumeration in the .NET API can be found at:
https://p4.natinst.com/browser/perforce/RfProtocols/RFmx/SpecAn/DotNetSupport/Assembly/mx/trunk/19.0.1/source/RFmxSpecAnMXIQDeleteOnFetch.cs

### Why should this Pull Request be merged?

Making the parameter an enum makes it easier to call this API from the autogenerated RfmxSpecAn .NET client API.

### What testing has been done?

Built and ran the existing NiRFmxSpecAnRestrictedDriverApiTests automated tests that exercise this API and verified that they pass.
