### PR TITLE
Import ni-fake metadata from hapigen export.

### DIFF
--- a/generated/nifake/nifake.proto
+++ b/generated/nifake/nifake.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-FAKE API metadata version 1.2.0d9
+// This file is generated from NI-FAKE API metadata version 23.0.0
 //---------------------------------------------------------------------
 // Proto file for the NI-FAKE Metadata
 //---------------------------------------------------------------------
@@ -22,8 +22,10 @@ service NiFake {
   rpc AcceptViUInt32Array(AcceptViUInt32ArrayRequest) returns (AcceptViUInt32ArrayResponse);
   rpc BoolArrayInputFunction(BoolArrayInputFunctionRequest) returns (BoolArrayInputFunctionResponse);
   rpc BoolArrayOutputFunction(BoolArrayOutputFunctionRequest) returns (BoolArrayOutputFunctionResponse);
+  rpc Close(CloseRequest) returns (CloseResponse);
   rpc CloseExtCal(CloseExtCalRequest) returns (CloseExtCalResponse);
   rpc CommandWithReservedParam(CommandWithReservedParamRequest) returns (CommandWithReservedParamResponse);
+  rpc Control4022(Control4022Request) returns (Control4022Response);
   rpc CreateConfigurationList(CreateConfigurationListRequest) returns (CreateConfigurationListResponse);
   rpc DoubleAllTheNums(DoubleAllTheNumsRequest) returns (DoubleAllTheNumsResponse);
   rpc EnumArrayOutputFunction(EnumArrayOutputFunctionRequest) returns (EnumArrayOutputFunctionResponse);
@@ -62,6 +64,12 @@ service NiFake {
   rpc InitExtCal(InitExtCalRequest) returns (InitExtCalResponse);
   rpc InitWithOptions(InitWithOptionsRequest) returns (InitWithOptionsResponse);
   rpc InitWithVarArgs(InitWithVarArgsRequest) returns (InitWithVarArgsResponse);
+  rpc MethodUsingEnumWithGrpcNameValues(MethodUsingEnumWithGrpcNameValuesRequest) returns (MethodUsingEnumWithGrpcNameValuesResponse);
+  rpc MethodUsingWholeAndFractionalNumbers(MethodUsingWholeAndFractionalNumbersRequest) returns (MethodUsingWholeAndFractionalNumbersResponse);
+  rpc MethodUsingWholeMappedNumbers(MethodUsingWholeMappedNumbersRequest) returns (MethodUsingWholeMappedNumbersResponse);
+  rpc MethodWithGetLastErrorParam(MethodWithGetLastErrorParamRequest) returns (MethodWithGetLastErrorParamResponse);
+  rpc MethodWithGrpcFieldNumber(MethodWithGrpcFieldNumberRequest) returns (MethodWithGrpcFieldNumberResponse);
+  rpc MethodWithGrpcOnlyParam(MethodWithGrpcOnlyParamRequest) returns (MethodWithGrpcOnlyParamResponse);
   rpc MultipleArrayTypes(MultipleArrayTypesRequest) returns (MultipleArrayTypesResponse);
   rpc MultipleArraysSameSize(MultipleArraysSameSizeRequest) returns (MultipleArraysSameSizeResponse);
   rpc MultipleArraysSameSizeWithOptional(MultipleArraysSameSizeWithOptionalRequest) returns (MultipleArraysSameSizeWithOptionalResponse);
@@ -86,7 +94,6 @@ service NiFake {
   rpc ViUInt8ArrayInputFunction(ViUInt8ArrayInputFunctionRequest) returns (ViUInt8ArrayInputFunctionResponse);
   rpc ViUInt8ArrayOutputFunction(ViUInt8ArrayOutputFunctionRequest) returns (ViUInt8ArrayOutputFunctionResponse);
   rpc WriteWaveform(WriteWaveformRequest) returns (WriteWaveformResponse);
-  rpc Close(CloseRequest) returns (CloseResponse);
 }
 
 enum NiFakeAttribute {
@@ -96,7 +103,7 @@ enum NiFakeAttribute {
   NIFAKE_ATTRIBUTE_READ_WRITE_STRING = 1000002;
   NIFAKE_ATTRIBUTE_READ_WRITE_COLOR = 1000003;
   NIFAKE_ATTRIBUTE_READ_WRITE_INTEGER = 1000004;
-  NIFAKE_ATTRIBUTE_FLOAT_ENUM = 1000005;
+  NIFAKE_ATTRIBUTE_FLOAT_ENUM_NAME_OVERRIDE = 1000005;
   NIFAKE_ATTRIBUTE_READ_WRITE_INT64 = 1000006;
   NIFAKE_ATTRIBUTE_READ_WRITE_DOUBLE_WITH_CONVERTER = 1000007;
   NIFAKE_ATTRIBUTE_READ_WRITE_INTEGER_WITH_CONVERTER = 1000008;
@@ -112,12 +119,34 @@ enum Bitfield {
   BITFIELD_FLAG_D = 8;
 }
 
-enum Color {
-  COLOR_UNSPECIFIED = 0;
-  COLOR_RED = 1;
-  COLOR_BLUE = 2;
-  COLOR_YELLOW = 5;
-  COLOR_BLACK = 42;
+enum DecimalMixedNumber {
+  DECIMAL_MIXED_NUMBER_UNSPECIFIED = 0;
+  DECIMAL_MIXED_NUMBER_TWENTY_TWO = 1;
+  DECIMAL_MIXED_NUMBER_TWO_POINT_TWO = 2;
+  DECIMAL_MIXED_NUMBER_NEGATIVE_THREE = 3;
+  DECIMAL_MIXED_NUMBER_MAX_INT_32 = 4;
+  DECIMAL_MIXED_NUMBER_MAX_INT_32_PLUS_ONE = 5;
+  DECIMAL_MIXED_NUMBER_MIN_INT_32 = 6;
+  DECIMAL_MIXED_NUMBER_MIN_INT_32_MINUS_ONE = 7;
+}
+
+enum DecimalWholeNumber {
+  DECIMAL_WHOLE_NUMBER_ZERO = 0;
+  DECIMAL_WHOLE_NUMBER_NEGATIVE_ONE = -1;
+  DECIMAL_WHOLE_NUMBER_TWENTY_TWO = 22;
+}
+
+enum DecimalWholeNumberMapped {
+  DECIMAL_WHOLE_NUMBER_MAPPED_UNSPECIFIED = 0;
+  DECIMAL_WHOLE_NUMBER_MAPPED_ZERO = 1;
+  DECIMAL_WHOLE_NUMBER_MAPPED_NEGATIVE_ONE = 2;
+  DECIMAL_WHOLE_NUMBER_MAPPED_TWENTY_TWO = 3;
+}
+
+enum EnumWithGrpcNameValues {
+  ENUM_WITH_GRPC_NAME_VALUES_UNSPECIFIED = 0;
+  ENUM_WITH_GRPC_NAME_VALUES_ALTERED_GRPC_NAME_ONE = 1;
+  ENUM_WITH_GRPC_NAME_VALUES_TWO = 2;
 }
 
 enum FloatEnum {
@@ -129,6 +158,14 @@ enum FloatEnum {
   FLOAT_ENUM_SEVEN_POINT_FIVE = 5;
 }
 
+enum GrpcColorOverride {
+  GRPC_COLOR_OVERRIDE_UNSPECIFIED = 0;
+  GRPC_COLOR_OVERRIDE_RED = 1;
+  GRPC_COLOR_OVERRIDE_BLUE = 2;
+  GRPC_COLOR_OVERRIDE_YELLOW = 5;
+  GRPC_COLOR_OVERRIDE_BLACK = 42;
+}
+
 enum MobileOSNames {
   MOBILE_OS_NAMES_UNSPECIFIED = 0;
   MOBILE_OS_NAMES_ANDROID = 1;
@@ -138,10 +175,10 @@ enum MobileOSNames {
 
 enum NiFakeInt32AttributeValues {
   NIFAKE_INT32_UNSPECIFIED = 0;
-  NIFAKE_INT32_COLOR_RED = 1;
-  NIFAKE_INT32_COLOR_BLUE = 2;
-  NIFAKE_INT32_COLOR_YELLOW = 5;
-  NIFAKE_INT32_COLOR_BLACK = 42;
+  NIFAKE_INT32_GRPC_COLOR_OVERRIDE_RED = 1;
+  NIFAKE_INT32_GRPC_COLOR_OVERRIDE_BLUE = 2;
+  NIFAKE_INT32_GRPC_COLOR_OVERRIDE_YELLOW = 5;
+  NIFAKE_INT32_GRPC_COLOR_OVERRIDE_BLACK = 42;
 }
 
 enum NiFakeReal64AttributeValuesMapped {
@@ -163,6 +200,10 @@ enum Turtle {
 message FakeCustomStruct {
   sint32 struct_int = 1;
   double struct_double = 2;
+}
+
+message CustomNamedType {
+  string string_arg = 1;
 }
 
 message StringAndTurtle {
@@ -225,6 +266,14 @@ message BoolArrayOutputFunctionResponse {
   repeated bool an_array = 2;
 }
 
+message CloseRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message CloseResponse {
+  int32 status = 1;
+}
+
 message CloseExtCalRequest {
   nidevice_grpc.Session vi = 1;
   sint32 action = 2;
@@ -239,6 +288,15 @@ message CommandWithReservedParamRequest {
 }
 
 message CommandWithReservedParamResponse {
+  int32 status = 1;
+}
+
+message Control4022Request {
+  string resource_name = 1;
+  sint32 configuration = 2;
+}
+
+message Control4022Response {
   int32 status = 1;
 }
 
@@ -379,11 +437,12 @@ message GetAnIviDanceWithATwistByteArrayResponse {
 }
 
 message GetAnIviDanceWithATwistStringRequest {
+  nidevice_grpc.Session vi = 1;
 }
 
 message GetAnIviDanceWithATwistStringResponse {
   int32 status = 1;
-  string array_out = 2;
+  string a_string = 2;
   sint32 actual_size = 3;
 }
 
@@ -421,7 +480,7 @@ message GetArrayViUInt8WithEnumRequest {
 
 message GetArrayViUInt8WithEnumResponse {
   int32 status = 1;
-  repeated Color u_int8_enum_array = 2;
+  repeated GrpcColorOverride u_int8_enum_array = 2;
   bytes u_int8_enum_array_raw = 3;
 }
 
@@ -471,12 +530,13 @@ message GetAttributeViReal64Response {
 
 message GetAttributeViSessionRequest {
   nidevice_grpc.Session vi = 1;
-  sint32 attribute_id = 2;
+  string channel_name = 2;
+  NiFakeAttribute attribute_id = 3;
 }
 
 message GetAttributeViSessionResponse {
   int32 status = 1;
-  nidevice_grpc.Session session_out = 2;
+  nidevice_grpc.Session attribute_value = 2;
 }
 
 message GetAttributeViStringRequest {
@@ -623,6 +683,62 @@ message InitWithVarArgsRequest {
 message InitWithVarArgsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+}
+
+message MethodUsingEnumWithGrpcNameValuesRequest {
+  oneof using_enum_enum {
+    EnumWithGrpcNameValues using_enum = 1;
+    sint32 using_enum_raw = 2;
+  }
+}
+
+message MethodUsingEnumWithGrpcNameValuesResponse {
+  int32 status = 1;
+}
+
+message MethodUsingWholeAndFractionalNumbersRequest {
+}
+
+message MethodUsingWholeAndFractionalNumbersResponse {
+  int32 status = 1;
+  DecimalWholeNumber whole_number = 2;
+  sint32 whole_number_raw = 3;
+  DecimalMixedNumber fractional_number_mapped = 4;
+  double fractional_number_raw = 5;
+}
+
+message MethodUsingWholeMappedNumbersRequest {
+}
+
+message MethodUsingWholeMappedNumbersResponse {
+  int32 status = 1;
+  DecimalWholeNumberMapped whole_number_mapped = 2;
+  double whole_number_raw = 3;
+}
+
+message MethodWithGetLastErrorParamRequest {
+}
+
+message MethodWithGetLastErrorParamResponse {
+  int32 status = 1;
+  string last_error = 2 [deprecated = true];
+}
+
+message MethodWithGrpcFieldNumberRequest {
+  sint32 attribute_value = 5;
+}
+
+message MethodWithGrpcFieldNumberResponse {
+  int32 status = 1;
+}
+
+message MethodWithGrpcOnlyParamRequest {
+  sint32 simple_param = 1;
+}
+
+message MethodWithGrpcOnlyParamResponse {
+  int32 status = 1;
+  sint32 grpc_only_param = 2;
 }
 
 message MultipleArrayTypesRequest {
@@ -885,14 +1001,6 @@ message WriteWaveformRequest {
 }
 
 message WriteWaveformResponse {
-  int32 status = 1;
-}
-
-message CloseRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message CloseResponse {
   int32 status = 1;
 }
 

--- a/generated/nifake/nifake_client.cpp
+++ b/generated/nifake/nifake_client.cpp
@@ -125,6 +125,23 @@ bool_array_output_function(const StubPtr& stub, const nidevice_grpc::Session& vi
   return response;
 }
 
+CloseResponse
+close(const StubPtr& stub, const nidevice_grpc::Session& vi)
+{
+  ::grpc::ClientContext context;
+
+  auto request = CloseRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+
+  auto response = CloseResponse{};
+
+  raise_if_error(
+      stub->Close(&context, request, &response),
+      context);
+
+  return response;
+}
+
 CloseExtCalResponse
 close_ext_cal(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& action)
 {
@@ -155,6 +172,24 @@ command_with_reserved_param(const StubPtr& stub, const nidevice_grpc::Session& v
 
   raise_if_error(
       stub->CommandWithReservedParam(&context, request, &response),
+      context);
+
+  return response;
+}
+
+Control4022Response
+control4022(const StubPtr& stub, const pb::string& resource_name, const pb::int32& configuration)
+{
+  ::grpc::ClientContext context;
+
+  auto request = Control4022Request{};
+  request.set_resource_name(resource_name);
+  request.set_configuration(configuration);
+
+  auto response = Control4022Response{};
+
+  raise_if_error(
+      stub->Control4022(&context, request, &response),
       context);
 
   return response;
@@ -410,11 +445,12 @@ get_an_ivi_dance_with_a_twist_byte_array(const StubPtr& stub)
 }
 
 GetAnIviDanceWithATwistStringResponse
-get_an_ivi_dance_with_a_twist_string(const StubPtr& stub)
+get_an_ivi_dance_with_a_twist_string(const StubPtr& stub, const nidevice_grpc::Session& vi)
 {
   ::grpc::ClientContext context;
 
   auto request = GetAnIviDanceWithATwistStringRequest{};
+  request.mutable_vi()->CopyFrom(vi);
 
   auto response = GetAnIviDanceWithATwistStringResponse{};
 
@@ -570,12 +606,13 @@ get_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
 }
 
 GetAttributeViSessionResponse
-get_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& attribute_id)
+get_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id)
 {
   ::grpc::ClientContext context;
 
   auto request = GetAttributeViSessionRequest{};
   request.mutable_vi()->CopyFrom(vi);
+  request.set_channel_name(channel_name);
   request.set_attribute_id(attribute_id);
 
   auto response = GetAttributeViSessionResponse{};
@@ -831,6 +868,112 @@ init_with_var_args(const StubPtr& stub, const pb::string& resource_name, const s
 
   raise_if_error(
       stub->InitWithVarArgs(&context, request, &response),
+      context);
+
+  return response;
+}
+
+MethodUsingEnumWithGrpcNameValuesResponse
+method_using_enum_with_grpc_name_values(const StubPtr& stub, const simple_variant<EnumWithGrpcNameValues, pb::int32>& using_enum)
+{
+  ::grpc::ClientContext context;
+
+  auto request = MethodUsingEnumWithGrpcNameValuesRequest{};
+  const auto using_enum_ptr = using_enum.get_if<EnumWithGrpcNameValues>();
+  const auto using_enum_raw_ptr = using_enum.get_if<pb::int32>();
+  if (using_enum_ptr) {
+    request.set_using_enum(*using_enum_ptr);
+  }
+  else if (using_enum_raw_ptr) {
+    request.set_using_enum_raw(*using_enum_raw_ptr);
+  }
+
+  auto response = MethodUsingEnumWithGrpcNameValuesResponse{};
+
+  raise_if_error(
+      stub->MethodUsingEnumWithGrpcNameValues(&context, request, &response),
+      context);
+
+  return response;
+}
+
+MethodUsingWholeAndFractionalNumbersResponse
+method_using_whole_and_fractional_numbers(const StubPtr& stub)
+{
+  ::grpc::ClientContext context;
+
+  auto request = MethodUsingWholeAndFractionalNumbersRequest{};
+
+  auto response = MethodUsingWholeAndFractionalNumbersResponse{};
+
+  raise_if_error(
+      stub->MethodUsingWholeAndFractionalNumbers(&context, request, &response),
+      context);
+
+  return response;
+}
+
+MethodUsingWholeMappedNumbersResponse
+method_using_whole_mapped_numbers(const StubPtr& stub)
+{
+  ::grpc::ClientContext context;
+
+  auto request = MethodUsingWholeMappedNumbersRequest{};
+
+  auto response = MethodUsingWholeMappedNumbersResponse{};
+
+  raise_if_error(
+      stub->MethodUsingWholeMappedNumbers(&context, request, &response),
+      context);
+
+  return response;
+}
+
+MethodWithGetLastErrorParamResponse
+method_with_get_last_error_param(const StubPtr& stub)
+{
+  ::grpc::ClientContext context;
+
+  auto request = MethodWithGetLastErrorParamRequest{};
+
+  auto response = MethodWithGetLastErrorParamResponse{};
+
+  raise_if_error(
+      stub->MethodWithGetLastErrorParam(&context, request, &response),
+      context);
+
+  return response;
+}
+
+MethodWithGrpcFieldNumberResponse
+method_with_grpc_field_number(const StubPtr& stub, const pb::int32& attribute_value)
+{
+  ::grpc::ClientContext context;
+
+  auto request = MethodWithGrpcFieldNumberRequest{};
+  request.set_attribute_value(attribute_value);
+
+  auto response = MethodWithGrpcFieldNumberResponse{};
+
+  raise_if_error(
+      stub->MethodWithGrpcFieldNumber(&context, request, &response),
+      context);
+
+  return response;
+}
+
+MethodWithGrpcOnlyParamResponse
+method_with_grpc_only_param(const StubPtr& stub, const pb::int32& simple_param)
+{
+  ::grpc::ClientContext context;
+
+  auto request = MethodWithGrpcOnlyParamRequest{};
+  request.set_simple_param(simple_param);
+
+  auto response = MethodWithGrpcOnlyParamResponse{};
+
+  raise_if_error(
+      stub->MethodWithGrpcOnlyParam(&context, request, &response),
       context);
 
   return response;
@@ -1296,23 +1439,6 @@ write_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const std:
 
   raise_if_error(
       stub->WriteWaveform(&context, request, &response),
-      context);
-
-  return response;
-}
-
-CloseResponse
-close(const StubPtr& stub, const nidevice_grpc::Session& vi)
-{
-  ::grpc::ClientContext context;
-
-  auto request = CloseRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-
-  auto response = CloseResponse{};
-
-  raise_if_error(
-      stub->Close(&context, request, &response),
       context);
 
   return response;

--- a/generated/nifake/nifake_client.h
+++ b/generated/nifake/nifake_client.h
@@ -28,8 +28,10 @@ AcceptViSessionArrayResponse accept_vi_session_array(const StubPtr& stub, const 
 AcceptViUInt32ArrayResponse accept_vi_uint32_array(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::vector<pb::uint32>& u_int32_array);
 BoolArrayInputFunctionResponse bool_array_input_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& number_of_elements, const std::vector<bool>& an_array);
 BoolArrayOutputFunctionResponse bool_array_output_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& number_of_elements);
+CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& vi);
 CloseExtCalResponse close_ext_cal(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& action);
 CommandWithReservedParamResponse command_with_reserved_param(const StubPtr& stub, const nidevice_grpc::Session& vi);
+Control4022Response control4022(const StubPtr& stub, const pb::string& resource_name, const pb::int32& configuration);
 CreateConfigurationListResponse create_configuration_list(const StubPtr& stub, const std::vector<NiFakeAttribute>& list_attribute_ids);
 DoubleAllTheNumsResponse double_all_the_nums(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::vector<double>& numbers);
 EnumArrayOutputFunctionResponse enum_array_output_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& number_of_elements);
@@ -44,7 +46,7 @@ GetAnIviDanceWithATwistArrayResponse get_an_ivi_dance_with_a_twist_array(const S
 GetAnIviDanceWithATwistArrayOfCustomTypeResponse get_an_ivi_dance_with_a_twist_array_of_custom_type(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetAnIviDanceWithATwistArrayWithInputArrayResponse get_an_ivi_dance_with_a_twist_array_with_input_array(const StubPtr& stub, const std::vector<pb::int32>& data_in);
 GetAnIviDanceWithATwistByteArrayResponse get_an_ivi_dance_with_a_twist_byte_array(const StubPtr& stub);
-GetAnIviDanceWithATwistStringResponse get_an_ivi_dance_with_a_twist_string(const StubPtr& stub);
+GetAnIviDanceWithATwistStringResponse get_an_ivi_dance_with_a_twist_string(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetAnIviDanceWithATwistStringStrlenBugResponse get_an_ivi_dance_with_a_twist_string_strlen_bug(const StubPtr& stub);
 GetArraySizeForCustomCodeResponse get_array_size_for_custom_code(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetArrayUsingIviDanceResponse get_array_using_ivi_dance(const StubPtr& stub, const nidevice_grpc::Session& vi);
@@ -53,7 +55,7 @@ GetAttributeViBooleanResponse get_attribute_vi_boolean(const StubPtr& stub, cons
 GetAttributeViInt32Response get_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id);
 GetAttributeViInt64Response get_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id);
 GetAttributeViReal64Response get_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id);
-GetAttributeViSessionResponse get_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& attribute_id);
+GetAttributeViSessionResponse get_attribute_vi_session(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id);
 GetAttributeViStringResponse get_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id);
 GetBitfieldAsEnumArrayResponse get_bitfield_as_enum_array(const StubPtr& stub);
 GetCalDateAndTimeResponse get_cal_date_and_time(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& cal_type);
@@ -68,6 +70,12 @@ ImportAttributeConfigurationBufferResponse import_attribute_configuration_buffer
 InitExtCalResponse init_ext_cal(const StubPtr& stub, const pb::string& resource_name, const pb::string& calibration_password);
 InitWithOptionsResponse init_with_options(const StubPtr& stub, const pb::string& resource_name, const bool& id_query, const bool& reset_device, const pb::string& option_string);
 InitWithVarArgsResponse init_with_var_args(const StubPtr& stub, const pb::string& resource_name, const std::vector<StringAndTurtle>& name_and_turtle);
+MethodUsingEnumWithGrpcNameValuesResponse method_using_enum_with_grpc_name_values(const StubPtr& stub, const simple_variant<EnumWithGrpcNameValues, pb::int32>& using_enum);
+MethodUsingWholeAndFractionalNumbersResponse method_using_whole_and_fractional_numbers(const StubPtr& stub);
+MethodUsingWholeMappedNumbersResponse method_using_whole_mapped_numbers(const StubPtr& stub);
+MethodWithGetLastErrorParamResponse method_with_get_last_error_param(const StubPtr& stub);
+MethodWithGrpcFieldNumberResponse method_with_grpc_field_number(const StubPtr& stub, const pb::int32& attribute_value);
+MethodWithGrpcOnlyParamResponse method_with_grpc_only_param(const StubPtr& stub, const pb::int32& simple_param);
 MultipleArrayTypesResponse multiple_array_types(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& output_array_size, const std::vector<double>& input_array_of_floats, const std::vector<pb::int32>& input_array_of_integers);
 MultipleArraysSameSizeResponse multiple_arrays_same_size(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::vector<double>& values1, const std::vector<double>& values2, const std::vector<double>& values3, const std::vector<double>& values4);
 MultipleArraysSameSizeWithOptionalResponse multiple_arrays_same_size_with_optional(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::vector<double>& values1, const std::vector<double>& values2, const std::vector<double>& values3, const std::vector<double>& values4, const std::vector<FakeCustomStruct>& values5);
@@ -92,7 +100,6 @@ ViInt16ArrayInputFunctionResponse vi_int16_array_input_function(const StubPtr& s
 ViUInt8ArrayInputFunctionResponse vi_uint8_array_input_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& number_of_elements, const pb::string& an_array);
 ViUInt8ArrayOutputFunctionResponse vi_uint8_array_output_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& number_of_elements);
 WriteWaveformResponse write_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::vector<double>& waveform);
-CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& vi);
 
 } // namespace nifake_grpc::experimental::client
 

--- a/generated/nifake/nifake_library.cpp
+++ b/generated/nifake/nifake_library.cpp
@@ -27,12 +27,15 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.AcceptViUInt32Array = reinterpret_cast<AcceptViUInt32ArrayPtr>(shared_library_.get_function_pointer("niFake_AcceptViUInt32Array"));
   function_pointers_.BoolArrayInputFunction = reinterpret_cast<BoolArrayInputFunctionPtr>(shared_library_.get_function_pointer("niFake_BoolArrayInputFunction"));
   function_pointers_.BoolArrayOutputFunction = reinterpret_cast<BoolArrayOutputFunctionPtr>(shared_library_.get_function_pointer("niFake_BoolArrayOutputFunction"));
+  function_pointers_.Close = reinterpret_cast<ClosePtr>(shared_library_.get_function_pointer("niFake_close"));
   function_pointers_.CloseExtCal = reinterpret_cast<CloseExtCalPtr>(shared_library_.get_function_pointer("niFake_CloseExtCal"));
   function_pointers_.CommandWithReservedParam = reinterpret_cast<CommandWithReservedParamPtr>(shared_library_.get_function_pointer("niFake_CommandWithReservedParam"));
+  function_pointers_.Control4022 = reinterpret_cast<Control4022Ptr>(shared_library_.get_function_pointer("niFake_4022Control"));
   function_pointers_.CreateConfigurationList = reinterpret_cast<CreateConfigurationListPtr>(shared_library_.get_function_pointer("niFake_CreateConfigurationList"));
   function_pointers_.DoubleAllTheNums = reinterpret_cast<DoubleAllTheNumsPtr>(shared_library_.get_function_pointer("niFake_DoubleAllTheNums"));
   function_pointers_.EnumArrayOutputFunction = reinterpret_cast<EnumArrayOutputFunctionPtr>(shared_library_.get_function_pointer("niFake_EnumArrayOutputFunction"));
   function_pointers_.EnumInputFunctionWithDefaults = reinterpret_cast<EnumInputFunctionWithDefaultsPtr>(shared_library_.get_function_pointer("niFake_EnumInputFunctionWithDefaults"));
+  function_pointers_.ErrorMessage = reinterpret_cast<ErrorMessagePtr>(shared_library_.get_function_pointer("niFake_error_message"));
   function_pointers_.ExportAttributeConfigurationBuffer = reinterpret_cast<ExportAttributeConfigurationBufferPtr>(shared_library_.get_function_pointer("niFake_ExportAttributeConfigurationBuffer"));
   function_pointers_.FetchWaveform = reinterpret_cast<FetchWaveformPtr>(shared_library_.get_function_pointer("niFake_FetchWaveform"));
   function_pointers_.GetABoolean = reinterpret_cast<GetABooleanPtr>(shared_library_.get_function_pointer("niFake_GetABoolean"));
@@ -69,6 +72,12 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.InitWithOptions = reinterpret_cast<InitWithOptionsPtr>(shared_library_.get_function_pointer("niFake_InitWithOptions"));
   function_pointers_.InitWithVarArgs = reinterpret_cast<InitWithVarArgsPtr>(shared_library_.get_function_pointer("niFake_InitWithVarArgs"));
   function_pointers_.Initiate = reinterpret_cast<InitiatePtr>(shared_library_.get_function_pointer("niFake_Initiate"));
+  function_pointers_.MethodUsingEnumWithGrpcNameValues = reinterpret_cast<MethodUsingEnumWithGrpcNameValuesPtr>(shared_library_.get_function_pointer("niFake_MethodUsingEnumWithGrpcNameValues"));
+  function_pointers_.MethodUsingWholeAndFractionalNumbers = reinterpret_cast<MethodUsingWholeAndFractionalNumbersPtr>(shared_library_.get_function_pointer("niFake_MethodUsingWholeAndFractionalNumbers"));
+  function_pointers_.MethodUsingWholeMappedNumbers = reinterpret_cast<MethodUsingWholeMappedNumbersPtr>(shared_library_.get_function_pointer("niFake_MethodUsingWholeMappedNumbers"));
+  function_pointers_.MethodWithGetLastErrorParam = reinterpret_cast<MethodWithGetLastErrorParamPtr>(shared_library_.get_function_pointer("niFake_MethodWithGetLastErrorParam"));
+  function_pointers_.MethodWithGrpcFieldNumber = reinterpret_cast<MethodWithGrpcFieldNumberPtr>(shared_library_.get_function_pointer("niFake_MethodWithGrpcFieldNumber"));
+  function_pointers_.MethodWithGrpcOnlyParam = reinterpret_cast<MethodWithGrpcOnlyParamPtr>(shared_library_.get_function_pointer("niFake_MethodWithGrpcOnlyParam"));
   function_pointers_.MultipleArrayTypes = reinterpret_cast<MultipleArrayTypesPtr>(shared_library_.get_function_pointer("niFake_MultipleArrayTypes"));
   function_pointers_.MultipleArraysSameSize = reinterpret_cast<MultipleArraysSameSizePtr>(shared_library_.get_function_pointer("niFake_MultipleArraysSameSize"));
   function_pointers_.MultipleArraysSameSizeWithOptional = reinterpret_cast<MultipleArraysSameSizeWithOptionalPtr>(shared_library_.get_function_pointer("niFake_MultipleArraysSameSizeWithOptional"));
@@ -83,6 +92,7 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.ReturnDurationInSeconds = reinterpret_cast<ReturnDurationInSecondsPtr>(shared_library_.get_function_pointer("niFake_ReturnDurationInSeconds"));
   function_pointers_.ReturnListOfDurationsInSeconds = reinterpret_cast<ReturnListOfDurationsInSecondsPtr>(shared_library_.get_function_pointer("niFake_ReturnListOfDurationsInSeconds"));
   function_pointers_.ReturnMultipleTypes = reinterpret_cast<ReturnMultipleTypesPtr>(shared_library_.get_function_pointer("niFake_ReturnMultipleTypes"));
+  function_pointers_.SelfTest = reinterpret_cast<SelfTestPtr>(shared_library_.get_function_pointer("niFake_self_test"));
   function_pointers_.SetAttributeViBoolean = reinterpret_cast<SetAttributeViBooleanPtr>(shared_library_.get_function_pointer("niFake_SetAttributeViBoolean"));
   function_pointers_.SetAttributeViInt32 = reinterpret_cast<SetAttributeViInt32Ptr>(shared_library_.get_function_pointer("niFake_SetAttributeViInt32"));
   function_pointers_.SetAttributeViInt64 = reinterpret_cast<SetAttributeViInt64Ptr>(shared_library_.get_function_pointer("niFake_SetAttributeViInt64"));
@@ -98,9 +108,6 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.ViUInt8ArrayInputFunction = reinterpret_cast<ViUInt8ArrayInputFunctionPtr>(shared_library_.get_function_pointer("niFake_ViUInt8ArrayInputFunction"));
   function_pointers_.ViUInt8ArrayOutputFunction = reinterpret_cast<ViUInt8ArrayOutputFunctionPtr>(shared_library_.get_function_pointer("niFake_ViUInt8ArrayOutputFunction"));
   function_pointers_.WriteWaveform = reinterpret_cast<WriteWaveformPtr>(shared_library_.get_function_pointer("niFake_WriteWaveform"));
-  function_pointers_.close = reinterpret_cast<closePtr>(shared_library_.get_function_pointer("niFake_close"));
-  function_pointers_.error_message = reinterpret_cast<error_messagePtr>(shared_library_.get_function_pointer("niFake_error_message"));
-  function_pointers_.self_test = reinterpret_cast<self_testPtr>(shared_library_.get_function_pointer("niFake_self_test"));
 }
 
 NiFakeLibrary::~NiFakeLibrary()
@@ -186,6 +193,18 @@ ViStatus NiFakeLibrary::BoolArrayOutputFunction(ViSession vi, ViInt32 numberOfEl
 #endif
 }
 
+ViStatus NiFakeLibrary::Close(ViSession vi)
+{
+  if (!function_pointers_.Close) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_close.");
+  }
+#if defined(_MSC_VER)
+  return niFake_close(vi);
+#else
+  return function_pointers_.Close(vi);
+#endif
+}
+
 ViStatus NiFakeLibrary::CloseExtCal(ViSession vi, ViInt32 action)
 {
   if (!function_pointers_.CloseExtCal) {
@@ -207,6 +226,18 @@ ViStatus NiFakeLibrary::CommandWithReservedParam(ViSession vi, ViBoolean* reserv
   return niFake_CommandWithReservedParam(vi, reserved);
 #else
   return function_pointers_.CommandWithReservedParam(vi, reserved);
+#endif
+}
+
+ViStatus NiFakeLibrary::Control4022(ViString resourceName, ViInt32 configuration)
+{
+  if (!function_pointers_.Control4022) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_4022Control.");
+  }
+#if defined(_MSC_VER)
+  return niFake_4022Control(resourceName, configuration);
+#else
+  return function_pointers_.Control4022(resourceName, configuration);
 #endif
 }
 
@@ -256,6 +287,14 @@ ViStatus NiFakeLibrary::EnumInputFunctionWithDefaults(ViSession vi, ViInt16 aTur
 #else
   return function_pointers_.EnumInputFunctionWithDefaults(vi, aTurtle);
 #endif
+}
+
+ViStatus NiFakeLibrary::ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[256])
+{
+  if (!function_pointers_.ErrorMessage) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_error_message.");
+  }
+  return function_pointers_.ErrorMessage(vi, errorCode, errorMessage);
 }
 
 ViStatus NiFakeLibrary::ExportAttributeConfigurationBuffer(ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[])
@@ -378,15 +417,15 @@ ViStatus NiFakeLibrary::GetAnIviDanceWithATwistByteArray(ViInt32 bufferSize, ViI
 #endif
 }
 
-ViStatus NiFakeLibrary::GetAnIviDanceWithATwistString(ViInt32 bufferSize, ViChar arrayOut[], ViInt32* actualSize)
+ViStatus NiFakeLibrary::GetAnIviDanceWithATwistString(ViSession vi, ViInt32 bufferSize, ViChar aString[], ViInt32* actualSize)
 {
   if (!function_pointers_.GetAnIviDanceWithATwistString) {
     throw nidevice_grpc::LibraryLoadException("Could not find niFake_GetAnIviDanceWithATwistString.");
   }
 #if defined(_MSC_VER)
-  return niFake_GetAnIviDanceWithATwistString(bufferSize, arrayOut, actualSize);
+  return niFake_GetAnIviDanceWithATwistString(vi, bufferSize, aString, actualSize);
 #else
-  return function_pointers_.GetAnIviDanceWithATwistString(bufferSize, arrayOut, actualSize);
+  return function_pointers_.GetAnIviDanceWithATwistString(vi, bufferSize, aString, actualSize);
 #endif
 }
 
@@ -486,15 +525,15 @@ ViStatus NiFakeLibrary::GetAttributeViReal64(ViSession vi, ViConstString channel
 #endif
 }
 
-ViStatus NiFakeLibrary::GetAttributeViSession(ViSession vi, ViInt32 attributeId, ViSession* sessionOut)
+ViStatus NiFakeLibrary::GetAttributeViSession(ViSession vi, ViConstString channelName, ViAttr attributeId, ViSession* attributeValue)
 {
   if (!function_pointers_.GetAttributeViSession) {
     throw nidevice_grpc::LibraryLoadException("Could not find niFake_GetAttributeViSession.");
   }
 #if defined(_MSC_VER)
-  return niFake_GetAttributeViSession(vi, attributeId, sessionOut);
+  return niFake_GetAttributeViSession(vi, channelName, attributeId, attributeValue);
 #else
-  return function_pointers_.GetAttributeViSession(vi, attributeId, sessionOut);
+  return function_pointers_.GetAttributeViSession(vi, channelName, attributeId, attributeValue);
 #endif
 }
 
@@ -682,6 +721,78 @@ ViStatus NiFakeLibrary::Initiate(ViSession vi)
   return function_pointers_.Initiate(vi);
 }
 
+ViStatus NiFakeLibrary::MethodUsingEnumWithGrpcNameValues(ViInt32 usingEnum)
+{
+  if (!function_pointers_.MethodUsingEnumWithGrpcNameValues) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_MethodUsingEnumWithGrpcNameValues.");
+  }
+#if defined(_MSC_VER)
+  return niFake_MethodUsingEnumWithGrpcNameValues(usingEnum);
+#else
+  return function_pointers_.MethodUsingEnumWithGrpcNameValues(usingEnum);
+#endif
+}
+
+ViStatus NiFakeLibrary::MethodUsingWholeAndFractionalNumbers(ViInt32* wholeNumber, ViReal64* fractionalNumber)
+{
+  if (!function_pointers_.MethodUsingWholeAndFractionalNumbers) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_MethodUsingWholeAndFractionalNumbers.");
+  }
+#if defined(_MSC_VER)
+  return niFake_MethodUsingWholeAndFractionalNumbers(wholeNumber, fractionalNumber);
+#else
+  return function_pointers_.MethodUsingWholeAndFractionalNumbers(wholeNumber, fractionalNumber);
+#endif
+}
+
+ViStatus NiFakeLibrary::MethodUsingWholeMappedNumbers(ViReal64* wholeNumber)
+{
+  if (!function_pointers_.MethodUsingWholeMappedNumbers) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_MethodUsingWholeMappedNumbers.");
+  }
+#if defined(_MSC_VER)
+  return niFake_MethodUsingWholeMappedNumbers(wholeNumber);
+#else
+  return function_pointers_.MethodUsingWholeMappedNumbers(wholeNumber);
+#endif
+}
+
+ViStatus NiFakeLibrary::MethodWithGetLastErrorParam()
+{
+  if (!function_pointers_.MethodWithGetLastErrorParam) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_MethodWithGetLastErrorParam.");
+  }
+#if defined(_MSC_VER)
+  return niFake_MethodWithGetLastErrorParam();
+#else
+  return function_pointers_.MethodWithGetLastErrorParam();
+#endif
+}
+
+ViStatus NiFakeLibrary::MethodWithGrpcFieldNumber(ViInt32 attributeValue)
+{
+  if (!function_pointers_.MethodWithGrpcFieldNumber) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_MethodWithGrpcFieldNumber.");
+  }
+#if defined(_MSC_VER)
+  return niFake_MethodWithGrpcFieldNumber(attributeValue);
+#else
+  return function_pointers_.MethodWithGrpcFieldNumber(attributeValue);
+#endif
+}
+
+ViStatus NiFakeLibrary::MethodWithGrpcOnlyParam(ViInt32 simpleParam, ViInt32* grpcOnlyParam)
+{
+  if (!function_pointers_.MethodWithGrpcOnlyParam) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_MethodWithGrpcOnlyParam.");
+  }
+#if defined(_MSC_VER)
+  return niFake_MethodWithGrpcOnlyParam(simpleParam, grpcOnlyParam);
+#else
+  return function_pointers_.MethodWithGrpcOnlyParam(simpleParam, grpcOnlyParam);
+#endif
+}
+
 ViStatus NiFakeLibrary::MultipleArrayTypes(ViSession vi, ViInt32 outputArraySize, ViReal64 outputArray[], ViReal64 outputArrayOfFixedLength[3], ViInt32 inputArraySizes, ViReal64 inputArrayOfFloats[], ViInt16 inputArrayOfIntegers[])
 {
   if (!function_pointers_.MultipleArrayTypes) {
@@ -850,6 +961,14 @@ ViStatus NiFakeLibrary::ReturnMultipleTypes(ViSession vi, ViBoolean* aBoolean, V
 #endif
 }
 
+ViStatus NiFakeLibrary::SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256])
+{
+  if (!function_pointers_.SelfTest) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_self_test.");
+  }
+  return function_pointers_.SelfTest(vi, selfTestResult, selfTestMessage);
+}
+
 ViStatus NiFakeLibrary::SetAttributeViBoolean(ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean attributeValue)
 {
   if (!function_pointers_.SetAttributeViBoolean) {
@@ -1008,34 +1127,6 @@ ViStatus NiFakeLibrary::WriteWaveform(ViSession vi, ViInt32 numberOfSamples, ViR
 #else
   return function_pointers_.WriteWaveform(vi, numberOfSamples, waveform);
 #endif
-}
-
-ViStatus NiFakeLibrary::close(ViSession vi)
-{
-  if (!function_pointers_.close) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFake_close.");
-  }
-#if defined(_MSC_VER)
-  return niFake_close(vi);
-#else
-  return function_pointers_.close(vi);
-#endif
-}
-
-ViStatus NiFakeLibrary::error_message(ViSession vi, ViStatus errorCode, ViChar errorMessage[256])
-{
-  if (!function_pointers_.error_message) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFake_error_message.");
-  }
-  return function_pointers_.error_message(vi, errorCode, errorMessage);
-}
-
-ViStatus NiFakeLibrary::self_test(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256])
-{
-  if (!function_pointers_.self_test) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niFake_self_test.");
-  }
-  return function_pointers_.self_test(vi, selfTestResult, selfTestMessage);
 }
 
 }  // namespace nifake_grpc

