### PR TITLE
Update ni-fake imported metadata and support new initialization behavior for init methods.

### DIFF
--- a/generated/nifake/nifake.proto
+++ b/generated/nifake/nifake.proto
@@ -31,6 +31,7 @@ service NiFake {
   rpc DoubleAllTheNums(DoubleAllTheNumsRequest) returns (DoubleAllTheNumsResponse);
   rpc EnumArrayOutputFunction(EnumArrayOutputFunctionRequest) returns (EnumArrayOutputFunctionResponse);
   rpc EnumInputFunctionWithDefaults(EnumInputFunctionWithDefaultsRequest) returns (EnumInputFunctionWithDefaultsResponse);
+  rpc ErrorMessage(ErrorMessageRequest) returns (ErrorMessageResponse);
   rpc ExportAttributeConfigurationBuffer(ExportAttributeConfigurationBufferRequest) returns (ExportAttributeConfigurationBufferResponse);
   rpc FetchWaveform(FetchWaveformRequest) returns (FetchWaveformResponse);
   rpc GetABoolean(GetABooleanRequest) returns (GetABooleanResponse);
@@ -58,6 +59,7 @@ service NiFake {
   rpc GetCustomType(GetCustomTypeRequest) returns (GetCustomTypeResponse);
   rpc GetCustomTypeArray(GetCustomTypeArrayRequest) returns (GetCustomTypeArrayResponse);
   rpc GetEnumValue(GetEnumValueRequest) returns (GetEnumValueResponse);
+  rpc GetError(GetErrorRequest) returns (GetErrorResponse);
   rpc GetViInt32Array(GetViInt32ArrayRequest) returns (GetViInt32ArrayResponse);
   rpc GetViUInt32Array(GetViUInt32ArrayRequest) returns (GetViUInt32ArrayResponse);
   rpc GetViUInt8(GetViUInt8Request) returns (GetViUInt8Response);
@@ -71,6 +73,7 @@ service NiFake {
   rpc MethodWithGetLastErrorParam(MethodWithGetLastErrorParamRequest) returns (MethodWithGetLastErrorParamResponse);
   rpc MethodWithGrpcFieldNumber(MethodWithGrpcFieldNumberRequest) returns (MethodWithGrpcFieldNumberResponse);
   rpc MethodWithGrpcOnlyParam(MethodWithGrpcOnlyParamRequest) returns (MethodWithGrpcOnlyParamResponse);
+  rpc MethodWithProtoOnlyParameter(MethodWithProtoOnlyParameterRequest) returns (MethodWithProtoOnlyParameterResponse);
   rpc MultipleArrayTypes(MultipleArrayTypesRequest) returns (MultipleArrayTypesResponse);
   rpc MultipleArraysSameSize(MultipleArraysSameSizeRequest) returns (MultipleArraysSameSizeResponse);
   rpc MultipleArraysSameSizeWithOptional(MultipleArraysSameSizeWithOptionalRequest) returns (MultipleArraysSameSizeWithOptionalResponse);
@@ -85,6 +88,11 @@ service NiFake {
   rpc ReturnDurationInSeconds(ReturnDurationInSecondsRequest) returns (ReturnDurationInSecondsResponse);
   rpc ReturnListOfDurationsInSeconds(ReturnListOfDurationsInSecondsRequest) returns (ReturnListOfDurationsInSecondsResponse);
   rpc ReturnMultipleTypes(ReturnMultipleTypesRequest) returns (ReturnMultipleTypesResponse);
+  rpc SetAttributeViBoolean(SetAttributeViBooleanRequest) returns (SetAttributeViBooleanResponse);
+  rpc SetAttributeViInt32(SetAttributeViInt32Request) returns (SetAttributeViInt32Response);
+  rpc SetAttributeViInt64(SetAttributeViInt64Request) returns (SetAttributeViInt64Response);
+  rpc SetAttributeViReal64(SetAttributeViReal64Request) returns (SetAttributeViReal64Response);
+  rpc SetAttributeViString(SetAttributeViStringRequest) returns (SetAttributeViStringResponse);
   rpc SetCustomType(SetCustomTypeRequest) returns (SetCustomTypeResponse);
   rpc SetCustomTypeArray(SetCustomTypeArrayRequest) returns (SetCustomTypeArrayResponse);
   rpc StringValuedEnumInputFunctionWithDefaults(StringValuedEnumInputFunctionWithDefaultsRequest) returns (StringValuedEnumInputFunctionWithDefaultsResponse);
@@ -360,6 +368,16 @@ message EnumInputFunctionWithDefaultsResponse {
   int32 status = 1;
 }
 
+message ErrorMessageRequest {
+  nidevice_grpc.Session vi = 1;
+  sint32 error_code = 2;
+}
+
+message ErrorMessageResponse {
+  int32 status = 1;
+  string error_message = 2;
+}
+
 message ExportAttributeConfigurationBufferRequest {
   nidevice_grpc.Session vi = 1;
 }
@@ -632,6 +650,16 @@ message GetEnumValueResponse {
   sint32 a_turtle_raw = 4;
 }
 
+message GetErrorRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetErrorResponse {
+  int32 status = 1;
+  sint32 error_code = 2;
+  string description = 3;
+}
+
 message GetViInt32ArrayRequest {
   nidevice_grpc.Session vi = 1;
   sint32 array_len = 2;
@@ -687,11 +715,13 @@ message InitWithOptionsRequest {
   bool id_query = 3;
   bool reset_device = 4;
   string option_string = 5;
+  nidevice_grpc.SessionInitializationBehavior requested_behavior = 6;
 }
 
 message InitWithOptionsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  bool new_session_initialized = 3;
 }
 
 message InitWithVarArgsRequest {
@@ -759,6 +789,14 @@ message MethodWithGrpcOnlyParamRequest {
 message MethodWithGrpcOnlyParamResponse {
   int32 status = 1;
   sint32 grpc_only_param = 2;
+}
+
+message MethodWithProtoOnlyParameterRequest {
+  sint32 attribute_value = 1;
+}
+
+message MethodWithProtoOnlyParameterResponse {
+  int32 status = 1;
 }
 
 message MultipleArrayTypesRequest {
@@ -924,6 +962,67 @@ message ReturnMultipleTypesResponse {
   double a_float_enum_raw = 9;
   repeated double an_array = 10;
   string a_string = 11;
+}
+
+message SetAttributeViBooleanRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFakeAttribute attribute_id = 3;
+  bool attribute_value = 4;
+}
+
+message SetAttributeViBooleanResponse {
+  int32 status = 1;
+}
+
+message SetAttributeViInt32Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFakeAttribute attribute_id = 3;
+  oneof attribute_value_enum {
+    NiFakeInt32AttributeValues attribute_value = 4;
+    sint32 attribute_value_raw = 5;
+  }
+}
+
+message SetAttributeViInt32Response {
+  int32 status = 1;
+}
+
+message SetAttributeViInt64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFakeAttribute attribute_id = 3;
+  int64 attribute_value_raw = 4;
+}
+
+message SetAttributeViInt64Response {
+  int32 status = 1;
+}
+
+message SetAttributeViReal64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFakeAttribute attribute_id = 3;
+  oneof attribute_value_enum {
+    NiFakeReal64AttributeValuesMapped attribute_value_mapped = 4;
+    double attribute_value_raw = 5;
+  }
+}
+
+message SetAttributeViReal64Response {
+  int32 status = 1;
+}
+
+message SetAttributeViStringRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFakeAttribute attribute_id = 3;
+  string attribute_value_raw = 4;
+}
+
+message SetAttributeViStringResponse {
+  int32 status = 1;
 }
 
 message SetCustomTypeRequest {

--- a/generated/nifake/nifake_client.cpp
+++ b/generated/nifake/nifake_client.cpp
@@ -290,6 +290,24 @@ enum_input_function_with_defaults(const StubPtr& stub, const nidevice_grpc::Sess
   return response;
 }
 
+ErrorMessageResponse
+error_message(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& error_code)
+{
+  ::grpc::ClientContext context;
+
+  auto request = ErrorMessageRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+  request.set_error_code(error_code);
+
+  auto response = ErrorMessageResponse{};
+
+  raise_if_error(
+      stub->ErrorMessage(&context, request, &response),
+      context);
+
+  return response;
+}
+
 ExportAttributeConfigurationBufferResponse
 export_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::Session& vi)
 {
@@ -763,6 +781,23 @@ get_enum_value(const StubPtr& stub, const nidevice_grpc::Session& vi)
   return response;
 }
 
+GetErrorResponse
+get_error(const StubPtr& stub, const nidevice_grpc::Session& vi)
+{
+  ::grpc::ClientContext context;
+
+  auto request = GetErrorRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+
+  auto response = GetErrorResponse{};
+
+  raise_if_error(
+      stub->GetError(&context, request, &response),
+      context);
+
+  return response;
+}
+
 GetViInt32ArrayResponse
 get_vi_int32_array(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& array_len)
 {
@@ -853,7 +888,7 @@ init_ext_cal(const StubPtr& stub, const pb::string& resource_name, const pb::str
 }
 
 InitWithOptionsResponse
-init_with_options(const StubPtr& stub, const pb::string& resource_name, const bool& id_query, const bool& reset_device, const pb::string& option_string)
+init_with_options(const StubPtr& stub, const pb::string& resource_name, const bool& id_query, const bool& reset_device, const pb::string& option_string, const nidevice_grpc::SessionInitializationBehavior& requested_behavior)
 {
   ::grpc::ClientContext context;
 
@@ -862,6 +897,7 @@ init_with_options(const StubPtr& stub, const pb::string& resource_name, const bo
   request.set_id_query(id_query);
   request.set_reset_device(reset_device);
   request.set_option_string(option_string);
+  request.set_requested_behavior(requested_behavior);
 
   auto response = InitWithOptionsResponse{};
 
@@ -991,6 +1027,23 @@ method_with_grpc_only_param(const StubPtr& stub, const pb::int32& simple_param)
 
   raise_if_error(
       stub->MethodWithGrpcOnlyParam(&context, request, &response),
+      context);
+
+  return response;
+}
+
+MethodWithProtoOnlyParameterResponse
+method_with_proto_only_parameter(const StubPtr& stub, const pb::int32& attribute_value)
+{
+  ::grpc::ClientContext context;
+
+  auto request = MethodWithProtoOnlyParameterRequest{};
+  request.set_attribute_value(attribute_value);
+
+  auto response = MethodWithProtoOnlyParameterResponse{};
+
+  raise_if_error(
+      stub->MethodWithProtoOnlyParameter(&context, request, &response),
       context);
 
   return response;
@@ -1266,6 +1319,120 @@ return_multiple_types(const StubPtr& stub, const nidevice_grpc::Session& vi, con
 
   raise_if_error(
       stub->ReturnMultipleTypes(&context, request, &response),
+      context);
+
+  return response;
+}
+
+SetAttributeViBooleanResponse
+set_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const bool& attribute_value)
+{
+  ::grpc::ClientContext context;
+
+  auto request = SetAttributeViBooleanRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+  request.set_channel_name(channel_name);
+  request.set_attribute_id(attribute_id);
+  request.set_attribute_value(attribute_value);
+
+  auto response = SetAttributeViBooleanResponse{};
+
+  raise_if_error(
+      stub->SetAttributeViBoolean(&context, request, &response),
+      context);
+
+  return response;
+}
+
+SetAttributeViInt32Response
+set_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const simple_variant<NiFakeInt32AttributeValues, pb::int32>& attribute_value)
+{
+  ::grpc::ClientContext context;
+
+  auto request = SetAttributeViInt32Request{};
+  request.mutable_vi()->CopyFrom(vi);
+  request.set_channel_name(channel_name);
+  request.set_attribute_id(attribute_id);
+  const auto attribute_value_ptr = attribute_value.get_if<NiFakeInt32AttributeValues>();
+  const auto attribute_value_raw_ptr = attribute_value.get_if<pb::int32>();
+  if (attribute_value_ptr) {
+    request.set_attribute_value(*attribute_value_ptr);
+  }
+  else if (attribute_value_raw_ptr) {
+    request.set_attribute_value_raw(*attribute_value_raw_ptr);
+  }
+
+  auto response = SetAttributeViInt32Response{};
+
+  raise_if_error(
+      stub->SetAttributeViInt32(&context, request, &response),
+      context);
+
+  return response;
+}
+
+SetAttributeViInt64Response
+set_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const pb::int64& attribute_value)
+{
+  ::grpc::ClientContext context;
+
+  auto request = SetAttributeViInt64Request{};
+  request.mutable_vi()->CopyFrom(vi);
+  request.set_channel_name(channel_name);
+  request.set_attribute_id(attribute_id);
+  request.set_attribute_value_raw(attribute_value);
+
+  auto response = SetAttributeViInt64Response{};
+
+  raise_if_error(
+      stub->SetAttributeViInt64(&context, request, &response),
+      context);
+
+  return response;
+}
+
+SetAttributeViReal64Response
+set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const simple_variant<NiFakeReal64AttributeValuesMapped, double>& attribute_value)
+{
+  ::grpc::ClientContext context;
+
+  auto request = SetAttributeViReal64Request{};
+  request.mutable_vi()->CopyFrom(vi);
+  request.set_channel_name(channel_name);
+  request.set_attribute_id(attribute_id);
+  const auto attribute_value_ptr = attribute_value.get_if<NiFakeReal64AttributeValuesMapped>();
+  const auto attribute_value_raw_ptr = attribute_value.get_if<double>();
+  if (attribute_value_ptr) {
+    request.set_attribute_value_mapped(*attribute_value_ptr);
+  }
+  else if (attribute_value_raw_ptr) {
+    request.set_attribute_value_raw(*attribute_value_raw_ptr);
+  }
+
+  auto response = SetAttributeViReal64Response{};
+
+  raise_if_error(
+      stub->SetAttributeViReal64(&context, request, &response),
+      context);
+
+  return response;
+}
+
+SetAttributeViStringResponse
+set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const pb::string& attribute_value)
+{
+  ::grpc::ClientContext context;
+
+  auto request = SetAttributeViStringRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+  request.set_channel_name(channel_name);
+  request.set_attribute_id(attribute_id);
+  request.set_attribute_value_raw(attribute_value);
+
+  auto response = SetAttributeViStringResponse{};
+
+  raise_if_error(
+      stub->SetAttributeViString(&context, request, &response),
       context);
 
   return response;

--- a/generated/nifake/nifake_client.h
+++ b/generated/nifake/nifake_client.h
@@ -37,6 +37,7 @@ CustomNestedStructRoundtripResponse custom_nested_struct_roundtrip(const StubPtr
 DoubleAllTheNumsResponse double_all_the_nums(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::vector<double>& numbers);
 EnumArrayOutputFunctionResponse enum_array_output_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& number_of_elements);
 EnumInputFunctionWithDefaultsResponse enum_input_function_with_defaults(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<Turtle, pb::int32>& a_turtle);
+ErrorMessageResponse error_message(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& error_code);
 ExportAttributeConfigurationBufferResponse export_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::Session& vi);
 FetchWaveformResponse fetch_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& number_of_samples);
 GetABooleanResponse get_a_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi);
