### PR TITLE
Fix nimxlcTerminalAdaptor_restricted system test failure

### DIFF
--- a/source/tests/system/nimxlcterminaladaptor_restricted_driver_api_tests.cpp
+++ b/source/tests/system/nimxlcterminaladaptor_restricted_driver_api_tests.cpp
@@ -14,8 +14,6 @@ namespace tests {
 namespace system {
 namespace {
 
-constexpr auto DEFAULT_HOSTNAME = "localhost";
-
 class NiMxLcTerminalAdaptorRestrictedDriverApiTests : public Test {
  protected:
   NiMxLcTerminalAdaptorRestrictedDriverApiTests()

--- a/source/tests/system/nimxlcterminaladaptor_restricted_driver_api_tests.cpp
+++ b/source/tests/system/nimxlcterminaladaptor_restricted_driver_api_tests.cpp
@@ -48,18 +48,13 @@ class NiMxLcTerminalAdaptorRestrictedDriverApiTests : public Test {
   std::unique_ptr<NimxlcTerminalAdaptorRestricted::Stub> nimxlcterminaladaptor_stub_;
 };
 
-nidevice_grpc::Session init_session(const client::StubPtr& stub, const std::string& hostname)
+nidevice_grpc::Session init_session(const client::StubPtr& stub)
 {
-  auto response = client::create_session(stub, hostname.c_str());
+  auto response = client::create_session(stub, "");
   EXPECT_EQ(0, response.status());
   EXPECT_EQ(0, response.c_status().code());
   auto session = response.handle();
   return session;
-}
-
-nidevice_grpc::Session init_session(const client::StubPtr& stub)
-{
-  return init_session(stub, DEFAULT_HOSTNAME);
 }
 
 TEST_F(NiMxLcTerminalAdaptorRestrictedDriverApiTests, RefreshedTerminalCache_GetDeviceContainer_StatusOK)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Remove the hostname passed to the nimxlcTerminalAdaptor create session call from the system test, since the intention is for mxlcCore to look for devices on the localhost.

### Why should this Pull Request be merged?

This fixes a failing system test.

### What testing has been done?

Run Windows system test workflow.
