### PR TITLE
Export artifact that lists provided service interfaces

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -120,6 +120,7 @@ jobs:
         -C ${GITHUB_WORKSPACE}/build
         ni_grpc_device_server
         server_config.json
+        server_impl_info.json
         -C ${GITHUB_WORKSPACE}
         LICENSE
         ThirdPartyNotices.txt
@@ -173,6 +174,7 @@ jobs:
         path: |
           build/Release/ni_grpc_device_server.exe
           build/Release/server_config.json
+          build/Release/server_impl_info.json
         retention-days: 5
 
     - name: Upload Windows Test Binaries Artifact

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -120,7 +120,7 @@ jobs:
         -C ${GITHUB_WORKSPACE}/build
         ni_grpc_device_server
         server_config.json
-        server_impl_info.json
+        server_capabilities.json
         -C ${GITHUB_WORKSPACE}
         LICENSE
         ThirdPartyNotices.txt
@@ -174,7 +174,7 @@ jobs:
         path: |
           build/Release/ni_grpc_device_server.exe
           build/Release/server_config.json
-          build/Release/server_impl_info.json
+          build/Release/server_capabilities.json
         retention-days: 5
 
     - name: Upload Windows Test Binaries Artifact

--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -136,7 +136,7 @@ jobs:
         -C ${GITHUB_WORKSPACE}/build
         ni_grpc_device_server
         server_config.json
-        server_impl_info.json
+        server_capabilities.json
         -C ${GITHUB_WORKSPACE}
         LICENSE
         ThirdPartyNotices.txt

--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -136,6 +136,7 @@ jobs:
         -C ${GITHUB_WORKSPACE}/build
         ni_grpc_device_server
         server_config.json
+        server_impl_info.json
         -C ${GITHUB_WORKSPACE}
         LICENSE
         ThirdPartyNotices.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,6 +388,15 @@ add_custom_command(
             $<TARGET_FILE_DIR:ni_grpc_device_server>/server_config.json)
 
 #----------------------------------------------------------------------
+# Generate server_impl_info.json to binary output directory
+#----------------------------------------------------------------------
+add_custom_command(
+   TARGET ni_grpc_device_server POST_BUILD
+   COMMAND  ${PYTHON_EXE} ${codegen_dir}/generate_server_impl_info.py ${metadata_dir}/
+            -o $<TARGET_FILE_DIR:ni_grpc_device_server>/)
+
+
+#----------------------------------------------------------------------
 # Add JSON parser and configure google tests
 #----------------------------------------------------------------------
 if(CMAKE_CROSSCOMPILING AND NOT _GRPC_DEVICE_NILRT_LEGACY_TOOLCHAIN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,11 +388,11 @@ add_custom_command(
             $<TARGET_FILE_DIR:ni_grpc_device_server>/server_config.json)
 
 #----------------------------------------------------------------------
-# Generate server_impl_info.json to binary output directory
+# Generate server_capabilities.json to binary output directory
 #----------------------------------------------------------------------
 add_custom_command(
    TARGET ni_grpc_device_server POST_BUILD
-   COMMAND  ${PYTHON_EXE} ${codegen_dir}/generate_server_impl_info.py ${metadata_dir}/
+   COMMAND  ${PYTHON_EXE} ${codegen_dir}/generate_server_capabilities.py ${metadata_dir}/
             -o $<TARGET_FILE_DIR:ni_grpc_device_server>/)
 
 

--- a/source/codegen/generate_server_capabilities.py
+++ b/source/codegen/generate_server_capabilities.py
@@ -4,6 +4,7 @@ import argparse
 import json
 from pathlib import Path
 
+from common_helpers import get_driver_readiness
 from template_helpers import load_metadata
 
 
@@ -16,11 +17,12 @@ def _generate_file(metadata_dir: Path, output_dir: Path) -> None:
     ]
     for data in driver_modules:
         config = data["config"]