@@ -64,12 +65,13 @@ GetCalIntervalResponse get_cal_interval(const StubPtr& stub, const nidevice_grpc
 GetCustomTypeResponse get_custom_type(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetCustomTypeArrayResponse get_custom_type_array(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& number_of_elements);
 GetEnumValueResponse get_enum_value(const StubPtr& stub, const nidevice_grpc::Session& vi);
+GetErrorResponse get_error(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetViInt32ArrayResponse get_vi_int32_array(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& array_len);
 GetViUInt32ArrayResponse get_vi_uint32_array(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& array_len);
 GetViUInt8Response get_vi_uint8(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ImportAttributeConfigurationBufferResponse import_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& configuration);
 InitExtCalResponse init_ext_cal(const StubPtr& stub, const pb::string& resource_name, const pb::string& calibration_password);
-InitWithOptionsResponse init_with_options(const StubPtr& stub, const pb::string& resource_name, const bool& id_query, const bool& reset_device, const pb::string& option_string);
+InitWithOptionsResponse init_with_options(const StubPtr& stub, const pb::string& resource_name, const bool& id_query, const bool& reset_device, const pb::string& option_string, const nidevice_grpc::SessionInitializationBehavior& requested_behavior);
 InitWithVarArgsResponse init_with_var_args(const StubPtr& stub, const pb::string& resource_name, const std::vector<StringAndTurtle>& name_and_turtle);
 MethodUsingEnumWithGrpcNameValuesResponse method_using_enum_with_grpc_name_values(const StubPtr& stub, const simple_variant<EnumWithGrpcNameValues, pb::int32>& using_enum);
 MethodUsingWholeAndFractionalNumbersResponse method_using_whole_and_fractional_numbers(const StubPtr& stub);
@@ -77,6 +79,7 @@ MethodUsingWholeMappedNumbersResponse method_using_whole_mapped_numbers(const St
 MethodWithGetLastErrorParamResponse method_with_get_last_error_param(const StubPtr& stub);
 MethodWithGrpcFieldNumberResponse method_with_grpc_field_number(const StubPtr& stub, const pb::int32& attribute_value);
 MethodWithGrpcOnlyParamResponse method_with_grpc_only_param(const StubPtr& stub, const pb::int32& simple_param);
+MethodWithProtoOnlyParameterResponse method_with_proto_only_parameter(const StubPtr& stub, const pb::int32& attribute_value);
 MultipleArrayTypesResponse multiple_array_types(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& output_array_size, const std::vector<double>& input_array_of_floats, const std::vector<pb::int32>& input_array_of_integers);
 MultipleArraysSameSizeResponse multiple_arrays_same_size(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::vector<double>& values1, const std::vector<double>& values2, const std::vector<double>& values3, const std::vector<double>& values4);
 MultipleArraysSameSizeWithOptionalResponse multiple_arrays_same_size_with_optional(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::vector<double>& values1, const std::vector<double>& values2, const std::vector<double>& values3, const std::vector<double>& values4, const std::vector<FakeCustomStruct>& values5);
@@ -91,6 +94,11 @@ ReturnANumberAndAStringResponse return_a_number_and_a_string(const StubPtr& stub
 ReturnDurationInSecondsResponse return_duration_in_seconds(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ReturnListOfDurationsInSecondsResponse return_list_of_durations_in_seconds(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& number_of_elements);
 ReturnMultipleTypesResponse return_multiple_types(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& array_size);
+SetAttributeViBooleanResponse set_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const bool& attribute_value);
+SetAttributeViInt32Response set_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const simple_variant<NiFakeInt32AttributeValues, pb::int32>& attribute_value);
+SetAttributeViInt64Response set_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const pb::int64& attribute_value);
+SetAttributeViReal64Response set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const simple_variant<NiFakeReal64AttributeValuesMapped, double>& attribute_value);
+SetAttributeViStringResponse set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const pb::string& attribute_value);
 SetCustomTypeResponse set_custom_type(const StubPtr& stub, const nidevice_grpc::Session& vi, const FakeCustomStruct& cs);
 SetCustomTypeArrayResponse set_custom_type_array(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::vector<FakeCustomStruct>& cs);
 StringValuedEnumInputFunctionWithDefaultsResponse string_valued_enum_input_function_with_defaults(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<MobileOSNames, std::string>& a_mobile_os_name);

--- a/generated/nifake/nifake_library.cpp
+++ b/generated/nifake/nifake_library.cpp
@@ -79,6 +79,7 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.MethodWithGetLastErrorParam = reinterpret_cast<MethodWithGetLastErrorParamPtr>(shared_library_.get_function_pointer("niFake_MethodWithGetLastErrorParam"));
   function_pointers_.MethodWithGrpcFieldNumber = reinterpret_cast<MethodWithGrpcFieldNumberPtr>(shared_library_.get_function_pointer("niFake_MethodWithGrpcFieldNumber"));
   function_pointers_.MethodWithGrpcOnlyParam = reinterpret_cast<MethodWithGrpcOnlyParamPtr>(shared_library_.get_function_pointer("niFake_MethodWithGrpcOnlyParam"));
+  function_pointers_.MethodWithProtoOnlyParameter = reinterpret_cast<MethodWithProtoOnlyParameterPtr>(shared_library_.get_function_pointer("niFake_MethodWithProtoOnlyParameter"));
   function_pointers_.MultipleArrayTypes = reinterpret_cast<MultipleArrayTypesPtr>(shared_library_.get_function_pointer("niFake_MultipleArrayTypes"));
   function_pointers_.MultipleArraysSameSize = reinterpret_cast<MultipleArraysSameSizePtr>(shared_library_.get_function_pointer("niFake_MultipleArraysSameSize"));
   function_pointers_.MultipleArraysSameSizeWithOptional = reinterpret_cast<MultipleArraysSameSizeWithOptionalPtr>(shared_library_.get_function_pointer("niFake_MultipleArraysSameSizeWithOptional"));
@@ -307,7 +308,11 @@ ViStatus NiFakeLibrary::ErrorMessage(ViSession vi, ViStatus errorCode, ViChar er
   if (!function_pointers_.ErrorMessage) {
     throw nidevice_grpc::LibraryLoadException("Could not find niFake_error_message.");
   }
+#if defined(_MSC_VER)
+  return niFake_error_message(vi, errorCode, errorMessage);
+#else
   return function_pointers_.ErrorMessage(vi, errorCode, errorMessage);
+#endif
 }
 
 ViStatus NiFakeLibrary::ExportAttributeConfigurationBuffer(ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[])
@@ -639,7 +644,11 @@ ViStatus NiFakeLibrary::GetError(ViSession vi, ViStatus* errorCode, ViInt32 buff
   if (!function_pointers_.GetError) {
     throw nidevice_grpc::LibraryLoadException("Could not find niFake_GetError.");
   }
+#if defined(_MSC_VER)
+  return niFake_GetError(vi, errorCode, bufferSize, description);
+#else
   return function_pointers_.GetError(vi, errorCode, bufferSize, description);
+#endif
 }
 
 ViStatus NiFakeLibrary::GetViInt32Array(ViSession vi, ViInt32 arrayLen, ViInt32 int32Array[])
@@ -803,6 +812,18 @@ ViStatus NiFakeLibrary::MethodWithGrpcOnlyParam(ViInt32 simpleParam, ViInt32* gr
   return niFake_MethodWithGrpcOnlyParam(simpleParam, grpcOnlyParam);
 #else
   return function_pointers_.MethodWithGrpcOnlyParam(simpleParam, grpcOnlyParam);
+#endif
+}
+
+ViStatus NiFakeLibrary::MethodWithProtoOnlyParameter()
+{
+  if (!function_pointers_.MethodWithProtoOnlyParameter) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_MethodWithProtoOnlyParameter.");
+  }
+#if defined(_MSC_VER)
+  return niFake_MethodWithProtoOnlyParameter();
+#else
+  return function_pointers_.MethodWithProtoOnlyParameter();
 #endif
 }
 
