### PR TITLE
Trigger AzDo CIs workflow after main GitHub CI is completely finished.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,3 @@ jobs:
       - build_nilrt
       - create_client_artifacts
     uses: ./.github/workflows/create_release.yml
-  trigger_azdo_ci:
-    needs:
-     - run_win_system_tests
-     - run_ubuntu_system_tests
-     - build_nilrt
-     - create_client_artifacts
-     - create_release
-    uses: ./.github/workflows/trigger_azdo_ci.yml
-    secrets:
-      AZDO_PIPELINE_TRIGGERS: ${{secrets.AZDO_PIPELINE_TRIGGERS}}

--- a/.github/workflows/trigger_azdo_ci.yml
+++ b/.github/workflows/trigger_azdo_ci.yml
@@ -5,9 +5,6 @@ on:
     workflows: [CI]
     types:
       - completed
-    secrets:
-      AZDO_PIPELINE_TRIGGERS:
-        required: true
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/trigger_azdo_ci.yml
+++ b/.github/workflows/trigger_azdo_ci.yml
@@ -1,7 +1,10 @@
 name: Trigger AzDO CIs
 
 on:
-  workflow_call:
+  workflow_run:
+    workflows: [CI]
+    types:
+      - completed
     secrets:
       AZDO_PIPELINE_TRIGGERS:
         required: true


### PR DESCRIPTION
### What does this Pull Request accomplish?

Triggers the AzDo CIs after the main GitHub CI completes.

### Why should this Pull Request be merged?

[AB#2197310](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2197310)

1. Having it trigger as the last step of the main GitHub CI workflow is a little brittle if new steps are added.
2. This is better timing wise to make sure the GitHub CI workflow is completely finished before triggering the AzDo CIs, which depends on the finished CI workflow to get its artifacts.

It should also be merged because the PR # is lucky 🎰

### What testing has been done?

Using PR build to test new workflow ordering/triggering.
