### PR TITLE
Fix pipeline names.

### DIFF
--- a/.github/workflows/trigger_azdo_ci.yml
+++ b/.github/workflows/trigger_azdo_ci.yml
@@ -17,7 +17,7 @@ jobs:
       if: ${{ github.repository == 'ni/grpc-device' && github.ref == 'refs/heads/main' }}
       with:
         azure-devops-project-url: 'https://dev.azure.com/ni/DevCentral'
-        azure-pipeline-name: 'ni-central-grpc-device-main-desktop'
+        azure-pipeline-name: 'ni-central-grpc_device-main-desktop'
         azure-devops-token: ${{ secrets.AZDO_PIPELINE_TRIGGERS }}
 
     - name: Trigger Release CI
@@ -25,7 +25,7 @@ jobs:
       if: ${{ github.repository == 'ni/grpc-device' && startsWith(github.ref, 'refs/heads/releases') }}
       with:
         azure-devops-project-url: 'https://dev.azure.com/ni/DevCentral'
-        azure-pipeline-name: 'ni-central-grpc-device-release-desktop'
+        azure-pipeline-name: 'ni-central-grpc_device-release-desktop'
         azure-devops-token: ${{ secrets.AZDO_PIPELINE_TRIGGERS }}
 
     - name: Trigger Main CI
@@ -33,7 +33,7 @@ jobs:
       if: ${{ github.repository == 'ni/grpc-device' && github.ref == 'refs/heads/main' }}
       with:
         azure-devops-project-url: 'https://dev.azure.com/ni/DevCentral'
-        azure-pipeline-name: 'ni-central-grpc-device-main-linux-rt'
+        azure-pipeline-name: 'ni-central-grpc_device-main-linux-rt'
         azure-devops-token: ${{ secrets.AZDO_PIPELINE_TRIGGERS }}
 
     - name: Trigger Release CI
@@ -41,5 +41,5 @@ jobs:
       if: ${{ github.repository == 'ni/grpc-device' && startsWith(github.ref, 'refs/heads/releases') }}
       with:
         azure-devops-project-url: 'https://dev.azure.com/ni/DevCentral'
-        azure-pipeline-name: 'ni-central-grpc-device-release-linux-rt'
+        azure-pipeline-name: 'ni-central-grpc_device-release-linux-rt'
         azure-devops-token: ${{ secrets.AZDO_PIPELINE_TRIGGERS }}


### PR DESCRIPTION
### What does this Pull Request accomplish?
Fixed AzDo pipeline names.

### Why should this Pull Request be merged?
Currently our main/release CI pipelines are not running on AzDo. 

From @davidcorrigan714:
The token looks valid. The pipeline that workflow is triggering looks to be “ni-central-grpc-device-main-desktop” which doesn’t exist. Looks like someone may have changed a dash to an underscore in the name.

### What testing has been done?
TBD