@@ -987,7 +1008,11 @@ ViStatus NiFakeLibrary::SetAttributeViBoolean(ViSession vi, ViConstString channe
   if (!function_pointers_.SetAttributeViBoolean) {
     throw nidevice_grpc::LibraryLoadException("Could not find niFake_SetAttributeViBoolean.");
   }
+#if defined(_MSC_VER)
+  return niFake_SetAttributeViBoolean(vi, channelName, attributeId, attributeValue);
+#else
   return function_pointers_.SetAttributeViBoolean(vi, channelName, attributeId, attributeValue);
+#endif
 }
 
 ViStatus NiFakeLibrary::SetAttributeViInt32(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 attributeValue)
@@ -995,7 +1020,11 @@ ViStatus NiFakeLibrary::SetAttributeViInt32(ViSession vi, ViConstString channelN
   if (!function_pointers_.SetAttributeViInt32) {
     throw nidevice_grpc::LibraryLoadException("Could not find niFake_SetAttributeViInt32.");
   }
+#if defined(_MSC_VER)
+  return niFake_SetAttributeViInt32(vi, channelName, attributeId, attributeValue);
+#else
   return function_pointers_.SetAttributeViInt32(vi, channelName, attributeId, attributeValue);
+#endif
 }
 
 ViStatus NiFakeLibrary::SetAttributeViInt64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64 attributeValue)
@@ -1003,7 +1032,11 @@ ViStatus NiFakeLibrary::SetAttributeViInt64(ViSession vi, ViConstString channelN
   if (!function_pointers_.SetAttributeViInt64) {
     throw nidevice_grpc::LibraryLoadException("Could not find niFake_SetAttributeViInt64.");
   }
+#if defined(_MSC_VER)
+  return niFake_SetAttributeViInt64(vi, channelName, attributeId, attributeValue);
+#else
   return function_pointers_.SetAttributeViInt64(vi, channelName, attributeId, attributeValue);
+#endif
 }
 
 ViStatus NiFakeLibrary::SetAttributeViReal64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViReal64 attributeValue)
@@ -1011,7 +1044,11 @@ ViStatus NiFakeLibrary::SetAttributeViReal64(ViSession vi, ViConstString channel
   if (!function_pointers_.SetAttributeViReal64) {
     throw nidevice_grpc::LibraryLoadException("Could not find niFake_SetAttributeViReal64.");
   }
+#if defined(_MSC_VER)
+  return niFake_SetAttributeViReal64(vi, channelName, attributeId, attributeValue);
+#else
   return function_pointers_.SetAttributeViReal64(vi, channelName, attributeId, attributeValue);
+#endif
 }
 
 ViStatus NiFakeLibrary::SetAttributeViString(ViSession vi, ViConstString channelName, ViAttr attributeId, ViConstString attributeValue)
@@ -1019,7 +1056,11 @@ ViStatus NiFakeLibrary::SetAttributeViString(ViSession vi, ViConstString channel
   if (!function_pointers_.SetAttributeViString) {
     throw nidevice_grpc::LibraryLoadException("Could not find niFake_SetAttributeViString.");
   }
+#if defined(_MSC_VER)
+  return niFake_SetAttributeViString(vi, channelName, attributeId, attributeValue);
+#else
   return function_pointers_.SetAttributeViString(vi, channelName, attributeId, attributeValue);
+#endif
 }
 
 ViStatus NiFakeLibrary::SetCustomType(ViSession vi, CustomStruct cs)

--- a/generated/nifake/nifake_library.h
+++ b/generated/nifake/nifake_library.h
@@ -76,6 +76,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus MethodWithGetLastErrorParam();
   ViStatus MethodWithGrpcFieldNumber(ViInt32 attributeValue);
   ViStatus MethodWithGrpcOnlyParam(ViInt32 simpleParam, ViInt32* grpcOnlyParam);
+  ViStatus MethodWithProtoOnlyParameter();
   ViStatus MultipleArrayTypes(ViSession vi, ViInt32 outputArraySize, ViReal64 outputArray[], ViReal64 outputArrayOfFixedLength[3], ViInt32 inputArraySizes, ViReal64 inputArrayOfFloats[], ViInt16 inputArrayOfIntegers[]);
   ViStatus MultipleArraysSameSize(ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], ViInt32 size);
   ViStatus MultipleArraysSameSizeWithOptional(ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], CustomStruct values5[], ViInt32 size);
@@ -123,7 +124,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using DoubleAllTheNumsPtr = decltype(&niFake_DoubleAllTheNums);
   using EnumArrayOutputFunctionPtr = decltype(&niFake_EnumArrayOutputFunction);
   using EnumInputFunctionWithDefaultsPtr = decltype(&niFake_EnumInputFunctionWithDefaults);
-  using ErrorMessagePtr = ViStatus (*)(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]);
+  using ErrorMessagePtr = decltype(&niFake_error_message);
   using ExportAttributeConfigurationBufferPtr = decltype(&niFake_ExportAttributeConfigurationBuffer);
   using FetchWaveformPtr = decltype(&niFake_FetchWaveform);
   using GetABooleanPtr = decltype(&niFake_GetABoolean);
@@ -151,7 +152,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using GetCustomTypePtr = decltype(&niFake_GetCustomType);
   using GetCustomTypeArrayPtr = decltype(&niFake_GetCustomTypeArray);
   using GetEnumValuePtr = decltype(&niFake_GetEnumValue);
-  using GetErrorPtr = ViStatus (*)(ViSession vi, ViStatus* errorCode, ViInt32 bufferSize, ViChar description[]);
+  using GetErrorPtr = decltype(&niFake_GetError);
   using GetViInt32ArrayPtr = decltype(&niFake_GetViInt32Array);
   using GetViUInt32ArrayPtr = decltype(&niFake_GetViUInt32Array);
   using GetViUInt8Ptr = decltype(&niFake_GetViUInt8);
@@ -166,6 +167,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using MethodWithGetLastErrorParamPtr = decltype(&niFake_MethodWithGetLastErrorParam);
   using MethodWithGrpcFieldNumberPtr = decltype(&niFake_MethodWithGrpcFieldNumber);
   using MethodWithGrpcOnlyParamPtr = decltype(&niFake_MethodWithGrpcOnlyParam);
+  using MethodWithProtoOnlyParameterPtr = decltype(&niFake_MethodWithProtoOnlyParameter);
   using MultipleArrayTypesPtr = decltype(&niFake_MultipleArrayTypes);
   using MultipleArraysSameSizePtr = decltype(&niFake_MultipleArraysSameSize);
   using MultipleArraysSameSizeWithOptionalPtr = decltype(&niFake_MultipleArraysSameSizeWithOptional);
@@ -181,11 +183,11 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using ReturnListOfDurationsInSecondsPtr = decltype(&niFake_ReturnListOfDurationsInSeconds);
   using ReturnMultipleTypesPtr = decltype(&niFake_ReturnMultipleTypes);
   using SelfTestPtr = ViStatus (*)(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]);
