### PR TITLE
Fix warning checks in success and error cases in nidaqmx examples.

### DIFF
--- a/examples/nidaqmx/analog-input-every-n-samples.py
+++ b/examples/nidaqmx/analog-input-every-n-samples.py
@@ -165,6 +165,8 @@ async def _main():
                     pass
 
             await asyncio.gather(read_data(), wait_for_done())
+            stop_task_response = await client.StopTask(nidaqmx_types.StopTaskRequest(task=task))
+            check_for_warning(stop_task_response)
 
         except grpc.RpcError as rpc_error:
             error_message = rpc_error.details()
@@ -181,10 +183,7 @@ async def _main():
             print(f"{error_message}")
         finally:
             if client and task:
-                clear_task_response = await client.ClearTask(
-                    nidaqmx_types.ClearTaskRequest(task=task)
-                )
-                check_for_warning(clear_task_response)
+                await client.ClearTask(nidaqmx_types.ClearTaskRequest(task=task))
 
 
 ## Run main

--- a/examples/nidaqmx/analog-input-every-n-samples.py
+++ b/examples/nidaqmx/analog-input-every-n-samples.py
@@ -62,7 +62,7 @@ async def _main():
                         nidaqmx_types.GetErrorStringRequest(error_code=response.status)
                     )
                     sys.stderr.write(
-                        f"{warning_message.error_message}\nWarning status: {response.status}\n"
+                        f"{warning_message.error_string}\nWarning status: {response.status}\n"
                     )
 
             create_response: nidaqmx_types.CreateTaskResponse = await client.CreateTask(

--- a/examples/nidaqmx/analog-input.py
+++ b/examples/nidaqmx/analog-input.py
@@ -106,6 +106,9 @@ try:
             timeout=10.0,
         )
     )
+
+    stop_task_response = client.StopTask(nidaqmx_types.StopTaskRequest(task=task))
+    check_for_warning(stop_task_response)
     print(
         f"Acquired {len(response.read_array)} samples",
         f"({response.samps_per_chan_read} samples per channel)",
@@ -125,5 +128,4 @@ except grpc.RpcError as rpc_error:
     print(f"{error_message}")
 finally:
     if task:
-        clear_task_response = client.ClearTask(nidaqmx_types.ClearTaskRequest(task=task))
-        check_for_warning(clear_task_response)
+        client.ClearTask(nidaqmx_types.ClearTaskRequest(task=task))

--- a/examples/nidaqmx/analog-input.py
+++ b/examples/nidaqmx/analog-input.py
@@ -57,7 +57,7 @@ def check_for_warning(response):
         warning_message = client.GetErrorString(
             nidaqmx_types.GetErrorStringRequest(error_code=response.status)
         )
-        sys.stderr.write(f"{warning_message.error_message}\nWarning status: {response.status}\n")
+        sys.stderr.write(f"{warning_message.error_string}\nWarning status: {response.status}\n")
 
 
 try:

--- a/examples/nidaqmx/analog-output.py
+++ b/examples/nidaqmx/analog-output.py
@@ -56,7 +56,7 @@ def check_for_warning(response):
         warning_message = client.GetErrorString(
             nidaqmx_types.GetErrorStringRequest(error_code=response.status)
         )
-        sys.stderr.write(f"{warning_message.error_message}\nWarning status: {response.status}\n")
+        sys.stderr.write(f"{warning_message.error_string}\nWarning status: {response.status}\n")
 
 
 try:

--- a/examples/nidaqmx/analog-output.py
+++ b/examples/nidaqmx/analog-output.py
@@ -87,6 +87,8 @@ try:
     )
     check_for_warning(write_response)
 
+    stop_task_response = client.StopTask(nidaqmx_types.StopTaskRequest(task=task))
+    check_for_warning(stop_task_response)
     print(f"Output was successfully written to {PHYSICAL_CHANNEL}.")
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
@@ -103,5 +105,4 @@ except grpc.RpcError as rpc_error:
     print(f"{error_message}")
 finally:
     if task:
-        clear_task_response = client.ClearTask(nidaqmx_types.ClearTaskRequest(task=task))
-        check_for_warning(clear_task_response)
+        client.ClearTask(nidaqmx_types.ClearTaskRequest(task=task))