-        service_name = f'{config["module_name"]}_grpc.{config["service_class_prefix"]}'
-        service_instance_names.append(service_name)
+        if get_driver_readiness(config) == "Release":
+            service_name = f'{config["module_name"]}_grpc.{config["service_class_prefix"]}'
+            service_instance_names.append(service_name)
     service_information_dict = {}
     service_information_dict["provided_service_interfaces"] = service_instance_names
-    output_file_path = Path(output_dir).joinpath("server_impl_info.json")
+    output_file_path = Path(output_dir).joinpath("server_capabilities.json")
     with open(output_file_path, "w") as outfile:
         json.dump(service_information_dict, outfile, indent=4)
 

--- a/source/codegen/generate_server_impl_info.py
+++ b/source/codegen/generate_server_impl_info.py
@@ -1,0 +1,43 @@
+"""Service information generation."""
+
+import argparse
+import json
+
+from pathlib import Path
+from template_helpers import load_metadata
+
+
+def _generate_file(metadata_dir: Path, output_dir: Path) -> None:
+    service_instance_names = []
+    driver_modules = [
+        load_metadata(p)
+        for p in sorted(metadata_dir.iterdir())
+        if p.is_dir() and "fake" not in p.name
+    ]
+    for data in driver_modules:
+        config = data["config"]
+        service_name = f'{config["module_name"]}_grpc.{config["service_class_prefix"]}'
+        service_instance_names.append(service_name)
+    service_information_dict = {}
+    service_information_dict["provided_service_interfaces"] = service_instance_names
+    output_file_path = Path(output_dir).joinpath("server_impl_info.json")
+    with open(output_file_path, "w") as outfile:
+        json.dump(service_information_dict, outfile, indent=4)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Generate NI gRPC-device server implementation information."
+    )
+    parser.add_argument(
+        "metadata",
+        help="The path to the directory containing the metadata for the API being generated.",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        help="The path to the top-level directory to save the generated files. The API-specific sub-directories will be automatically created.",
+    )
+    args = parser.parse_args()
+    output_path = "." if args.output is None else args.output
+    _generate_file(Path(args.metadata), Path(output_path))

--- a/source/codegen/generate_server_impl_info.py
+++ b/source/codegen/generate_server_impl_info.py
@@ -2,8 +2,8 @@
 
 import argparse
 import json
-
 from pathlib import Path
+
 from template_helpers import load_metadata
 
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Generates the file `server_capabilities.json` adjacent to the server executable. It is included in the exported artifacts.
- Currently the file contains only the provided service interfaces. This can be easily extended in the future.
- Chose to not put this in the same file as the server configuration, because it's intended for a totally different use.

### Why should this Pull Request be merged?

[Task 2206702](https://ni.visualstudio.com/DevCentral/_workitems/edit/2206702): Export information with gRPC server about what proto files are supported

### What testing has been done?

Built locally. It contains these lines:
```
{
    "provided_service_interfaces": [
        "nidaqmx_grpc.NiDAQmx",
        "nidcpower_grpc.NiDCPower",
        "nidigitalpattern_grpc.NiDigital",
        "nidmm_grpc.NiDmm",
        "nifgen_grpc.NiFgen",
        "nirfmxbluetooth_grpc.NiRFmxBluetooth",
        "nirfmxinstr_grpc.NiRFmxInstr",
        "nirfmxlte_grpc.NiRFmxLTE",
        "nirfmxnr_grpc.NiRFmxNR",
        "nirfmxspecan_grpc.NiRFmxSpecAn",
        "nirfmxwlan_grpc.NiRFmxWLAN",
        "nirfsa_grpc.NiRFSA",
        "nirfsg_grpc.NiRFSG",
        "niscope_grpc.NiScope",
        "niswitch_grpc.NiSwitch",
        "nisync_grpc.NiSync",
        "nitclk_grpc.NiTClk",
        "nixnet_grpc.NiXnet",
        "nixnetsocket_grpc.NiXnetSocket"
    ]
}
```