--- a/generated/nifake/nifake_library.h
+++ b/generated/nifake/nifake_library.h
@@ -24,12 +24,15 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus AcceptViUInt32Array(ViSession vi, ViInt32 arrayLen, ViUInt32 uInt32Array[]);
   ViStatus BoolArrayInputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]);
   ViStatus BoolArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]);
+  ViStatus Close(ViSession vi);
   ViStatus CloseExtCal(ViSession vi, ViInt32 action);
   ViStatus CommandWithReservedParam(ViSession vi, ViBoolean* reserved);
+  ViStatus Control4022(ViString resourceName, ViInt32 configuration);
   ViStatus CreateConfigurationList(ViInt32 numberOfListAttributes, ViAttr listAttributeIds[]);
   ViStatus DoubleAllTheNums(ViSession vi, ViInt32 numberCount, ViReal64 numbers[]);
   ViStatus EnumArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViInt16 anArray[]);
   ViStatus EnumInputFunctionWithDefaults(ViSession vi, ViInt16 aTurtle);
+  ViStatus ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]);
   ViStatus ExportAttributeConfigurationBuffer(ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[]);
   ViStatus FetchWaveform(ViSession vi, ViInt32 numberOfSamples, ViReal64 waveformData[], ViInt32* actualNumberOfSamples);
   ViStatus GetABoolean(ViSession vi, ViBoolean* aBoolean);