-  using SetAttributeViBooleanPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean attributeValue);
-  using SetAttributeViInt32Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 attributeValue);
-  using SetAttributeViInt64Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64 attributeValue);
-  using SetAttributeViReal64Ptr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViReal64 attributeValue);
-  using SetAttributeViStringPtr = ViStatus (*)(ViSession vi, ViConstString channelName, ViAttr attributeId, ViConstString attributeValue);
+  using SetAttributeViBooleanPtr = decltype(&niFake_SetAttributeViBoolean);
+  using SetAttributeViInt32Ptr = decltype(&niFake_SetAttributeViInt32);
+  using SetAttributeViInt64Ptr = decltype(&niFake_SetAttributeViInt64);
+  using SetAttributeViReal64Ptr = decltype(&niFake_SetAttributeViReal64);
+  using SetAttributeViStringPtr = decltype(&niFake_SetAttributeViString);
   using SetCustomTypePtr = decltype(&niFake_SetCustomType);
   using SetCustomTypeArrayPtr = decltype(&niFake_SetCustomTypeArray);
   using StringValuedEnumInputFunctionWithDefaultsPtr = decltype(&niFake_StringValuedEnumInputFunctionWithDefaults);
@@ -256,6 +258,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     MethodWithGetLastErrorParamPtr MethodWithGetLastErrorParam;
     MethodWithGrpcFieldNumberPtr MethodWithGrpcFieldNumber;
     MethodWithGrpcOnlyParamPtr MethodWithGrpcOnlyParam;
+    MethodWithProtoOnlyParameterPtr MethodWithProtoOnlyParameter;
     MultipleArrayTypesPtr MultipleArrayTypes;
     MultipleArraysSameSizePtr MultipleArraysSameSize;
     MultipleArraysSameSizeWithOptionalPtr MultipleArraysSameSizeWithOptional;

--- a/generated/nifake/nifake_library_interface.h
+++ b/generated/nifake/nifake_library_interface.h
@@ -73,6 +73,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus MethodWithGetLastErrorParam() = 0;
   virtual ViStatus MethodWithGrpcFieldNumber(ViInt32 attributeValue) = 0;
   virtual ViStatus MethodWithGrpcOnlyParam(ViInt32 simpleParam, ViInt32* grpcOnlyParam) = 0;
+  virtual ViStatus MethodWithProtoOnlyParameter() = 0;
   virtual ViStatus MultipleArrayTypes(ViSession vi, ViInt32 outputArraySize, ViReal64 outputArray[], ViReal64 outputArrayOfFixedLength[3], ViInt32 inputArraySizes, ViReal64 inputArrayOfFloats[], ViInt16 inputArrayOfIntegers[]) = 0;
   virtual ViStatus MultipleArraysSameSize(ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], ViInt32 size) = 0;
   virtual ViStatus MultipleArraysSameSizeWithOptional(ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], CustomStruct values5[], ViInt32 size) = 0;

--- a/generated/nifake/nifake_mock_library.h
+++ b/generated/nifake/nifake_mock_library.h
@@ -75,6 +75,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, MethodWithGetLastErrorParam, (), (override));
   MOCK_METHOD(ViStatus, MethodWithGrpcFieldNumber, (ViInt32 attributeValue), (override));
   MOCK_METHOD(ViStatus, MethodWithGrpcOnlyParam, (ViInt32 simpleParam, ViInt32* grpcOnlyParam), (override));
