### PR TITLE
Users/jscholtz/version

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Setup python3
       uses: actions/setup-python@v2

--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
     - name: Checkout Repo
       uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Setup python3
       uses: actions/setup-python@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,14 +21,22 @@ if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
 else(EXISTS "${CMAKE_SOURCE_DIR}/.git")
-  set(GIT_TAG "")
+  set(GIT_TAG "v0.0.0")
 endif(EXISTS "${CMAKE_SOURCE_DIR}/.git")
 
 message(STATUS "Parsing Git tag ${GIT_TAG}.")
 
-string(REGEX REPLACE "^v([0-9]+)\\..*" "\\1" GIT_TAG_MAJOR "${GIT_TAG}")
-string(REGEX REPLACE "^v[0-9]+\\.([0-9]+).*" "\\1" GIT_TAG_MINOR "${GIT_TAG}")
-string(REGEX REPLACE "^v[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" GIT_TAG_PATCH "${GIT_TAG}")
+if(GIT_TAG MATCHES "^v([0-9]+)\\.([0-9]+)\\.?([0-9]+)?")
+  set(GIT_TAG_MAJOR ${CMAKE_MATCH_1})
+  set(GIT_TAG_MINOR ${CMAKE_MATCH_2})
+  if(CMAKE_MATCH_3)
+    set(GIT_TAG_PATCH ${CMAKE_MATCH_3})
+  else()
+    set(GIT_TAG_PATCH "0")
+  endif()
+else()
+  message(FATAL_ERROR "Unable to parse Git tag. Tag must contain major and minor version with optional patch. e.g. \"v1.33.7\"")
+endif()
 
 #----------------------------------------------------------------------
 # Use the grpc targets directly from this build, only when not cross-compiling.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.12.0)
 
-
-
 project(ni_grpc_device_server VERSION 1.5.2.0 LANGUAGES C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.12.0)
 