@@ -40,7 +43,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus GetAnIviDanceWithATwistArrayOfCustomType(ViSession vi, ViInt32 bufferSize, CustomStruct arrayOut[], ViInt32* actualSize);
   ViStatus GetAnIviDanceWithATwistArrayWithInputArray(ViInt32 dataIn[], ViInt32 arraySizeIn, ViInt32 bufferSize, ViInt32 arrayOut[], ViInt32* actualSize);
   ViStatus GetAnIviDanceWithATwistByteArray(ViInt32 bufferSize, ViInt8 arrayOut[], ViInt32* actualSize);
-  ViStatus GetAnIviDanceWithATwistString(ViInt32 bufferSize, ViChar arrayOut[], ViInt32* actualSize);
+  ViStatus GetAnIviDanceWithATwistString(ViSession vi, ViInt32 bufferSize, ViChar aString[], ViInt32* actualSize);
   ViStatus GetAnIviDanceWithATwistStringStrlenBug(ViInt32 bufferSize, ViChar stringOut[], ViInt32* actualSize);
   ViStatus GetArraySizeForCustomCode(ViSession vi, ViInt32* sizeOut);
   ViStatus GetArrayUsingIviDance(ViSession vi, ViInt32 arraySize, ViReal64 arrayOut[]);
@@ -49,7 +52,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus GetAttributeViInt32(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32* attributeValue);
   ViStatus GetAttributeViInt64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64* attributeValue);
   ViStatus GetAttributeViReal64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViReal64* attributeValue);
-  ViStatus GetAttributeViSession(ViSession vi, ViInt32 attributeId, ViSession* sessionOut);
+  ViStatus GetAttributeViSession(ViSession vi, ViConstString channelName, ViAttr attributeId, ViSession* attributeValue);
   ViStatus GetAttributeViString(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 bufferSize, ViChar attributeValue[]);
   ViStatus GetBitfieldAsEnumArray(ViInt64* flags);
   ViStatus GetCalDateAndTime(ViSession vi, ViInt32 calType, ViInt32* month, ViInt32* day, ViInt32* year, ViInt32* hour, ViInt32* minute);
@@ -66,6 +69,12 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus InitWithOptions(ViString resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViConstString optionString, ViSession* vi);
   ViStatus InitWithVarArgs(ViRsrc resourceName, ViSession* vi, ViConstString stringArg, ViInt16 turtle, ViConstString stringArg0, ViInt16 turtle0, ViConstString stringArg1, ViInt16 turtle1, ViConstString stringArg2, ViInt16 turtle2);
   ViStatus Initiate(ViSession vi);
+  ViStatus MethodUsingEnumWithGrpcNameValues(ViInt32 usingEnum);
+  ViStatus MethodUsingWholeAndFractionalNumbers(ViInt32* wholeNumber, ViReal64* fractionalNumber);
+  ViStatus MethodUsingWholeMappedNumbers(ViReal64* wholeNumber);
+  ViStatus MethodWithGetLastErrorParam();
+  ViStatus MethodWithGrpcFieldNumber(ViInt32 attributeValue);
+  ViStatus MethodWithGrpcOnlyParam(ViInt32 simpleParam, ViInt32* grpcOnlyParam);
   ViStatus MultipleArrayTypes(ViSession vi, ViInt32 outputArraySize, ViReal64 outputArray[], ViReal64 outputArrayOfFixedLength[3], ViInt32 inputArraySizes, ViReal64 inputArrayOfFloats[], ViInt16 inputArrayOfIntegers[]);
   ViStatus MultipleArraysSameSize(ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], ViInt32 size);
   ViStatus MultipleArraysSameSizeWithOptional(ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], CustomStruct values5[], ViInt32 size);
@@ -80,6 +89,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus ReturnDurationInSeconds(ViSession vi, ViReal64* timedelta);
   ViStatus ReturnListOfDurationsInSeconds(ViSession vi, ViInt32 numberOfElements, ViReal64 timedeltas[]);
   ViStatus ReturnMultipleTypes(ViSession vi, ViBoolean* aBoolean, ViInt32* anInt32, ViInt64* anInt64, ViInt16* anIntEnum, ViReal64* aFloat, ViReal64* aFloatEnum, ViInt32 arraySize, ViReal64 anArray[], ViInt32 stringSize, ViChar aString[]);
+  ViStatus SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]);
   ViStatus SetAttributeViBoolean(ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean attributeValue);
   ViStatus SetAttributeViInt32(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 attributeValue);
   ViStatus SetAttributeViInt64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64 attributeValue);
@@ -95,9 +105,6 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus ViUInt8ArrayInputFunction(ViSession vi, ViInt32 numberOfElements, ViUInt8 anArray[]);
   ViStatus ViUInt8ArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViUInt8 anArray[]);
   ViStatus WriteWaveform(ViSession vi, ViInt32 numberOfSamples, ViReal64 waveform[]);
-  ViStatus close(ViSession vi);
-  ViStatus error_message(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]);
-  ViStatus self_test(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]);
 
  private:
   using AbortPtr = decltype(&niFake_Abort);
@@ -106,12 +113,15 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using AcceptViUInt32ArrayPtr = decltype(&niFake_AcceptViUInt32Array);
   using BoolArrayInputFunctionPtr = decltype(&niFake_BoolArrayInputFunction);
   using BoolArrayOutputFunctionPtr = decltype(&niFake_BoolArrayOutputFunction);
+  using ClosePtr = decltype(&niFake_close);
   using CloseExtCalPtr = decltype(&niFake_CloseExtCal);
   using CommandWithReservedParamPtr = decltype(&niFake_CommandWithReservedParam);
+  using Control4022Ptr = decltype(&niFake_4022Control);
   using CreateConfigurationListPtr = decltype(&niFake_CreateConfigurationList);
   using DoubleAllTheNumsPtr = decltype(&niFake_DoubleAllTheNums);
   using EnumArrayOutputFunctionPtr = decltype(&niFake_EnumArrayOutputFunction);
   using EnumInputFunctionWithDefaultsPtr = decltype(&niFake_EnumInputFunctionWithDefaults);
+  using ErrorMessagePtr = ViStatus (*)(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]);
   using ExportAttributeConfigurationBufferPtr = decltype(&niFake_ExportAttributeConfigurationBuffer);
   using FetchWaveformPtr = decltype(&niFake_FetchWaveform);
   using GetABooleanPtr = decltype(&niFake_GetABoolean);
@@ -148,6 +158,12 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using InitWithOptionsPtr = decltype(&niFake_InitWithOptions);
   using InitWithVarArgsPtr = decltype(&niFake_InitWithVarArgs);
   using InitiatePtr = ViStatus (*)(ViSession vi);
+  using MethodUsingEnumWithGrpcNameValuesPtr = decltype(&niFake_MethodUsingEnumWithGrpcNameValues);
+  using MethodUsingWholeAndFractionalNumbersPtr = decltype(&niFake_MethodUsingWholeAndFractionalNumbers);
+  using MethodUsingWholeMappedNumbersPtr = decltype(&niFake_MethodUsingWholeMappedNumbers);
+  using MethodWithGetLastErrorParamPtr = decltype(&niFake_MethodWithGetLastErrorParam);
+  using MethodWithGrpcFieldNumberPtr = decltype(&niFake_MethodWithGrpcFieldNumber);
+  using MethodWithGrpcOnlyParamPtr = decltype(&niFake_MethodWithGrpcOnlyParam);
   using MultipleArrayTypesPtr = decltype(&niFake_MultipleArrayTypes);
   using MultipleArraysSameSizePtr = decltype(&niFake_MultipleArraysSameSize);
   using MultipleArraysSameSizeWithOptionalPtr = decltype(&niFake_MultipleArraysSameSizeWithOptional);
@@ -162,6 +178,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using ReturnDurationInSecondsPtr = decltype(&niFake_ReturnDurationInSeconds);
   using ReturnListOfDurationsInSecondsPtr = decltype(&niFake_ReturnListOfDurationsInSeconds);
   using ReturnMultipleTypesPtr = decltype(&niFake_ReturnMultipleTypes);
+  using SelfTestPtr = ViStatus (*)(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]);
   using SetAttributeViBooleanPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean attributeValue);
   using SetAttributeViInt32Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 attributeValue);
   using SetAttributeViInt64Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64 attributeValue);
@@ -177,9 +194,6 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using ViUInt8ArrayInputFunctionPtr = decltype(&niFake_ViUInt8ArrayInputFunction);
   using ViUInt8ArrayOutputFunctionPtr = decltype(&niFake_ViUInt8ArrayOutputFunction);
   using WriteWaveformPtr = decltype(&niFake_WriteWaveform);
-  using closePtr = decltype(&niFake_close);
-  using error_messagePtr = ViStatus (*)(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]);
-  using self_testPtr = ViStatus (*)(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]);
 
   typedef struct FunctionPointers {
     AbortPtr Abort;
@@ -188,12 +202,15 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     AcceptViUInt32ArrayPtr AcceptViUInt32Array;
     BoolArrayInputFunctionPtr BoolArrayInputFunction;
     BoolArrayOutputFunctionPtr BoolArrayOutputFunction;
+    ClosePtr Close;
     CloseExtCalPtr CloseExtCal;
     CommandWithReservedParamPtr CommandWithReservedParam;
+    Control4022Ptr Control4022;
     CreateConfigurationListPtr CreateConfigurationList;
     DoubleAllTheNumsPtr DoubleAllTheNums;
     EnumArrayOutputFunctionPtr EnumArrayOutputFunction;
     EnumInputFunctionWithDefaultsPtr EnumInputFunctionWithDefaults;
+    ErrorMessagePtr ErrorMessage;
     ExportAttributeConfigurationBufferPtr ExportAttributeConfigurationBuffer;
     FetchWaveformPtr FetchWaveform;
     GetABooleanPtr GetABoolean;
@@ -230,6 +247,12 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     InitWithOptionsPtr InitWithOptions;
     InitWithVarArgsPtr InitWithVarArgs;
     InitiatePtr Initiate;
+    MethodUsingEnumWithGrpcNameValuesPtr MethodUsingEnumWithGrpcNameValues;
+    MethodUsingWholeAndFractionalNumbersPtr MethodUsingWholeAndFractionalNumbers;
+    MethodUsingWholeMappedNumbersPtr MethodUsingWholeMappedNumbers;
+    MethodWithGetLastErrorParamPtr MethodWithGetLastErrorParam;
+    MethodWithGrpcFieldNumberPtr MethodWithGrpcFieldNumber;
+    MethodWithGrpcOnlyParamPtr MethodWithGrpcOnlyParam;
     MultipleArrayTypesPtr MultipleArrayTypes;
     MultipleArraysSameSizePtr MultipleArraysSameSize;
     MultipleArraysSameSizeWithOptionalPtr MultipleArraysSameSizeWithOptional;
@@ -244,6 +267,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     ReturnDurationInSecondsPtr ReturnDurationInSeconds;
     ReturnListOfDurationsInSecondsPtr ReturnListOfDurationsInSeconds;
     ReturnMultipleTypesPtr ReturnMultipleTypes;
+    SelfTestPtr SelfTest;
     SetAttributeViBooleanPtr SetAttributeViBoolean;
     SetAttributeViInt32Ptr SetAttributeViInt32;
     SetAttributeViInt64Ptr SetAttributeViInt64;
@@ -259,9 +283,6 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     ViUInt8ArrayInputFunctionPtr ViUInt8ArrayInputFunction;
     ViUInt8ArrayOutputFunctionPtr ViUInt8ArrayOutputFunction;
     WriteWaveformPtr WriteWaveform;
-    closePtr close;
-    error_messagePtr error_message;
-    self_testPtr self_test;
   } FunctionLoadStatus;
 
   nidevice_grpc::SharedLibrary shared_library_;

--- a/generated/nifake/nifake_library_interface.h
+++ b/generated/nifake/nifake_library_interface.h
@@ -21,12 +21,15 @@ class NiFakeLibraryInterface {
   virtual ViStatus AcceptViUInt32Array(ViSession vi, ViInt32 arrayLen, ViUInt32 uInt32Array[]) = 0;
   virtual ViStatus BoolArrayInputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]) = 0;
   virtual ViStatus BoolArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]) = 0;
+  virtual ViStatus Close(ViSession vi) = 0;
   virtual ViStatus CloseExtCal(ViSession vi, ViInt32 action) = 0;
   virtual ViStatus CommandWithReservedParam(ViSession vi, ViBoolean* reserved) = 0;
+  virtual ViStatus Control4022(ViString resourceName, ViInt32 configuration) = 0;
   virtual ViStatus CreateConfigurationList(ViInt32 numberOfListAttributes, ViAttr listAttributeIds[]) = 0;
   virtual ViStatus DoubleAllTheNums(ViSession vi, ViInt32 numberCount, ViReal64 numbers[]) = 0;
   virtual ViStatus EnumArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViInt16 anArray[]) = 0;
   virtual ViStatus EnumInputFunctionWithDefaults(ViSession vi, ViInt16 aTurtle) = 0;
+  virtual ViStatus ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]) = 0;
   virtual ViStatus ExportAttributeConfigurationBuffer(ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[]) = 0;
   virtual ViStatus FetchWaveform(ViSession vi, ViInt32 numberOfSamples, ViReal64 waveformData[], ViInt32* actualNumberOfSamples) = 0;
   virtual ViStatus GetABoolean(ViSession vi, ViBoolean* aBoolean) = 0;
@@ -37,7 +40,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus GetAnIviDanceWithATwistArrayOfCustomType(ViSession vi, ViInt32 bufferSize, CustomStruct arrayOut[], ViInt32* actualSize) = 0;
   virtual ViStatus GetAnIviDanceWithATwistArrayWithInputArray(ViInt32 dataIn[], ViInt32 arraySizeIn, ViInt32 bufferSize, ViInt32 arrayOut[], ViInt32* actualSize) = 0;
   virtual ViStatus GetAnIviDanceWithATwistByteArray(ViInt32 bufferSize, ViInt8 arrayOut[], ViInt32* actualSize) = 0;
-  virtual ViStatus GetAnIviDanceWithATwistString(ViInt32 bufferSize, ViChar arrayOut[], ViInt32* actualSize) = 0;
+  virtual ViStatus GetAnIviDanceWithATwistString(ViSession vi, ViInt32 bufferSize, ViChar aString[], ViInt32* actualSize) = 0;
   virtual ViStatus GetAnIviDanceWithATwistStringStrlenBug(ViInt32 bufferSize, ViChar stringOut[], ViInt32* actualSize) = 0;
   virtual ViStatus GetArraySizeForCustomCode(ViSession vi, ViInt32* sizeOut) = 0;
   virtual ViStatus GetArrayUsingIviDance(ViSession vi, ViInt32 arraySize, ViReal64 arrayOut[]) = 0;
@@ -46,7 +49,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus GetAttributeViInt32(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32* attributeValue) = 0;
   virtual ViStatus GetAttributeViInt64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64* attributeValue) = 0;
   virtual ViStatus GetAttributeViReal64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViReal64* attributeValue) = 0;
-  virtual ViStatus GetAttributeViSession(ViSession vi, ViInt32 attributeId, ViSession* sessionOut) = 0;
+  virtual ViStatus GetAttributeViSession(ViSession vi, ViConstString channelName, ViAttr attributeId, ViSession* attributeValue) = 0;
   virtual ViStatus GetAttributeViString(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 bufferSize, ViChar attributeValue[]) = 0;
   virtual ViStatus GetBitfieldAsEnumArray(ViInt64* flags) = 0;
   virtual ViStatus GetCalDateAndTime(ViSession vi, ViInt32 calType, ViInt32* month, ViInt32* day, ViInt32* year, ViInt32* hour, ViInt32* minute) = 0;
@@ -63,6 +66,12 @@ class NiFakeLibraryInterface {
   virtual ViStatus InitWithOptions(ViString resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViConstString optionString, ViSession* vi) = 0;
   virtual ViStatus InitWithVarArgs(ViRsrc resourceName, ViSession* vi, ViConstString stringArg, ViInt16 turtle, ViConstString stringArg0, ViInt16 turtle0, ViConstString stringArg1, ViInt16 turtle1, ViConstString stringArg2, ViInt16 turtle2) = 0;
   virtual ViStatus Initiate(ViSession vi) = 0;
+  virtual ViStatus MethodUsingEnumWithGrpcNameValues(ViInt32 usingEnum) = 0;
+  virtual ViStatus MethodUsingWholeAndFractionalNumbers(ViInt32* wholeNumber, ViReal64* fractionalNumber) = 0;
+  virtual ViStatus MethodUsingWholeMappedNumbers(ViReal64* wholeNumber) = 0;
+  virtual ViStatus MethodWithGetLastErrorParam() = 0;
+  virtual ViStatus MethodWithGrpcFieldNumber(ViInt32 attributeValue) = 0;
+  virtual ViStatus MethodWithGrpcOnlyParam(ViInt32 simpleParam, ViInt32* grpcOnlyParam) = 0;
   virtual ViStatus MultipleArrayTypes(ViSession vi, ViInt32 outputArraySize, ViReal64 outputArray[], ViReal64 outputArrayOfFixedLength[3], ViInt32 inputArraySizes, ViReal64 inputArrayOfFloats[], ViInt16 inputArrayOfIntegers[]) = 0;
   virtual ViStatus MultipleArraysSameSize(ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], ViInt32 size) = 0;
   virtual ViStatus MultipleArraysSameSizeWithOptional(ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], CustomStruct values5[], ViInt32 size) = 0;
@@ -77,6 +86,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus ReturnDurationInSeconds(ViSession vi, ViReal64* timedelta) = 0;
   virtual ViStatus ReturnListOfDurationsInSeconds(ViSession vi, ViInt32 numberOfElements, ViReal64 timedeltas[]) = 0;
   virtual ViStatus ReturnMultipleTypes(ViSession vi, ViBoolean* aBoolean, ViInt32* anInt32, ViInt64* anInt64, ViInt16* anIntEnum, ViReal64* aFloat, ViReal64* aFloatEnum, ViInt32 arraySize, ViReal64 anArray[], ViInt32 stringSize, ViChar aString[]) = 0;
+  virtual ViStatus SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]) = 0;
   virtual ViStatus SetAttributeViBoolean(ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean attributeValue) = 0;
   virtual ViStatus SetAttributeViInt32(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 attributeValue) = 0;
   virtual ViStatus SetAttributeViInt64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64 attributeValue) = 0;
@@ -92,9 +102,6 @@ class NiFakeLibraryInterface {
   virtual ViStatus ViUInt8ArrayInputFunction(ViSession vi, ViInt32 numberOfElements, ViUInt8 anArray[]) = 0;
   virtual ViStatus ViUInt8ArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViUInt8 anArray[]) = 0;
   virtual ViStatus WriteWaveform(ViSession vi, ViInt32 numberOfSamples, ViReal64 waveform[]) = 0;
-  virtual ViStatus close(ViSession vi) = 0;
-  virtual ViStatus error_message(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]) = 0;
-  virtual ViStatus self_test(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]) = 0;
 };
 
 }  // namespace nifake_grpc

--- a/generated/nifake/nifake_mock_library.h
+++ b/generated/nifake/nifake_mock_library.h
@@ -23,12 +23,15 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, AcceptViUInt32Array, (ViSession vi, ViInt32 arrayLen, ViUInt32 uInt32Array[]), (override));
   MOCK_METHOD(ViStatus, BoolArrayInputFunction, (ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]), (override));
   MOCK_METHOD(ViStatus, BoolArrayOutputFunction, (ViSession vi, ViInt32 numberOfElements, ViBoolean anArray[]), (override));
+  MOCK_METHOD(ViStatus, Close, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, CloseExtCal, (ViSession vi, ViInt32 action), (override));
   MOCK_METHOD(ViStatus, CommandWithReservedParam, (ViSession vi, ViBoolean* reserved), (override));
+  MOCK_METHOD(ViStatus, Control4022, (ViString resourceName, ViInt32 configuration), (override));
   MOCK_METHOD(ViStatus, CreateConfigurationList, (ViInt32 numberOfListAttributes, ViAttr listAttributeIds[]), (override));
   MOCK_METHOD(ViStatus, DoubleAllTheNums, (ViSession vi, ViInt32 numberCount, ViReal64 numbers[]), (override));
   MOCK_METHOD(ViStatus, EnumArrayOutputFunction, (ViSession vi, ViInt32 numberOfElements, ViInt16 anArray[]), (override));
   MOCK_METHOD(ViStatus, EnumInputFunctionWithDefaults, (ViSession vi, ViInt16 aTurtle), (override));
+  MOCK_METHOD(ViStatus, ErrorMessage, (ViSession vi, ViStatus errorCode, ViChar errorMessage[256]), (override));
   MOCK_METHOD(ViStatus, ExportAttributeConfigurationBuffer, (ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[]), (override));
   MOCK_METHOD(ViStatus, FetchWaveform, (ViSession vi, ViInt32 numberOfSamples, ViReal64 waveformData[], ViInt32* actualNumberOfSamples), (override));
   MOCK_METHOD(ViStatus, GetABoolean, (ViSession vi, ViBoolean* aBoolean), (override));
@@ -39,7 +42,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, GetAnIviDanceWithATwistArrayOfCustomType, (ViSession vi, ViInt32 bufferSize, CustomStruct arrayOut[], ViInt32* actualSize), (override));
   MOCK_METHOD(ViStatus, GetAnIviDanceWithATwistArrayWithInputArray, (ViInt32 dataIn[], ViInt32 arraySizeIn, ViInt32 bufferSize, ViInt32 arrayOut[], ViInt32* actualSize), (override));
   MOCK_METHOD(ViStatus, GetAnIviDanceWithATwistByteArray, (ViInt32 bufferSize, ViInt8 arrayOut[], ViInt32* actualSize), (override));
