### PR TITLE
Added GetSessionUniqueIdentifier method to NiRFmxInstrRestricted service

### DIFF
--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted.proto
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted.proto
@@ -37,6 +37,7 @@ service NiRFmxInstrRestricted {
   rpc GetOpenSessionsInformation(GetOpenSessionsInformationRequest) returns (GetOpenSessionsInformationResponse);
   rpc GetPrivilegeLevel(GetPrivilegeLevelRequest) returns (GetPrivilegeLevelResponse);
   rpc GetRFmxVersion(GetRFmxVersionRequest) returns (GetRFmxVersionResponse);
+  rpc GetSessionUniqueIdentifier(GetSessionUniqueIdentifierRequest) returns (GetSessionUniqueIdentifierResponse);
   rpc GetSignalConfigurationState64(GetSignalConfigurationState64Request) returns (GetSignalConfigurationState64Response);
   rpc GetSnapshotState(GetSnapshotStateRequest) returns (GetSnapshotStateResponse);
   rpc GetTracesInfoForMonitorSnapshot(GetTracesInfoForMonitorSnapshotRequest) returns (GetTracesInfoForMonitorSnapshotResponse);
@@ -289,6 +290,16 @@ message GetRFmxVersionRequest {
 message GetRFmxVersionResponse {
   int32 status = 1;
   string version = 2;
+}
+
+message GetSessionUniqueIdentifierRequest {
+  string resource_names = 1;
+  string option_string = 2;
+}
+
+message GetSessionUniqueIdentifierResponse {
+  int32 status = 1;
+  string session_unique_identifier = 2;
 }
 
 message GetSignalConfigurationState64Request {

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.cpp
@@ -404,6 +404,24 @@ get_r_fmx_version(const StubPtr& stub, const nidevice_grpc::Session& instrument)
   return response;
 }
 
+GetSessionUniqueIdentifierResponse
+get_session_unique_identifier(const StubPtr& stub, const pb::string& resource_names, const pb::string& option_string)
+{
+  ::grpc::ClientContext context;
+
+  auto request = GetSessionUniqueIdentifierRequest{};
+  request.set_resource_names(resource_names);
+  request.set_option_string(option_string);
+
+  auto response = GetSessionUniqueIdentifierResponse{};
+
+  raise_if_error(
+      stub->GetSessionUniqueIdentifier(&context, request, &response),
+      context);
+
+  return response;
+}
+
 GetSignalConfigurationState64Response
 get_signal_configuration_state64(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& signal_name, const pb::uint32& signal_type)
 {

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.h
@@ -43,6 +43,7 @@ GetLatestConfigurationSnapshotResponse get_latest_configuration_snapshot(const S
 GetOpenSessionsInformationResponse get_open_sessions_information(const StubPtr& stub, const pb::string& resource_name);
 GetPrivilegeLevelResponse get_privilege_level(const StubPtr& stub, const nidevice_grpc::Session& instrument);
 GetRFmxVersionResponse get_r_fmx_version(const StubPtr& stub, const nidevice_grpc::Session& instrument);
+GetSessionUniqueIdentifierResponse get_session_unique_identifier(const StubPtr& stub, const pb::string& resource_names, const pb::string& option_string);
 GetSignalConfigurationState64Response get_signal_configuration_state64(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& signal_name, const pb::uint32& signal_type);
 GetSnapshotStateResponse get_snapshot_state(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::int32& personality, const pb::string& selector_string);
 GetTracesInfoForMonitorSnapshotResponse get_traces_info_for_monitor_snapshot(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::string& selector_string);

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.cpp
@@ -44,6 +44,7 @@ NiRFmxInstrRestrictedLibrary::NiRFmxInstrRestrictedLibrary() : shared_library_(k
   function_pointers_.GetOpenSessionsInformation = reinterpret_cast<GetOpenSessionsInformationPtr>(shared_library_.get_function_pointer("RFmxInstr_GetOpenSessionsInformation"));
   function_pointers_.GetPrivilegeLevel = reinterpret_cast<GetPrivilegeLevelPtr>(shared_library_.get_function_pointer("RFmxInstr_GetPrivilegeLevel"));
   function_pointers_.GetRFmxVersion = reinterpret_cast<GetRFmxVersionPtr>(shared_library_.get_function_pointer("RFmxInstr_GetRFmxVersion"));
+  function_pointers_.GetSessionUniqueIdentifier = reinterpret_cast<GetSessionUniqueIdentifierPtr>(shared_library_.get_function_pointer("RFmxInstr_GetSessionUniqueIdentifier"));
   function_pointers_.GetSignalConfigurationState64 = reinterpret_cast<GetSignalConfigurationState64Ptr>(shared_library_.get_function_pointer("RFmxInstr_GetSignalConfigurationState64"));
   function_pointers_.GetSnapshotState = reinterpret_cast<GetSnapshotStatePtr>(shared_library_.get_function_pointer("RFmxInstr_GetSnapshotState"));
   function_pointers_.GetTracesInfoForMonitorSnapshot = reinterpret_cast<GetTracesInfoForMonitorSnapshotPtr>(shared_library_.get_function_pointer("RFmxInstr_GetTracesInfoForMonitorSnapshot"));
@@ -251,6 +252,14 @@ int32 NiRFmxInstrRestrictedLibrary::GetRFmxVersion(niRFmxInstrHandle instrumentH
     throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_GetRFmxVersion.");
   }
   return function_pointers_.GetRFmxVersion(instrumentHandle, arraySize, RFmxVersion);
+}
+
+int32 NiRFmxInstrRestrictedLibrary::GetSessionUniqueIdentifier(char resourceNames[], char optionString[], int32 sessionUniqueIdentifierSize, char sessionUniqueIdentifier[])
+{
+  if (!function_pointers_.GetSessionUniqueIdentifier) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_GetSessionUniqueIdentifier.");
+  }
+  return function_pointers_.GetSessionUniqueIdentifier(resourceNames, optionString, sessionUniqueIdentifierSize, sessionUniqueIdentifier);
 }
 
 int32 NiRFmxInstrRestrictedLibrary::GetSignalConfigurationState64(niRFmxInstrHandle instrumentHandle, char signalName[], uInt32 signalType, int32* signalState, uInt64* timeStamp)

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.h
@@ -41,6 +41,7 @@ class NiRFmxInstrRestrictedLibrary : public nirfmxinstr_restricted_grpc::NiRFmxI
   int32 GetOpenSessionsInformation(char resourceName[], int32 infoJsonSize, char infoJson[]);
   int32 GetPrivilegeLevel(niRFmxInstrHandle instrumentHandle, int32* isConnectionAlive, int32* privilegeLevel);
   int32 GetRFmxVersion(niRFmxInstrHandle instrumentHandle, int32 arraySize, char RFmxVersion[]);
+  int32 GetSessionUniqueIdentifier(char resourceNames[], char optionString[], int32 sessionUniqueIdentifierSize, char sessionUniqueIdentifier[]);
   int32 GetSignalConfigurationState64(niRFmxInstrHandle instrumentHandle, char signalName[], uInt32 signalType, int32* signalState, uInt64* timeStamp);
   int32 GetSnapshotState(niRFmxInstrHandle instrumentHandle, int32 personality, char selectorString[], int32* snapshotState);
   int32 GetTracesInfoForMonitorSnapshot(niRFmxInstrHandle instrumentHandle, char selectorString[], int32* allTracesEnabled);
@@ -78,6 +79,7 @@ class NiRFmxInstrRestrictedLibrary : public nirfmxinstr_restricted_grpc::NiRFmxI
   using GetOpenSessionsInformationPtr = int32 (*)(char resourceName[], int32 infoJsonSize, char infoJson[]);
   using GetPrivilegeLevelPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, int32* isConnectionAlive, int32* privilegeLevel);
   using GetRFmxVersionPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, int32 arraySize, char RFmxVersion[]);
+  using GetSessionUniqueIdentifierPtr = int32 (*)(char resourceNames[], char optionString[], int32 sessionUniqueIdentifierSize, char sessionUniqueIdentifier[]);
   using GetSignalConfigurationState64Ptr = int32 (*)(niRFmxInstrHandle instrumentHandle, char signalName[], uInt32 signalType, int32* signalState, uInt64* timeStamp);
   using GetSnapshotStatePtr = int32 (*)(niRFmxInstrHandle instrumentHandle, int32 personality, char selectorString[], int32* snapshotState);
   using GetTracesInfoForMonitorSnapshotPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], int32* allTracesEnabled);
