### PR TITLE
Rename --include-prerelease to --ignore-release-readiness

### DIFF
--- a/source/codegen/stage_client_files.py
+++ b/source/codegen/stage_client_files.py
@@ -15,7 +15,7 @@ class _ArtifactReadiness:
 
     _module_to_readiness = {}  # type: Dict[str, str]
 
-    def __init__(self, metadata_dir: Path, override_release_readiness: bool):
+    def __init__(self, metadata_dir: Path, ignore_release_readiness: bool):
         modules = [
             load_metadata(p) for p in metadata_dir.iterdir() if p.is_dir() and "fake" not in p.name
         ]
@@ -24,7 +24,7 @@ class _ArtifactReadiness:
             d["config"]["module_name"]: get_driver_readiness(d["config"]) for d in modules
         }
 
-        self.override_release_readiness = override_release_readiness
+        self.ignore_release_readiness = ignore_release_readiness
 
     def is_release_ready(self, module_path: Path) -> bool:
         """Determine release-readiness.
@@ -49,7 +49,7 @@ class _ArtifactReadiness:
         return (
             d
             for d in directory.iterdir()
-            if d.is_dir() and (self.is_release_ready(d) or self.override_release_readiness)
+            if d.is_dir() and (self.is_release_ready(d) or self.ignore_release_readiness)
         )
 
 
@@ -90,11 +90,11 @@ def _get_release_example_directories(
     return readiness.get_release_ready_subdirs(artifact_locations.examples)
 
 
-def stage_client_files(output_path: Path, override_release_readiness: bool):
+def stage_client_files(output_path: Path, ignore_release_readiness: bool):
     """Stage the client files into the given output path."""
     repo_root = Path(__file__).parent.parent.parent
     artifact_locations = _ArtifactLocations(repo_root)
-    readiness = _ArtifactReadiness(artifact_locations.metadata_dir, override_release_readiness)
+    readiness = _ArtifactReadiness(artifact_locations.metadata_dir, ignore_release_readiness)
 
     proto_path = output_path / "proto"
     proto_path.mkdir(parents=True)
@@ -124,13 +124,13 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--override-release-readiness", action="store_true", help="Force-include all artifacts."
+        "--ignore-release-readiness", action="store_true", help="Force-include all artifacts."
     )
 
     args = parser.parse_args()
 
     if args.output:
-        stage_client_files(Path(args.output), args.override_release_readiness)
+        stage_client_files(Path(args.output), args.ignore_release_readiness)
     else:
         print(
             """
@@ -140,7 +140,7 @@ Performing Dry Run.
         )
         with TemporaryDirectory() as tempdir:
             tempdirpath = Path(tempdir)
-            stage_client_files(tempdirpath, args.override_release_readiness)
+            stage_client_files(tempdirpath, args.ignore_release_readiness)
             created_files = (f for f in tempdirpath.glob("**/*") if not f.is_dir())
             for out_file in created_files:
                 print(out_file.relative_to(tempdirpath))

--- a/source/codegen/stage_client_files.py
+++ b/source/codegen/stage_client_files.py
@@ -15,7 +15,7 @@ class _ArtifactReadiness:
 
     _module_to_readiness = {}  # type: Dict[str, str]
 
-    def __init__(self, metadata_dir: Path, include_prerelease: bool):
+    def __init__(self, metadata_dir: Path, override_release_readiness: bool):
         modules = [
             load_metadata(p) for p in metadata_dir.iterdir() if p.is_dir() and "fake" not in p.name
         ]
@@ -24,7 +24,7 @@ class _ArtifactReadiness:
             d["config"]["module_name"]: get_driver_readiness(d["config"]) for d in modules
         }
 
-        self.include_prerelease = include_prerelease
+        self.override_release_readiness = override_release_readiness
 
     def is_release_ready(self, module_path: Path) -> bool:
         """Determine release-readiness.
@@ -49,7 +49,7 @@ class _ArtifactReadiness:
         return (
             d
             for d in directory.iterdir()
-            if d.is_dir() and (self.is_release_ready(d) or self.include_prerelease)
+            if d.is_dir() and (self.is_release_ready(d) or self.override_release_readiness)
         )
 
 
@@ -90,11 +90,11 @@ def _get_release_example_directories(
     return readiness.get_release_ready_subdirs(artifact_locations.examples)
 
 
-def stage_client_files(output_path: Path, include_prerelease: bool):
+def stage_client_files(output_path: Path, override_release_readiness: bool):
     """Stage the client files into the given output path."""
     repo_root = Path(__file__).parent.parent.parent
     artifact_locations = _ArtifactLocations(repo_root)
-    readiness = _ArtifactReadiness(artifact_locations.metadata_dir, include_prerelease)
+    readiness = _ArtifactReadiness(artifact_locations.metadata_dir, override_release_readiness)
 
     proto_path = output_path / "proto"
     proto_path.mkdir(parents=True)
@@ -124,13 +124,13 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--include-prerelease", action="store_true", help="Include pre-release artifacts."
+        "--override-release-readiness", action="store_true", help="Force-include all artifacts."
     )
 
     args = parser.parse_args()
 
     if args.output:
-        stage_client_files(Path(args.output), args.include_prerelease)
+        stage_client_files(Path(args.output), args.override_release_readiness)
     else:
         print(
             """
@@ -140,7 +140,7 @@ Performing Dry Run.
         )
         with TemporaryDirectory() as tempdir:
             tempdirpath = Path(tempdir)
-            stage_client_files(tempdirpath, args.include_prerelease)
+            stage_client_files(tempdirpath, args.override_release_readiness)
             created_files = (f for f in tempdirpath.glob("**/*") if not f.is_dir())
             for out_file in created_files:
                 print(out_file.relative_to(tempdirpath))


### PR DESCRIPTION
### What does this Pull Request accomplish?

This is the first PR toward

[Technical Debt 2009053](https://dev.azure.com/ni/DevCentral/_workitems/edit/2009053): Import grpc-device protocol files as NuGet package

under its first task

[Task 2181573](https://dev.azure.com/ni/DevCentral/_workitems/edit/2181573): Update stage_client_files.py on GitHub to include an artifact that adds the restricted .proto files

### Why should this Pull Request be merged?

I tried adding a new option named `--include-restricted` for this specific need, but when I implemented it, I saw that it had the same effect as using `--include-prelease`. Instead, I chose to rename the parameter to match its behavior: `--ignore-release-readiness`.

### What testing has been done?

No GitHub workflows reference this parameter when invoking `stage_client_files.py`, so I'm unsure how to test other than comparing the before/after output when using this renamed option. Doing this, the staged files were the same.

```bat
$ grep -rIn --color stage_client_files\.py
.github/workflows/create_client_artifacts.yml:38:        python source/codegen/stage_client_files.py -o ${{ runner.temp }}/staging/
```