-  MOCK_METHOD(ViStatus, GetAnIviDanceWithATwistString, (ViInt32 bufferSize, ViChar arrayOut[], ViInt32* actualSize), (override));
+  MOCK_METHOD(ViStatus, GetAnIviDanceWithATwistString, (ViSession vi, ViInt32 bufferSize, ViChar aString[], ViInt32* actualSize), (override));
   MOCK_METHOD(ViStatus, GetAnIviDanceWithATwistStringStrlenBug, (ViInt32 bufferSize, ViChar stringOut[], ViInt32* actualSize), (override));
   MOCK_METHOD(ViStatus, GetArraySizeForCustomCode, (ViSession vi, ViInt32* sizeOut), (override));
   MOCK_METHOD(ViStatus, GetArrayUsingIviDance, (ViSession vi, ViInt32 arraySize, ViReal64 arrayOut[]), (override));
@@ -48,7 +51,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, GetAttributeViInt32, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32* attributeValue), (override));
   MOCK_METHOD(ViStatus, GetAttributeViInt64, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64* attributeValue), (override));
   MOCK_METHOD(ViStatus, GetAttributeViReal64, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViReal64* attributeValue), (override));
-  MOCK_METHOD(ViStatus, GetAttributeViSession, (ViSession vi, ViInt32 attributeId, ViSession* sessionOut), (override));
+  MOCK_METHOD(ViStatus, GetAttributeViSession, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViSession* attributeValue), (override));
   MOCK_METHOD(ViStatus, GetAttributeViString, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 bufferSize, ViChar attributeValue[]), (override));
   MOCK_METHOD(ViStatus, GetBitfieldAsEnumArray, (ViInt64* flags), (override));
   MOCK_METHOD(ViStatus, GetCalDateAndTime, (ViSession vi, ViInt32 calType, ViInt32* month, ViInt32* day, ViInt32* year, ViInt32* hour, ViInt32* minute), (override));
@@ -65,6 +68,12 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, InitWithOptions, (ViString resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViConstString optionString, ViSession* vi), (override));
   MOCK_METHOD(ViStatus, InitWithVarArgs, (ViRsrc resourceName, ViSession* vi, ViConstString stringArg, ViInt16 turtle, ViConstString stringArg0, ViInt16 turtle0, ViConstString stringArg1, ViInt16 turtle1, ViConstString stringArg2, ViInt16 turtle2), (override));
   MOCK_METHOD(ViStatus, Initiate, (ViSession vi), (override));
+  MOCK_METHOD(ViStatus, MethodUsingEnumWithGrpcNameValues, (ViInt32 usingEnum), (override));
+  MOCK_METHOD(ViStatus, MethodUsingWholeAndFractionalNumbers, (ViInt32* wholeNumber, ViReal64* fractionalNumber), (override));
+  MOCK_METHOD(ViStatus, MethodUsingWholeMappedNumbers, (ViReal64* wholeNumber), (override));
+  MOCK_METHOD(ViStatus, MethodWithGetLastErrorParam, (), (override));
+  MOCK_METHOD(ViStatus, MethodWithGrpcFieldNumber, (ViInt32 attributeValue), (override));
+  MOCK_METHOD(ViStatus, MethodWithGrpcOnlyParam, (ViInt32 simpleParam, ViInt32* grpcOnlyParam), (override));
   MOCK_METHOD(ViStatus, MultipleArrayTypes, (ViSession vi, ViInt32 outputArraySize, ViReal64 outputArray[], ViReal64 outputArrayOfFixedLength[3], ViInt32 inputArraySizes, ViReal64 inputArrayOfFloats[], ViInt16 inputArrayOfIntegers[]), (override));
   MOCK_METHOD(ViStatus, MultipleArraysSameSize, (ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], ViInt32 size), (override));
   MOCK_METHOD(ViStatus, MultipleArraysSameSizeWithOptional, (ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], CustomStruct values5[], ViInt32 size), (override));
@@ -79,6 +88,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, ReturnDurationInSeconds, (ViSession vi, ViReal64* timedelta), (override));
   MOCK_METHOD(ViStatus, ReturnListOfDurationsInSeconds, (ViSession vi, ViInt32 numberOfElements, ViReal64 timedeltas[]), (override));
   MOCK_METHOD(ViStatus, ReturnMultipleTypes, (ViSession vi, ViBoolean* aBoolean, ViInt32* anInt32, ViInt64* anInt64, ViInt16* anIntEnum, ViReal64* aFloat, ViReal64* aFloatEnum, ViInt32 arraySize, ViReal64 anArray[], ViInt32 stringSize, ViChar aString[]), (override));
+  MOCK_METHOD(ViStatus, SelfTest, (ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]), (override));
   MOCK_METHOD(ViStatus, SetAttributeViBoolean, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean attributeValue), (override));
   MOCK_METHOD(ViStatus, SetAttributeViInt32, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 attributeValue), (override));
   MOCK_METHOD(ViStatus, SetAttributeViInt64, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64 attributeValue), (override));
@@ -94,9 +104,6 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, ViUInt8ArrayInputFunction, (ViSession vi, ViInt32 numberOfElements, ViUInt8 anArray[]), (override));
   MOCK_METHOD(ViStatus, ViUInt8ArrayOutputFunction, (ViSession vi, ViInt32 numberOfElements, ViUInt8 anArray[]), (override));
   MOCK_METHOD(ViStatus, WriteWaveform, (ViSession vi, ViInt32 numberOfSamples, ViReal64 waveform[]), (override));
-  MOCK_METHOD(ViStatus, close, (ViSession vi), (override));
-  MOCK_METHOD(ViStatus, error_message, (ViSession vi, ViStatus errorCode, ViChar errorMessage[256]), (override));
-  MOCK_METHOD(ViStatus, self_test, (ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]), (override));
 };
 
 }  // namespace unit

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -203,6 +203,29 @@ namespace nifake_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
+      auto status = library_->Close(vi);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::CloseExtCal(::grpc::ServerContext* context, const CloseExtCalRequest* request, CloseExtCalResponse* response)
   {
     if (context->IsCancelled()) {
@@ -239,6 +262,28 @@ namespace nifake_grpc {
       auto status = library_->CommandWithReservedParam(vi, reserved);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::Control4022(::grpc::ServerContext* context, const Control4022Request* request, Control4022Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      ViString resource_name = (ViString)request->resource_name().c_str();
+      ViInt32 configuration = request->configuration();
+      auto status = library_->Control4022(resource_name, configuration);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
       return ::grpc::Status::OK;
@@ -690,28 +735,30 @@ namespace nifake_grpc {
       return ::grpc::Status::CANCELLED;
     }
     try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
       ViInt32 actual_size {};
       while (true) {
-        auto status = library_->GetAnIviDanceWithATwistString(0, nullptr, &actual_size);
+        auto status = library_->GetAnIviDanceWithATwistString(vi, 0, nullptr, &actual_size);
         if (!status_ok(status)) {
-          return ConvertApiErrorStatusForViSession(context, status, 0);
+          return ConvertApiErrorStatusForViSession(context, status, vi);
         }
-        std::string array_out;
+        std::string a_string;
         if (actual_size > 0) {
-            array_out.resize(actual_size - 1);
+            a_string.resize(actual_size - 1);
         }
         auto buffer_size = actual_size;
-        status = library_->GetAnIviDanceWithATwistString(buffer_size, (ViChar*)array_out.data(), &actual_size);
+        status = library_->GetAnIviDanceWithATwistString(vi, buffer_size, (ViChar*)a_string.data(), &actual_size);
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again
           continue;
         }
         if (!status_ok(status)) {
-          return ConvertApiErrorStatusForViSession(context, status, 0);
+          return ConvertApiErrorStatusForViSession(context, status, vi);
         }
         response->set_status(status);
-        response->set_array_out(array_out);
-        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_array_out()));
+        response->set_a_string(a_string);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_a_string()));
         response->set_actual_size(actual_size);
         return ::grpc::Status::OK;
       }
@@ -961,15 +1008,16 @@ namespace nifake_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      ViInt32 attribute_id = request->attribute_id();
-      ViSession session_out {};
-      auto status = library_->GetAttributeViSession(vi, attribute_id, &session_out);
+      auto channel_name = request->channel_name().c_str();
+      ViAttr attribute_id = request->attribute_id();
+      ViSession attribute_value {};
+      auto status = library_->GetAttributeViSession(vi, channel_name, attribute_id, &attribute_value);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
       }
       response->set_status(status);
-      auto session_id = session_repository_->resolve_session_id(session_out);
-      response->mutable_session_out()->set_id(session_id);
+      auto session_id = session_repository_->resolve_session_id(attribute_value);
+      response->mutable_attribute_value()->set_id(session_id);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::LibraryLoadException& ex) {
@@ -1336,7 +1384,7 @@ namespace nifake_grpc {
       };
       uint32_t session_id = 0;
       const std::string& grpc_device_session_name = request->session_name();
-      auto cleanup_lambda = [&] (ViSession id) { library_->close(id); };
+      auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
@@ -1390,7 +1438,7 @@ namespace nifake_grpc {
       };
       uint32_t session_id = 0;
       const std::string& grpc_device_session_name = request->session_name();
-      auto cleanup_lambda = [&] (ViSession id) { library_->close(id); };
+      auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
       int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
@@ -1404,6 +1452,161 @@ namespace nifake_grpc {
     }
     catch (nidevice_grpc::SessionException& ex) {
       return ::grpc::Status(::grpc::INVALID_ARGUMENT, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::MethodUsingEnumWithGrpcNameValues(::grpc::ServerContext* context, const MethodUsingEnumWithGrpcNameValuesRequest* request, MethodUsingEnumWithGrpcNameValuesResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      ViInt32 using_enum;
+      switch (request->using_enum_enum_case()) {
+        case nifake_grpc::MethodUsingEnumWithGrpcNameValuesRequest::UsingEnumEnumCase::kUsingEnum: {
+          using_enum = static_cast<ViInt32>(request->using_enum());
+          break;
+        }
+        case nifake_grpc::MethodUsingEnumWithGrpcNameValuesRequest::UsingEnumEnumCase::kUsingEnumRaw: {
+          using_enum = static_cast<ViInt32>(request->using_enum_raw());
+          break;
+        }
+        case nifake_grpc::MethodUsingEnumWithGrpcNameValuesRequest::UsingEnumEnumCase::USING_ENUM_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for using_enum was not specified or out of range");
+          break;
+        }
+      }
+
+      auto status = library_->MethodUsingEnumWithGrpcNameValues(using_enum);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, 0);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::MethodUsingWholeAndFractionalNumbers(::grpc::ServerContext* context, const MethodUsingWholeAndFractionalNumbersRequest* request, MethodUsingWholeAndFractionalNumbersResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      ViInt32 whole_number {};
+      ViReal64 fractional_number {};
+      auto status = library_->MethodUsingWholeAndFractionalNumbers(&whole_number, &fractional_number);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, 0);
+      }
+      response->set_status(status);
+      response->set_whole_number(static_cast<nifake_grpc::DecimalWholeNumber>(whole_number));
+      response->set_whole_number_raw(whole_number);
+      auto fractional_number_omap_it = decimalmixednumber_output_map_.find(fractional_number);
+      if(fractional_number_omap_it != decimalmixednumber_output_map_.end()) {
+        response->set_fractional_number_mapped(static_cast<nifake_grpc::DecimalMixedNumber>(fractional_number_omap_it->second));
+      }
+      response->set_fractional_number_raw(fractional_number);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::MethodUsingWholeMappedNumbers(::grpc::ServerContext* context, const MethodUsingWholeMappedNumbersRequest* request, MethodUsingWholeMappedNumbersResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      ViReal64 whole_number {};
+      auto status = library_->MethodUsingWholeMappedNumbers(&whole_number);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, 0);
+      }
+      response->set_status(status);
+      auto whole_number_omap_it = decimalwholenumbermapped_output_map_.find(whole_number);
+      if(whole_number_omap_it != decimalwholenumbermapped_output_map_.end()) {
+        response->set_whole_number_mapped(static_cast<nifake_grpc::DecimalWholeNumberMapped>(whole_number_omap_it->second));
+      }
+      response->set_whole_number_raw(whole_number);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::MethodWithGetLastErrorParam(::grpc::ServerContext* context, const MethodWithGetLastErrorParamRequest* request, MethodWithGetLastErrorParamResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto status = library_->MethodWithGetLastErrorParam();
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, 0);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::MethodWithGrpcFieldNumber(::grpc::ServerContext* context, const MethodWithGrpcFieldNumberRequest* request, MethodWithGrpcFieldNumberResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      ViInt32 attribute_value = request->attribute_value();
+      auto status = library_->MethodWithGrpcFieldNumber(attribute_value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, 0);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::MethodWithGrpcOnlyParam(::grpc::ServerContext* context, const MethodWithGrpcOnlyParamRequest* request, MethodWithGrpcOnlyParamResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      ViInt32 simple_param = request->simple_param();
+      ViInt32 grpc_only_param {};
+      auto status = library_->MethodWithGrpcOnlyParam(simple_param, &grpc_only_param);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, 0);
+      }
+      response->set_status(status);
+      response->set_grpc_only_param(grpc_only_param);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::LibraryLoadException& ex) {
+      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
     }
   }
 
@@ -2179,29 +2382,6 @@ namespace nifake_grpc {
       ViInt32 number_of_samples = static_cast<ViInt32>(request->waveform().size());
       auto waveform = const_cast<ViReal64*>(request->waveform().data());
       auto status = library_->WriteWaveform(vi, number_of_samples, waveform);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForViSession(context, status, vi);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::LibraryLoadException& ex) {
-      return ::grpc::Status(::grpc::NOT_FOUND, ex.what());
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiFakeService::Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
-      auto status = library_->close(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
       }

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -47,8 +47,10 @@ public:
   ::grpc::Status AcceptViUInt32Array(::grpc::ServerContext* context, const AcceptViUInt32ArrayRequest* request, AcceptViUInt32ArrayResponse* response) override;
   ::grpc::Status BoolArrayInputFunction(::grpc::ServerContext* context, const BoolArrayInputFunctionRequest* request, BoolArrayInputFunctionResponse* response) override;
   ::grpc::Status BoolArrayOutputFunction(::grpc::ServerContext* context, const BoolArrayOutputFunctionRequest* request, BoolArrayOutputFunctionResponse* response) override;
+  ::grpc::Status Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response) override;
   ::grpc::Status CloseExtCal(::grpc::ServerContext* context, const CloseExtCalRequest* request, CloseExtCalResponse* response) override;
   ::grpc::Status CommandWithReservedParam(::grpc::ServerContext* context, const CommandWithReservedParamRequest* request, CommandWithReservedParamResponse* response) override;
+  ::grpc::Status Control4022(::grpc::ServerContext* context, const Control4022Request* request, Control4022Response* response) override;
   ::grpc::Status CreateConfigurationList(::grpc::ServerContext* context, const CreateConfigurationListRequest* request, CreateConfigurationListResponse* response) override;
   ::grpc::Status DoubleAllTheNums(::grpc::ServerContext* context, const DoubleAllTheNumsRequest* request, DoubleAllTheNumsResponse* response) override;
   ::grpc::Status EnumArrayOutputFunction(::grpc::ServerContext* context, const EnumArrayOutputFunctionRequest* request, EnumArrayOutputFunctionResponse* response) override;
@@ -87,6 +89,12 @@ public:
   ::grpc::Status InitExtCal(::grpc::ServerContext* context, const InitExtCalRequest* request, InitExtCalResponse* response) override;
   ::grpc::Status InitWithOptions(::grpc::ServerContext* context, const InitWithOptionsRequest* request, InitWithOptionsResponse* response) override;
   ::grpc::Status InitWithVarArgs(::grpc::ServerContext* context, const InitWithVarArgsRequest* request, InitWithVarArgsResponse* response) override;
+  ::grpc::Status MethodUsingEnumWithGrpcNameValues(::grpc::ServerContext* context, const MethodUsingEnumWithGrpcNameValuesRequest* request, MethodUsingEnumWithGrpcNameValuesResponse* response) override;
+  ::grpc::Status MethodUsingWholeAndFractionalNumbers(::grpc::ServerContext* context, const MethodUsingWholeAndFractionalNumbersRequest* request, MethodUsingWholeAndFractionalNumbersResponse* response) override;
+  ::grpc::Status MethodUsingWholeMappedNumbers(::grpc::ServerContext* context, const MethodUsingWholeMappedNumbersRequest* request, MethodUsingWholeMappedNumbersResponse* response) override;
+  ::grpc::Status MethodWithGetLastErrorParam(::grpc::ServerContext* context, const MethodWithGetLastErrorParamRequest* request, MethodWithGetLastErrorParamResponse* response) override;
+  ::grpc::Status MethodWithGrpcFieldNumber(::grpc::ServerContext* context, const MethodWithGrpcFieldNumberRequest* request, MethodWithGrpcFieldNumberResponse* response) override;
+  ::grpc::Status MethodWithGrpcOnlyParam(::grpc::ServerContext* context, const MethodWithGrpcOnlyParamRequest* request, MethodWithGrpcOnlyParamResponse* response) override;
   ::grpc::Status MultipleArrayTypes(::grpc::ServerContext* context, const MultipleArrayTypesRequest* request, MultipleArrayTypesResponse* response) override;
   ::grpc::Status MultipleArraysSameSize(::grpc::ServerContext* context, const MultipleArraysSameSizeRequest* request, MultipleArraysSameSizeResponse* response) override;
   ::grpc::Status MultipleArraysSameSizeWithOptional(::grpc::ServerContext* context, const MultipleArraysSameSizeWithOptionalRequest* request, MultipleArraysSameSizeWithOptionalResponse* response) override;
@@ -111,7 +119,6 @@ public:
   ::grpc::Status ViUInt8ArrayInputFunction(::grpc::ServerContext* context, const ViUInt8ArrayInputFunctionRequest* request, ViUInt8ArrayInputFunctionResponse* response) override;
   ::grpc::Status ViUInt8ArrayOutputFunction(::grpc::ServerContext* context, const ViUInt8ArrayOutputFunctionRequest* request, ViUInt8ArrayOutputFunctionResponse* response) override;
   ::grpc::Status WriteWaveform(::grpc::ServerContext* context, const WriteWaveformRequest* request, WriteWaveformResponse* response) override;
-  ::grpc::Status Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response) override;
 private:
   NiFakeLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
@@ -119,6 +126,10 @@ private:
   void Copy(const std::vector<ViBoolean>& input, google::protobuf::RepeatedField<bool>* output);
   template <typename TEnum>
   void CopyBytesToEnums(const std::string& input, google::protobuf::RepeatedField<TEnum>* output);
+  std::map<std::int32_t, std::int32_t> decimalmixednumber_input_map_ { {0, 0},{1, 22},{2, 2.2f},{3, -3},{4, 2147483647},{5, 2147483648.0f},{6, -2147483648},{7, -2147483649.0f}, };
+  std::map<std::int32_t, std::int32_t> decimalmixednumber_output_map_ { {0, 0},{22, 1},{2.2f, 2},{-3, 3},{2147483647, 4},{2147483648.0f, 5},{-2147483648, 6},{-2147483649.0f, 7}, };
+  std::map<std::int32_t, double> decimalwholenumbermapped_input_map_ { {1, 0.0f},{2, -1.0f},{3, 22.0f}, };
+  std::map<double, std::int32_t> decimalwholenumbermapped_output_map_ { {0.0f, 1},{-1.0f, 2},{22.0f, 3}, };
   std::map<std::int32_t, double> floatenum_input_map_ { {1, 3.5f},{2, 4.5f},{3, 5.5f},{4, 6.5f},{5, 7.5f}, };
   std::map<double, std::int32_t> floatenum_output_map_ { {3.5f, 1},{4.5f, 2},{5.5f, 3},{6.5f, 4},{7.5f, 5}, };
   std::map<std::int32_t, std::string> mobileosnames_input_map_ { {1, "Android"},{2, "iOS"},{3, "None"}, };

