### PR TITLE
Update Trigger AzDo CI to only run after CI completes on main or releases branch.

### DIFF
--- a/.github/workflows/trigger_azdo_ci.yml
+++ b/.github/workflows/trigger_azdo_ci.yml
@@ -5,6 +5,9 @@ on:
     workflows: [CI]
     types:
       - completed
+    branches:
+      - main
+      - 'releases/**'
   workflow_dispatch:
 
 jobs:
@@ -14,7 +17,7 @@ jobs:
     steps:
     - name: Trigger Main CI
       uses: Azure/pipelines@v1
-      if: ${{ github.repository == 'ni/grpc-device' && github.ref == 'refs/heads/main' }}
+      if: ${{ github.repository == 'ni/grpc-device' && github.event.workflow_run.head_branch == 'main' }}
       with:
         azure-devops-project-url: 'https://dev.azure.com/ni/DevCentral'
         azure-pipeline-name: 'ni-central-grpc_device-main-desktop'
@@ -22,7 +25,7 @@ jobs:
 
     - name: Trigger Release CI
       uses: Azure/pipelines@v1
-      if: ${{ github.repository == 'ni/grpc-device' && startsWith(github.ref, 'refs/heads/releases') }}
+      if: ${{ github.repository == 'ni/grpc-device' && startsWith(github.event.workflow_run.head_branch, 'releases') }}
       with:
         azure-devops-project-url: 'https://dev.azure.com/ni/DevCentral'
         azure-pipeline-name: 'ni-central-grpc_device-release-desktop'
@@ -30,7 +33,7 @@ jobs:
 
     - name: Trigger Main CI
       uses: Azure/pipelines@v1
-      if: ${{ github.repository == 'ni/grpc-device' && github.ref == 'refs/heads/main' }}
+      if: ${{ github.repository == 'ni/grpc-device' && github.event.workflow_run.head_branch == 'main' }}
       with:
         azure-devops-project-url: 'https://dev.azure.com/ni/DevCentral'
         azure-pipeline-name: 'ni-central-grpc_device-main-linux-rt'
@@ -38,7 +41,7 @@ jobs:
 
     - name: Trigger Release CI
       uses: Azure/pipelines@v1
-      if: ${{ github.repository == 'ni/grpc-device' && startsWith(github.ref, 'refs/heads/releases') }}
+      if: ${{ github.repository == 'ni/grpc-device' && startsWith(github.event.workflow_run.head_branch, 'releases') }}
       with:
         azure-devops-project-url: 'https://dev.azure.com/ni/DevCentral'
         azure-pipeline-name: 'ni-central-grpc_device-release-linux-rt'


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Trigger AzDo CI now only triggers after a CI is completed on main or a releases branch
- Trigger AzDo CI looks at the branch the CI completed on to know which AzDo Pipeline to trigger (previously it would always trigger the main one).

### Why should this Pull Request be merged?

Noticed after my recent submission that the Trigger AzDo CI workflow was triggering after any completed CI, not just the ones on main or releases branches.

### What testing has been done?

None. Hard to test without submission.