### PR TITLE
Added 'strlen-bug' tag to RFmx GetOpenSessionsInformation metadata

### DIFF
--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
@@ -721,7 +721,7 @@ namespace nirfmxinstr_restricted_grpc {
 
         std::string info_json;
         if (info_json_size > 0) {
-            info_json.resize(info_json_size - 1);
+            info_json.resize(info_json_size /* Workaround: strlen-bug */);
         }
         status = library_->GetOpenSessionsInformation(resource_name, info_json_size, (char*)info_json.data());
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(info_json_size)) {

--- a/source/codegen/metadata/nirfmxinstr_restricted/functions.py
+++ b/source/codegen/metadata/nirfmxinstr_restricted/functions.py
@@ -752,6 +752,9 @@ functions = {
                 'name': 'infoJson',
                 'size': {
                     'mechanism': 'ivi-dance',
+                    'tags': [
+                        'strlen-bug'
+                    ],
                     'value': 'infoJsonSize'
                 },
                 'type': 'char[]'


### PR DESCRIPTION
### What does this Pull Request accomplish?
Add the 'strlen-bug' tag to GetOpenSessionsInformation in nirfmxinstr_restricted metadata.

### Why should this Pull Request be merged?
Previously, calling GetOpenSessionsInformation and passing the JSON string returned in the response message to a JSON parser would fail because it was not returning the closing curly brace.  This PR makes the GetOpenSessionsInformation method return the entire JSON string.

### What testing has been done?
Built and ran debug server on machine with RF hardware.  Was able to call method and successfully parse JSON returned in the response.