@@ -115,6 +117,7 @@ class NiRFmxInstrRestrictedLibrary : public nirfmxinstr_restricted_grpc::NiRFmxI
     GetOpenSessionsInformationPtr GetOpenSessionsInformation;
     GetPrivilegeLevelPtr GetPrivilegeLevel;
     GetRFmxVersionPtr GetRFmxVersion;
+    GetSessionUniqueIdentifierPtr GetSessionUniqueIdentifier;
     GetSignalConfigurationState64Ptr GetSignalConfigurationState64;
     GetSnapshotStatePtr GetSnapshotState;
     GetTracesInfoForMonitorSnapshotPtr GetTracesInfoForMonitorSnapshot;

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library_interface.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library_interface.h
@@ -38,6 +38,7 @@ class NiRFmxInstrRestrictedLibraryInterface {
   virtual int32 GetOpenSessionsInformation(char resourceName[], int32 infoJsonSize, char infoJson[]) = 0;
   virtual int32 GetPrivilegeLevel(niRFmxInstrHandle instrumentHandle, int32* isConnectionAlive, int32* privilegeLevel) = 0;
   virtual int32 GetRFmxVersion(niRFmxInstrHandle instrumentHandle, int32 arraySize, char RFmxVersion[]) = 0;
+  virtual int32 GetSessionUniqueIdentifier(char resourceNames[], char optionString[], int32 sessionUniqueIdentifierSize, char sessionUniqueIdentifier[]) = 0;
   virtual int32 GetSignalConfigurationState64(niRFmxInstrHandle instrumentHandle, char signalName[], uInt32 signalType, int32* signalState, uInt64* timeStamp) = 0;
   virtual int32 GetSnapshotState(niRFmxInstrHandle instrumentHandle, int32 personality, char selectorString[], int32* snapshotState) = 0;
   virtual int32 GetTracesInfoForMonitorSnapshot(niRFmxInstrHandle instrumentHandle, char selectorString[], int32* allTracesEnabled) = 0;

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_mock_library.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_mock_library.h
@@ -40,6 +40,7 @@ class NiRFmxInstrRestrictedMockLibrary : public nirfmxinstr_restricted_grpc::NiR
   MOCK_METHOD(int32, GetOpenSessionsInformation, (char resourceName[], int32 infoJsonSize, char infoJson[]), (override));
   MOCK_METHOD(int32, GetPrivilegeLevel, (niRFmxInstrHandle instrumentHandle, int32* isConnectionAlive, int32* privilegeLevel), (override));
   MOCK_METHOD(int32, GetRFmxVersion, (niRFmxInstrHandle instrumentHandle, int32 arraySize, char RFmxVersion[]), (override));
+  MOCK_METHOD(int32, GetSessionUniqueIdentifier, (char resourceNames[], char optionString[], int32 sessionUniqueIdentifierSize, char sessionUniqueIdentifier[]), (override));
   MOCK_METHOD(int32, GetSignalConfigurationState64, (niRFmxInstrHandle instrumentHandle, char signalName[], uInt32 signalType, int32* signalState, uInt64* timeStamp), (override));
   MOCK_METHOD(int32, GetSnapshotState, (niRFmxInstrHandle instrumentHandle, int32 personality, char selectorString[], int32* snapshotState), (override));
   MOCK_METHOD(int32, GetTracesInfoForMonitorSnapshot, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32* allTracesEnabled), (override));

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
@@ -811,6 +811,47 @@ namespace nirfmxinstr_restricted_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxInstrRestrictedService::GetSessionUniqueIdentifier(::grpc::ServerContext* context, const GetSessionUniqueIdentifierRequest* request, GetSessionUniqueIdentifierResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      char* resource_names = (char*)request->resource_names().c_str();
+      char* option_string = (char*)request->option_string().c_str();
+
+      while (true) {
+        auto status = library_->GetSessionUniqueIdentifier(resource_names, option_string, 0, nullptr);
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
+        }
+        int32 session_unique_identifier_size = status;
+
+        std::string session_unique_identifier;
+        if (session_unique_identifier_size > 0) {
+            session_unique_identifier.resize(session_unique_identifier_size - 1);
+        }
+        status = library_->GetSessionUniqueIdentifier(resource_names, option_string, session_unique_identifier_size, (char*)session_unique_identifier.data());
+        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(session_unique_identifier_size)) {
+          // buffer is now too small, try again
+          continue;
+        }
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForNiRFmxInstrHandle(status, 0);
+        }
+        response->set_status(status);
+        response->set_session_unique_identifier(session_unique_identifier);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_session_unique_identifier()));
+        return ::grpc::Status::OK;
+      }
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiRFmxInstrRestrictedService::GetSignalConfigurationState64(::grpc::ServerContext* context, const GetSignalConfigurationState64Request* request, GetSignalConfigurationState64Response* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.h
@@ -62,6 +62,7 @@ public:
   ::grpc::Status GetOpenSessionsInformation(::grpc::ServerContext* context, const GetOpenSessionsInformationRequest* request, GetOpenSessionsInformationResponse* response) override;
   ::grpc::Status GetPrivilegeLevel(::grpc::ServerContext* context, const GetPrivilegeLevelRequest* request, GetPrivilegeLevelResponse* response) override;
   ::grpc::Status GetRFmxVersion(::grpc::ServerContext* context, const GetRFmxVersionRequest* request, GetRFmxVersionResponse* response) override;
+  ::grpc::Status GetSessionUniqueIdentifier(::grpc::ServerContext* context, const GetSessionUniqueIdentifierRequest* request, GetSessionUniqueIdentifierResponse* response) override;
   ::grpc::Status GetSignalConfigurationState64(::grpc::ServerContext* context, const GetSignalConfigurationState64Request* request, GetSignalConfigurationState64Response* response) override;
   ::grpc::Status GetSnapshotState(::grpc::ServerContext* context, const GetSnapshotStateRequest* request, GetSnapshotStateResponse* response) override;
   ::grpc::Status GetTracesInfoForMonitorSnapshot(::grpc::ServerContext* context, const GetTracesInfoForMonitorSnapshotRequest* request, GetTracesInfoForMonitorSnapshotResponse* response) override;

--- a/source/codegen/metadata/nirfmxinstr_restricted/functions.py
+++ b/source/codegen/metadata/nirfmxinstr_restricted/functions.py
@@ -806,6 +806,35 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'GetSessionUniqueIdentifier': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'resourceNames',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'optionString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'sessionUniqueIdentifierSize',
+                'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'name': 'sessionUniqueIdentifier',
+                'size': {
+                    'mechanism': 'ivi-dance',
+                    'value': 'sessionUniqueIdentifierSize'
+                },
+                'type': 'char[]'
+            }
+        ],
+        'returns': 'int32'
+    },
     'GetSignalConfigurationState64': {
         'parameters': [
             {


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds support for GetSessionUniqueIdentifier method to NiRFmxInstrRestricted service.

### Why should this Pull Request be merged?

The equivalent C entrypoint RFmxInstr_GetSessionUniqueIdentifier is used by the .NET API implementation during session lookup and creation.

### What testing has been done?

Installed local Windows server build on a PXI chassis and successfully called the method from a .NET assembly that includes client support generated from nirfmxinstr_restricted.proto.
