### PR TITLE
Adds Restricted readiness levels to sever_configuration_parser

### DIFF
--- a/source/server/server_configuration_parser.cpp
+++ b/source/server/server_configuration_parser.cpp
@@ -180,8 +180,12 @@ FeatureToggles::CodeReadiness ServerConfigurationParser::parse_code_readiness() 
       using ReadinessMap = std::unordered_map<std::string, FeatureToggles::CodeReadiness>;
       const auto READINESS_MAP = ReadinessMap{
           {"release", FeatureToggles::CodeReadiness::kRelease},
+          {"restrictedrelease", FeatureToggles::CodeReadiness::kRestrictedRelease},
+          {"restricted_release", FeatureToggles::CodeReadiness::kRestrictedRelease},
           {"nextrelease", FeatureToggles::CodeReadiness::kNextRelease},
           {"next_release", FeatureToggles::CodeReadiness::kNextRelease},
+          {"restrictednextrelease", FeatureToggles::CodeReadiness::kRestrictedNextRelease},
+          {"restricted_next_release", FeatureToggles::CodeReadiness::kRestrictedNextRelease},
           {"incomplete", FeatureToggles::CodeReadiness::kIncomplete},
           {"prototype", FeatureToggles::CodeReadiness::kPrototype}};
 

--- a/source/server/server_configuration_parser.h
+++ b/source/server/server_configuration_parser.h
@@ -18,7 +18,7 @@ static const char* kFileNotFoundMessage = "The following certificate file was no
 static const char* kInvalidExePathMessage = "The server was unable to resolve the current executable path.";
 static const char* kInvalidMaxMessageSizeMessage = "The max message size must be an integer.";
 static const char* kInvalidFeatureToggleMessage = "Feature Toggles must be specified as boolean fields in the form \"feature_toggles\": { \"feature1\": true, \"feature2\": false }. \n\n";
-static const char* kInvalidCodeReadinessMessage = "code_readiness must be a string in [Release, NextRelease, Incomplete, Prototype].\n\n";
+static const char* kInvalidCodeReadinessMessage = "code_readiness must be a string in [Release, RestrictedRelease, NextRelease, RestrictedNextRelease, Incomplete, Prototype].\n\n";
 static const char* kDefaultAddressPrefix = "[::]:";
 constexpr int UNLIMITED_MAX_MESSAGE_SIZE = -1;
 

--- a/source/tests/unit/server_configuration_parser_tests.cpp
+++ b/source/tests/unit/server_configuration_parser_tests.cpp
@@ -361,7 +361,13 @@ TEST(ServerConfigurationParserTests, JsonConfigWithMissingRootCertFile_ParseRoot
   }
 }
 
-const auto ALL_READINESS = {CodeReadiness::kRelease, CodeReadiness::kNextRelease, CodeReadiness::kIncomplete, CodeReadiness::kPrototype};
+const auto ALL_READINESS = {
+    CodeReadiness::kRelease,
+    CodeReadiness::kRestrictedRelease,
+    CodeReadiness::kNextRelease,
+    CodeReadiness::kRestrictedNextRelease,
+    CodeReadiness::kIncomplete,
+    CodeReadiness::kPrototype};
 
 TEST(ServerConfigurationParserTests, JsonConfigWithEnabledFeature_ParseFeatureToggles_FeatureIsEnabled)
 {
@@ -551,6 +557,10 @@ INSTANTIATE_TEST_SUITE_P(
         {R"({"code_readiness": "Prototype"})", Readiness::kPrototype},
         {R"({"code_readiness": "prototype"})", Readiness::kPrototype},
         {R"({"code_readiness": "iNcOmPlete"})", Readiness::kIncomplete},
+        {R"({"code_readiness": "RestrictedRelease"})", Readiness::kRestrictedRelease},
+        {R"({"code_readiness": "restricted_Release"})", Readiness::kRestrictedRelease},
+        {R"({"code_readiness": "restricted_next_release"})", Readiness::kRestrictedNextRelease},
+        {R"({"code_readiness": "RestrictedNextRelease"})", Readiness::kRestrictedNextRelease},
     }));
 
 TEST_P(ServerConfigurationParserCodeReadinessTests, CodeReadinessConfiguration_ParseCodeReadiness_ReturnsExpectedReadiness)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add `RestrictedRelease` and `RestrictedNextRelease` `code_readiness` levels to the `server_configuration_parser`.

### Why should this Pull Request be merged?

This is how we want to enable `restricted` features in deployed servers without also enabling `Incomplete` or `NextRelease` features.

### What testing has been done?

Ran and passed included tests.