--- a/examples/nidaqmx/counter-input.py
+++ b/examples/nidaqmx/counter-input.py
@@ -84,6 +84,9 @@ try:
         nidaqmx_types.ReadCounterScalarF64Request(task=task, timeout=10.0)
     )
     check_for_warning(response)
+
+    stop_task_response = client.StopTask(nidaqmx_types.StopTaskRequest(task=task))
+    check_for_warning(stop_task_response)
     print(f"Frequency: {response.value} Hz")
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
@@ -100,5 +103,4 @@ except grpc.RpcError as rpc_error:
     print(f"{error_message}")
 finally:
     if task:
-        clear_task_response = client.ClearTask(nidaqmx_types.ClearTaskRequest(task=task))
-        check_for_warning(clear_task_response)
+        client.ClearTask(nidaqmx_types.ClearTaskRequest(task=task))

--- a/examples/nidaqmx/counter-input.py
+++ b/examples/nidaqmx/counter-input.py
@@ -56,7 +56,7 @@ def check_for_warning(response):
         warning_message = client.GetErrorString(
             nidaqmx_types.GetErrorStringRequest(error_code=response.status)
         )
-        sys.stderr.write(f"{warning_message.error_message}\nWarning status: {response.status}\n")
+        sys.stderr.write(f"{warning_message.error_string}\nWarning status: {response.status}\n")
 
 
 try:

--- a/examples/nidaqmx/counter-output.py
+++ b/examples/nidaqmx/counter-output.py
@@ -56,7 +56,7 @@ def check_for_warning(response):
         warning_message = client.GetErrorString(
             nidaqmx_types.GetErrorStringRequest(error_code=response.status)
         )
-        sys.stderr.write(f"{warning_message.error_message}\nWarning status: {response.status}\n")
+        sys.stderr.write(f"{warning_message.error_string}\nWarning status: {response.status}\n")
 
 
 try:

--- a/examples/nidaqmx/counter-output.py
+++ b/examples/nidaqmx/counter-output.py
@@ -83,6 +83,8 @@ try:
     )
     check_for_warning(wait_until_task_done_response)
 
+    stop_task_response = client.StopTask(nidaqmx_types.StopTaskRequest(task=task))
+    check_for_warning(stop_task_response)
     print(f"Output was successfully written to {COUNTER_NAME}.")
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
@@ -99,5 +101,4 @@ except grpc.RpcError as rpc_error:
     print(f"{error_message}")
 finally:
     if task:
-        clear_task_response = client.ClearTask(nidaqmx_types.ClearTaskRequest(task=task))
-        check_for_warning(clear_task_response)
+        client.ClearTask(nidaqmx_types.ClearTaskRequest(task=task))

--- a/examples/nidaqmx/digital-input.py
+++ b/examples/nidaqmx/digital-input.py
@@ -56,7 +56,7 @@ def check_for_warning(response):
         warning_message = client.GetErrorString(
             nidaqmx_types.GetErrorStringRequest(error_code=response.status)
         )
-        sys.stderr.write(f"{warning_message.error_message}\nWarning status: {response.status}\n")
+        sys.stderr.write(f"{warning_message.error_string}\nWarning status: {response.status}\n")
 
 
 try:

--- a/examples/nidaqmx/digital-input.py
+++ b/examples/nidaqmx/digital-input.py
@@ -82,6 +82,9 @@ try:
         )
     )
     check_for_warning(response)
+
+    stop_task_response = client.StopTask(nidaqmx_types.StopTaskRequest(task=task))
+    check_for_warning(stop_task_response)
     print(f"Data acquired: {hex(response.read_array[0])}")
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
@@ -98,5 +101,4 @@ except grpc.RpcError as rpc_error:
     print(f"{error_message}")
 finally:
     if task:
-        clear_task_response = client.ClearTask(nidaqmx_types.ClearTaskRequest(task=task))
-        check_for_warning(clear_task_response)
+        client.ClearTask(nidaqmx_types.ClearTaskRequest(task=task))

--- a/examples/nidaqmx/digital-output.py
+++ b/examples/nidaqmx/digital-output.py
@@ -56,7 +56,7 @@ def check_for_warning(response):
         warning_message = client.GetErrorString(
             nidaqmx_types.GetErrorStringRequest(error_code=response.status)
         )
-        sys.stderr.write(f"{warning_message.error_message}\nWarning status: {response.status}\n")
+        sys.stderr.write(f"{warning_message.error_string}\nWarning status: {response.status}\n")
 
 
 try:

