### PR TITLE
Trigger AzDo CI after all other steps have completed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,11 @@ jobs:
     uses: ./.github/workflows/create_release.yml
   trigger_azdo_ci:
     needs:
-     - build_desktop
+     - run_win_system_tests
+     - run_ubuntu_system_tests
      - build_nilrt
      - create_client_artifacts
+     - create_release
     uses: ./.github/workflows/trigger_azdo_ci.yml
     secrets:
       AZDO_PIPELINE_TRIGGERS: ${{secrets.AZDO_PIPELINE_TRIGGERS}}


### PR DESCRIPTION
### What does this Pull Request accomplish?

Puts the `trigger_azdo_ci` step at the very end of the CI workflow.

### Why should this Pull Request be merged?

Before, it was triggerring the AzDo CI before the other steps necessarily finished. This proved problematic recently because the system_tests were stuck and the AzDo CI was triggered and pulled an older commit that had a finished CI as the basis for it's CI which was incorrect.

### What testing has been done?

CI Workflow before:

![image](https://user-images.githubusercontent.com/77176215/195184501-99963320-0014-4173-81fb-ac06d3349f8d.png)


CI Workflow now:

![image](https://user-images.githubusercontent.com/77176215/195184250-2b260058-c790-4ba0-9b8c-ef4085ea1380.png)