-project(ni_grpc_device_server C CXX)
+
+
+project(ni_grpc_device_server VERSION 1.2.3.4 LANGUAGES C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(CreateVirtualEnvironment)
@@ -39,11 +41,11 @@ else()
 endif()
 
 CreateVirtualEnvironment(virtual_environment
-  REQUIREMENTS_TXT 
+  REQUIREMENTS_TXT
     ${CMAKE_SOURCE_DIR}/python_build_requirements.txt
   ENV_NAME
     venv
-  OUT_PYTHON_EXE 
+  OUT_PYTHON_EXE
     PYTHON_EXE
 )
 
@@ -101,12 +103,12 @@ set(codegen_scripts
   "${codegen_dir}/templates/proto.mako"
   "${codegen_dir}/templates/proto_helpers.mako"
   "${codegen_dir}/templates/register_all_services.h.mako"
-  "${codegen_dir}/templates/register_all_services.cpp.mako"  
+  "${codegen_dir}/templates/register_all_services.cpp.mako"
   "${codegen_dir}/templates/service.cpp.mako"
   "${codegen_dir}/templates/service_helpers.mako"
   "${codegen_dir}/templates/service.h.mako"
   "${codegen_dir}/templates/service_registrar.h.mako"
-  "${codegen_dir}/templates/service_registrar.cpp.mako"  
+  "${codegen_dir}/templates/service_registrar.cpp.mako"
   )
 
 # Populated in the api loop below.
@@ -177,16 +179,16 @@ foreach(api ${nidrivers})
 endforeach()
 
 add_custom_command(
-  OUTPUT 
+  OUTPUT
     ${service_output_dir}/register_all_services.cpp
     ${service_output_dir}/register_all_services.h
-  COMMAND 
+  COMMAND
     ${PYTHON_EXE} ${codegen_dir}/generate_shared_service_files.py ${metadata_dir}/ -o ${service_output_dir}/
-  COMMENT 
+  COMMENT
     "Generating shared service files"
   DEPENDS
     ${all_codegen_dependencies}
-    ${codegen_scripts} 
+    ${codegen_scripts}
     virtual_environment
 )
 
@@ -240,9 +242,9 @@ GenerateGrpcSources(
   PROTO
     ${session_proto}
   OUTPUT
-    "${session_proto_srcs}" 
-    "${session_proto_hdrs}" 
-    "${session_grpc_srcs}" 
+    "${session_proto_srcs}"
+    "${session_proto_hdrs}"
+    "${session_grpc_srcs}"
     "${session_grpc_hdrs}"
 )
 
@@ -290,6 +292,21 @@ add_executable(ni_grpc_device_server
    ${session_proto_srcs}
    ${session_grpc_srcs}
    ${nidriver_service_srcs})
+
+if(WIN32)
+  set(version_generated_dir "${CMAKE_CURRENT_BINARY_DIR}/version")
+  file(MAKE_DIRECTORY ${version_generated_dir})
+
+  # Generate version resource file for Windows
+  configure_file(
+    source/server/version.rc.in
+    ${version_generated_dir}/version.rc
+    @ONLY)
+
+  target_sources(ni_grpc_device_server
+    PRIVATE "${version_generated_dir}/version.rc"
+  )
+endif()
 
 if(CMAKE_SYSTEM_NAME STREQUAL Linux)
   target_sources(ni_grpc_device_server
@@ -428,7 +445,7 @@ add_executable(UnitTestsRunner
     "${custom_dir}/nixnet_service.custom.cpp"
 )
 
-# ni_fake_service_tests.cpp and several DAQ cpp files exceed the MSVC limit for the number of sections 
+# ni_fake_service_tests.cpp and several DAQ cpp files exceed the MSVC limit for the number of sections
 # in an obj file defined by PE-COFF. This line disables the limit.
 if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /D_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING")
@@ -503,7 +520,7 @@ set(system_test_runner_sources
 
 if(WIN32)
   list(
-    APPEND 
+    APPEND
       system_test_runner_sources
         "source/tests/system/nimxlcterminaladaptor_restricted_driver_api_tests.cpp"
         "source/tests/system/nirfmxbluetooth_driver_api_tests.cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12.0)
 
 
 
-project(ni_grpc_device_server VERSION 1.2.3.4 LANGUAGES C CXX)
+project(ni_grpc_device_server VERSION 1.5.2.0 LANGUAGES C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(CreateVirtualEnvironment)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12.0)
 
-project(ni_grpc_device_server VERSION 1.5.2.0 LANGUAGES C CXX)
+project(ni_grpc_device_server C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(CreateVirtualEnvironment)
@@ -9,6 +9,26 @@ include(CreateVirtualEnvironment)
 if (CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
   set(CMAKE_SYSTEM_PROCESSOR "amd64")
 endif()
+
+#----------------------------------------------------------------------
+# Determine version using current branch Git tag (e.g. v1.5.2)
+#----------------------------------------------------------------------
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+  execute_process(
+    COMMAND git describe --tags
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE GIT_TAG
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+else(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+  set(GIT_TAG "")
+endif(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+
+message(STATUS "Parsing Git tag ${GIT_TAG}.")
+
+string(REGEX REPLACE "^v([0-9]+)\\..*" "\\1" GIT_TAG_MAJOR "${GIT_TAG}")
+string(REGEX REPLACE "^v[0-9]+\\.([0-9]+).*" "\\1" GIT_TAG_MINOR "${GIT_TAG}")
+string(REGEX REPLACE "^v[0-9]+\\.[0-9]+\\.([0-9]+).*" "\\1" GIT_TAG_PATCH "${GIT_TAG}")
 
 #----------------------------------------------------------------------
 # Use the grpc targets directly from this build, only when not cross-compiling.

--- a/source/server/version.rc.in
+++ b/source/server/version.rc.in
@@ -35,7 +35,7 @@ BEGIN
             VALUE "FileDescription", ""
             VALUE "FileVersion", "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@.@PROJECT_VERSION_TWEAK@"
             VALUE "InternalName", ""
-            VALUE "LegalCopyright", "Copyright (C) 2022"
+            VALUE "LegalCopyright", "Copyright (C) 2021 - 2022"
             VALUE "OriginalFilename", "ni_grpc_device_server.exe"
             VALUE "ProductName", "NI gRPC Device Server"
             VALUE "ProductVersion", "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@"

--- a/source/server/version.rc.in
+++ b/source/server/version.rc.in
@@ -1,0 +1,48 @@
+#if defined(__MINGW64__) || defined(__MINGW32__)
+    // MinGW-w64, MinGW
+    #if defined(__has_include) && __has_include(<winres.h>)
+        #include <winres.h>
+    #else
+        #include <afxres.h>
+        #include <winresrc.h>
+    #endif
+#else
+    // MSVC, Windows SDK
+    #include <winres.h>
+#endif
+
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+#pragma code_page(1252)
+
+VS_VERSION_INFO VERSIONINFO
+    FILEVERSION @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@,@PROJECT_VERSION_TWEAK@
+    PRODUCTVERSION @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,0,0
+    FILEFLAGSMASK 0x3fL
+#ifdef _DEBUG
+    FILEFLAGS 0x1L
+#else
+    FILEFLAGS 0x0L
+#endif
+    FILEOS 0x40004L
+    FILETYPE 0x1L
+    FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904b0"
+        BEGIN
+            VALUE "CompanyName", "NI"
+            VALUE "FileDescription", ""
+            VALUE "FileVersion", "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@.@PROJECT_VERSION_TWEAK@"
+            VALUE "InternalName", ""
+            VALUE "LegalCopyright", "Copyright (C) 2022"
+            VALUE "OriginalFilename", "ni_grpc_device_server.exe"
+            VALUE "ProductName", "NI gRPC Device Server"
+            VALUE "ProductVersion", "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END

--- a/source/server/version.rc.in
+++ b/source/server/version.rc.in
@@ -15,8 +15,8 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 #pragma code_page(1252)
 
 VS_VERSION_INFO VERSIONINFO
-    FILEVERSION @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@,@PROJECT_VERSION_TWEAK@
-    PRODUCTVERSION @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,0,0
+    FILEVERSION @GIT_TAG_MAJOR@,@GIT_TAG_MINOR@,@GIT_TAG_PATCH@,0
+    PRODUCTVERSION @GIT_TAG_MAJOR@,@GIT_TAG_MINOR@,0,0
     FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
     FILEFLAGS 0x1L
@@ -33,12 +33,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "NI"
             VALUE "FileDescription", ""
-            VALUE "FileVersion", "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@.@PROJECT_VERSION_TWEAK@"
+            VALUE "FileVersion", "@GIT_TAG_MAJOR@.@GIT_TAG_MINOR@.@GIT_TAG_PATCH@.0"
             VALUE "InternalName", ""
             VALUE "LegalCopyright", "Copyright (C) 2021 - 2022"
             VALUE "OriginalFilename", "ni_grpc_device_server.exe"
             VALUE "ProductName", "NI gRPC Device Server"
-            VALUE "ProductVersion", "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@"
+            VALUE "ProductVersion", "@GIT_TAG_MAJOR@.@GIT_TAG_MINOR@"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
### What does this Pull Request accomplish?
Add version resource file for gRPC Device Server (Windows). This adds version and product information to file properties. The version information is parsed from `git describe --tags` command and is used to generate the version.rc file at build time.

### Why should this Pull Request be merged?
Currently we have no easy way to distinguish different version of the Windows executable downloaded from release artifacts. This will add some traceability of file version.

### What testing has been done?
Building dev branch locally. Right click on file and review properties.
![image](https://user-images.githubusercontent.com/4081815/194384620-70d81c9a-c528-4e7c-a855-1936fda1bd2c.png)