--- a/examples/nidaqmx/digital-output.py
+++ b/examples/nidaqmx/digital-output.py
@@ -84,6 +84,8 @@ try:
     )
     check_for_warning(response)
 
+    stop_task_response = client.StopTask(nidaqmx_types.StopTaskRequest(task=task))
+    check_for_warning(stop_task_response)
     print(f"Output was successfully written to {LINES}.")
 except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
@@ -100,5 +102,4 @@ except grpc.RpcError as rpc_error:
     print(f"{error_message}")
 finally:
     if task:
-        clear_task_response = client.ClearTask(nidaqmx_types.ClearTaskRequest(task=task))
-        check_for_warning(clear_task_response)
+        client.ClearTask(nidaqmx_types.ClearTaskRequest(task=task))

--- a/examples/nidaqmx/dsa-shared-timebase-and-trig-analog-input-and-output.py
+++ b/examples/nidaqmx/dsa-shared-timebase-and-trig-analog-input-and-output.py
@@ -116,7 +116,7 @@ def check_for_warning(response):
         warning_message = client.GetErrorString(
             nidaqmx_types.GetErrorStringRequest(error_code=response.status)
         )
-        sys.stderr.write(f"{warning_message.error_message}\nWarning status: {response.status}\n")
+        sys.stderr.write(f"{warning_message.error_string}\nWarning status: {response.status}\n")
 
 
 async def _main():

--- a/examples/nidaqmx/dsa-shared-timebase-and-trig-analog-input-and-output.py
+++ b/examples/nidaqmx/dsa-shared-timebase-and-trig-analog-input-and-output.py
@@ -508,6 +508,14 @@ async def _main():
                 wait_for_done(stream) for stream in done_event_stream_list
             ]
             await asyncio.gather(*tasks)
+            stop_task_response = await client.StopTask(nidaqmx_types.StopTaskRequest(task=leader_input_task))
+            check_for_warning(stop_task_response)
+            stop_task_response = await client.StopTask(nidaqmx_types.StopTaskRequest(task=leader_output_task))
+            check_for_warning(stop_task_response)
+            stop_task_response = await client.StopTask(nidaqmx_types.StopTaskRequest(task=follower_input_task))
+            check_for_warning(stop_task_response)
+            stop_task_response = await client.StopTask(nidaqmx_types.StopTaskRequest(task=follower_output_task))
+            check_for_warning(stop_task_response)
 
         except grpc.RpcError as rpc_error:
             error_message = rpc_error.details()
@@ -531,28 +539,16 @@ async def _cleanup():
     global leader_input_task, leader_output_task, follower_input_task, follower_output_task
     if client:
         if leader_input_task:
-            clear_task_response = await client.ClearTask(
-                nidaqmx_types.ClearTaskRequest(task=leader_input_task)
-            )
-            check_for_warning(clear_task_response)
+            await client.ClearTask(nidaqmx_types.ClearTaskRequest(task=leader_input_task))
             leader_input_task = None
         if leader_output_task:
-            clear_task_response = await client.ClearTask(
-                nidaqmx_types.ClearTaskRequest(task=leader_output_task)
-            )
-            check_for_warning(clear_task_response)
+            await client.ClearTask(nidaqmx_types.ClearTaskRequest(task=leader_output_task))
             leader_output_task = None
         if follower_input_task:
-            clear_task_response = await client.ClearTask(
-                nidaqmx_types.ClearTaskRequest(task=follower_input_task)
-            )
-            check_for_warning(clear_task_response)
+            await client.ClearTask(nidaqmx_types.ClearTaskRequest(task=follower_input_task))
             follower_input_task = None
         if follower_output_task:
-            clear_task_response = await client.ClearTask(
-                nidaqmx_types.ClearTaskRequest(task=follower_output_task)
-            )
-            check_for_warning(clear_task_response)
+            await client.ClearTask(nidaqmx_types.ClearTaskRequest(task=follower_output_task))
             follower_output_task = None
 
 

--- a/examples/nidaqmx/dsa-shared-timebase-and-trig-analog-input-and-output.py
+++ b/examples/nidaqmx/dsa-shared-timebase-and-trig-analog-input-and-output.py
@@ -508,13 +508,21 @@ async def _main():
                 wait_for_done(stream) for stream in done_event_stream_list
             ]
             await asyncio.gather(*tasks)