+  MOCK_METHOD(ViStatus, MethodWithProtoOnlyParameter, (), (override));
   MOCK_METHOD(ViStatus, MultipleArrayTypes, (ViSession vi, ViInt32 outputArraySize, ViReal64 outputArray[], ViReal64 outputArrayOfFixedLength[3], ViInt32 inputArraySizes, ViReal64 inputArrayOfFloats[], ViInt16 inputArrayOfIntegers[]), (override));
   MOCK_METHOD(ViStatus, MultipleArraysSameSize, (ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], ViInt32 size), (override));
   MOCK_METHOD(ViStatus, MultipleArraysSameSizeWithOptional, (ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], CustomStruct values5[], ViInt32 size), (override));

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -1467,7 +1467,7 @@ namespace nifake_grpc {
       auto option_string = request->option_string().c_str();
       auto requested_behavior = request->requested_behavior();
 
-      bool new_session_initialized = false;
+      bool new_session_initialized {};
       auto init_lambda = [&] () {
         ViSession vi;
         auto status = library_->InitWithOptions(resource_name, id_query, reset_device, option_string, &vi);

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -417,6 +417,32 @@ namespace nifake_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::ErrorMessage(::grpc::ServerContext* context, const ErrorMessageRequest* request, ErrorMessageResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViStatus error_code = request->error_code();
+      std::string error_message(256 - 1, '\0');
+      auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      response->set_error_message(error_message);
+      nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_error_message()));
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::ExportAttributeConfigurationBuffer(::grpc::ServerContext* context, const ExportAttributeConfigurationBufferRequest* request, ExportAttributeConfigurationBufferResponse* response)
   {
     if (context->IsCancelled()) {
@@ -1256,6 +1282,49 @@ namespace nifake_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::GetError(::grpc::ServerContext* context, const GetErrorRequest* request, GetErrorResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+
+      while (true) {
+        auto status = library_->GetError(vi, nullptr, 0, nullptr);
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForViSession(context, status, vi);
+        }
+        ViInt32 buffer_size = status;
+
+        ViStatus error_code {};
+        std::string description;
+        if (buffer_size > 0) {
+            description.resize(buffer_size - 1);
+        }
+        status = library_->GetError(vi, &error_code, buffer_size, (ViChar*)description.data());
+        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(buffer_size)) {
+          // buffer is now too small, try again
+          continue;
+        }
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForViSession(context, status, vi);
+        }
+        response->set_status(status);
+        response->set_error_code(error_code);
+        response->set_description(description);
+        nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_description()));
+        return ::grpc::Status::OK;
+      }
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::GetViInt32Array(::grpc::ServerContext* context, const GetViInt32ArrayRequest* request, GetViInt32ArrayResponse* response)
   {
     if (context->IsCancelled()) {
@@ -1396,7 +1465,9 @@ namespace nifake_grpc {
       ViBoolean id_query = request->id_query();
       ViBoolean reset_device = request->reset_device();
       auto option_string = request->option_string().c_str();
+      auto requested_behavior = request->requested_behavior();
 
+      bool new_session_initialized;
       auto init_lambda = [&] () {
         ViSession vi;
         auto status = library_->InitWithOptions(resource_name, id_query, reset_device, option_string, &vi);
@@ -1405,12 +1476,13 @@ namespace nifake_grpc {
       uint32_t session_id = 0;
       const std::string& grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id, requested_behavior, &new_session_initialized);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
       response->mutable_vi()->set_id(session_id);
+      response->set_new_session_initialized(new_session_initialized);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -1617,6 +1689,27 @@ namespace nifake_grpc {
       }
       response->set_status(status);
       response->set_grpc_only_param(grpc_only_param);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::MethodWithProtoOnlyParameter(::grpc::ServerContext* context, const MethodWithProtoOnlyParameterRequest* request, MethodWithProtoOnlyParameterResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      ViInt32 attribute_value = request->attribute_value();
+      auto status = library_->MethodWithProtoOnlyParameter();
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, 0);
+      }
+      response->set_status(status);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -2129,6 +2222,165 @@ namespace nifake_grpc {
         nidevice_grpc::converters::trim_trailing_nulls(*(response->mutable_a_string()));
         return ::grpc::Status::OK;
       }
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::SetAttributeViBoolean(::grpc::ServerContext* context, const SetAttributeViBooleanRequest* request, SetAttributeViBooleanResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      auto channel_name = request->channel_name().c_str();
+      ViAttr attribute_id = request->attribute_id();
+      ViBoolean attribute_value = request->attribute_value();
+      auto status = library_->SetAttributeViBoolean(vi, channel_name, attribute_id, attribute_value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::SetAttributeViInt32(::grpc::ServerContext* context, const SetAttributeViInt32Request* request, SetAttributeViInt32Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      auto channel_name = request->channel_name().c_str();
+      ViAttr attribute_id = request->attribute_id();
+      ViInt32 attribute_value;
+      switch (request->attribute_value_enum_case()) {
+        case nifake_grpc::SetAttributeViInt32Request::AttributeValueEnumCase::kAttributeValue: {
+          attribute_value = static_cast<ViInt32>(request->attribute_value());
+          break;
+        }
+        case nifake_grpc::SetAttributeViInt32Request::AttributeValueEnumCase::kAttributeValueRaw: {
+          attribute_value = static_cast<ViInt32>(request->attribute_value_raw());
+          break;
+        }
+        case nifake_grpc::SetAttributeViInt32Request::AttributeValueEnumCase::ATTRIBUTE_VALUE_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute_value was not specified or out of range");
+          break;
+        }
+      }
+
+      auto status = library_->SetAttributeViInt32(vi, channel_name, attribute_id, attribute_value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::SetAttributeViInt64(::grpc::ServerContext* context, const SetAttributeViInt64Request* request, SetAttributeViInt64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      auto channel_name = request->channel_name().c_str();
+      ViAttr attribute_id = request->attribute_id();
+      ViInt64 attribute_value = request->attribute_value_raw();
+      auto status = library_->SetAttributeViInt64(vi, channel_name, attribute_id, attribute_value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::SetAttributeViReal64(::grpc::ServerContext* context, const SetAttributeViReal64Request* request, SetAttributeViReal64Response* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      auto channel_name = request->channel_name().c_str();
+      ViAttr attribute_id = request->attribute_id();
+      ViReal64 attribute_value;
+      switch (request->attribute_value_enum_case()) {
+        case nifake_grpc::SetAttributeViReal64Request::AttributeValueEnumCase::kAttributeValueMapped: {
+          auto attribute_value_imap_it = nifakereal64attributevaluesmapped_input_map_.find(request->attribute_value_mapped());
+          if (attribute_value_imap_it == nifakereal64attributevaluesmapped_input_map_.end()) {
+            return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute_value_mapped was not specified or out of range.");
+          }
+          attribute_value = static_cast<ViReal64>(attribute_value_imap_it->second);
+          break;
+        }
+        case nifake_grpc::SetAttributeViReal64Request::AttributeValueEnumCase::kAttributeValueRaw: {
+          attribute_value = static_cast<ViReal64>(request->attribute_value_raw());
+          break;
+        }
+        case nifake_grpc::SetAttributeViReal64Request::AttributeValueEnumCase::ATTRIBUTE_VALUE_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for attribute_value was not specified or out of range");
+          break;
+        }
+      }
+
+      auto status = library_->SetAttributeViReal64(vi, channel_name, attribute_id, attribute_value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::SetAttributeViString(::grpc::ServerContext* context, const SetAttributeViStringRequest* request, SetAttributeViStringResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      auto channel_name = request->channel_name().c_str();
+      ViAttr attribute_id = request->attribute_id();
+      auto attribute_value = request->attribute_value_raw().c_str();
+      auto status = library_->SetAttributeViString(vi, channel_name, attribute_id, attribute_value);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
       return ex.GetStatus();

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -1467,7 +1467,7 @@ namespace nifake_grpc {
       auto option_string = request->option_string().c_str();
       auto requested_behavior = request->requested_behavior();
 
-      bool new_session_initialized;
+      bool new_session_initialized = false;
       auto init_lambda = [&] () {
         ViSession vi;
         auto status = library_->InitWithOptions(resource_name, id_query, reset_device, option_string, &vi);

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -56,6 +56,7 @@ public:
   ::grpc::Status DoubleAllTheNums(::grpc::ServerContext* context, const DoubleAllTheNumsRequest* request, DoubleAllTheNumsResponse* response) override;
   ::grpc::Status EnumArrayOutputFunction(::grpc::ServerContext* context, const EnumArrayOutputFunctionRequest* request, EnumArrayOutputFunctionResponse* response) override;
   ::grpc::Status EnumInputFunctionWithDefaults(::grpc::ServerContext* context, const EnumInputFunctionWithDefaultsRequest* request, EnumInputFunctionWithDefaultsResponse* response) override;
+  ::grpc::Status ErrorMessage(::grpc::ServerContext* context, const ErrorMessageRequest* request, ErrorMessageResponse* response) override;
   ::grpc::Status ExportAttributeConfigurationBuffer(::grpc::ServerContext* context, const ExportAttributeConfigurationBufferRequest* request, ExportAttributeConfigurationBufferResponse* response) override;
   ::grpc::Status FetchWaveform(::grpc::ServerContext* context, const FetchWaveformRequest* request, FetchWaveformResponse* response) override;
   ::grpc::Status GetABoolean(::grpc::ServerContext* context, const GetABooleanRequest* request, GetABooleanResponse* response) override;
@@ -83,6 +84,7 @@ public:
   ::grpc::Status GetCustomType(::grpc::ServerContext* context, const GetCustomTypeRequest* request, GetCustomTypeResponse* response) override;
   ::grpc::Status GetCustomTypeArray(::grpc::ServerContext* context, const GetCustomTypeArrayRequest* request, GetCustomTypeArrayResponse* response) override;
   ::grpc::Status GetEnumValue(::grpc::ServerContext* context, const GetEnumValueRequest* request, GetEnumValueResponse* response) override;
+  ::grpc::Status GetError(::grpc::ServerContext* context, const GetErrorRequest* request, GetErrorResponse* response) override;
   ::grpc::Status GetViInt32Array(::grpc::ServerContext* context, const GetViInt32ArrayRequest* request, GetViInt32ArrayResponse* response) override;
   ::grpc::Status GetViUInt32Array(::grpc::ServerContext* context, const GetViUInt32ArrayRequest* request, GetViUInt32ArrayResponse* response) override;
   ::grpc::Status GetViUInt8(::grpc::ServerContext* context, const GetViUInt8Request* request, GetViUInt8Response* response) override;
@@ -96,6 +98,7 @@ public:
   ::grpc::Status MethodWithGetLastErrorParam(::grpc::ServerContext* context, const MethodWithGetLastErrorParamRequest* request, MethodWithGetLastErrorParamResponse* response) override;
   ::grpc::Status MethodWithGrpcFieldNumber(::grpc::ServerContext* context, const MethodWithGrpcFieldNumberRequest* request, MethodWithGrpcFieldNumberResponse* response) override;
   ::grpc::Status MethodWithGrpcOnlyParam(::grpc::ServerContext* context, const MethodWithGrpcOnlyParamRequest* request, MethodWithGrpcOnlyParamResponse* response) override;
+  ::grpc::Status MethodWithProtoOnlyParameter(::grpc::ServerContext* context, const MethodWithProtoOnlyParameterRequest* request, MethodWithProtoOnlyParameterResponse* response) override;
   ::grpc::Status MultipleArrayTypes(::grpc::ServerContext* context, const MultipleArrayTypesRequest* request, MultipleArrayTypesResponse* response) override;
   ::grpc::Status MultipleArraysSameSize(::grpc::ServerContext* context, const MultipleArraysSameSizeRequest* request, MultipleArraysSameSizeResponse* response) override;
   ::grpc::Status MultipleArraysSameSizeWithOptional(::grpc::ServerContext* context, const MultipleArraysSameSizeWithOptionalRequest* request, MultipleArraysSameSizeWithOptionalResponse* response) override;
@@ -110,6 +113,11 @@ public:
   ::grpc::Status ReturnDurationInSeconds(::grpc::ServerContext* context, const ReturnDurationInSecondsRequest* request, ReturnDurationInSecondsResponse* response) override;
   ::grpc::Status ReturnListOfDurationsInSeconds(::grpc::ServerContext* context, const ReturnListOfDurationsInSecondsRequest* request, ReturnListOfDurationsInSecondsResponse* response) override;
   ::grpc::Status ReturnMultipleTypes(::grpc::ServerContext* context, const ReturnMultipleTypesRequest* request, ReturnMultipleTypesResponse* response) override;
+  ::grpc::Status SetAttributeViBoolean(::grpc::ServerContext* context, const SetAttributeViBooleanRequest* request, SetAttributeViBooleanResponse* response) override;
+  ::grpc::Status SetAttributeViInt32(::grpc::ServerContext* context, const SetAttributeViInt32Request* request, SetAttributeViInt32Response* response) override;
+  ::grpc::Status SetAttributeViInt64(::grpc::ServerContext* context, const SetAttributeViInt64Request* request, SetAttributeViInt64Response* response) override;
+  ::grpc::Status SetAttributeViReal64(::grpc::ServerContext* context, const SetAttributeViReal64Request* request, SetAttributeViReal64Response* response) override;
+  ::grpc::Status SetAttributeViString(::grpc::ServerContext* context, const SetAttributeViStringRequest* request, SetAttributeViStringResponse* response) override;
   ::grpc::Status SetCustomType(::grpc::ServerContext* context, const SetCustomTypeRequest* request, SetCustomTypeResponse* response) override;
   ::grpc::Status SetCustomTypeArray(::grpc::ServerContext* context, const SetCustomTypeArrayRequest* request, SetCustomTypeArrayResponse* response) override;
   ::grpc::Status StringValuedEnumInputFunctionWithDefaults(::grpc::ServerContext* context, const StringValuedEnumInputFunctionWithDefaultsRequest* request, StringValuedEnumInputFunctionWithDefaultsResponse* response) override;

--- a/source/codegen/client_helpers.py
+++ b/source/codegen/client_helpers.py
@@ -40,6 +40,7 @@ PROTOBUF_TYPE_TO_CPP_TYPE = {
     "string": "string",
     "bytes": "string",
 }
+NIDEVICE_ENUMS = ["nidevice_grpc.SessionInitializationBehavior"]
 
 
 def _to_parameter_list(client_params: List[ClientParam]) -> List[str]:
@@ -74,6 +75,7 @@ def _is_basic_type(grpc_type: str) -> bool:
         or grpc_type in PROTOBUF_TYPE_TO_CPP_TYPE
         or grpc_type.endswith("Attributes")
         or grpc_type.endswith("Attribute")
+        or grpc_type in NIDEVICE_ENUMS
     )
 
 

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -228,7 +228,7 @@ def is_string_arg(parameter):
     return parameter["grpc_type"] in ["string", "bytes"]
 
 
-def is_nidevice_enum_param(grpc_type):
+def is_nidevice_enum_parameter(grpc_type):
     """Whether the grpc_type is one of the enums in nidevice_grpc."""
     return grpc_type in ["nidevice_grpc.SessionInitializationBehavior"]
 

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -227,6 +227,7 @@ def is_string_arg(parameter):
     """Whether the parameter's type is string or bytes."""
     return parameter["grpc_type"] in ["string", "bytes"]
 
+
 def is_nidevice_enum_param(grpc_type):
     """Whether the grpc_type is one of the enums in nidevice_grpc."""
     return grpc_type in ["nidevice_grpc.SessionInitializationBehavior"]

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -47,7 +47,7 @@ def is_repeated_varargs_parameter(parameter: dict):
     return parameter.get("repeated_var_args", False)
 
 
-def is_proto_only_paramater(parameter: dict):
+def is_proto_only_parameter(parameter: dict):
     """Whether the parameter is only included in the proto file and not the driver API."""
     return parameter.get("proto_only", False)
 
@@ -226,6 +226,10 @@ def _is_null_terminated_in_c(parameter):
 def is_string_arg(parameter):
     """Whether the parameter's type is string or bytes."""
     return parameter["grpc_type"] in ["string", "bytes"]
+
+def is_nidevice_enum_param(grpc_type):
+    """Whether the grpc_type is one of the enums in nidevice_grpc."""
+    return grpc_type in ["nidevice_grpc.SessionInitializationBehavior"]
 
 
 def strip_repeated_from_grpc_type(grpc_type):
@@ -1158,6 +1162,6 @@ def get_driver_api_params(parameters: List[dict]) -> List[dict]:
         p
         for p in parameters
         if not (
-            is_return_value(p) or is_get_last_error_output_param(p) or is_proto_only_paramater(p)
+            is_return_value(p) or is_get_last_error_output_param(p) or is_proto_only_parameter(p)
         )
     ]

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -1166,3 +1166,13 @@ def get_driver_api_params(parameters: List[dict]) -> List[dict]:
             is_return_value(p) or is_get_last_error_output_param(p) or is_proto_only_parameter(p)
         )
     ]
+
+
+def get_params_needing_initialization(parameters: List[dict]) -> List[dict]:
+    """Return all parameters that need to be initialized before the API call.
+
+    Excludes:
+    * Return values.
+    * Outputs that are calculated/populated after the API call.
+    """
+    return [p for p in parameters if not (is_return_value(p) or is_get_last_error_output_param(p))]

--- a/source/codegen/metadata/nifake/attributes.py
+++ b/source/codegen/metadata/nifake/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 23.0.0d26
+# This file is generated from NI-FAKE API metadata version 23.0.0d45
 attributes = {
     1000000: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nifake/config.py
+++ b/source/codegen/metadata/nifake/config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 23.0.0d26
+# This file is generated from NI-FAKE API metadata version 23.0.0d45
 config = {
     'additional_headers': {
     },

--- a/source/codegen/metadata/nifake/enums.py
+++ b/source/codegen/metadata/nifake/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 23.0.0d26
+# This file is generated from NI-FAKE API metadata version 23.0.0d45
 enums = {
     'Bitfield': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 23.0.0d26
+# This file is generated from NI-FAKE API metadata version 23.0.0d45
 functions = {
     'Abort': {
         'codegen_method': 'public',
@@ -399,7 +399,7 @@ functions = {
     },
     'ErrorMessage': {
         'cname': 'niFake_error_message',
-        'codegen_method': 'private',
+        'codegen_method': 'public',
         'is_error_handling': True,
         'parameters': [
             {
@@ -1331,7 +1331,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'GetError': {
-        'codegen_method': 'private',
+        'codegen_method': 'public',
         'is_error_handling': True,
         'parameters': [
             {
@@ -1559,6 +1559,22 @@ functions = {
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
+            },
+            {
+                'cppName': 'requestedBehavior',
+                'direction': 'in',
+                'grpc_type': 'nidevice_grpc.SessionInitializationBehavior',
+                'name': 'requestedBehavior',
+                'proto_only': True,
+                'type': 'ViInt32'
+            },
+            {
+                'cppName': 'newSessionInitialized',
+                'direction': 'out',
+                'grpc_type': 'bool',
+                'name': 'newSessionInitialized',
+                'proto_only': True,
+                'type': 'bool'
             }
         ],
         'returns': 'ViStatus'
@@ -1721,6 +1737,20 @@ functions = {
                 'direction': 'out',
                 'grpc_type': 'sint32',
                 'name': 'grpcOnlyParam',
+                'type': 'ViInt32'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'MethodWithProtoOnlyParameter': {
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'cppName': 'attributeValue',
+                'direction': 'in',
+                'grpc_type': 'sint32',
+                'name': 'attributeValue',
+                'proto_only': True,
                 'type': 'ViInt32'
             }
         ],
@@ -2453,7 +2483,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'SetAttributeViBoolean': {
-        'codegen_method': 'private',
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
@@ -2487,7 +2517,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'SetAttributeViInt32': {
-        'codegen_method': 'private',
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
@@ -2522,7 +2552,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'SetAttributeViInt64': {
-        'codegen_method': 'private',
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
@@ -2556,7 +2586,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'SetAttributeViReal64': {
-        'codegen_method': 'private',
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',
@@ -2591,7 +2621,7 @@ functions = {
         'returns': 'ViStatus'
     },
     'SetAttributeViString': {
-        'codegen_method': 'private',
+        'codegen_method': 'public',
         'parameters': [
             {
                 'cppName': 'vi',

--- a/source/codegen/metadata/nifake/nifake.proto
+++ b/source/codegen/metadata/nifake/nifake.proto
@@ -31,6 +31,7 @@ service NiFake {
   rpc DoubleAllTheNums(DoubleAllTheNumsRequest) returns (DoubleAllTheNumsResponse);
   rpc EnumArrayOutputFunction(EnumArrayOutputFunctionRequest) returns (EnumArrayOutputFunctionResponse);
   rpc EnumInputFunctionWithDefaults(EnumInputFunctionWithDefaultsRequest) returns (EnumInputFunctionWithDefaultsResponse);
+  rpc ErrorMessage(ErrorMessageRequest) returns (ErrorMessageResponse);
   rpc ExportAttributeConfigurationBuffer(ExportAttributeConfigurationBufferRequest) returns (ExportAttributeConfigurationBufferResponse);
   rpc FetchWaveform(FetchWaveformRequest) returns (FetchWaveformResponse);
   rpc GetABoolean(GetABooleanRequest) returns (GetABooleanResponse);
@@ -58,6 +59,7 @@ service NiFake {
   rpc GetCustomType(GetCustomTypeRequest) returns (GetCustomTypeResponse);
   rpc GetCustomTypeArray(GetCustomTypeArrayRequest) returns (GetCustomTypeArrayResponse);
   rpc GetEnumValue(GetEnumValueRequest) returns (GetEnumValueResponse);
+  rpc GetError(GetErrorRequest) returns (GetErrorResponse);
   rpc GetViInt32Array(GetViInt32ArrayRequest) returns (GetViInt32ArrayResponse);
   rpc GetViUInt32Array(GetViUInt32ArrayRequest) returns (GetViUInt32ArrayResponse);
   rpc GetViUInt8(GetViUInt8Request) returns (GetViUInt8Response);
@@ -71,6 +73,7 @@ service NiFake {
   rpc MethodWithGetLastErrorParam(MethodWithGetLastErrorParamRequest) returns (MethodWithGetLastErrorParamResponse);
   rpc MethodWithGrpcFieldNumber(MethodWithGrpcFieldNumberRequest) returns (MethodWithGrpcFieldNumberResponse);
   rpc MethodWithGrpcOnlyParam(MethodWithGrpcOnlyParamRequest) returns (MethodWithGrpcOnlyParamResponse);
+  rpc MethodWithProtoOnlyParameter(MethodWithProtoOnlyParameterRequest) returns (MethodWithProtoOnlyParameterResponse);
   rpc MultipleArrayTypes(MultipleArrayTypesRequest) returns (MultipleArrayTypesResponse);
   rpc MultipleArraysSameSize(MultipleArraysSameSizeRequest) returns (MultipleArraysSameSizeResponse);
   rpc MultipleArraysSameSizeWithOptional(MultipleArraysSameSizeWithOptionalRequest) returns (MultipleArraysSameSizeWithOptionalResponse);
@@ -85,6 +88,11 @@ service NiFake {
   rpc ReturnDurationInSeconds(ReturnDurationInSecondsRequest) returns (ReturnDurationInSecondsResponse);
   rpc ReturnListOfDurationsInSeconds(ReturnListOfDurationsInSecondsRequest) returns (ReturnListOfDurationsInSecondsResponse);
   rpc ReturnMultipleTypes(ReturnMultipleTypesRequest) returns (ReturnMultipleTypesResponse);
+  rpc SetAttributeViBoolean(SetAttributeViBooleanRequest) returns (SetAttributeViBooleanResponse);
+  rpc SetAttributeViInt32(SetAttributeViInt32Request) returns (SetAttributeViInt32Response);
+  rpc SetAttributeViInt64(SetAttributeViInt64Request) returns (SetAttributeViInt64Response);
+  rpc SetAttributeViReal64(SetAttributeViReal64Request) returns (SetAttributeViReal64Response);
+  rpc SetAttributeViString(SetAttributeViStringRequest) returns (SetAttributeViStringResponse);
   rpc SetCustomType(SetCustomTypeRequest) returns (SetCustomTypeResponse);
   rpc SetCustomTypeArray(SetCustomTypeArrayRequest) returns (SetCustomTypeArrayResponse);
   rpc StringValuedEnumInputFunctionWithDefaults(StringValuedEnumInputFunctionWithDefaultsRequest) returns (StringValuedEnumInputFunctionWithDefaultsResponse);
@@ -360,6 +368,16 @@ message EnumInputFunctionWithDefaultsResponse {
   int32 status = 1;
 }
 
+message ErrorMessageRequest {
+  nidevice_grpc.Session vi = 1;
+  sint32 error_code = 2;
+}
+
+message ErrorMessageResponse {
+  int32 status = 1;
+  string error_message = 2;
+}
+
 message ExportAttributeConfigurationBufferRequest {
   nidevice_grpc.Session vi = 1;
 }
@@ -632,6 +650,16 @@ message GetEnumValueResponse {
   sint32 a_turtle_raw = 4;
 }
 
+message GetErrorRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetErrorResponse {
+  int32 status = 1;
+  sint32 error_code = 2;
+  string description = 3;
+}
+
 message GetViInt32ArrayRequest {
   nidevice_grpc.Session vi = 1;
   sint32 array_len = 2;
@@ -687,11 +715,13 @@ message InitWithOptionsRequest {
   bool id_query = 3;
   bool reset_device = 4;
   string option_string = 5;
+  nidevice_grpc.SessionInitializationBehavior requested_behavior = 6;
 }
 
 message InitWithOptionsResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
+  bool new_session_initialized = 3;
 }
 
 message InitWithVarArgsRequest {
@@ -759,6 +789,14 @@ message MethodWithGrpcOnlyParamRequest {
 message MethodWithGrpcOnlyParamResponse {
   int32 status = 1;
   sint32 grpc_only_param = 2;
+}
+
+message MethodWithProtoOnlyParameterRequest {
+  sint32 attribute_value = 1;
+}
+
+message MethodWithProtoOnlyParameterResponse {
+  int32 status = 1;
 }
 
 message MultipleArrayTypesRequest {
@@ -924,6 +962,67 @@ message ReturnMultipleTypesResponse {
   double a_float_enum_raw = 9;
   repeated double an_array = 10;
   string a_string = 11;
+}
+
+message SetAttributeViBooleanRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFakeAttribute attribute_id = 3;
+  bool attribute_value = 4;
+}
+
+message SetAttributeViBooleanResponse {
+  int32 status = 1;
+}
+
+message SetAttributeViInt32Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFakeAttribute attribute_id = 3;
+  oneof attribute_value_enum {
+    NiFakeInt32AttributeValues attribute_value = 4;
+    sint32 attribute_value_raw = 5;
+  }
+}
+
+message SetAttributeViInt32Response {
+  int32 status = 1;
+}
+
+message SetAttributeViInt64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFakeAttribute attribute_id = 3;
+  int64 attribute_value_raw = 4;
+}
+
+message SetAttributeViInt64Response {
+  int32 status = 1;
+}
+
+message SetAttributeViReal64Request {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFakeAttribute attribute_id = 3;
+  oneof attribute_value_enum {
+    NiFakeReal64AttributeValuesMapped attribute_value_mapped = 4;
+    double attribute_value_raw = 5;
+  }
+}
+
+message SetAttributeViReal64Response {
+  int32 status = 1;
+}
+
+message SetAttributeViStringRequest {
+  nidevice_grpc.Session vi = 1;
+  string channel_name = 2;
+  NiFakeAttribute attribute_id = 3;
+  string attribute_value_raw = 4;
+}
+
+message SetAttributeViStringResponse {
+  int32 status = 1;
 }
 
 message SetCustomTypeRequest {

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -27,9 +27,6 @@
 %>\
 ${initialize_input_params(function_name, parameters)}
 ${initialize_output_params(output_parameters_to_initialize)}\
-% if session_initialized_param:
-      bool ${session_initialized_param_name} = false;
-% endif
       auto init_lambda = [&] () {
 ## If the session is not returned, it's an output param and need to be declared before calling.
 % if not service_helpers.is_session_returned_from_function(parameters):
@@ -664,7 +661,7 @@ ${initialize_standard_input_param(function_name, parameter)}
 ## Initialize the output parameters for an API call.
 <%def name="initialize_output_params(output_parameters)">\
 <%
-  output_parameters = common_helpers.get_driver_api_params(output_parameters)
+  output_parameters = common_helpers.get_params_needing_initialization(output_parameters)
 %>\
 % for parameter in output_parameters:
 <%

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -28,7 +28,7 @@
 ${initialize_input_params(function_name, parameters)}
 ${initialize_output_params(output_parameters_to_initialize)}\
 % if session_initialized_param:
-      bool ${session_initialized_param_name};
+      bool ${session_initialized_param_name} = false;
 % endif
       auto init_lambda = [&] () {
 ## If the session is not returned, it's an output param and need to be declared before calling.

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -640,7 +640,7 @@ ${initialize_standard_input_param(function_name, parameter)}
         });
 % elif common_helpers.is_array(c_type):
       auto ${parameter_name} = const_cast<${c_type_pointer}>(${request_snippet}.data());\
-% elif common_helpers.is_nidevice_enum_param(grpc_type):
+% elif common_helpers.is_nidevice_enum_parameter(grpc_type):
       auto ${parameter_name} = ${request_snippet};\
 % else:
       ${c_type} ${parameter_name} = ${request_snippet};\

--- a/source/server/session_repository.cpp
+++ b/source/server/session_repository.cpp
@@ -30,20 +30,20 @@ int SessionRepository::add_session(
     InitFunc init_func,
     CleanupSessionFunc cleanup_func,
     uint32_t& session_id,
-    SessionInitializationBehavior initializationBehavior,
-    bool* initializedNewSession)
+    SessionInitializationBehavior initialization_behavior,
+    bool* initialized_new_session)
 {
-  if (initializedNewSession) {
-    *initializedNewSession = false;
+  if (initialized_new_session) {
+    *initialized_new_session = false;
   }
   session_id = 0;
   std::unique_lock<std::shared_mutex> lock(repository_lock_);
   auto now = std::chrono::steady_clock::now();
   auto it = named_sessions_.find(session_name);
-  if (initializationBehavior == SESSION_INITIALIZATION_BEHAVIOR_INITIALIZE_NEW && it != named_sessions_.end()) {
+  if (initialization_behavior == SESSION_INITIALIZATION_BEHAVIOR_INITIALIZE_NEW && it != named_sessions_.end()) {
     throw NonDriverException(::grpc::StatusCode::ALREADY_EXISTS, "Cannot initialize '" + session_name + "' when a session already exists.");
   }
-  else if (initializationBehavior == SESSION_INITIALIZATION_BEHAVIOR_ATTACH_TO_EXISTING && it == named_sessions_.end()) {
+  else if (initialization_behavior == SESSION_INITIALIZATION_BEHAVIOR_ATTACH_TO_EXISTING && it == named_sessions_.end()) {
     throw NonDriverException(::grpc::StatusCode::FAILED_PRECONDITION, "Cannot attach to '" + session_name + "' because a session has not been initialized.");
   }
 
@@ -66,8 +66,8 @@ int SessionRepository::add_session(
     info->name = session_name;
     named_sessions_.emplace(session_name, info);
   }
-  if (initializedNewSession) {
-    *initializedNewSession = true;
+  if (initialized_new_session) {
+    *initialized_new_session = true;
   }
   return 0;
 }

--- a/source/server/session_repository.h
+++ b/source/server/session_repository.h
@@ -31,8 +31,8 @@ class SessionRepository {
       InitFunc init_func,
       CleanupSessionFunc cleanup_func,
       uint32_t& session_id,
-      SessionInitializationBehavior initializationBehavior = SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED,
-      bool* initializedNewSession = nullptr);
+      SessionInitializationBehavior initialization_behavior = SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED,
+      bool* initialized_new_session = nullptr);
   uint32_t access_session(uint32_t session_id, const std::string& session_name);
   void remove_session(uint32_t id);
 

--- a/source/tests/integration/ni_fake_service_tests_endtoend.cpp
+++ b/source/tests/integration/ni_fake_service_tests_endtoend.cpp
@@ -66,7 +66,7 @@ class NiFakeServiceTests_EndToEnd : public ::testing::Test {
 
 InitWithOptionsResponse init(const client::StubPtr& stub)
 {
-  return client::init_with_options(stub, "", false, false, "");
+  return client::init_with_options(stub, "", false, false, "", nidevice_grpc::SessionInitializationBehavior::SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED);
 }
 
 TEST_F(NiFakeServiceTests_EndToEnd, PassMappedEnumToGeneratedClient_PassesStringValueToLibraryAndSucceeds)

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -169,6 +169,69 @@ TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsSucceeds_CreatesAndStoresS
   nidevice_grpc::Session session = response.vi();
   EXPECT_NE(0, session_repository.access_session(session.id(), ""));
   EXPECT_NE(0, session_repository.access_session(0, session_name));
+  EXPECT_TRUE(response.new_session_initialized());
+}
+
+TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsWithAttachBehavior_DoesNotCallIntoDriverAndReturnsFailedPreconditionError)
+{
+  nidevice_grpc::SessionRepository session_repository;
+  NiFakeMockLibrary library;
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  const char* resource_name = "Dev0";
+  const char* option_string = "Simulate = 1";
+  bool id_query = false, reset_device = true;
+  const char* session_name = "sessionName";
+  EXPECT_CALL(library, InitWithOptions)
+      .Times(0);
+
+  ::grpc::ServerContext context;
+  nifake_grpc::InitWithOptionsRequest request;
+  request.set_resource_name(resource_name);
+  request.set_id_query(id_query);
+  request.set_reset_device(reset_device);
+  request.set_option_string(option_string);
+  request.set_session_name(session_name);
+  request.set_requested_behavior(nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_ATTACH_TO_EXISTING);
+  nifake_grpc::InitWithOptionsResponse response;
+  ::grpc::Status status = service.InitWithOptions(&context, &request, &response);
+
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(::grpc::StatusCode::FAILED_PRECONDITION, status.error_code());
+  const char* expected_error_message = "Cannot attach to 'sessionName' because a session has not been initialized.";
+  EXPECT_STREQ(expected_error_message, status.error_message().c_str());
+}
+
+TEST(NiFakeServiceTests, NiFakeServiceWithSession_InitWithOptionsWithInitializeBehavior_ReturnsAlreadyExistsError)
+{
+  nidevice_grpc::SessionRepository session_repository;
+  NiFakeMockLibrary library;
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  const char* session_name = "sessionName";
+  auto session_id = create_session(library, service, session_name, kTestViSession);
+  const char* resource_name = "Dev0";
+  const char* option_string = "Simulate = 1";
+  bool id_query = false, reset_device = true;
+  
+  EXPECT_CALL(library, InitWithOptions)
+      .Times(0);
+
+  ::grpc::ServerContext context;
+  nifake_grpc::InitWithOptionsRequest request;
+  request.set_resource_name(resource_name);
+  request.set_id_query(id_query);
+  request.set_reset_device(reset_device);
+  request.set_option_string(option_string);
+  request.set_session_name(session_name);
+  request.set_requested_behavior(nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_INITIALIZE_NEW);
+  nifake_grpc::InitWithOptionsResponse response;
+  ::grpc::Status status = service.InitWithOptions(&context, &request, &response);
+
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(::grpc::StatusCode::ALREADY_EXISTS, status.error_code());
+  const char* expected_error_message = "Cannot initialize 'sessionName' when a session already exists.";
+  EXPECT_STREQ(expected_error_message, status.error_message().c_str());
 }
 
 TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsFails_NoSessionIsStored)
@@ -190,6 +253,7 @@ TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsFails_NoSessionIsStored)
   EXPECT_EQ(message, status.error_message());
   nidevice_grpc::Session session = response.vi();
   EXPECT_EQ(0, session_repository.access_session(session.id(), ""));
+  EXPECT_FALSE(response.new_session_initialized());
 }
 
 TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsAndResetServer_SessionIsClosed)

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -202,6 +202,38 @@ TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsWithAttachBehavior_DoesNot
   EXPECT_STREQ(expected_error_message, status.error_message().c_str());
 }
 
+TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsWithInitializeBehavior_CreatesAndStoresSession)
+{
+  nidevice_grpc::SessionRepository session_repository;
+  NiFakeMockLibrary library;
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  const char* resource_name = "Dev0";
+  const char* option_string = "Simulate = 1";
+  bool id_query = false, reset_device = true;
+  const char* session_name = "sessionName";
+  EXPECT_CALL(library, InitWithOptions(Pointee(*resource_name), id_query, reset_device, Pointee(*option_string), _))
+      .WillOnce(DoAll(SetArgPointee<4>(kTestViSession), Return(kDriverSuccess)));
+
+  ::grpc::ServerContext context;
+  nifake_grpc::InitWithOptionsRequest request;
+  request.set_resource_name(resource_name);
+  request.set_id_query(id_query);
+  request.set_reset_device(reset_device);
+  request.set_option_string(option_string);
+  request.set_session_name(session_name);
+  request.set_requested_behavior(nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_INITIALIZE_NEW);
+  nifake_grpc::InitWithOptionsResponse response;
+  ::grpc::Status status = service.InitWithOptions(&context, &request, &response);
+
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(kDriverSuccess, response.status());
+  nidevice_grpc::Session session = response.vi();
+  EXPECT_NE(0, session_repository.access_session(session.id(), ""));
+  EXPECT_NE(0, session_repository.access_session(0, session_name));
+  EXPECT_TRUE(response.new_session_initialized());
+}
+
 TEST(NiFakeServiceTests, NiFakeServiceWithSession_InitWithOptionsWithInitializeBehavior_ReturnsAlreadyExistsError)
 {
   nidevice_grpc::SessionRepository session_repository;
@@ -213,7 +245,6 @@ TEST(NiFakeServiceTests, NiFakeServiceWithSession_InitWithOptionsWithInitializeB
   const char* resource_name = "Dev0";
   const char* option_string = "Simulate = 1";
   bool id_query = false, reset_device = true;
-  
   EXPECT_CALL(library, InitWithOptions)
       .Times(0);
 
@@ -232,6 +263,40 @@ TEST(NiFakeServiceTests, NiFakeServiceWithSession_InitWithOptionsWithInitializeB
   EXPECT_EQ(::grpc::StatusCode::ALREADY_EXISTS, status.error_code());
   const char* expected_error_message = "Cannot initialize 'sessionName' when a session already exists.";
   EXPECT_STREQ(expected_error_message, status.error_message().c_str());
+}
+
+TEST(NiFakeServiceTests, NiFakeServiceWithSession_InitWithOptionsWithAttachBehavior_ReturnsAlreadyInitializedSession)
+{
+  nidevice_grpc::SessionRepository session_repository;
+  NiFakeMockLibrary library;
+  auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
+  nifake_grpc::NiFakeService service(&library, resource_repository);
+  const char* session_name = "sessionName";
+  auto session_id = create_session(library, service, session_name, kTestViSession);
+  const char* resource_name = "Dev0";
+  const char* option_string = "Simulate = 1";
+  bool id_query = false, reset_device = true;
+
+  EXPECT_CALL(library, InitWithOptions)
+      .Times(0);
+
+  ::grpc::ServerContext context;
+  nifake_grpc::InitWithOptionsRequest request;
+  request.set_resource_name(resource_name);
+  request.set_id_query(id_query);
+  request.set_reset_device(reset_device);
+  request.set_option_string(option_string);
+  request.set_session_name(session_name);
+  request.set_requested_behavior(nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_ATTACH_TO_EXISTING);
+  nifake_grpc::InitWithOptionsResponse response;
+  ::grpc::Status status = service.InitWithOptions(&context, &request, &response);
+
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(kDriverSuccess, response.status());
+  nidevice_grpc::Session session = response.vi();
+  EXPECT_NE(0, session_repository.access_session(session.id(), ""));
+  EXPECT_NE(0, session_repository.access_session(0, session_name));
+  EXPECT_FALSE(response.new_session_initialized());
 }
 
 TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsFails_NoSessionIsStored)
@@ -253,7 +318,6 @@ TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsFails_NoSessionIsStored)
   EXPECT_EQ(message, status.error_message());
   nidevice_grpc::Session session = response.vi();
   EXPECT_EQ(0, session_repository.access_session(session.id(), ""));
-  EXPECT_FALSE(response.new_session_initialized());
 }
 
 TEST(NiFakeServiceTests, NiFakeService_InitWithOptionsAndResetServer_SessionIsClosed)

--- a/source/tests/unit/session_repository_tests.cpp
+++ b/source/tests/unit/session_repository_tests.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <server/exceptions.h>
 #include <server/semaphore.h>
 #include <server/session_repository.h>
 
@@ -24,19 +25,64 @@ TEST(SessionRepositoryTests, AddSessionWithNonZeroStatus_ReturnsStatusAndDoesNot
   EXPECT_FALSE(session_repository.access_session(session_id, ""));
 }
 
+TEST(SessionRepositoryTests, AddSessionWithNonZeroStatus_InitializedNewSessionIsFalse)
+{
+  nidevice_grpc::SessionRepository session_repository;
+  uint32_t session_id = 42;
+  bool initialized_new_session;
+  int status = session_repository.add_session(
+      "",
+      [session_id]() { return 1; },
+      NULL,
+      session_id,
+      nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED,
+      &initialized_new_session);
+
+  EXPECT_FALSE(initialized_new_session);
+}
+
 TEST(SessionRepositoryTests, AddSession_StoresSessionWithGivenId)
 {
   nidevice_grpc::SessionRepository session_repository;
   uint32_t session_id;
+  bool initialized_new_session;
   int status = session_repository.add_session(
       "",
       []() { return 0; },
       NULL,
-      session_id);
+      session_id,
+      nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED,
+      &initialized_new_session);
 
   EXPECT_EQ(status, 0);
   EXPECT_EQ(session_id, EXPECTED_FIRST_SESSION_ID);
   EXPECT_EQ(session_repository.access_session(session_id, ""), session_id);
+  EXPECT_TRUE(initialized_new_session);
+}
+
+TEST(SessionRepositoryTests, NoSessions_AddSessionWithAttachToExistingBehavior_ExceptionThrown)
+{
+  std::string session_name = "session_name";
+  nidevice_grpc::SessionRepository session_repository;
+  uint32_t first_session_id;
+
+  EXPECT_THROW(
+      {
+        try {
+          session_repository.add_session(
+              session_name,
+              []() { return 0; },
+              NULL,
+              first_session_id,
+              nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_ATTACH_TO_EXISTING);
+        }
+        catch (const nidevice_grpc::NonDriverException& e) {
+          auto exception_status = e.GetStatus();
+          EXPECT_EQ(::grpc::StatusCode::FAILED_PRECONDITION, exception_status.error_code());
+          throw e;
+        }
+      },
+      nidevice_grpc::NonDriverException);
 }
 
 TEST(SessionRepositoryTests, AddNamedSession_StoresSessionWithGivenIdAndName)
@@ -44,16 +90,20 @@ TEST(SessionRepositoryTests, AddNamedSession_StoresSessionWithGivenIdAndName)
   std::string session_name = "session_name";
   nidevice_grpc::SessionRepository session_repository;
   uint32_t session_id;
+  bool initialized_new_session;
   int status = session_repository.add_session(
       session_name,
       []() { return 0; },
       NULL,
-      session_id);
+      session_id,
+      nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED,
+      &initialized_new_session);
 
   EXPECT_EQ(status, 0);
   EXPECT_EQ(session_id, EXPECTED_FIRST_SESSION_ID);
   EXPECT_EQ(session_repository.access_session(session_id, ""), session_id);
   EXPECT_EQ(session_repository.access_session(0, session_name), session_id);
+  EXPECT_TRUE(initialized_new_session);
 }
 
 TEST(SessionRepositoryTests, UnnamedSessionAdded_RemoveSession_RemovesSession)
@@ -101,6 +151,7 @@ TEST(SessionRepositoryTests, NamedSessionAdded_AddSessionWithSameName_ReturnsFir
 
   uint32_t second_session_id;
   bool init_called = false;
+  bool initialized_new_session;
   session_repository.add_session(
       session_name,
       [init_called]() mutable {
@@ -108,10 +159,48 @@ TEST(SessionRepositoryTests, NamedSessionAdded_AddSessionWithSameName_ReturnsFir
         return 0;
       },
       NULL,
-      second_session_id);
+      second_session_id,
+      nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED,
+      &initialized_new_session);
 
   EXPECT_FALSE(init_called);
+  EXPECT_FALSE(initialized_new_session);
   EXPECT_EQ(first_session_id, second_session_id);
+}
+
+TEST(SessionRepositoryTests, NamedSessionAdded_AddSessionWithSameNameWithInitializeNewBehavior_ExceptionThrown)
+{
+  std::string session_name = "session_name";
+  nidevice_grpc::SessionRepository session_repository;
+  uint32_t first_session_id;
+  session_repository.add_session(
+      session_name,
+      []() { return 0; },
+      NULL,
+      first_session_id);
+
+  uint32_t second_session_id;
+  bool init_called = false;
+  EXPECT_THROW(
+      {
+        try {
+          session_repository.add_session(
+              session_name,
+              [init_called]() mutable {
+                init_called = true;
+                return 0;
+              },
+              NULL,
+              second_session_id,
+              nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_INITIALIZE_NEW);
+        }
+        catch (const nidevice_grpc::NonDriverException& e) {
+          auto exception_status = e.GetStatus();
+          EXPECT_EQ(::grpc::StatusCode::ALREADY_EXISTS, exception_status.error_code());
+          throw e;
+        }
+      },
+      nidevice_grpc::NonDriverException);
 }
 
 TEST(SessionRepositoryTests, NamedSessionAdded_ResetServer_RemovesSession)


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Updates ni-fake from the `nifake_grpc_device` export 23.0.0d45
- Adds codegen support for the new `requestedBehavior` input and `newSessionInitialized` output that will start showing up on init methods (starting with ni-fake).

### Why should this Pull Request be merged?

Fixes [AB#2186876](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2186876)

These changes add support to handle new parameters on `init_method`s. Specifically handling a new input specifying the initialization behavior and an output boolean to signify if a session was initialized or not.

### What testing has been done?

Existing ni-fake unit and integration tests pass.

Added unit tests for new session_repository behavior.
Added unit tests for success and error cases in ni-fake with the new initialize behavior.