### PR TITLE
nidaqmx-gRPC Local Thread Memory (GetExtendedErrorInfo)

### DIFF
--- a/generated/nidaqmx/nidaqmx.proto
+++ b/generated/nidaqmx/nidaqmx.proto
@@ -179,7 +179,6 @@ service NiDAQmx {
   rpc GetExportedSignalAttributeInt32(GetExportedSignalAttributeInt32Request) returns (GetExportedSignalAttributeInt32Response);
   rpc GetExportedSignalAttributeString(GetExportedSignalAttributeStringRequest) returns (GetExportedSignalAttributeStringResponse);
   rpc GetExportedSignalAttributeUInt32(GetExportedSignalAttributeUInt32Request) returns (GetExportedSignalAttributeUInt32Response);
-  rpc GetExtendedErrorInfo(GetExtendedErrorInfoRequest) returns (GetExtendedErrorInfoResponse);
   rpc GetFirstSampClkWhen(GetFirstSampClkWhenRequest) returns (GetFirstSampClkWhenResponse);
   rpc GetFirstSampTimestampVal(GetFirstSampTimestampValRequest) returns (GetFirstSampTimestampValResponse);
   rpc GetNthTaskChannel(GetNthTaskChannelRequest) returns (GetNthTaskChannelResponse);
@@ -7248,14 +7247,6 @@ message GetExportedSignalAttributeUInt32Request {
 message GetExportedSignalAttributeUInt32Response {
   int32 status = 1;
   uint32 value = 2;
-}
-
-message GetExtendedErrorInfoRequest {
-}
-
-message GetExtendedErrorInfoResponse {
-  int32 status = 1;
-  string error_string = 2;
 }
 
 message GetFirstSampClkWhenRequest {

--- a/generated/nidaqmx/nidaqmx_client.cpp
+++ b/generated/nidaqmx/nidaqmx_client.cpp
@@ -5453,22 +5453,6 @@ get_exported_signal_attribute_uint32(const StubPtr& stub, const nidevice_grpc::S
   return response;
 }
 
-GetExtendedErrorInfoResponse
-get_extended_error_info(const StubPtr& stub)
-{
-  ::grpc::ClientContext context;
-
-  auto request = GetExtendedErrorInfoRequest{};
-
-  auto response = GetExtendedErrorInfoResponse{};
-
-  raise_if_error(
-      stub->GetExtendedErrorInfo(&context, request, &response),
-      context);
-
-  return response;
-}
-
 GetFirstSampClkWhenResponse
 get_first_samp_clk_when(const StubPtr& stub, const nidevice_grpc::Session& task)
 {

--- a/generated/nidaqmx/nidaqmx_client.h
+++ b/generated/nidaqmx/nidaqmx_client.h
@@ -184,7 +184,6 @@ GetExportedSignalAttributeDoubleResponse get_exported_signal_attribute_double(co
 GetExportedSignalAttributeInt32Response get_exported_signal_attribute_int32(const StubPtr& stub, const nidevice_grpc::Session& task, const simple_variant<ExportSignalInt32Attribute, pb::int32>& attribute);
 GetExportedSignalAttributeStringResponse get_exported_signal_attribute_string(const StubPtr& stub, const nidevice_grpc::Session& task, const simple_variant<ExportSignalStringAttribute, pb::int32>& attribute);
 GetExportedSignalAttributeUInt32Response get_exported_signal_attribute_uint32(const StubPtr& stub, const nidevice_grpc::Session& task, const simple_variant<ExportSignalUInt32Attribute, pb::int32>& attribute);
-GetExtendedErrorInfoResponse get_extended_error_info(const StubPtr& stub);
 GetFirstSampClkWhenResponse get_first_samp_clk_when(const StubPtr& stub, const nidevice_grpc::Session& task);
 GetFirstSampTimestampValResponse get_first_samp_timestamp_val(const StubPtr& stub, const nidevice_grpc::Session& task);
 GetNthTaskChannelResponse get_nth_task_channel(const StubPtr& stub, const nidevice_grpc::Session& task, const pb::uint32& index);

--- a/generated/nidaqmx/nidaqmx_library.cpp
+++ b/generated/nidaqmx/nidaqmx_library.cpp
@@ -2369,11 +2369,7 @@ int32 NiDAQmxLibrary::GetExtendedErrorInfo(char errorString[], uInt32 bufferSize
   if (!function_pointers_.GetExtendedErrorInfo) {
     throw nidevice_grpc::LibraryLoadException("Could not find DAQmxGetExtendedErrorInfo.");
   }
-#if defined(_MSC_VER)
-  return DAQmxGetExtendedErrorInfo(errorString, bufferSize);
-#else
   return function_pointers_.GetExtendedErrorInfo(errorString, bufferSize);
-#endif
 }
 
 int32 NiDAQmxLibrary::GetFirstSampClkWhen(TaskHandle task, CVIAbsoluteTime* data)

--- a/generated/nidaqmx/nidaqmx_library.h
+++ b/generated/nidaqmx/nidaqmx_library.h
@@ -568,7 +568,7 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   using GetExportedSignalAttributeInt32Ptr = decltype(&DAQmxGetExportedSignalAttribute);
   using GetExportedSignalAttributeStringPtr = decltype(&DAQmxGetExportedSignalAttribute);
   using GetExportedSignalAttributeUInt32Ptr = decltype(&DAQmxGetExportedSignalAttribute);
-  using GetExtendedErrorInfoPtr = decltype(&DAQmxGetExtendedErrorInfo);
+  using GetExtendedErrorInfoPtr = int32 (*)(char errorString[], uInt32 bufferSize);
   using GetFirstSampClkWhenPtr = decltype(&DAQmxGetFirstSampClkWhen);
   using GetFirstSampTimestampValPtr = decltype(&DAQmxGetFirstSampTimestampVal);
   using GetNthTaskChannelPtr = decltype(&DAQmxGetNthTaskChannel);

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -8984,45 +8984,6 @@ namespace nidaqmx_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiDAQmxService::GetExtendedErrorInfo(::grpc::ServerContext* context, const GetExtendedErrorInfoRequest* request, GetExtendedErrorInfoResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-
-      while (true) {
-        auto status = library_->GetExtendedErrorInfo(nullptr, 0);
-        if (!status_ok(status)) {
-          return ConvertApiErrorStatusForTaskHandle(context, status, 0);
-        }
-        uInt32 buffer_size = status;
-
-        std::string error_string;
-        if (buffer_size > 0) {
-            error_string.resize(buffer_size - 1);
-        }
-        status = library_->GetExtendedErrorInfo((char*)error_string.data(), buffer_size);
-        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(buffer_size)) {
-          // buffer is now too small, try again
-          continue;
-        }
-        if (!status_ok(status)) {
-          return ConvertApiErrorStatusForTaskHandle(context, status, 0);
-        }
-        response->set_status(status);
-        response->set_error_string(error_string);
-        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_string()));
-        return ::grpc::Status::OK;
-      }
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiDAQmxService::GetFirstSampClkWhen(::grpc::ServerContext* context, const GetFirstSampClkWhenRequest* request, GetFirstSampClkWhenResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nidaqmx/nidaqmx_service.h
+++ b/generated/nidaqmx/nidaqmx_service.h
@@ -204,7 +204,6 @@ public:
   ::grpc::Status GetExportedSignalAttributeInt32(::grpc::ServerContext* context, const GetExportedSignalAttributeInt32Request* request, GetExportedSignalAttributeInt32Response* response) override;
   ::grpc::Status GetExportedSignalAttributeString(::grpc::ServerContext* context, const GetExportedSignalAttributeStringRequest* request, GetExportedSignalAttributeStringResponse* response) override;
   ::grpc::Status GetExportedSignalAttributeUInt32(::grpc::ServerContext* context, const GetExportedSignalAttributeUInt32Request* request, GetExportedSignalAttributeUInt32Response* response) override;
-  ::grpc::Status GetExtendedErrorInfo(::grpc::ServerContext* context, const GetExtendedErrorInfoRequest* request, GetExtendedErrorInfoResponse* response) override;
   ::grpc::Status GetFirstSampClkWhen(::grpc::ServerContext* context, const GetFirstSampClkWhenRequest* request, GetFirstSampClkWhenResponse* response) override;
   ::grpc::Status GetFirstSampTimestampVal(::grpc::ServerContext* context, const GetFirstSampTimestampValRequest* request, GetFirstSampTimestampValResponse* response) override;
   ::grpc::Status GetNthTaskChannel(::grpc::ServerContext* context, const GetNthTaskChannelRequest* request, GetNthTaskChannelResponse* response) override;

--- a/source/codegen/metadata/nidaqmx/functions.py
+++ b/source/codegen/metadata/nidaqmx/functions.py
@@ -6909,6 +6909,7 @@ functions = {
         'returns': 'int32'
     },
     'GetExtendedErrorInfo': {
+        'codegen_method': 'private',
         'parameters': [
             {
                 'direction': 'out',


### PR DESCRIPTION
### What does this Pull Request accomplish?
This Pull Request acts on the Issue 684 (https://github.com/ni/grpc-device/issues/684) removing the use of GetExtendedErrorInfo to get errors as they use thread local storage and instead utilizing grpc error codes.

### Breaking changes

-  GetExtendedErrorInfo: In (source/codegen/metadata/nidaqmx/functions.py) Changed codegen method from 'public' to 'private' thus removing use within services and clients .cpp files.
- nidaqmx.proto: Removes generated method creating a breaking change for the GetExtendedErrorInfo method.
- Error message retrieval: When a call is made that fails, the gRPC status object now includes the error message.

### Why should this Pull Request be merged?
This should be merged to make GetExtendedErrorInfo unusable by the users as it will generate unwanted error responses.

### What testing has been done?
Local builds have been done to ensure building is functional and testing of getting a error locally was done as well.
[AB#2085088](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2085088)