-            stop_task_response = await client.StopTask(nidaqmx_types.StopTaskRequest(task=leader_input_task))
+            stop_task_response = await client.StopTask(
+                nidaqmx_types.StopTaskRequest(task=leader_input_task)
+            )
             check_for_warning(stop_task_response)
-            stop_task_response = await client.StopTask(nidaqmx_types.StopTaskRequest(task=leader_output_task))
+            stop_task_response = await client.StopTask(
+                nidaqmx_types.StopTaskRequest(task=leader_output_task)
+            )
             check_for_warning(stop_task_response)
-            stop_task_response = await client.StopTask(nidaqmx_types.StopTaskRequest(task=follower_input_task))
+            stop_task_response = await client.StopTask(
+                nidaqmx_types.StopTaskRequest(task=follower_input_task)
+            )
             check_for_warning(stop_task_response)
-            stop_task_response = await client.StopTask(nidaqmx_types.StopTaskRequest(task=follower_output_task))
+            stop_task_response = await client.StopTask(
+                nidaqmx_types.StopTaskRequest(task=follower_output_task)
+            )
             check_for_warning(stop_task_response)
 
         except grpc.RpcError as rpc_error:


### PR DESCRIPTION
### What does this Pull Request accomplish?

This pull request addresses a problem that @bkeryan pointed out after the recent submission of [#718: Update nidaqmx example error handling.](https://github.com/ni/grpc-device/pull/718) `ClearTask()` does not report warnings, so we shouldn't be checking for warnings when clearing tasks in the `finally` clauses. We should, however, call `StopTask()` in the success cases, since that function reports warnings that we can check for. `ClearTask()` is sufficient for the error cases.

### Why should this Pull Request be merged?

We should merge this pull request so that any warnings that `StopTask()` might return are caught when the examples are run.

### What testing has been done?

Builds locally. The examples all show the expected error code and description when run with an incorrect device handle:

```
PS C:\dev\grpc-device\examples\nidaqmx> py analog-input.py localhost 31763 dev1
Device identifier is invalid.
Device Specified: empty string
Suggested Device(s): PXI1Slot2

Task Name: my task

Status Code: -200220
Error status: -200220
PS C:\dev\grpc-device\examples\nidaqmx> py analog-input-every-n-samples.py localhost 31763 dev1
Device identifier is invalid.
Device Specified: empty string
Suggested Device(s): PXI1Slot2

Task Name: _unnamedTask<0>

Status Code: -200220
Error status: -200220
PS C:\dev\grpc-device\examples\nidaqmx> py analog-output.py localhost 31763 dev1
Device identifier is invalid.
Device Specified: empty string
Suggested Device(s): PXI1Slot2

Task Name: my task

Status Code: -200220
Error status: -200220
PS C:\dev\grpc-device\examples\nidaqmx> py counter-input.py localhost 31763 dev1
Device identifier is invalid.
Device Specified: empty string
Suggested Device(s): PXI1Slot2

Task Name: my task

Status Code: -200220
Error status: -200220
PS C:\dev\grpc-device\examples\nidaqmx> py counter-output.py localhost 31763 dev1
Device identifier is invalid.
Device Specified: empty string
Suggested Device(s): PXI1Slot2

Task Name: my task

Status Code: -200220
Error status: -200220
PS C:\dev\grpc-device\examples\nidaqmx> py digital-input.py localhost 31763 dev1
Physical channel specified does not exist on this device.
Refer to the documentation for channels available on this device.
Physical Channel Name: dev1

Task Name: my task

Status Code: -200170
Error status: -200170
PS C:\dev\grpc-device\examples\nidaqmx> py digital-output.py localhost 31763 dev1
Physical channel specified does not exist on this device.
Refer to the documentation for channels available on this device.
Physical Channel Name: dev1

Task Name: my task

Status Code: -200170
Error status: -200170
PS C:\dev\grpc-device\examples\nidaqmx> py dsa-shared-timebase-and-trig-analog-input-and-output.py localhost 31763 dev1
Device identifier is invalid.
Device Specified: dev1
Suggested Device(s): PXI1Slot2

Task Name: Leader input task

Status Code: -200220
Error status: -200220
PS C:\dev\grpc-device\examples\nidaqmx>
```