--- a/source/codegen/metadata/nifake/attributes.py
+++ b/source/codegen/metadata/nifake/attributes.py
@@ -1,129 +1,83 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 1.2.0d9
+# This file is generated from NI-FAKE API metadata version 23.0.0d18
 attributes = {
     1000000: {
-        'access': 'read-write',
-        'channel_based': False,
-        'documentation': {
-            'description': 'An attribute of type bool with read/write access.'
-        },
-        'lv_property': 'Fake attributes:Read Write Bool',
+        'codegen_method': 'public',
+        'grpc_type': 'bool',
         'name': 'READ_WRITE_BOOL',
         'resettable': False,
         'type': 'ViBoolean'
     },
     1000001: {
-        'access': 'read-write',
-        'channel_based': False,
-        'documentation': {
-            'description': 'An attribute of type float with read/write access.'
-        },
-        'lv_property': 'Fake attributes:Read Write Float',
+        'codegen_method': 'public',
+        'grpc_type': 'double',
         'name': 'READ_WRITE_DOUBLE',
         'resettable': False,
         'type': 'ViReal64'
     },
     1000002: {
-        'access': 'read-write',
-        'channel_based': False,
-        'documentation': {
-            'description': 'An attribute of type string with read/write access.'
-        },
-        'lv_property': 'Fake attributes:Read Write String',
+        'codegen_method': 'public',
+        'grpc_type': 'string',
         'name': 'READ_WRITE_STRING',
         'resettable': False,
         'type': 'ViString'
     },
     1000003: {
-        'access': 'read-write',
-        'channel_based': False,
-        'documentation': {
-            'description': 'An attribute of type Color with read/write access.'
-        },
-        'enum': 'Color',
-        'lv_property': 'Fake attributes:Read Write Color',
+        'codegen_method': 'public',
+        'enum': 'GrpcColorOverride',
+        'grpc_type': 'sint32',
         'name': 'READ_WRITE_COLOR',
         'resettable': False,
         'type': 'ViInt32'
     },
     1000004: {
-        'access': 'read-write',
-        'channel_based': False,
-        'documentation': {
-            'description': 'An attribute of type integer with read/write access.'
-        },
-        'lv_property': 'Fake attributes:Read Write Int',
+        'codegen_method': 'public',
+        'grpc_type': 'sint32',
         'name': 'READ_WRITE_INTEGER',
         'resettable': True,
         'type': 'ViInt32'
     },
     1000005: {
-        'access': 'read-write',
-        'channel_based': False,
-        'documentation': {
-            'description': 'An attribute with an enum that is also a float'
-        },
+        'codegen_method': 'public',
         'enum': 'FloatEnum',
-        'lv_property': 'Fake attributes:Float enum',
-        'name': 'FLOAT_ENUM',
+        'grpc_type': 'double',
+        'name': 'FLOAT_ENUM_NAME_OVERRIDE',
         'resettable': False,
         'type': 'ViReal64'
     },
     1000006: {
-        'access': 'read-write',
-        'channel_based': False,
-        'documentation': {
-            'description': 'An attribute of type 64-bit integer with read/write access.'
-        },
-        'lv_property': 'Fake attributes:Read Write long long',
+        'codegen_method': 'public',
+        'grpc_type': 'int64',
         'name': 'READ_WRITE_INT64',
         'resettable': False,
         'type': 'ViInt64'
     },
     1000007: {
-        'access': 'read-write',
-        'attribute_class': 'AttributeViReal64TimeDeltaSeconds',
-        'channel_based': False,
-        'documentation': {
-            'description': 'Attribute in seconds'
-        },
-        'lv_property': 'Fake attributes:Read Write Double with Converter',
+        'codegen_method': 'public',
+        'grpc_type': 'double',
         'name': 'READ_WRITE_DOUBLE_WITH_CONVERTER',
         'resettable': False,
-        'type': 'ViReal64',
-        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
+        'type': 'ViReal64'
     },
     1000008: {
-        'access': 'read-write',
-        'attribute_class': 'AttributeViInt32TimeDeltaMilliseconds',
-        'channel_based': False,
-        'documentation': {
-            'description': 'Attribute in milliseconds'
-        },
-        'lv_property': 'Fake attributes:Read Write Int with Converter',
+        'codegen_method': 'public',
+        'grpc_type': 'sint32',
         'name': 'READ_WRITE_INTEGER_WITH_CONVERTER',
         'resettable': False,
-        'type': 'ViInt32',
-        'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or int in milliseconds'
+        'type': 'ViInt32'
     },
     1000009: {
-        'access': 'read-write',
-        'channel_based': True,
+        'codegen_method': 'public',
+        'grpc_type': 'double',
         'name': 'READ_WRITE_DOUBLE_WITH_REPEATED_CAPABILITY',
         'resettable': False,
         'type': 'ViReal64'
     },
     1000010: {
-        'access': 'read-write',
-        'attribute_class': 'AttributeViStringRepeatedCapability',
-        'channel_based': False,
-        'documentation': {
-            'description': 'An attribute with read/write access, that represents a repeated capability'
-        },
-        'lv_property': 'Fake attributes:Read Write String Repeated Capability',
+        'codegen_method': 'public',
+        'grpc_type': 'string',
         'name': 'READ_WRITE_STRING_REPEATED_CAPABILITY',
         'resettable': False,
-        'type': 'ViString',
-        'type_in_documentation': "Any repeated capability type, as defined in nimi-python:\n        - str\n        - str - Comma delimited list\n        - str - Range (using '-' or ':')\n        - int\n        - Basic sequence types (list, tuple, range, slice) of other supported types"
+        'type': 'ViString'
     }
 }

