### PR TITLE
test_helpers fix: Don't dereference iterator if element not found

### DIFF
--- a/source/tests/utilities/test_helpers.h
+++ b/source/tests/utilities/test_helpers.h
@@ -9,7 +9,12 @@ inline void expect_driver_error(const nidevice_grpc::experimental::client::grpc_
 {
   EXPECT_EQ(::grpc::StatusCode::UNKNOWN, ex.StatusCode());
   EXPECT_LT(expected_error, 0);
-  const auto& actual_error = ex.Trailers().find("ni-error")->second;
+  std::string actual_error = "";
+  auto iterator = ex.Trailers().find("ni-error");
+  if (iterator != ex.Trailers().end())
+  {
+    actual_error = iterator->second;
+  }
   EXPECT_EQ(expected_error, std::stoi(actual_error));
 }
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Running tests on systems without drivers was hitting an assertion:
>`C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.33.31629\include\xtree(183) : Assertion failed: cannot dereference end map/set iterator`

... instead of just failing the test.

### Why should this Pull Request be merged?

If contributors are testing changes that apply only to one or some drivers, they should still be able to run all the system tests on a machine without some drivers installed, and simply get test failures for the drivers that are missing instead of a full stop error.

### What testing has been done?

* Ran `UnitTestsRunner.exe`, `IntegrationTestsRunner.exe`, and `SystemTestsRunner.exe` on a system with no drivers - all unit and integration tests passed as expected, nearly all system tests failed as expected. Test runs completed without error.
* Ran same test executables on a system with _some_ drivers and not others. Test runs completed without error. All unit and integration tests passed. System tests for missing drivers failed as expected. The rest of the tests passed, except for a couple that always fail on my test machine, and a small handful of RFmx ones that seem unrelated...
```
[  FAILED  ] SessionUtilitiesServiceTests.SysCfgLibraryPresent_EnumerateDevices_DevicePropertiesIncludesNameModelVendorSerialNumberProductId
[  FAILED  ] NiDCPowerDriverApiTest.CalSelfCalibrate_CompletesSuccessfully
[  FAILED  ] NiRFmxNRDriverApiTests.ULModAccSpeedOptimizedFromExample_FetchData_DataLooksReasonable
[  FAILED  ] NiRFmxSpecAnDriverApiTests.LutDpdFromExample_ReturnsSynchronizationNotFoundWarningWithData
[  FAILED  ] NiRFmxSpecAnDriverApiTests.ConfigureDPDLookupTableWithNoComplexGains_Initiate_Succeeds
[  FAILED  ] NiRFmxSpecAnDriverApiTests.ConfigureDPDLookupTableWithNoInputPowers_Initiate_Succeeds
[  FAILED  ] NiRFmxSpecAnDriverApiTests.ConfigureDPDLookupTableWithBothInputs_Initiate_Succeeds
```