--- a/source/codegen/metadata/nifake/config.py
+++ b/source/codegen/metadata/nifake/config.py
@@ -1,26 +1,23 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 1.2.0d9
+# This file is generated from NI-FAKE API metadata version 23.0.0d18
 config = {
-    'api_version': '1.2.0d9',
+    'additional_headers': {
+    },
+    'api_version': '23.0.0',
     'c_function_prefix': 'niFake_',
     'c_header': 'niFake.h',
-    'close_function': 'close',
-    'context_manager_name': {
-        'abort_function': 'Abort',
-        'initiate_function': 'Initiate',
-        'task': 'acquisition'
-    },
+    'close_function': 'Close',
     'csharp_namespace': 'NationalInstruments.Grpc.Fake',
     'custom_types': [
         {
             'fields': [
                 {
-                    'grpc_name': 'struct_int',
+                    'grpc_type': 'sint32',
                     'name': 'structInt',
                     'type': 'ViInt32'
                 },
                 {
-                    'grpc_name': 'struct_double',
+                    'grpc_type': 'double',
                     'name': 'structDouble',
                     'type': 'ViReal64'
                 }
@@ -31,12 +28,25 @@ config = {
         {
             'fields': [
                 {
+                    'grpc_type': 'string',
+                    'name': 'stringArg',
+                    'type': 'ViConstString'
+                }
+            ],
+            'grpc_name': 'CustomNamedType',
+            'name': 'namedType_custom'
+        },
+        {
+            'fields': [
+                {
+                    'grpc_type': 'string',
                     'name': 'stringArg',
                     'type': 'ViConstString'
                 },
                 {
                     'coerced': True,
                     'enum': 'Turtle',
+                    'grpc_type': 'Turtle',
                     'name': 'turtle',
                     'type': 'ViInt16'
                 }
@@ -46,14 +56,6 @@ config = {
         }
     ],
     'driver_name': 'NI-FAKE',
-    'enum_whitelist_suffix': [
-        '_POINT_FIVE'
-    ],
-    'extra_errors_used': [
-        'InvalidRepeatedCapabilityError',
-        'SelfTestError'
-    ],
-    'init_function': 'InitWithOptions',
     'java_package': 'com.ni.grpc.fake',
     'library_info': {
         'Linux': {
@@ -74,22 +76,9 @@ config = {
         }
     },
     'linux_rt_support': False,
-    'metadata_version': '2.0',
     'module_name': 'nifake',
     'namespace_component': 'nifake',
-    'repeated_capabilities': [
-        {
-            'prefix': '',
-            'python_name': 'channels'
-        },
-        {
-            'prefix': 'site',
-            'python_name': 'sites'
-        }
-    ],
     'service_class_prefix': 'NiFake',
-    'session_class_description': 'An NI-FAKE session to a fake MI driver whose sole purpose is to test nimi-python code generation',
     'session_handle_parameter_name': 'vi',
-    'status_ok': 'status >= 0',
-    'uses_nitclk': True
+    'status_ok': 'status >= 0'
 }

--- a/source/codegen/metadata/nifake/enums.py
+++ b/source/codegen/metadata/nifake/enums.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 1.2.0d9
+# This file is generated from NI-FAKE API metadata version 23.0.0d18
 enums = {
     'Bitfield': {
+        'codegen_method': 'public',
         'values': [
             {
                 'name': 'FLAG_A',
@@ -21,27 +22,90 @@ enums = {
             }
         ]
     },
-    'Color': {
+    'DecimalMixedNumber': {
+        'codegen_method': 'public',
+        'generate-mappings': True,
         'values': [
             {
-                'name': 'RED',
+                'name': 'TWENTY_TWO',
+                'value': 22
+            },
+            {
+                'name': 'TWO_POINT_TWO',
+                'value': 2.2
+            },
+            {
+                'name': 'NEGATIVE_THREE',
+                'value': -3
+            },
+            {
+                'name': 'MAX_INT_32',
+                'value': 2147483647
+            },
+            {
+                'name': 'MAX_INT_32_PLUS_ONE',
+                'value': 2147483648.0
+            },
+            {
+                'name': 'MIN_INT_32',
+                'value': -2147483648
+            },
+            {
+                'name': 'MIN_INT_32_MINUS_ONE',
+                'value': -2147483649.0
+            }
+        ]
+    },
+    'DecimalWholeNumber': {
+        'codegen_method': 'public',
+        'values': [
+            {
+                'name': 'ZERO',
+                'value': 0
+            },
+            {
+                'name': 'NEGATIVE_ONE',
+                'value': -1
+            },
+            {
+                'name': 'TWENTY_TWO',
+                'value': 22
+            }
+        ]
+    },
+    'DecimalWholeNumberMapped': {
+        'codegen_method': 'public',
+        'generate-mappings': True,
+        'values': [
+            {
+                'name': 'ZERO',
+                'value': 0.0
+            },
+            {
+                'name': 'NEGATIVE_ONE',
+                'value': -1.0
+            },
+            {
+                'name': 'TWENTY_TWO',
+                'value': 22.0
+            }
+        ]
+    },
+    'EnumWithGrpcNameValues': {
+        'codegen_method': 'public',
+        'values': [
+            {
+                'name': 'ALTERED_GRPC_NAME_ONE',
                 'value': 1
             },
             {
-                'name': 'BLUE',
+                'name': 'TWO',
                 'value': 2
-            },
-            {
-                'name': 'YELLOW',
-                'value': 5
-            },
-            {
-                'name': 'BLACK',
-                'value': 42
             }
         ]
     },
     'FloatEnum': {
+        'codegen_method': 'public',
         'generate-mappings': True,
         'values': [
             {
@@ -66,7 +130,29 @@ enums = {
             }
         ]
     },
+    'GrpcColorOverride': {
+        'codegen_method': 'public',
+        'values': [
+            {
+                'name': 'RED',
+                'value': 1
+            },
+            {
+                'name': 'BLUE',
+                'value': 2
+            },
+            {
+                'name': 'YELLOW',
+                'value': 5
+            },
+            {
+                'name': 'BLACK',
+                'value': 42
+            }
+        ]
+    },
     'MobileOSNames': {
+        'codegen_method': 'public',
         'generate-mappings': True,
         'values': [
             {
@@ -88,19 +174,19 @@ enums = {
         'generate-mappings': False,
         'values': [
             {
-                'name': 'COLOR_RED',
+                'name': 'GRPC_COLOR_OVERRIDE_RED',
                 'value': 1
             },
             {
-                'name': 'COLOR_BLUE',
+                'name': 'GRPC_COLOR_OVERRIDE_BLUE',
                 'value': 2
             },
             {
-                'name': 'COLOR_YELLOW',
+                'name': 'GRPC_COLOR_OVERRIDE_YELLOW',
                 'value': 5
             },
             {
-                'name': 'COLOR_BLACK',
+                'name': 'GRPC_COLOR_OVERRIDE_BLACK',
                 'value': 42
             }
         ]
@@ -132,6 +218,7 @@ enums = {
         ]
     },
     'Turtle': {
+        'codegen_method': 'public',
         'values': [
             {
                 'name': 'LEONARDO',

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -1,18 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 1.2.0d9
+# This file is generated from NI-FAKE API metadata version 23.0.0d18
 functions = {
     'Abort': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Aborts a previously initiated thingie.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -22,16 +16,10 @@ functions = {
     },
     'AcceptListOfDurationsInSeconds': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Accepts list of floats or hightime.timedelta instances representing time delays.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -42,9 +30,6 @@ functions = {
                     'delays'
                 ],
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Count of input values.'
-                },
                 'grpc_type': 'sint32',
                 'include_in_proto': False,
                 'is_size_param': True,
@@ -55,18 +40,13 @@ functions = {
             {
                 'cppName': 'delays',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'A collection of time delay values.'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'delays',
-                'python_api_converter_name': 'convert_timedeltas_to_seconds_real64',
                 'size': {
                     'mechanism': 'len',
                     'value': 'count'
                 },
-                'type': 'ViReal64[]',
-                'type_in_documentation': 'hightime.timedelta, datetime.timedelta, or float in seconds'
+                'type': 'ViReal64[]'
             }
         ],
         'returns': 'ViStatus'
@@ -97,6 +77,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'AcceptViUInt32Array': {
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
@@ -134,16 +115,10 @@ functions = {
     },
     'BoolArrayInputFunction': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'This function accepts an array of booleans.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session. You obtain the **vi** parameter from niFake_InitWithOptions.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -151,9 +126,6 @@ functions = {
             {
                 'cppName': 'numberOfElements',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Number of elements in the array.'
-                },
                 'grpc_type': 'sint32',
                 'is_size_param': True,
                 'name': 'numberOfElements',
@@ -162,9 +134,6 @@ functions = {
             {
                 'cppName': 'anArray',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Input boolean array'
-                },
                 'grpc_type': 'repeated bool',
                 'name': 'anArray',
                 'size': {
@@ -178,16 +147,10 @@ functions = {
     },
     'BoolArrayOutputFunction': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'This function returns an array of booleans.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session. You obtain the **vi** parameter from niFake_InitWithOptions.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -195,9 +158,6 @@ functions = {
             {
                 'cppName': 'numberOfElements',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Number of elements in the array.'
-                },
                 'grpc_type': 'sint32',
                 'is_size_param': True,
                 'name': 'numberOfElements',
@@ -206,9 +166,6 @@ functions = {
             {
                 'cppName': 'anArray',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Contains an array of booleans'
-                },
                 'grpc_type': 'repeated bool',
                 'name': 'anArray',
                 'size': {
@@ -216,6 +173,20 @@ functions = {
                     'value': 'numberOfElements'
                 },
                 'type': 'ViBoolean[]'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'Close': {
+        'cname': 'niFake_close',
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'cppName': 'vi',
+                'direction': 'in',
+                'grpc_type': 'nidevice_grpc.Session',
+                'name': 'vi',
+                'type': 'ViSession'
             }
         ],
         'returns': 'ViStatus'
@@ -242,6 +213,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'CommandWithReservedParam': {
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
@@ -263,7 +235,29 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'Control4022': {
+        'cname': 'niFake_4022Control',
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'cppName': 'resourceName',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'resourceName',
+                'type': 'ViString'
+            },
+            {
+                'cppName': 'configuration',
+                'direction': 'in',
+                'grpc_type': 'sint32',
+                'name': 'configuration',
+                'type': 'ViInt32'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'CreateConfigurationList': {
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'numberOfListAttributes',
@@ -293,16 +287,11 @@ functions = {
         'returns': 'ViStatus'
     },
     'DoubleAllTheNums': {
-        'documentation': {
-            'description': 'Test for buffer with converter'
-        },
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session. You obtain the **vi** parameter from niFake_InitWithOptions.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -313,9 +302,6 @@ functions = {
                     'numbers'
                 ],
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Number of elements in the number array'
-                },
                 'grpc_type': 'sint32',
                 'include_in_proto': False,
                 'is_size_param': True,
@@ -326,12 +312,8 @@ functions = {
             {
                 'cppName': 'numbers',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'numbers is an array of numbers we want to double.'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'numbers',
-                'python_api_converter_name': 'convert_double_each_element',
                 'size': {
                     'mechanism': 'len',
                     'value': 'numberCount'
@@ -343,16 +325,10 @@ functions = {
     },
     'EnumArrayOutputFunction': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'This function returns an array of enums, stored as 16 bit integers under the hood.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session. You obtain the **vi** parameter from niFake_InitWithOptions.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -360,9 +336,6 @@ functions = {
             {
                 'cppName': 'numberOfElements',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Number of elements in the array.'
-                },
                 'grpc_type': 'sint32',
                 'is_size_param': True,
                 'name': 'numberOfElements',
@@ -371,9 +344,6 @@ functions = {
             {
                 'cppName': 'anArray',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Contains an array of enums, stored as 16 bit integers under the hood '
-                },
                 'enum': 'Turtle',
                 'grpc_type': 'repeated sint32',
                 'name': 'anArray',
@@ -388,45 +358,17 @@ functions = {
     },
     'EnumInputFunctionWithDefaults': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'This function takes one parameter other than the session, which happens to be an enum and has a default value.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session. You obtain the **vi** parameter from niFake_InitWithOptions.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
             },
             {
                 'cppName': 'aTurtle',
-                'default_value': 'Turtle.LEONARDO',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Indicates a ninja turtle',
-                    'table_body': [
-                        [
-                            '0',
-                            'Leonardo'
-                        ],
-                        [
-                            '1',
-                            'Donatello'
-                        ],
-                        [
-                            '2',
-                            'Raphael'
-                        ],
-                        [
-                            '3',
-                            'Mich elangelo'
-                        ]
-                    ]
-                },
                 'enum': 'Turtle',
                 'grpc_type': 'sint32',
                 'name': 'aTurtle',
@@ -435,10 +377,41 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'ErrorMessage': {
+        'cname': 'niFake_error_message',
+        'codegen_method': 'private',
+        'is_error_handling': True,
+        'parameters': [
+            {
+                'cppName': 'vi',
+                'direction': 'in',
+                'grpc_type': 'nidevice_grpc.Session',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'cppName': 'errorCode',
+                'direction': 'in',
+                'grpc_type': 'sint32',
+                'name': 'errorCode',
+                'type': 'ViStatus'
+            },
+            {
+                'cppName': 'errorMessage',
+                'direction': 'out',
+                'grpc_type': 'string',
+                'name': 'errorMessage',
+                'size': {
+                    'mechanism': 'fixed',
+                    'value': 256
+                },
+                'type': 'ViChar[]'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'ExportAttributeConfigurationBuffer': {
-        'documentation': {
-            'description': 'Export configuration buffer.'
-        },
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
@@ -461,42 +434,21 @@ functions = {
                 'direction': 'out',
                 'grpc_type': 'bytes',
                 'name': 'configuration',
-                'python_api_converter_name': 'convert_to_bytes',
                 'size': {
                     'mechanism': 'ivi-dance',
                     'value': 'sizeInBytes'
                 },
-                'type': 'ViInt8[]',
-                'type_in_documentation': 'bytes',
-                'use_array': True
+                'type': 'ViInt8[]'
             }
         ],
         'returns': 'ViStatus'
     },
     'FetchWaveform': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Returns waveform data.'
-        },
-        'method_templates': [
-            {
-                'documentation_filename': 'default_method',
-                'method_python_name_suffix': '',
-                'session_filename': 'default_method'
-            },
-            {
-                'documentation_filename': 'numpy_method',
-                'method_python_name_suffix': '_into',
-                'session_filename': 'numpy_read_method'
-            }
-        ],
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -504,9 +456,6 @@ functions = {
             {
                 'cppName': 'numberOfSamples',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Number of samples to return'
-                },
                 'grpc_type': 'sint32',
                 'is_size_param': True,
                 'name': 'numberOfSamples',
@@ -515,46 +464,30 @@ functions = {
             {
                 'cppName': 'waveformData',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Samples fetched from the device. Array should be numberOfSamples big.'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'waveformData',
-                'numpy': True,
                 'size': {
                     'mechanism': 'passed-in',
                     'value': 'numberOfSamples'
                 },
-                'type': 'ViReal64[]',
-                'use_array': True
+                'type': 'ViReal64[]'
             },
             {
                 'cppName': 'actualNumberOfSamples',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Number of samples actually fetched.'
-                },
                 'grpc_type': 'sint32',
                 'name': 'actualNumberOfSamples',
-                'type': 'ViInt32',
-                'use_in_python_api': False
+                'type': 'ViInt32'
             }
         ],
         'returns': 'ViStatus'
     },
     'GetABoolean': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Returns a boolean.',
-            'note': 'This function rules!'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -562,9 +495,6 @@ functions = {
             {
                 'cppName': 'aBoolean',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Contains a boolean.'
-                },
                 'grpc_type': 'bool',
                 'name': 'aBoolean',
                 'type': 'ViBoolean'
@@ -574,17 +504,10 @@ functions = {
     },
     'GetANumber': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Returns a number.',
-            'note': 'This function rules!'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -592,9 +515,6 @@ functions = {
             {
                 'cppName': 'aNumber',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Contains a number.'
-                },
                 'grpc_type': 'sint32',
                 'name': 'aNumber',
                 'type': 'ViInt16'
@@ -604,16 +524,10 @@ functions = {
     },
     'GetAStringOfFixedMaximumSize': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Illustrates returning a string of fixed size.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -621,9 +535,6 @@ functions = {
             {
                 'cppName': 'aString',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'String comes back here. Buffer must be 256 big.'
-                },
                 'grpc_type': 'string',
                 'name': 'aString',
                 'size': {
@@ -637,16 +548,10 @@ functions = {
     },
     'GetAnIviDanceString': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Returns a string using the IVI dance.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -654,9 +559,6 @@ functions = {
             {
                 'cppName': 'bufferSize',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Number of bytes in aString You can IVI-dance with this.'
-                },
                 'grpc_type': 'sint32',
                 'include_in_proto': False,
                 'is_size_param': True,
@@ -666,9 +568,6 @@ functions = {
             {
                 'cppName': 'aString',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Returns the string.'
-                },
                 'grpc_type': 'string',
                 'name': 'aString',
                 'size': {
@@ -681,6 +580,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetAnIviDanceWithATwistArray': {
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
@@ -728,6 +628,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetAnIviDanceWithATwistArrayOfCustomType': {
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
@@ -768,6 +669,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetAnIviDanceWithATwistArrayWithInputArray': {
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'dataIn',
@@ -825,6 +727,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetAnIviDanceWithATwistByteArray': {
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'bufferSize',
@@ -858,7 +761,15 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetAnIviDanceWithATwistString': {
+        'codegen_method': 'public',
         'parameters': [
+            {
+                'cppName': 'vi',
+                'direction': 'in',
+                'grpc_type': 'nidevice_grpc.Session',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
             {
                 'cppName': 'bufferSize',
                 'direction': 'in',
@@ -869,10 +780,10 @@ functions = {
                 'type': 'ViInt32'
             },
             {
-                'cppName': 'arrayOut',
+                'cppName': 'aString',
                 'direction': 'out',
                 'grpc_type': 'string',
-                'name': 'arrayOut',
+                'name': 'aString',
                 'size': {
                     'mechanism': 'ivi-dance-with-a-twist',
                     'value': 'bufferSize',
@@ -891,6 +802,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetAnIviDanceWithATwistStringStrlenBug': {
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'bufferSize',
@@ -928,16 +840,10 @@ functions = {
     },
     'GetArraySizeForCustomCode': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'This function returns the size of the array for use in custom-code size mechanism.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -945,9 +851,6 @@ functions = {
             {
                 'cppName': 'sizeOut',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Size of array'
-                },
                 'grpc_type': 'sint32',
                 'name': 'sizeOut',
                 'type': 'ViInt32'
@@ -957,16 +860,10 @@ functions = {
     },
     'GetArrayUsingIviDance': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'This function returns an array of float whose size is determined with the IVI dance.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -974,9 +871,6 @@ functions = {
             {
                 'cppName': 'arraySize',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies the size of the buffer for copyint arrayOut onto.'
-                },
                 'grpc_type': 'sint32',
                 'include_in_proto': False,
                 'is_size_param': True,
@@ -986,9 +880,6 @@ functions = {
             {
                 'cppName': 'arrayOut',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'The array returned by this function'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'arrayOut',
                 'size': {
@@ -1001,6 +892,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetArrayViUInt8WithEnum': {
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
@@ -1020,7 +912,7 @@ functions = {
             {
                 'cppName': 'uInt8EnumArray',
                 'direction': 'out',
-                'enum': 'Color',
+                'enum': 'GrpcColorOverride',
                 'grpc_type': 'bytes',
                 'name': 'uInt8EnumArray',
                 'size': {
@@ -1034,16 +926,10 @@ functions = {
     },
     'GetAttributeViBoolean': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Queries the value of a ViBoolean attribute.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -1051,9 +937,6 @@ functions = {
             {
                 'cppName': 'channelName',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'This is the channel(s) that this function will apply to.'
-                },
                 'grpc_type': 'string',
                 'name': 'channelName',
                 'type': 'ViConstString'
@@ -1061,9 +944,6 @@ functions = {
             {
                 'cppName': 'attributeId',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Pass the ID of an attribute.'
-                },
                 'grpc_type': 'NiFakeAttribute',
                 'name': 'attributeId',
                 'type': 'ViAttr'
@@ -1071,9 +951,6 @@ functions = {
             {
                 'cppName': 'attributeValue',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Returns the value of the attribute.'
-                },
                 'grpc_type': 'bool',
                 'name': 'attributeValue',
                 'type': 'ViBoolean'
@@ -1083,16 +960,10 @@ functions = {
     },
     'GetAttributeViInt32': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Queries the value of a ViInt32 attribute.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -1100,9 +971,6 @@ functions = {
             {
                 'cppName': 'channelName',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'This is the channel(s) that this function will apply to.'
-                },
                 'grpc_type': 'string',
                 'name': 'channelName',
                 'type': 'ViConstString'
@@ -1110,9 +978,6 @@ functions = {
             {
                 'cppName': 'attributeId',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Pass the ID of an attribute.'
-                },
                 'grpc_type': 'NiFakeAttribute',
                 'name': 'attributeId',
                 'type': 'ViAttr'
@@ -1120,9 +985,6 @@ functions = {
             {
                 'cppName': 'attributeValue',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Returns the value of the attribute.'
-                },
                 'grpc_type': 'sint32',
                 'name': 'attributeValue',
                 'type': 'ViInt32'
@@ -1132,16 +994,10 @@ functions = {
     },
     'GetAttributeViInt64': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Queries the value of a ViInt64 attribute.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -1149,9 +1005,6 @@ functions = {
             {
                 'cppName': 'channelName',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'This is the channel(s) that this function will apply to.'
-                },
                 'grpc_type': 'string',
                 'name': 'channelName',
                 'type': 'ViConstString'
@@ -1159,9 +1012,6 @@ functions = {
             {
                 'cppName': 'attributeId',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Pass the ID of an attribute.'
-                },
                 'grpc_type': 'NiFakeAttribute',
                 'name': 'attributeId',
                 'type': 'ViAttr'
@@ -1169,9 +1019,6 @@ functions = {
             {
                 'cppName': 'attributeValue',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Returns the value of the attribute.'
-                },
                 'grpc_type': 'int64',
                 'name': 'attributeValue',
                 'type': 'ViInt64'
@@ -1181,16 +1028,10 @@ functions = {
     },
     'GetAttributeViReal64': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Queries the value of a ViReal attribute.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -1198,9 +1039,6 @@ functions = {
             {
                 'cppName': 'channelName',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'This is the channel(s) that this function will apply to.'
-                },
                 'grpc_type': 'string',
                 'name': 'channelName',
                 'type': 'ViConstString'
@@ -1208,9 +1046,6 @@ functions = {
             {
                 'cppName': 'attributeId',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Pass the ID of an attribute.'
-                },
                 'grpc_type': 'NiFakeAttribute',
                 'name': 'attributeId',
                 'type': 'ViAttr'
@@ -1218,9 +1053,6 @@ functions = {
             {
                 'cppName': 'attributeValue',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Returns the value of the attribute.'
-                },
                 'grpc_type': 'double',
                 'name': 'attributeValue',
                 'type': 'ViReal64'
@@ -1229,43 +1061,11 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetAttributeViSession': {
-        'parameters': [
-            {
-                'cppName': 'vi',
-                'direction': 'in',
-                'grpc_type': 'nidevice_grpc.Session',
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'cppName': 'attributeId',
-                'direction': 'in',
-                'grpc_type': 'sint32',
-                'name': 'attributeId',
-                'type': 'ViInt32'
-            },
-            {
-                'cppName': 'sessionOut',
-                'direction': 'out',
-                'grpc_type': 'nidevice_grpc.Session',
-                'name': 'sessionOut',
-                'type': 'ViSession'
-            }
-        ],
-        'returns': 'ViStatus'
-    },
-    'GetAttributeViString': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Queries the value of a ViBoolean attribute.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -1273,9 +1073,6 @@ functions = {
             {
                 'cppName': 'channelName',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'This is the channel(s) that this function will apply to.'
-                },
                 'grpc_type': 'string',
                 'name': 'channelName',
                 'type': 'ViConstString'
@@ -1283,9 +1080,40 @@ functions = {
             {
                 'cppName': 'attributeId',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Pass the ID of an attribute.'
-                },
+                'grpc_type': 'NiFakeAttribute',
+                'name': 'attributeId',
+                'type': 'ViAttr'
+            },
+            {
+                'cppName': 'attributeValue',
+                'direction': 'out',
+                'grpc_type': 'nidevice_grpc.Session',
+                'name': 'attributeValue',
+                'type': 'ViSession'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'GetAttributeViString': {
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'cppName': 'vi',
+                'direction': 'in',
+                'grpc_type': 'nidevice_grpc.Session',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'cppName': 'channelName',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'channelName',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'attributeId',
+                'direction': 'in',
                 'grpc_type': 'NiFakeAttribute',
                 'name': 'attributeId',
                 'type': 'ViAttr'
@@ -1293,9 +1121,6 @@ functions = {
             {
                 'cppName': 'bufferSize',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Number of bytes in attributeValue. You can IVI-dance with this.'
-                },
                 'grpc_type': 'sint32',
                 'include_in_proto': False,
                 'is_size_param': True,
@@ -1305,9 +1130,6 @@ functions = {
             {
                 'cppName': 'attributeValue',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Returns the value of the attribute.'
-                },
                 'grpc_type': 'string',
                 'name': 'attributeValue',
                 'size': {
@@ -1320,6 +1142,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetBitfieldAsEnumArray': {
+        'codegen_method': 'public',
         'parameters': [
             {
                 'bitfield_as_enum_array': 'Bitfield',
@@ -1334,16 +1157,10 @@ functions = {
     },
     'GetCalDateAndTime': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Returns the date and time of the last calibration performed.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -1351,9 +1168,6 @@ functions = {
             {
                 'cppName': 'calType',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies the type of calibration performed (external or self-calibration).'
-                },
                 'grpc_type': 'sint32',
                 'name': 'calType',
                 'type': 'ViInt32'
@@ -1361,9 +1175,6 @@ functions = {
             {
                 'cppName': 'month',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Indicates the **month** of the last calibration.'
-                },
                 'grpc_type': 'sint32',
                 'name': 'month',
                 'type': 'ViInt32'
@@ -1371,9 +1182,6 @@ functions = {
             {
                 'cppName': 'day',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Indicates the **day** of the last calibration.'
-                },
                 'grpc_type': 'sint32',
                 'name': 'day',
                 'type': 'ViInt32'
@@ -1381,9 +1189,6 @@ functions = {
             {
                 'cppName': 'year',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Indicates the **year** of the last calibration.'
-                },
                 'grpc_type': 'sint32',
                 'name': 'year',
                 'type': 'ViInt32'
@@ -1391,9 +1196,6 @@ functions = {
             {
                 'cppName': 'hour',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Indicates the **hour** of the last calibration.'
-                },
                 'grpc_type': 'sint32',
                 'name': 'hour',
                 'type': 'ViInt32'
@@ -1401,9 +1203,6 @@ functions = {
             {
                 'cppName': 'minute',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Indicates the **minute** of the last calibration.'
-                },
                 'grpc_type': 'sint32',
                 'name': 'minute',
                 'type': 'ViInt32'
@@ -1412,16 +1211,11 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetCalInterval': {
-        'documentation': {
-            'description': 'Returns the recommended maximum interval, in **months**, between external calibrations.'
-        },
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -1429,29 +1223,19 @@ functions = {
             {
                 'cppName': 'months',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Specifies the recommended maximum interval, in **months**, between external calibrations.'
-                },
                 'grpc_type': 'sint32',
                 'name': 'months',
-                'python_api_converter_name': 'convert_month_to_timedelta',
-                'type': 'ViInt32',
-                'type_in_documentation': 'hightime.timedelta'
+                'type': 'ViInt32'
             }
         ],
         'returns': 'ViStatus'
     },
     'GetCustomType': {
-        'documentation': {
-            'description': 'This function returns a custom type.'
-        },
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -1459,9 +1243,6 @@ functions = {
             {
                 'cppName': 'cs',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Set using custom type'
-                },
                 'grpc_type': 'FakeCustomStruct',
                 'name': 'cs',
                 'type': 'struct CustomStruct'
@@ -1471,16 +1252,10 @@ functions = {
     },
     'GetCustomTypeArray': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'This function returns a custom type.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -1488,9 +1263,6 @@ functions = {
             {
                 'cppName': 'numberOfElements',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Number of elements in the array.'
-                },
                 'grpc_type': 'sint32',
                 'is_size_param': True,
                 'name': 'numberOfElements',
@@ -1499,9 +1271,6 @@ functions = {
             {
                 'cppName': 'cs',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Get using custom type'
-                },
                 'grpc_type': 'repeated FakeCustomStruct',
                 'name': 'cs',
                 'size': {
@@ -1515,17 +1284,10 @@ functions = {
     },
     'GetEnumValue': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Returns an enum value',
-            'note': 'Splinter is not supported.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -1533,10 +1295,6 @@ functions = {
             {
                 'cppName': 'aQuantity',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'This is an amount.',
-                    'note': 'The amount will be between -2^31 and (2^31-1)'
-                },
                 'grpc_type': 'sint32',
                 'name': 'aQuantity',
                 'type': 'ViInt32'
@@ -1544,27 +1302,6 @@ functions = {
             {
                 'cppName': 'aTurtle',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Indicates a ninja turtle',
-                    'table_body': [
-                        [
-                            '0',
-                            'Leonardo'
-                        ],
-                        [
-                            '1',
-                            'Donatello'
-                        ],
-                        [
-                            '2',
-                            'Raphael'
-                        ],
-                        [
-                            '3',
-                            'Mich elangelo'
-                        ]
-                    ]
-                },
                 'enum': 'Turtle',
                 'grpc_type': 'sint32',
                 'name': 'aTurtle',
@@ -1575,17 +1312,11 @@ functions = {
     },
     'GetError': {
         'codegen_method': 'private',
-        'documentation': {
-            'description': 'Returns the error information associated with the session.'
-        },
         'is_error_handling': True,
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -1593,9 +1324,6 @@ functions = {
             {
                 'cppName': 'errorCode',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Returns errorCode for the session. If you pass 0 for bufferSize, you can pass VI_NULL for this.'
-                },
                 'grpc_type': 'sint32',
                 'name': 'errorCode',
                 'type': 'ViStatus'
@@ -1603,9 +1331,6 @@ functions = {
             {
                 'cppName': 'bufferSize',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Number of bytes in description buffer.'
-                },
                 'grpc_type': 'sint32',
                 'include_in_proto': False,
                 'is_size_param': True,
@@ -1615,9 +1340,6 @@ functions = {
             {
                 'cppName': 'description',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'At least bufferSize big, string comes out here.'
-                },
                 'grpc_type': 'string',
                 'name': 'description',
                 'size': {
@@ -1627,10 +1349,10 @@ functions = {
                 'type': 'ViChar[]'
             }
         ],
-        'returns': 'ViStatus',
-        'use_session_lock': False
+        'returns': 'ViStatus'
     },
     'GetViInt32Array': {
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
@@ -1662,6 +1384,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetViUInt32Array': {
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
@@ -1713,9 +1436,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'ImportAttributeConfigurationBuffer': {
-        'documentation': {
-            'description': 'Import configuration buffer.'
-        },
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
@@ -1742,13 +1463,11 @@ functions = {
                 'direction': 'in',
                 'grpc_type': 'bytes',
                 'name': 'configuration',
-                'python_api_converter_name': 'convert_to_bytes',
                 'size': {
                     'mechanism': 'len',
                     'value': 'sizeInBytes'
                 },
-                'type': 'ViInt8[]',
-                'type_in_documentation': 'bytes'
+                'type': 'ViInt8[]'
             }
         ],
         'returns': 'ViStatus'
@@ -1784,65 +1503,25 @@ functions = {
     },
     'InitWithOptions': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Creates a new IVI instrument driver session.'
-        },
         'init_method': True,
         'parameters': [
             {
                 'cppName': 'resourceName',
                 'direction': 'in',
-                'documentation': {
-                    'caution': 'This is just some string.',
-                    'description': 'Contains the **resource_name** of the device to initialize.'
-                },
                 'grpc_type': 'string',
                 'name': 'resourceName',
                 'type': 'ViString'
             },
             {
                 'cppName': 'idQuery',
-                'default_value': False,
                 'direction': 'in',
-                'documentation': {
-                    'description': 'NI-FAKE is probably not needed.',
-                    'table_body': [
-                        [
-                            'VI_TRUE (default)',
-                            '1',
-                            'Perform ID Query'
-                        ],
-                        [
-                            'VI_FALSE',
-                            '0',
-                            'Skip ID Query'
-                        ]
-                    ]
-                },
                 'grpc_type': 'bool',
                 'name': 'idQuery',
-                'type': 'ViBoolean',
-                'use_in_python_api': False
+                'type': 'ViBoolean'
             },
             {
                 'cppName': 'resetDevice',
-                'default_value': False,
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies whether to reset',
-                    'table_body': [
-                        [
-                            'VI_TRUE (default)',
-                            '1',
-                            'Reset Device'
-                        ],
-                        [
-                            'VI_FALSE',
-                            '0',
-                            "Don't Reset"
-                        ]
-                    ]
-                },
                 'grpc_type': 'bool',
                 'name': 'resetDevice',
                 'type': 'ViBoolean'
@@ -1850,28 +1529,19 @@ functions = {
             {
                 'cppName': 'optionString',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Some options'
-                },
                 'grpc_type': 'string',
                 'name': 'optionString',
-                'python_api_converter_name': 'convert_init_with_options_dictionary',
-                'type': 'ViConstString',
-                'type_in_documentation': 'dict'
+                'type': 'ViConstString'
             },
             {
                 'cppName': 'vi',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Returns a ViSession handle that you use.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
             }
         ],
-        'returns': 'ViStatus',
-        'use_session_lock': False
+        'returns': 'ViStatus'
     },
     'InitWithVarArgs': {
         'codegen_method': 'public',
@@ -1925,16 +1595,10 @@ functions = {
     },
     'Initiate': {
         'codegen_method': 'private',
-        'documentation': {
-            'description': 'Initiates a thingie.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -1942,18 +1606,112 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'MethodUsingEnumWithGrpcNameValues': {
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'cppName': 'usingEnum',
+                'direction': 'in',
+                'enum': 'EnumWithGrpcNameValues',
+                'grpc_type': 'sint32',
+                'name': 'usingEnum',
+                'type': 'ViInt32'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'MethodUsingWholeAndFractionalNumbers': {
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'cppName': 'wholeNumber',
+                'direction': 'out',
+                'enum': 'DecimalWholeNumber',
+                'grpc_type': 'sint32',
+                'name': 'wholeNumber',
+                'type': 'ViInt32'
+            },
+            {
+                'cppName': 'fractionalNumber',
+                'direction': 'out',
+                'grpc_type': 'double',
+                'mapped-enum': 'DecimalMixedNumber',
+                'name': 'fractionalNumber',
+                'type': 'ViReal64'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'MethodUsingWholeMappedNumbers': {
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'cppName': 'wholeNumber',
+                'direction': 'out',
+                'grpc_type': 'double',
+                'mapped-enum': 'DecimalWholeNumberMapped',
+                'name': 'wholeNumber',
+                'type': 'ViReal64'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'MethodWithGetLastErrorParam': {
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'cppName': 'lastError',
+                'direction': 'out',
+                'get_last_error': 'deprecated',
+                'grpc_type': 'string',
+                'name': 'lastError',
+                'type': 'ViChar[]'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'MethodWithGrpcFieldNumber': {
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'cppName': 'attributeValue',
+                'direction': 'in',
+                'grpc_field_number': '5',
+                'grpc_mapped_field_number': '6',
+                'grpc_raw_field_number': '4',
+                'grpc_type': 'sint32',
+                'name': 'attributeValue',
+                'type': 'ViInt32'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'MethodWithGrpcOnlyParam': {
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'cppName': 'simpleParam',
+                'direction': 'in',
+                'grpc_type': 'sint32',
+                'name': 'simpleParam',
+                'type': 'ViInt32'
+            },
+            {
+                'cppName': 'grpcOnlyParam',
+                'direction': 'out',
+                'grpc_type': 'sint32',
+                'name': 'grpcOnlyParam',
+                'type': 'ViInt32'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'MultipleArrayTypes': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Receives and returns multiple types of arrays.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -1961,9 +1719,6 @@ functions = {
             {
                 'cppName': 'outputArraySize',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Size of the array that will be returned.'
-                },
                 'grpc_type': 'sint32',
                 'is_size_param': True,
                 'name': 'outputArraySize',
@@ -1972,10 +1727,6 @@ functions = {
             {
                 'cppName': 'outputArray',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Array that will be returned.',
-                    'note': 'The size must be at least outputArraySize.'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'outputArray',
                 'size': {
@@ -1987,9 +1738,6 @@ functions = {
             {
                 'cppName': 'outputArrayOfFixedLength',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'An array of doubles with fixed size.'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'outputArrayOfFixedLength',
                 'size': {
@@ -2005,9 +1753,6 @@ functions = {
                     'inputArrayOfIntegers'
                 ],
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Size of inputArrayOfFloats and inputArrayOfIntegers'
-                },
                 'grpc_type': 'sint32',
                 'include_in_proto': False,
                 'is_size_param': True,
@@ -2018,9 +1763,6 @@ functions = {
             {
                 'cppName': 'inputArrayOfFloats',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Array of floats'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'inputArrayOfFloats',
                 'size': {
@@ -2031,11 +1773,7 @@ functions = {
             },
             {
                 'cppName': 'inputArrayOfIntegers',
-                'default_value': None,
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Array of integers. Optional. If passed in then size must match that of inputArrayOfFloats.'
-                },
                 'grpc_type': 'repeated sint32',
                 'name': 'inputArrayOfIntegers',
                 'size': {
@@ -2048,16 +1786,11 @@ functions = {
         'returns': 'ViStatus'
     },
     'MultipleArraysSameSize': {
-        'documentation': {
-            'description': 'Function to test multiple arrays that use the same size'
-        },
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -2065,9 +1798,6 @@ functions = {
             {
                 'cppName': 'values1',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Array 1 of same size.'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'values1',
                 'size': {
@@ -2079,9 +1809,6 @@ functions = {
             {
                 'cppName': 'values2',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Array 2 of same size.'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'values2',
                 'size': {
@@ -2093,9 +1820,6 @@ functions = {
             {
                 'cppName': 'values3',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Array 3 of same size.'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'values3',
                 'size': {
@@ -2107,9 +1831,6 @@ functions = {
             {
                 'cppName': 'values4',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Array 4 of same size.'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'values4',
                 'size': {
@@ -2127,9 +1848,6 @@ functions = {
                     'values4'
                 ],
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Size for all arrays'
-                },
                 'grpc_type': 'sint32',
                 'include_in_proto': False,
                 'is_size_param': True,
@@ -2141,16 +1859,11 @@ functions = {
         'returns': 'ViStatus'
     },
     'MultipleArraysSameSizeWithOptional': {
-        'documentation': {
-            'description': 'Function to test multiple arrays that use the same size'
-        },
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -2158,9 +1871,6 @@ functions = {
             {
                 'cppName': 'values1',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Array 1 of same size.'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'values1',
                 'size': {
@@ -2175,9 +1885,6 @@ functions = {
             {
                 'cppName': 'values2',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Array 2 of same size.'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'values2',
                 'size': {
@@ -2192,9 +1899,6 @@ functions = {
             {
                 'cppName': 'values3',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Array 3 of same size.'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'values3',
                 'size': {
@@ -2209,9 +1913,6 @@ functions = {
             {
                 'cppName': 'values4',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Array 4 of same size.'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'values4',
                 'size': {
@@ -2226,9 +1927,6 @@ functions = {
             {
                 'cppName': 'values5',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Array 5 of same size.'
-                },
                 'grpc_type': 'repeated FakeCustomStruct',
                 'name': 'values5',
                 'size': {
@@ -2250,9 +1948,6 @@ functions = {
                     'values5'
                 ],
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Size for all arrays'
-                },
                 'grpc_type': 'sint32',
                 'include_in_proto': False,
                 'is_size_param': True,
@@ -2265,16 +1960,10 @@ functions = {
     },
     'OneInputFunction': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'This function takes one parameter other than the session.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session. You obtain the **vi** parameter from niFake_InitWithOptions.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -2282,9 +1971,6 @@ functions = {
             {
                 'cppName': 'aNumber',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Contains a number'
-                },
                 'grpc_type': 'sint32',
                 'name': 'aNumber',
                 'type': 'ViInt32'
@@ -2294,16 +1980,10 @@ functions = {
     },
     'ParametersAreMultipleTypes': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Has parameters of multiple types.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -2311,9 +1991,6 @@ functions = {
             {
                 'cppName': 'aBoolean',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Contains a boolean.'
-                },
                 'grpc_type': 'bool',
                 'name': 'aBoolean',
                 'type': 'ViBoolean'
@@ -2321,9 +1998,6 @@ functions = {
             {
                 'cppName': 'anInt32',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Contains a 32-bit integer.'
-                },
                 'grpc_type': 'sint32',
                 'name': 'anInt32',
                 'type': 'ViInt32'
@@ -2331,9 +2005,6 @@ functions = {
             {
                 'cppName': 'anInt64',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Contains a 64-bit integer.'
-                },
                 'grpc_type': 'int64',
                 'name': 'anInt64',
                 'type': 'ViInt64'
@@ -2341,27 +2012,6 @@ functions = {
             {
                 'cppName': 'anIntEnum',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Indicates a ninja turtle',
-                    'table_body': [
-                        [
-                            '0',
-                            'Leonardo'
-                        ],
-                        [
-                            '1',
-                            'Donatello'
-                        ],
-                        [
-                            '2',
-                            'Raphael'
-                        ],
-                        [
-                            '3',
-                            'Mich elangelo'
-                        ]
-                    ]
-                },
                 'enum': 'Turtle',
                 'grpc_type': 'sint32',
                 'name': 'anIntEnum',
@@ -2370,9 +2020,6 @@ functions = {
             {
                 'cppName': 'aFloat',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'The measured value.'
-                },
                 'grpc_type': 'double',
                 'name': 'aFloat',
                 'type': 'ViReal64'
@@ -2380,9 +2027,6 @@ functions = {
             {
                 'cppName': 'aFloatEnum',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'A float enum.'
-                },
                 'grpc_type': 'double',
                 'mapped-enum': 'FloatEnum',
                 'name': 'aFloatEnum',
@@ -2394,9 +2038,6 @@ functions = {
                     'aString'
                 ],
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Number of bytes allocated for aString'
-                },
                 'grpc_type': 'sint32',
                 'include_in_proto': False,
                 'is_size_param': True,
@@ -2407,9 +2048,6 @@ functions = {
             {
                 'cppName': 'aString',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'An IVI dance string.'
-                },
                 'grpc_type': 'string',
                 'name': 'aString',
                 'size': {
@@ -2423,36 +2061,23 @@ functions = {
     },
     'PoorlyNamedSimpleFunction': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'This function takes no parameters other than the session.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session. You obtain the **vi** parameter from niFake_InitWithOptions.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
             }
         ],
-        'python_name': 'simple_function',
         'returns': 'ViStatus'
     },
     'Read': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Acquires a single measurement and returns the measured value.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -2460,21 +2085,13 @@ functions = {
             {
                 'cppName': 'maximumTime',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies the **maximum_time** allowed in seconds.'
-                },
                 'grpc_type': 'double',
                 'name': 'maximumTime',
-                'python_api_converter_name': 'convert_timedelta_to_seconds_real64',
-                'type': 'ViReal64',
-                'type_in_documentation': 'hightime.timedelta'
+                'type': 'ViReal64'
             },
             {
                 'cppName': 'reading',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'The measured value.'
-                },
                 'grpc_type': 'double',
                 'name': 'reading',
                 'type': 'ViReal64'
@@ -2483,6 +2100,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'ReadDataWithInOutIviTwist': {
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'data',
@@ -2508,6 +2126,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'ReadDataWithMultipleIviTwistParamSets': {
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'bufferSize',
@@ -2570,16 +2189,10 @@ functions = {
     },
     'ReadFromChannel': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Acquires a single measurement and returns the measured value.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -2587,9 +2200,6 @@ functions = {
             {
                 'cppName': 'channelName',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'This is the channel(s) that this function will apply to.'
-                },
                 'grpc_type': 'string',
                 'name': 'channelName',
                 'type': 'ViConstString'
@@ -2597,21 +2207,13 @@ functions = {
             {
                 'cppName': 'maximumTime',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Specifies the **maximum_time** allowed in milliseconds.'
-                },
                 'grpc_type': 'sint32',
                 'name': 'maximumTime',
-                'python_api_converter_name': 'convert_timedelta_to_milliseconds_int32',
-                'type': 'ViInt32',
-                'type_in_documentation': 'hightime.timedelta'
+                'type': 'ViInt32'
             },
             {
                 'cppName': 'reading',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'The measured value.'
-                },
                 'grpc_type': 'double',
                 'name': 'reading',
                 'type': 'ViReal64'
@@ -2621,17 +2223,10 @@ functions = {
     },
     'ReturnANumberAndAString': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Returns a number and a string.',
-            'note': 'This function rules!'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -2639,9 +2234,6 @@ functions = {
             {
                 'cppName': 'aNumber',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Contains a number.'
-                },
                 'grpc_type': 'sint32',
                 'name': 'aNumber',
                 'type': 'ViInt16'
@@ -2649,9 +2241,6 @@ functions = {
             {
                 'cppName': 'aString',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Contains a string. Buffer must be 256 bytes or larger.'
-                },
                 'grpc_type': 'string',
                 'name': 'aString',
                 'size': {
@@ -2665,16 +2254,10 @@ functions = {
     },
     'ReturnDurationInSeconds': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Returns a hightime.timedelta instance.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -2682,30 +2265,19 @@ functions = {
             {
                 'cppName': 'timedelta',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Duration in seconds.'
-                },
                 'grpc_type': 'double',
                 'name': 'timedelta',
-                'python_api_converter_name': 'convert_seconds_real64_to_timedelta',
-                'type': 'ViReal64',
-                'type_in_documentation': 'hightime.timedelta'
+                'type': 'ViReal64'
             }
         ],
         'returns': 'ViStatus'
     },
     'ReturnListOfDurationsInSeconds': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Returns a list of hightime.timedelta instances.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -2713,9 +2285,6 @@ functions = {
             {
                 'cppName': 'numberOfElements',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Number of elements in output.'
-                },
                 'grpc_type': 'sint32',
                 'is_size_param': True,
                 'name': 'numberOfElements',
@@ -2724,34 +2293,23 @@ functions = {
             {
                 'cppName': 'timedeltas',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Contains a list of hightime.timedelta instances.'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'timedeltas',
-                'python_api_converter_name': 'convert_seconds_real64_to_timedeltas',
                 'size': {
                     'mechanism': 'passed-in',
                     'value': 'numberOfElements'
                 },
-                'type': 'ViReal64[]',
-                'type_in_documentation': 'hightime.timedelta'
+                'type': 'ViReal64[]'
             }
         ],
         'returns': 'ViStatus'
     },
     'ReturnMultipleTypes': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Returns multiple types.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -2759,9 +2317,6 @@ functions = {
             {
                 'cppName': 'aBoolean',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Contains a boolean.'
-                },
                 'grpc_type': 'bool',
                 'name': 'aBoolean',
                 'type': 'ViBoolean'
@@ -2769,9 +2324,6 @@ functions = {
             {
                 'cppName': 'anInt32',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Contains a 32-bit integer.'
-                },
                 'grpc_type': 'sint32',
                 'name': 'anInt32',
                 'type': 'ViInt32'
@@ -2779,9 +2331,6 @@ functions = {
             {
                 'cppName': 'anInt64',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Contains a 64-bit integer.'
-                },
                 'grpc_type': 'int64',
                 'name': 'anInt64',
                 'type': 'ViInt64'
@@ -2789,27 +2338,6 @@ functions = {
             {
                 'cppName': 'anIntEnum',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'Indicates a ninja turtle',
-                    'table_body': [
-                        [
-                            '0',
-                            'Leonardo'
-                        ],
-                        [
-                            '1',
-                            'Donatello'
-                        ],
-                        [
-                            '2',
-                            'Raphael'
-                        ],
-                        [
-                            '3',
-                            'Mich elangelo'
-                        ]
-                    ]
-                },
                 'enum': 'Turtle',
                 'grpc_type': 'sint32',
                 'name': 'anIntEnum',
@@ -2818,9 +2346,6 @@ functions = {
             {
                 'cppName': 'aFloat',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'The measured value.'
-                },
                 'grpc_type': 'double',
                 'name': 'aFloat',
                 'type': 'ViReal64'
@@ -2828,9 +2353,6 @@ functions = {
             {
                 'cppName': 'aFloatEnum',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'A float enum.'
-                },
                 'grpc_type': 'double',
                 'mapped-enum': 'FloatEnum',
                 'name': 'aFloatEnum',
@@ -2839,9 +2361,6 @@ functions = {
             {
                 'cppName': 'arraySize',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Number of measurements to acquire.'
-                },
                 'grpc_type': 'sint32',
                 'is_size_param': True,
                 'name': 'arraySize',
@@ -2850,10 +2369,6 @@ functions = {
             {
                 'cppName': 'anArray',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'An array of measurement values.',
-                    'note': 'The size must be at least arraySize.'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'anArray',
                 'size': {
@@ -2865,9 +2380,6 @@ functions = {
             {
                 'cppName': 'stringSize',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Number of bytes allocated for aString'
-                },
                 'grpc_type': 'sint32',
                 'include_in_proto': False,
                 'is_size_param': True,
@@ -2877,9 +2389,6 @@ functions = {
             {
                 'cppName': 'aString',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'An IVI dance string.'
-                },
                 'grpc_type': 'string',
                 'name': 'aString',
                 'size': {
@@ -2891,18 +2400,44 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
-    'SetAttributeViBoolean': {
+    'SelfTest': {
+        'cname': 'niFake_self_test',
         'codegen_method': 'private',
-        'documentation': {
-            'description': 'This function sets the value of a ViBoolean attribute.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
+                'grpc_type': 'nidevice_grpc.Session',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'cppName': 'selfTestResult',
+                'direction': 'out',
+                'grpc_type': 'sint32',
+                'name': 'selfTestResult',
+                'type': 'ViInt16'
+            },
+            {
+                'cppName': 'selfTestMessage',
+                'direction': 'out',
+                'grpc_type': 'string',
+                'name': 'selfTestMessage',
+                'size': {
+                    'mechanism': 'fixed',
+                    'value': 256
                 },
+                'type': 'ViChar[]'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'SetAttributeViBoolean': {
+        'codegen_method': 'private',
+        'parameters': [
+            {
+                'cppName': 'vi',
+                'direction': 'in',
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -2910,9 +2445,6 @@ functions = {
             {
                 'cppName': 'channelName',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'This is the channel(s) that this function will apply to.'
-                },
                 'grpc_type': 'string',
                 'name': 'channelName',
                 'type': 'ViConstString'
@@ -2920,9 +2452,6 @@ functions = {
             {
                 'cppName': 'attributeId',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Pass the ID of an attribute.'
-                },
                 'grpc_type': 'NiFakeAttribute',
                 'name': 'attributeId',
                 'type': 'ViAttr'
@@ -2930,9 +2459,6 @@ functions = {
             {
                 'cppName': 'attributeValue',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Pass the value that you want to set the attribute to.'
-                },
                 'grpc_type': 'bool',
                 'name': 'attributeValue',
                 'type': 'ViBoolean'
@@ -2942,16 +2468,10 @@ functions = {
     },
     'SetAttributeViInt32': {
         'codegen_method': 'private',
-        'documentation': {
-            'description': 'This function sets the value of a ViInt32 attribute.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -2959,9 +2479,6 @@ functions = {
             {
                 'cppName': 'channelName',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'This is the channel(s) that this function will apply to.'
-                },
                 'grpc_type': 'string',
                 'name': 'channelName',
                 'type': 'ViConstString'
@@ -2969,9 +2486,6 @@ functions = {
             {
                 'cppName': 'attributeId',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Pass the ID of an attribute.'
-                },
                 'grpc_type': 'NiFakeAttribute',
                 'name': 'attributeId',
                 'type': 'ViAttr'
@@ -2979,9 +2493,6 @@ functions = {
             {
                 'cppName': 'attributeValue',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Pass the value that you want to set the attribute to.'
-                },
                 'enum': 'NiFakeInt32AttributeValues',
                 'grpc_type': 'sint32',
                 'name': 'attributeValue',
@@ -2992,16 +2503,10 @@ functions = {
     },
     'SetAttributeViInt64': {
         'codegen_method': 'private',
-        'documentation': {
-            'description': 'This function sets the value of a ViInt64 attribute.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -3009,9 +2514,6 @@ functions = {
             {
                 'cppName': 'channelName',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'This is the channel(s) that this function will apply to.'
-                },
                 'grpc_type': 'string',
                 'name': 'channelName',
                 'type': 'ViConstString'
@@ -3019,9 +2521,6 @@ functions = {
             {
                 'cppName': 'attributeId',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Pass the ID of an attribute.'
-                },
                 'grpc_type': 'NiFakeAttribute',
                 'name': 'attributeId',
                 'type': 'ViAttr'
@@ -3029,9 +2528,6 @@ functions = {
             {
                 'cppName': 'attributeValue',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Pass the value that you want to set the attribute to.'
-                },
                 'grpc_type': 'int64',
                 'name': 'attributeValue_raw',
                 'type': 'ViInt64'
@@ -3041,16 +2537,10 @@ functions = {
     },
     'SetAttributeViReal64': {
         'codegen_method': 'private',
-        'documentation': {
-            'description': 'This function sets the value of a ViReal64 attribute.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -3058,9 +2548,6 @@ functions = {
             {
                 'cppName': 'channelName',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'This is the channel(s) that this function will apply to.'
-                },
                 'grpc_type': 'string',
                 'name': 'channelName',
                 'type': 'ViConstString'
@@ -3068,9 +2555,6 @@ functions = {
             {
                 'cppName': 'attributeId',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Pass the ID of an attribute.'
-                },
                 'grpc_type': 'NiFakeAttribute',
                 'name': 'attributeId',
                 'type': 'ViAttr'
@@ -3078,9 +2562,6 @@ functions = {
             {
                 'cppName': 'attributeValue',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Pass the value that you want to set the attribute to.'
-                },
                 'grpc_type': 'double',
                 'mapped-enum': 'NiFakeReal64AttributeValuesMapped',
                 'name': 'attributeValue',
@@ -3091,16 +2572,10 @@ functions = {
     },
     'SetAttributeViString': {
         'codegen_method': 'private',
-        'documentation': {
-            'description': 'This function sets the value of a ViString attribute.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -3108,9 +2583,6 @@ functions = {
             {
                 'cppName': 'channelName',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'This is the channel(s) that this function will apply to.'
-                },
                 'grpc_type': 'string',
                 'name': 'channelName',
                 'type': 'ViConstString'
@@ -3118,9 +2590,6 @@ functions = {
             {
                 'cppName': 'attributeId',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Pass the ID of an attribute.'
-                },
                 'grpc_type': 'NiFakeAttribute',
                 'name': 'attributeId',
                 'type': 'ViAttr'
@@ -3128,9 +2597,6 @@ functions = {
             {
                 'cppName': 'attributeValue',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Pass the value that you want to set the attribute to.'
-                },
                 'grpc_type': 'string',
                 'name': 'attributeValue_raw',
                 'type': 'ViConstString'
@@ -3139,16 +2605,11 @@ functions = {
         'returns': 'ViStatus'
     },
     'SetCustomType': {
-        'documentation': {
-            'description': 'This function takes a custom type.'
-        },
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -3156,9 +2617,6 @@ functions = {
             {
                 'cppName': 'cs',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Set using custom type'
-                },
                 'grpc_type': 'FakeCustomStruct',
                 'name': 'cs',
                 'type': 'struct CustomStruct'
@@ -3167,16 +2625,11 @@ functions = {
         'returns': 'ViStatus'
     },
     'SetCustomTypeArray': {
-        'documentation': {
-            'description': 'This function takes an array of custom types.'
-        },
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -3187,9 +2640,6 @@ functions = {
                     'cs'
                 ],
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Number of elements in the array.'
-                },
                 'grpc_type': 'sint32',
                 'include_in_proto': False,
                 'is_size_param': True,
@@ -3200,9 +2650,6 @@ functions = {
             {
                 'cppName': 'cs',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Set using custom type'
-                },
                 'grpc_type': 'repeated FakeCustomStruct',
                 'name': 'cs',
                 'size': {
@@ -3216,41 +2663,17 @@ functions = {
     },
     'StringValuedEnumInputFunctionWithDefaults': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'This function takes one parameter other than the session, which happens to be a string-valued enum and has a default value.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session. You obtain the **vi**'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
             },
             {
                 'cppName': 'aMobileOSName',
-                'default_value': 'MobileOSNames.ANDROID',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Indicates a Mobile OS',
-                    'table_body': [
-                        [
-                            'ANDROID',
-                            'Android'
-                        ],
-                        [
-                            'IOS',
-                            'iOS'
-                        ],
-                        [
-                            'NONE',
-                            'None'
-                        ]
-                    ]
-                },
                 'grpc_type': 'string',
                 'mapped-enum': 'MobileOSNames',
                 'name': 'aMobileOSName',
@@ -3261,16 +2684,10 @@ functions = {
     },
     'TwoInputFunction': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'This function takes two parameters other than the session.'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session. You obtain the **vi** parameter from niFake_InitWithOptions.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -3278,9 +2695,6 @@ functions = {
             {
                 'cppName': 'aNumber',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Contains a number'
-                },
                 'grpc_type': 'double',
                 'name': 'aNumber',
                 'type': 'ViReal64'
@@ -3288,9 +2702,6 @@ functions = {
             {
                 'cppName': 'aString',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Contains a string'
-                },
                 'grpc_type': 'string',
                 'name': 'aString',
                 'type': 'ViString'
@@ -3300,17 +2711,10 @@ functions = {
     },
     'Use64BitNumber': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Returns a number and a string.',
-            'note': 'This function rules!'
-        },
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -3318,9 +2722,6 @@ functions = {
             {
                 'cppName': 'input',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'A big number on its way in.'
-                },
                 'grpc_type': 'int64',
                 'name': 'input',
                 'type': 'ViInt64'
@@ -3328,9 +2729,6 @@ functions = {
             {
                 'cppName': 'output',
                 'direction': 'out',
-                'documentation': {
-                    'description': 'A big number on its way out.'
-                },
                 'grpc_type': 'int64',
                 'name': 'output',
                 'type': 'ViInt64'
@@ -3339,6 +2737,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'UseATwoDimensionParameter': {
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
@@ -3488,28 +2887,10 @@ functions = {
     },
     'WriteWaveform': {
         'codegen_method': 'public',
-        'documentation': {
-            'description': 'Writes waveform to the driver'
-        },
-        'method_templates': [
-            {
-                'documentation_filename': 'default_method',
-                'method_python_name_suffix': '',
-                'session_filename': 'default_method'
-            },
-            {
-                'documentation_filename': 'numpy_method',
-                'method_python_name_suffix': '_numpy',
-                'session_filename': 'numpy_write_method'
-            }
-        ],
         'parameters': [
             {
                 'cppName': 'vi',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
@@ -3520,9 +2901,6 @@ functions = {
                     'waveform'
                 ],
                 'direction': 'in',
-                'documentation': {
-                    'description': 'How many samples the waveform contains.'
-                },
                 'grpc_type': 'sint32',
                 'include_in_proto': False,
                 'is_size_param': True,
@@ -3533,127 +2911,13 @@ functions = {
             {
                 'cppName': 'waveform',
                 'direction': 'in',
-                'documentation': {
-                    'description': 'Waveform data.'
-                },
                 'grpc_type': 'repeated double',
                 'name': 'waveform',
-                'numpy': True,
                 'size': {
                     'mechanism': 'len',
                     'value': 'numberOfSamples'
                 },
-                'type': 'ViReal64[]',
-                'use_array': True
-            }
-        ],
-        'returns': 'ViStatus'
-    },
-    'close': {
-        'codegen_method': 'public',
-        'documentation': {
-            'description': 'Closes the specified session and deallocates resources that it reserved.'
-        },
-        'parameters': [
-            {
-                'cppName': 'vi',
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
-                'grpc_type': 'nidevice_grpc.Session',
-                'name': 'vi',
-                'type': 'ViSession'
-            }
-        ],
-        'python_name': '_close',
-        'returns': 'ViStatus',
-        'use_session_lock': False
-    },
-    'error_message': {
-        'codegen_method': 'private',
-        'documentation': {
-            'description': 'Takes the errorCode returned by a functiona and returns it as a user-readable string.'
-        },
-        'is_error_handling': True,
-        'parameters': [
-            {
-                'cppName': 'vi',
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session.'
-                },
-                'grpc_type': 'nidevice_grpc.Session',
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'cppName': 'errorCode',
-                'direction': 'in',
-                'documentation': {
-                    'description': 'The errorCode returned from the instrument.'
-                },
-                'grpc_type': 'sint32',
-                'name': 'errorCode',
-                'type': 'ViStatus'
-            },
-            {
-                'cppName': 'errorMessage',
-                'direction': 'out',
-                'documentation': {
-                    'description': 'The error information formatted into a string.'
-                },
-                'grpc_type': 'string',
-                'name': 'errorMessage',
-                'size': {
-                    'mechanism': 'fixed',
-                    'value': 256
-                },
-                'type': 'ViChar[]'
-            }
-        ],
-        'returns': 'ViStatus',
-        'use_session_lock': False
-    },
-    'self_test': {
-        'codegen_method': 'private',
-        'documentation': {
-            'description': 'Performs a self-test.'
-        },
-        'parameters': [
-            {
-                'cppName': 'vi',
-                'direction': 'in',
-                'documentation': {
-                    'description': 'Identifies a particular instrument session. You obtain the **vi** parameter from niFake_InitWithOptions.'
-                },
-                'grpc_type': 'nidevice_grpc.Session',
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'cppName': 'selfTestResult',
-                'direction': 'out',
-                'documentation': {
-                    'description': 'Contains the value returned from the instrument self-test. Zero indicates success.'
-                },
-                'grpc_type': 'sint32',
-                'name': 'selfTestResult',
-                'type': 'ViInt16'
-            },
-            {
-                'cppName': 'selfTestMessage',
-                'direction': 'out',
-                'documentation': {
-                    'description': 'This parameter contains the string returned from the instrument self-test. The array must contain at least 256 elements.'
-                },
-                'grpc_type': 'string',
-                'name': 'selfTestMessage',
-                'size': {
-                    'mechanism': 'fixed',
-                    'value': 256
-                },
-                'type': 'ViChar[]'
+                'type': 'ViReal64[]'
             }
         ],
         'returns': 'ViStatus'

--- a/source/codegen/metadata/nifake/nifake.proto
+++ b/source/codegen/metadata/nifake/nifake.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-FAKE API metadata version 1.2.0d9
+// This file is generated from NI-FAKE API metadata version 23.0.0
 //---------------------------------------------------------------------
 // Proto file for the NI-FAKE Metadata
 //---------------------------------------------------------------------
@@ -22,8 +22,10 @@ service NiFake {
   rpc AcceptViUInt32Array(AcceptViUInt32ArrayRequest) returns (AcceptViUInt32ArrayResponse);
   rpc BoolArrayInputFunction(BoolArrayInputFunctionRequest) returns (BoolArrayInputFunctionResponse);
   rpc BoolArrayOutputFunction(BoolArrayOutputFunctionRequest) returns (BoolArrayOutputFunctionResponse);
+  rpc Close(CloseRequest) returns (CloseResponse);
   rpc CloseExtCal(CloseExtCalRequest) returns (CloseExtCalResponse);
   rpc CommandWithReservedParam(CommandWithReservedParamRequest) returns (CommandWithReservedParamResponse);
+  rpc Control4022(Control4022Request) returns (Control4022Response);
   rpc CreateConfigurationList(CreateConfigurationListRequest) returns (CreateConfigurationListResponse);
   rpc DoubleAllTheNums(DoubleAllTheNumsRequest) returns (DoubleAllTheNumsResponse);
   rpc EnumArrayOutputFunction(EnumArrayOutputFunctionRequest) returns (EnumArrayOutputFunctionResponse);
@@ -62,6 +64,12 @@ service NiFake {
   rpc InitExtCal(InitExtCalRequest) returns (InitExtCalResponse);
   rpc InitWithOptions(InitWithOptionsRequest) returns (InitWithOptionsResponse);
   rpc InitWithVarArgs(InitWithVarArgsRequest) returns (InitWithVarArgsResponse);
+  rpc MethodUsingEnumWithGrpcNameValues(MethodUsingEnumWithGrpcNameValuesRequest) returns (MethodUsingEnumWithGrpcNameValuesResponse);
+  rpc MethodUsingWholeAndFractionalNumbers(MethodUsingWholeAndFractionalNumbersRequest) returns (MethodUsingWholeAndFractionalNumbersResponse);
+  rpc MethodUsingWholeMappedNumbers(MethodUsingWholeMappedNumbersRequest) returns (MethodUsingWholeMappedNumbersResponse);
+  rpc MethodWithGetLastErrorParam(MethodWithGetLastErrorParamRequest) returns (MethodWithGetLastErrorParamResponse);
+  rpc MethodWithGrpcFieldNumber(MethodWithGrpcFieldNumberRequest) returns (MethodWithGrpcFieldNumberResponse);
+  rpc MethodWithGrpcOnlyParam(MethodWithGrpcOnlyParamRequest) returns (MethodWithGrpcOnlyParamResponse);
   rpc MultipleArrayTypes(MultipleArrayTypesRequest) returns (MultipleArrayTypesResponse);
   rpc MultipleArraysSameSize(MultipleArraysSameSizeRequest) returns (MultipleArraysSameSizeResponse);
   rpc MultipleArraysSameSizeWithOptional(MultipleArraysSameSizeWithOptionalRequest) returns (MultipleArraysSameSizeWithOptionalResponse);
@@ -86,7 +94,6 @@ service NiFake {
   rpc ViUInt8ArrayInputFunction(ViUInt8ArrayInputFunctionRequest) returns (ViUInt8ArrayInputFunctionResponse);
   rpc ViUInt8ArrayOutputFunction(ViUInt8ArrayOutputFunctionRequest) returns (ViUInt8ArrayOutputFunctionResponse);
   rpc WriteWaveform(WriteWaveformRequest) returns (WriteWaveformResponse);
-  rpc Close(CloseRequest) returns (CloseResponse);
 }
 
 enum NiFakeAttribute {
@@ -96,7 +103,7 @@ enum NiFakeAttribute {
   NIFAKE_ATTRIBUTE_READ_WRITE_STRING = 1000002;
   NIFAKE_ATTRIBUTE_READ_WRITE_COLOR = 1000003;
   NIFAKE_ATTRIBUTE_READ_WRITE_INTEGER = 1000004;
-  NIFAKE_ATTRIBUTE_FLOAT_ENUM = 1000005;
+  NIFAKE_ATTRIBUTE_FLOAT_ENUM_NAME_OVERRIDE = 1000005;
   NIFAKE_ATTRIBUTE_READ_WRITE_INT64 = 1000006;
   NIFAKE_ATTRIBUTE_READ_WRITE_DOUBLE_WITH_CONVERTER = 1000007;
   NIFAKE_ATTRIBUTE_READ_WRITE_INTEGER_WITH_CONVERTER = 1000008;
@@ -112,12 +119,34 @@ enum Bitfield {
   BITFIELD_FLAG_D = 8;
 }
 
-enum Color {
-  COLOR_UNSPECIFIED = 0;
-  COLOR_RED = 1;
-  COLOR_BLUE = 2;
-  COLOR_YELLOW = 5;
-  COLOR_BLACK = 42;
+enum DecimalMixedNumber {
+  DECIMAL_MIXED_NUMBER_UNSPECIFIED = 0;
+  DECIMAL_MIXED_NUMBER_TWENTY_TWO = 1;
+  DECIMAL_MIXED_NUMBER_TWO_POINT_TWO = 2;
+  DECIMAL_MIXED_NUMBER_NEGATIVE_THREE = 3;
+  DECIMAL_MIXED_NUMBER_MAX_INT_32 = 4;
+  DECIMAL_MIXED_NUMBER_MAX_INT_32_PLUS_ONE = 5;
+  DECIMAL_MIXED_NUMBER_MIN_INT_32 = 6;
+  DECIMAL_MIXED_NUMBER_MIN_INT_32_MINUS_ONE = 7;
+}
+
+enum DecimalWholeNumber {
+  DECIMAL_WHOLE_NUMBER_ZERO = 0;
+  DECIMAL_WHOLE_NUMBER_NEGATIVE_ONE = -1;
+  DECIMAL_WHOLE_NUMBER_TWENTY_TWO = 22;
+}
+
+enum DecimalWholeNumberMapped {
+  DECIMAL_WHOLE_NUMBER_MAPPED_UNSPECIFIED = 0;
+  DECIMAL_WHOLE_NUMBER_MAPPED_ZERO = 1;
+  DECIMAL_WHOLE_NUMBER_MAPPED_NEGATIVE_ONE = 2;
+  DECIMAL_WHOLE_NUMBER_MAPPED_TWENTY_TWO = 3;
+}
+
+enum EnumWithGrpcNameValues {
+  ENUM_WITH_GRPC_NAME_VALUES_UNSPECIFIED = 0;
+  ENUM_WITH_GRPC_NAME_VALUES_ALTERED_GRPC_NAME_ONE = 1;
+  ENUM_WITH_GRPC_NAME_VALUES_TWO = 2;
 }
 
 enum FloatEnum {
@@ -129,6 +158,14 @@ enum FloatEnum {
   FLOAT_ENUM_SEVEN_POINT_FIVE = 5;
 }
 
+enum GrpcColorOverride {
+  GRPC_COLOR_OVERRIDE_UNSPECIFIED = 0;
+  GRPC_COLOR_OVERRIDE_RED = 1;
+  GRPC_COLOR_OVERRIDE_BLUE = 2;
+  GRPC_COLOR_OVERRIDE_YELLOW = 5;
+  GRPC_COLOR_OVERRIDE_BLACK = 42;
+}
+
 enum MobileOSNames {
   MOBILE_OS_NAMES_UNSPECIFIED = 0;
   MOBILE_OS_NAMES_ANDROID = 1;
@@ -138,10 +175,10 @@ enum MobileOSNames {
 
 enum NiFakeInt32AttributeValues {
   NIFAKE_INT32_UNSPECIFIED = 0;
-  NIFAKE_INT32_COLOR_RED = 1;
-  NIFAKE_INT32_COLOR_BLUE = 2;
-  NIFAKE_INT32_COLOR_YELLOW = 5;
-  NIFAKE_INT32_COLOR_BLACK = 42;
+  NIFAKE_INT32_GRPC_COLOR_OVERRIDE_RED = 1;
+  NIFAKE_INT32_GRPC_COLOR_OVERRIDE_BLUE = 2;
+  NIFAKE_INT32_GRPC_COLOR_OVERRIDE_YELLOW = 5;
+  NIFAKE_INT32_GRPC_COLOR_OVERRIDE_BLACK = 42;
 }
 
 enum NiFakeReal64AttributeValuesMapped {
@@ -163,6 +200,10 @@ enum Turtle {
 message FakeCustomStruct {
   sint32 struct_int = 1;
   double struct_double = 2;
+}
+
+message CustomNamedType {
+  string string_arg = 1;
 }
 
 message StringAndTurtle {
@@ -225,6 +266,14 @@ message BoolArrayOutputFunctionResponse {
   repeated bool an_array = 2;
 }
 
+message CloseRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message CloseResponse {
+  int32 status = 1;
+}
+
 message CloseExtCalRequest {
   nidevice_grpc.Session vi = 1;
   sint32 action = 2;
@@ -239,6 +288,15 @@ message CommandWithReservedParamRequest {
 }
 
 message CommandWithReservedParamResponse {
+  int32 status = 1;
+}
+
+message Control4022Request {
+  string resource_name = 1;
+  sint32 configuration = 2;
+}
+
+message Control4022Response {
   int32 status = 1;
 }
 
@@ -379,11 +437,12 @@ message GetAnIviDanceWithATwistByteArrayResponse {
 }
 
 message GetAnIviDanceWithATwistStringRequest {
+  nidevice_grpc.Session vi = 1;
 }
 
 message GetAnIviDanceWithATwistStringResponse {
   int32 status = 1;
-  string array_out = 2;
+  string a_string = 2;
   sint32 actual_size = 3;
 }
 
@@ -421,7 +480,7 @@ message GetArrayViUInt8WithEnumRequest {
 
 message GetArrayViUInt8WithEnumResponse {
   int32 status = 1;
-  repeated Color u_int8_enum_array = 2;
+  repeated GrpcColorOverride u_int8_enum_array = 2;
   bytes u_int8_enum_array_raw = 3;
 }
 
@@ -471,12 +530,13 @@ message GetAttributeViReal64Response {
 
 message GetAttributeViSessionRequest {
   nidevice_grpc.Session vi = 1;
-  sint32 attribute_id = 2;
+  string channel_name = 2;
+  NiFakeAttribute attribute_id = 3;
 }
 
 message GetAttributeViSessionResponse {
   int32 status = 1;
-  nidevice_grpc.Session session_out = 2;
+  nidevice_grpc.Session attribute_value = 2;
 }
 
 message GetAttributeViStringRequest {
@@ -623,6 +683,62 @@ message InitWithVarArgsRequest {
 message InitWithVarArgsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+}
+
+message MethodUsingEnumWithGrpcNameValuesRequest {
+  oneof using_enum_enum {
+    EnumWithGrpcNameValues using_enum = 1;
+    sint32 using_enum_raw = 2;
+  }
+}
+
+message MethodUsingEnumWithGrpcNameValuesResponse {
+  int32 status = 1;
+}
+
+message MethodUsingWholeAndFractionalNumbersRequest {
+}
+
+message MethodUsingWholeAndFractionalNumbersResponse {
+  int32 status = 1;
+  DecimalWholeNumber whole_number = 2;
+  sint32 whole_number_raw = 3;
+  DecimalMixedNumber fractional_number_mapped = 4;
+  double fractional_number_raw = 5;
+}
+
+message MethodUsingWholeMappedNumbersRequest {
+}
+
+message MethodUsingWholeMappedNumbersResponse {
+  int32 status = 1;
+  DecimalWholeNumberMapped whole_number_mapped = 2;
+  double whole_number_raw = 3;
+}
+
+message MethodWithGetLastErrorParamRequest {
+}
+
+message MethodWithGetLastErrorParamResponse {
+  int32 status = 1;
+  string last_error = 2 [deprecated = true];
+}
+
+message MethodWithGrpcFieldNumberRequest {
+  sint32 attribute_value = 5;
+}
+
+message MethodWithGrpcFieldNumberResponse {
+  int32 status = 1;
+}
+
+message MethodWithGrpcOnlyParamRequest {
+  sint32 simple_param = 1;
+}
+
+message MethodWithGrpcOnlyParamResponse {
+  int32 status = 1;
+  sint32 grpc_only_param = 2;
 }
 
 message MultipleArrayTypesRequest {
@@ -885,14 +1001,6 @@ message WriteWaveformRequest {
 }
 
 message WriteWaveformResponse {
-  int32 status = 1;
-}
-
-message CloseRequest {
-  nidevice_grpc.Session vi = 1;
-}
-
-message CloseResponse {
   int32 status = 1;
 }
 

--- a/source/custom/nifake_service.custom.cpp
+++ b/source/custom/nifake_service.custom.cpp
@@ -5,7 +5,7 @@ namespace nifake_grpc {
 ::grpc::Status NiFakeService::ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi)
 {
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');
-  library_->error_message(vi, status, &description[0]);
+  library_->ErrorMessage(vi, status, &description[0]);
   return nidevice_grpc::ApiErrorAndDescriptionToStatus(context, status, description);
 }
 

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -161,7 +161,7 @@ TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsAndResetServer_SessionIsCl
   const char* session_name = "sessionName";
   EXPECT_CALL(library, InitWithOptions)
       .WillOnce(DoAll(SetArgPointee<4>(kTestViSession), Return(kDriverSuccess)));
-  EXPECT_CALL(library, close(kTestViSession))
+  EXPECT_CALL(library, Close(kTestViSession))
       .WillOnce(Return(kDriverSuccess));
 
   ::grpc::ServerContext context;
@@ -216,7 +216,7 @@ TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsThenClose_SessionIsClosed)
   std::string session_name = "sessionName";
   EXPECT_CALL(library, InitWithOptions)
       .WillOnce(DoAll(SetArgPointee<4>(kTestViSession), Return(kDriverSuccess)));
-  EXPECT_CALL(library, close(kTestViSession))
+  EXPECT_CALL(library, Close(kTestViSession))
       .WillOnce(Return(kDriverSuccess));
 
   ::grpc::ServerContext context;
@@ -2158,25 +2158,26 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistStringWithSmallerS
   const auto NEW_SIZE = static_cast<ViInt32>(DATA.size() + 1);
   const auto OLD_SIZE = NEW_SIZE + 1;
   // ivi-dance-with-a-twist call
-  EXPECT_CALL(library, GetAnIviDanceWithATwistString(0, nullptr, _))
+  EXPECT_CALL(library, GetAnIviDanceWithATwistString(kTestViSession, 0, nullptr, _))
       .WillOnce(DoAll(
-          SetArgPointee<2>(OLD_SIZE),
+          SetArgPointee<3>(OLD_SIZE),
           Return(kDriverSuccess)));
   // follow up call - return that the array now needs to be smaller.
-  EXPECT_CALL(library, GetAnIviDanceWithATwistString(OLD_SIZE, _, _))
+  EXPECT_CALL(library, GetAnIviDanceWithATwistString(kTestViSession, OLD_SIZE, _, _))
       .WillOnce(DoAll(
-          SetArrayArgument<1>(DATA.c_str(), DATA.c_str() + NEW_SIZE),
-          SetArgPointee<2>(NEW_SIZE),
+          SetArrayArgument<2>(DATA.c_str(), DATA.c_str() + NEW_SIZE),
+          SetArgPointee<3>(NEW_SIZE),
           Return(kDriverSuccess)));
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAnIviDanceWithATwistStringRequest request;
+  request.mutable_vi()->set_id(session_id);
   nifake_grpc::GetAnIviDanceWithATwistStringResponse response;
   ::grpc::Status status = service.GetAnIviDanceWithATwistString(&context, &request, &response);
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kDriverSuccess, response.status());
-  EXPECT_EQ(DATA, response.array_out());
+  EXPECT_EQ(DATA, response.a_string());
   EXPECT_EQ(response.actual_size(), NEW_SIZE);
 }
 
@@ -2456,8 +2457,16 @@ TEST(NiFakeServiceTests, NiFakeService_GetArrayViUInt8WithEnum_CallsGetArrayViUI
   nifake_grpc::NiFakeService service(&library, resource_repository);
   std::uint32_t session_id = create_session(library, service, kTestViSession);
   int array_len = 3;
-  ViUInt8 uint8_array[] = {nifake_grpc::Color::COLOR_RED, nifake_grpc::Color::COLOR_BLACK, nifake_grpc::Color::COLOR_BLUE};
-  nifake_grpc::Color enum_array[] = {nifake_grpc::Color::COLOR_RED, nifake_grpc::Color::COLOR_BLACK, nifake_grpc::Color::COLOR_BLUE};
+  ViUInt8 uint8_array[] = {
+      nifake_grpc::GrpcColorOverride::GRPC_COLOR_OVERRIDE_RED,
+      nifake_grpc::GrpcColorOverride::GRPC_COLOR_OVERRIDE_BLACK,
+      nifake_grpc::GrpcColorOverride::GRPC_COLOR_OVERRIDE_BLUE,
+  };
+  nifake_grpc::GrpcColorOverride enum_array[] = {
+      nifake_grpc::GrpcColorOverride::GRPC_COLOR_OVERRIDE_RED,
+      nifake_grpc::GrpcColorOverride::GRPC_COLOR_OVERRIDE_BLACK,
+      nifake_grpc::GrpcColorOverride::GRPC_COLOR_OVERRIDE_BLUE,
+  };
   EXPECT_CALL(library, GetArrayViUInt8WithEnum(kTestViSession, array_len, _))
       .WillOnce(
           DoAll(
@@ -2484,23 +2493,24 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViSession_ReturnsSessionId)
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
   std::uint32_t session_id = create_session(library, service, kTestViSession);
-  const ViInt32 kAttributeId = 1234;
-  EXPECT_CALL(library, GetAttributeViSession(kTestViSession, kAttributeId, _))
+  nifake_grpc::NiFakeAttribute attribute_id = nifake_grpc::NIFAKE_ATTRIBUTE_READ_WRITE_STRING;
+  EXPECT_CALL(library, GetAttributeViSession(kTestViSession, Pointee(*kTestChannelName), attribute_id, _))
       .WillOnce(
           DoAll(
-              SetArgPointee<2>(kTestViSession),
+              SetArgPointee<3>(kTestViSession),
               Return(kDriverSuccess)));
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAttributeViSessionRequest request;
   request.mutable_vi()->set_id(session_id);
-  request.set_attribute_id(kAttributeId);
+  request.set_attribute_id(attribute_id);
+  request.set_channel_name(kTestChannelName);
   nifake_grpc::GetAttributeViSessionResponse response;
   auto status = service.GetAttributeViSession(&context, &request, &response);
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kDriverSuccess, response.status());
-  EXPECT_EQ(session_id, response.session_out().id());
+  EXPECT_EQ(session_id, response.attribute_value().id());
 }
 
 TEST(NiFakeServiceTests, NiFakeExtensionService_CallMethodWithSesionStartedByNIFakeService_PassesThroughSession)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Like the other MI drivers, we should get the ni-fake grpc-device metadata from its hapigen export.

### Why should this Pull Request be merged?

1. Gets ni-fake grpc-device metadata in sync with changes made in hapigen.
2. Want to get this version in since our hapigen work is nearing completion. There will be one upcoming ni-fake change to test out nested custom_types which is needed for DC Power. But that diff will be simpler if we get this baseline ni-fake change in first.

[AB#2173878](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2173878)

### What testing has been done?

Unit and Integration tests against ni-fake pass locally.

Note: No new tests were added since there's no new grpc-device codegen capabilities to test. The pre-existing Unit and Integration tests should be sufficient.
