### PR TITLE
Remove id from Session message

### DIFF
--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -77,7 +77,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel_names = request->channel_names().c_str();
       auto status = library_->AddGlobalChansToTask(task, channel_names);
       if (!status_ok(status)) {
@@ -217,7 +217,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto trigger_source = request->trigger_source().c_str();
       int32 trigger_slope;
       switch (request->trigger_slope_enum_case()) {
@@ -258,7 +258,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto trigger_source = request->trigger_source().c_str();
       int32 trigger_slope;
       switch (request->trigger_slope_enum_case()) {
@@ -298,7 +298,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto trigger_sources = request->trigger_sources().c_str();
       auto trigger_slope_array = reinterpret_cast<const int32*>(request->trigger_slope_array().data());
       auto trigger_level_array = const_cast<const float64*>(request->trigger_level_array().data());
@@ -336,7 +336,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto trigger_sources = request->trigger_sources().c_str();
       auto trigger_slope_array = reinterpret_cast<const int32*>(request->trigger_slope_array().data());
       auto trigger_level_array = const_cast<const float64*>(request->trigger_level_array().data());
@@ -373,7 +373,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto trigger_source = request->trigger_source().c_str();
       int32 trigger_when;
       switch (request->trigger_when_enum_case()) {
@@ -415,7 +415,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto trigger_source = request->trigger_source().c_str();
       int32 trigger_when;
       switch (request->trigger_when_enum_case()) {
@@ -456,7 +456,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 sample_mode;
       switch (request->sample_mode_enum_case()) {
         case nidaqmx_grpc::CfgBurstHandshakingTimingExportClockRequest::SampleModeEnumCase::kSampleMode: {
@@ -545,7 +545,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 sample_mode;
       switch (request->sample_mode_enum_case()) {
         case nidaqmx_grpc::CfgBurstHandshakingTimingImportClockRequest::SampleModeEnumCase::kSampleMode: {
@@ -634,7 +634,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto rising_edge_chan = request->rising_edge_chan().c_str();
       auto falling_edge_chan = request->falling_edge_chan().c_str();
       int32 sample_mode;
@@ -675,7 +675,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto trigger_source = request->trigger_source().c_str();
       int32 trigger_edge;
       switch (request->trigger_edge_enum_case()) {
@@ -715,7 +715,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto trigger_source = request->trigger_source().c_str();
       int32 trigger_edge;
       switch (request->trigger_edge_enum_case()) {
@@ -754,7 +754,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto trigger_source = request->trigger_source().c_str();
       auto trigger_pattern = request->trigger_pattern().c_str();
       int32 trigger_when;
@@ -795,7 +795,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto trigger_source = request->trigger_source().c_str();
       auto trigger_pattern = request->trigger_pattern().c_str();
       int32 trigger_when;
@@ -835,7 +835,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 sample_mode;
       switch (request->sample_mode_enum_case()) {
         case nidaqmx_grpc::CfgHandshakingTimingRequest::SampleModeEnumCase::kSampleMode: {
@@ -874,7 +874,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 sample_mode;
       switch (request->sample_mode_enum_case()) {
         case nidaqmx_grpc::CfgImplicitTimingRequest::SampleModeEnumCase::kSampleMode: {
@@ -913,7 +913,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       uInt32 num_samps_per_chan = request->num_samps_per_chan();
       auto status = library_->CfgInputBuffer(task, num_samps_per_chan);
       if (!status_ok(status)) {
@@ -936,7 +936,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       uInt32 num_samps_per_chan = request->num_samps_per_chan();
       auto status = library_->CfgOutputBuffer(task, num_samps_per_chan);
       if (!status_ok(status)) {
@@ -959,7 +959,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto source = request->source().c_str();
       float64 rate = request->rate();
       int32 active_edge;
@@ -1016,7 +1016,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto source = request->source().c_str();
       float64 rate = request->rate();
       int32 active_edge;
@@ -1073,7 +1073,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto when = convert_from_grpc<CVIAbsoluteTime>(request->when());
       int32 timescale;
       switch (request->timescale_enum_case()) {
@@ -1112,7 +1112,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel_names = request->channel_names().c_str();
       auto expir_state_array = const_cast<const float64*>(request->expir_state_array().data());
       auto output_type_array_vector = std::vector<int32>();
@@ -1157,7 +1157,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel_names = request->channel_names().c_str();
       auto expir_state_array_vector = std::vector<int32>();
       expir_state_array_vector.reserve(request->expir_state_array().size());
@@ -1190,7 +1190,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel_names = request->channel_names().c_str();
       auto expir_state_array_vector = std::vector<int32>();
       expir_state_array_vector.reserve(request->expir_state_array().size());
@@ -1244,8 +1244,8 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
-      session_repository_->remove_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
+      session_repository_->remove_session(task_grpc_session.name());
       auto status = library_->ClearTask(task);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForTaskHandle(context, status, task);
@@ -1267,7 +1267,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto file_path = request->file_path().c_str();
       int32 logging_mode;
       switch (request->logging_mode_enum_case()) {
@@ -1383,7 +1383,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 action;
       switch (request->action_enum_case()) {
         case nidaqmx_grpc::ControlWatchdogTaskRequest::ActionEnumCase::kAction: {
@@ -1421,7 +1421,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -1515,7 +1515,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -1608,7 +1608,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -1684,7 +1684,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -1761,7 +1761,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -1820,7 +1820,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -1896,7 +1896,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -1972,7 +1972,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -2085,7 +2085,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -2198,7 +2198,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -2311,7 +2311,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -2404,7 +2404,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -2449,7 +2449,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -2525,7 +2525,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -2585,7 +2585,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -2679,7 +2679,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -2773,7 +2773,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -2886,7 +2886,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -2999,7 +2999,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -3112,7 +3112,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -3204,7 +3204,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -3280,7 +3280,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -3362,7 +3362,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -3443,7 +3443,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 units;
@@ -3483,7 +3483,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -3559,7 +3559,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -3637,7 +3637,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -3716,7 +3716,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -3829,7 +3829,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -3942,7 +3942,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -4055,7 +4055,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -4148,7 +4148,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -4207,7 +4207,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -4300,7 +4300,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -4359,7 +4359,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -4402,7 +4402,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 type;
@@ -4445,7 +4445,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -4488,7 +4488,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 decoding_type;
@@ -4565,7 +4565,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -4625,7 +4625,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 edge;
@@ -4682,7 +4682,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_freq = request->min_freq();
@@ -4725,7 +4725,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -4802,7 +4802,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 units;
@@ -4859,7 +4859,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 decoding_type;
@@ -4936,7 +4936,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -4996,7 +4996,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -5073,7 +5073,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -5115,7 +5115,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       auto source_terminal = request->source_terminal().c_str();
@@ -5142,7 +5142,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -5184,7 +5184,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -5243,7 +5243,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -5286,7 +5286,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -5361,7 +5361,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 units;
@@ -5420,7 +5420,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       auto source_terminal = request->source_terminal().c_str();
@@ -5464,7 +5464,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto counter = request->counter().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 units;
@@ -5523,7 +5523,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto lines = request->lines().c_str();
       auto name_to_assign_to_lines = request->name_to_assign_to_lines().c_str();
       int32 line_grouping;
@@ -5563,7 +5563,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto lines = request->lines().c_str();
       auto name_to_assign_to_lines = request->name_to_assign_to_lines().c_str();
       int32 line_grouping;
@@ -5727,7 +5727,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -5803,7 +5803,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -5863,7 +5863,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -5939,7 +5939,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -5999,7 +5999,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -6075,7 +6075,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -6150,7 +6150,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -6227,7 +6227,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -6304,7 +6304,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -6364,7 +6364,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -6439,7 +6439,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -6515,7 +6515,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -6577,7 +6577,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -6637,7 +6637,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -6712,7 +6712,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -6788,7 +6788,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       float64 min_val = request->min_val();
@@ -6848,7 +6848,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -6907,7 +6907,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto physical_channel = request->physical_channel().c_str();
       auto name_to_assign_to_channel = request->name_to_assign_to_channel().c_str();
       int32 terminal_config;
@@ -7031,15 +7031,14 @@ namespace nidaqmx_grpc {
         auto status = library_->CreateTask(session_name, &task);
         return std::make_tuple(status, task);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (TaskHandle id) { library_->ClearTask(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForTaskHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_task()->set_id(session_id);
+      response->mutable_task()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -7084,15 +7083,14 @@ namespace nidaqmx_grpc {
         auto status = ((NiDAQmxLibrary*)library_)->CreateWatchdogTimerTask(device_name, session_name, &task, timeout, get_lines_if(exp_states, 0), get_expState_if(exp_states, 0), get_lines_if(exp_states, 1), get_expState_if(exp_states, 1), get_lines_if(exp_states, 2), get_expState_if(exp_states, 2), get_lines_if(exp_states, 3), get_expState_if(exp_states, 3), get_lines_if(exp_states, 4), get_expState_if(exp_states, 4), get_lines_if(exp_states, 5), get_expState_if(exp_states, 5), get_lines_if(exp_states, 6), get_expState_if(exp_states, 6), get_lines_if(exp_states, 7), get_expState_if(exp_states, 7), get_lines_if(exp_states, 8), get_expState_if(exp_states, 8), get_lines_if(exp_states, 9), get_expState_if(exp_states, 9), get_lines_if(exp_states, 10), get_expState_if(exp_states, 10), get_lines_if(exp_states, 11), get_expState_if(exp_states, 11), get_lines_if(exp_states, 12), get_expState_if(exp_states, 12), get_lines_if(exp_states, 13), get_expState_if(exp_states, 13), get_lines_if(exp_states, 14), get_expState_if(exp_states, 14), get_lines_if(exp_states, 15), get_expState_if(exp_states, 15), get_lines_if(exp_states, 16), get_expState_if(exp_states, 16), get_lines_if(exp_states, 17), get_expState_if(exp_states, 17), get_lines_if(exp_states, 18), get_expState_if(exp_states, 18), get_lines_if(exp_states, 19), get_expState_if(exp_states, 19), get_lines_if(exp_states, 20), get_expState_if(exp_states, 20), get_lines_if(exp_states, 21), get_expState_if(exp_states, 21), get_lines_if(exp_states, 22), get_expState_if(exp_states, 22), get_lines_if(exp_states, 23), get_expState_if(exp_states, 23), get_lines_if(exp_states, 24), get_expState_if(exp_states, 24), get_lines_if(exp_states, 25), get_expState_if(exp_states, 25), get_lines_if(exp_states, 26), get_expState_if(exp_states, 26), get_lines_if(exp_states, 27), get_expState_if(exp_states, 27), get_lines_if(exp_states, 28), get_expState_if(exp_states, 28), get_lines_if(exp_states, 29), get_expState_if(exp_states, 29), get_lines_if(exp_states, 30), get_expState_if(exp_states, 30), get_lines_if(exp_states, 31), get_expState_if(exp_states, 31), get_lines_if(exp_states, 32), get_expState_if(exp_states, 32), get_lines_if(exp_states, 33), get_expState_if(exp_states, 33), get_lines_if(exp_states, 34), get_expState_if(exp_states, 34), get_lines_if(exp_states, 35), get_expState_if(exp_states, 35), get_lines_if(exp_states, 36), get_expState_if(exp_states, 36), get_lines_if(exp_states, 37), get_expState_if(exp_states, 37), get_lines_if(exp_states, 38), get_expState_if(exp_states, 38), get_lines_if(exp_states, 39), get_expState_if(exp_states, 39), get_lines_if(exp_states, 40), get_expState_if(exp_states, 40), get_lines_if(exp_states, 41), get_expState_if(exp_states, 41), get_lines_if(exp_states, 42), get_expState_if(exp_states, 42), get_lines_if(exp_states, 43), get_expState_if(exp_states, 43), get_lines_if(exp_states, 44), get_expState_if(exp_states, 44), get_lines_if(exp_states, 45), get_expState_if(exp_states, 45), get_lines_if(exp_states, 46), get_expState_if(exp_states, 46), get_lines_if(exp_states, 47), get_expState_if(exp_states, 47), get_lines_if(exp_states, 48), get_expState_if(exp_states, 48), get_lines_if(exp_states, 49), get_expState_if(exp_states, 49), get_lines_if(exp_states, 50), get_expState_if(exp_states, 50), get_lines_if(exp_states, 51), get_expState_if(exp_states, 51), get_lines_if(exp_states, 52), get_expState_if(exp_states, 52), get_lines_if(exp_states, 53), get_expState_if(exp_states, 53), get_lines_if(exp_states, 54), get_expState_if(exp_states, 54), get_lines_if(exp_states, 55), get_expState_if(exp_states, 55), get_lines_if(exp_states, 56), get_expState_if(exp_states, 56), get_lines_if(exp_states, 57), get_expState_if(exp_states, 57), get_lines_if(exp_states, 58), get_expState_if(exp_states, 58), get_lines_if(exp_states, 59), get_expState_if(exp_states, 59), get_lines_if(exp_states, 60), get_expState_if(exp_states, 60), get_lines_if(exp_states, 61), get_expState_if(exp_states, 61), get_lines_if(exp_states, 62), get_expState_if(exp_states, 62), get_lines_if(exp_states, 63), get_expState_if(exp_states, 63), get_lines_if(exp_states, 64), get_expState_if(exp_states, 64), get_lines_if(exp_states, 65), get_expState_if(exp_states, 65), get_lines_if(exp_states, 66), get_expState_if(exp_states, 66), get_lines_if(exp_states, 67), get_expState_if(exp_states, 67), get_lines_if(exp_states, 68), get_expState_if(exp_states, 68), get_lines_if(exp_states, 69), get_expState_if(exp_states, 69), get_lines_if(exp_states, 70), get_expState_if(exp_states, 70), get_lines_if(exp_states, 71), get_expState_if(exp_states, 71), get_lines_if(exp_states, 72), get_expState_if(exp_states, 72), get_lines_if(exp_states, 73), get_expState_if(exp_states, 73), get_lines_if(exp_states, 74), get_expState_if(exp_states, 74), get_lines_if(exp_states, 75), get_expState_if(exp_states, 75), get_lines_if(exp_states, 76), get_expState_if(exp_states, 76), get_lines_if(exp_states, 77), get_expState_if(exp_states, 77), get_lines_if(exp_states, 78), get_expState_if(exp_states, 78), get_lines_if(exp_states, 79), get_expState_if(exp_states, 79), get_lines_if(exp_states, 80), get_expState_if(exp_states, 80), get_lines_if(exp_states, 81), get_expState_if(exp_states, 81), get_lines_if(exp_states, 82), get_expState_if(exp_states, 82), get_lines_if(exp_states, 83), get_expState_if(exp_states, 83), get_lines_if(exp_states, 84), get_expState_if(exp_states, 84), get_lines_if(exp_states, 85), get_expState_if(exp_states, 85), get_lines_if(exp_states, 86), get_expState_if(exp_states, 86), get_lines_if(exp_states, 87), get_expState_if(exp_states, 87), get_lines_if(exp_states, 88), get_expState_if(exp_states, 88), get_lines_if(exp_states, 89), get_expState_if(exp_states, 89), get_lines_if(exp_states, 90), get_expState_if(exp_states, 90), get_lines_if(exp_states, 91), get_expState_if(exp_states, 91), get_lines_if(exp_states, 92), get_expState_if(exp_states, 92), get_lines_if(exp_states, 93), get_expState_if(exp_states, 93), get_lines_if(exp_states, 94), get_expState_if(exp_states, 94), get_lines_if(exp_states, 95), get_expState_if(exp_states, 95), get_lines_if(exp_states, 96), get_expState_if(exp_states, 96));
         return std::make_tuple(status, task);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (TaskHandle id) { library_->ClearTask(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForTaskHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_task()->set_id(session_id);
+      response->mutable_task()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -7117,15 +7115,14 @@ namespace nidaqmx_grpc {
         auto status = library_->CreateWatchdogTimerTaskEx(device_name, session_name, &task, timeout);
         return std::make_tuple(status, task);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (TaskHandle id) { library_->ClearTask(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForTaskHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_task()->set_id(session_id);
+      response->mutable_task()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -7249,7 +7246,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto status = library_->DisableRefTrig(task);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForTaskHandle(context, status, task);
@@ -7271,7 +7268,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto status = library_->DisableStartTrig(task);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForTaskHandle(context, status, task);
@@ -7315,7 +7312,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 signal_id;
       switch (request->signal_id_enum_case()) {
         case nidaqmx_grpc::ExportSignalRequest::SignalIdEnumCase::kSignalId: {
@@ -7354,7 +7351,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       uInt32 year {};
       uInt32 month {};
@@ -7387,7 +7384,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       uInt32 year {};
       uInt32 month {};
@@ -7508,7 +7505,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       CVIAbsoluteTime data {};
       auto status = library_->GetArmStartTrigTimestampVal(task, &data);
       if (!status_ok(status)) {
@@ -7532,7 +7529,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       CVIAbsoluteTime data {};
       auto status = library_->GetArmStartTrigTrigWhen(task, &data);
       if (!status_ok(status)) {
@@ -7595,7 +7592,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetBufferAttributeUInt32Request::AttributeEnumCase::kAttribute: {
@@ -7826,7 +7823,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel = request->channel().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -7871,7 +7868,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel = request->channel().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -7916,7 +7913,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel = request->channel().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -7973,7 +7970,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel = request->channel().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -8024,7 +8021,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel = request->channel().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -8085,7 +8082,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel = request->channel().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -8740,7 +8737,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetExportedSignalAttributeBoolRequest::AttributeEnumCase::kAttribute: {
@@ -8784,7 +8781,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetExportedSignalAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
@@ -8828,7 +8825,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetExportedSignalAttributeInt32Request::AttributeEnumCase::kAttribute: {
@@ -8878,7 +8875,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetExportedSignalAttributeStringRequest::AttributeEnumCase::kAttribute: {
@@ -8938,7 +8935,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetExportedSignalAttributeUInt32Request::AttributeEnumCase::kAttribute: {
@@ -8982,7 +8979,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       CVIAbsoluteTime data {};
       auto status = library_->GetFirstSampClkWhen(task, &data);
       if (!status_ok(status)) {
@@ -9006,7 +9003,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       CVIAbsoluteTime data {};
       auto status = library_->GetFirstSampTimestampVal(task, &data);
       if (!status_ok(status)) {
@@ -9030,7 +9027,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       uInt32 index = request->index();
 
       while (true) {
@@ -9072,7 +9069,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       uInt32 index = request->index();
 
       while (true) {
@@ -9114,7 +9111,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       uInt32 index = request->index();
 
       while (true) {
@@ -9933,7 +9930,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetReadAttributeBoolRequest::AttributeEnumCase::kAttribute: {
@@ -9977,7 +9974,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetReadAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
@@ -10021,7 +10018,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetReadAttributeInt32Request::AttributeEnumCase::kAttribute: {
@@ -10071,7 +10068,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetReadAttributeStringRequest::AttributeEnumCase::kAttribute: {
@@ -10131,7 +10128,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetReadAttributeUInt32Request::AttributeEnumCase::kAttribute: {
@@ -10175,7 +10172,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetReadAttributeUInt64Request::AttributeEnumCase::kAttribute: {
@@ -10219,7 +10216,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetRealTimeAttributeBoolRequest::AttributeEnumCase::kAttribute: {
@@ -10263,7 +10260,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetRealTimeAttributeInt32Request::AttributeEnumCase::kAttribute: {
@@ -10313,7 +10310,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetRealTimeAttributeUInt32Request::AttributeEnumCase::kAttribute: {
@@ -10357,7 +10354,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       CVIAbsoluteTime data {};
       auto status = library_->GetRefTrigTimestampVal(task, &data);
       if (!status_ok(status)) {
@@ -10618,7 +10615,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       CVIAbsoluteTime data {};
       auto status = library_->GetStartTrigTimestampVal(task, &data);
       if (!status_ok(status)) {
@@ -10642,7 +10639,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       CVIAbsoluteTime data {};
       auto status = library_->GetStartTrigTrigWhen(task, &data);
       if (!status_ok(status)) {
@@ -10666,7 +10663,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       CVIAbsoluteTime data {};
       auto status = library_->GetSyncPulseTimeWhen(task, &data);
       if (!status_ok(status)) {
@@ -10790,7 +10787,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTaskAttributeBoolRequest::AttributeEnumCase::kAttribute: {
@@ -10834,7 +10831,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTaskAttributeStringRequest::AttributeEnumCase::kAttribute: {
@@ -10894,7 +10891,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTaskAttributeUInt32Request::AttributeEnumCase::kAttribute: {
@@ -10938,7 +10935,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeBoolRequest::AttributeEnumCase::kAttribute: {
@@ -10982,7 +10979,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
@@ -11026,7 +11023,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto device_names = request->device_names().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -11071,7 +11068,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto device_names = request->device_names().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -11116,7 +11113,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto device_names = request->device_names().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -11167,7 +11164,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto device_names = request->device_names().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -11228,7 +11225,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto device_names = request->device_names().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -11273,7 +11270,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto device_names = request->device_names().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -11318,7 +11315,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto device_names = request->device_names().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -11363,7 +11360,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeInt32Request::AttributeEnumCase::kAttribute: {
@@ -11413,7 +11410,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeStringRequest::AttributeEnumCase::kAttribute: {
@@ -11473,7 +11470,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeTimestampRequest::AttributeEnumCase::kAttribute: {
@@ -11517,7 +11514,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeUInt32Request::AttributeEnumCase::kAttribute: {
@@ -11561,7 +11558,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTimingAttributeUInt64Request::AttributeEnumCase::kAttribute: {
@@ -11605,7 +11602,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTrigAttributeBoolRequest::AttributeEnumCase::kAttribute: {
@@ -11649,7 +11646,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTrigAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
@@ -11693,7 +11690,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTrigAttributeDoubleArrayRequest::AttributeEnumCase::kAttribute: {
@@ -11749,7 +11746,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTrigAttributeInt32Request::AttributeEnumCase::kAttribute: {
@@ -11799,7 +11796,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTrigAttributeInt32ArrayRequest::AttributeEnumCase::kAttribute: {
@@ -11869,7 +11866,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTrigAttributeStringRequest::AttributeEnumCase::kAttribute: {
@@ -11929,7 +11926,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTrigAttributeTimestampRequest::AttributeEnumCase::kAttribute: {
@@ -11973,7 +11970,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetTrigAttributeUInt32Request::AttributeEnumCase::kAttribute: {
@@ -12017,7 +12014,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto lines = request->lines().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -12062,7 +12059,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto lines = request->lines().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -12107,7 +12104,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto lines = request->lines().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -12158,7 +12155,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto lines = request->lines().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -12219,7 +12216,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetWriteAttributeBoolRequest::AttributeEnumCase::kAttribute: {
@@ -12263,7 +12260,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetWriteAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
@@ -12307,7 +12304,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetWriteAttributeInt32Request::AttributeEnumCase::kAttribute: {
@@ -12357,7 +12354,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetWriteAttributeStringRequest::AttributeEnumCase::kAttribute: {
@@ -12417,7 +12414,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetWriteAttributeUInt32Request::AttributeEnumCase::kAttribute: {
@@ -12461,7 +12458,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::GetWriteAttributeUInt64Request::AttributeEnumCase::kAttribute: {
@@ -12505,7 +12502,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       bool32 is_task_done {};
       auto status = library_->IsTaskDone(task, &is_task_done);
       if (!status_ok(status)) {
@@ -12535,15 +12532,14 @@ namespace nidaqmx_grpc {
         auto status = library_->LoadTask(session_name, &task);
         return std::make_tuple(status, task);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (TaskHandle id) { library_->ClearTask(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForTaskHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_task()->set_id(session_id);
+      response->mutable_task()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -12560,7 +12556,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       float64 timeout = request->timeout();
       int32 fill_mode;
@@ -12606,7 +12602,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       float64 timeout = request->timeout();
       auto reserved = nullptr;
       float64 value {};
@@ -12632,7 +12628,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       float64 timeout = request->timeout();
       int32 fill_mode;
@@ -12686,7 +12682,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       float64 timeout = request->timeout();
       int32 fill_mode;
@@ -12732,7 +12728,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       float64 timeout = request->timeout();
       int32 fill_mode;
@@ -12786,7 +12782,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       float64 timeout = request->timeout();
       int32 fill_mode;
@@ -12832,7 +12828,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       float64 timeout = request->timeout();
       uInt32 array_size_in_samps = request->array_size_in_samps();
@@ -12862,7 +12858,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       float64 timeout = request->timeout();
       int32 fill_mode;
@@ -12908,7 +12904,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       float64 timeout = request->timeout();
       auto reserved = nullptr;
       float64 value {};
@@ -12934,7 +12930,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       float64 timeout = request->timeout();
       auto reserved = nullptr;
       uInt32 value {};
@@ -12960,7 +12956,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       float64 timeout = request->timeout();
       uInt32 array_size_in_samps = request->array_size_in_samps();
@@ -12990,7 +12986,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       float64 timeout = request->timeout();
       int32 fill_mode;
@@ -13036,7 +13032,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       float64 timeout = request->timeout();
       int32 interleaved;
@@ -13084,7 +13080,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       float64 timeout = request->timeout();
       auto reserved = nullptr;
       float64 frequency {};
@@ -13112,7 +13108,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       float64 timeout = request->timeout();
       int32 interleaved;
@@ -13160,7 +13156,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       float64 timeout = request->timeout();
       auto reserved = nullptr;
       uInt32 high_ticks {};
@@ -13188,7 +13184,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       float64 timeout = request->timeout();
       int32 interleaved;
@@ -13236,7 +13232,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       float64 timeout = request->timeout();
       auto reserved = nullptr;
       float64 high_time {};
@@ -13264,7 +13260,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       float64 timeout = request->timeout();
       int32 fill_mode;
@@ -13312,7 +13308,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       float64 timeout = request->timeout();
       auto reserved = nullptr;
       uInt32 value {};
@@ -13338,7 +13334,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       float64 timeout = request->timeout();
       int32 fill_mode;
@@ -13392,7 +13388,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       float64 timeout = request->timeout();
       int32 fill_mode;
@@ -13438,7 +13434,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       float64 timeout = request->timeout();
       int32 fill_mode;
@@ -13484,7 +13480,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       float64 timeout = request->timeout();
       uInt32 array_size_in_bytes = request->array_size_in_bytes();
@@ -13536,7 +13532,7 @@ namespace nidaqmx_grpc {
         });
 
         auto task_grpc_session = request->task();
-        TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+        TaskHandle task = session_repository_->access_session(task_grpc_session.name());
         auto options = 0U;
 
         auto status = library->RegisterDoneEvent(task, options, CallbackRouter::handle_callback, handler->token());
@@ -13594,7 +13590,7 @@ namespace nidaqmx_grpc {
         });
 
         auto task_grpc_session = request->task();
-        TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+        TaskHandle task = session_repository_->access_session(task_grpc_session.name());
         int32 every_n_samples_event_type;
         switch (request->every_n_samples_event_type_enum_case()) {
           case nidaqmx_grpc::RegisterEveryNSamplesEventRequest::EveryNSamplesEventTypeEnumCase::kEveryNSamplesEventType: {
@@ -13667,7 +13663,7 @@ namespace nidaqmx_grpc {
         });
 
         auto task_grpc_session = request->task();
-        TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+        TaskHandle task = session_repository_->access_session(task_grpc_session.name());
         int32 signal_id;
         switch (request->signal_id_enum_case()) {
           case nidaqmx_grpc::RegisterSignalEventRequest::SignalIdEnumCase::kSignalId: {
@@ -13762,7 +13758,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::ResetBufferAttributeRequest::AttributeEnumCase::kAttribute: {
@@ -13803,7 +13799,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel = request->channel().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -13866,7 +13862,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::ResetExportedSignalAttributeRequest::AttributeEnumCase::kAttribute: {
@@ -13907,7 +13903,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::ResetReadAttributeRequest::AttributeEnumCase::kAttribute: {
@@ -13948,7 +13944,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::ResetRealTimeAttributeRequest::AttributeEnumCase::kAttribute: {
@@ -13989,7 +13985,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::ResetTimingAttributeRequest::AttributeEnumCase::kAttribute: {
@@ -14030,7 +14026,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto device_names = request->device_names().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -14072,7 +14068,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::ResetTrigAttributeRequest::AttributeEnumCase::kAttribute: {
@@ -14113,7 +14109,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto lines = request->lines().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -14155,7 +14151,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::ResetWriteAttributeRequest::AttributeEnumCase::kAttribute: {
@@ -14196,7 +14192,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto save_as = request->save_as().c_str();
       auto author = request->author().c_str();
@@ -14276,7 +14272,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto save_as = request->save_as().c_str();
       auto author = request->author().c_str();
       uInt32 options;
@@ -14358,7 +14354,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       uInt32 year = request->year();
       uInt32 month = request->month();
@@ -14386,7 +14382,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       uInt32 year = request->year();
       uInt32 month = request->month();
@@ -14504,7 +14500,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto data = convert_from_grpc<CVIAbsoluteTime>(request->data());
       auto status = library_->SetArmStartTrigTrigWhen(task, data);
       if (!status_ok(status)) {
@@ -14527,7 +14523,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetBufferAttributeUInt32Request::AttributeEnumCase::kAttribute: {
@@ -14737,7 +14733,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel = request->channel().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -14781,7 +14777,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel = request->channel().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -14825,7 +14821,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel = request->channel().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -14869,7 +14865,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel = request->channel().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -14928,7 +14924,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel = request->channel().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -14972,7 +14968,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto channel = request->channel().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -15135,7 +15131,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetExportedSignalAttributeBoolRequest::AttributeEnumCase::kAttribute: {
@@ -15178,7 +15174,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetExportedSignalAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
@@ -15221,7 +15217,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetExportedSignalAttributeInt32Request::AttributeEnumCase::kAttribute: {
@@ -15279,7 +15275,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetExportedSignalAttributeStringRequest::AttributeEnumCase::kAttribute: {
@@ -15322,7 +15318,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetExportedSignalAttributeUInt32Request::AttributeEnumCase::kAttribute: {
@@ -15365,7 +15361,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto data = convert_from_grpc<CVIAbsoluteTime>(request->data());
       auto status = library_->SetFirstSampClkWhen(task, data);
       if (!status_ok(status)) {
@@ -15388,7 +15384,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetReadAttributeBoolRequest::AttributeEnumCase::kAttribute: {
@@ -15431,7 +15427,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetReadAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
@@ -15474,7 +15470,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetReadAttributeInt32Request::AttributeEnumCase::kAttribute: {
@@ -15532,7 +15528,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetReadAttributeStringRequest::AttributeEnumCase::kAttribute: {
@@ -15575,7 +15571,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetReadAttributeUInt32Request::AttributeEnumCase::kAttribute: {
@@ -15618,7 +15614,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetReadAttributeUInt64Request::AttributeEnumCase::kAttribute: {
@@ -15661,7 +15657,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetRealTimeAttributeBoolRequest::AttributeEnumCase::kAttribute: {
@@ -15704,7 +15700,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetRealTimeAttributeInt32Request::AttributeEnumCase::kAttribute: {
@@ -15762,7 +15758,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetRealTimeAttributeUInt32Request::AttributeEnumCase::kAttribute: {
@@ -15988,7 +15984,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto data = convert_from_grpc<CVIAbsoluteTime>(request->data());
       auto status = library_->SetStartTrigTrigWhen(task, data);
       if (!status_ok(status)) {
@@ -16011,7 +16007,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto data = convert_from_grpc<CVIAbsoluteTime>(request->data());
       auto status = library_->SetSyncPulseTimeWhen(task, data);
       if (!status_ok(status)) {
@@ -16034,7 +16030,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeBoolRequest::AttributeEnumCase::kAttribute: {
@@ -16077,7 +16073,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
@@ -16120,7 +16116,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto device_names = request->device_names().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -16164,7 +16160,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto device_names = request->device_names().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -16208,7 +16204,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto device_names = request->device_names().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -16267,7 +16263,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto device_names = request->device_names().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -16311,7 +16307,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto device_names = request->device_names().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -16355,7 +16351,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto device_names = request->device_names().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -16399,7 +16395,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto device_names = request->device_names().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -16443,7 +16439,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeInt32Request::AttributeEnumCase::kAttribute: {
@@ -16501,7 +16497,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeStringRequest::AttributeEnumCase::kAttribute: {
@@ -16544,7 +16540,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeTimestampRequest::AttributeEnumCase::kAttribute: {
@@ -16587,7 +16583,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeUInt32Request::AttributeEnumCase::kAttribute: {
@@ -16630,7 +16626,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTimingAttributeUInt64Request::AttributeEnumCase::kAttribute: {
@@ -16673,7 +16669,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTrigAttributeBoolRequest::AttributeEnumCase::kAttribute: {
@@ -16716,7 +16712,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTrigAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
@@ -16759,7 +16755,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTrigAttributeDoubleArrayRequest::AttributeEnumCase::kAttribute: {
@@ -16802,7 +16798,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTrigAttributeInt32Request::AttributeEnumCase::kAttribute: {
@@ -16860,7 +16856,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTrigAttributeInt32ArrayRequest::AttributeEnumCase::kAttribute: {
@@ -16903,7 +16899,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTrigAttributeStringRequest::AttributeEnumCase::kAttribute: {
@@ -16946,7 +16942,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTrigAttributeTimestampRequest::AttributeEnumCase::kAttribute: {
@@ -16989,7 +16985,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetTrigAttributeUInt32Request::AttributeEnumCase::kAttribute: {
@@ -17032,7 +17028,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto lines = request->lines().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -17076,7 +17072,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto lines = request->lines().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -17120,7 +17116,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto lines = request->lines().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -17179,7 +17175,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto lines = request->lines().c_str();
       int32 attribute;
       switch (request->attribute_enum_case()) {
@@ -17223,7 +17219,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetWriteAttributeBoolRequest::AttributeEnumCase::kAttribute: {
@@ -17266,7 +17262,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetWriteAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
@@ -17309,7 +17305,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetWriteAttributeInt32Request::AttributeEnumCase::kAttribute: {
@@ -17367,7 +17363,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetWriteAttributeStringRequest::AttributeEnumCase::kAttribute: {
@@ -17410,7 +17406,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetWriteAttributeUInt32Request::AttributeEnumCase::kAttribute: {
@@ -17453,7 +17449,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nidaqmx_grpc::SetWriteAttributeUInt64Request::AttributeEnumCase::kAttribute: {
@@ -17496,7 +17492,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto file_path = request->file_path().c_str();
       auto status = library_->StartNewFile(task, file_path);
       if (!status_ok(status)) {
@@ -17519,7 +17515,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto status = library_->StartTask(task);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForTaskHandle(context, status, task);
@@ -17541,7 +17537,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       auto status = library_->StopTask(task);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForTaskHandle(context, status, task);
@@ -17563,7 +17559,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 action;
       switch (request->action_enum_case()) {
         case nidaqmx_grpc::TaskControlRequest::ActionEnumCase::kAction: {
@@ -17643,7 +17639,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       float64 timeout = request->timeout();
       bool32 is_late {};
       auto status = library_->WaitForNextSampleClock(task, timeout, &is_late);
@@ -17668,7 +17664,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 timestamp_event;
       switch (request->timestamp_event_enum_case()) {
         case nidaqmx_grpc::WaitForValidTimestampRequest::TimestampEventEnumCase::kTimestampEvent: {
@@ -17709,7 +17705,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       float64 time_to_wait = request->time_to_wait();
       auto status = library_->WaitUntilTaskDone(task, time_to_wait);
       if (!status_ok(status)) {
@@ -17732,7 +17728,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();
@@ -17777,7 +17773,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();
       float64 value = request->value();
@@ -17803,7 +17799,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();
@@ -17865,7 +17861,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();
@@ -17910,7 +17906,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();
@@ -17972,7 +17968,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();
@@ -18017,7 +18013,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();
@@ -18063,7 +18059,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();
       float64 frequency = request->frequency();
@@ -18090,7 +18086,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();
@@ -18136,7 +18132,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();
       uInt32 high_ticks = request->high_ticks();
@@ -18163,7 +18159,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();
@@ -18209,7 +18205,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();
       float64 high_time = request->high_time();
@@ -18236,7 +18232,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();
@@ -18281,7 +18277,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();
       uInt32 value = request->value();
@@ -18307,7 +18303,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();
@@ -18369,7 +18365,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();
@@ -18414,7 +18410,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps_per_chan = request->num_samps_per_chan();
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();
@@ -18459,7 +18455,7 @@ namespace nidaqmx_grpc {
     }
     try {
       auto task_grpc_session = request->task();
-      TaskHandle task = session_repository_->access_session(task_grpc_session.id(), task_grpc_session.name());
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
       int32 num_samps = request->num_samps();
       bool32 auto_start = request->auto_start();
       float64 timeout = request->timeout();

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -166,7 +166,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 output_cutoff_reason;
       switch (request->output_cutoff_reason_enum_case()) {
@@ -3540,7 +3540,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 output_cutoff_reason;
       switch (request->output_cutoff_reason_enum_case()) {

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -54,7 +54,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Abort(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -76,7 +76,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->AbortWithChannels(vi, channel_name);
       if (!status_ok(status)) {
@@ -99,7 +99,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->CalSelfCalibrate(vi, channel_name);
       if (!status_ok(status)) {
@@ -122,7 +122,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ClearError(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -144,7 +144,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ClearInterchangeWarnings(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -166,8 +166,8 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      session_repository_->remove_session(vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -189,7 +189,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Commit(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -211,7 +211,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->CommitWithChannels(vi, channel_name);
       if (!status_ok(status)) {
@@ -234,7 +234,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 aperture_time = request->aperture_time();
       ViInt32 units;
@@ -274,7 +274,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 auto_zero;
       switch (request->auto_zero_enum_case()) {
@@ -313,7 +313,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 level = request->level();
       auto status = library_->ConfigureCurrentLevel(vi, channel_name, level);
@@ -337,7 +337,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 range = request->range();
       auto status = library_->ConfigureCurrentLevelRange(vi, channel_name, range);
@@ -361,7 +361,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 behavior;
       switch (request->behavior_enum_case()) {
@@ -401,7 +401,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 range = request->range();
       auto status = library_->ConfigureCurrentLimitRange(vi, channel_name, range);
@@ -425,7 +425,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto input_terminal = request->input_terminal().c_str();
       ViInt32 edge;
       switch (request->edge_enum_case()) {
@@ -464,7 +464,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto input_terminal = request->input_terminal().c_str();
       ViInt32 edge;
@@ -504,7 +504,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto input_terminal = request->input_terminal().c_str();
       ViInt32 edge;
       switch (request->edge_enum_case()) {
@@ -543,7 +543,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto input_terminal = request->input_terminal().c_str();
       ViInt32 edge;
@@ -583,7 +583,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto input_terminal = request->input_terminal().c_str();
       ViInt32 edge;
       switch (request->edge_enum_case()) {
@@ -622,7 +622,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto input_terminal = request->input_terminal().c_str();
       ViInt32 edge;
@@ -662,7 +662,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto input_terminal = request->input_terminal().c_str();
       ViInt32 edge;
@@ -702,7 +702,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto input_terminal = request->input_terminal().c_str();
       ViInt32 edge;
       switch (request->edge_enum_case()) {
@@ -741,7 +741,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto input_terminal = request->input_terminal().c_str();
       ViInt32 edge;
@@ -781,7 +781,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto input_terminal = request->input_terminal().c_str();
       ViInt32 edge;
       switch (request->edge_enum_case()) {
@@ -820,7 +820,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto input_terminal = request->input_terminal().c_str();
       ViInt32 edge;
@@ -860,7 +860,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 compensation_data_size = static_cast<ViInt32>(request->compensation_data().size());
       ViInt8* compensation_data = (ViInt8*)request->compensation_data().c_str();
@@ -885,7 +885,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 custom_cable_compensation_data_size = static_cast<ViInt32>(request->custom_cable_compensation_data().size());
       ViInt8* custom_cable_compensation_data = (ViInt8*)request->custom_cable_compensation_data().c_str();
@@ -910,7 +910,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViBoolean enabled = request->enabled();
       auto status = library_->ConfigureOutputEnabled(vi, channel_name, enabled);
@@ -934,7 +934,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 function;
       switch (request->function_enum_case()) {
@@ -973,7 +973,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 range_type = request->range_type();
       ViReal64 range = request->range();
@@ -998,7 +998,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 resistance = request->resistance();
       auto status = library_->ConfigureOutputResistance(vi, channel_name, resistance);
@@ -1022,7 +1022,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViBoolean enabled = request->enabled();
       ViReal64 limit = request->limit();
@@ -1047,7 +1047,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 powerline_frequency;
       switch (request->powerline_frequency_enum_case()) {
         case nidcpower_grpc::ConfigurePowerLineFrequencyRequest::PowerlineFrequencyEnumCase::kPowerlineFrequency: {
@@ -1085,7 +1085,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 level = request->level();
       auto status = library_->ConfigurePulseBiasCurrentLevel(vi, channel_name, level);
@@ -1109,7 +1109,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 limit = request->limit();
       auto status = library_->ConfigurePulseBiasCurrentLimit(vi, channel_name, limit);
@@ -1133,7 +1133,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 level = request->level();
       auto status = library_->ConfigurePulseBiasVoltageLevel(vi, channel_name, level);
@@ -1157,7 +1157,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 limit = request->limit();
       auto status = library_->ConfigurePulseBiasVoltageLimit(vi, channel_name, limit);
@@ -1181,7 +1181,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 level = request->level();
       auto status = library_->ConfigurePulseCurrentLevel(vi, channel_name, level);
@@ -1205,7 +1205,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 range = request->range();
       auto status = library_->ConfigurePulseCurrentLevelRange(vi, channel_name, range);
@@ -1229,7 +1229,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 limit = request->limit();
       auto status = library_->ConfigurePulseCurrentLimit(vi, channel_name, limit);
@@ -1253,7 +1253,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 range = request->range();
       auto status = library_->ConfigurePulseCurrentLimitRange(vi, channel_name, range);
@@ -1277,7 +1277,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 level = request->level();
       auto status = library_->ConfigurePulseVoltageLevel(vi, channel_name, level);
@@ -1301,7 +1301,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 range = request->range();
       auto status = library_->ConfigurePulseVoltageLevelRange(vi, channel_name, range);
@@ -1325,7 +1325,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 limit = request->limit();
       auto status = library_->ConfigurePulseVoltageLimit(vi, channel_name, limit);
@@ -1349,7 +1349,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 range = request->range();
       auto status = library_->ConfigurePulseVoltageLimitRange(vi, channel_name, range);
@@ -1373,7 +1373,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 sense;
       switch (request->sense_enum_case()) {
@@ -1412,7 +1412,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgeMeasureTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1434,7 +1434,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->ConfigureSoftwareEdgeMeasureTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
@@ -1457,7 +1457,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgePulseTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1479,7 +1479,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->ConfigureSoftwareEdgePulseTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
@@ -1502,7 +1502,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgeSequenceAdvanceTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1524,7 +1524,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->ConfigureSoftwareEdgeSequenceAdvanceTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
@@ -1547,7 +1547,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->ConfigureSoftwareEdgeShutdownTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
@@ -1570,7 +1570,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgeSourceTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1592,7 +1592,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->ConfigureSoftwareEdgeSourceTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
@@ -1615,7 +1615,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgeStartTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1637,7 +1637,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->ConfigureSoftwareEdgeStartTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
@@ -1660,7 +1660,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 source_mode;
       switch (request->source_mode_enum_case()) {
         case nidcpower_grpc::ConfigureSourceModeRequest::SourceModeEnumCase::kSourceMode: {
@@ -1698,7 +1698,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 source_mode;
       switch (request->source_mode_enum_case()) {
@@ -1737,7 +1737,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 level = request->level();
       auto status = library_->ConfigureVoltageLevel(vi, channel_name, level);
@@ -1761,7 +1761,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 range = request->range();
       auto status = library_->ConfigureVoltageLevelRange(vi, channel_name, range);
@@ -1785,7 +1785,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 limit = request->limit();
       auto status = library_->ConfigureVoltageLimit(vi, channel_name, limit);
@@ -1809,7 +1809,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 range = request->range();
       auto status = library_->ConfigureVoltageLimitRange(vi, channel_name, range);
@@ -1833,7 +1833,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto sequence_name = request->sequence_name().c_str();
       ViInt32 attribute_id_count = static_cast<ViInt32>(request->attribute_ids().size());
       auto attribute_ids = const_cast<ViInt32*>(reinterpret_cast<const ViInt32*>(request->attribute_ids().data()));
@@ -1859,7 +1859,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViBoolean set_as_active_step = request->set_as_active_step();
       auto status = library_->CreateAdvancedSequenceCommitStepWithChannels(vi, channel_name, set_as_active_step);
@@ -1883,7 +1883,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean set_as_active_step = request->set_as_active_step();
       auto status = library_->CreateAdvancedSequenceStep(vi, set_as_active_step);
       if (!status_ok(status)) {
@@ -1906,7 +1906,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViBoolean set_as_active_step = request->set_as_active_step();
       auto status = library_->CreateAdvancedSequenceStepWithChannels(vi, channel_name, set_as_active_step);
@@ -1930,7 +1930,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto sequence_name = request->sequence_name().c_str();
       ViInt32 attribute_id_count = static_cast<ViInt32>(request->attribute_ids().size());
@@ -1957,7 +1957,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto sequence_name = request->sequence_name().c_str();
       auto status = library_->DeleteAdvancedSequence(vi, sequence_name);
       if (!status_ok(status)) {
@@ -1980,7 +1980,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto sequence_name = request->sequence_name().c_str();
       auto status = library_->DeleteAdvancedSequenceWithChannels(vi, channel_name, sequence_name);
@@ -2004,7 +2004,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Disable(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2026,7 +2026,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DisablePulseTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2048,7 +2048,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->DisablePulseTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
@@ -2071,7 +2071,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DisableSequenceAdvanceTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2093,7 +2093,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->DisableSequenceAdvanceTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
@@ -2116,7 +2116,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->DisableShutdownTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
@@ -2139,7 +2139,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DisableSourceTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2161,7 +2161,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->DisableSourceTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
@@ -2184,7 +2184,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DisableStartTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2206,7 +2206,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->DisableStartTriggerWithChannels(vi, channel_name);
       if (!status_ok(status)) {
@@ -2229,7 +2229,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViStatus error_code = request->error_code();
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
@@ -2255,7 +2255,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 error_code {};
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorQuery(vi, &error_code, (ViChar*)error_message.data());
@@ -2282,7 +2282,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
@@ -2319,7 +2319,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto file_path = request->file_path().c_str();
       auto status = library_->ExportAttributeConfigurationFile(vi, file_path);
       if (!status_ok(status)) {
@@ -2342,7 +2342,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 signal;
       switch (request->signal_enum_case()) {
         case nidcpower_grpc::ExportSignalRequest::SignalEnumCase::kSignal: {
@@ -2382,7 +2382,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 signal;
       switch (request->signal_enum_case()) {
@@ -2423,7 +2423,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 timeout = request->timeout();
       ViInt32 count = request->count();
@@ -2456,7 +2456,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 timeout = request->timeout();
       ViInt32 count = request->count();
@@ -2485,7 +2485,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean attribute_value {};
@@ -2511,7 +2511,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 attribute_value {};
@@ -2537,7 +2537,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt64 attribute_value {};
@@ -2563,7 +2563,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 attribute_value {};
@@ -2589,7 +2589,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViSession attribute_value {};
@@ -2598,8 +2598,8 @@ namespace nidcpower_grpc {
         return ConvertApiErrorStatusForViSession(context, status, vi);
       }
       response->set_status(status);
-      auto session_id = session_repository_->resolve_session_id(attribute_value);
-      response->mutable_attribute_value()->set_id(session_id);
+      auto grpc_device_session_name = session_repository_->resolve_session_name(attribute_value);
+      response->mutable_attribute_value()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -2616,7 +2616,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
 
@@ -2659,7 +2659,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 index = request->index();
 
       while (true) {
@@ -2701,7 +2701,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto index = request->index().c_str();
 
       while (true) {
@@ -2743,7 +2743,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetError(vi, nullptr, 0, nullptr);
@@ -2786,7 +2786,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 year {};
       ViInt32 month {};
       ViInt32 day {};
@@ -2818,7 +2818,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 temperature {};
       auto status = library_->GetExtCalLastTemp(vi, &temperature);
       if (!status_ok(status)) {
@@ -2842,7 +2842,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 months {};
       auto status = library_->GetExtCalRecommendedInterval(vi, &months);
       if (!status_ok(status)) {
@@ -2866,7 +2866,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
 
       while (true) {
@@ -2904,7 +2904,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 compensation_type;
       switch (request->compensation_type_enum_case()) {
@@ -2953,7 +2953,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
 
       while (true) {
@@ -2991,7 +2991,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetNextCoercionRecord(vi, 0, nullptr);
@@ -3032,7 +3032,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetNextInterchangeWarning(vi, 0, nullptr);
@@ -3073,7 +3073,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 year {};
       ViInt32 month {};
       ViInt32 day {};
@@ -3105,7 +3105,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 temperature {};
       auto status = library_->GetSelfCalLastTemp(vi, &temperature);
       if (!status_ok(status)) {
@@ -3129,7 +3129,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 size = static_cast<ViInt32>(request->configuration().size());
       ViInt8* configuration = (ViInt8*)request->configuration().c_str();
       auto status = library_->ImportAttributeConfigurationBuffer(vi, size, configuration);
@@ -3153,7 +3153,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto file_path = request->file_path().c_str();
       auto status = library_->ImportAttributeConfigurationFile(vi, file_path);
       if (!status_ok(status)) {
@@ -3187,15 +3187,14 @@ namespace nidcpower_grpc {
         auto status = library_->InitializeWithChannels(resource_name, channels, reset, option_string, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id, initialization_behavior, &new_session_initialized);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       response->set_new_session_initialized(new_session_initialized);
       return ::grpc::Status::OK;
     }
@@ -3223,15 +3222,14 @@ namespace nidcpower_grpc {
         auto status = library_->InitializeWithIndependentChannels(resource_name, reset, option_string, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id, initialization_behavior, &new_session_initialized);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       response->set_new_session_initialized(new_session_initialized);
       return ::grpc::Status::OK;
     }
@@ -3249,7 +3247,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Initiate(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -3271,7 +3269,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->InitiateWithChannels(vi, channel_name);
       if (!status_ok(status)) {
@@ -3294,7 +3292,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->InvalidateAllAttributes(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -3316,7 +3314,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 measurement_type;
       switch (request->measurement_type_enum_case()) {
@@ -3357,7 +3355,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 num_compensation_spots = static_cast<ViInt32>(request->compensation_spots().size());
       auto compensation_spots = convert_from_grpc<NILCRLoadCompensationSpot_struct>(request->compensation_spots());
@@ -3382,7 +3380,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 num_frequencies = static_cast<ViInt32>(request->additional_frequencies().size());
       auto additional_frequencies = const_cast<ViReal64*>(request->additional_frequencies().data());
@@ -3407,7 +3405,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->PerformLCROpenCustomCableCompensation(vi, channel_name);
       if (!status_ok(status)) {
@@ -3430,7 +3428,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 num_frequencies = static_cast<ViInt32>(request->additional_frequencies().size());
       auto additional_frequencies = const_cast<ViReal64*>(request->additional_frequencies().data());
@@ -3455,7 +3453,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->PerformLCRShortCustomCableCompensation(vi, channel_name);
       if (!status_ok(status)) {
@@ -3478,7 +3476,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViBoolean in_compliance {};
       auto status = library_->QueryInCompliance(vi, channel_name, &in_compliance);
@@ -3503,7 +3501,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 voltage_level = request->voltage_level();
       ViReal64 max_current_limit {};
@@ -3529,7 +3527,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 current_limit = request->current_limit();
       ViReal64 max_voltage_level {};
@@ -3555,7 +3553,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 voltage_level = request->voltage_level();
       ViReal64 min_current_limit {};
@@ -3581,7 +3579,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 output_state;
       switch (request->output_state_enum_case()) {
@@ -3622,7 +3620,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 temperature {};
       auto status = library_->ReadCurrentTemperature(vi, &temperature);
       if (!status_ok(status)) {
@@ -3646,7 +3644,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -3668,7 +3666,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ResetDevice(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -3690,7 +3688,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ResetInterchangeCheck(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -3712,7 +3710,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->ResetWithChannels(vi, channel_name);
       if (!status_ok(status)) {
@@ -3735,7 +3733,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ResetWithDefaults(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -3757,7 +3755,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       std::string instrument_driver_revision(256 - 1, '\0');
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
@@ -3785,7 +3783,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt16 self_test_result {};
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
@@ -3812,7 +3810,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 trigger;
       switch (request->trigger_enum_case()) {
         case nidcpower_grpc::SendSoftwareEdgeTriggerRequest::TriggerEnumCase::kTrigger: {
@@ -3850,7 +3848,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 trigger;
       switch (request->trigger_enum_case()) {
@@ -3889,7 +3887,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean attribute_value = request->attribute_value();
@@ -3914,7 +3912,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 attribute_value;
@@ -3954,7 +3952,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt64 attribute_value = request->attribute_value_raw();
@@ -3979,7 +3977,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 attribute_value;
@@ -4019,11 +4017,11 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto attribute_value_grpc_session = request->attribute_value();
-      ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.id(), attribute_value_grpc_session.name());
+      ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.name());
       auto status = library_->SetAttributeViSession(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -4045,7 +4043,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto attribute_value = request->attribute_value_raw().c_str();
@@ -4070,7 +4068,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto values = const_cast<ViReal64*>(request->values().data());
       auto source_delays = const_cast<ViReal64*>(request->source_delays().data());
@@ -4107,7 +4105,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 event_id;
       switch (request->event_id_enum_case()) {
         case nidcpower_grpc::WaitForEventRequest::EventIdEnumCase::kEventId: {
@@ -4146,7 +4144,7 @@ namespace nidcpower_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 event_id;
       switch (request->event_id_enum_case()) {

--- a/generated/nidigitalpattern/nidigitalpattern_service.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_service.cpp
@@ -63,7 +63,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Abort(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -85,7 +85,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->AbortKeepAlive(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -107,7 +107,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto site_list = request->site_list().c_str();
       auto levels_sheet = request->levels_sheet().c_str();
       auto timing_sheet = request->timing_sheet().c_str();
@@ -135,7 +135,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 num_offsets = static_cast<ViInt32>(request->offsets().size());
       auto offsets = const_cast<ViReal64*>(request->offsets().data());
@@ -160,7 +160,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto site_list = request->site_list().c_str();
       auto start_label = request->start_label().c_str();
       ViBoolean select_digital_function = request->select_digital_function();
@@ -193,7 +193,7 @@ namespace nidigitalpattern_grpc {
         sessions_request.begin(),
         sessions_request.end(),
         std::back_inserter(sessions),
-        [&](auto session) { return session_repository_->access_session(session.id(), session.name()); }); 
+        [&](auto session) { return session_repository_->access_session(session.name()); }); 
       auto site_list = request->site_list().c_str();
       auto start_label = request->start_label().c_str();
       ViBoolean select_digital_function = request->select_digital_function();
@@ -220,7 +220,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ClearError(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -242,7 +242,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       auto status = library_->ClockGeneratorAbort(vi, channel_list);
       if (!status_ok(status)) {
@@ -265,7 +265,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 frequency = request->frequency();
       ViBoolean select_digital_function = request->select_digital_function();
@@ -290,7 +290,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       auto status = library_->ClockGeneratorInitiate(vi, channel_list);
       if (!status_ok(status)) {
@@ -313,8 +313,8 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      session_repository_->remove_session(vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -336,7 +336,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Commit(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -358,7 +358,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 iol = request->iol();
       ViReal64 ioh = request->ioh();
@@ -384,7 +384,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt64 cycle_number = request->cycle_number();
       ViInt32 pretrigger_samples = request->pretrigger_samples();
       auto status = library_->ConfigureCycleNumberHistoryRAMTrigger(vi, cycle_number, pretrigger_samples);
@@ -408,7 +408,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto trigger_identifier = request->trigger_identifier().c_str();
       auto source = request->source().c_str();
       ViInt32 edge;
@@ -448,7 +448,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto source = request->source().c_str();
       ViInt32 edge;
       switch (request->edge_enum_case()) {
@@ -487,7 +487,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 pretrigger_samples = request->pretrigger_samples();
       auto status = library_->ConfigureFirstFailureHistoryRAMTrigger(vi, pretrigger_samples);
       if (!status_ok(status)) {
@@ -510,7 +510,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 cycles_to_acquire;
       switch (request->cycles_to_acquire_enum_case()) {
         case nidigitalpattern_grpc::ConfigureHistoryRAMCyclesToAcquireRequest::CyclesToAcquireEnumCase::kCyclesToAcquire: {
@@ -548,7 +548,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto site_list = request->site_list().c_str();
       auto status = library_->ConfigurePatternBurstSites(vi, site_list);
       if (!status_ok(status)) {
@@ -571,7 +571,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto label = request->label().c_str();
       ViInt64 vector_offset = request->vector_offset();
       ViInt64 cycle_offset = request->cycle_offset();
@@ -597,7 +597,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto trigger_identifier = request->trigger_identifier().c_str();
       auto status = library_->ConfigureSoftwareEdgeConditionalJumpTrigger(vi, trigger_identifier);
       if (!status_ok(status)) {
@@ -620,7 +620,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgeStartTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -642,7 +642,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto label = request->label().c_str();
       auto status = library_->ConfigureStartLabel(vi, label);
       if (!status_ok(status)) {
@@ -665,7 +665,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 mode;
       switch (request->mode_enum_case()) {
@@ -704,7 +704,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto pin_list = request->pin_list().c_str();
       auto time_set_name = request->time_set_name().c_str();
       ViReal64 strobe_edge = request->strobe_edge();
@@ -729,7 +729,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto pin_list = request->pin_list().c_str();
       auto time_set_name = request->time_set_name().c_str();
       ViReal64 strobe_edge = request->strobe_edge();
@@ -755,7 +755,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto pin_list = request->pin_list().c_str();
       auto time_set_name = request->time_set_name().c_str();
       ViInt32 format;
@@ -799,7 +799,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto pin_list = request->pin_list().c_str();
       auto time_set_name = request->time_set_name().c_str();
       ViInt32 format;
@@ -845,7 +845,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto pin_list = request->pin_list().c_str();
       auto time_set_name = request->time_set_name().c_str();
       ViInt32 drive_format;
@@ -885,7 +885,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto pin_list = request->pin_list().c_str();
       auto time_set_name = request->time_set_name().c_str();
       ViInt32 edge;
@@ -926,7 +926,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto pin_list = request->pin_list().c_str();
       auto time_set_name = request->time_set_name().c_str();
       ViInt32 edge_multiplier = request->edge_multiplier();
@@ -951,7 +951,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto time_set_name = request->time_set_name().c_str();
       ViReal64 period = request->period();
       auto status = library_->ConfigureTimeSetPeriod(vi, time_set_name, period);
@@ -975,7 +975,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 vil = request->vil();
       ViReal64 vih = request->vih();
@@ -1003,7 +1003,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto waveform_name = request->waveform_name().c_str();
       auto waveform_file_path = request->waveform_file_path().c_str();
       auto status = library_->CreateCaptureWaveformFromFileDigicapture(vi, waveform_name, waveform_file_path);
@@ -1027,7 +1027,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto pin_list = request->pin_list().c_str();
       auto waveform_name = request->waveform_name().c_str();
       auto status = library_->CreateCaptureWaveformParallel(vi, pin_list, waveform_name);
@@ -1051,7 +1051,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto pin_list = request->pin_list().c_str();
       auto waveform_name = request->waveform_name().c_str();
       ViUInt32 sample_width = request->sample_width();
@@ -1092,7 +1092,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 num_sites = request->num_sites();
       auto status = library_->CreateChannelMap(vi, num_sites);
       if (!status_ok(status)) {
@@ -1115,7 +1115,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto pin_group_name = request->pin_group_name().c_str();
       auto pin_list = request->pin_list().c_str();
       auto status = library_->CreatePinGroup(vi, pin_group_name, pin_list);
@@ -1139,7 +1139,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto dut_pin_list = request->dut_pin_list().c_str();
       auto system_pin_list = request->system_pin_list().c_str();
       auto status = library_->CreatePinMap(vi, dut_pin_list, system_pin_list);
@@ -1163,7 +1163,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto waveform_name = request->waveform_name().c_str();
       auto waveform_file_path = request->waveform_file_path().c_str();
       ViBoolean write_waveform_data = request->write_waveform_data();
@@ -1188,7 +1188,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto pin_list = request->pin_list().c_str();
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 data_mapping;
@@ -1228,7 +1228,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto pin_list = request->pin_list().c_str();
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 data_mapping;
@@ -1285,7 +1285,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto name = request->name().c_str();
       auto status = library_->CreateTimeSet(vi, name);
       if (!status_ok(status)) {
@@ -1308,7 +1308,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DeleteAllTimeSets(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1330,7 +1330,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto trigger_identifier = request->trigger_identifier().c_str();
       auto status = library_->DisableConditionalJumpTrigger(vi, trigger_identifier);
       if (!status_ok(status)) {
@@ -1353,7 +1353,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto site_list = request->site_list().c_str();
       auto status = library_->DisableSites(vi, site_list);
       if (!status_ok(status)) {
@@ -1376,7 +1376,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DisableStartTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1404,9 +1404,9 @@ namespace nidigitalpattern_grpc {
         sessions_request.begin(),
         sessions_request.end(),
         std::back_inserter(sessions),
-        [&](auto session) { return session_repository_->access_session(session.id(), session.name()); }); 
+        [&](auto session) { return session_repository_->access_session(session.name()); }); 
       auto sync_session_grpc_session = request->sync_session();
-      ViSession sync_session = session_repository_->access_session(sync_session_grpc_session.id(), sync_session_grpc_session.name());
+      ViSession sync_session = session_repository_->access_session(sync_session_grpc_session.name());
       auto status = library_->EnableMatchFailCombination(session_count, sessions.data(), sync_session);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, sync_session);
@@ -1428,7 +1428,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto site_list = request->site_list().c_str();
       auto status = library_->EnableSites(vi, site_list);
       if (!status_ok(status)) {
@@ -1451,7 +1451,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->EndChannelMap(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1473,7 +1473,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViStatus error_code = request->error_code();
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
@@ -1499,7 +1499,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 signal;
       switch (request->signal_enum_case()) {
         case nidigitalpattern_grpc::ExportSignalRequest::SignalEnumCase::kSignal: {
@@ -1539,7 +1539,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto site = request->site().c_str();
       ViInt64 sample_index = request->sample_index();
       ViInt32 pattern_index {};
@@ -1573,7 +1573,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto site = request->site().c_str();
       auto pin_list = request->pin_list().c_str();
       ViInt64 sample_index = request->sample_index();
@@ -1623,7 +1623,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto site = request->site().c_str();
       ViInt64 sample_index = request->sample_index();
       ViInt64 scan_cycle_number {};
@@ -1649,7 +1649,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 measurement_mode;
       switch (request->measurement_mode_enum_case()) {
         case nidigitalpattern_grpc::FrequencyCounterConfigureMeasurementModeRequest::MeasurementModeEnumCase::kMeasurementMode: {
@@ -1687,7 +1687,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 measurement_time = request->measurement_time();
       auto status = library_->FrequencyCounterConfigureMeasurementTime(vi, channel_list, measurement_time);
@@ -1711,7 +1711,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 actual_num_frequencies {};
       while (true) {
@@ -1750,7 +1750,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute = request->attribute();
       ViBoolean value {};
@@ -1776,7 +1776,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute = request->attribute();
       ViInt32 value {};
@@ -1802,7 +1802,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute = request->attribute();
       ViInt64 value {};
@@ -1828,7 +1828,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute = request->attribute();
       ViReal64 value {};
@@ -1854,7 +1854,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute = request->attribute();
       ViSession value {};
@@ -1863,8 +1863,8 @@ namespace nidigitalpattern_grpc {
         return ConvertApiErrorStatusForViSession(context, status, vi);
       }
       response->set_status(status);
-      auto session_id = session_repository_->resolve_session_id(value);
-      response->mutable_value()->set_id(session_id);
+      auto grpc_device_session_name = session_repository_->resolve_session_name(value);
+      response->mutable_value()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -1881,7 +1881,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute = request->attribute();
 
@@ -1924,7 +1924,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 index = request->index();
 
       while (true) {
@@ -1966,7 +1966,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto indices = request->indices().c_str();
 
       while (true) {
@@ -2008,7 +2008,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetError(vi, nullptr, 0, nullptr);
@@ -2051,7 +2051,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 actual_num_read {};
       while (true) {
@@ -2090,7 +2090,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto site = request->site().c_str();
       ViInt64 sample_count {};
       auto status = library_->GetHistoryRAMSampleCount(vi, site, &sample_count);
@@ -2115,7 +2115,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 pattern_index = request->pattern_index();
 
       while (true) {
@@ -2157,7 +2157,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto start_label = request->start_label().c_str();
       ViInt32 actual_num_pins {};
       while (true) {
@@ -2196,7 +2196,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto start_label = request->start_label().c_str();
 
       while (true) {
@@ -2238,7 +2238,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 pin_index = request->pin_index();
 
       while (true) {
@@ -2280,7 +2280,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 actual_num_values {};
       while (true) {
@@ -2325,7 +2325,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto site_list = request->site_list().c_str();
       ViInt32 actual_num_sites {};
       while (true) {
@@ -2364,7 +2364,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto site_list = request->site_list().c_str();
       ViInt32 site_result_type;
       switch (request->site_result_type_enum_case()) {
@@ -2419,7 +2419,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto pin = request->pin().c_str();
       auto time_set_name = request->time_set_name().c_str();
       ViInt32 format {};
@@ -2446,7 +2446,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto pin = request->pin().c_str();
       auto time_set_name = request->time_set_name().c_str();
       ViInt32 edge;
@@ -2488,7 +2488,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto pin = request->pin().c_str();
       auto time_set_name = request->time_set_name().c_str();
       ViInt32 edge_multiplier {};
@@ -2514,7 +2514,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 time_set_index = request->time_set_index();
 
       while (true) {
@@ -2556,7 +2556,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto time_set_name = request->time_set_name().c_str();
       ViReal64 period {};
       auto status = library_->GetTimeSetPeriod(vi, time_set_name, &period);
@@ -2591,15 +2591,14 @@ namespace nidigitalpattern_grpc {
         auto status = library_->Init(resource_name, id_query, reset_device, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id, initialization_behavior, &new_session_initialized);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       response->set_new_session_initialized(new_session_initialized);
       return ::grpc::Status::OK;
     }
@@ -2628,15 +2627,14 @@ namespace nidigitalpattern_grpc {
         auto status = library_->InitWithOptions(resource_name, id_query, reset_device, option_string, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id, initialization_behavior, &new_session_initialized);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       response->set_new_session_initialized(new_session_initialized);
       return ::grpc::Status::OK;
     }
@@ -2654,7 +2652,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Initiate(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2676,7 +2674,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean done {};
       auto status = library_->IsDone(vi, &done);
       if (!status_ok(status)) {
@@ -2700,7 +2698,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto site = request->site().c_str();
       ViBoolean enable {};
       auto status = library_->IsSiteEnabled(vi, site, &enable);
@@ -2725,7 +2723,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto file_path = request->file_path().c_str();
       auto status = library_->LoadLevels(vi, file_path);
       if (!status_ok(status)) {
@@ -2748,7 +2746,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto file_path = request->file_path().c_str();
       auto status = library_->LoadPattern(vi, file_path);
       if (!status_ok(status)) {
@@ -2771,7 +2769,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto file_path = request->file_path().c_str();
       auto status = library_->LoadPinMap(vi, file_path);
       if (!status_ok(status)) {
@@ -2794,7 +2792,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto file_path = request->file_path().c_str();
       auto status = library_->LoadSpecifications(vi, file_path);
       if (!status_ok(status)) {
@@ -2817,7 +2815,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto file_path = request->file_path().c_str();
       auto status = library_->LoadTiming(vi, file_path);
       if (!status_ok(status)) {
@@ -2840,7 +2838,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto pin = request->pin().c_str();
       ViInt32 site = request->site();
       auto channel = request->channel().c_str();
@@ -2865,7 +2863,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 aperture_time = request->aperture_time();
       ViInt32 units;
@@ -2905,7 +2903,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 current_level = request->current_level();
       auto status = library_->PPMUConfigureCurrentLevel(vi, channel_list, current_level);
@@ -2929,7 +2927,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 range = request->range();
       auto status = library_->PPMUConfigureCurrentLevelRange(vi, channel_list, range);
@@ -2953,7 +2951,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 behavior;
       switch (request->behavior_enum_case()) {
@@ -2993,7 +2991,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 range = request->range();
       auto status = library_->PPMUConfigureCurrentLimitRange(vi, channel_list, range);
@@ -3017,7 +3015,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 output_function;
       switch (request->output_function_enum_case()) {
@@ -3056,7 +3054,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 voltage_level = request->voltage_level();
       auto status = library_->PPMUConfigureVoltageLevel(vi, channel_list, voltage_level);
@@ -3080,7 +3078,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 lower_voltage_limit = request->lower_voltage_limit();
       ViReal64 upper_voltage_limit = request->upper_voltage_limit();
@@ -3105,7 +3103,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 measurement_type;
       switch (request->measurement_type_enum_case()) {
@@ -3160,7 +3158,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       auto status = library_->PPMUSource(vi, channel_list);
       if (!status_ok(status)) {
@@ -3183,7 +3181,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto flag = request->flag().c_str();
       ViBoolean value {};
       auto status = library_->ReadSequencerFlag(vi, flag, &value);
@@ -3208,7 +3206,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto reg = request->reg().c_str();
       ViInt32 value {};
       auto status = library_->ReadSequencerRegister(vi, reg, &value);
@@ -3233,7 +3231,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 actual_num_read {};
       while (true) {
@@ -3273,7 +3271,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -3295,7 +3293,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(vi, channel_name, attribute_id);
@@ -3319,7 +3317,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ResetDevice(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -3341,7 +3339,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 function;
       switch (request->function_enum_case()) {
@@ -3380,7 +3378,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->SelfCalibrate(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -3402,7 +3400,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt16 test_result {};
       std::string test_message(2048 - 1, '\0');
       auto status = library_->SelfTest(vi, &test_result, (ViChar*)test_message.data());
@@ -3429,7 +3427,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 trigger;
       switch (request->trigger_enum_case()) {
         case nidigitalpattern_grpc::SendSoftwareEdgeTriggerRequest::TriggerEnumCase::kTrigger: {
@@ -3468,7 +3466,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute = request->attribute();
       ViBoolean value = request->value();
@@ -3493,7 +3491,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute = request->attribute();
       ViInt32 value;
@@ -3533,7 +3531,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute = request->attribute();
       ViInt64 value = request->value_raw();
@@ -3558,7 +3556,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute = request->attribute();
       ViReal64 value = request->value_raw();
@@ -3583,11 +3581,11 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute = request->attribute();
       auto value_grpc_session = request->value();
-      ViSession value = session_repository_->access_session(value_grpc_session.id(), value_grpc_session.name());
+      ViSession value = session_repository_->access_session(value_grpc_session.name());
       auto status = library_->SetAttributeViSession(vi, channel_list, attribute, value);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -3609,7 +3607,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute = request->attribute();
       auto value = request->value_raw().c_str();
@@ -3634,7 +3632,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViBoolean apply_offsets = request->apply_offsets();
       ViInt32 actual_num_offsets {};
@@ -3674,7 +3672,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean unload_keep_alive_pattern = request->unload_keep_alive_pattern();
       auto status = library_->UnloadAllPatterns(vi, unload_keep_alive_pattern);
       if (!status_ok(status)) {
@@ -3697,7 +3695,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto file_path = request->file_path().c_str();
       auto status = library_->UnloadSpecifications(vi, file_path);
       if (!status_ok(status)) {
@@ -3720,7 +3718,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 timeout = request->timeout();
       auto status = library_->WaitUntilDone(vi, timeout);
       if (!status_ok(status)) {
@@ -3743,7 +3741,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto flag = request->flag().c_str();
       ViBoolean value = request->value();
       auto status = library_->WriteSequencerFlag(vi, flag, value);
@@ -3773,7 +3771,7 @@ namespace nidigitalpattern_grpc {
         sessions_request.begin(),
         sessions_request.end(),
         std::back_inserter(sessions),
-        [&](auto session) { return session_repository_->access_session(session.id(), session.name()); }); 
+        [&](auto session) { return session_repository_->access_session(session.name()); }); 
       auto flag = request->flag().c_str();
       ViBoolean value = request->value();
       auto status = library_->WriteSequencerFlagSynchronized(session_count, sessions.data(), flag, value);
@@ -3797,7 +3795,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto reg = request->reg().c_str();
       ViInt32 value = request->value();
       auto status = library_->WriteSequencerRegister(vi, reg, value);
@@ -3821,7 +3819,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 waveform_size = static_cast<ViInt32>(request->waveform_data().size());
       auto waveform_data = const_cast<ViUInt32*>(reinterpret_cast<const ViUInt32*>(request->waveform_data().data()));
@@ -3846,7 +3844,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto waveform_name = request->waveform_name().c_str();
       auto waveform_file_path = request->waveform_file_path().c_str();
       auto status = library_->WriteSourceWaveformDataFromFileTDMS(vi, waveform_name, waveform_file_path);
@@ -3870,7 +3868,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto site_list = request->site_list().c_str();
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 num_waveforms = request->num_waveforms();
@@ -3897,7 +3895,7 @@ namespace nidigitalpattern_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViUInt8 state;
       switch (request->state_enum_case()) {

--- a/generated/nidmm/nidmm_service.cpp
+++ b/generated/nidmm/nidmm_service.cpp
@@ -54,7 +54,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Abort(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -76,7 +76,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean attribute_value = request->attribute_value();
@@ -101,7 +101,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 attribute_value;
@@ -141,7 +141,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 attribute_value;
@@ -189,11 +189,11 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto attribute_value_grpc_session = request->attribute_value();
-      ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.id(), attribute_value_grpc_session.name());
+      ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.name());
       auto status = library_->CheckAttributeViSession(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -215,7 +215,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViString attribute_value = (ViString)request->attribute_value_raw().c_str();
@@ -240,7 +240,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ClearError(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -262,7 +262,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ClearInterchangeWarnings(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -284,8 +284,8 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      session_repository_->remove_session(vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -307,7 +307,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 ac_minimum_frequency_hz = request->ac_minimum_frequency_hz();
       ViReal64 ac_maximum_frequency_hz = request->ac_maximum_frequency_hz();
       auto status = library_->ConfigureACBandwidth(vi, ac_minimum_frequency_hz, ac_maximum_frequency_hz);
@@ -331,7 +331,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 adc_calibration = request->adc_calibration();
       auto status = library_->ConfigureADCCalibration(vi, adc_calibration);
       if (!status_ok(status)) {
@@ -354,7 +354,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 auto_zero_mode = request->auto_zero_mode();
       auto status = library_->ConfigureAutoZeroMode(vi, auto_zero_mode);
       if (!status_ok(status)) {
@@ -377,7 +377,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 cable_comp_type = request->cable_comp_type();
       auto status = library_->ConfigureCableCompType(vi, cable_comp_type);
       if (!status_ok(status)) {
@@ -400,7 +400,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 current_source = request->current_source();
       auto status = library_->ConfigureCurrentSource(vi, current_source);
       if (!status_ok(status)) {
@@ -423,7 +423,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 fixed_reference_junction = request->fixed_reference_junction();
       auto status = library_->ConfigureFixedRefJunction(vi, fixed_reference_junction);
       if (!status_ok(status)) {
@@ -446,7 +446,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 voltage_range;
       switch (request->voltage_range_enum_case()) {
         case nidmm_grpc::ConfigureFrequencyVoltageRangeRequest::VoltageRangeEnumCase::kVoltageRange: {
@@ -484,7 +484,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 meas_complete_destination = request->meas_complete_destination();
       auto status = library_->ConfigureMeasCompleteDest(vi, meas_complete_destination);
       if (!status_ok(status)) {
@@ -507,7 +507,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 meas_complete_slope = request->meas_complete_slope();
       auto status = library_->ConfigureMeasCompleteSlope(vi, meas_complete_slope);
       if (!status_ok(status)) {
@@ -530,7 +530,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 measurement_function;
       switch (request->measurement_function_enum_case()) {
         case nidmm_grpc::ConfigureMeasurementAbsoluteRequest::MeasurementFunctionEnumCase::kMeasurementFunction: {
@@ -570,7 +570,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 measurement_function;
       switch (request->measurement_function_enum_case()) {
         case nidmm_grpc::ConfigureMeasurementDigitsRequest::MeasurementFunctionEnumCase::kMeasurementFunction: {
@@ -610,7 +610,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 trigger_count;
       switch (request->trigger_count_enum_case()) {
         case nidmm_grpc::ConfigureMultiPointRequest::TriggerCountEnumCase::kTriggerCount: {
@@ -696,7 +696,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 offset_comp_ohms;
       switch (request->offset_comp_ohms_enum_case()) {
         case nidmm_grpc::ConfigureOffsetCompOhmsRequest::OffsetCompOhmsEnumCase::kOffsetCompOhms: {
@@ -734,7 +734,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 conductance = request->conductance();
       ViReal64 susceptance = request->susceptance();
       auto status = library_->ConfigureOpenCableCompValues(vi, conductance, susceptance);
@@ -758,7 +758,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 power_line_frequency_hz;
       switch (request->power_line_frequency_hz_enum_case()) {
         case nidmm_grpc::ConfigurePowerLineFrequencyRequest::PowerLineFrequencyHzEnumCase::kPowerLineFrequencyHz: {
@@ -796,7 +796,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 rtd_a = request->rtd_a();
       ViReal64 rtd_b = request->rtd_b();
       ViReal64 rtd_c = request->rtd_c();
@@ -821,7 +821,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 rtd_type;
       switch (request->rtd_type_enum_case()) {
         case nidmm_grpc::ConfigureRTDTypeRequest::RtdTypeEnumCase::kRtdType: {
@@ -860,7 +860,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 sample_trigger_slope;
       switch (request->sample_trigger_slope_enum_case()) {
         case nidmm_grpc::ConfigureSampleTriggerSlopeRequest::SampleTriggerSlopeEnumCase::kSampleTriggerSlope: {
@@ -898,7 +898,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 resistance = request->resistance();
       ViReal64 reactance = request->reactance();
       auto status = library_->ConfigureShortCableCompValues(vi, resistance, reactance);
@@ -922,7 +922,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 thermistor_a = request->thermistor_a();
       ViReal64 thermistor_b = request->thermistor_b();
       ViReal64 thermistor_c = request->thermistor_c();
@@ -947,7 +947,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 thermistor_type = request->thermistor_type();
       auto status = library_->ConfigureThermistorType(vi, thermistor_type);
       if (!status_ok(status)) {
@@ -970,7 +970,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 thermocouple_type;
       switch (request->thermocouple_type_enum_case()) {
         case nidmm_grpc::ConfigureThermocoupleRequest::ThermocoupleTypeEnumCase::kThermocoupleType: {
@@ -1024,7 +1024,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 transducer_type = request->transducer_type();
       auto status = library_->ConfigureTransducerType(vi, transducer_type);
       if (!status_ok(status)) {
@@ -1047,7 +1047,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 trigger_source;
       switch (request->trigger_source_enum_case()) {
         case nidmm_grpc::ConfigureTriggerRequest::TriggerSourceEnumCase::kTriggerSource: {
@@ -1101,7 +1101,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 trigger_slope;
       switch (request->trigger_slope_enum_case()) {
         case nidmm_grpc::ConfigureTriggerSlopeRequest::TriggerSlopeEnumCase::kTriggerSlope: {
@@ -1139,7 +1139,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 measurement_function;
       switch (request->measurement_function_enum_case()) {
         case nidmm_grpc::ConfigureWaveformAcquisitionRequest::MeasurementFunctionEnumCase::kMeasurementFunction: {
@@ -1180,7 +1180,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 waveform_coupling = request->waveform_coupling();
       auto status = library_->ConfigureWaveformCoupling(vi, waveform_coupling);
       if (!status_ok(status)) {
@@ -1203,7 +1203,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 control_action;
       switch (request->control_action_enum_case()) {
         case nidmm_grpc::ControlRequest::ControlActionEnumCase::kControlAction: {
@@ -1241,7 +1241,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Disable(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1263,7 +1263,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
@@ -1300,7 +1300,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto file_path = request->file_path().c_str();
       auto status = library_->ExportAttributeConfigurationFile(vi, file_path);
       if (!status_ok(status)) {
@@ -1323,7 +1323,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 maximum_time;
       switch (request->maximum_time_enum_case()) {
         case nidmm_grpc::FetchRequest::MaximumTimeEnumCase::kMaximumTime: {
@@ -1363,7 +1363,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 maximum_time;
       switch (request->maximum_time_enum_case()) {
         case nidmm_grpc::FetchMultiPointRequest::MaximumTimeEnumCase::kMaximumTime: {
@@ -1406,7 +1406,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 maximum_time;
       switch (request->maximum_time_enum_case()) {
         case nidmm_grpc::FetchWaveformRequest::MaximumTimeEnumCase::kMaximumTime: {
@@ -1449,7 +1449,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 aperture_time {};
       ViInt32 aperture_time_units {};
       auto status = library_->GetApertureTimeInfo(vi, &aperture_time, &aperture_time_units);
@@ -1479,7 +1479,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean attribute_value {};
@@ -1505,7 +1505,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 attribute_value {};
@@ -1531,7 +1531,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 attribute_value {};
@@ -1557,7 +1557,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViSession attribute_value {};
@@ -1566,8 +1566,8 @@ namespace nidmm_grpc {
         return ConvertApiErrorStatusForViSession(context, status, vi);
       }
       response->set_status(status);
-      auto session_id = session_repository_->resolve_session_id(attribute_value);
-      response->mutable_attribute_value()->set_id(session_id);
+      auto grpc_device_session_name = session_repository_->resolve_session_name(attribute_value);
+      response->mutable_attribute_value()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -1584,7 +1584,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
 
@@ -1627,7 +1627,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 actual_range {};
       auto status = library_->GetAutoRangeValue(vi, &actual_range);
       if (!status_ok(status)) {
@@ -1651,7 +1651,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 cal_type;
       switch (request->cal_type_enum_case()) {
         case nidmm_grpc::GetCalDateAndTimeRequest::CalTypeEnumCase::kCalType: {
@@ -1699,7 +1699,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 index = request->index();
 
       while (true) {
@@ -1741,7 +1741,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViString options = (ViString)request->options().c_str();
       ViReal64 temperature {};
       auto status = library_->GetDevTemp(vi, options, &temperature);
@@ -1766,7 +1766,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetError(vi, nullptr, 0, nullptr);
@@ -1809,7 +1809,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViStatus error_code = request->error_code();
 
       while (true) {
@@ -1851,7 +1851,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 months {};
       auto status = library_->GetExtCalRecommendedInterval(vi, &months);
       if (!status_ok(status)) {
@@ -1875,7 +1875,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 cal_type;
       switch (request->cal_type_enum_case()) {
         case nidmm_grpc::GetLastCalTempRequest::CalTypeEnumCase::kCalType: {
@@ -1915,7 +1915,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 period {};
       auto status = library_->GetMeasurementPeriod(vi, &period);
       if (!status_ok(status)) {
@@ -1939,7 +1939,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetNextCoercionRecord(vi, 0, nullptr);
@@ -1980,7 +1980,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetNextInterchangeWarning(vi, 0, nullptr);
@@ -2021,7 +2021,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean self_cal_supported {};
       auto status = library_->GetSelfCalSupported(vi, &self_cal_supported);
       if (!status_ok(status)) {
@@ -2045,7 +2045,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 size = static_cast<ViInt32>(request->configuration().size());
       ViInt8* configuration = (ViInt8*)request->configuration().c_str();
       auto status = library_->ImportAttributeConfigurationBuffer(vi, size, configuration);
@@ -2069,7 +2069,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto file_path = request->file_path().c_str();
       auto status = library_->ImportAttributeConfigurationFile(vi, file_path);
       if (!status_ok(status)) {
@@ -2102,15 +2102,14 @@ namespace nidmm_grpc {
         auto status = library_->Init(resource_name, id_query, reset_device, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id, initialization_behavior, &new_session_initialized);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       response->set_new_session_initialized(new_session_initialized);
       return ::grpc::Status::OK;
     }
@@ -2139,15 +2138,14 @@ namespace nidmm_grpc {
         auto status = library_->InitWithOptions(resource_name, id_query, reset_device, option_string, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id, initialization_behavior, &new_session_initialized);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       response->set_new_session_initialized(new_session_initialized);
       return ::grpc::Status::OK;
     }
@@ -2165,7 +2163,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Initiate(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2187,7 +2185,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->InvalidateAllAttributes(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2209,7 +2207,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 measurement_value = request->measurement_value();
       ViBoolean is_over_range {};
       auto status = library_->IsOverRange(vi, measurement_value, &is_over_range);
@@ -2234,7 +2232,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 measurement_value = request->measurement_value();
       ViBoolean is_under_range {};
       auto status = library_->IsUnderRange(vi, measurement_value, &is_under_range);
@@ -2259,7 +2257,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 conductance {};
       ViReal64 susceptance {};
       auto status = library_->PerformOpenCableComp(vi, &conductance, &susceptance);
@@ -2285,7 +2283,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 resistance {};
       ViReal64 reactance {};
       auto status = library_->PerformShortCableComp(vi, &resistance, &reactance);
@@ -2311,7 +2309,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 maximum_time;
       switch (request->maximum_time_enum_case()) {
         case nidmm_grpc::ReadRequest::MaximumTimeEnumCase::kMaximumTime: {
@@ -2351,7 +2349,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 maximum_time;
       switch (request->maximum_time_enum_case()) {
         case nidmm_grpc::ReadMultiPointRequest::MaximumTimeEnumCase::kMaximumTime: {
@@ -2394,7 +2392,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 acquisition_backlog {};
       ViInt16 acquisition_status {};
       auto status = library_->ReadStatus(vi, &acquisition_backlog, &acquisition_status);
@@ -2421,7 +2419,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 maximum_time;
       switch (request->maximum_time_enum_case()) {
         case nidmm_grpc::ReadWaveformRequest::MaximumTimeEnumCase::kMaximumTime: {
@@ -2464,7 +2462,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2486,7 +2484,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ResetInterchangeCheck(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2508,7 +2506,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ResetWithDefaults(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2530,7 +2528,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       std::string instrument_driver_revision(256 - 1, '\0');
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
@@ -2558,7 +2556,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->SelfCal(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2580,7 +2578,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt16 self_test_result {};
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
@@ -2607,7 +2605,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->SendSoftwareTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2629,7 +2627,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean attribute_value = request->attribute_value();
@@ -2654,7 +2652,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 attribute_value;
@@ -2694,7 +2692,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 attribute_value;
@@ -2742,11 +2740,11 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto attribute_value_grpc_session = request->attribute_value();
-      ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.id(), attribute_value_grpc_session.name());
+      ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.name());
       auto status = library_->SetAttributeViSession(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2768,7 +2766,7 @@ namespace nidmm_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViString attribute_value = (ViString)request->attribute_value_raw().c_str();

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -63,7 +63,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Abort(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -85,7 +85,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 count = static_cast<ViInt32>(request->delays().size());
       auto delays = const_cast<ViReal64*>(request->delays().data());
       auto status = library_->AcceptListOfDurationsInSeconds(vi, count, delays);
@@ -115,7 +115,7 @@ namespace nifake_grpc {
         session_array_request.begin(),
         session_array_request.end(),
         std::back_inserter(session_array),
-        [&](auto session) { return session_repository_->access_session(session.id(), session.name()); }); 
+        [&](auto session) { return session_repository_->access_session(session.name()); }); 
       auto status = library_->AcceptViSessionArray(session_count, session_array.data());
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
@@ -137,7 +137,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 array_len = static_cast<ViInt32>(request->u_int32_array().size());
       auto u_int32_array = const_cast<ViUInt32*>(reinterpret_cast<const ViUInt32*>(request->u_int32_array().data()));
       auto status = library_->AcceptViUInt32Array(vi, array_len, u_int32_array);
@@ -161,7 +161,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 number_of_elements = request->number_of_elements();
       auto an_array = convert_from_grpc<ViBoolean>(request->an_array());
       auto status = library_->BoolArrayInputFunction(vi, number_of_elements, an_array.data());
@@ -185,7 +185,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 number_of_elements = request->number_of_elements();
       std::vector<ViBoolean> an_array(number_of_elements, ViBoolean());
       auto status = library_->BoolArrayOutputFunction(vi, number_of_elements, an_array.data());
@@ -210,8 +210,8 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      session_repository_->remove_session(vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -233,9 +233,9 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 action = request->action();
-      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
+      session_repository_->remove_session(vi_grpc_session.name());
       auto status = library_->CloseExtCal(vi, action);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -257,7 +257,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto reserved = nullptr;
       auto status = library_->CommandWithReservedParam(vi, reserved);
       if (!status_ok(status)) {
@@ -347,7 +347,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 number_count = static_cast<ViInt32>(request->numbers().size());
       auto numbers = const_cast<ViReal64*>(request->numbers().data());
       auto status = library_->DoubleAllTheNums(vi, number_count, numbers);
@@ -386,7 +386,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt16 a_turtle;
       switch (request->a_turtle_enum_case()) {
         case nifake_grpc::EnumInputFunctionWithDefaultsRequest::ATurtleEnumCase::kATurtle: {
@@ -424,7 +424,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViStatus error_code = request->error_code();
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
@@ -450,7 +450,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
@@ -487,7 +487,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 number_of_samples = request->number_of_samples();
       response->mutable_waveform_data()->Resize(number_of_samples, 0);
       ViReal64* waveform_data = response->mutable_waveform_data()->mutable_data();
@@ -514,7 +514,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean a_boolean {};
       auto status = library_->GetABoolean(vi, &a_boolean);
       if (!status_ok(status)) {
@@ -538,7 +538,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt16 a_number {};
       auto status = library_->GetANumber(vi, &a_number);
       if (!status_ok(status)) {
@@ -562,7 +562,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       std::string a_string(256 - 1, '\0');
       auto status = library_->GetAStringOfFixedMaximumSize(vi, (ViChar*)a_string.data());
       if (!status_ok(status)) {
@@ -587,7 +587,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetAnIviDanceString(vi, 0, nullptr);
@@ -628,7 +628,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto a_string = request->a_string().c_str();
       ViInt32 actual_size {};
       while (true) {
@@ -667,7 +667,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 actual_size {};
       while (true) {
         auto status = library_->GetAnIviDanceWithATwistArrayOfCustomType(vi, 0, nullptr, &actual_size);
@@ -785,7 +785,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 actual_size {};
       while (true) {
         auto status = library_->GetAnIviDanceWithATwistString(vi, 0, nullptr, &actual_size);
@@ -865,7 +865,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 size_out {};
       auto status = library_->GetArraySizeForCustomCode(vi, &size_out);
       if (!status_ok(status)) {
@@ -889,7 +889,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetArrayUsingIviDance(vi, 0, nullptr);
@@ -926,7 +926,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 array_len = request->array_len();
       std::string u_int8_enum_array(array_len, '\0');
       auto status = library_->GetArrayViUInt8WithEnum(vi, array_len, (ViUInt8*)u_int8_enum_array.data());
@@ -952,7 +952,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean attribute_value {};
@@ -978,7 +978,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 attribute_value {};
@@ -1004,7 +1004,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt64 attribute_value {};
@@ -1030,7 +1030,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 attribute_value {};
@@ -1056,7 +1056,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViSession attribute_value {};
@@ -1065,8 +1065,8 @@ namespace nifake_grpc {
         return ConvertApiErrorStatusForViSession(context, status, vi);
       }
       response->set_status(status);
-      auto session_id = session_repository_->resolve_session_id(attribute_value);
-      response->mutable_attribute_value()->set_id(session_id);
+      auto grpc_device_session_name = session_repository_->resolve_session_name(attribute_value);
+      response->mutable_attribute_value()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -1083,7 +1083,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
 
@@ -1156,7 +1156,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 cal_type = request->cal_type();
       ViInt32 month {};
       ViInt32 day {};
@@ -1189,7 +1189,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 months {};
       auto status = library_->GetCalInterval(vi, &months);
       if (!status_ok(status)) {
@@ -1213,7 +1213,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       CustomStruct cs {};
       auto status = library_->GetCustomType(vi, &cs);
       if (!status_ok(status)) {
@@ -1237,7 +1237,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 number_of_elements = request->number_of_elements();
       std::vector<CustomStruct> cs(number_of_elements, CustomStruct());
       auto status = library_->GetCustomTypeArray(vi, number_of_elements, cs.data());
@@ -1262,7 +1262,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 a_quantity {};
       ViInt16 a_turtle {};
       auto status = library_->GetEnumValue(vi, &a_quantity, &a_turtle);
@@ -1289,7 +1289,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetError(vi, nullptr, 0, nullptr);
@@ -1332,7 +1332,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 array_len = request->array_len();
       response->mutable_int32_array()->Resize(array_len, 0);
       ViInt32* int32_array = reinterpret_cast<ViInt32*>(response->mutable_int32_array()->mutable_data());
@@ -1357,7 +1357,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 array_len = request->array_len();
       response->mutable_u_int32_array()->Resize(array_len, 0);
       ViUInt32* u_int32_array = reinterpret_cast<ViUInt32*>(response->mutable_u_int32_array()->mutable_data());
@@ -1382,7 +1382,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViUInt8 a_uint8_number {};
       auto status = library_->GetViUInt8(vi, &a_uint8_number);
       if (!status_ok(status)) {
@@ -1406,7 +1406,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 size_in_bytes = static_cast<ViInt32>(request->configuration().size());
       ViInt8* configuration = (ViInt8*)request->configuration().c_str();
       auto status = library_->ImportAttributeConfigurationBuffer(vi, size_in_bytes, configuration);
@@ -1437,15 +1437,14 @@ namespace nifake_grpc {
         auto status = library_->InitExtCal(resource_name, calibration_password, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->CloseExtCal(id, 0); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -1473,15 +1472,14 @@ namespace nifake_grpc {
         auto status = library_->InitWithOptions(resource_name, id_query, reset_device, option_string, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id, initialization_behavior, &new_session_initialized);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       response->set_new_session_initialized(new_session_initialized);
       return ::grpc::Status::OK;
     }
@@ -1525,15 +1523,14 @@ namespace nifake_grpc {
         auto status = library_->InitWithVarArgs(resource_name, &vi, get_stringArg_if(name_and_turtle, 0), get_turtle_if(name_and_turtle, 0), get_stringArg_if(name_and_turtle, 1), get_turtle_if(name_and_turtle, 1), get_stringArg_if(name_and_turtle, 2), get_turtle_if(name_and_turtle, 2), get_stringArg_if(name_and_turtle, 3), get_turtle_if(name_and_turtle, 3));
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -1726,7 +1723,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 output_array_size = request->output_array_size();
       auto input_array_sizes_determine_from_sizes = std::array<int, 2>
       {
@@ -1773,7 +1770,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto values1 = const_cast<ViReal64*>(request->values1().data());
       auto values2 = const_cast<ViReal64*>(request->values2().data());
       auto values3 = const_cast<ViReal64*>(request->values3().data());
@@ -1813,7 +1810,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto values1 = const_cast<ViReal64*>(request->values1().data());
       auto values2 = const_cast<ViReal64*>(request->values2().data());
       auto values3 = const_cast<ViReal64*>(request->values3().data());
@@ -1863,7 +1860,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 a_number = request->a_number();
       auto status = library_->OneInputFunction(vi, a_number);
       if (!status_ok(status)) {
@@ -1886,7 +1883,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean a_boolean = request->a_boolean();
       ViInt32 an_int32 = request->an_int32();
       ViInt64 an_int64 = request->an_int64();
@@ -1950,7 +1947,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->PoorlyNamedSimpleFunction(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1972,7 +1969,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 maximum_time = request->maximum_time();
       ViReal64 reading {};
       auto status = library_->Read(vi, maximum_time, &reading);
@@ -2074,7 +2071,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 maximum_time = request->maximum_time();
       ViReal64 reading {};
@@ -2100,7 +2097,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt16 a_number {};
       std::string a_string(256 - 1, '\0');
       auto status = library_->ReturnANumberAndAString(vi, &a_number, (ViChar*)a_string.data());
@@ -2127,7 +2124,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 timedelta {};
       auto status = library_->ReturnDurationInSeconds(vi, &timedelta);
       if (!status_ok(status)) {
@@ -2151,7 +2148,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 number_of_elements = request->number_of_elements();
       response->mutable_timedeltas()->Resize(number_of_elements, 0);
       ViReal64* timedeltas = response->mutable_timedeltas()->mutable_data();
@@ -2176,7 +2173,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 array_size = request->array_size();
 
       while (true) {
@@ -2237,7 +2234,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean attribute_value = request->attribute_value();
@@ -2262,7 +2259,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 attribute_value;
@@ -2302,7 +2299,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt64 attribute_value = request->attribute_value_raw();
@@ -2327,7 +2324,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 attribute_value;
@@ -2371,7 +2368,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto attribute_value = request->attribute_value_raw().c_str();
@@ -2396,7 +2393,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto cs = convert_from_grpc<CustomStruct>(request->cs());
       auto status = library_->SetCustomType(vi, cs);
       if (!status_ok(status)) {
@@ -2419,7 +2416,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 number_of_elements = static_cast<ViInt32>(request->cs().size());
       auto cs = convert_from_grpc<CustomStruct>(request->cs());
       auto status = library_->SetCustomTypeArray(vi, number_of_elements, cs.data());
@@ -2443,7 +2440,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViConstString a_mobile_os_name;
       switch (request->a_mobile_os_name_enum_case()) {
         case nifake_grpc::StringValuedEnumInputFunctionWithDefaultsRequest::AMobileOsNameEnumCase::kAMobileOsNameMapped: {
@@ -2485,7 +2482,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 a_number = request->a_number();
       ViString a_string = (ViString)request->a_string().c_str();
       auto status = library_->TwoInputFunction(vi, a_number, a_string);
@@ -2509,7 +2506,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt64 input = request->input();
       ViInt64 output {};
       auto status = library_->Use64BitNumber(vi, input, &output);
@@ -2534,7 +2531,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto array = const_cast<ViInt32*>(reinterpret_cast<const ViInt32*>(request->array().data()));
       auto total_length = std::accumulate(request->array_lengths().cbegin(), request->array_lengths().cend(), 0);
 
@@ -2565,7 +2562,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 number_of_elements = static_cast<ViInt32>(request->an_array().size());
       auto an_array_request = request->an_array();
       std::vector<ViInt16> an_array;
@@ -2595,7 +2592,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 number_of_elements = request->number_of_elements();
       ViUInt8* an_array = (ViUInt8*)request->an_array().c_str();
       auto status = library_->ViUInt8ArrayInputFunction(vi, number_of_elements, an_array);
@@ -2619,7 +2616,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 number_of_elements = request->number_of_elements();
       std::string an_array(number_of_elements, '\0');
       auto status = library_->ViUInt8ArrayOutputFunction(vi, number_of_elements, (ViUInt8*)an_array.data());
@@ -2644,7 +2641,7 @@ namespace nifake_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 number_of_samples = static_cast<ViInt32>(request->waveform().size());
       auto waveform = const_cast<ViReal64*>(request->waveform().data());
       auto status = library_->WriteWaveform(vi, number_of_samples, waveform);

--- a/generated/nifake_extension/nifake_extension_service.cpp
+++ b/generated/nifake_extension/nifake_extension_service.cpp
@@ -50,7 +50,7 @@ namespace nifake_extension_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 param = request->param();
       auto status = library_->AddCoolFunctionality(vi, param);
       if (!status_ok(status)) {

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -114,7 +114,7 @@ namespace nifake_non_ivi_grpc {
         int status = library_->GetCrossDriverSession(handle, &cross_driver_session);
         return std::make_tuple(status, cross_driver_session);
       };
-      std::string session_name;
+      std::string session_name = request->session_name();
       int status = fake_cross_driver_handle_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_name);
       response->set_status(status);
       if (status == 0) {

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.cpp
@@ -60,8 +60,8 @@ namespace nifake_non_ivi_grpc {
     }
     try {
       auto handle_grpc_session = request->handle();
-      FakeHandle handle = session_repository_->access_session(handle_grpc_session.id(), handle_grpc_session.name());
-      session_repository_->remove_session(handle_grpc_session.id(), handle_grpc_session.name());
+      FakeHandle handle = session_repository_->access_session(handle_grpc_session.name());
+      session_repository_->remove_session(handle_grpc_session.name());
       auto status = library_->Close(handle);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForFakeHandle(context, status, handle);
@@ -83,8 +83,8 @@ namespace nifake_non_ivi_grpc {
     }
     try {
       auto secondary_session_handle_grpc_session = request->secondary_session_handle();
-      SecondarySessionHandle secondary_session_handle = secondary_session_handle_resource_repository_->access_session(secondary_session_handle_grpc_session.id(), secondary_session_handle_grpc_session.name());
-      secondary_session_handle_resource_repository_->remove_session(secondary_session_handle_grpc_session.id(), secondary_session_handle_grpc_session.name());
+      SecondarySessionHandle secondary_session_handle = secondary_session_handle_resource_repository_->access_session(secondary_session_handle_grpc_session.name());
+      secondary_session_handle_resource_repository_->remove_session(secondary_session_handle_grpc_session.name());
       auto status = library_->CloseSecondarySession(secondary_session_handle);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForSecondarySessionHandle(context, status, secondary_session_handle);
@@ -106,20 +106,19 @@ namespace nifake_non_ivi_grpc {
     }
     try {
       auto handle_grpc_session = request->handle();
-      FakeHandle handle = session_repository_->access_session(handle_grpc_session.id(), handle_grpc_session.name());
+      FakeHandle handle = session_repository_->access_session(handle_grpc_session.name());
 
-      auto initiating_session_id = session_repository_->access_session_id(handle_grpc_session.id(), handle_grpc_session.name());
+      auto initiating_session_name = handle_grpc_session.name();
       auto init_lambda = [&] () {
         FakeCrossDriverHandle cross_driver_session;
         int status = library_->GetCrossDriverSession(handle, &cross_driver_session);
         return std::make_tuple(status, cross_driver_session);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
-      int status = fake_cross_driver_handle_resource_repository_->add_dependent_session(grpc_device_session_name, init_lambda, initiating_session_id, session_id);
+      std::string session_name;
+      int status = fake_cross_driver_handle_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_name);
       response->set_status(status);
       if (status == 0) {
-        response->mutable_cross_driver_session()->set_id(session_id);
+        response->mutable_cross_driver_session()->set_name(session_name);
       }
       return ::grpc::Status::OK;
     }
@@ -200,7 +199,7 @@ namespace nifake_non_ivi_grpc {
     }
     try {
       auto handle_grpc_session = request->handle();
-      FakeHandle handle = session_repository_->access_session(handle_grpc_session.id(), handle_grpc_session.name());
+      FakeHandle handle = session_repository_->access_session(handle_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nifake_non_ivi_grpc::GetMarbleAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
@@ -243,7 +242,7 @@ namespace nifake_non_ivi_grpc {
     }
     try {
       auto handle_grpc_session = request->handle();
-      FakeHandle handle = session_repository_->access_session(handle_grpc_session.id(), handle_grpc_session.name());
+      FakeHandle handle = session_repository_->access_session(handle_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nifake_non_ivi_grpc::GetMarbleAttributeInt32Request::AttributeEnumCase::kAttribute: {
@@ -292,7 +291,7 @@ namespace nifake_non_ivi_grpc {
     }
     try {
       auto handle_grpc_session = request->handle();
-      FakeHandle handle = session_repository_->access_session(handle_grpc_session.id(), handle_grpc_session.name());
+      FakeHandle handle = session_repository_->access_session(handle_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nifake_non_ivi_grpc::GetMarbleAttributeInt32ArrayRequest::AttributeEnumCase::kAttribute: {
@@ -355,15 +354,14 @@ namespace nifake_non_ivi_grpc {
         auto status = library_->Init(session_name, &handle);
         return std::make_tuple(status, handle);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (FakeHandle id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForFakeHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_handle()->set_id(session_id);
+      response->mutable_handle()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -380,22 +378,21 @@ namespace nifake_non_ivi_grpc {
     }
     try {
       auto cross_driver_session_grpc_session = request->cross_driver_session();
-      int32 cross_driver_session = fake_cross_driver_handle_resource_repository_->access_session(cross_driver_session_grpc_session.id(), cross_driver_session_grpc_session.name());
+      int32 cross_driver_session = fake_cross_driver_handle_resource_repository_->access_session(cross_driver_session_grpc_session.name());
 
       auto init_lambda = [&] () {
         FakeHandle handle;
         auto status = library_->InitFromCrossDriverSession(cross_driver_session, &handle);
         return std::make_tuple(status, handle);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (FakeHandle id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForFakeHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_handle()->set_id(session_id);
+      response->mutable_handle()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -417,7 +414,7 @@ namespace nifake_non_ivi_grpc {
         cross_driver_session_array_request.begin(),
         cross_driver_session_array_request.end(),
         std::back_inserter(cross_driver_session_array),
-        [&](auto session) { return fake_cross_driver_handle_resource_repository_->access_session(session.id(), session.name()); }); 
+        [&](auto session) { return fake_cross_driver_handle_resource_repository_->access_session(session.name()); }); 
       int32 number_of_cross_driver_sessions = static_cast<int32>(request->cross_driver_session_array().size());
 
       auto init_lambda = [&] () {
@@ -425,15 +422,14 @@ namespace nifake_non_ivi_grpc {
         auto status = library_->InitFromCrossDriverSessionArray(cross_driver_session_array.data(), number_of_cross_driver_sessions, &handle);
         return std::make_tuple(status, handle);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (FakeHandle id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForFakeHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_handle()->set_id(session_id);
+      response->mutable_handle()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -455,15 +451,14 @@ namespace nifake_non_ivi_grpc {
         auto status = library_->InitSecondarySession(&secondary_session_handle);
         return std::make_tuple(status, secondary_session_handle);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (SecondarySessionHandle id) { library_->CloseSecondarySession(id); };
-      int status = secondary_session_handle_resource_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = secondary_session_handle_resource_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForFakeHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_secondary_session_handle()->set_id(session_id);
+      response->mutable_secondary_session_handle()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -486,15 +481,14 @@ namespace nifake_non_ivi_grpc {
         auto status = library_->InitWithHandleNameAsSessionName(handle_name, &handle);
         return std::make_tuple(status, handle);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->handle_name();
+      std::string grpc_device_session_name = request->handle_name();
       auto cleanup_lambda = [&] (FakeHandle id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForFakeHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_handle()->set_id(session_id);
+      response->mutable_handle()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -517,15 +511,14 @@ namespace nifake_non_ivi_grpc {
         auto status = handle == 0xDEADBEEF ? -1 : 0;
         return std::make_tuple(status, handle);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->handle_name();
+      std::string grpc_device_session_name = request->handle_name();
       auto cleanup_lambda = [&] (FakeHandle id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForFakeHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_handle()->set_id(session_id);
+      response->mutable_handle()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -961,7 +954,7 @@ namespace nifake_non_ivi_grpc {
     }
     try {
       auto handle_grpc_session = request->handle();
-      FakeHandle handle = session_repository_->access_session(handle_grpc_session.id(), handle_grpc_session.name());
+      FakeHandle handle = session_repository_->access_session(handle_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nifake_non_ivi_grpc::ResetMarbleAttributeRequest::AttributeEnumCase::kAttribute: {
@@ -1052,7 +1045,7 @@ namespace nifake_non_ivi_grpc {
     }
     try {
       auto handle_grpc_session = request->handle();
-      FakeHandle handle = session_repository_->access_session(handle_grpc_session.id(), handle_grpc_session.name());
+      FakeHandle handle = session_repository_->access_session(handle_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nifake_non_ivi_grpc::SetMarbleAttributeDoubleRequest::AttributeEnumCase::kAttribute: {
@@ -1094,7 +1087,7 @@ namespace nifake_non_ivi_grpc {
     }
     try {
       auto handle_grpc_session = request->handle();
-      FakeHandle handle = session_repository_->access_session(handle_grpc_session.id(), handle_grpc_session.name());
+      FakeHandle handle = session_repository_->access_session(handle_grpc_session.name());
       int32 attribute;
       switch (request->attribute_enum_case()) {
         case nifake_non_ivi_grpc::SetMarbleAttributeInt32Request::AttributeEnumCase::kAttribute: {

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -54,7 +54,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->AbortGeneration(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -76,7 +76,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 adjustment_time = request->adjustment_time();
       auto status = library_->AdjustSampleClockRelativeDelay(vi, adjustment_time);
       if (!status_ok(status)) {
@@ -99,7 +99,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 waveform_size = request->waveform_size();
@@ -124,7 +124,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 waveform_size = request->waveform_size();
       ViInt32 waveform_handle {};
@@ -150,7 +150,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean attribute_value = request->attribute_value();
@@ -175,7 +175,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 attribute_value;
@@ -215,7 +215,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt64 attribute_value = request->attribute_value_raw();
@@ -240,7 +240,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 attribute_value;
@@ -280,11 +280,11 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto attribute_value_grpc_session = request->attribute_value();
-      ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.id(), attribute_value_grpc_session.name());
+      ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.name());
       auto status = library_->CheckAttributeViSession(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -306,7 +306,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViConstString attribute_value;
@@ -350,7 +350,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ClearArbMemory(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -372,7 +372,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 sequence_handle;
       switch (request->sequence_handle_enum_case()) {
         case nifgen_grpc::ClearArbSequenceRequest::SequenceHandleEnumCase::kSequenceHandle: {
@@ -410,7 +410,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 waveform_handle;
       switch (request->waveform_handle_enum_case()) {
         case nifgen_grpc::ClearArbWaveformRequest::WaveformHandleEnumCase::kWaveformHandle: {
@@ -448,7 +448,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ClearError(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -470,7 +470,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 frequency_list_handle;
       switch (request->frequency_list_handle_enum_case()) {
         case nifgen_grpc::ClearFreqListRequest::FrequencyListHandleEnumCase::kFrequencyListHandle: {
@@ -508,7 +508,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ClearInterchangeWarnings(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -530,7 +530,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->ClearUserStandardWaveform(vi, channel_name);
       if (!status_ok(status)) {
@@ -553,8 +553,8 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      session_repository_->remove_session(vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -576,7 +576,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Commit(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -598,7 +598,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 amplitude = request->amplitude();
       auto status = library_->ConfigureAmplitude(vi, channel_name, amplitude);
@@ -622,7 +622,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 sequence_handle = request->sequence_handle();
       ViReal64 gain = request->gain();
@@ -648,7 +648,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 waveform_handle = request->waveform_handle();
       ViReal64 gain = request->gain();
@@ -674,7 +674,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channels = request->channels().c_str();
       auto status = library_->ConfigureChannels(vi, channels);
       if (!status_ok(status)) {
@@ -697,7 +697,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 clock_mode;
       switch (request->clock_mode_enum_case()) {
         case nifgen_grpc::ConfigureClockModeRequest::ClockModeEnumCase::kClockMode: {
@@ -735,7 +735,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 number_of_coefficients = static_cast<ViInt32>(request->coefficients_array().size());
       auto coefficients_array = const_cast<ViReal64*>(request->coefficients_array().data());
@@ -760,7 +760,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto trigger_id = request->trigger_id().c_str();
       auto source = request->source().c_str();
       ViInt32 edge = request->edge();
@@ -785,7 +785,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto source = request->source().c_str();
       ViInt32 edge = request->edge();
       auto status = library_->ConfigureDigitalEdgeStartTrigger(vi, source, edge);
@@ -809,7 +809,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto trigger_id = request->trigger_id().c_str();
       auto source = request->source().c_str();
       ViInt32 trigger_when;
@@ -849,7 +849,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 frequency_list_handle = request->frequency_list_handle();
       ViReal64 amplitude = request->amplitude();
@@ -876,7 +876,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 frequency = request->frequency();
       auto status = library_->ConfigureFrequency(vi, channel_name, frequency);
@@ -900,7 +900,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 operation_mode = request->operation_mode();
       auto status = library_->ConfigureOperationMode(vi, channel_name, operation_mode);
@@ -924,7 +924,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViBoolean enabled = request->enabled();
       auto status = library_->ConfigureOutputEnabled(vi, channel_name, enabled);
@@ -948,7 +948,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 impedance = request->impedance();
       auto status = library_->ConfigureOutputImpedance(vi, channel_name, impedance);
@@ -972,7 +972,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 output_mode;
       switch (request->output_mode_enum_case()) {
         case nifgen_grpc::ConfigureOutputModeRequest::OutputModeEnumCase::kOutputMode: {
@@ -1010,7 +1010,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 p2p_endpoint_fullness_level = request->p2p_endpoint_fullness_level();
       auto status = library_->ConfigureP2PEndpointFullnessStartTrigger(vi, p2p_endpoint_fullness_level);
       if (!status_ok(status)) {
@@ -1033,7 +1033,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto reference_clock_source = request->reference_clock_source().c_str();
       ViReal64 reference_clock_frequency = request->reference_clock_frequency();
       auto status = library_->ConfigureReferenceClock(vi, reference_clock_source, reference_clock_frequency);
@@ -1057,7 +1057,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto sample_clock_source = request->sample_clock_source().c_str();
       auto status = library_->ConfigureSampleClockSource(vi, sample_clock_source);
       if (!status_ok(status)) {
@@ -1080,7 +1080,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 sample_rate = request->sample_rate();
       auto status = library_->ConfigureSampleRate(vi, sample_rate);
       if (!status_ok(status)) {
@@ -1103,7 +1103,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto trigger_id = request->trigger_id().c_str();
       auto status = library_->ConfigureSoftwareEdgeScriptTrigger(vi, trigger_id);
       if (!status_ok(status)) {
@@ -1126,7 +1126,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgeStartTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1148,7 +1148,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 waveform;
       switch (request->waveform_enum_case()) {
@@ -1191,7 +1191,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 synchronization_source = request->synchronization_source();
       auto status = library_->ConfigureSynchronization(vi, channel_name, synchronization_source);
@@ -1215,7 +1215,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 trigger_mode;
       switch (request->trigger_mode_enum_case()) {
@@ -1254,7 +1254,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto sequence_length_determine_from_sizes = std::array<int, 2>
       {
         request->waveform_handles_array_size(),
@@ -1292,7 +1292,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 waveform;
       switch (request->waveform_enum_case()) {
         case nifgen_grpc::CreateFreqListRequest::WaveformEnumCase::kWaveform: {
@@ -1346,7 +1346,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 number_of_samples = static_cast<ViInt32>(request->waveform_data_array().size());
       auto waveform_data_array = convert_from_grpc<NIComplexNumber_struct>(request->waveform_data_array());
@@ -1373,7 +1373,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 waveform_size = static_cast<ViInt32>(request->waveform_data_array().size());
       auto waveform_data_array = const_cast<ViReal64*>(request->waveform_data_array().data());
@@ -1400,7 +1400,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto file_name = request->file_name().c_str();
       ViInt32 byte_order;
@@ -1442,7 +1442,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto file_name = request->file_name().c_str();
       ViBoolean use_rate_from_waveform = request->use_rate_from_waveform();
@@ -1470,7 +1470,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto file_name = request->file_name().c_str();
       ViInt32 byte_order;
@@ -1512,7 +1512,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 waveform_size = static_cast<ViInt32>(request->waveform_data_array().size());
       auto waveform_data_array_request = request->waveform_data_array();
@@ -1545,7 +1545,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 waveform_size = static_cast<ViInt32>(request->waveform_data_array().size());
       auto waveform_data_array = const_cast<ViReal64*>(request->waveform_data_array().data());
@@ -1570,7 +1570,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto waveform_name = request->waveform_name().c_str();
       auto status = library_->DeleteNamedWaveform(vi, channel_name, waveform_name);
@@ -1594,7 +1594,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto script_name = request->script_name().c_str();
       auto status = library_->DeleteScript(vi, channel_name, script_name);
@@ -1618,7 +1618,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Disable(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1640,7 +1640,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->DisableAnalogFilter(vi, channel_name);
       if (!status_ok(status)) {
@@ -1663,7 +1663,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->DisableDigitalFilter(vi, channel_name);
       if (!status_ok(status)) {
@@ -1686,7 +1686,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->DisableDigitalPatterning(vi, channel_name);
       if (!status_ok(status)) {
@@ -1709,7 +1709,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto trigger_id = request->trigger_id().c_str();
       auto status = library_->DisableScriptTrigger(vi, trigger_id);
       if (!status_ok(status)) {
@@ -1732,7 +1732,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DisableStartTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1754,7 +1754,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViReal64 filter_correction_frequency = request->filter_correction_frequency();
       auto status = library_->EnableAnalogFilter(vi, channel_name, filter_correction_frequency);
@@ -1778,7 +1778,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->EnableDigitalFilter(vi, channel_name);
       if (!status_ok(status)) {
@@ -1801,7 +1801,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto status = library_->EnableDigitalPatterning(vi, channel_name);
       if (!status_ok(status)) {
@@ -1824,7 +1824,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViStatus error_code = request->error_code();
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorHandler(vi, error_code, (ViChar*)error_message.data());
@@ -1850,7 +1850,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViStatus error_code = request->error_code();
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
@@ -1876,7 +1876,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 error_code {};
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorQuery(vi, &error_code, (ViChar*)error_message.data());
@@ -1903,7 +1903,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
@@ -1940,7 +1940,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto file_path = request->file_path().c_str();
       auto status = library_->ExportAttributeConfigurationFile(vi, file_path);
       if (!status_ok(status)) {
@@ -1963,7 +1963,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 signal;
       switch (request->signal_enum_case()) {
         case nifgen_grpc::ExportSignalRequest::SignalEnumCase::kSignal: {
@@ -2003,7 +2003,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean attribute_value {};
@@ -2029,7 +2029,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 attribute_value {};
@@ -2055,7 +2055,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt64 attribute_value {};
@@ -2081,7 +2081,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 attribute_value {};
@@ -2107,7 +2107,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViSession attribute_value {};
@@ -2116,8 +2116,8 @@ namespace nifgen_grpc {
         return ConvertApiErrorStatusForViSession(context, status, vi);
       }
       response->set_status(status);
-      auto session_id = session_repository_->resolve_session_id(attribute_value);
-      response->mutable_attribute_value()->set_id(session_id);
+      auto grpc_device_session_name = session_repository_->resolve_session_name(attribute_value);
+      response->mutable_attribute_value()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -2134,7 +2134,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
 
@@ -2177,7 +2177,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 index = request->index();
 
       while (true) {
@@ -2219,7 +2219,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetError(vi, nullptr, 0, nullptr);
@@ -2262,7 +2262,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 year {};
       ViInt32 month {};
       ViInt32 day {};
@@ -2294,7 +2294,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 temperature {};
       auto status = library_->GetExtCalLastTemp(vi, &temperature);
       if (!status_ok(status)) {
@@ -2318,7 +2318,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 months {};
       auto status = library_->GetExtCalRecommendedInterval(vi, &months);
       if (!status_ok(status)) {
@@ -2342,7 +2342,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 number_of_coefficients_read {};
       while (true) {
@@ -2381,7 +2381,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 state {};
       auto status = library_->GetHardwareState(vi, &state);
       if (!status_ok(status)) {
@@ -2406,7 +2406,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetNextCoercionRecord(vi, 0, nullptr);
@@ -2447,7 +2447,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetNextInterchangeWarning(vi, 0, nullptr);
@@ -2488,7 +2488,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 year {};
       ViInt32 month {};
       ViInt32 day {};
@@ -2520,7 +2520,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 temperature {};
       auto status = library_->GetSelfCalLastTemp(vi, &temperature);
       if (!status_ok(status)) {
@@ -2544,7 +2544,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean self_cal_supported {};
       auto status = library_->GetSelfCalSupported(vi, &self_cal_supported);
       if (!status_ok(status)) {
@@ -2568,7 +2568,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto stream_endpoint = request->stream_endpoint().c_str();
       ViUInt32 reader_handle {};
       auto status = library_->GetStreamEndpointHandle(vi, stream_endpoint, &reader_handle);
@@ -2593,7 +2593,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 size_in_bytes = static_cast<ViInt32>(request->configuration().size());
       ViInt8* configuration = (ViInt8*)request->configuration().c_str();
       auto status = library_->ImportAttributeConfigurationBuffer(vi, size_in_bytes, configuration);
@@ -2617,7 +2617,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto file_path = request->file_path().c_str();
       auto status = library_->ImportAttributeConfigurationFile(vi, file_path);
       if (!status_ok(status)) {
@@ -2650,15 +2650,14 @@ namespace nifgen_grpc {
         auto status = library_->Init(resource_name, id_query, reset_device, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id, initialization_behavior, &new_session_initialized);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       response->set_new_session_initialized(new_session_initialized);
       return ::grpc::Status::OK;
     }
@@ -2687,15 +2686,14 @@ namespace nifgen_grpc {
         auto status = library_->InitWithOptions(resource_name, id_query, reset_device, option_string, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id, initialization_behavior, &new_session_initialized);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       response->set_new_session_initialized(new_session_initialized);
       return ::grpc::Status::OK;
     }
@@ -2724,15 +2722,14 @@ namespace nifgen_grpc {
         auto status = library_->InitializeWithChannels(resource_name, channel_name, reset_device, option_string, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id, initialization_behavior, &new_session_initialized);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       response->set_new_session_initialized(new_session_initialized);
       return ::grpc::Status::OK;
     }
@@ -2750,7 +2747,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->InitiateGeneration(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2772,7 +2769,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->InvalidateAllAttributes(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2794,7 +2791,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean done {};
       auto status = library_->IsDone(vi, &done);
       if (!status_ok(status)) {
@@ -2818,7 +2815,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto endpoint_name = request->endpoint_name().c_str();
       auto status = library_->ManualEnableP2PStream(vi, endpoint_name);
       if (!status_ok(status)) {
@@ -2841,7 +2838,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 maximum_number_of_sequences {};
       ViInt32 minimum_sequence_length {};
       ViInt32 maximum_sequence_length {};
@@ -2871,7 +2868,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 maximum_number_of_waveforms {};
       ViInt32 waveform_quantum {};
       ViInt32 minimum_waveform_size {};
@@ -2901,7 +2898,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 maximum_number_of_freq_lists {};
       ViInt32 minimum_frequency_list_length {};
       ViInt32 maximum_frequency_list_length {};
@@ -2935,7 +2932,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 temperature {};
       auto status = library_->ReadCurrentTemperature(vi, &temperature);
       if (!status_ok(status)) {
@@ -2959,7 +2956,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2981,7 +2978,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(vi, channel_name, attribute_id);
@@ -3005,7 +3002,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ResetDevice(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -3027,7 +3024,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ResetInterchangeCheck(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -3049,7 +3046,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ResetWithDefaults(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -3071,7 +3068,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       std::string instrument_driver_revision(256 - 1, '\0');
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
@@ -3099,7 +3096,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 route_signal_from;
       switch (request->route_signal_from_enum_case()) {
@@ -3154,7 +3151,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->SelfCal(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -3176,7 +3173,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt16 self_test_result {};
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
@@ -3203,7 +3200,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 trigger;
       switch (request->trigger_enum_case()) {
         case nifgen_grpc::SendSoftwareEdgeTriggerRequest::TriggerEnumCase::kTrigger: {
@@ -3242,7 +3239,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean attribute_value = request->attribute_value();
@@ -3267,7 +3264,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 attribute_value;
@@ -3307,7 +3304,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt64 attribute_value = request->attribute_value_raw();
@@ -3332,7 +3329,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 attribute_value;
@@ -3372,11 +3369,11 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto attribute_value_grpc_session = request->attribute_value();
-      ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.id(), attribute_value_grpc_session.name());
+      ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.name());
       auto status = library_->SetAttributeViSession(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -3398,7 +3395,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViConstString attribute_value;
@@ -3442,7 +3439,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 relative_to;
@@ -3483,7 +3480,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 waveform_handle = request->waveform_handle();
       ViInt32 relative_to;
@@ -3524,7 +3521,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 max_time = request->max_time();
       auto status = library_->WaitUntilDone(vi, max_time);
       if (!status_ok(status)) {
@@ -3547,7 +3544,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 waveform_handle = request->waveform_handle();
       ViInt32 size = static_cast<ViInt32>(request->data().size());
@@ -3579,7 +3576,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 waveform_handle = request->waveform_handle();
       ViInt32 size = static_cast<ViInt32>(request->data().size());
@@ -3605,7 +3602,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 size = static_cast<ViInt32>(request->data().size());
@@ -3631,7 +3628,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 size = static_cast<ViInt32>(request->data().size());
@@ -3657,7 +3654,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 size = static_cast<ViInt32>(request->data().size());
@@ -3683,7 +3680,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 size = static_cast<ViInt32>(request->data().size());
@@ -3715,7 +3712,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto endpoint_name = request->endpoint_name().c_str();
       ViInt32 number_of_samples = static_cast<ViInt32>(request->endpoint_data().size());
       auto endpoint_data_request = request->endpoint_data();
@@ -3746,7 +3743,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto script = request->script().c_str();
       auto status = library_->WriteScript(vi, channel_name, script);
@@ -3770,7 +3767,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 waveform_handle = request->waveform_handle();
       ViInt32 size = static_cast<ViInt32>(request->data().size());
@@ -3796,7 +3793,7 @@ namespace nifgen_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 number_of_samples = static_cast<ViInt32>(request->data().size());
       auto data = convert_from_grpc<NIComplexNumber_struct>(request->data());

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
@@ -56,7 +56,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -96,7 +96,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 burst_synchronization_type;
       switch (request->burst_synchronization_type_enum_case()) {
@@ -135,7 +135,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_offsets = request->number_of_offsets();
       auto status = library_->ACPCfgNumberOfOffsets(instrument, selector_string, number_of_offsets);
@@ -159,7 +159,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 offset_channel_mode;
       switch (request->offset_channel_mode_enum_case()) {
@@ -198,7 +198,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -242,7 +242,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -289,7 +289,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 measurement_status {};
@@ -316,7 +316,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 lower_absolute_power {};
@@ -352,7 +352,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -407,7 +407,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 reference_channel_power {};
@@ -433,7 +433,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -477,7 +477,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->AbortMeasurements(instrument, selector_string);
       if (!status_ok(status)) {
@@ -500,7 +500,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* result_name = (char*)request->result_name().c_str();
       float64 x0 = request->x0();
@@ -530,7 +530,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       auto status = library_->AutoDetectSignal(instrument, selector_string, timeout);
@@ -554,7 +554,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 measurement_interval = request->measurement_interval();
       float64 reference_level {};
@@ -703,7 +703,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 channel_number = request->channel_number();
       auto status = library_->CfgChannelNumber(instrument, selector_string, channel_number);
@@ -727,7 +727,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 data_rate = request->data_rate();
       auto status = library_->CfgDataRate(instrument, selector_string, data_rate);
@@ -751,7 +751,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* digital_edge_source = (char*)request->digital_edge_source().c_str();
       int32 digital_edge;
@@ -793,7 +793,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 external_attenuation = request->external_attenuation();
       auto status = library_->CfgExternalAttenuation(instrument, selector_string, external_attenuation);
@@ -817,7 +817,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 center_frequency = request->center_frequency();
       auto status = library_->CfgFrequency(instrument, selector_string, center_frequency);
@@ -841,7 +841,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 standard;
       switch (request->standard_enum_case()) {
@@ -881,7 +881,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       char* frequency_reference_source;
       switch (request->frequency_reference_source_enum_case()) {
@@ -925,7 +925,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* iq_power_edge_source = (char*)request->iq_power_edge_source().c_str();
       int32 iq_power_edge_slope;
@@ -1001,7 +1001,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 direction_finding_mode;
       switch (request->direction_finding_mode_enum_case()) {
@@ -1042,7 +1042,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 mechanical_attenuation_auto;
       switch (request->mechanical_attenuation_auto_enum_case()) {
@@ -1082,7 +1082,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 packet_type;
       switch (request->packet_type_enum_case()) {
@@ -1121,7 +1121,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 payload_bit_pattern;
       switch (request->payload_bit_pattern_enum_case()) {
@@ -1160,7 +1160,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 payload_length_mode;
       switch (request->payload_length_mode_enum_case()) {
@@ -1200,7 +1200,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 center_frequency = request->center_frequency();
       float64 reference_level = request->reference_level();
@@ -1226,7 +1226,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 rf_attenuation_auto;
       switch (request->rf_attenuation_auto_enum_case()) {
@@ -1266,7 +1266,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 reference_level = request->reference_level();
       auto status = library_->CfgReferenceLevel(instrument, selector_string, reference_level);
@@ -1290,7 +1290,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 trigger_delay = request->trigger_delay();
       int32 enable_trigger = request->enable_trigger();
@@ -1315,7 +1315,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 is_done {};
       auto status = library_->CheckMeasurementStatus(instrument, selector_string, &is_done);
@@ -1340,7 +1340,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearAllNamedResults(instrument, selector_string);
       if (!status_ok(status)) {
@@ -1363,7 +1363,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearNamedResult(instrument, selector_string);
       if (!status_ok(status)) {
@@ -1386,7 +1386,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* old_signal_name = (char*)request->old_signal_name().c_str();
       char* new_signal_name = (char*)request->new_signal_name().c_str();
       auto status = library_->CloneSignalConfiguration(instrument, old_signal_name, new_signal_name);
@@ -1410,9 +1410,9 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 force_destroy = request->force_destroy();
-      session_repository_->remove_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      session_repository_->remove_session(instrument_grpc_session.name());
       auto status = library_->Close(instrument, force_destroy);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -1434,7 +1434,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->Commit(instrument, selector_string);
       if (!status_ok(status)) {
@@ -1457,7 +1457,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->CreateSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
@@ -1480,7 +1480,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->DeleteSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
@@ -1503,7 +1503,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->DisableTrigger(instrument, selector_string);
       if (!status_ok(status)) {
@@ -1526,7 +1526,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -1566,7 +1566,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 span = request->span();
       auto status = library_->FrequencyRangeCfgSpan(instrument, selector_string, span);
@@ -1590,7 +1590,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 high_frequency {};
@@ -1618,7 +1618,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -1662,7 +1662,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 actual_result_names_size {};
       int32 default_result_exists {};
@@ -1706,7 +1706,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float32 attr_val {};
@@ -1732,7 +1732,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -1772,7 +1772,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float64 attr_val {};
@@ -1798,7 +1798,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -1838,7 +1838,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int16 attr_val {};
@@ -1864,7 +1864,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 attr_val {};
@@ -1896,7 +1896,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -1950,7 +1950,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int64 attr_val {};
@@ -1976,7 +1976,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2016,7 +2016,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int8 attr_val {};
@@ -2042,7 +2042,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2090,7 +2090,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2136,7 +2136,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2182,7 +2182,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
 
@@ -2225,7 +2225,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt16 attr_val {};
@@ -2251,7 +2251,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt32 attr_val {};
@@ -2277,7 +2277,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2317,7 +2317,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2357,7 +2357,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8 attr_val {};
@@ -2383,7 +2383,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2423,7 +2423,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
 
       while (true) {
         auto status = library_->GetError(instrument, nullptr, 0, nullptr);
@@ -2466,7 +2466,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 error_code = request->error_code();
 
       while (true) {
@@ -2516,15 +2516,14 @@ namespace nirfmxbluetooth_grpc {
         auto status = library_->Initialize(resource_name, option_string, &instrument, &is_new_session);
         return std::make_tuple(status, instrument);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXBT_VAL_FALSE); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_instrument()->set_id(session_id);
+      response->mutable_instrument()->set_name(grpc_device_session_name);
       response->set_is_new_session(is_new_session);
       return ::grpc::Status::OK;
     }
@@ -2542,22 +2541,21 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto nirfsa_session_grpc_session = request->nirfsa_session();
-      uInt32 nirfsa_session = vi_session_resource_repository_->access_session(nirfsa_session_grpc_session.id(), nirfsa_session_grpc_session.name());
+      uInt32 nirfsa_session = vi_session_resource_repository_->access_session(nirfsa_session_grpc_session.name());
 
       auto init_lambda = [&] () {
         niRFmxInstrHandle instrument;
         auto status = library_->InitializeFromNIRFSASession(nirfsa_session, &instrument);
         return std::make_tuple(status, instrument);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXBT_VAL_FALSE); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_instrument()->set_id(session_id);
+      response->mutable_instrument()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -2574,7 +2572,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* result_name = (char*)request->result_name().c_str();
       auto status = library_->Initiate(instrument, selector_string, result_name);
@@ -2598,7 +2596,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -2638,7 +2636,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 burst_synchronization_type;
       switch (request->burst_synchronization_type_enum_case()) {
@@ -2677,7 +2675,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -2723,7 +2721,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 peak_rms_devm_maximum {};
@@ -2753,7 +2751,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 average_rms_magnitude_error_mean {};
@@ -2781,7 +2779,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -2821,7 +2819,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 average_rms_phase_error_mean {};
@@ -2849,7 +2847,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -2897,7 +2895,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 df1avg_maximum {};
@@ -2925,7 +2923,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -2968,7 +2966,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 df2avg_minimum {};
@@ -2996,7 +2994,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -3039,7 +3037,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 initial_frequency_error_maximum {};
@@ -3069,7 +3067,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 header_frequency_error_wi_maximum {};
@@ -3099,7 +3097,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 peak_frequency_error_maximum {};
@@ -3131,7 +3129,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -3174,7 +3172,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -3217,7 +3215,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -3260,7 +3258,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -3304,7 +3302,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -3344,7 +3342,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(instrument, selector_string, attribute_id);
@@ -3368,7 +3366,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ResetToDefault(instrument, selector_string);
       if (!status_ok(status)) {
@@ -3391,7 +3389,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       uInt32 measurements;
       switch (request->measurements_enum_case()) {
@@ -3431,7 +3429,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       auto status = library_->SendSoftwareEdgeTrigger(instrument);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -3453,7 +3451,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float32 attr_val = request->attr_val();
@@ -3478,7 +3476,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<float32*>(request->attr_val().data());
@@ -3504,7 +3502,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float64 attr_val = request->attr_val();
@@ -3529,7 +3527,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<float64*>(request->attr_val().data());
@@ -3555,7 +3553,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -3589,7 +3587,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 attr_val;
@@ -3629,7 +3627,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_vector = std::vector<int32>();
@@ -3663,7 +3661,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int64 attr_val = request->attr_val();
@@ -3688,7 +3686,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<int64*>(reinterpret_cast<const int64*>(request->attr_val().data()));
@@ -3714,7 +3712,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -3748,7 +3746,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -3791,7 +3789,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = convert_from_grpc<NIComplexDouble>(request->attr_val());
@@ -3817,7 +3815,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = convert_from_grpc<NIComplexSingle>(request->attr_val());
@@ -3843,7 +3841,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       char* attr_val;
@@ -3887,7 +3885,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -3921,7 +3919,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt32 attr_val = request->attr_val();
@@ -3946,7 +3944,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<uInt32*>(reinterpret_cast<const uInt32*>(request->attr_val().data()));
@@ -3972,7 +3970,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<uInt64*>(reinterpret_cast<const uInt64*>(request->attr_val().data()));
@@ -3998,7 +3996,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8 attr_val = request->attr_val();
@@ -4023,7 +4021,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8* attr_val = (uInt8*)request->attr_val().c_str();
@@ -4049,7 +4047,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -4089,7 +4087,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 burst_synchronization_type;
       switch (request->burst_synchronization_type_enum_case()) {
@@ -4128,7 +4126,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 edr_gfsk_average_power_mean {};
@@ -4158,7 +4156,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 reference_period_average_power_mean {};
@@ -4186,7 +4184,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 transmit_slot_average_power_mean {};
@@ -4214,7 +4212,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4257,7 +4255,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -4301,7 +4299,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 average_power_mean {};
@@ -4333,7 +4331,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -4373,7 +4371,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 peak_power {};
@@ -4405,7 +4403,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -4449,7 +4447,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       float64 timeout = request->timeout();
       auto status = library_->WaitForAcquisitionComplete(instrument, timeout);
       if (!status_ok(status)) {
@@ -4472,7 +4470,7 @@ namespace nirfmxbluetooth_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       auto status = library_->WaitForMeasurementComplete(instrument, selector_string, timeout);

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -1763,7 +1763,7 @@ namespace nirfmxinstr_grpc {
         int status = library_->GetNIRFSASession(instrument, &nirfsa_session);
         return std::make_tuple(status, nirfsa_session);
       };
-      std::string session_name;
+      std::string session_name = request->session_name();
       int status = vi_session_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_name);
       response->set_status(status);
       if (status == 0) {

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -219,7 +219,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* table_name = (char*)request->table_name().c_str();
       int32 format;
@@ -259,7 +259,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* table_name = (char*)request->table_name().c_str();
       auto status = library_->CfgExternalAttenuationInterpolationNearest(instrument, selector_string, table_name);
@@ -283,7 +283,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* table_name = (char*)request->table_name().c_str();
       auto status = library_->CfgExternalAttenuationInterpolationSpline(instrument, selector_string, table_name);
@@ -307,7 +307,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* table_name = (char*)request->table_name().c_str();
       auto frequency = const_cast<float64*>(request->frequency().data());
@@ -350,7 +350,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       char* frequency_reference_source;
       switch (request->frequency_reference_source_enum_case()) {
@@ -394,7 +394,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 mechanical_attenuation_auto;
       switch (request->mechanical_attenuation_auto_enum_case()) {
@@ -434,7 +434,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 rf_attenuation_auto;
       switch (request->rf_attenuation_auto_enum_case()) {
@@ -474,7 +474,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* table_name = (char*)request->table_name().c_str();
       auto frequency = const_cast<float64*>(request->frequency().data());
@@ -519,7 +519,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 s_parameter_type;
       switch (request->s_parameter_type_enum_case()) {
@@ -558,7 +558,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 acquisition_done {};
       auto status = library_->CheckAcquisitionStatus(instrument, &acquisition_done);
       if (!status_ok(status)) {
@@ -582,7 +582,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* list_name = (char*)request->list_name().c_str();
       int32 list_exists {};
       int32 personality {};
@@ -610,7 +610,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* signal_name = (char*)request->signal_name().c_str();
       int32 signal_configuration_exists {};
       int32 personality {};
@@ -638,9 +638,9 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 force_destroy = request->force_destroy();
-      session_repository_->remove_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      session_repository_->remove_session(instrument_grpc_session.name());
       auto status = library_->Close(instrument, force_destroy);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -662,7 +662,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->DeleteAllExternalAttenuationTables(instrument, selector_string);
       if (!status_ok(status)) {
@@ -685,7 +685,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* table_name = (char*)request->table_name().c_str();
       auto status = library_->DeleteExternalAttenuationTable(instrument, selector_string, table_name);
@@ -709,7 +709,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->DisableCalibrationPlane(instrument, selector_string);
       if (!status_ok(status)) {
@@ -732,7 +732,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->EnableCalibrationPlane(instrument, selector_string);
       if (!status_ok(status)) {
@@ -755,7 +755,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 export_signal_source;
       switch (request->export_signal_source_enum_case()) {
         case nirfmxinstr_grpc::ExportSignalRequest::ExportSignalSourceEnumCase::kExportSignalSource: {
@@ -813,7 +813,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       float32 attr_val {};
@@ -839,7 +839,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -879,7 +879,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       float64 attr_val {};
@@ -905,7 +905,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -945,7 +945,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int16 attr_val {};
@@ -971,7 +971,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int32 attr_val {};
@@ -1003,7 +1003,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -1057,7 +1057,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int64 attr_val {};
@@ -1083,7 +1083,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -1123,7 +1123,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int8 attr_val {};
@@ -1149,7 +1149,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -1197,7 +1197,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -1243,7 +1243,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -1289,7 +1289,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
 
@@ -1332,7 +1332,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       uInt16 attr_val {};
@@ -1358,7 +1358,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       uInt32 attr_val {};
@@ -1384,7 +1384,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -1424,7 +1424,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -1464,7 +1464,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8 attr_val {};
@@ -1490,7 +1490,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -1530,7 +1530,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
 
       while (true) {
@@ -1572,7 +1572,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
 
       while (true) {
         auto status = library_->GetError(instrument, nullptr, 0, nullptr);
@@ -1615,7 +1615,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 error_code = request->error_code();
 
       while (true) {
@@ -1657,7 +1657,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 external_attenuation {};
       auto status = library_->GetExternalAttenuationTableActualValue(instrument, selector_string, &external_attenuation);
@@ -1682,7 +1682,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 personality_filter;
       switch (request->personality_filter_enum_case()) {
@@ -1755,20 +1755,19 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
 
-      auto initiating_session_id = session_repository_->access_session_id(instrument_grpc_session.id(), instrument_grpc_session.name());
+      auto initiating_session_name = instrument_grpc_session.name();
       auto init_lambda = [&] () {
         ViSession nirfsa_session;
         int status = library_->GetNIRFSASession(instrument, &nirfsa_session);
         return std::make_tuple(status, nirfsa_session);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
-      int status = vi_session_resource_repository_->add_dependent_session(grpc_device_session_name, init_lambda, initiating_session_id, session_id);
+      std::string session_name;
+      int status = vi_session_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_name);
       response->set_status(status);
       if (status == 0) {
-        response->mutable_nirfsa_session()->set_id(session_id);
+        response->mutable_nirfsa_session()->set_name(session_name);
       }
       return ::grpc::Status::OK;
     }
@@ -1786,7 +1785,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 s_parameter_type {};
       auto status = library_->GetSParameterExternalAttenuationType(instrument, selector_string, &s_parameter_type);
@@ -1812,7 +1811,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int64 self_calibrate_step;
       switch (request->self_calibrate_step_enum_case()) {
@@ -1853,7 +1852,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int64 self_calibrate_step;
       switch (request->self_calibrate_step_enum_case()) {
@@ -1894,7 +1893,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 personality_filter;
       switch (request->personality_filter_enum_case()) {
@@ -1966,15 +1965,14 @@ namespace nirfmxinstr_grpc {
         auto status = library_->Initialize(resource_name, option_string, &instrument, &is_new_session);
         return std::make_tuple(status, instrument);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXINSTR_VAL_FALSE); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_instrument()->set_id(session_id);
+      response->mutable_instrument()->set_name(grpc_device_session_name);
       response->set_is_new_session(is_new_session);
       return ::grpc::Status::OK;
     }
@@ -1992,22 +1990,21 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto nirfsa_session_grpc_session = request->nirfsa_session();
-      uInt32 nirfsa_session = vi_session_resource_repository_->access_session(nirfsa_session_grpc_session.id(), nirfsa_session_grpc_session.name());
+      uInt32 nirfsa_session = vi_session_resource_repository_->access_session(nirfsa_session_grpc_session.name());
 
       auto init_lambda = [&] () {
         niRFmxInstrHandle instrument;
         auto status = library_->InitializeFromNIRFSASession(nirfsa_session, &instrument);
         return std::make_tuple(status, instrument);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXINSTR_VAL_FALSE); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_instrument()->set_id(session_id);
+      response->mutable_instrument()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -2029,7 +2026,7 @@ namespace nirfmxinstr_grpc {
         nirfsa_sessions_request.begin(),
         nirfsa_sessions_request.end(),
         std::back_inserter(nirfsa_sessions),
-        [&](auto session) { return vi_session_resource_repository_->access_session(session.id(), session.name()); }); 
+        [&](auto session) { return vi_session_resource_repository_->access_session(session.name()); }); 
       int32 number_of_nirfsa_sessions = static_cast<int32>(request->nirfsa_sessions().size());
 
       auto init_lambda = [&] () {
@@ -2037,15 +2034,14 @@ namespace nirfmxinstr_grpc {
         auto status = library_->InitializeFromNIRFSASessionArray(nirfsa_sessions.data(), number_of_nirfsa_sessions, &instrument);
         return std::make_tuple(status, instrument);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXINSTR_VAL_FALSE); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_instrument()->set_id(session_id);
+      response->mutable_instrument()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -2062,7 +2058,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 self_calibrate_valid {};
       int32 valid_steps {};
@@ -2109,7 +2105,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* file_path = (char*)request->file_path().c_str();
       int32 load_rf_instr_configuration = request->load_rf_instr_configuration();
       auto status = library_->LoadAllConfigurations(instrument, file_path, load_rf_instr_configuration);
@@ -2133,7 +2129,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* table_name = (char*)request->table_name().c_str();
       char* s2p_file_path = (char*)request->s2p_file_path().c_str();
@@ -2174,7 +2170,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(instrument, channel_name, attribute_id);
@@ -2198,7 +2194,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       auto status = library_->ResetDriver(instrument);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -2220,7 +2216,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       auto status = library_->ResetEntireSession(instrument);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -2242,7 +2238,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       auto status = library_->ResetToDefault(instrument);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -2264,7 +2260,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* file_path = (char*)request->file_path().c_str();
       auto status = library_->SaveAllConfigurations(instrument, file_path);
       if (!status_ok(status)) {
@@ -2287,7 +2283,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* table_name = (char*)request->table_name().c_str();
       auto status = library_->SelectActiveExternalAttenuationTable(instrument, selector_string, table_name);
@@ -2311,7 +2307,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 steps_to_omit;
       switch (request->steps_to_omit_enum_case()) {
@@ -2350,7 +2346,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 steps_to_omit;
       switch (request->steps_to_omit_enum_case()) {
@@ -2393,7 +2389,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       auto status = library_->SendSoftwareEdgeAdvanceTrigger(instrument);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -2415,7 +2411,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       auto status = library_->SendSoftwareEdgeStartTrigger(instrument);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -2437,7 +2433,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       float32 attr_val = request->attr_val();
@@ -2462,7 +2458,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<float32*>(request->attr_val().data());
@@ -2488,7 +2484,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       float64 attr_val = request->attr_val();
@@ -2513,7 +2509,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<float64*>(request->attr_val().data());
@@ -2539,7 +2535,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -2573,7 +2569,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int32 attr_val;
@@ -2613,7 +2609,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_vector = std::vector<int32>();
@@ -2647,7 +2643,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int64 attr_val = request->attr_val();
@@ -2672,7 +2668,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<int64*>(reinterpret_cast<const int64*>(request->attr_val().data()));
@@ -2698,7 +2694,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -2732,7 +2728,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -2775,7 +2771,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = convert_from_grpc<NIComplexDouble>(request->attr_val());
@@ -2801,7 +2797,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = convert_from_grpc<NIComplexSingle>(request->attr_val());
@@ -2827,7 +2823,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       char* attr_val;
@@ -2871,7 +2867,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -2905,7 +2901,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       uInt32 attr_val = request->attr_val();
@@ -2930,7 +2926,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<uInt32*>(reinterpret_cast<const uInt32*>(request->attr_val().data()));
@@ -2956,7 +2952,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<uInt64*>(reinterpret_cast<const uInt64*>(request->attr_val().data()));
@@ -2982,7 +2978,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8 attr_val = request->attr_val();
@@ -3007,7 +3003,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8* attr_val = (uInt8*)request->attr_val().c_str();
@@ -3082,7 +3078,7 @@ namespace nirfmxinstr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       float64 timeout = request->timeout();
       auto status = library_->WaitForAcquisitionComplete(instrument, timeout);
       if (!status_ok(status)) {

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
@@ -53,7 +53,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       float64 reference_or_trigger_level_in = request->reference_or_trigger_level_in();
       int32 input_power_units = request->input_power_units();
       int32 output_power_units = request->output_power_units();
@@ -82,7 +82,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 personality = request->personality();
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->DeleteSnapshot(instrument, personality, selector_string);
@@ -106,7 +106,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* signal_name = (char*)request->signal_name().c_str();
       uInt32 signal_type = request->signal_type();
       int32 actual_result_size {};
@@ -151,7 +151,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
 
       while (true) {
@@ -193,7 +193,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 attr_val {};
@@ -219,7 +219,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       float32 attr_val {};
@@ -245,7 +245,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -285,7 +285,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       float64 attr_val {};
@@ -311,7 +311,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -351,7 +351,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int32 attr_val {};
@@ -377,7 +377,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
       int64 attr_val {};
@@ -403,7 +403,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attribute_id = request->attribute_id();
 
@@ -446,7 +446,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 calibration_plane_enabled {};
       auto status = library_->GetCalibrationPlaneEnabled(instrument, selector_string, &calibration_plane_enabled);
@@ -471,7 +471,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
 
       while (true) {
@@ -513,7 +513,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
 
       while (true) {
@@ -555,7 +555,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attr_val {};
       auto status = library_->GetForceAllTracesEnabled(instrument, channel_name, &attr_val);
@@ -620,7 +620,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 is_connection_alive {};
       int32 privilege_level {};
       auto status = library_->GetPrivilegeLevel(instrument, &is_connection_alive, &privilege_level);
@@ -646,7 +646,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
 
       while (true) {
         auto status = library_->GetRFmxVersion(instrument, 0, nullptr);
@@ -728,7 +728,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* signal_name = (char*)request->signal_name().c_str();
       uInt32 signal_type = request->signal_type();
       int32 signal_state {};
@@ -756,7 +756,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 personality = request->personality();
       char* selector_string = (char*)request->selector_string().c_str();
       int32 snapshot_state {};
@@ -782,7 +782,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 all_traces_enabled {};
       auto status = library_->GetTracesInfoForMonitorSnapshot(instrument, selector_string, &all_traces_enabled);
@@ -807,7 +807,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* file_path = (char*)request->file_path().c_str();
       auto status = library_->LoadAllForRevert(instrument, file_path);
       if (!status_ok(status)) {
@@ -830,7 +830,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* json_string = (char*)request->json_string().c_str();
       int32 array_size = static_cast<int32>(request->json_string().size());
       auto status = library_->LoadConfigurationsFromJSON(instrument, json_string, array_size);
@@ -875,7 +875,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 privilege_level = request->privilege_level();
       auto status = library_->RequestPrivilege(instrument, privilege_level);
       if (!status_ok(status)) {
@@ -898,7 +898,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* file_path = (char*)request->file_path().c_str();
       auto status = library_->SaveAllForRevert(instrument, file_path);
       if (!status_ok(status)) {
@@ -921,7 +921,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* signal_names = (char*)request->signal_names().c_str();
       int32 actual_array_size {};
       while (true) {
@@ -963,7 +963,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 attr_val = request->attr_val();
       auto status = library_->SetForceAllTracesEnabled(instrument, channel_name, attr_val);
@@ -987,7 +987,7 @@ namespace nirfmxinstr_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 io_trace_status = request->io_trace_status();
       auto status = library_->SetIOTraceStatus(instrument, io_trace_status);
       if (!status_ok(status)) {

--- a/generated/nirfmxlte/nirfmxlte_service.cpp
+++ b/generated/nirfmxlte/nirfmxlte_service.cpp
@@ -56,7 +56,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -112,7 +112,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 configurable_number_of_offsets_enabled;
       switch (request->configurable_number_of_offsets_enabled_enum_case()) {
@@ -151,7 +151,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 measurement_method;
       switch (request->measurement_method_enum_case()) {
@@ -190,7 +190,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 noise_compensation_enabled;
       switch (request->noise_compensation_enabled_enum_case()) {
@@ -229,7 +229,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_eutra_offsets = request->number_of_eutra_offsets();
       auto status = library_->ACPCfgNumberOfEUTRAOffsets(instrument, selector_string, number_of_eutra_offsets);
@@ -253,7 +253,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_gsm_offsets = request->number_of_gsm_offsets();
       auto status = library_->ACPCfgNumberOfGSMOffsets(instrument, selector_string, number_of_gsm_offsets);
@@ -277,7 +277,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_utra_offsets = request->number_of_utra_offsets();
       auto status = library_->ACPCfgNumberOfUTRAOffsets(instrument, selector_string, number_of_utra_offsets);
@@ -301,7 +301,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 power_units;
       switch (request->power_units_enum_case()) {
@@ -340,7 +340,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rbw_auto;
       switch (request->rbw_auto_enum_case()) {
@@ -396,7 +396,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sweep_time_auto;
       switch (request->sweep_time_auto_enum_case()) {
@@ -436,7 +436,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_utra_offsets = request->number_of_utra_offsets();
       int32 number_of_eutra_offsets = request->number_of_eutra_offsets();
@@ -461,7 +461,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 trace_index = request->trace_index();
@@ -506,7 +506,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 absolute_power {};
@@ -534,7 +534,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -577,7 +577,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 lower_relative_power {};
@@ -609,7 +609,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -658,7 +658,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 trace_index = request->trace_index();
@@ -703,7 +703,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -747,7 +747,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 subblock_power {};
@@ -777,7 +777,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 total_aggregated_power {};
@@ -803,7 +803,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 noise_calibration_data_valid {};
       auto status = library_->ACPValidateNoiseCalibrationData(instrument, selector_string, &noise_calibration_data_valid);
@@ -829,7 +829,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->AbortMeasurements(instrument, selector_string);
       if (!status_ok(status)) {
@@ -852,7 +852,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* result_name = (char*)request->result_name().c_str();
       float64 x0 = request->x0();
@@ -882,7 +882,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* result_name = (char*)request->result_name().c_str();
       float64 x0 = request->x0();
@@ -912,7 +912,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 measurement_interval = request->measurement_interval();
       float64 reference_level {};
@@ -1225,7 +1225,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -1281,7 +1281,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 integration_bandwidth_type;
       switch (request->integration_bandwidth_type_enum_case()) {
@@ -1320,7 +1320,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rbw_auto;
       switch (request->rbw_auto_enum_case()) {
@@ -1376,7 +1376,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sweep_time_auto;
       switch (request->sweep_time_auto_enum_case()) {
@@ -1416,7 +1416,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 absolute_power {};
@@ -1444,7 +1444,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -1487,7 +1487,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -1531,7 +1531,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 subblock_power {};
@@ -1561,7 +1561,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 total_aggregated_power {};
@@ -1587,7 +1587,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 noise_calibration_data_valid {};
       auto status = library_->CHPValidateNoiseCalibrationData(instrument, selector_string, &noise_calibration_data_valid);
@@ -1613,7 +1613,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 auto_dmrs_detection_enabled;
       switch (request->auto_dmrs_detection_enabled_enum_case()) {
@@ -1652,7 +1652,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 auto_npusch_channel_detection_enabled;
       switch (request->auto_npusch_channel_detection_enabled_enum_case()) {
@@ -1691,7 +1691,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 auto_resource_block_detection_enabled;
       switch (request->auto_resource_block_detection_enabled_enum_case()) {
@@ -1730,7 +1730,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 band = request->band();
       auto status = library_->CfgBand(instrument, selector_string, band);
@@ -1754,7 +1754,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 cell_specific_ratio;
       switch (request->cell_specific_ratio_enum_case()) {
@@ -1793,7 +1793,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 component_carrier_bandwidth = request->component_carrier_bandwidth();
       float64 component_carrier_frequency = request->component_carrier_frequency();
@@ -1819,7 +1819,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto component_carrier_bandwidth = const_cast<float64*>(request->component_carrier_bandwidth().data());
       auto component_carrier_frequency = const_cast<float64*>(request->component_carrier_frequency().data());
@@ -1864,7 +1864,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 component_carrier_spacing_type;
       switch (request->component_carrier_spacing_type_enum_case()) {
@@ -1904,7 +1904,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* digital_edge_source;
       switch (request->digital_edge_source_enum_case()) {
@@ -1965,7 +1965,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 auto_cell_id_detection_enabled;
       switch (request->auto_cell_id_detection_enabled_enum_case()) {
@@ -2004,7 +2004,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 auto_pdsch_channel_detection_enabled;
       switch (request->auto_pdsch_channel_detection_enabled_enum_case()) {
@@ -2076,7 +2076,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 channel_configuration_mode;
       switch (request->channel_configuration_mode_enum_case()) {
@@ -2115,7 +2115,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_subframes = request->number_of_subframes();
       auto status = library_->CfgDownlinkNumberOfSubframes(instrument, selector_string, number_of_subframes);
@@ -2139,7 +2139,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 pss_power = request->pss_power();
       float64 sss_power = request->sss_power();
@@ -2164,7 +2164,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 downlink_test_model;
       switch (request->downlink_test_model_enum_case()) {
@@ -2203,7 +2203,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto downlink_test_model_vector = std::vector<int32>();
       downlink_test_model_vector.reserve(request->downlink_test_model().size());
@@ -2236,7 +2236,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 duplex_scheme;
       switch (request->duplex_scheme_enum_case()) {
@@ -2291,7 +2291,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 emtc_analysis_enabled;
       switch (request->emtc_analysis_enabled_enum_case()) {
@@ -2330,7 +2330,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 external_attenuation = request->external_attenuation();
       auto status = library_->CfgExternalAttenuation(instrument, selector_string, external_attenuation);
@@ -2354,7 +2354,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 center_frequency = request->center_frequency();
       auto status = library_->CfgFrequency(instrument, selector_string, center_frequency);
@@ -2378,7 +2378,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 link_direction;
       switch (request->link_direction_enum_case()) {
@@ -2419,7 +2419,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       char* frequency_reference_source;
       switch (request->frequency_reference_source_enum_case()) {
@@ -2463,7 +2463,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* iq_power_edge_source = (char*)request->iq_power_edge_source().c_str();
       int32 iq_power_edge_slope;
@@ -2539,7 +2539,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 link_direction;
       switch (request->link_direction_enum_case()) {
@@ -2578,7 +2578,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 mechanical_attenuation_auto;
       switch (request->mechanical_attenuation_auto_enum_case()) {
@@ -2618,7 +2618,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 n_cell_id = request->n_cell_id();
       int32 uplink_subcarrier_spacing;
@@ -2658,7 +2658,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 npusch_dmrs_base_sequence_mode;
       switch (request->npusch_dmrs_base_sequence_mode_enum_case()) {
@@ -2716,7 +2716,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 format = request->format();
       auto status = library_->CfgNPUSCHFormat(instrument, selector_string, format);
@@ -2740,7 +2740,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 starting_slot = request->starting_slot();
       auto status = library_->CfgNPUSCHStartingSlot(instrument, selector_string, starting_slot);
@@ -2764,7 +2764,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 tone_offset = request->tone_offset();
       int32 number_of_tones = request->number_of_tones();
@@ -2805,7 +2805,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_component_carriers = request->number_of_component_carriers();
       auto status = library_->CfgNumberOfComponentCarriers(instrument, selector_string, number_of_component_carriers);
@@ -2829,7 +2829,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_dut_antennas = request->number_of_dut_antennas();
       auto status = library_->CfgNumberOfDUTAntennas(instrument, selector_string, number_of_dut_antennas);
@@ -2853,7 +2853,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_pdsch_channels = request->number_of_pdsch_channels();
       auto status = library_->CfgNumberOfPDSCHChannels(instrument, selector_string, number_of_pdsch_channels);
@@ -2877,7 +2877,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_resource_block_clusters = request->number_of_resource_block_clusters();
       auto status = library_->CfgNumberOfPUSCHResourceBlockClusters(instrument, selector_string, number_of_resource_block_clusters);
@@ -2901,7 +2901,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_subblocks = request->number_of_subblocks();
       auto status = library_->CfgNumberOfSubblocks(instrument, selector_string, number_of_subblocks);
@@ -2925,7 +2925,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 pbch_power = request->pbch_power();
       auto status = library_->CfgPBCH(instrument, selector_string, pbch_power);
@@ -2949,7 +2949,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 cfi = request->cfi();
       float64 power = request->power();
@@ -2974,7 +2974,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 pdcch_power = request->pdcch_power();
       auto status = library_->CfgPDCCH(instrument, selector_string, pdcch_power);
@@ -2998,7 +2998,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 cw0_modulation_type;
       switch (request->cw0_modulation_type_enum_case()) {
@@ -3039,7 +3039,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 resource;
       switch (request->resource_enum_case()) {
@@ -3095,7 +3095,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 modulation_type = request->modulation_type();
       auto status = library_->CfgPSSCHModulationType(instrument, selector_string, modulation_type);
@@ -3119,7 +3119,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 resource_block_offset = request->resource_block_offset();
       int32 number_of_resource_blocks = request->number_of_resource_blocks();
@@ -3144,7 +3144,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 modulation_type;
       switch (request->modulation_type_enum_case()) {
@@ -3183,7 +3183,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 resource_block_offset = request->resource_block_offset();
       int32 number_of_resource_blocks = request->number_of_resource_blocks();
@@ -3208,7 +3208,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 center_frequency = request->center_frequency();
       float64 reference_level = request->reference_level();
@@ -3234,7 +3234,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 rf_attenuation_auto;
       switch (request->rf_attenuation_auto_enum_case()) {
@@ -3274,7 +3274,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 reference_level = request->reference_level();
       auto status = library_->CfgReferenceLevel(instrument, selector_string, reference_level);
@@ -3298,7 +3298,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 trigger_delay = request->trigger_delay();
       int32 enable_trigger = request->enable_trigger();
@@ -3323,7 +3323,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 transmit_antenna_to_analyze = request->transmit_antenna_to_analyze();
       auto status = library_->CfgTransmitAntennaToAnalyze(instrument, selector_string, transmit_antenna_to_analyze);
@@ -3347,7 +3347,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 enodeb_category;
       switch (request->enodeb_category_enum_case()) {
@@ -3386,7 +3386,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 is_done {};
       auto status = library_->CheckMeasurementStatus(instrument, selector_string, &is_done);
@@ -3411,7 +3411,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearAllNamedResults(instrument, selector_string);
       if (!status_ok(status)) {
@@ -3434,7 +3434,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearNamedResult(instrument, selector_string);
       if (!status_ok(status)) {
@@ -3457,7 +3457,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearNoiseCalibrationDatabase(instrument, selector_string);
       if (!status_ok(status)) {
@@ -3480,7 +3480,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* old_signal_name = (char*)request->old_signal_name().c_str();
       char* new_signal_name = (char*)request->new_signal_name().c_str();
       auto status = library_->CloneSignalConfiguration(instrument, old_signal_name, new_signal_name);
@@ -3504,9 +3504,9 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 force_destroy = request->force_destroy();
-      session_repository_->remove_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      session_repository_->remove_session(instrument_grpc_session.name());
       auto status = library_->Close(instrument, force_destroy);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -3528,7 +3528,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->Commit(instrument, selector_string);
       if (!status_ok(status)) {
@@ -3551,7 +3551,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->CreateSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
@@ -3574,7 +3574,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->DeleteSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
@@ -3597,7 +3597,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->DisableTrigger(instrument, selector_string);
       if (!status_ok(status)) {
@@ -3620,7 +3620,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 actual_result_names_size {};
       int32 default_result_exists {};
@@ -3664,7 +3664,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float32 attr_val {};
@@ -3690,7 +3690,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -3730,7 +3730,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float64 attr_val {};
@@ -3756,7 +3756,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -3796,7 +3796,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int16 attr_val {};
@@ -3822,7 +3822,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 attr_val {};
@@ -3854,7 +3854,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -3908,7 +3908,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int64 attr_val {};
@@ -3934,7 +3934,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -3974,7 +3974,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int8 attr_val {};
@@ -4000,7 +4000,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -4048,7 +4048,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -4094,7 +4094,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -4140,7 +4140,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
 
@@ -4183,7 +4183,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt16 attr_val {};
@@ -4209,7 +4209,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt32 attr_val {};
@@ -4235,7 +4235,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -4275,7 +4275,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -4315,7 +4315,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8 attr_val {};
@@ -4341,7 +4341,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -4381,7 +4381,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
 
       while (true) {
         auto status = library_->GetError(instrument, nullptr, 0, nullptr);
@@ -4424,7 +4424,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 error_code = request->error_code();
 
       while (true) {
@@ -4474,15 +4474,14 @@ namespace nirfmxlte_grpc {
         auto status = library_->Initialize(resource_name, option_string, &instrument, &is_new_session);
         return std::make_tuple(status, instrument);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXLTE_VAL_FALSE); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_instrument()->set_id(session_id);
+      response->mutable_instrument()->set_name(grpc_device_session_name);
       response->set_is_new_session(is_new_session);
       return ::grpc::Status::OK;
     }
@@ -4500,22 +4499,21 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto nirfsa_session_grpc_session = request->nirfsa_session();
-      uInt32 nirfsa_session = vi_session_resource_repository_->access_session(nirfsa_session_grpc_session.id(), nirfsa_session_grpc_session.name());
+      uInt32 nirfsa_session = vi_session_resource_repository_->access_session(nirfsa_session_grpc_session.name());
 
       auto init_lambda = [&] () {
         niRFmxInstrHandle instrument;
         auto status = library_->InitializeFromNIRFSASession(nirfsa_session, &instrument);
         return std::make_tuple(status, instrument);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXLTE_VAL_FALSE); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_instrument()->set_id(session_id);
+      response->mutable_instrument()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -4532,7 +4530,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* result_name = (char*)request->result_name().c_str();
       auto status = library_->Initiate(instrument, selector_string, result_name);
@@ -4556,7 +4554,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -4596,7 +4594,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 common_clock_source_enabled;
       switch (request->common_clock_source_enabled_enum_case()) {
@@ -4635,7 +4633,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 evm_unit;
       switch (request->evm_unit_enum_case()) {
@@ -4674,7 +4672,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 fft_window_offset = request->fft_window_offset();
       auto status = library_->ModAccCfgFFTWindowOffset(instrument, selector_string, fft_window_offset);
@@ -4698,7 +4696,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 fft_window_type;
       switch (request->fft_window_type_enum_case()) {
@@ -4739,7 +4737,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 in_band_emission_mask_type;
       switch (request->in_band_emission_mask_type_enum_case()) {
@@ -4778,7 +4776,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 synchronization_mode;
       switch (request->synchronization_mode_enum_case()) {
@@ -4819,7 +4817,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4865,7 +4863,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 mean_rms_csrs_evm {};
@@ -4891,7 +4889,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4931,7 +4929,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 mean_rms_composite_evm {};
@@ -4967,7 +4965,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -5022,7 +5020,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 mean_rms_composite_magnitude_error {};
@@ -5054,7 +5052,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -5103,7 +5101,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 detected_cell_id {};
@@ -5129,7 +5127,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -5169,7 +5167,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -5215,7 +5213,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -5261,7 +5259,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -5307,7 +5305,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -5353,7 +5351,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       auto reserved1 = nullptr;
@@ -5383,7 +5381,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       auto reserved1 = nullptr;
@@ -5428,7 +5426,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5472,7 +5470,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5516,7 +5514,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5560,7 +5558,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5604,7 +5602,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5648,7 +5646,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 mean_iq_origin_offset {};
@@ -5678,7 +5676,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -5724,7 +5722,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 in_band_emission_margin {};
@@ -5750,7 +5748,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -5790,7 +5788,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5837,7 +5835,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5881,7 +5879,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5925,7 +5923,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5969,7 +5967,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -6013,7 +6011,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -6057,7 +6055,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 data_constellation_actual_array_size {};
@@ -6115,7 +6113,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 npusch_mean_rms_dmrs_evm {};
@@ -6143,7 +6141,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 npusch_mean_rms_data_evm {};
@@ -6171,7 +6169,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 npusch_mean_data_power {};
@@ -6199,7 +6197,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -6245,7 +6243,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 mean_rms_1024qam_evm {};
@@ -6271,7 +6269,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -6311,7 +6309,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -6357,7 +6355,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -6403,7 +6401,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -6449,7 +6447,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 mean_rms_evm {};
@@ -6483,7 +6481,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -6535,7 +6533,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -6581,7 +6579,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 data_constellation_actual_array_size {};
@@ -6639,7 +6637,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 pssch_mean_rms_dmrs_evm {};
@@ -6667,7 +6665,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -6710,7 +6708,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 pssch_mean_rms_data_evm {};
@@ -6738,7 +6736,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -6781,7 +6779,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 pssch_mean_data_power {};
@@ -6809,7 +6807,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -6852,7 +6850,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 data_constellation_actual_array_size {};
@@ -6910,7 +6908,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 mean_rms_dmrs_evm {};
@@ -6938,7 +6936,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -6981,7 +6979,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 mean_rms_data_evm {};
@@ -7009,7 +7007,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7052,7 +7050,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7100,7 +7098,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 pusch_mean_data_power {};
@@ -7128,7 +7126,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7171,7 +7169,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -7215,7 +7213,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -7259,7 +7257,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7305,7 +7303,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 mean_rms_srs_evm {};
@@ -7333,7 +7331,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7376,7 +7374,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 range1_maximum_to_range1_minimum {};
@@ -7408,7 +7406,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7457,7 +7455,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -7507,7 +7505,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 subblock_mean_iq_origin_offset {};
@@ -7537,7 +7535,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 subblock_in_band_emission_margin {};
@@ -7563,7 +7561,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7609,7 +7607,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7664,7 +7662,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 mean_rms_pss_evm {};
@@ -7692,7 +7690,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7735,7 +7733,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -7791,7 +7789,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rbw_auto;
       switch (request->rbw_auto_enum_case()) {
@@ -7847,7 +7845,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sweep_time_auto;
       switch (request->sweep_time_auto_enum_case()) {
@@ -7887,7 +7885,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 occupied_bandwidth {};
@@ -7919,7 +7917,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -7963,7 +7961,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -8019,7 +8017,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 measurement_method;
       switch (request->measurement_method_enum_case()) {
@@ -8058,7 +8056,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 off_power_exclusion_before = request->off_power_exclusion_before();
       float64 off_power_exclusion_after = request->off_power_exclusion_after();
@@ -8083,7 +8081,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 measurement_status {};
@@ -8118,7 +8116,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -8179,7 +8177,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -8226,7 +8224,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(instrument, selector_string, attribute_id);
@@ -8250,7 +8248,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ResetToDefault(instrument, selector_string);
       if (!status_ok(status)) {
@@ -8273,7 +8271,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -8329,7 +8327,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 component_carrier_maximum_output_power = request->component_carrier_maximum_output_power();
       auto status = library_->SEMCfgComponentCarrierMaximumOutputPower(instrument, selector_string, component_carrier_maximum_output_power);
@@ -8353,7 +8351,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto component_carrier_maximum_output_power = const_cast<float64*>(request->component_carrier_maximum_output_power().data());
       int32 number_of_elements = static_cast<int32>(request->component_carrier_maximum_output_power().size());
@@ -8378,7 +8376,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 downlink_mask_type;
       switch (request->downlink_mask_type_enum_case()) {
@@ -8419,7 +8417,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_offsets = request->number_of_offsets();
       auto status = library_->SEMCfgNumberOfOffsets(instrument, selector_string, number_of_offsets);
@@ -8443,7 +8441,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 offset_absolute_limit_start = request->offset_absolute_limit_start();
       float64 offset_absolute_limit_stop = request->offset_absolute_limit_stop();
@@ -8468,7 +8466,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto offset_absolute_limit_start = const_cast<float64*>(request->offset_absolute_limit_start().data());
       auto offset_absolute_limit_stop = const_cast<float64*>(request->offset_absolute_limit_stop().data());
@@ -8510,7 +8508,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 offset_bandwidth_integral = request->offset_bandwidth_integral();
       auto status = library_->SEMCfgOffsetBandwidthIntegral(instrument, selector_string, offset_bandwidth_integral);
@@ -8534,7 +8532,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto offset_bandwidth_integral = const_cast<int32*>(reinterpret_cast<const int32*>(request->offset_bandwidth_integral().data()));
       int32 number_of_elements = static_cast<int32>(request->offset_bandwidth_integral().size());
@@ -8559,7 +8557,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 offset_start_frequency = request->offset_start_frequency();
       float64 offset_stop_frequency = request->offset_stop_frequency();
@@ -8600,7 +8598,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto offset_start_frequency = const_cast<float64*>(request->offset_start_frequency().data());
       auto offset_stop_frequency = const_cast<float64*>(request->offset_stop_frequency().data());
@@ -8653,7 +8651,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 limit_fail_mask;
       switch (request->limit_fail_mask_enum_case()) {
@@ -8692,7 +8690,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto limit_fail_mask_vector = std::vector<int32>();
       limit_fail_mask_vector.reserve(request->limit_fail_mask().size());
@@ -8725,7 +8723,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 offset_rbw = request->offset_rbw();
       int32 offset_rbw_filter_type;
@@ -8765,7 +8763,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto offset_rbw = const_cast<float64*>(request->offset_rbw().data());
       auto offset_rbw_filter_type_vector = std::vector<int32>();
@@ -8815,7 +8813,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 relative_limit_start = request->relative_limit_start();
       float64 relative_limit_stop = request->relative_limit_stop();
@@ -8840,7 +8838,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto relative_limit_start = const_cast<float64*>(request->relative_limit_start().data());
       auto relative_limit_stop = const_cast<float64*>(request->relative_limit_stop().data());
@@ -8882,7 +8880,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sweep_time_auto;
       switch (request->sweep_time_auto_enum_case()) {
@@ -8922,7 +8920,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 uplink_mask_type;
       switch (request->uplink_mask_type_enum_case()) {
@@ -8961,7 +8959,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 absolute_integrated_power {};
@@ -8989,7 +8987,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -9032,7 +9030,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 measurement_status {};
@@ -9067,7 +9065,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -9128,7 +9126,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 absolute_integrated_power {};
@@ -9162,7 +9160,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -9214,7 +9212,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 measurement_status {};
@@ -9241,7 +9239,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -9288,7 +9286,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 subblock_power {};
@@ -9318,7 +9316,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 total_aggregated_power {};
@@ -9344,7 +9342,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 measurement_status {};
@@ -9379,7 +9377,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -9440,7 +9438,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 absolute_integrated_power {};
@@ -9474,7 +9472,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -9526,7 +9524,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       uInt32 measurements;
       switch (request->measurements_enum_case()) {
@@ -9566,7 +9564,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       auto status = library_->SendSoftwareEdgeTrigger(instrument);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -9588,7 +9586,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float32 attr_val = request->attr_val();
@@ -9613,7 +9611,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<float32*>(request->attr_val().data());
@@ -9639,7 +9637,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float64 attr_val = request->attr_val();
@@ -9664,7 +9662,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<float64*>(request->attr_val().data());
@@ -9690,7 +9688,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -9724,7 +9722,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 attr_val;
@@ -9764,7 +9762,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_vector = std::vector<int32>();
@@ -9798,7 +9796,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int64 attr_val = request->attr_val();
@@ -9823,7 +9821,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<int64*>(reinterpret_cast<const int64*>(request->attr_val().data()));
@@ -9849,7 +9847,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -9883,7 +9881,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -9926,7 +9924,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = convert_from_grpc<NIComplexDouble>(request->attr_val());
@@ -9952,7 +9950,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = convert_from_grpc<NIComplexSingle>(request->attr_val());
@@ -9978,7 +9976,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       char* attr_val;
@@ -10022,7 +10020,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -10056,7 +10054,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt32 attr_val = request->attr_val();
@@ -10081,7 +10079,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<uInt32*>(reinterpret_cast<const uInt32*>(request->attr_val().data()));
@@ -10107,7 +10105,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<uInt64*>(reinterpret_cast<const uInt64*>(request->attr_val().data()));
@@ -10133,7 +10131,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8 attr_val = request->attr_val();
@@ -10158,7 +10156,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8* attr_val = (uInt8*)request->attr_val().c_str();
@@ -10184,7 +10182,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 synchronization_mode;
       switch (request->synchronization_mode_enum_case()) {
@@ -10225,7 +10223,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 maximum_phase_discontinuity {};
@@ -10251,7 +10249,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -10291,7 +10289,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -10331,7 +10329,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -10375,7 +10373,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -10419,7 +10417,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 measurement_offset = request->measurement_offset();
       int32 measurement_length = request->measurement_length();
@@ -10444,7 +10442,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -10487,7 +10485,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       float64 timeout = request->timeout();
       auto status = library_->WaitForAcquisitionComplete(instrument, timeout);
       if (!status_ok(status)) {
@@ -10510,7 +10508,7 @@ namespace nirfmxlte_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       auto status = library_->WaitForMeasurementComplete(instrument, selector_string, timeout);

--- a/generated/nirfmxnr/nirfmxnr_service.cpp
+++ b/generated/nirfmxnr/nirfmxnr_service.cpp
@@ -56,7 +56,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -112,7 +112,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 measurement_method;
       switch (request->measurement_method_enum_case()) {
@@ -151,7 +151,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 noise_compensation_enabled;
       switch (request->noise_compensation_enabled_enum_case()) {
@@ -190,7 +190,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_endc_offsets = request->number_of_endc_offsets();
       auto status = library_->ACPCfgNumberOfENDCOffsets(instrument, selector_string, number_of_endc_offsets);
@@ -214,7 +214,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_eutra_offsets = request->number_of_eutra_offsets();
       auto status = library_->ACPCfgNumberOfEUTRAOffsets(instrument, selector_string, number_of_eutra_offsets);
@@ -238,7 +238,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_nr_offsets = request->number_of_nr_offsets();
       auto status = library_->ACPCfgNumberOfNROffsets(instrument, selector_string, number_of_nr_offsets);
@@ -262,7 +262,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_utra_offsets = request->number_of_utra_offsets();
       auto status = library_->ACPCfgNumberOfUTRAOffsets(instrument, selector_string, number_of_utra_offsets);
@@ -286,7 +286,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 power_units;
       switch (request->power_units_enum_case()) {
@@ -325,7 +325,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rbw_auto;
       switch (request->rbw_auto_enum_case()) {
@@ -381,7 +381,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sweep_time_auto;
       switch (request->sweep_time_auto_enum_case()) {
@@ -421,7 +421,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 trace_index = request->trace_index();
@@ -466,7 +466,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 absolute_power {};
@@ -494,7 +494,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -537,7 +537,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 lower_relative_power {};
@@ -569,7 +569,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -618,7 +618,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 trace_index = request->trace_index();
@@ -663,7 +663,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -707,7 +707,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 subblock_power {};
@@ -737,7 +737,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 total_aggregated_power {};
@@ -763,7 +763,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 noise_calibration_data_valid {};
       auto status = library_->ACPValidateNoiseCalibrationData(instrument, selector_string, &noise_calibration_data_valid);
@@ -789,7 +789,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->AbortMeasurements(instrument, selector_string);
       if (!status_ok(status)) {
@@ -812,7 +812,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* result_name = (char*)request->result_name().c_str();
       float64 x0 = request->x0();
@@ -842,7 +842,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* result_name = (char*)request->result_name().c_str();
       float64 x0 = request->x0();
@@ -872,7 +872,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 measurement_interval = request->measurement_interval();
       float64 reference_level {};
@@ -1514,7 +1514,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -1570,7 +1570,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rbw_auto;
       switch (request->rbw_auto_enum_case()) {
@@ -1626,7 +1626,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sweep_time_auto;
       switch (request->sweep_time_auto_enum_case()) {
@@ -1666,7 +1666,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 absolute_power {};
@@ -1694,7 +1694,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -1737,7 +1737,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -1781,7 +1781,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 subblock_power {};
@@ -1807,7 +1807,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 total_aggregated_power {};
@@ -1833,7 +1833,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 noise_calibration_data_valid {};
       auto status = library_->CHPValidateNoiseCalibrationData(instrument, selector_string, &noise_calibration_data_valid);
@@ -1859,7 +1859,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* digital_edge_source;
       switch (request->digital_edge_source_enum_case()) {
@@ -1920,7 +1920,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 external_attenuation = request->external_attenuation();
       auto status = library_->CfgExternalAttenuation(instrument, selector_string, external_attenuation);
@@ -1944,7 +1944,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 center_frequency = request->center_frequency();
       auto status = library_->CfgFrequency(instrument, selector_string, center_frequency);
@@ -1968,7 +1968,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       char* frequency_reference_source;
       switch (request->frequency_reference_source_enum_case()) {
@@ -2012,7 +2012,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* iq_power_edge_source = (char*)request->iq_power_edge_source().c_str();
       int32 iq_power_edge_slope;
@@ -2088,7 +2088,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 mechanical_attenuation_auto;
       switch (request->mechanical_attenuation_auto_enum_case()) {
@@ -2128,7 +2128,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 center_frequency = request->center_frequency();
       float64 reference_level = request->reference_level();
@@ -2154,7 +2154,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 rf_attenuation_auto;
       switch (request->rf_attenuation_auto_enum_case()) {
@@ -2194,7 +2194,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 reference_level = request->reference_level();
       auto status = library_->CfgReferenceLevel(instrument, selector_string, reference_level);
@@ -2218,7 +2218,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 trigger_delay = request->trigger_delay();
       int32 enable_trigger = request->enable_trigger();
@@ -2243,7 +2243,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 gnodeb_category;
       switch (request->gnodeb_category_enum_case()) {
@@ -2282,7 +2282,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 is_done {};
       auto status = library_->CheckMeasurementStatus(instrument, selector_string, &is_done);
@@ -2307,7 +2307,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearAllNamedResults(instrument, selector_string);
       if (!status_ok(status)) {
@@ -2330,7 +2330,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearNamedResult(instrument, selector_string);
       if (!status_ok(status)) {
@@ -2353,7 +2353,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearNoiseCalibrationDatabase(instrument, selector_string);
       if (!status_ok(status)) {
@@ -2376,7 +2376,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* old_signal_name = (char*)request->old_signal_name().c_str();
       char* new_signal_name = (char*)request->new_signal_name().c_str();
       auto status = library_->CloneSignalConfiguration(instrument, old_signal_name, new_signal_name);
@@ -2400,9 +2400,9 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 force_destroy = request->force_destroy();
-      session_repository_->remove_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      session_repository_->remove_session(instrument_grpc_session.name());
       auto status = library_->Close(instrument, force_destroy);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -2424,7 +2424,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->Commit(instrument, selector_string);
       if (!status_ok(status)) {
@@ -2447,7 +2447,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* list_name = (char*)request->list_name().c_str();
       auto status = library_->CreateList(instrument, list_name);
       if (!status_ok(status)) {
@@ -2470,7 +2470,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 created_step_index {};
       auto status = library_->CreateListStep(instrument, selector_string, &created_step_index);
@@ -2495,7 +2495,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->CreateSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
@@ -2518,7 +2518,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* list_name = (char*)request->list_name().c_str();
       auto status = library_->DeleteList(instrument, list_name);
       if (!status_ok(status)) {
@@ -2541,7 +2541,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->DeleteSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
@@ -2564,7 +2564,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->DisableTrigger(instrument, selector_string);
       if (!status_ok(status)) {
@@ -2587,7 +2587,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 actual_result_names_size {};
       int32 default_result_exists {};
@@ -2631,7 +2631,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float32 attr_val {};
@@ -2657,7 +2657,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2697,7 +2697,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float64 attr_val {};
@@ -2723,7 +2723,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2763,7 +2763,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int16 attr_val {};
@@ -2789,7 +2789,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 attr_val {};
@@ -2821,7 +2821,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2875,7 +2875,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int64 attr_val {};
@@ -2901,7 +2901,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2941,7 +2941,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int8 attr_val {};
@@ -2967,7 +2967,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -3015,7 +3015,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -3061,7 +3061,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -3107,7 +3107,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
 
@@ -3150,7 +3150,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt16 attr_val {};
@@ -3176,7 +3176,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt32 attr_val {};
@@ -3202,7 +3202,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -3242,7 +3242,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -3282,7 +3282,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8 attr_val {};
@@ -3308,7 +3308,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -3348,7 +3348,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
 
       while (true) {
         auto status = library_->GetError(instrument, nullptr, 0, nullptr);
@@ -3391,7 +3391,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 error_code = request->error_code();
 
       while (true) {
@@ -3441,15 +3441,14 @@ namespace nirfmxnr_grpc {
         auto status = library_->Initialize(resource_name, option_string, &instrument, &is_new_session);
         return std::make_tuple(status, instrument);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXNR_VAL_FALSE); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_instrument()->set_id(session_id);
+      response->mutable_instrument()->set_name(grpc_device_session_name);
       response->set_is_new_session(is_new_session);
       return ::grpc::Status::OK;
     }
@@ -3467,22 +3466,21 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto nirfsa_session_grpc_session = request->nirfsa_session();
-      uInt32 nirfsa_session = vi_session_resource_repository_->access_session(nirfsa_session_grpc_session.id(), nirfsa_session_grpc_session.name());
+      uInt32 nirfsa_session = vi_session_resource_repository_->access_session(nirfsa_session_grpc_session.name());
 
       auto init_lambda = [&] () {
         niRFmxInstrHandle instrument;
         auto status = library_->InitializeFromNIRFSASession(nirfsa_session, &instrument);
         return std::make_tuple(status, instrument);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXNR_VAL_FALSE); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_instrument()->set_id(session_id);
+      response->mutable_instrument()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -3499,7 +3497,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* result_name = (char*)request->result_name().c_str();
       auto status = library_->Initiate(instrument, selector_string, result_name);
@@ -3523,7 +3521,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       auto status = library_->ModAccAutoLevel(instrument, selector_string, timeout);
@@ -3547,7 +3545,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 measurement_mode;
       switch (request->measurement_mode_enum_case()) {
@@ -3586,7 +3584,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 noise_compensation_enabled;
       switch (request->noise_compensation_enabled_enum_case()) {
@@ -3625,7 +3623,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 x0 = request->x0();
       float64 dx = request->dx();
@@ -3652,7 +3650,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       auto status = library_->ModAccClearNoiseCalibrationDatabase(instrument);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -3674,7 +3672,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 composite_rms_evm_mean {};
@@ -3702,7 +3700,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 frequency_error_mean {};
@@ -3728,7 +3726,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -3772,7 +3770,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -3816,7 +3814,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -3860,7 +3858,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -3907,7 +3905,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -3953,7 +3951,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -3997,7 +3995,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -4041,7 +4039,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4087,7 +4085,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -4131,7 +4129,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -4175,7 +4173,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4221,7 +4219,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4267,7 +4265,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4313,7 +4311,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4359,7 +4357,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4405,7 +4403,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4451,7 +4449,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4497,7 +4495,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4545,7 +4543,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4591,7 +4589,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4637,7 +4635,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4683,7 +4681,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -4727,7 +4725,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -4771,7 +4769,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4817,7 +4815,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4863,7 +4861,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4911,7 +4909,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4957,7 +4955,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5001,7 +4999,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5045,7 +5043,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5089,7 +5087,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5133,7 +5131,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5177,7 +5175,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5221,7 +5219,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5265,7 +5263,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5309,7 +5307,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -5355,7 +5353,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5399,7 +5397,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5443,7 +5441,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5493,7 +5491,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -5539,7 +5537,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 calibration_data_valid {};
       auto status = library_->ModAccValidateCalibrationData(instrument, selector_string, &calibration_data_valid);
@@ -5565,7 +5563,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -5621,7 +5619,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rbw_auto;
       switch (request->rbw_auto_enum_case()) {
@@ -5677,7 +5675,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sweep_time_auto;
       switch (request->sweep_time_auto_enum_case()) {
@@ -5717,7 +5715,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 occupied_bandwidth {};
@@ -5749,7 +5747,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5793,7 +5791,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -5849,7 +5847,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 measurement_method;
       switch (request->measurement_method_enum_case()) {
@@ -5888,7 +5886,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 off_power_exclusion_before = request->off_power_exclusion_before();
       float64 off_power_exclusion_after = request->off_power_exclusion_after();
@@ -5913,7 +5911,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 measurement_status {};
@@ -5948,7 +5946,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -6009,7 +6007,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -6056,7 +6054,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -6100,7 +6098,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(instrument, selector_string, attribute_id);
@@ -6124,7 +6122,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ResetToDefault(instrument, selector_string);
       if (!status_ok(status)) {
@@ -6147,7 +6145,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -6203,7 +6201,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 component_carrier_rated_output_power = request->component_carrier_rated_output_power();
       auto status = library_->SEMCfgComponentCarrierRatedOutputPower(instrument, selector_string, component_carrier_rated_output_power);
@@ -6227,7 +6225,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto component_carrier_rated_output_power = const_cast<float64*>(request->component_carrier_rated_output_power().data());
       int32 number_of_elements = static_cast<int32>(request->component_carrier_rated_output_power().size());
@@ -6252,7 +6250,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_offsets = request->number_of_offsets();
       auto status = library_->SEMCfgNumberOfOffsets(instrument, selector_string, number_of_offsets);
@@ -6276,7 +6274,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 absolute_limit_start = request->absolute_limit_start();
       float64 absolute_limit_stop = request->absolute_limit_stop();
@@ -6301,7 +6299,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto absolute_limit_start = const_cast<float64*>(request->absolute_limit_start().data());
       auto absolute_limit_stop = const_cast<float64*>(request->absolute_limit_stop().data());
@@ -6343,7 +6341,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 bandwidth_integral = request->bandwidth_integral();
       auto status = library_->SEMCfgOffsetBandwidthIntegral(instrument, selector_string, bandwidth_integral);
@@ -6367,7 +6365,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto bandwidth_integral = const_cast<int32*>(reinterpret_cast<const int32*>(request->bandwidth_integral().data()));
       int32 number_of_elements = static_cast<int32>(request->bandwidth_integral().size());
@@ -6392,7 +6390,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 offset_start_frequency = request->offset_start_frequency();
       float64 offset_stop_frequency = request->offset_stop_frequency();
@@ -6433,7 +6431,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto offset_start_frequency = const_cast<float64*>(request->offset_start_frequency().data());
       auto offset_stop_frequency = const_cast<float64*>(request->offset_stop_frequency().data());
@@ -6486,7 +6484,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 limit_fail_mask;
       switch (request->limit_fail_mask_enum_case()) {
@@ -6525,7 +6523,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto limit_fail_mask_vector = std::vector<int32>();
       limit_fail_mask_vector.reserve(request->limit_fail_mask().size());
@@ -6558,7 +6556,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 offset_rbw = request->offset_rbw();
       int32 offset_rbw_filter_type;
@@ -6598,7 +6596,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto offset_rbw = const_cast<float64*>(request->offset_rbw().data());
       auto offset_rbw_filter_type_vector = std::vector<int32>();
@@ -6648,7 +6646,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 relative_limit_start = request->relative_limit_start();
       float64 relative_limit_stop = request->relative_limit_stop();
@@ -6673,7 +6671,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto relative_limit_start = const_cast<float64*>(request->relative_limit_start().data());
       auto relative_limit_stop = const_cast<float64*>(request->relative_limit_stop().data());
@@ -6715,7 +6713,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sweep_time_auto;
       switch (request->sweep_time_auto_enum_case()) {
@@ -6755,7 +6753,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 uplink_mask_type;
       switch (request->uplink_mask_type_enum_case()) {
@@ -6794,7 +6792,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 absolute_power {};
@@ -6826,7 +6824,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -6875,7 +6873,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 measurement_status {};
@@ -6910,7 +6908,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -6971,7 +6969,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 total_absolute_power {};
@@ -7005,7 +7003,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7057,7 +7055,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 measurement_status {};
@@ -7084,7 +7082,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -7131,7 +7129,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 subblock_power {};
@@ -7161,7 +7159,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 total_aggregated_power {};
@@ -7187,7 +7185,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 measurement_status {};
@@ -7222,7 +7220,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7283,7 +7281,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 total_absolute_power {};
@@ -7317,7 +7315,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7369,7 +7367,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       uInt32 measurements;
       switch (request->measurements_enum_case()) {
@@ -7409,7 +7407,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       auto status = library_->SendSoftwareEdgeTrigger(instrument);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -7431,7 +7429,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float32 attr_val = request->attr_val();
@@ -7456,7 +7454,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<float32*>(request->attr_val().data());
@@ -7482,7 +7480,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float64 attr_val = request->attr_val();
@@ -7507,7 +7505,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<float64*>(request->attr_val().data());
@@ -7533,7 +7531,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -7567,7 +7565,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 attr_val;
@@ -7607,7 +7605,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_vector = std::vector<int32>();
@@ -7641,7 +7639,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int64 attr_val = request->attr_val();
@@ -7666,7 +7664,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<int64*>(reinterpret_cast<const int64*>(request->attr_val().data()));
@@ -7692,7 +7690,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -7726,7 +7724,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -7769,7 +7767,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = convert_from_grpc<NIComplexDouble>(request->attr_val());
@@ -7795,7 +7793,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = convert_from_grpc<NIComplexSingle>(request->attr_val());
@@ -7821,7 +7819,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       char* attr_val;
@@ -7865,7 +7863,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -7899,7 +7897,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt32 attr_val = request->attr_val();
@@ -7924,7 +7922,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<uInt32*>(reinterpret_cast<const uInt32*>(request->attr_val().data()));
@@ -7950,7 +7948,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<uInt64*>(reinterpret_cast<const uInt64*>(request->attr_val().data()));
@@ -7976,7 +7974,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8 attr_val = request->attr_val();
@@ -8001,7 +7999,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8* attr_val = (uInt8*)request->attr_val().c_str();
@@ -8027,7 +8025,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 average_power_mean {};
@@ -8055,7 +8053,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -8099,7 +8097,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       float64 timeout = request->timeout();
       auto status = library_->WaitForAcquisitionComplete(instrument, timeout);
       if (!status_ok(status)) {
@@ -8122,7 +8120,7 @@ namespace nirfmxnr_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       auto status = library_->WaitForMeasurementComplete(instrument, selector_string, timeout);

--- a/generated/nirfmxspecan/nirfmxspecan_service.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_service.cpp
@@ -56,7 +56,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -112,7 +112,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 integration_bandwidth = request->integration_bandwidth();
       int32 number_of_offsets = request->number_of_offsets();
@@ -138,7 +138,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 carrier_frequency = request->carrier_frequency();
       auto status = library_->ACPCfgCarrierFrequency(instrument, selector_string, carrier_frequency);
@@ -162,7 +162,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 integration_bandwidth = request->integration_bandwidth();
       auto status = library_->ACPCfgCarrierIntegrationBandwidth(instrument, selector_string, integration_bandwidth);
@@ -186,7 +186,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 carrier_mode;
       switch (request->carrier_mode_enum_case()) {
@@ -225,7 +225,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rrc_filter_enabled;
       switch (request->rrc_filter_enabled_enum_case()) {
@@ -265,7 +265,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 fft_window;
       switch (request->fft_window_enum_case()) {
@@ -305,7 +305,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 measurement_method;
       switch (request->measurement_method_enum_case()) {
@@ -344,7 +344,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 noise_compensation_enabled;
       switch (request->noise_compensation_enabled_enum_case()) {
@@ -383,7 +383,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_carriers = request->number_of_carriers();
       auto status = library_->ACPCfgNumberOfCarriers(instrument, selector_string, number_of_carriers);
@@ -407,7 +407,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_offsets = request->number_of_offsets();
       auto status = library_->ACPCfgNumberOfOffsets(instrument, selector_string, number_of_offsets);
@@ -431,7 +431,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 offset_frequency = request->offset_frequency();
       int32 offset_sideband;
@@ -487,7 +487,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto offset_frequency = const_cast<float64*>(request->offset_frequency().data());
       auto offset_sideband_vector = std::vector<int32>();
@@ -548,7 +548,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 offset_frequency_definition;
       switch (request->offset_frequency_definition_enum_case()) {
@@ -587,7 +587,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 integration_bandwidth = request->integration_bandwidth();
       auto status = library_->ACPCfgOffsetIntegrationBandwidth(instrument, selector_string, integration_bandwidth);
@@ -611,7 +611,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto integration_bandwidth = const_cast<float64*>(request->integration_bandwidth().data());
       int32 number_of_elements = static_cast<int32>(request->integration_bandwidth().size());
@@ -636,7 +636,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 offset_reference_carrier;
       switch (request->offset_reference_carrier_enum_case()) {
@@ -676,7 +676,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto offset_power_reference_carrier_vector = std::vector<int32>();
       offset_power_reference_carrier_vector.reserve(request->offset_power_reference_carrier().size());
@@ -726,7 +726,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rrc_filter_enabled;
       switch (request->rrc_filter_enabled_enum_case()) {
@@ -766,7 +766,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto rrc_filter_enabled_vector = std::vector<int32>();
       rrc_filter_enabled_vector.reserve(request->rrc_filter_enabled().size());
@@ -816,7 +816,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 relative_attenuation = request->relative_attenuation();
       auto status = library_->ACPCfgOffsetRelativeAttenuation(instrument, selector_string, relative_attenuation);
@@ -840,7 +840,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto relative_attenuation = const_cast<float64*>(request->relative_attenuation().data());
       int32 number_of_elements = static_cast<int32>(request->relative_attenuation().size());
@@ -865,7 +865,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 power_units;
       switch (request->power_units_enum_case()) {
@@ -904,7 +904,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rbw_auto;
       switch (request->rbw_auto_enum_case()) {
@@ -960,7 +960,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sweep_time_auto;
       switch (request->sweep_time_auto_enum_case()) {
@@ -1000,7 +1000,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 trace_index = request->trace_index();
@@ -1045,7 +1045,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 absolute_power {};
@@ -1077,7 +1077,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 frequency_resolution {};
@@ -1103,7 +1103,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 lower_relative_power {};
@@ -1135,7 +1135,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -1184,7 +1184,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 trace_index = request->trace_index();
@@ -1229,7 +1229,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -1273,7 +1273,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 total_carrier_power {};
@@ -1299,7 +1299,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 carrier_absolute_power {};
@@ -1333,7 +1333,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 noise_calibration_data_valid {};
       auto status = library_->ACPValidateNoiseCalibrationData(instrument, selector_string, &noise_calibration_data_valid);
@@ -1359,7 +1359,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 am_to_am_curve_fit_order = request->am_to_am_curve_fit_order();
       int32 am_to_am_curve_fit_type;
@@ -1399,7 +1399,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 am_to_pm_curve_fit_order = request->am_to_pm_curve_fit_order();
       int32 am_to_pm_curve_fit_type;
@@ -1439,7 +1439,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -1479,7 +1479,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 compression_point_enabled;
       switch (request->compression_point_enabled_enum_case()) {
@@ -1520,7 +1520,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 dut_average_input_power = request->dut_average_input_power();
       auto status = library_->AMPMCfgDUTAverageInputPower(instrument, selector_string, dut_average_input_power);
@@ -1544,7 +1544,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 measurement_interval = request->measurement_interval();
       auto status = library_->AMPMCfgMeasurementInterval(instrument, selector_string, measurement_interval);
@@ -1568,7 +1568,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sample_rate_mode;
       switch (request->sample_rate_mode_enum_case()) {
@@ -1608,7 +1608,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 reference_power_type;
       switch (request->reference_power_type_enum_case()) {
@@ -1647,7 +1647,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 x0 = request->x0();
       float64 dx = request->dx();
@@ -1706,7 +1706,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 synchronization_method;
       switch (request->synchronization_method_enum_case()) {
@@ -1745,7 +1745,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 threshold_enabled;
       switch (request->threshold_enabled_enum_case()) {
@@ -1801,7 +1801,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -1847,7 +1847,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -1893,7 +1893,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -1936,7 +1936,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -1979,7 +1979,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 am_to_am_residual {};
@@ -2007,7 +2007,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 mean_linear_gain {};
@@ -2037,7 +2037,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 gain_error_range {};
@@ -2067,7 +2067,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -2117,7 +2117,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -2167,7 +2167,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -2211,7 +2211,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -2255,7 +2255,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->AbortMeasurements(instrument, selector_string);
       if (!status_ok(status)) {
@@ -2278,7 +2278,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* result_name = (char*)request->result_name().c_str();
       float64 x0 = request->x0();
@@ -2308,7 +2308,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* result_name = (char*)request->result_name().c_str();
       float64 x0 = request->x0();
@@ -2338,7 +2338,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 bandwidth = request->bandwidth();
       float64 measurement_interval = request->measurement_interval();
@@ -2860,7 +2860,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 measurement_interval = request->measurement_interval();
       auto status = library_->CCDFCfgMeasurementInterval(instrument, selector_string, measurement_interval);
@@ -2884,7 +2884,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_records = request->number_of_records();
       auto status = library_->CCDFCfgNumberOfRecords(instrument, selector_string, number_of_records);
@@ -2908,7 +2908,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 rbw = request->rbw();
       int32 rbw_filter_type;
@@ -2949,7 +2949,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 threshold_enabled;
       switch (request->threshold_enabled_enum_case()) {
@@ -3005,7 +3005,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 ten_percent_power {};
@@ -3041,7 +3041,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -3085,7 +3085,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 mean_power {};
@@ -3117,7 +3117,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -3161,7 +3161,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 mean_power {};
@@ -3193,7 +3193,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -3249,7 +3249,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 carrier_frequency = request->carrier_frequency();
       auto status = library_->CHPCfgCarrierOffset(instrument, selector_string, carrier_frequency);
@@ -3273,7 +3273,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 fft_window;
       switch (request->fft_window_enum_case()) {
@@ -3313,7 +3313,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 integration_bandwidth = request->integration_bandwidth();
       auto status = library_->CHPCfgIntegrationBandwidth(instrument, selector_string, integration_bandwidth);
@@ -3337,7 +3337,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_carriers = request->number_of_carriers();
       auto status = library_->CHPCfgNumberOfCarriers(instrument, selector_string, number_of_carriers);
@@ -3361,7 +3361,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rbw_auto;
       switch (request->rbw_auto_enum_case()) {
@@ -3417,7 +3417,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rrc_filter_enabled;
       switch (request->rrc_filter_enabled_enum_case()) {
@@ -3457,7 +3457,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 span = request->span();
       auto status = library_->CHPCfgSpan(instrument, selector_string, span);
@@ -3481,7 +3481,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sweep_time_auto;
       switch (request->sweep_time_auto_enum_case()) {
@@ -3521,7 +3521,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 absolute_power {};
@@ -3551,7 +3551,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -3595,7 +3595,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 total_carrier_power {};
@@ -3621,7 +3621,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 absolute_power {};
@@ -3649,7 +3649,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 noise_calibration_data_valid {};
       auto status = library_->CHPValidateNoiseCalibrationData(instrument, selector_string, &noise_calibration_data_valid);
@@ -3675,7 +3675,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* digital_edge_source;
       switch (request->digital_edge_source_enum_case()) {
@@ -3736,7 +3736,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 external_attenuation = request->external_attenuation();
       auto status = library_->CfgExternalAttenuation(instrument, selector_string, external_attenuation);
@@ -3760,7 +3760,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 center_frequency = request->center_frequency();
       auto status = library_->CfgFrequency(instrument, selector_string, center_frequency);
@@ -3784,7 +3784,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       char* frequency_reference_source;
       switch (request->frequency_reference_source_enum_case()) {
@@ -3828,7 +3828,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* iq_power_edge_source = (char*)request->iq_power_edge_source().c_str();
       float64 iq_power_edge_level = request->iq_power_edge_level();
@@ -3888,7 +3888,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 mechanical_attenuation_auto;
       switch (request->mechanical_attenuation_auto_enum_case()) {
@@ -3928,7 +3928,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 center_frequency = request->center_frequency();
       float64 reference_level = request->reference_level();
@@ -3954,7 +3954,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 rf_attenuation_auto;
       switch (request->rf_attenuation_auto_enum_case()) {
@@ -3994,7 +3994,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 reference_level = request->reference_level();
       auto status = library_->CfgReferenceLevel(instrument, selector_string, reference_level);
@@ -4018,7 +4018,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 trigger_delay = request->trigger_delay();
       int32 enable_trigger = request->enable_trigger();
@@ -4043,7 +4043,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 is_done {};
       auto status = library_->CheckMeasurementStatus(instrument, selector_string, &is_done);
@@ -4068,7 +4068,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearAllNamedResults(instrument, selector_string);
       if (!status_ok(status)) {
@@ -4091,7 +4091,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearNamedResult(instrument, selector_string);
       if (!status_ok(status)) {
@@ -4114,7 +4114,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearNoiseCalibrationDatabase(instrument, selector_string);
       if (!status_ok(status)) {
@@ -4137,7 +4137,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* old_signal_name = (char*)request->old_signal_name().c_str();
       char* new_signal_name = (char*)request->new_signal_name().c_str();
       auto status = library_->CloneSignalConfiguration(instrument, old_signal_name, new_signal_name);
@@ -4161,9 +4161,9 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 force_destroy = request->force_destroy();
-      session_repository_->remove_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      session_repository_->remove_session(instrument_grpc_session.name());
       auto status = library_->Close(instrument, force_destroy);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -4185,7 +4185,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->Commit(instrument, selector_string);
       if (!status_ok(status)) {
@@ -4208,7 +4208,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* list_name = (char*)request->list_name().c_str();
       auto status = library_->CreateList(instrument, list_name);
       if (!status_ok(status)) {
@@ -4231,7 +4231,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 created_step_index {};
       auto status = library_->CreateListStep(instrument, selector_string, &created_step_index);
@@ -4256,7 +4256,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->CreateSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
@@ -4279,7 +4279,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 x0_in = request->x0_in();
       float64 dx_in = request->dx_in();
@@ -4353,7 +4353,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 x0_in = request->x0_in();
       float64 dx_in = request->dx_in();
@@ -4424,7 +4424,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 configuration_input;
       switch (request->configuration_input_enum_case()) {
@@ -4463,7 +4463,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 lut_correction_type;
       switch (request->lut_correction_type_enum_case()) {
@@ -4502,7 +4502,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 memory_model_correction_type;
       switch (request->memory_model_correction_type_enum_case()) {
@@ -4541,7 +4541,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto dpd_polynomial = convert_from_grpc<NIComplexSingle>(request->dpd_polynomial());
       int32 array_size = static_cast<int32>(request->dpd_polynomial().size());
@@ -4566,7 +4566,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto lut_input_powers = const_cast<float32*>(request->lut_input_powers().data());
       auto lut_complex_gains = convert_from_grpc<NIComplexSingle>(request->lut_complex_gains());
@@ -4608,7 +4608,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -4648,7 +4648,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 dpd_model;
       switch (request->dpd_model_enum_case()) {
@@ -4687,7 +4687,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 dut_average_input_power = request->dut_average_input_power();
       auto status = library_->DPDCfgDUTAverageInputPower(instrument, selector_string, dut_average_input_power);
@@ -4711,7 +4711,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 memory_polynomial_lead_order = request->memory_polynomial_lead_order();
       int32 memory_polynomial_lag_order = request->memory_polynomial_lag_order();
@@ -4740,7 +4740,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 iterative_dpd_enabled;
       switch (request->iterative_dpd_enabled_enum_case()) {
@@ -4779,7 +4779,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 am_to_am_curve_fit_order = request->am_to_am_curve_fit_order();
       int32 am_to_am_curve_fit_type;
@@ -4819,7 +4819,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 am_to_pm_curve_fit_order = request->am_to_pm_curve_fit_order();
       int32 am_to_pm_curve_fit_type;
@@ -4859,7 +4859,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 step_size = request->step_size();
       auto status = library_->DPDCfgLookupTableStepSize(instrument, selector_string, step_size);
@@ -4883,7 +4883,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 threshold_enabled;
       switch (request->threshold_enabled_enum_case()) {
@@ -4939,7 +4939,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 lookup_table_type;
       switch (request->lookup_table_type_enum_case()) {
@@ -4978,7 +4978,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 measurement_interval = request->measurement_interval();
       auto status = library_->DPDCfgMeasurementInterval(instrument, selector_string, measurement_interval);
@@ -5002,7 +5002,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sample_rate_mode;
       switch (request->sample_rate_mode_enum_case()) {
@@ -5042,7 +5042,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 memory_polynomial_order = request->memory_polynomial_order();
       int32 memory_polynomial_memory_depth = request->memory_polynomial_memory_depth();
@@ -5067,7 +5067,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto previous_dpd_polynomial = convert_from_grpc<NIComplexSingle>(request->previous_dpd_polynomial());
       int32 array_size = static_cast<int32>(request->previous_dpd_polynomial().size());
@@ -5092,7 +5092,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 x0 = request->x0();
       float64 dx = request->dx();
@@ -5151,7 +5151,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 synchronization_method;
       switch (request->synchronization_method_enum_case()) {
@@ -5190,7 +5190,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 pre_cfr_papr {};
@@ -5216,7 +5216,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 average_gain {};
@@ -5242,7 +5242,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -5288,7 +5288,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -5337,7 +5337,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 nmse {};
@@ -5363,7 +5363,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5413,7 +5413,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5463,7 +5463,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* list_name = (char*)request->list_name().c_str();
       auto status = library_->DeleteList(instrument, list_name);
       if (!status_ok(status)) {
@@ -5486,7 +5486,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->DeleteSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
@@ -5509,7 +5509,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->DisableTrigger(instrument, selector_string);
       if (!status_ok(status)) {
@@ -5532,7 +5532,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -5588,7 +5588,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 measurement_interval = request->measurement_interval();
       auto status = library_->FCntCfgMeasurementInterval(instrument, selector_string, measurement_interval);
@@ -5612,7 +5612,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 rbw = request->rbw();
       int32 rbw_filter_type;
@@ -5653,7 +5653,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 threshold_enabled;
       switch (request->threshold_enabled_enum_case()) {
@@ -5709,7 +5709,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 allan_deviation {};
@@ -5735,7 +5735,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5779,7 +5779,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 average_relative_frequency {};
@@ -5809,7 +5809,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5853,7 +5853,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5897,7 +5897,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 average_relative_frequency {};
@@ -5927,7 +5927,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 actual_result_names_size {};
       int32 default_result_exists {};
@@ -5971,7 +5971,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float32 attr_val {};
@@ -5997,7 +5997,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -6037,7 +6037,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float64 attr_val {};
@@ -6063,7 +6063,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -6103,7 +6103,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int16 attr_val {};
@@ -6129,7 +6129,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 attr_val {};
@@ -6161,7 +6161,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -6215,7 +6215,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int64 attr_val {};
@@ -6241,7 +6241,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -6281,7 +6281,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int8 attr_val {};
@@ -6307,7 +6307,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -6355,7 +6355,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -6401,7 +6401,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -6447,7 +6447,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
 
@@ -6490,7 +6490,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt16 attr_val {};
@@ -6516,7 +6516,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt32 attr_val {};
@@ -6542,7 +6542,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -6582,7 +6582,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -6622,7 +6622,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8 attr_val {};
@@ -6648,7 +6648,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -6688,7 +6688,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
 
       while (true) {
         auto status = library_->GetError(instrument, nullptr, 0, nullptr);
@@ -6731,7 +6731,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 error_code = request->error_code();
 
       while (true) {
@@ -6773,7 +6773,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 auto_harmonics_setup_enabled;
       switch (request->auto_harmonics_setup_enabled_enum_case()) {
@@ -6812,7 +6812,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -6868,7 +6868,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 measurement_interval = request->measurement_interval();
       auto status = library_->HarmCfgFundamentalMeasurementInterval(instrument, selector_string, measurement_interval);
@@ -6892,7 +6892,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 rbw = request->rbw();
       int32 rbw_filter_type;
@@ -6933,7 +6933,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 harmonic_order = request->harmonic_order();
       float64 harmonic_bandwidth = request->harmonic_bandwidth();
@@ -6975,7 +6975,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto harmonic_order = const_cast<int32*>(reinterpret_cast<const int32*>(request->harmonic_order().data()));
       auto harmonic_bandwidth = const_cast<float64*>(request->harmonic_bandwidth().data());
@@ -7031,7 +7031,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_harmonics = request->number_of_harmonics();
       auto status = library_->HarmCfgNumberOfHarmonics(instrument, selector_string, number_of_harmonics);
@@ -7055,7 +7055,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 average_relative_power {};
@@ -7087,7 +7087,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7136,7 +7136,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -7180,7 +7180,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 total_harmonic_distortion {};
@@ -7210,7 +7210,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 total_harmonic_distortion {};
@@ -7238,7 +7238,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 auto_intermods_setup_enabled;
       switch (request->auto_intermods_setup_enabled_enum_case()) {
@@ -7278,7 +7278,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -7334,7 +7334,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 fft_window;
       switch (request->fft_window_enum_case()) {
@@ -7374,7 +7374,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 frequency_definition;
       switch (request->frequency_definition_enum_case()) {
@@ -7413,7 +7413,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 lower_tone_frequency = request->lower_tone_frequency();
       float64 upper_tone_frequency = request->upper_tone_frequency();
@@ -7438,7 +7438,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 intermod_order = request->intermod_order();
       float64 lower_intermod_frequency = request->lower_intermod_frequency();
@@ -7496,7 +7496,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto intermod_order = const_cast<int32*>(reinterpret_cast<const int32*>(request->intermod_order().data()));
       auto lower_intermod_frequency = const_cast<float64*>(request->lower_intermod_frequency().data());
@@ -7563,7 +7563,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 measurement_method;
       switch (request->measurement_method_enum_case()) {
@@ -7602,7 +7602,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_intermods = request->number_of_intermods();
       auto status = library_->IMCfgNumberOfIntermods(instrument, selector_string, number_of_intermods);
@@ -7626,7 +7626,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rbw_auto;
       switch (request->rbw_auto_enum_case()) {
@@ -7682,7 +7682,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sweep_time_auto;
       switch (request->sweep_time_auto_enum_case()) {
@@ -7722,7 +7722,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 lower_tone_power {};
@@ -7750,7 +7750,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 intermod_order {};
@@ -7782,7 +7782,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7831,7 +7831,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 intermod_order {};
@@ -7861,7 +7861,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7907,7 +7907,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 spectrum_index = request->spectrum_index();
@@ -7952,7 +7952,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 sample_rate = request->sample_rate();
       int32 number_of_records = request->number_of_records();
@@ -7979,7 +7979,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 bandwidth_auto;
       switch (request->bandwidth_auto_enum_case()) {
@@ -8019,7 +8019,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 record_to_fetch = request->record_to_fetch();
@@ -8071,7 +8071,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 records_done {};
       auto status = library_->IQGetRecordsDone(instrument, selector_string, &records_done);
@@ -8104,15 +8104,14 @@ namespace nirfmxspecan_grpc {
         auto status = library_->Initialize(resource_name, option_string, &instrument, &is_new_session);
         return std::make_tuple(status, instrument);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXSPECAN_VAL_FALSE); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_instrument()->set_id(session_id);
+      response->mutable_instrument()->set_name(grpc_device_session_name);
       response->set_is_new_session(is_new_session);
       return ::grpc::Status::OK;
     }
@@ -8130,22 +8129,21 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto nirfsa_session_grpc_session = request->nirfsa_session();
-      uInt32 nirfsa_session = vi_session_resource_repository_->access_session(nirfsa_session_grpc_session.id(), nirfsa_session_grpc_session.name());
+      uInt32 nirfsa_session = vi_session_resource_repository_->access_session(nirfsa_session_grpc_session.name());
 
       auto init_lambda = [&] () {
         niRFmxInstrHandle instrument;
         auto status = library_->InitializeFromNIRFSASession(nirfsa_session, &instrument);
         return std::make_tuple(status, instrument);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXSPECAN_VAL_FALSE); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_instrument()->set_id(session_id);
+      response->mutable_instrument()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -8162,7 +8160,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* result_name = (char*)request->result_name().c_str();
       auto status = library_->Initiate(instrument, selector_string, result_name);
@@ -8186,7 +8184,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_markers = request->number_of_markers();
       auto status = library_->MarkerCfgNumberOfMarkers(instrument, selector_string, number_of_markers);
@@ -8210,7 +8208,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 peak_excursion_enabled;
       switch (request->peak_excursion_enabled_enum_case()) {
@@ -8250,7 +8248,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 reference_marker = request->reference_marker();
       auto status = library_->MarkerCfgReferenceMarker(instrument, selector_string, reference_marker);
@@ -8274,7 +8272,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 threshold_enabled;
       switch (request->threshold_enabled_enum_case()) {
@@ -8314,7 +8312,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 trace;
       switch (request->trace_enum_case()) {
@@ -8353,7 +8351,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 marker_type;
       switch (request->marker_type_enum_case()) {
@@ -8392,7 +8390,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 marker_x_location = request->marker_x_location();
       auto status = library_->MarkerCfgXLocation(instrument, selector_string, marker_x_location);
@@ -8416,7 +8414,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 marker_x_location {};
       float64 marker_y_location {};
@@ -8443,7 +8441,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 next_peak;
       switch (request->next_peak_enum_case()) {
@@ -8484,7 +8482,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_peaks {};
       auto status = library_->MarkerPeakSearch(instrument, selector_string, &number_of_peaks);
@@ -8509,7 +8507,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -8549,7 +8547,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 calibration_loss_compensation_enabled;
       switch (request->calibration_loss_compensation_enabled_enum_case()) {
@@ -8608,7 +8606,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto dut_s_parameters_frequency = const_cast<float64*>(request->dut_s_parameters_frequency().data());
       auto dut_s21 = const_cast<float64*>(request->dut_s21().data());
@@ -8659,7 +8657,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto termination_vswr = const_cast<float64*>(request->termination_vswr().data());
       auto termination_vswr_frequency = const_cast<float64*>(request->termination_vswr_frequency().data());
@@ -8702,7 +8700,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 cold_source_mode;
       switch (request->cold_source_mode_enum_case()) {
@@ -8741,7 +8739,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 dut_input_loss_compensation_enabled;
       switch (request->dut_input_loss_compensation_enabled_enum_case()) {
@@ -8800,7 +8798,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 dut_output_loss_compensation_enabled;
       switch (request->dut_output_loss_compensation_enabled_enum_case()) {
@@ -8859,7 +8857,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto frequency_list = const_cast<float64*>(request->frequency_list().data());
       int32 array_size = static_cast<int32>(request->frequency_list().size());
@@ -8884,7 +8882,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 start_frequency = request->start_frequency();
       float64 stop_frequency = request->stop_frequency();
@@ -8910,7 +8908,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 start_frequency = request->start_frequency();
       float64 stop_frequency = request->stop_frequency();
@@ -8936,7 +8934,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 measurement_bandwidth = request->measurement_bandwidth();
       auto status = library_->NFCfgMeasurementBandwidth(instrument, selector_string, measurement_bandwidth);
@@ -8960,7 +8958,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 measurement_interval = request->measurement_interval();
       auto status = library_->NFCfgMeasurementInterval(instrument, selector_string, measurement_interval);
@@ -8984,7 +8982,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 measurement_method;
       switch (request->measurement_method_enum_case()) {
@@ -9023,7 +9021,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 y_factor_mode;
       switch (request->y_factor_mode_enum_case()) {
@@ -9062,7 +9060,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto enr_frequency = const_cast<float64*>(request->enr_frequency().data());
       auto enr = const_cast<float64*>(request->enr().data());
@@ -9106,7 +9104,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 noise_source_loss_compensation_enabled;
       switch (request->noise_source_loss_compensation_enabled_enum_case()) {
@@ -9165,7 +9163,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 settling_time = request->settling_time();
       auto status = library_->NFCfgYFactorNoiseSourceSettlingTime(instrument, selector_string, settling_time);
@@ -9189,7 +9187,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* calibration_setup_id = (char*)request->calibration_setup_id().c_str();
       auto status = library_->NFClearCalibrationDatabase(instrument, calibration_setup_id);
       if (!status_ok(status)) {
@@ -9212,7 +9210,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -9252,7 +9250,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -9292,7 +9290,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -9338,7 +9336,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -9381,7 +9379,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -9424,7 +9422,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 dut_max_gain = request->dut_max_gain();
       float64 dut_max_noise_figure = request->dut_max_noise_figure();
@@ -9451,7 +9449,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 calibration_data_valid {};
       auto status = library_->NFValidateCalibrationData(instrument, selector_string, &calibration_data_valid);
@@ -9477,7 +9475,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -9533,7 +9531,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 bandwidth_percentage = request->bandwidth_percentage();
       auto status = library_->OBWCfgBandwidthPercentage(instrument, selector_string, bandwidth_percentage);
@@ -9557,7 +9555,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 fft_window;
       switch (request->fft_window_enum_case()) {
@@ -9597,7 +9595,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 power_units;
       switch (request->power_units_enum_case()) {
@@ -9636,7 +9634,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rbw_auto;
       switch (request->rbw_auto_enum_case()) {
@@ -9692,7 +9690,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 span = request->span();
       auto status = library_->OBWCfgSpan(instrument, selector_string, span);
@@ -9716,7 +9714,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sweep_time_auto;
       switch (request->sweep_time_auto_enum_case()) {
@@ -9756,7 +9754,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 occupied_bandwidth {};
@@ -9790,7 +9788,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -9834,7 +9832,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 occupied_bandwidth {};
@@ -9868,7 +9866,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 measurement_bandwidth = request->measurement_bandwidth();
       auto status = library_->PAVTCfgMeasurementBandwidth(instrument, selector_string, measurement_bandwidth);
@@ -9892,7 +9890,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 measurement_offset = request->measurement_offset();
       float64 measurement_length = request->measurement_length();
@@ -9917,7 +9915,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 measurement_interval_mode;
       switch (request->measurement_interval_mode_enum_case()) {
@@ -9956,7 +9954,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 measurement_location_type;
       switch (request->measurement_location_type_enum_case()) {
@@ -9995,7 +9993,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_segments = request->number_of_segments();
       auto status = library_->PAVTCfgNumberOfSegments(instrument, selector_string, number_of_segments);
@@ -10019,7 +10017,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 segment_measurement_offset = request->segment_measurement_offset();
       float64 segment_measurement_length = request->segment_measurement_length();
@@ -10044,7 +10042,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto segment_measurement_offset = const_cast<float64*>(request->segment_measurement_offset().data());
       auto segment_measurement_length = const_cast<float64*>(request->segment_measurement_length().data());
@@ -10086,7 +10084,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto segment_start_time = const_cast<float64*>(request->segment_start_time().data());
       int32 number_of_elements = static_cast<int32>(request->segment_start_time().size());
@@ -10111,7 +10109,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_segments = request->number_of_segments();
       float64 segment0_start_time = request->segment0_start_time();
@@ -10137,7 +10135,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 segment_type;
       switch (request->segment_type_enum_case()) {
@@ -10176,7 +10174,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto segment_type_vector = std::vector<int32>();
       segment_type_vector.reserve(request->segment_type().size());
@@ -10209,7 +10207,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 trace_index = request->trace_index();
@@ -10254,7 +10252,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 mean_relative_phase {};
@@ -10286,7 +10284,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -10335,7 +10333,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 trace_index = request->trace_index();
@@ -10380,7 +10378,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 start_frequency = request->start_frequency();
       float64 stop_frequency = request->stop_frequency();
@@ -10406,7 +10404,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_multiplier = request->averaging_multiplier();
       auto status = library_->PhaseNoiseCfgAveragingMultiplier(instrument, selector_string, averaging_multiplier);
@@ -10430,7 +10428,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 cancellation_enabled;
       switch (request->cancellation_enabled_enum_case()) {
@@ -10489,7 +10487,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 integrated_noise_range_definition;
       switch (request->integrated_noise_range_definition_enum_case()) {
@@ -10547,7 +10545,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_ranges = request->number_of_ranges();
       auto status = library_->PhaseNoiseCfgNumberOfRanges(instrument, selector_string, number_of_ranges);
@@ -10571,7 +10569,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto range_start_frequency = const_cast<float64*>(request->range_start_frequency().data());
       auto range_stop_frequency = const_cast<float64*>(request->range_stop_frequency().data());
@@ -10619,7 +10617,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 range_definition;
       switch (request->range_definition_enum_case()) {
@@ -10658,7 +10656,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 smoothing_type;
       switch (request->smoothing_type_enum_case()) {
@@ -10698,7 +10696,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto frequency_list = const_cast<float64*>(request->frequency_list().data());
       int32 array_size = static_cast<int32>(request->frequency_list().size());
@@ -10723,7 +10721,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 spur_removal_enabled;
       switch (request->spur_removal_enabled_enum_case()) {
@@ -10763,7 +10761,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 carrier_frequency {};
@@ -10791,7 +10789,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -10843,7 +10841,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -10886,7 +10884,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -10929,7 +10927,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -10969,7 +10967,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(instrument, selector_string, attribute_id);
@@ -10993,7 +10991,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ResetToDefault(instrument, selector_string);
       if (!status_ok(status)) {
@@ -11016,7 +11014,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -11072,7 +11070,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 carrier_channel_bandwidth = request->carrier_channel_bandwidth();
       auto status = library_->SEMCfgCarrierChannelBandwidth(instrument, selector_string, carrier_channel_bandwidth);
@@ -11096,7 +11094,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 carrier_enabled;
       switch (request->carrier_enabled_enum_case()) {
@@ -11135,7 +11133,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 carrier_frequency = request->carrier_frequency();
       auto status = library_->SEMCfgCarrierFrequency(instrument, selector_string, carrier_frequency);
@@ -11159,7 +11157,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 integration_bandwidth = request->integration_bandwidth();
       auto status = library_->SEMCfgCarrierIntegrationBandwidth(instrument, selector_string, integration_bandwidth);
@@ -11183,7 +11181,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rbw_auto;
       switch (request->rbw_auto_enum_case()) {
@@ -11239,7 +11237,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rrc_filter_enabled;
       switch (request->rrc_filter_enabled_enum_case()) {
@@ -11279,7 +11277,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 fft_window;
       switch (request->fft_window_enum_case()) {
@@ -11319,7 +11317,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_carriers = request->number_of_carriers();
       auto status = library_->SEMCfgNumberOfCarriers(instrument, selector_string, number_of_carriers);
@@ -11343,7 +11341,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_offsets = request->number_of_offsets();
       auto status = library_->SEMCfgNumberOfOffsets(instrument, selector_string, number_of_offsets);
@@ -11367,7 +11365,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 absolute_limit_mode;
       switch (request->absolute_limit_mode_enum_case()) {
@@ -11408,7 +11406,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto absolute_limit_mode_vector = std::vector<int32>();
       absolute_limit_mode_vector.reserve(request->absolute_limit_mode().size());
@@ -11461,7 +11459,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 bandwidth_integral = request->bandwidth_integral();
       auto status = library_->SEMCfgOffsetBandwidthIntegral(instrument, selector_string, bandwidth_integral);
@@ -11485,7 +11483,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 offset_start_frequency = request->offset_start_frequency();
       float64 offset_stop_frequency = request->offset_stop_frequency();
@@ -11542,7 +11540,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto offset_start_frequency = const_cast<float64*>(request->offset_start_frequency().data());
       auto offset_stop_frequency = const_cast<float64*>(request->offset_stop_frequency().data());
@@ -11606,7 +11604,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 offset_frequency_definition;
       switch (request->offset_frequency_definition_enum_case()) {
@@ -11645,7 +11643,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 limit_fail_mask;
       switch (request->limit_fail_mask_enum_case()) {
@@ -11684,7 +11682,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rbw_auto;
       switch (request->rbw_auto_enum_case()) {
@@ -11740,7 +11738,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto rbw_auto_vector = std::vector<int32>();
       rbw_auto_vector.reserve(request->rbw_auto().size());
@@ -11801,7 +11799,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 relative_attenuation = request->relative_attenuation();
       auto status = library_->SEMCfgOffsetRelativeAttenuation(instrument, selector_string, relative_attenuation);
@@ -11825,7 +11823,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto relative_attenuation = const_cast<float64*>(request->relative_attenuation().data());
       int32 number_of_elements = static_cast<int32>(request->relative_attenuation().size());
@@ -11850,7 +11848,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 relative_limit_mode;
       switch (request->relative_limit_mode_enum_case()) {
@@ -11891,7 +11889,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto relative_limit_mode_vector = std::vector<int32>();
       relative_limit_mode_vector.reserve(request->relative_limit_mode().size());
@@ -11944,7 +11942,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 power_units;
       switch (request->power_units_enum_case()) {
@@ -11983,7 +11981,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 reference_type;
       switch (request->reference_type_enum_case()) {
@@ -12022,7 +12020,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sweep_time_auto;
       switch (request->sweep_time_auto_enum_case()) {
@@ -12062,7 +12060,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -12106,7 +12104,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 absolute_power {};
@@ -12138,7 +12136,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 composite_measurement_status {};
@@ -12165,7 +12163,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 frequency_resolution {};
@@ -12191,7 +12189,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 measurement_status {};
@@ -12226,7 +12224,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -12287,7 +12285,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 total_absolute_power {};
@@ -12321,7 +12319,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -12373,7 +12371,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -12417,7 +12415,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -12461,7 +12459,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 total_carrier_power {};
@@ -12487,7 +12485,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 measurement_status {};
@@ -12522,7 +12520,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -12583,7 +12581,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 total_absolute_power {};
@@ -12617,7 +12615,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -12669,7 +12667,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       uInt32 measurements;
       switch (request->measurements_enum_case()) {
@@ -12709,7 +12707,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       auto status = library_->SendSoftwareEdgeTrigger(instrument);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -12731,7 +12729,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float32 attr_val = request->attr_val();
@@ -12756,7 +12754,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<float32*>(request->attr_val().data());
@@ -12782,7 +12780,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float64 attr_val = request->attr_val();
@@ -12807,7 +12805,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<float64*>(request->attr_val().data());
@@ -12833,7 +12831,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -12867,7 +12865,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 attr_val;
@@ -12907,7 +12905,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_vector = std::vector<int32>();
@@ -12941,7 +12939,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int64 attr_val = request->attr_val();
@@ -12966,7 +12964,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<int64*>(reinterpret_cast<const int64*>(request->attr_val().data()));
@@ -12992,7 +12990,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -13026,7 +13024,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -13069,7 +13067,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = convert_from_grpc<NIComplexDouble>(request->attr_val());
@@ -13095,7 +13093,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = convert_from_grpc<NIComplexSingle>(request->attr_val());
@@ -13121,7 +13119,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       char* attr_val;
@@ -13165,7 +13163,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -13199,7 +13197,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt32 attr_val = request->attr_val();
@@ -13224,7 +13222,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<uInt32*>(reinterpret_cast<const uInt32*>(request->attr_val().data()));
@@ -13250,7 +13248,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<uInt64*>(reinterpret_cast<const uInt64*>(request->attr_val().data()));
@@ -13276,7 +13274,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8 attr_val = request->attr_val();
@@ -13301,7 +13299,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8* attr_val = (uInt8*)request->attr_val().c_str();
@@ -13327,7 +13325,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -13383,7 +13381,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 detector_type;
       switch (request->detector_type_enum_case()) {
@@ -13423,7 +13421,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 fft_window;
       switch (request->fft_window_enum_case()) {
@@ -13463,7 +13461,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 start_frequency = request->start_frequency();
       float64 stop_frequency = request->stop_frequency();
@@ -13488,7 +13486,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 noise_compensation_enabled;
       switch (request->noise_compensation_enabled_enum_case()) {
@@ -13527,7 +13525,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 spectrum_power_units;
       switch (request->spectrum_power_units_enum_case()) {
@@ -13566,7 +13564,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rbw_auto;
       switch (request->rbw_auto_enum_case()) {
@@ -13622,7 +13620,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 span = request->span();
       auto status = library_->SpectrumCfgSpan(instrument, selector_string, span);
@@ -13646,7 +13644,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sweep_time_auto;
       switch (request->sweep_time_auto_enum_case()) {
@@ -13686,7 +13684,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 vbw_auto;
       switch (request->vbw_auto_enum_case()) {
@@ -13727,7 +13725,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 peak_amplitude {};
@@ -13757,7 +13755,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -13801,7 +13799,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -13845,7 +13843,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -13889,7 +13887,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 noise_calibration_data_valid {};
       auto status = library_->SpectrumValidateNoiseCalibrationData(instrument, selector_string, &noise_calibration_data_valid);
@@ -13915,7 +13913,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -13971,7 +13969,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 fft_window;
       switch (request->fft_window_enum_case()) {
@@ -14010,7 +14008,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_ranges = request->number_of_ranges();
       auto status = library_->SpurCfgNumberOfRanges(instrument, selector_string, number_of_ranges);
@@ -14034,7 +14032,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 absolute_limit_mode;
       switch (request->absolute_limit_mode_enum_case()) {
@@ -14075,7 +14073,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto absolute_limit_mode_vector = std::vector<int32>();
       absolute_limit_mode_vector.reserve(request->absolute_limit_mode().size());
@@ -14128,7 +14126,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 detector_type;
       switch (request->detector_type_enum_case()) {
@@ -14168,7 +14166,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto detector_type_vector = std::vector<int32>();
       detector_type_vector.reserve(request->detector_type().size());
@@ -14218,7 +14216,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 start_frequency = request->start_frequency();
       float64 stop_frequency = request->stop_frequency();
@@ -14259,7 +14257,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto start_frequency = const_cast<float64*>(request->start_frequency().data());
       auto stop_frequency = const_cast<float64*>(request->stop_frequency().data());
@@ -14312,7 +14310,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_spurs_to_report = request->number_of_spurs_to_report();
       auto status = library_->SpurCfgRangeNumberOfSpursToReport(instrument, selector_string, number_of_spurs_to_report);
@@ -14336,7 +14334,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto number_of_spurs_to_report = const_cast<int32*>(reinterpret_cast<const int32*>(request->number_of_spurs_to_report().data()));
       int32 number_of_elements = static_cast<int32>(request->number_of_spurs_to_report().size());
@@ -14361,7 +14359,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 threshold = request->threshold();
       float64 excursion = request->excursion();
@@ -14386,7 +14384,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto threshold = const_cast<float64*>(request->threshold().data());
       auto excursion = const_cast<float64*>(request->excursion().data());
@@ -14428,7 +14426,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto rbw_auto_vector = std::vector<int32>();
       rbw_auto_vector.reserve(request->rbw_auto().size());
@@ -14489,7 +14487,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 rbw_auto;
       switch (request->rbw_auto_enum_case()) {
@@ -14545,7 +14543,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 relative_attenuation = request->relative_attenuation();
       auto status = library_->SpurCfgRangeRelativeAttenuation(instrument, selector_string, relative_attenuation);
@@ -14569,7 +14567,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto relative_attenuation = const_cast<float64*>(request->relative_attenuation().data());
       int32 number_of_elements = static_cast<int32>(request->relative_attenuation().size());
@@ -14594,7 +14592,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sweep_time_auto;
       switch (request->sweep_time_auto_enum_case()) {
@@ -14634,7 +14632,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto sweep_time_auto_vector = std::vector<int32>();
       sweep_time_auto_vector.reserve(request->sweep_time_auto().size());
@@ -14684,7 +14682,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 vbw_auto;
       switch (request->vbw_auto_enum_case()) {
@@ -14725,7 +14723,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto vbw_auto_vector = std::vector<int32>();
       vbw_auto_vector.reserve(request->vbw_auto().size());
@@ -14778,7 +14776,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 trace_range_index = request->trace_range_index();
       auto status = library_->SpurCfgTraceRangeIndex(instrument, selector_string, trace_range_index);
@@ -14802,7 +14800,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -14854,7 +14852,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 measurement_status {};
@@ -14881,7 +14879,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -14925,7 +14923,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -14969,7 +14967,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 range_status {};
@@ -14998,7 +14996,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -15050,7 +15048,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 spur_frequency {};
@@ -15082,7 +15080,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -15131,7 +15129,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -15187,7 +15185,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 measurement_interval = request->measurement_interval();
       auto status = library_->TXPCfgMeasurementInterval(instrument, selector_string, measurement_interval);
@@ -15211,7 +15209,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 rbw = request->rbw();
       int32 rbw_filter_type;
@@ -15252,7 +15250,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 threshold_enabled;
       switch (request->threshold_enabled_enum_case()) {
@@ -15308,7 +15306,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 vbw_auto;
       switch (request->vbw_auto_enum_case()) {
@@ -15349,7 +15347,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 average_mean_power {};
@@ -15381,7 +15379,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -15425,7 +15423,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 average_mean_power {};
@@ -15457,7 +15455,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       float64 timeout = request->timeout();
       auto status = library_->WaitForAcquisitionComplete(instrument, timeout);
       if (!status_ok(status)) {
@@ -15480,7 +15478,7 @@ namespace nirfmxspecan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       auto status = library_->WaitForMeasurementComplete(instrument, selector_string, timeout);

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_service.cpp
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_service.cpp
@@ -53,7 +53,7 @@ namespace nirfmxspecan_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 selector_string_out_size = request->selector_string_out_size();
       std::string selector_string_out;
@@ -83,7 +83,7 @@ namespace nirfmxspecan_restricted_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 record_to_fetch = request->record_to_fetch();

--- a/generated/nirfmxwlan/nirfmxwlan_service.cpp
+++ b/generated/nirfmxwlan/nirfmxwlan_service.cpp
@@ -57,7 +57,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->AbortMeasurements(instrument, selector_string);
       if (!status_ok(status)) {
@@ -80,7 +80,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* result_name = (char*)request->result_name().c_str();
       float64 x0 = request->x0();
@@ -110,7 +110,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* result_name = (char*)request->result_name().c_str();
       auto x0 = const_cast<float64*>(request->x0().data());
@@ -158,7 +158,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* result_name = (char*)request->result_name().c_str();
       auto x0 = const_cast<float64*>(request->x0().data());
@@ -206,7 +206,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* result_name = (char*)request->result_name().c_str();
       float64 x0 = request->x0();
@@ -236,7 +236,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       auto status = library_->AutoDetectSignal(instrument, selector_string, timeout);
@@ -260,7 +260,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 measurement_interval = request->measurement_interval();
       auto status = library_->AutoLevel(instrument, selector_string, measurement_interval);
@@ -571,7 +571,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 channel_bandwidth = request->channel_bandwidth();
       auto status = library_->CfgChannelBandwidth(instrument, selector_string, channel_bandwidth);
@@ -595,7 +595,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* digital_edge_source = (char*)request->digital_edge_source().c_str();
       int32 digital_edge;
@@ -637,7 +637,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 external_attenuation = request->external_attenuation();
       auto status = library_->CfgExternalAttenuation(instrument, selector_string, external_attenuation);
@@ -661,7 +661,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 center_frequency = request->center_frequency();
       auto status = library_->CfgFrequency(instrument, selector_string, center_frequency);
@@ -685,7 +685,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto center_frequency = const_cast<float64*>(request->center_frequency().data());
       int32 number_of_elements = static_cast<int32>(request->center_frequency().size());
@@ -710,7 +710,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       char* frequency_reference_source;
       switch (request->frequency_reference_source_enum_case()) {
@@ -754,7 +754,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* iq_power_edge_source = (char*)request->iq_power_edge_source().c_str();
       int32 iq_power_edge_slope;
@@ -830,7 +830,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 mechanical_attenuation_auto;
       switch (request->mechanical_attenuation_auto_enum_case()) {
@@ -870,7 +870,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_frequency_segments = request->number_of_frequency_segments();
       int32 number_of_receive_chains = request->number_of_receive_chains();
@@ -895,7 +895,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* channel_name = (char*)request->channel_name().c_str();
       int32 rf_attenuation_auto;
       switch (request->rf_attenuation_auto_enum_case()) {
@@ -935,7 +935,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 reference_level = request->reference_level();
       auto status = library_->CfgReferenceLevel(instrument, selector_string, reference_level);
@@ -959,7 +959,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* selected_ports = (char*)request->selected_ports().c_str();
       auto status = library_->CfgSelectedPortsMultiple(instrument, selector_string, selected_ports);
@@ -983,7 +983,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 trigger_delay = request->trigger_delay();
       int32 enable_trigger = request->enable_trigger();
@@ -1008,7 +1008,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 standard;
       switch (request->standard_enum_case()) {
@@ -1047,7 +1047,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 is_done {};
       auto status = library_->CheckMeasurementStatus(instrument, selector_string, &is_done);
@@ -1072,7 +1072,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearAllNamedResults(instrument, selector_string);
       if (!status_ok(status)) {
@@ -1095,7 +1095,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ClearNamedResult(instrument, selector_string);
       if (!status_ok(status)) {
@@ -1118,7 +1118,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* old_signal_name = (char*)request->old_signal_name().c_str();
       char* new_signal_name = (char*)request->new_signal_name().c_str();
       auto status = library_->CloneSignalConfiguration(instrument, old_signal_name, new_signal_name);
@@ -1142,9 +1142,9 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 force_destroy = request->force_destroy();
-      session_repository_->remove_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      session_repository_->remove_session(instrument_grpc_session.name());
       auto status = library_->Close(instrument, force_destroy);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -1166,7 +1166,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->Commit(instrument, selector_string);
       if (!status_ok(status)) {
@@ -1189,7 +1189,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->CreateSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
@@ -1212,7 +1212,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 acquisition_length_mode;
       switch (request->acquisition_length_mode_enum_case()) {
@@ -1252,7 +1252,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -1292,7 +1292,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 evm_unit;
       switch (request->evm_unit_enum_case()) {
@@ -1331,7 +1331,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 measurement_offset = request->measurement_offset();
       int32 maximum_measurement_length = request->maximum_measurement_length();
@@ -1356,7 +1356,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto start_time = const_cast<float64*>(request->start_time().data());
       auto stop_time = const_cast<float64*>(request->stop_time().data());
@@ -1398,7 +1398,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 power_measurement_enabled;
       switch (request->power_measurement_enabled_enum_case()) {
@@ -1437,7 +1437,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_custom_gates = request->number_of_custom_gates();
       auto status = library_->DSSSModAccCfgPowerMeasurementNumberOfCustomGates(instrument, selector_string, number_of_custom_gates);
@@ -1461,7 +1461,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 preamble_average_power_mean {};
@@ -1493,7 +1493,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -1539,7 +1539,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -1582,7 +1582,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -1622,7 +1622,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -1662,7 +1662,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 rms_evm_mean {};
@@ -1700,7 +1700,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -1744,7 +1744,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 iq_origin_offset_mean {};
@@ -1774,7 +1774,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 data_modulation_format {};
@@ -1814,7 +1814,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 preamble_peak_power_maximum {};
@@ -1846,7 +1846,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* signal_name = (char*)request->signal_name().c_str();
       auto status = library_->DeleteSignalConfiguration(instrument, signal_name);
       if (!status_ok(status)) {
@@ -1869,7 +1869,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->DisableTrigger(instrument, selector_string);
       if (!status_ok(status)) {
@@ -1892,7 +1892,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 actual_result_names_size {};
       int32 default_result_exists {};
@@ -1936,7 +1936,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float32 attr_val {};
@@ -1962,7 +1962,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2002,7 +2002,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float64 attr_val {};
@@ -2028,7 +2028,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2068,7 +2068,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int16 attr_val {};
@@ -2094,7 +2094,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 attr_val {};
@@ -2126,7 +2126,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2180,7 +2180,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int64 attr_val {};
@@ -2206,7 +2206,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2246,7 +2246,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int8 attr_val {};
@@ -2272,7 +2272,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2320,7 +2320,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2366,7 +2366,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2412,7 +2412,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
 
@@ -2455,7 +2455,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt16 attr_val {};
@@ -2481,7 +2481,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt32 attr_val {};
@@ -2507,7 +2507,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2547,7 +2547,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2587,7 +2587,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8 attr_val {};
@@ -2613,7 +2613,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 actual_array_size {};
@@ -2653,7 +2653,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
 
       while (true) {
         auto status = library_->GetError(instrument, nullptr, 0, nullptr);
@@ -2696,7 +2696,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       int32 error_code = request->error_code();
 
       while (true) {
@@ -2746,15 +2746,14 @@ namespace nirfmxwlan_grpc {
         auto status = library_->Initialize(resource_name, option_string, &instrument, &is_new_session);
         return std::make_tuple(status, instrument);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXWLAN_VAL_FALSE); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_instrument()->set_id(session_id);
+      response->mutable_instrument()->set_name(grpc_device_session_name);
       response->set_is_new_session(is_new_session);
       return ::grpc::Status::OK;
     }
@@ -2772,22 +2771,21 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto nirfsa_session_grpc_session = request->nirfsa_session();
-      uInt32 nirfsa_session = vi_session_resource_repository_->access_session(nirfsa_session_grpc_session.id(), nirfsa_session_grpc_session.name());
+      uInt32 nirfsa_session = vi_session_resource_repository_->access_session(nirfsa_session_grpc_session.name());
 
       auto init_lambda = [&] () {
         niRFmxInstrHandle instrument;
         auto status = library_->InitializeFromNIRFSASession(nirfsa_session, &instrument);
         return std::make_tuple(status, instrument);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (niRFmxInstrHandle id) { library_->Close(id, RFMXWLAN_VAL_FALSE); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_instrument()->set_id(session_id);
+      response->mutable_instrument()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -2804,7 +2802,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       char* result_name = (char*)request->result_name().c_str();
       auto status = library_->Initiate(instrument, selector_string, result_name);
@@ -2828,7 +2826,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       auto status = library_->OFDMModAccAutoLevel(instrument, selector_string, timeout);
@@ -2852,7 +2850,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 x0 = request->x0();
       float64 dx = request->dx();
@@ -2879,7 +2877,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 acquisition_length_mode;
       switch (request->acquisition_length_mode_enum_case()) {
@@ -2919,7 +2917,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 amplitude_tracking_enabled;
       switch (request->amplitude_tracking_enabled_enum_case()) {
@@ -2958,7 +2956,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -2998,7 +2996,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 channel_estimation_type;
       switch (request->channel_estimation_type_enum_case()) {
@@ -3037,7 +3035,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 common_clock_source_enabled;
       switch (request->common_clock_source_enabled_enum_case()) {
@@ -3076,7 +3074,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 evm_unit;
       switch (request->evm_unit_enum_case()) {
@@ -3115,7 +3113,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 frequency_error_estimation_method;
       switch (request->frequency_error_estimation_method_enum_case()) {
@@ -3154,7 +3152,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 measurement_offset = request->measurement_offset();
       int32 maximum_measurement_length = request->maximum_measurement_length();
@@ -3179,7 +3177,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 measurement_mode;
       switch (request->measurement_mode_enum_case()) {
@@ -3218,7 +3216,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto x0 = const_cast<float64*>(request->x0().data());
       auto dx = const_cast<float64*>(request->dx().data());
@@ -3264,7 +3262,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 noise_compensation_enabled;
       switch (request->noise_compensation_enabled_enum_case()) {
@@ -3303,7 +3301,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 optimize_dynamic_range_for_evm_enabled;
       switch (request->optimize_dynamic_range_for_evm_enabled_enum_case()) {
@@ -3343,7 +3341,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 phase_tracking_enabled;
       switch (request->phase_tracking_enabled_enum_case()) {
@@ -3382,7 +3380,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 symbol_clock_error_correction_enabled;
       switch (request->symbol_clock_error_correction_enabled_enum_case()) {
@@ -3421,7 +3419,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       auto status = library_->OFDMModAccClearNoiseCalibrationDatabase(instrument);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -3443,7 +3441,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -3487,7 +3485,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -3531,7 +3529,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 chain_rms_evm_mean {};
@@ -3561,7 +3559,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -3605,7 +3603,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -3649,7 +3647,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -3696,7 +3694,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -3743,7 +3741,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 composite_rms_evm_mean {};
@@ -3773,7 +3771,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 cross_power_mean {};
@@ -3799,7 +3797,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -3842,7 +3840,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 data_average_power_mean {};
@@ -3868,7 +3866,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -3914,7 +3912,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 data_peak_power_maximum {};
@@ -3940,7 +3938,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -3980,7 +3978,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4020,7 +4018,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4060,7 +4058,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4100,7 +4098,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4140,7 +4138,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4180,7 +4178,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4220,7 +4218,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4260,7 +4258,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 frequency_error_ccdf_10_percent {};
@@ -4286,7 +4284,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 frequency_error_mean {};
@@ -4312,7 +4310,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -4356,7 +4354,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 guard_interval_type {};
@@ -4383,7 +4381,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -4427,7 +4425,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 relative_iq_origin_offset_mean {};
@@ -4461,7 +4459,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -4505,7 +4503,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 l_sig_parity_check_status {};
@@ -4532,7 +4530,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 ltf_size {};
@@ -4559,7 +4557,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 mcs_index {};
@@ -4585,7 +4583,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 number_of_he_sig_b_symbols {};
@@ -4611,7 +4609,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 number_of_space_time_streams {};
@@ -4637,7 +4635,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 number_of_users {};
@@ -4663,7 +4661,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 number_of_symbols_used {};
@@ -4689,7 +4687,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 pe_average_power_mean {};
@@ -4715,7 +4713,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 pe_duration {};
@@ -4741,7 +4739,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 pe_peak_power_maximum {};
@@ -4767,7 +4765,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 ppdu_average_power_mean {};
@@ -4793,7 +4791,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 ppdu_peak_power_maximum {};
@@ -4819,7 +4817,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 ppdu_type {};
@@ -4846,7 +4844,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 psdu_crc_status {};
@@ -4873,7 +4871,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -4917,7 +4915,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -4963,7 +4961,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 vht_sig_a_average_power_mean {};
@@ -4995,7 +4993,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 rl_sig_average_power_mean {};
@@ -5029,7 +5027,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 ht_sig_average_power_mean {};
@@ -5061,7 +5059,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 l_stf_average_power_mean {};
@@ -5091,7 +5089,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5135,7 +5133,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 vht_sig_a_peak_power_maximum {};
@@ -5167,7 +5165,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 rl_sig_peak_power_maximum {};
@@ -5201,7 +5199,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 ht_sig_peak_power_maximum {};
@@ -5233,7 +5231,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 l_stf_peak_power_maximum {};
@@ -5263,7 +5261,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 ru_offset {};
@@ -5291,7 +5289,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 sig_b_crc_status {};
@@ -5318,7 +5316,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 sig_crc_status {};
@@ -5345,7 +5343,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 spectral_flatness_margin {};
@@ -5373,7 +5371,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5423,7 +5421,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5467,7 +5465,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5511,7 +5509,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 stream_rms_evm_mean {};
@@ -5541,7 +5539,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5585,7 +5583,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5629,7 +5627,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 subcarrier_index = request->subcarrier_index();
@@ -5674,7 +5672,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 subcarrier_index = request->subcarrier_index();
@@ -5719,7 +5717,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 symbol_index = request->symbol_index();
@@ -5764,7 +5762,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 symbol_clock_error_mean {};
@@ -5790,7 +5788,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 symbol_index = request->symbol_index();
@@ -5835,7 +5833,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 unused_tone_error_margin {};
@@ -5863,7 +5861,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -5903,7 +5901,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -5950,7 +5948,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -5996,7 +5994,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -6042,7 +6040,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 user_power_mean {};
@@ -6068,7 +6066,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -6112,7 +6110,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -6156,7 +6154,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 user_stream_rms_evm_mean {};
@@ -6186,7 +6184,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -6230,7 +6228,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -6274,7 +6272,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 calibration_data_valid {};
       auto status = library_->OFDMModAccValidateCalibrationData(instrument, selector_string, &calibration_data_valid);
@@ -6300,7 +6298,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 acquisition_length = request->acquisition_length();
       auto status = library_->PowerRampCfgAcquisitionLength(instrument, selector_string, acquisition_length);
@@ -6324,7 +6322,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -6364,7 +6362,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -6417,7 +6415,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 rise_time_mean {};
@@ -6445,7 +6443,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -6498,7 +6496,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(instrument, selector_string, attribute_id);
@@ -6522,7 +6520,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto status = library_->ResetToDefault(instrument, selector_string);
       if (!status_ok(status)) {
@@ -6545,7 +6543,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -6601,7 +6599,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 mask_type;
       switch (request->mask_type_enum_case()) {
@@ -6640,7 +6638,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 number_of_offsets = request->number_of_offsets();
       auto status = library_->SEMCfgNumberOfOffsets(instrument, selector_string, number_of_offsets);
@@ -6664,7 +6662,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto offset_start_frequency = const_cast<float64*>(request->offset_start_frequency().data());
       auto offset_stop_frequency = const_cast<float64*>(request->offset_stop_frequency().data());
@@ -6717,7 +6715,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       auto relative_limit_start = const_cast<float64*>(request->relative_limit_start().data());
       auto relative_limit_stop = const_cast<float64*>(request->relative_limit_stop().data());
@@ -6759,7 +6757,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 span_auto;
       switch (request->span_auto_enum_case()) {
@@ -6799,7 +6797,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 sweep_time_auto;
       switch (request->sweep_time_auto_enum_case()) {
@@ -6839,7 +6837,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 absolute_power {};
@@ -6867,7 +6865,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 measurement_status {};
@@ -6902,7 +6900,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -6963,7 +6961,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 total_absolute_power {};
@@ -6997,7 +6995,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7049,7 +7047,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 measurement_status {};
@@ -7076,7 +7074,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -7123,7 +7121,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 measurement_status {};
@@ -7158,7 +7156,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7219,7 +7217,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 total_absolute_power {};
@@ -7253,7 +7251,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       int32 actual_array_size {};
@@ -7305,7 +7303,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       uInt32 measurements;
       switch (request->measurements_enum_case()) {
@@ -7345,7 +7343,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       auto status = library_->SendSoftwareEdgeTrigger(instrument);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
@@ -7367,7 +7365,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float32 attr_val = request->attr_val();
@@ -7392,7 +7390,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<float32*>(request->attr_val().data());
@@ -7418,7 +7416,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       float64 attr_val = request->attr_val();
@@ -7443,7 +7441,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<float64*>(request->attr_val().data());
@@ -7469,7 +7467,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -7503,7 +7501,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int32 attr_val;
@@ -7543,7 +7541,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_vector = std::vector<int32>();
@@ -7577,7 +7575,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       int64 attr_val = request->attr_val();
@@ -7602,7 +7600,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<int64*>(reinterpret_cast<const int64*>(request->attr_val().data()));
@@ -7628,7 +7626,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -7662,7 +7660,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -7705,7 +7703,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = convert_from_grpc<NIComplexDouble>(request->attr_val());
@@ -7731,7 +7729,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = convert_from_grpc<NIComplexSingle>(request->attr_val());
@@ -7757,7 +7755,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       char* attr_val;
@@ -7801,7 +7799,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val_raw = request->attr_val();
@@ -7835,7 +7833,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt32 attr_val = request->attr_val();
@@ -7860,7 +7858,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<uInt32*>(reinterpret_cast<const uInt32*>(request->attr_val().data()));
@@ -7886,7 +7884,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       auto attr_val = const_cast<uInt64*>(reinterpret_cast<const uInt64*>(request->attr_val().data()));
@@ -7912,7 +7910,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8 attr_val = request->attr_val();
@@ -7937,7 +7935,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 attribute_id = request->attribute_id();
       uInt8* attr_val = (uInt8*)request->attr_val().c_str();
@@ -7963,7 +7961,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 averaging_enabled;
       switch (request->averaging_enabled_enum_case()) {
@@ -8003,7 +8001,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       int32 burst_detection_enabled;
       switch (request->burst_detection_enabled_enum_case()) {
@@ -8042,7 +8040,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 maximum_measurement_interval = request->maximum_measurement_interval();
       auto status = library_->TXPCfgMaximumMeasurementInterval(instrument, selector_string, maximum_measurement_interval);
@@ -8066,7 +8064,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 average_power_mean {};
@@ -8094,7 +8092,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       float64 x0 {};
@@ -8138,7 +8136,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       float64 timeout = request->timeout();
       auto status = library_->WaitForAcquisitionComplete(instrument, timeout);
       if (!status_ok(status)) {
@@ -8161,7 +8159,7 @@ namespace nirfmxwlan_grpc {
     }
     try {
       auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       char* selector_string = (char*)request->selector_string().c_str();
       float64 timeout = request->timeout();
       auto status = library_->WaitForMeasurementComplete(instrument, selector_string, timeout);

--- a/generated/nirfsa/nirfsa_service.cpp
+++ b/generated/nirfsa/nirfsa_service.cpp
@@ -55,7 +55,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Abort(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -77,7 +77,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean is_done {};
       auto status = library_->CheckAcquisitionStatus(vi, &is_done);
       if (!status_ok(status)) {
@@ -101,7 +101,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ClearError(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -123,7 +123,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ClearSelfCalibrateRange(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -145,8 +145,8 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      session_repository_->remove_session(vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -168,7 +168,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Commit(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -190,7 +190,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 acquisition_type;
       switch (request->acquisition_type_enum_case()) {
         case nirfsa_grpc::ConfigureAcquisitionTypeRequest::AcquisitionTypeEnumCase::kAcquisitionType: {
@@ -228,7 +228,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto port = request->port().c_str();
       auto table_name = request->table_name().c_str();
       ViInt32 format;
@@ -268,7 +268,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto port = request->port().c_str();
       auto table_name = request->table_name().c_str();
       auto status = library_->ConfigureDeembeddingTableInterpolationNearest(vi, port, table_name);
@@ -292,7 +292,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto port = request->port().c_str();
       auto table_name = request->table_name().c_str();
       auto status = library_->ConfigureDeembeddingTableInterpolationSpline(vi, port, table_name);
@@ -316,7 +316,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViConstString source;
       switch (request->source_enum_case()) {
         case nirfsa_grpc::ConfigureDigitalEdgeAdvanceTriggerRequest::SourceEnumCase::kSourceMapped: {
@@ -374,7 +374,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViConstString source;
       switch (request->source_enum_case()) {
         case nirfsa_grpc::ConfigureDigitalEdgeRefTriggerRequest::SourceEnumCase::kSourceMapped: {
@@ -433,7 +433,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViConstString source;
       switch (request->source_enum_case()) {
         case nirfsa_grpc::ConfigureDigitalEdgeStartTriggerRequest::SourceEnumCase::kSourceMapped: {
@@ -491,7 +491,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 carrier_frequency = request->carrier_frequency();
       auto status = library_->ConfigureIQCarrierFrequency(vi, channel_list, carrier_frequency);
@@ -515,7 +515,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto source = "0";
       ViReal64 level = request->level();
       ViInt32 slope;
@@ -556,7 +556,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 iq_rate = request->iq_rate();
       auto status = library_->ConfigureIQRate(vi, channel_list, iq_rate);
@@ -580,7 +580,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViBoolean number_of_records_is_finite = request->number_of_records_is_finite();
       ViInt64 number_of_records = request->number_of_records();
@@ -605,7 +605,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViBoolean number_of_samples_is_finite = request->number_of_samples_is_finite();
       ViInt64 samples_per_record = request->samples_per_record();
@@ -630,7 +630,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViConstString pxi_clk10_source;
       switch (request->pxi_clk10_source_enum_case()) {
         case nirfsa_grpc::ConfigurePXIChassisClk10Request::PxiClk10SourceEnumCase::kPxiClk10SourceMapped: {
@@ -672,7 +672,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViConstString clock_source;
       switch (request->clock_source_enum_case()) {
         case nirfsa_grpc::ConfigureRefClockRequest::ClockSourceEnumCase::kClockSourceMapped: {
@@ -715,7 +715,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 reference_level = request->reference_level();
       auto status = library_->ConfigureReferenceLevel(vi, channel_list, reference_level);
@@ -739,7 +739,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 resolution_bandwidth = request->resolution_bandwidth();
       auto status = library_->ConfigureResolutionBandwidth(vi, channel_list, resolution_bandwidth);
@@ -763,7 +763,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgeAdvanceTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -785,7 +785,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt64 pretrigger_samples = request->pretrigger_samples();
       auto status = library_->ConfigureSoftwareEdgeRefTrigger(vi, pretrigger_samples);
       if (!status_ok(status)) {
@@ -808,7 +808,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareEdgeStartTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -830,7 +830,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 center_frequency = request->center_frequency();
       ViReal64 span = request->span();
@@ -855,7 +855,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 start_frequency = request->start_frequency();
       ViReal64 stop_frequency = request->stop_frequency();
@@ -880,7 +880,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto list_name = request->list_name().c_str();
       ViInt32 number_of_list_attributes = static_cast<ViInt32>(request->list_attribute_ids().size());
       auto list_attribute_ids = const_cast<ViAttr*>(reinterpret_cast<const ViAttr*>(request->list_attribute_ids().data()));
@@ -906,7 +906,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean set_as_active_step = request->set_as_active_step();
       auto status = library_->CreateConfigurationListStep(vi, set_as_active_step);
       if (!status_ok(status)) {
@@ -929,7 +929,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto port = request->port().c_str();
       auto table_name = request->table_name().c_str();
       auto frequencies = const_cast<ViReal64*>(request->frequencies().data());
@@ -974,7 +974,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto port = request->port().c_str();
       auto table_name = request->table_name().c_str();
       auto s2p_file_path = request->s2p_file_path().c_str();
@@ -1015,7 +1015,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DeleteAllDeembeddingTables(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1037,7 +1037,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto list_name = request->list_name().c_str();
       auto status = library_->DeleteConfigurationList(vi, list_name);
       if (!status_ok(status)) {
@@ -1060,7 +1060,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto port = request->port().c_str();
       auto table_name = request->table_name().c_str();
       auto status = library_->DeleteDeembeddingTable(vi, port, table_name);
@@ -1084,7 +1084,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Disable(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1106,7 +1106,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DisableAdvanceTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1128,7 +1128,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DisableRefTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1150,7 +1150,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DisableStartTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1172,7 +1172,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean enable = request->enable();
       auto status = library_->EnableSessionAccess(vi, enable);
       if (!status_ok(status)) {
@@ -1195,7 +1195,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViStatus status_code = request->status_code();
       std::string error_message(1024 - 1, '\0');
       auto status = library_->ErrorMessage(vi, status_code, (ViChar*)error_message.data());
@@ -1221,7 +1221,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 error_code {};
       std::string error_message(1024 - 1, '\0');
       auto status = library_->ErrorQuery(vi, &error_code, (ViChar*)error_message.data());
@@ -1248,7 +1248,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 signal;
       switch (request->signal_enum_case()) {
         case nirfsa_grpc::ExportSignalRequest::SignalEnumCase::kSignal: {
@@ -1307,7 +1307,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt64 starting_record = request->starting_record();
       ViInt64 number_of_records = request->number_of_records();
@@ -1338,7 +1338,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt64 starting_record = request->starting_record();
       ViInt64 number_of_records = request->number_of_records();
@@ -1369,7 +1369,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt64 starting_record = request->starting_record();
       ViInt64 number_of_records = request->number_of_records();
@@ -1400,7 +1400,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt64 record_number = request->record_number();
       ViInt64 number_of_samples = request->number_of_samples();
@@ -1430,7 +1430,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt64 record_number = request->record_number();
       ViInt64 number_of_samples = request->number_of_samples();
@@ -1460,7 +1460,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt64 record_number = request->record_number();
       ViInt64 number_of_samples = request->number_of_samples();
@@ -1490,7 +1490,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean value {};
@@ -1516,7 +1516,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 value {};
@@ -1542,7 +1542,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt64 value {};
@@ -1568,7 +1568,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 value {};
@@ -1594,7 +1594,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViSession value {};
@@ -1603,8 +1603,8 @@ namespace nirfsa_grpc {
         return ConvertApiErrorStatusForViSession(context, status, vi);
       }
       response->set_status(status);
-      auto session_id = session_repository_->resolve_session_id(value);
-      response->mutable_value()->set_id(session_id);
+      auto grpc_device_session_name = session_repository_->resolve_session_name(value);
+      response->mutable_value()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -1621,7 +1621,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
 
@@ -1664,7 +1664,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       std::string info(2048 - 1, '\0');
       auto status = library_->GetCalUserDefinedInfo(vi, (ViChar*)info.data());
       if (!status_ok(status)) {
@@ -1689,7 +1689,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 info_size {};
       auto status = library_->GetCalUserDefinedInfoMaxSize(vi, &info_size);
       if (!status_ok(status)) {
@@ -1713,7 +1713,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 number_of_sparameters {};
       ViInt32 number_of_ports {};
       while (true) {
@@ -1759,7 +1759,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 response_type;
       switch (request->response_type_enum_case()) {
@@ -1820,7 +1820,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetError(vi, nullptr, 0, nullptr);
@@ -1863,7 +1863,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 year {};
       ViInt32 month {};
       ViInt32 day {};
@@ -1895,7 +1895,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 temperature {};
       auto status = library_->GetExtCalLastTemp(vi, &temperature);
       if (!status_ok(status)) {
@@ -1919,7 +1919,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 months {};
       auto status = library_->GetExtCalRecommendedInterval(vi, &months);
       if (!status_ok(status)) {
@@ -1943,7 +1943,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt64 record_number = request->record_number();
       ViInt64 backlog {};
@@ -1969,7 +1969,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 number_of_frequencies {};
       while (true) {
@@ -2014,7 +2014,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 number_of_coefficient_sets {};
       while (true) {
@@ -2059,7 +2059,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 number_of_spectral_lines {};
       auto status = library_->GetNumberOfSpectralLines(vi, channel_list, &number_of_spectral_lines);
@@ -2084,7 +2084,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 index = request->index();
       ViInt32 buffer_size {};
@@ -2126,7 +2126,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 buffer_size {};
       while (true) {
@@ -2164,7 +2164,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 number_of_coefficient_sets {};
       while (true) {
@@ -2209,7 +2209,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt64 self_calibration_step = request->self_calibration_step();
       ViInt32 year {};
       ViInt32 month {};
@@ -2242,7 +2242,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt64 self_calibration_step = request->self_calibration_step();
       ViReal64 temp {};
       auto status = library_->GetSelfCalLastTemp(vi, self_calibration_step, &temp);
@@ -2267,7 +2267,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       SmtSpectrumInfo_struct spectrum_info {};
       auto status = library_->GetSpectralInfoForSMT(vi, &spectrum_info);
       if (!status_ok(status)) {
@@ -2291,7 +2291,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto stream_endpoint = request->stream_endpoint().c_str();
       ViUInt32 writer_handle {};
       auto status = library_->GetStreamEndpointHandle(vi, stream_endpoint, &writer_handle);
@@ -2316,7 +2316,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 signal;
       switch (request->signal_enum_case()) {
         case nirfsa_grpc::GetTerminalNameRequest::SignalEnumCase::kSignal: {
@@ -2362,7 +2362,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto identifier = request->identifier().c_str();
       ViInt32 actual_data_size {};
       while (true) {
@@ -2409,15 +2409,14 @@ namespace nirfsa_grpc {
         auto status = library_->Init(resource_name, id_query, reset, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -2443,15 +2442,14 @@ namespace nirfsa_grpc {
         auto status = library_->InitWithOptions(resource_name, id_query, reset, option_string, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -2468,7 +2466,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Initiate(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2490,7 +2488,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->InvalidateAllAttributes(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2512,7 +2510,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean self_cal_valid {};
       ViInt64 valid_steps {};
       auto status = library_->IsSelfCalValid(vi, &self_cal_valid, &valid_steps);
@@ -2558,7 +2556,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->PerformThermalCorrection(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2580,7 +2578,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 timeout = request->timeout();
       ViInt64 data_array_size = request->data_array_size();
@@ -2609,7 +2607,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 timeout = request->timeout();
       ViInt32 data_array_size = request->data_array_size();
@@ -2638,7 +2636,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 timeout = request->timeout();
       ViInt32 data_array_size = request->data_array_size();
@@ -2667,7 +2665,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2689,7 +2687,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(vi, channel_name, attribute_id);
@@ -2713,7 +2711,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ResetDevice(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2735,7 +2733,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ResetWithDefaults(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2757,7 +2755,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViUInt64 steps_to_omit;
       switch (request->steps_to_omit_enum_case()) {
         case nirfsa_grpc::ResetWithOptionsRequest::StepsToOmitEnumCase::kStepsToOmit: {
@@ -2795,7 +2793,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       std::string driver_rev(256 - 1, '\0');
       std::string instr_rev(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)driver_rev.data(), (ViChar*)instr_rev.data());
@@ -2823,7 +2821,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->SelfCal(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2845,7 +2843,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt64 steps_to_omit;
       switch (request->steps_to_omit_enum_case()) {
         case nirfsa_grpc::SelfCalibrateRequest::StepsToOmitEnumCase::kStepsToOmit: {
@@ -2883,7 +2881,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt64 steps_to_omit;
       switch (request->steps_to_omit_enum_case()) {
         case nirfsa_grpc::SelfCalibrateRangeRequest::StepsToOmitEnumCase::kStepsToOmit: {
@@ -2925,7 +2923,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt16 test_result {};
       std::string test_message(2048 - 1, '\0');
       auto status = library_->SelfTest(vi, &test_result, (ViChar*)test_message.data());
@@ -2952,7 +2950,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 trigger;
       switch (request->trigger_enum_case()) {
         case nirfsa_grpc::SendSoftwareEdgeTriggerRequest::TriggerEnumCase::kTrigger: {
@@ -2991,7 +2989,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean value = request->value();
@@ -3016,7 +3014,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 value;
@@ -3056,7 +3054,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt64 value = request->value_raw();
@@ -3081,7 +3079,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 value = request->value_raw();
@@ -3106,11 +3104,11 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto value_grpc_session = request->value();
-      ViSession value = session_repository_->access_session(value_grpc_session.id(), value_grpc_session.name());
+      ViSession value = session_repository_->access_session(value_grpc_session.name());
       auto status = library_->SetAttributeViSession(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -3132,7 +3130,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViConstString value;
@@ -3176,7 +3174,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto info = request->info().c_str();
       auto status = library_->SetCalUserDefinedInfo(vi, info);
       if (!status_ok(status)) {
@@ -3199,7 +3197,7 @@ namespace nirfsa_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto identifier = request->identifier().c_str();
       ViInt32 buffer_size = request->buffer_size();
       std::string data(buffer_size, '\0');

--- a/generated/nirfsg/nirfsg_service.cpp
+++ b/generated/nirfsg/nirfsg_service.cpp
@@ -54,7 +54,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Abort(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -76,7 +76,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 size_in_samples = request->size_in_samples();
       auto status = library_->AllocateArbWaveform(vi, waveform_name, size_in_samples);
@@ -100,7 +100,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean value = request->value();
@@ -125,7 +125,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 value;
@@ -165,7 +165,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt64 value = request->value_raw();
@@ -190,7 +190,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 value;
@@ -230,11 +230,11 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto value_grpc_session = request->value();
-      ViSession value = session_repository_->access_session(value_grpc_session.id(), value_grpc_session.name());
+      ViSession value = session_repository_->access_session(value_grpc_session.name());
       auto status = library_->CheckAttributeViSession(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -256,7 +256,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViConstString value;
@@ -300,7 +300,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean is_done {};
       auto status = library_->CheckGenerationStatus(vi, &is_done);
       if (!status_ok(status)) {
@@ -324,7 +324,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto list_name = request->list_name().c_str();
       ViBoolean list_exists {};
       auto status = library_->CheckIfConfigurationListExists(vi, list_name, &list_exists);
@@ -349,7 +349,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto script_name = request->script_name().c_str();
       ViBoolean script_exists {};
       auto status = library_->CheckIfScriptExists(vi, script_name, &script_exists);
@@ -374,7 +374,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto waveform_name = request->waveform_name().c_str();
       ViBoolean waveform_exists {};
       auto status = library_->CheckIfWaveformExists(vi, waveform_name, &waveform_exists);
@@ -399,7 +399,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ClearAllArbWaveforms(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -421,7 +421,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto name = request->name().c_str();
       auto status = library_->ClearArbWaveform(vi, name);
       if (!status_ok(status)) {
@@ -444,7 +444,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ClearError(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -466,7 +466,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ClearSelfCalibrateRange(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -488,8 +488,8 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      session_repository_->remove_session(vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -511,7 +511,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Commit(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -533,7 +533,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto port = request->port().c_str();
       auto table_name = request->table_name().c_str();
       ViInt32 format;
@@ -573,7 +573,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto port = request->port().c_str();
       auto table_name = request->table_name().c_str();
       auto status = library_->ConfigureDeembeddingTableInterpolationNearest(vi, port, table_name);
@@ -597,7 +597,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto port = request->port().c_str();
       auto table_name = request->table_name().c_str();
       auto status = library_->ConfigureDeembeddingTableInterpolationSpline(vi, port, table_name);
@@ -621,7 +621,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViConstString source;
       switch (request->source_enum_case()) {
         case nirfsg_grpc::ConfigureDigitalEdgeConfigurationListStepTriggerRequest::SourceEnumCase::kSourceMapped: {
@@ -679,7 +679,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViConstString trigger_id;
       switch (request->trigger_id_enum_case()) {
         case nirfsg_grpc::ConfigureDigitalEdgeScriptTriggerRequest::TriggerIdEnumCase::kTriggerIdMapped: {
@@ -757,7 +757,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViConstString source;
       switch (request->source_enum_case()) {
         case nirfsg_grpc::ConfigureDigitalEdgeStartTriggerRequest::SourceEnumCase::kSourceMapped: {
@@ -815,7 +815,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViConstString trigger_id;
       switch (request->trigger_id_enum_case()) {
         case nirfsg_grpc::ConfigureDigitalLevelScriptTriggerRequest::TriggerIdEnumCase::kTriggerIdMapped: {
@@ -893,7 +893,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 number_of_samples = static_cast<ViInt32>(request->user_defined_waveform().size());
       ViInt8* user_defined_waveform = (ViInt8*)request->user_defined_waveform().c_str();
       auto status = library_->ConfigureDigitalModulationUserDefinedWaveform(vi, number_of_samples, user_defined_waveform);
@@ -917,7 +917,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 generation_mode;
       switch (request->generation_mode_enum_case()) {
         case nirfsg_grpc::ConfigureGenerationModeRequest::GenerationModeEnumCase::kGenerationMode: {
@@ -955,7 +955,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean output_enabled = request->output_enabled();
       auto status = library_->ConfigureOutputEnabled(vi, output_enabled);
       if (!status_ok(status)) {
@@ -978,7 +978,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt64 p2p_endpoint_fullness_level = request->p2p_endpoint_fullness_level();
       auto status = library_->ConfigureP2PEndpointFullnessStartTrigger(vi, p2p_endpoint_fullness_level);
       if (!status_ok(status)) {
@@ -1001,7 +1001,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViConstString pxi_clk10_source;
       switch (request->pxi_clk10_source_enum_case()) {
         case nirfsg_grpc::ConfigurePXIChassisClk10Request::PxiClk10SourceEnumCase::kPxiClk10SourceMapped: {
@@ -1043,7 +1043,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 power_level_type;
       switch (request->power_level_type_enum_case()) {
         case nirfsg_grpc::ConfigurePowerLevelTypeRequest::PowerLevelTypeEnumCase::kPowerLevelType: {
@@ -1081,7 +1081,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 frequency = request->frequency();
       ViReal64 power_level = request->power_level();
       auto status = library_->ConfigureRF(vi, frequency, power_level);
@@ -1105,7 +1105,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViConstString ref_clock_source;
       switch (request->ref_clock_source_enum_case()) {
         case nirfsg_grpc::ConfigureRefClockRequest::RefClockSourceEnumCase::kRefClockSourceMapped: {
@@ -1148,7 +1148,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 signal_bandwidth = request->signal_bandwidth();
       auto status = library_->ConfigureSignalBandwidth(vi, signal_bandwidth);
       if (!status_ok(status)) {
@@ -1171,7 +1171,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViConstString trigger_id;
       switch (request->trigger_id_enum_case()) {
         case nirfsg_grpc::ConfigureSoftwareScriptTriggerRequest::TriggerIdEnumCase::kTriggerIdMapped: {
@@ -1213,7 +1213,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ConfigureSoftwareStartTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1235,7 +1235,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 pll_settling_time = request->pll_settling_time();
       ViBoolean ensure_pll_locked = request->ensure_pll_locked();
       auto reserved_for_future_use = 0;
@@ -1260,7 +1260,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto list_name = request->list_name().c_str();
       ViInt32 number_of_attributes = static_cast<ViInt32>(request->configuration_list_attributes().size());
       auto configuration_list_attributes = const_cast<ViAttr*>(reinterpret_cast<const ViAttr*>(request->configuration_list_attributes().data()));
@@ -1286,7 +1286,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean set_as_active_step = request->set_as_active_step();
       auto status = library_->CreateConfigurationListStep(vi, set_as_active_step);
       if (!status_ok(status)) {
@@ -1309,7 +1309,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto port = request->port().c_str();
       auto table_name = request->table_name().c_str();
       auto frequencies = const_cast<ViReal64*>(request->frequencies().data());
@@ -1354,7 +1354,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto port = request->port().c_str();
       auto table_name = request->table_name().c_str();
       auto s2p_file_path = request->s2p_file_path().c_str();
@@ -1395,7 +1395,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DeleteAllDeembeddingTables(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1417,7 +1417,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto list_name = request->list_name().c_str();
       auto status = library_->DeleteConfigurationList(vi, list_name);
       if (!status_ok(status)) {
@@ -1440,7 +1440,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto port = request->port().c_str();
       auto table_name = request->table_name().c_str();
       auto status = library_->DeleteDeembeddingTable(vi, port, table_name);
@@ -1464,7 +1464,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto script_name = request->script_name().c_str();
       auto status = library_->DeleteScript(vi, script_name);
       if (!status_ok(status)) {
@@ -1487,7 +1487,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Disable(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1509,7 +1509,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DisableAllModulation(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1531,7 +1531,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DisableConfigurationListStepTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1553,7 +1553,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViConstString trigger_id;
       switch (request->trigger_id_enum_case()) {
         case nirfsg_grpc::DisableScriptTriggerRequest::TriggerIdEnumCase::kTriggerIdMapped: {
@@ -1595,7 +1595,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DisableStartTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1617,7 +1617,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViStatus error_code = request->error_code();
       std::string error_message(1024 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
@@ -1643,7 +1643,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 error_code {};
       std::string error_message(1024 - 1, '\0');
       auto status = library_->ErrorQuery(vi, &error_code, (ViChar*)error_message.data());
@@ -1670,7 +1670,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 signal;
       switch (request->signal_enum_case()) {
         case nirfsg_grpc::ExportSignalRequest::SignalEnumCase::kSignal: {
@@ -1748,7 +1748,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean value {};
@@ -1774,7 +1774,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 value {};
@@ -1800,7 +1800,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt64 value {};
@@ -1826,7 +1826,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 value {};
@@ -1852,7 +1852,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViSession value {};
@@ -1861,8 +1861,8 @@ namespace nirfsg_grpc {
         return ConvertApiErrorStatusForViSession(context, status, vi);
       }
       response->set_status(status);
-      auto session_id = session_repository_->resolve_session_id(value);
-      response->mutable_value()->set_id(session_id);
+      auto grpc_device_session_name = session_repository_->resolve_session_name(value);
+      response->mutable_value()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -1879,7 +1879,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
 
@@ -1922,7 +1922,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 index = request->index();
 
       while (true) {
@@ -1964,7 +1964,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 number_of_sparameters {};
       ViInt32 number_of_ports {};
       while (true) {
@@ -2010,7 +2010,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetError(vi, nullptr, 0, nullptr);
@@ -2053,7 +2053,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 year {};
       ViInt32 month {};
       ViInt32 day {};
@@ -2087,7 +2087,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 module;
       switch (request->module_enum_case()) {
         case nirfsg_grpc::GetSelfCalibrationDateAndTimeRequest::ModuleEnumCase::kModule: {
@@ -2137,7 +2137,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 module;
       switch (request->module_enum_case()) {
         case nirfsg_grpc::GetSelfCalibrationTemperatureRequest::ModuleEnumCase::kModule: {
@@ -2177,7 +2177,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 signal;
       switch (request->signal_enum_case()) {
         case nirfsg_grpc::GetTerminalNameRequest::SignalEnumCase::kSignal: {
@@ -2254,7 +2254,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto identifier = request->identifier().c_str();
       ViInt32 actual_data_size {};
       while (true) {
@@ -2293,7 +2293,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 required_size {};
       while (true) {
@@ -2332,7 +2332,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 required_size {};
       while (true) {
@@ -2371,7 +2371,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 required_size {};
       while (true) {
@@ -2418,15 +2418,14 @@ namespace nirfsg_grpc {
         auto status = library_->Init(resource_name, id_query, reset_device, &new_vi);
         return std::make_tuple(status, new_vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_new_vi()->set_id(session_id);
+      response->mutable_new_vi()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -2452,15 +2451,14 @@ namespace nirfsg_grpc {
         auto status = library_->InitWithOptions(resource_name, id_query, reset_device, option_string, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -2477,7 +2475,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Initiate(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2499,7 +2497,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->InvalidateAllAttributes(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2521,7 +2519,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto file_path = request->file_path().c_str();
       auto status = library_->LoadConfigurationsFromFile(vi, channel_name, file_path);
@@ -2545,7 +2543,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->PerformPowerSearch(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2567,7 +2565,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->PerformThermalCorrection(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2589,7 +2587,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 max_number_waveforms {};
       ViInt32 waveform_quantum {};
       ViInt32 min_waveform_size {};
@@ -2619,7 +2617,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto waveform_name = request->waveform_name().c_str();
       auto file_path = request->file_path().c_str();
       ViUInt32 waveform_index = request->waveform_index();
@@ -2644,7 +2642,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2666,7 +2664,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto status = library_->ResetAttribute(vi, channel_name, attribute_id);
@@ -2690,7 +2688,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ResetDevice(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2712,7 +2710,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ResetWithDefaults(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2734,7 +2732,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViUInt64 steps_to_omit;
       switch (request->steps_to_omit_enum_case()) {
         case nirfsg_grpc::ResetWithOptionsRequest::StepsToOmitEnumCase::kStepsToOmit: {
@@ -2772,7 +2770,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       std::string instrument_driver_revision(256 - 1, '\0');
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
@@ -2800,7 +2798,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       auto file_path = request->file_path().c_str();
       auto status = library_->SaveConfigurationsToFile(vi, channel_name, file_path);
@@ -2824,7 +2822,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto name = request->name().c_str();
       auto status = library_->SelectArbWaveform(vi, name);
       if (!status_ok(status)) {
@@ -2847,7 +2845,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->SelfCal(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2869,7 +2867,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt64 steps_to_omit;
       switch (request->steps_to_omit_enum_case()) {
         case nirfsg_grpc::SelfCalibrateRangeRequest::StepsToOmitEnumCase::kStepsToOmit: {
@@ -2911,7 +2909,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt16 self_test_result {};
       std::string self_test_message(2048 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
@@ -2938,7 +2936,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 trigger;
       switch (request->trigger_enum_case()) {
         case nirfsg_grpc::SendSoftwareEdgeTriggerRequest::TriggerEnumCase::kTrigger: {
@@ -2996,7 +2994,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 relative_to;
       switch (request->relative_to_enum_case()) {
@@ -3036,7 +3034,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean value = request->value();
@@ -3061,7 +3059,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 value;
@@ -3101,7 +3099,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt64 value = request->value_raw();
@@ -3126,7 +3124,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 value;
@@ -3166,11 +3164,11 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto value_grpc_session = request->value();
-      ViSession value = session_repository_->access_session(value_grpc_session.id(), value_grpc_session.name());
+      ViSession value = session_repository_->access_session(value_grpc_session.name());
       auto status = library_->SetAttributeViSession(vi, channel_name, attribute_id, value);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -3192,7 +3190,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViConstString value;
@@ -3236,7 +3234,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto identifier = request->identifier().c_str();
       ViInt32 buffer_size = static_cast<ViInt32>(request->data().size());
       ViInt8* data = (ViInt8*)request->data().c_str();
@@ -3261,7 +3259,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 number_of_locations = static_cast<ViInt32>(request->locations().size());
       auto locations = const_cast<ViReal64*>(request->locations().data());
@@ -3286,7 +3284,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 number_of_locations = static_cast<ViInt32>(request->locations().size());
       auto locations = const_cast<ViReal64*>(request->locations().data());
@@ -3311,7 +3309,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViInt32 number_of_locations = static_cast<ViInt32>(request->locations().size());
       auto locations = const_cast<ViReal64*>(request->locations().data());
@@ -3336,7 +3334,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 max_time_milliseconds = request->max_time_milliseconds();
       auto status = library_->WaitUntilSettled(vi, max_time_milliseconds);
       if (!status_ok(status)) {
@@ -3359,7 +3357,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto waveform_name = request->waveform_name().c_str();
       auto number_of_samples_determine_from_sizes = std::array<int, 2>
       {
@@ -3397,7 +3395,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 number_of_samples = static_cast<ViInt32>(request->wfm_data().size());
       auto wfm_data = convert_from_grpc<NIComplexNumberF32_struct>(request->wfm_data());
@@ -3423,7 +3421,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 number_of_samples = static_cast<ViInt32>(request->wfm_data().size());
       auto wfm_data = convert_from_grpc<NIComplexNumber_struct>(request->wfm_data());
@@ -3449,7 +3447,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto waveform_name = request->waveform_name().c_str();
       ViInt32 number_of_samples = static_cast<ViInt32>(request->wfm_data().size());
       auto wfm_data = convert_from_grpc<NIComplexI16_struct>(request->wfm_data());
@@ -3474,7 +3472,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto waveform_name = request->waveform_name().c_str();
       auto number_of_samples_determine_from_sizes = std::array<int, 2>
       {
@@ -3512,7 +3510,7 @@ namespace nirfsg_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto script = request->script().c_str();
       auto status = library_->WriteScript(vi, script);
       if (!status_ok(status)) {

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -54,7 +54,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Abort(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -76,7 +76,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 acquisition_status {};
       auto status = library_->AcquisitionStatus(vi, &acquisition_status);
       if (!status_ok(status)) {
@@ -101,7 +101,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 array_meas_function;
       switch (request->array_meas_function_enum_case()) {
         case niscope_grpc::ActualMeasWfmSizeRequest::ArrayMeasFunctionEnumCase::kArrayMeasFunction: {
@@ -141,7 +141,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 num_wfms {};
       auto status = library_->ActualNumWfms(vi, channel_list, &num_wfms);
@@ -166,7 +166,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 record_length {};
       auto status = library_->ActualRecordLength(vi, &record_length);
       if (!status_ok(status)) {
@@ -190,7 +190,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 meas_function;
       switch (request->meas_function_enum_case()) {
@@ -229,7 +229,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 delay = request->delay();
       auto status = library_->AdjustSampleClockRelativeDelay(vi, delay);
       if (!status_ok(status)) {
@@ -252,7 +252,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->AutoSetup(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -274,7 +274,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->CableSenseSignalStart(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -296,7 +296,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->CableSenseSignalStop(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -318,7 +318,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 option;
       switch (request->option_enum_case()) {
@@ -357,7 +357,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean value = request->value();
@@ -382,7 +382,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 value;
@@ -422,7 +422,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt64 value = request->value_raw();
@@ -447,7 +447,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 value;
@@ -495,11 +495,11 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto value_grpc_session = request->value();
-      ViSession value = session_repository_->access_session(value_grpc_session.id(), value_grpc_session.name());
+      ViSession value = session_repository_->access_session(value_grpc_session.name());
       auto status = library_->CheckAttributeViSession(vi, channel_list, attribute_id, value);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -521,7 +521,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViConstString value;
@@ -565,7 +565,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 clearable_measurement_function;
       switch (request->clearable_measurement_function_enum_case()) {
@@ -604,7 +604,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       auto status = library_->ClearWaveformProcessing(vi, channel_list);
       if (!status_ok(status)) {
@@ -627,8 +627,8 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      session_repository_->remove_session(vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -650,7 +650,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Commit(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -672,7 +672,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 acquisition_type = request->acquisition_type();
       auto status = library_->ConfigureAcquisition(vi, acquisition_type);
       if (!status_ok(status)) {
@@ -695,7 +695,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 input_impedance = request->input_impedance();
       ViReal64 max_input_frequency = request->max_input_frequency();
@@ -720,7 +720,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViConstString input_clock_source;
       switch (request->input_clock_source_enum_case()) {
         case niscope_grpc::ConfigureClockRequest::InputClockSourceEnumCase::kInputClockSourceMapped: {
@@ -803,7 +803,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 number_of_coefficients = static_cast<ViInt32>(request->coefficients().size());
       auto coefficients = const_cast<ViReal64*>(request->coefficients().data());
@@ -828,7 +828,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 min_sample_rate = request->min_sample_rate();
       ViInt32 min_num_pts = request->min_num_pts();
       ViReal64 ref_position = request->ref_position();
@@ -855,7 +855,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto trigger_source = request->trigger_source().c_str();
       ViInt32 slope;
       switch (request->slope_enum_case()) {
@@ -896,7 +896,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto trigger_source = request->trigger_source().c_str();
       ViReal64 level = request->level();
       ViInt32 slope;
@@ -954,7 +954,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto trigger_source = request->trigger_source().c_str();
       ViReal64 level = request->level();
       ViReal64 width = request->width();
@@ -1029,7 +1029,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto trigger_source = request->trigger_source().c_str();
       ViReal64 level = request->level();
       ViReal64 hysteresis = request->hysteresis();
@@ -1088,7 +1088,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ConfigureTriggerImmediate(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1110,7 +1110,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto trigger_source = request->trigger_source().c_str();
       ViReal64 low_threshold = request->low_threshold();
       ViReal64 high_threshold = request->high_threshold();
@@ -1169,7 +1169,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 holdoff = request->holdoff();
       ViReal64 delay = request->delay();
       auto status = library_->ConfigureTriggerSoftware(vi, holdoff, delay);
@@ -1193,7 +1193,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto trigger_source = request->trigger_source().c_str();
       ViBoolean enable_dc_restore = request->enable_dc_restore();
       ViInt32 signal_format;
@@ -1284,7 +1284,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto trigger_source = request->trigger_source().c_str();
       ViReal64 level = request->level();
       ViReal64 low_threshold = request->low_threshold();
@@ -1360,7 +1360,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto trigger_source = request->trigger_source().c_str();
       ViReal64 low_level = request->low_level();
       ViReal64 high_level = request->high_level();
@@ -1419,7 +1419,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViReal64 range = request->range();
       ViReal64 offset = request->offset();
@@ -1462,7 +1462,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Disable(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1484,7 +1484,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViStatus error_code = request->error_code();
       ViChar* error_source = (ViChar*)request->error_source().c_str();
       std::string error_description(642 - 1, '\0');
@@ -1511,7 +1511,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->ExportAttributeConfigurationBuffer(vi, 0, nullptr);
@@ -1548,7 +1548,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto file_path = request->file_path().c_str();
       auto status = library_->ExportAttributeConfigurationFile(vi, file_path);
       if (!status_ok(status)) {
@@ -1571,7 +1571,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 signal;
       switch (request->signal_enum_case()) {
         case niscope_grpc::ExportSignalRequest::SignalEnumCase::kSignal: {
@@ -1630,7 +1630,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean value {};
@@ -1656,7 +1656,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 value {};
@@ -1682,7 +1682,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt64 value {};
@@ -1708,7 +1708,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 value {};
@@ -1734,7 +1734,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViSession value {};
@@ -1743,8 +1743,8 @@ namespace niscope_grpc {
         return ConvertApiErrorStatusForViSession(context, status, vi);
       }
       response->set_status(status);
-      auto session_id = session_repository_->resolve_session_id(value);
-      response->mutable_value()->set_id(session_id);
+      auto grpc_device_session_name = session_repository_->resolve_session_name(value);
+      response->mutable_value()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -1761,7 +1761,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
 
@@ -1804,7 +1804,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 index = request->index();
 
       while (true) {
@@ -1846,7 +1846,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto index = request->index().c_str();
 
       while (true) {
@@ -1888,7 +1888,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel = request->channel().c_str();
       ViInt32 number_of_coefficients = request->number_of_coefficients();
       response->mutable_coefficients()->Resize(number_of_coefficients, 0);
@@ -1914,7 +1914,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetError(vi, nullptr, 0, nullptr);
@@ -1957,7 +1957,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViStatus error_code = request->error_code();
 
       while (true) {
@@ -1999,7 +1999,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel = request->channel().c_str();
       ViInt32 buffer_size = request->buffer_size();
       response->mutable_frequencies()->Resize(buffer_size, 0);
@@ -2031,7 +2031,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 number_of_coefficient_sets {};
       while (true) {
@@ -2076,7 +2076,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViInt32 number_of_coefficient_sets {};
       while (true) {
@@ -2121,7 +2121,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto stream_name = request->stream_name().c_str();
       ViUInt32 writer_handle {};
       auto status = library_->GetStreamEndpointHandle(vi, stream_name, &writer_handle);
@@ -2146,7 +2146,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 size_in_bytes = static_cast<ViInt32>(request->configuration().size());
       ViInt8* configuration = (ViInt8*)request->configuration().c_str();
       auto status = library_->ImportAttributeConfigurationBuffer(vi, size_in_bytes, configuration);
@@ -2170,7 +2170,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto file_path = request->file_path().c_str();
       auto status = library_->ImportAttributeConfigurationFile(vi, file_path);
       if (!status_ok(status)) {
@@ -2203,15 +2203,14 @@ namespace niscope_grpc {
         auto status = library_->Init(resource_name, id_query, reset_device, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id, initialization_behavior, &new_session_initialized);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       response->set_new_session_initialized(new_session_initialized);
       return ::grpc::Status::OK;
     }
@@ -2240,15 +2239,14 @@ namespace niscope_grpc {
         auto status = library_->InitWithOptions(resource_name, id_query, reset_device, option_string, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id, initialization_behavior, &new_session_initialized);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       response->set_new_session_initialized(new_session_initialized);
       return ::grpc::Status::OK;
     }
@@ -2266,7 +2264,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->InitiateAcquisition(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2288,7 +2286,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ProbeCompensationSignalStart(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2310,7 +2308,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ProbeCompensationSignalStop(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2332,7 +2330,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2354,7 +2352,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ResetDevice(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2376,7 +2374,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       std::string driver_revision(256 - 1, '\0');
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)driver_revision.data(), (ViChar*)firmware_revision.data());
@@ -2404,7 +2402,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 sample_mode {};
       auto status = library_->SampleMode(vi, &sample_mode);
       if (!status_ok(status)) {
@@ -2428,7 +2426,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 sample_rate {};
       auto status = library_->SampleRate(vi, &sample_rate);
       if (!status_ok(status)) {
@@ -2452,7 +2450,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt16 self_test_result {};
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
@@ -2479,7 +2477,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 which_trigger;
       switch (request->which_trigger_enum_case()) {
         case niscope_grpc::SendSoftwareTriggerEdgeRequest::WhichTriggerEnumCase::kWhichTrigger: {
@@ -2517,7 +2515,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean value = request->value();
@@ -2542,7 +2540,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 value;
@@ -2582,7 +2580,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt64 value = request->value_raw();
@@ -2607,7 +2605,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 value;
@@ -2655,11 +2653,11 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto value_grpc_session = request->value();
-      ViSession value = session_repository_->access_session(value_grpc_session.id(), value_grpc_session.name());
+      ViSession value = session_repository_->access_session(value_grpc_session.name());
       auto status = library_->SetAttributeViSession(vi, channel_list, attribute_id, value);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -2681,7 +2679,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_list = request->channel_list().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViConstString value;

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -318,7 +318,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 which_one;
       switch (request->which_one_enum_case()) {
         case niscope_grpc::CalFetchDateRequest::WhichOneEnumCase::kWhichOne: {
@@ -362,7 +362,7 @@ namespace niscope_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 which_one;
       switch (request->which_one_enum_case()) {
         case niscope_grpc::CalFetchTemperatureRequest::WhichOneEnumCase::kWhichOne: {

--- a/generated/niswitch/niswitch_service.cpp
+++ b/generated/niswitch/niswitch_service.cpp
@@ -54,7 +54,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->AbortScan(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -76,7 +76,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel1 = request->channel1().c_str();
       auto channel2 = request->channel2().c_str();
       ViInt32 path_capability {};
@@ -103,7 +103,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean attribute_value = request->attribute_value();
@@ -128,7 +128,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 attribute_value;
@@ -168,7 +168,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 attribute_value = request->attribute_value_raw();
@@ -193,11 +193,11 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto attribute_value_grpc_session = request->attribute_value();
-      ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.id(), attribute_value_grpc_session.name());
+      ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.name());
       auto status = library_->CheckAttributeViSession(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -219,7 +219,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViString attribute_value = (ViString)request->attribute_value_raw().c_str();
@@ -244,7 +244,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ClearError(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -266,7 +266,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ClearInterchangeWarnings(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -288,8 +288,8 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      session_repository_->remove_session(vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -311,7 +311,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Commit(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -333,7 +333,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto scanlist = request->scanlist().c_str();
       ViInt32 scan_mode;
       switch (request->scan_mode_enum_case()) {
@@ -372,7 +372,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 scan_delay = request->scan_delay();
       ViInt32 trigger_input;
       switch (request->trigger_input_enum_case()) {
@@ -427,7 +427,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel1 = request->channel1().c_str();
       auto channel2 = request->channel2().c_str();
       auto status = library_->Connect(vi, channel1, channel2);
@@ -451,7 +451,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto connection_list = request->connection_list().c_str();
       auto status = library_->ConnectMultiple(vi, connection_list);
       if (!status_ok(status)) {
@@ -474,7 +474,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Disable(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -496,7 +496,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel1 = request->channel1().c_str();
       auto channel2 = request->channel2().c_str();
       auto status = library_->Disconnect(vi, channel1, channel2);
@@ -520,7 +520,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DisconnectAll(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -542,7 +542,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto disconnection_list = request->disconnection_list().c_str();
       auto status = library_->DisconnectMultiple(vi, disconnection_list);
       if (!status_ok(status)) {
@@ -565,7 +565,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViStatus error_code = request->error_code();
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
@@ -591,7 +591,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 error_code {};
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorQuery(vi, &error_code, (ViChar*)error_message.data());
@@ -618,7 +618,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean attribute_value {};
@@ -644,7 +644,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 attribute_value {};
@@ -670,7 +670,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 attribute_value {};
@@ -696,7 +696,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViSession attribute_value {};
@@ -705,8 +705,8 @@ namespace niswitch_grpc {
         return ConvertApiErrorStatusForViSession(context, status, vi);
       }
       response->set_status(status);
-      auto session_id = session_repository_->resolve_session_id(attribute_value);
-      response->mutable_attribute_value()->set_id(session_id);
+      auto grpc_device_session_name = session_repository_->resolve_session_name(attribute_value);
+      response->mutable_attribute_value()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -723,7 +723,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
 
@@ -766,7 +766,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 index = request->index();
 
       while (true) {
@@ -808,7 +808,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetError(vi, nullptr, 0, nullptr);
@@ -851,7 +851,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetNextCoercionRecord(vi, 0, nullptr);
@@ -892,7 +892,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetNextInterchangeWarning(vi, 0, nullptr);
@@ -933,7 +933,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel1 = request->channel1().c_str();
       auto channel2 = request->channel2().c_str();
 
@@ -976,7 +976,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto relay_name = request->relay_name().c_str();
       ViInt32 relay_count {};
       auto status = library_->GetRelayCount(vi, relay_name, &relay_count);
@@ -1001,7 +1001,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 index = request->index();
 
       while (true) {
@@ -1043,7 +1043,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto relay_name = request->relay_name().c_str();
       ViInt32 relay_position {};
       auto status = library_->GetRelayPosition(vi, relay_name, &relay_position);
@@ -1079,15 +1079,14 @@ namespace niswitch_grpc {
         auto status = library_->Init(resource_name, id_query, reset_device, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id, initialization_behavior, &new_session_initialized);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       response->set_new_session_initialized(new_session_initialized);
       return ::grpc::Status::OK;
     }
@@ -1116,15 +1115,14 @@ namespace niswitch_grpc {
         auto status = library_->InitWithOptions(resource_name, id_query, reset_device, option_string, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id, initialization_behavior, &new_session_initialized);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       response->set_new_session_initialized(new_session_initialized);
       return ::grpc::Status::OK;
     }
@@ -1153,15 +1151,14 @@ namespace niswitch_grpc {
         auto status = library_->InitWithTopology(resource_name, topology, simulate, reset_device, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id, initialization_behavior, &new_session_initialized);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, initialization_behavior, &new_session_initialized);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       response->set_new_session_initialized(new_session_initialized);
       return ::grpc::Status::OK;
     }
@@ -1179,7 +1176,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->InitiateScan(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1201,7 +1198,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->InvalidateAllAttributes(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1223,7 +1220,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean is_debounced {};
       auto status = library_->IsDebounced(vi, &is_debounced);
       if (!status_ok(status)) {
@@ -1247,7 +1244,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean is_scanning {};
       auto status = library_->IsScanning(vi, &is_scanning);
       if (!status_ok(status)) {
@@ -1271,7 +1268,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto relay_name = request->relay_name().c_str();
       ViInt32 relay_action;
       switch (request->relay_action_enum_case()) {
@@ -1310,7 +1307,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1332,7 +1329,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ResetInterchangeCheck(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1354,7 +1351,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ResetWithDefaults(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1376,7 +1373,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       std::string instrument_driver_revision(256 - 1, '\0');
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)instrument_driver_revision.data(), (ViChar*)firmware_revision.data());
@@ -1404,7 +1401,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 scan_advanced_output_connector;
       switch (request->scan_advanced_output_connector_enum_case()) {
         case niswitch_grpc::RouteScanAdvancedOutputRequest::ScanAdvancedOutputConnectorEnumCase::kScanAdvancedOutputConnector: {
@@ -1459,7 +1456,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 trigger_input_connector;
       switch (request->trigger_input_connector_enum_case()) {
         case niswitch_grpc::RouteTriggerInputRequest::TriggerInputConnectorEnumCase::kTriggerInputConnector: {
@@ -1514,7 +1511,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto scanlist = request->scanlist().c_str();
       ViInt16 initiation;
       switch (request->initiation_enum_case()) {
@@ -1553,7 +1550,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt16 self_test_result {};
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
@@ -1580,7 +1577,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->SendSoftwareTrigger(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1602,7 +1599,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViBoolean attribute_value = request->attribute_value();
@@ -1627,7 +1624,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViInt32 attribute_value;
@@ -1667,7 +1664,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 attribute_value = request->attribute_value_raw();
@@ -1692,11 +1689,11 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto attribute_value_grpc_session = request->attribute_value();
-      ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.id(), attribute_value_grpc_session.name());
+      ViSession attribute_value = session_repository_->access_session(attribute_value_grpc_session.name());
       auto status = library_->SetAttributeViSession(vi, channel_name, attribute_id, attribute_value);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1718,7 +1715,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViString attribute_value = (ViString)request->attribute_value_raw().c_str();
@@ -1743,7 +1740,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViBoolean continuous_scan = request->continuous_scan();
       auto status = library_->SetContinuousScan(vi, continuous_scan);
       if (!status_ok(status)) {
@@ -1766,7 +1763,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto path_list = request->path_list().c_str();
       auto status = library_->SetPath(vi, path_list);
       if (!status_ok(status)) {
@@ -1789,7 +1786,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 maximum_time_ms = request->maximum_time_ms();
       auto status = library_->WaitForDebounce(vi, maximum_time_ms);
       if (!status_ok(status)) {
@@ -1812,7 +1809,7 @@ namespace niswitch_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 maximum_time_ms = request->maximum_time_ms();
       auto status = library_->WaitForScanComplete(vi, maximum_time_ms);
       if (!status_ok(status)) {

--- a/generated/nisync/nisync_service.cpp
+++ b/generated/nisync/nisync_service.cpp
@@ -61,15 +61,14 @@ namespace nisync_grpc {
         auto status = library_->Init(resource_name, id_query, reset_device, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -86,8 +85,8 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
-      session_repository_->remove_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      session_repository_->remove_session(vi_grpc_session.name());
       auto status = library_->Close(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -109,7 +108,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViStatus error_code = request->error_code();
       std::string error_message(256 - 1, '\0');
       auto status = library_->ErrorMessage(vi, error_code, (ViChar*)error_message.data());
@@ -135,7 +134,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Reset(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -157,7 +156,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->PersistConfig(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -179,7 +178,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt16 self_test_result {};
       std::string self_test_message(256 - 1, '\0');
       auto status = library_->SelfTest(vi, &self_test_result, (ViChar*)self_test_message.data());
@@ -206,7 +205,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       std::string driver_revision(256 - 1, '\0');
       std::string firmware_revision(256 - 1, '\0');
       auto status = library_->RevisionQuery(vi, (ViChar*)driver_revision.data(), (ViChar*)firmware_revision.data());
@@ -234,7 +233,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto src_terminal = request->src_terminal().c_str();
       auto dest_terminal = request->dest_terminal().c_str();
       auto sync_clock = request->sync_clock().c_str();
@@ -261,7 +260,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto src_terminal = request->src_terminal().c_str();
       auto dest_terminal = request->dest_terminal().c_str();
       auto status = library_->DisconnectTrigTerminals(vi, src_terminal, dest_terminal);
@@ -285,7 +284,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto src_terminal = request->src_terminal().c_str();
       auto dest_terminal = request->dest_terminal().c_str();
       auto sync_clock = request->sync_clock().c_str();
@@ -313,7 +312,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto src_terminal = request->src_terminal().c_str();
       auto dest_terminal = request->dest_terminal().c_str();
       auto status = library_->DisconnectSWTrigFromTerminal(vi, src_terminal, dest_terminal);
@@ -337,7 +336,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto src_terminal = request->src_terminal().c_str();
       auto status = library_->SendSoftwareTrigger(vi, src_terminal);
       if (!status_ok(status)) {
@@ -360,7 +359,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto src_terminal = request->src_terminal().c_str();
       auto dest_terminal = request->dest_terminal().c_str();
       auto status = library_->ConnectClkTerminals(vi, src_terminal, dest_terminal);
@@ -384,7 +383,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto src_terminal = request->src_terminal().c_str();
       auto dest_terminal = request->dest_terminal().c_str();
       auto status = library_->DisconnectClkTerminals(vi, src_terminal, dest_terminal);
@@ -408,7 +407,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto src_terminal = request->src_terminal().c_str();
       ViReal64 duration = request->duration();
       ViReal64 actual_duration {};
@@ -438,7 +437,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto src_terminal = request->src_terminal().c_str();
       ViReal64 duration = request->duration();
       ViUInt32 decimation_count = request->decimation_count();
@@ -469,7 +468,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Start1588(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -491,7 +490,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Stop1588(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -513,7 +512,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Start8021AS(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -535,7 +534,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->Stop8021AS(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -557,7 +556,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 time_source = request->time_source();
       ViUInt32 time_seconds = request->time_seconds();
       ViUInt32 time_nanoseconds = request->time_nanoseconds();
@@ -583,7 +582,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViUInt32 time_seconds {};
       ViUInt32 time_nanoseconds {};
       ViUInt16 time_fractional_nanoseconds {};
@@ -611,7 +610,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->ResetFrequency(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -633,7 +632,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto terminal = request->terminal().c_str();
       ViInt32 output_level = request->output_level();
       ViUInt32 time_seconds = request->time_seconds();
@@ -660,7 +659,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto terminal = request->terminal().c_str();
       auto status = library_->ClearFutureTimeEvents(vi, terminal);
       if (!status_ok(status)) {
@@ -683,7 +682,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto terminal = request->terminal().c_str();
       ViInt32 active_edge = request->active_edge();
       auto status = library_->EnableTimeStampTrigger(vi, terminal, active_edge);
@@ -707,7 +706,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto terminal = request->terminal().c_str();
       ViInt32 active_edge = request->active_edge();
       ViUInt32 decimation_count = request->decimation_count();
@@ -732,7 +731,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto terminal = request->terminal().c_str();
       ViReal64 timeout = request->timeout();
       ViUInt32 time_seconds {};
@@ -764,7 +763,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto terminal = request->terminal().c_str();
       auto status = library_->DisableTimeStampTrigger(vi, terminal);
       if (!status_ok(status)) {
@@ -787,7 +786,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto terminal = request->terminal().c_str();
       ViUInt32 high_ticks = request->high_ticks();
       ViUInt32 low_ticks = request->low_ticks();
@@ -818,7 +817,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto terminal = request->terminal().c_str();
       auto status = library_->ClearClock(vi, terminal);
       if (!status_ok(status)) {
@@ -841,7 +840,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->SetTimeReferenceFreeRunning(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -863,7 +862,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->SetTimeReferenceGPS(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -885,7 +884,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 irig_type = request->irig_type();
       auto terminal_name = request->terminal_name().c_str();
       auto status = library_->SetTimeReferenceIRIG(vi, irig_type, terminal_name);
@@ -909,7 +908,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto terminal_name = request->terminal_name().c_str();
       ViBoolean use_manual_time = request->use_manual_time();
       ViUInt32 initial_time_seconds = request->initial_time_seconds();
@@ -936,7 +935,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->SetTimeReference1588OrdinaryClock(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -958,7 +957,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->SetTimeReference8021AS(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -980,7 +979,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->EnableGPSTimestamping(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1002,7 +1001,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 irig_type = request->irig_type();
       auto terminal_name = request->terminal_name().c_str();
       auto status = library_->EnableIRIGTimestamping(vi, irig_type, terminal_name);
@@ -1026,7 +1025,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViUInt32 timestamp_seconds {};
       ViUInt32 timestamp_nanoseconds {};
       ViUInt16 timestamp_fractional_nanoseconds {};
@@ -1060,7 +1059,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto terminal = request->terminal().c_str();
       ViUInt32 timestamp_seconds {};
       ViUInt32 timestamp_nanoseconds {};
@@ -1095,7 +1094,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto status = library_->DisableGPSTimestamping(vi);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
@@ -1117,7 +1116,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto terminal_name = request->terminal_name().c_str();
       auto status = library_->DisableIRIGTimestamping(vi, terminal_name);
       if (!status_ok(status)) {
@@ -1140,7 +1139,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 east_velocity {};
       ViReal64 north_velocity {};
       ViReal64 up_velocity {};
@@ -1168,7 +1167,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 latitude {};
       ViReal64 longitude {};
       ViReal64 altitude {};
@@ -1196,7 +1195,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
 
       while (true) {
         auto status = library_->GetTimeReferenceNames(vi, 0, nullptr);
@@ -1237,7 +1236,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto active_item = request->active_item().c_str();
       ViAttr attribute = request->attribute();
       ViInt32 value {};
@@ -1263,7 +1262,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto active_item = request->active_item().c_str();
       ViAttr attribute = request->attribute();
       ViReal64 value {};
@@ -1289,7 +1288,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto active_item = request->active_item().c_str();
       ViAttr attribute = request->attribute();
       ViBoolean value {};
@@ -1315,7 +1314,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto active_item = request->active_item().c_str();
       ViAttr attribute = request->attribute();
 
@@ -1358,7 +1357,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto active_item = request->active_item().c_str();
       ViAttr attribute = request->attribute();
       ViInt32 value = request->value_raw();
@@ -1383,7 +1382,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto active_item = request->active_item().c_str();
       ViAttr attribute = request->attribute();
       ViReal64 value = request->value_raw();
@@ -1408,7 +1407,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto active_item = request->active_item().c_str();
       ViAttr attribute = request->attribute();
       ViBoolean value = request->value();
@@ -1433,7 +1432,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto active_item = request->active_item().c_str();
       ViAttr attribute = request->attribute();
       auto value = request->value_raw().c_str();
@@ -1458,7 +1457,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 year {};
       ViInt32 month {};
       ViInt32 day {};
@@ -1490,7 +1489,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 temp {};
       auto status = library_->GetExtCalLastTemp(vi, &temp);
       if (!status_ok(status)) {
@@ -1514,7 +1513,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 months {};
       auto status = library_->GetExtCalRecommendedInterval(vi, &months);
       if (!status_ok(status)) {
@@ -1538,7 +1537,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       auto old_password = request->old_password().c_str();
       auto new_password = request->new_password().c_str();
       auto status = library_->ChangeExtCalPassword(vi, old_password, new_password);
@@ -1562,7 +1561,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 temperature {};
       auto status = library_->ReadCurrentTemperature(vi, &temperature);
       if (!status_ok(status)) {
@@ -1586,7 +1585,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 voltage {};
       auto status = library_->CalGetOscillatorVoltage(vi, &voltage);
       if (!status_ok(status)) {
@@ -1610,7 +1609,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 voltage {};
       auto status = library_->CalGetClk10PhaseVoltage(vi, &voltage);
       if (!status_ok(status)) {
@@ -1634,7 +1633,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 voltage {};
       auto status = library_->CalGetDDSStartPulsePhaseVoltage(vi, &voltage);
       if (!status_ok(status)) {
@@ -1658,7 +1657,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 phase {};
       auto status = library_->CalGetDDSInitialPhase(vi, &phase);
       if (!status_ok(status)) {
@@ -1689,15 +1688,14 @@ namespace nisync_grpc {
         auto status = library_->InitExtCal(resource_name, password, &vi);
         return std::make_tuple(status, vi);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (ViSession id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_vi()->set_id(session_id);
+      response->mutable_vi()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -1714,7 +1712,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViInt32 action = request->action();
       auto status = library_->CloseExtCal(vi, action);
       if (!status_ok(status)) {
@@ -1737,7 +1735,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 measured_voltage = request->measured_voltage();
       ViReal64 old_voltage {};
       auto status = library_->CalAdjustOscillatorVoltage(vi, measured_voltage, &old_voltage);
@@ -1762,7 +1760,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 measured_voltage = request->measured_voltage();
       ViReal64 old_voltage {};
       auto status = library_->CalAdjustClk10PhaseVoltage(vi, measured_voltage, &old_voltage);
@@ -1787,7 +1785,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 measured_voltage = request->measured_voltage();
       ViReal64 old_voltage {};
       auto status = library_->CalAdjustDDSStartPulsePhaseVoltage(vi, measured_voltage, &old_voltage);
@@ -1812,7 +1810,7 @@ namespace nisync_grpc {
     }
     try {
       auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
       ViReal64 measured_phase = request->measured_phase();
       ViReal64 old_phase {};
       auto status = library_->CalAdjustDDSInitialPhase(vi, measured_phase, &old_phase);

--- a/generated/nitclk/nitclk_service.cpp
+++ b/generated/nitclk/nitclk_service.cpp
@@ -59,7 +59,7 @@ namespace nitclk_grpc {
         sessions_request.begin(),
         sessions_request.end(),
         std::back_inserter(sessions),
-        [&](auto session) { return session_repository_->access_session(session.id(), session.name()); }); 
+        [&](auto session) { return session_repository_->access_session(session.name()); }); 
       auto status = library_->ConfigureForHomogeneousTriggers(session_count, sessions.data());
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
@@ -87,7 +87,7 @@ namespace nitclk_grpc {
         sessions_request.begin(),
         sessions_request.end(),
         std::back_inserter(sessions),
-        [&](auto session) { return session_repository_->access_session(session.id(), session.name()); }); 
+        [&](auto session) { return session_repository_->access_session(session.name()); }); 
       ViReal64 min_time = request->min_time();
       auto status = library_->FinishSyncPulseSenderSynchronize(session_count, sessions.data(), min_time);
       if (!status_ok(status)) {
@@ -110,7 +110,7 @@ namespace nitclk_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      ViSession session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      ViSession session = session_repository_->access_session(session_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 value {};
@@ -136,7 +136,7 @@ namespace nitclk_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      ViSession session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      ViSession session = session_repository_->access_session(session_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViSession value {};
@@ -145,8 +145,8 @@ namespace nitclk_grpc {
         return ConvertApiErrorStatusForViSession(context, status, session);
       }
       response->set_status(status);
-      auto session_id = session_repository_->resolve_session_id(value);
-      response->mutable_value()->set_id(session_id);
+      auto grpc_device_session_name = session_repository_->resolve_session_name(value);
+      response->mutable_value()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -163,7 +163,7 @@ namespace nitclk_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      ViSession session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      ViSession session = session_repository_->access_session(session_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
 
@@ -251,7 +251,7 @@ namespace nitclk_grpc {
         sessions_request.begin(),
         sessions_request.end(),
         std::back_inserter(sessions),
-        [&](auto session) { return session_repository_->access_session(session.id(), session.name()); }); 
+        [&](auto session) { return session_repository_->access_session(session.name()); }); 
       auto status = library_->Initiate(session_count, sessions.data());
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, 0);
@@ -279,7 +279,7 @@ namespace nitclk_grpc {
         sessions_request.begin(),
         sessions_request.end(),
         std::back_inserter(sessions),
-        [&](auto session) { return session_repository_->access_session(session.id(), session.name()); }); 
+        [&](auto session) { return session_repository_->access_session(session.name()); }); 
       ViBoolean done {};
       auto status = library_->IsDone(session_count, sessions.data(), &done);
       if (!status_ok(status)) {
@@ -303,7 +303,7 @@ namespace nitclk_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      ViSession session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      ViSession session = session_repository_->access_session(session_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       ViReal64 value = request->value_raw();
@@ -328,11 +328,11 @@ namespace nitclk_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      ViSession session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      ViSession session = session_repository_->access_session(session_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto value_grpc_session = request->value();
-      ViSession value = session_repository_->access_session(value_grpc_session.id(), value_grpc_session.name());
+      ViSession value = session_repository_->access_session(value_grpc_session.name());
       auto status = library_->SetAttributeViSession(session, channel_name, attribute_id, value);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, session);
@@ -354,7 +354,7 @@ namespace nitclk_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      ViSession session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      ViSession session = session_repository_->access_session(session_grpc_session.name());
       auto channel_name = request->channel_name().c_str();
       ViAttr attribute_id = request->attribute_id();
       auto value = request->value_raw().c_str();
@@ -385,7 +385,7 @@ namespace nitclk_grpc {
         sessions_request.begin(),
         sessions_request.end(),
         std::back_inserter(sessions),
-        [&](auto session) { return session_repository_->access_session(session.id(), session.name()); }); 
+        [&](auto session) { return session_repository_->access_session(session.name()); }); 
       ViReal64 min_time = request->min_time();
       auto status = library_->SetupForSyncPulseSenderSynchronize(session_count, sessions.data(), min_time);
       if (!status_ok(status)) {
@@ -414,7 +414,7 @@ namespace nitclk_grpc {
         sessions_request.begin(),
         sessions_request.end(),
         std::back_inserter(sessions),
-        [&](auto session) { return session_repository_->access_session(session.id(), session.name()); }); 
+        [&](auto session) { return session_repository_->access_session(session.name()); }); 
       ViReal64 min_tclk_period = request->min_tclk_period();
       auto status = library_->Synchronize(session_count, sessions.data(), min_tclk_period);
       if (!status_ok(status)) {
@@ -443,7 +443,7 @@ namespace nitclk_grpc {
         sessions_request.begin(),
         sessions_request.end(),
         std::back_inserter(sessions),
-        [&](auto session) { return session_repository_->access_session(session.id(), session.name()); }); 
+        [&](auto session) { return session_repository_->access_session(session.name()); }); 
       ViReal64 min_time = request->min_time();
       auto status = library_->SynchronizeToSyncPulseSender(session_count, sessions.data(), min_time);
       if (!status_ok(status)) {
@@ -472,7 +472,7 @@ namespace nitclk_grpc {
         sessions_request.begin(),
         sessions_request.end(),
         std::back_inserter(sessions),
-        [&](auto session) { return session_repository_->access_session(session.id(), session.name()); }); 
+        [&](auto session) { return session_repository_->access_session(session.name()); }); 
       ViReal64 timeout = request->timeout();
       auto status = library_->WaitUntilDone(session_count, sessions.data(), timeout);
       if (!status_ok(status)) {

--- a/generated/nixnet/nixnet_service.cpp
+++ b/generated/nixnet/nixnet_service.cpp
@@ -53,7 +53,7 @@ namespace nixnet_grpc {
     }
     try {
       auto interface_ref_grpc_session = request->interface_ref();
-      nxSessionRef_t interface_ref = session_repository_->access_session(interface_ref_grpc_session.id(), interface_ref_grpc_session.name());
+      nxSessionRef_t interface_ref = session_repository_->access_session(interface_ref_grpc_session.name());
       u32 modifier;
       switch (request->modifier_enum_case()) {
         case nixnet_grpc::BlinkRequest::ModifierEnumCase::kModifier: {
@@ -91,8 +91,8 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
-      session_repository_->remove_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
+      session_repository_->remove_session(session_grpc_session.name());
       auto status = library_->Clear(session);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNxSessionRef_t(context, status, session);
@@ -114,7 +114,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       const char* source;
       switch (request->source_enum_case()) {
         case nixnet_grpc::ConnectTerminalsRequest::SourceEnumCase::kSourceMapped: {
@@ -176,7 +176,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       u8* value_buffer = (u8*)request->value_buffer().c_str();
       u32 size_of_value_buffer = static_cast<u32>(request->value_buffer().size() * sizeof(u8));
       u32 number_of_frames = request->number_of_frames();
@@ -222,7 +222,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       auto frame_buffer = convert_from_grpc<u8>(request->frame_buffer(), enetflags_input_map_);
       auto number_of_bytes_for_frames = frame_buffer.size();
       u32 size_of_value_buffer = request->size_of_value_buffer();
@@ -249,7 +249,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       u32 number_of_signals = request->number_of_signals();
       auto frame_buffer = convert_from_grpc<u8>(request->frame_buffer(), enetflags_input_map_);
       auto number_of_bytes_for_frames = frame_buffer.size();
@@ -280,7 +280,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       auto value_buffer = const_cast<f64*>(request->value_buffer().data());
       u32 size_of_value_buffer = static_cast<u32>(request->value_buffer().size() * sizeof(f64));
       u32 number_of_frames = request->number_of_frames();
@@ -397,15 +397,14 @@ namespace nixnet_grpc {
         auto status = library_->CreateSession(database_name, cluster_name, list, interface_name, mode, &session);
         return std::make_tuple(status, session);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (nxSessionRef_t id) { library_->Clear(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNxSessionRef_t(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_session()->set_id(session_id);
+      response->mutable_session()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -428,7 +427,7 @@ namespace nixnet_grpc {
         array_of_database_ref_request.begin(),
         array_of_database_ref_request.end(),
         std::back_inserter(array_of_database_ref),
-        [&](auto session) { return nx_database_ref_t_resource_repository_->access_session(session.id(), session.name()); }); 
+        [&](auto session) { return nx_database_ref_t_resource_repository_->access_session(session.name()); }); 
       auto interface_name = request->interface_name().c_str();
       u32 mode;
       switch (request->mode_enum_case()) {
@@ -452,15 +451,14 @@ namespace nixnet_grpc {
         auto status = library_->CreateSessionByRef(number_of_database_ref, array_of_database_ref.data(), interface_name, mode, &session);
         return std::make_tuple(status, session);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (nxSessionRef_t id) { library_->Clear(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNxSessionRef_t(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_session()->set_id(session_id);
+      response->mutable_session()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -523,9 +521,9 @@ namespace nixnet_grpc {
     }
     try {
       auto database_grpc_session = request->database();
-      nxDatabaseRef_t database = nx_database_ref_t_resource_repository_->access_session(database_grpc_session.id(), database_grpc_session.name());
+      nxDatabaseRef_t database = nx_database_ref_t_resource_repository_->access_session(database_grpc_session.name());
       u32 close_all_refs = request->close_all_refs();
-      nx_database_ref_t_resource_repository_->remove_session(database_grpc_session.id(), database_grpc_session.name());
+      nx_database_ref_t_resource_repository_->remove_session(database_grpc_session.name());
       auto status = library_->DbCloseDatabase(database, close_all_refs);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNxDatabaseRef_t(context, status, database);
@@ -547,22 +545,21 @@ namespace nixnet_grpc {
     }
     try {
       auto parent_object_grpc_session = request->parent_object();
-      nxDatabaseRef_t parent_object = nx_database_ref_t_resource_repository_->access_session(parent_object_grpc_session.id(), parent_object_grpc_session.name());
+      nxDatabaseRef_t parent_object = nx_database_ref_t_resource_repository_->access_session(parent_object_grpc_session.name());
       u32 object_class = request->object_class();
       auto object_name = request->object_name().c_str();
 
-      auto initiating_session_id = nx_database_ref_t_resource_repository_->access_session_id(parent_object_grpc_session.id(), parent_object_grpc_session.name());
+      auto initiating_session_name = parent_object_grpc_session.name();
       auto init_lambda = [&] () {
         nxDatabaseRef_t db_object;
         int status = library_->DbCreateObject(parent_object, object_class, object_name, &db_object);
         return std::make_tuple(status, db_object);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
-      int status = nx_database_ref_t_resource_repository_->add_dependent_session(grpc_device_session_name, init_lambda, initiating_session_id, session_id);
+      std::string session_name;
+      int status = nx_database_ref_t_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_name);
       response->set_status(status);
       if (status == 0) {
-        response->mutable_db_object()->set_id(session_id);
+        response->mutable_db_object()->set_name(session_name);
       }
       return ::grpc::Status::OK;
     }
@@ -580,8 +577,8 @@ namespace nixnet_grpc {
     }
     try {
       auto db_object_grpc_session = request->db_object();
-      nxDatabaseRef_t db_object = nx_database_ref_t_resource_repository_->access_session(db_object_grpc_session.id(), db_object_grpc_session.name());
-      nx_database_ref_t_resource_repository_->remove_session(db_object_grpc_session.id(), db_object_grpc_session.name());
+      nxDatabaseRef_t db_object = nx_database_ref_t_resource_repository_->access_session(db_object_grpc_session.name());
+      nx_database_ref_t_resource_repository_->remove_session(db_object_grpc_session.name());
       auto status = library_->DbDeleteObject(db_object);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNxDatabaseRef_t(context, status, db_object);
@@ -628,22 +625,21 @@ namespace nixnet_grpc {
     }
     try {
       auto parent_object_grpc_session = request->parent_object();
-      nxDatabaseRef_t parent_object = nx_database_ref_t_resource_repository_->access_session(parent_object_grpc_session.id(), parent_object_grpc_session.name());
+      nxDatabaseRef_t parent_object = nx_database_ref_t_resource_repository_->access_session(parent_object_grpc_session.name());
       u32 object_class = request->object_class();
       auto object_name = request->object_name().c_str();
 
-      auto initiating_session_id = nx_database_ref_t_resource_repository_->access_session_id(parent_object_grpc_session.id(), parent_object_grpc_session.name());
+      auto initiating_session_name = parent_object_grpc_session.name();
       auto init_lambda = [&] () {
         nxDatabaseRef_t db_object;
         int status = library_->DbFindObject(parent_object, object_class, object_name, &db_object);
         return std::make_tuple(status, db_object);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
-      int status = nx_database_ref_t_resource_repository_->add_dependent_session(grpc_device_session_name, init_lambda, initiating_session_id, session_id);
+      std::string session_name;
+      int status = nx_database_ref_t_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_name);
       response->set_status(status);
       if (status == 0) {
-        response->mutable_db_object()->set_id(session_id);
+        response->mutable_db_object()->set_name(session_name);
       }
       return ::grpc::Status::OK;
     }
@@ -661,7 +657,7 @@ namespace nixnet_grpc {
     }
     try {
       auto db_object_grpc_session = request->db_object();
-      nxDatabaseRef_t db_object = nx_database_ref_t_resource_repository_->access_session(db_object_grpc_session.id(), db_object_grpc_session.name());
+      nxDatabaseRef_t db_object = nx_database_ref_t_resource_repository_->access_session(db_object_grpc_session.name());
       u32 mode;
       switch (request->mode_enum_case()) {
         case nixnet_grpc::DbGetDBCAttributeSizeRequest::ModeEnumCase::kMode: {
@@ -727,7 +723,7 @@ namespace nixnet_grpc {
     }
     try {
       auto db_object_grpc_session = request->db_object();
-      nxDatabaseRef_t db_object = nx_database_ref_t_resource_repository_->access_session(db_object_grpc_session.id(), db_object_grpc_session.name());
+      nxDatabaseRef_t db_object = nx_database_ref_t_resource_repository_->access_session(db_object_grpc_session.name());
       u32 property_id;
       switch (request->property_id_enum_case()) {
         case nixnet_grpc::DbGetPropertySizeRequest::PropertyIdEnumCase::kPropertyId: {
@@ -767,9 +763,9 @@ namespace nixnet_grpc {
     }
     try {
       auto target_cluster_grpc_session = request->target_cluster();
-      nxDatabaseRef_t target_cluster = nx_database_ref_t_resource_repository_->access_session(target_cluster_grpc_session.id(), target_cluster_grpc_session.name());
+      nxDatabaseRef_t target_cluster = nx_database_ref_t_resource_repository_->access_session(target_cluster_grpc_session.name());
       auto source_obj_grpc_session = request->source_obj();
-      nxDatabaseRef_t source_obj = nx_database_ref_t_resource_repository_->access_session(source_obj_grpc_session.id(), source_obj_grpc_session.name());
+      nxDatabaseRef_t source_obj = nx_database_ref_t_resource_repository_->access_session(source_obj_grpc_session.name());
       u32 copy_mode;
       switch (request->copy_mode_enum_case()) {
         case nixnet_grpc::DbMergeRequest::CopyModeEnumCase::kCopyMode: {
@@ -817,15 +813,14 @@ namespace nixnet_grpc {
         auto status = library_->DbOpenDatabase(database_name, &database);
         return std::make_tuple(status, database);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (nxDatabaseRef_t id) { library_->DbCloseDatabase(id, false); };
-      int status = nx_database_ref_t_resource_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = nx_database_ref_t_resource_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNxSessionRef_t(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_database()->set_id(session_id);
+      response->mutable_database()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -863,7 +858,7 @@ namespace nixnet_grpc {
     }
     try {
       auto database_grpc_session = request->database();
-      nxDatabaseRef_t database = nx_database_ref_t_resource_repository_->access_session(database_grpc_session.id(), database_grpc_session.name());
+      nxDatabaseRef_t database = nx_database_ref_t_resource_repository_->access_session(database_grpc_session.name());
       auto db_filepath = request->db_filepath().c_str();
       auto status = library_->DbSaveDatabase(database, db_filepath);
       if (!status_ok(status)) {
@@ -908,7 +903,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       const char* source;
       switch (request->source_enum_case()) {
         case nixnet_grpc::DisconnectTerminalsRequest::SourceEnumCase::kSourceMapped: {
@@ -970,7 +965,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       auto status = library_->Flush(session);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNxSessionRef_t(context, status, session);
@@ -992,7 +987,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       nxTimestamp1ns_t when = request->when();
       u32 timescale;
       switch (request->timescale_enum_case()) {
@@ -1031,7 +1026,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       u32 property_id;
       switch (request->property_id_enum_case()) {
         case nixnet_grpc::GetPropertySizeRequest::PropertyIdEnumCase::kPropertyId: {
@@ -1071,7 +1066,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       u32 active_index = request->active_index();
       u32 property_id;
       switch (request->property_id_enum_case()) {
@@ -1112,7 +1107,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       int32 number_of_frames = request->number_of_frames();
       u32 max_payload_per_frame = request->max_payload_per_frame();
       u32 protocol;
@@ -1172,7 +1167,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       u32 number_of_signals = request->number_of_signals();
       auto size_of_value_buffer = number_of_signals * sizeof(f64);
       auto size_of_timestamp_buffer = number_of_signals * sizeof(f64);
@@ -1201,7 +1196,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       f64 timeout;
       switch (request->timeout_enum_case()) {
         case nixnet_grpc::ReadSignalWaveformRequest::TimeoutEnumCase::kTimeout: {
@@ -1249,7 +1244,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       nxTimestamp100ns_t time_limit = request->time_limit();
       u32 samples_per_signal = request->samples_per_signal();
       u32 number_of_signals = request->number_of_signals();
@@ -1283,7 +1278,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       f64 timeout;
       switch (request->timeout_enum_case()) {
         case nixnet_grpc::ReadStateTimeTriggerRequest::TimeoutEnumCase::kTimeout: {
@@ -1324,7 +1319,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       u32 scope;
       switch (request->scope_enum_case()) {
         case nixnet_grpc::StartRequest::ScopeEnumCase::kScope: {
@@ -1388,7 +1383,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       u32 scope;
       switch (request->scope_enum_case()) {
         case nixnet_grpc::StopRequest::ScopeEnumCase::kScope: {
@@ -1426,8 +1421,8 @@ namespace nixnet_grpc {
     }
     try {
       auto system_grpc_session = request->system();
-      nxSessionRef_t system = session_repository_->access_session(system_grpc_session.id(), system_grpc_session.name());
-      session_repository_->remove_session(system_grpc_session.id(), system_grpc_session.name());
+      nxSessionRef_t system = session_repository_->access_session(system_grpc_session.name());
+      session_repository_->remove_session(system_grpc_session.name());
       auto status = library_->SystemClose(system);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNxSessionRef_t(context, status, system);
@@ -1454,15 +1449,14 @@ namespace nixnet_grpc {
         auto status = library_->SystemOpen(&system);
         return std::make_tuple(status, system);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (nxSessionRef_t id) { library_->SystemClose(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNxSessionRef_t(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_system()->set_id(session_id);
+      response->mutable_system()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -1479,7 +1473,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       u32 condition;
       switch (request->condition_enum_case()) {
         case nixnet_grpc::WaitRequest::ConditionEnumCase::kCondition: {
@@ -1521,7 +1515,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       auto buffer = convert_from_grpc<u8>(request->buffer(), enetflags_input_map_);
       auto number_of_bytes_for_frames = buffer.size();
       f64 timeout;
@@ -1561,7 +1555,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       auto value_buffer = const_cast<f64*>(request->value_buffer().data());
       u32 size_of_value_buffer = static_cast<u32>(request->value_buffer().size() * sizeof(f64));
       auto status = library_->WriteSignalSinglePoint(session, value_buffer, size_of_value_buffer);
@@ -1585,7 +1579,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       f64 timeout;
       switch (request->timeout_enum_case()) {
         case nixnet_grpc::WriteSignalWaveformRequest::TimeoutEnumCase::kTimeout: {
@@ -1625,7 +1619,7 @@ namespace nixnet_grpc {
     }
     try {
       auto session_grpc_session = request->session();
-      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+      nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
       f64 timeout;
       switch (request->timeout_enum_case()) {
         case nixnet_grpc::WriteSignalXYRequest::TimeoutEnumCase::kTimeout: {

--- a/generated/nixnet/nixnet_service.cpp
+++ b/generated/nixnet/nixnet_service.cpp
@@ -555,7 +555,7 @@ namespace nixnet_grpc {
         int status = library_->DbCreateObject(parent_object, object_class, object_name, &db_object);
         return std::make_tuple(status, db_object);
       };
-      std::string session_name;
+      std::string session_name = request->session_name();
       int status = nx_database_ref_t_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_name);
       response->set_status(status);
       if (status == 0) {
@@ -635,7 +635,7 @@ namespace nixnet_grpc {
         int status = library_->DbFindObject(parent_object, object_class, object_name, &db_object);
         return std::make_tuple(status, db_object);
       };
-      std::string session_name;
+      std::string session_name = request->session_name();
       int status = nx_database_ref_t_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_name);
       response->set_status(status);
       if (status == 0) {

--- a/generated/nixnetsocket/nixnetsocket_service.cpp
+++ b/generated/nixnetsocket/nixnetsocket_service.cpp
@@ -54,7 +54,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto socket_grpc_session = request->socket();
-      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.name());
 
       auto addr = allocate_output_storage<nxsockaddr, SockAddr>();
       nxsocklen_t addrlen {};
@@ -63,16 +63,15 @@ namespace nixnetsocket_grpc {
         auto status = socket_out == -1 ? -1 : 0;
         return std::make_tuple(status, socket_out);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (nxSOCKET id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNxSOCKET(context, status, socket);
       }
       response->set_status(status);
       convert_to_grpc(addr, response->mutable_addr());
-      response->mutable_socket()->set_id(session_id);
+      response->mutable_socket()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -89,7 +88,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto socket_grpc_session = request->socket();
-      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.name());
       auto name = convert_from_grpc<nxsockaddr>(request->name());
       auto namelen = name.size();
       auto status = library_->Bind(socket, name, namelen);
@@ -113,8 +112,8 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto socket_grpc_session = request->socket();
-      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
-      session_repository_->remove_session(socket_grpc_session.id(), socket_grpc_session.name());
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.name());
+      session_repository_->remove_session(socket_grpc_session.name());
       auto status = library_->Close(socket);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNxSOCKET(context, status, socket);
@@ -136,7 +135,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto socket_grpc_session = request->socket();
-      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.name());
       auto name = convert_from_grpc<nxsockaddr>(request->name());
       auto namelen = name.size();
       auto status = library_->Connect(socket, name, namelen);
@@ -160,7 +159,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto fd_grpc_session = request->fd();
-      nxSOCKET fd = session_repository_->access_session(fd_grpc_session.id(), fd_grpc_session.name());
+      nxSOCKET fd = session_repository_->access_session(fd_grpc_session.name());
       auto set = convert_from_grpc<nxfd_set>(request->set(), session_repository_);
       auto is_set = library_->FdIsSet(fd, set);
       auto status = 0;
@@ -185,7 +184,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto stack_ref_grpc_session = request->stack_ref();
-      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
+      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.name());
       auto node = request->node().c_str();
       auto node_api = request->node() == "" ? nullptr : node;
       auto service = request->service().c_str();
@@ -214,7 +213,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto stack_ref_grpc_session = request->stack_ref();
-      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
+      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.name());
       auto addr = convert_from_grpc<nxsockaddr>(request->addr());
       auto addrlen = addr.size();
       nxsocklen_t hostlen = request->hostlen();
@@ -256,7 +255,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto socket_grpc_session = request->socket();
-      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.name());
       auto addr = allocate_output_storage<nxsockaddr, SockAddr>();
       auto addrlen = static_cast<nxsocklen_t>(sizeof(addr.storage));
       auto status = library_->GetPeerName(socket, &addr, &addrlen);
@@ -281,7 +280,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto socket_grpc_session = request->socket();
-      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.name());
       auto addr = allocate_output_storage<nxsockaddr, SockAddr>();
       auto addrlen = static_cast<nxsocklen_t>(sizeof(addr.storage));
       auto status = library_->GetSockName(socket, &addr, &addrlen);
@@ -306,7 +305,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto socket_grpc_session = request->socket();
-      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.name());
       int32_t level;
       switch (request->level_enum_case()) {
         case nixnetsocket_grpc::GetSockOptRequest::LevelEnumCase::kLevel: {
@@ -363,7 +362,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto stack_ref_grpc_session = request->stack_ref();
-      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
+      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.name());
       auto cp = request->cp().c_str();
       auto addr = library_->InetAddr(stack_ref, cp);
       auto status = addr == -1 ? -1 : 0;
@@ -388,7 +387,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto stack_ref_grpc_session = request->stack_ref();
-      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
+      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.name());
       auto cp = request->cp().c_str();
       auto name = allocate_output_storage<nxin_addr, InAddr>();
       auto status = library_->InetAToN(stack_ref, cp, &name);
@@ -413,7 +412,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto stack_ref_grpc_session = request->stack_ref();
-      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
+      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.name());
       auto in_addr = convert_from_grpc<nxin_addr>(request->in_addr());
       auto address = library_->InetNToA(stack_ref, in_addr);
       auto status = address ? 0 : -1;
@@ -439,7 +438,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto stack_ref_grpc_session = request->stack_ref();
-      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
+      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.name());
       auto af = get_address_family(request->addr().addr_case());
       auto addr = convert_from_grpc<void>(request->addr());
       auto size = nxINET6_ADDRSTRLEN;
@@ -468,7 +467,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto stack_ref_grpc_session = request->stack_ref();
-      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
+      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.name());
       int32_t af;
       switch (request->af_enum_case()) {
         case nixnetsocket_grpc::InetPToNRequest::AfEnumCase::kAf: {
@@ -509,8 +508,8 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto stack_ref_grpc_session = request->stack_ref();
-      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
-      nx_ip_stack_ref_t_resource_repository_->remove_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
+      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.name());
+      nx_ip_stack_ref_t_resource_repository_->remove_session(stack_ref_grpc_session.name());
       auto status = library_->IpStackClear(stack_ref);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNxIpStackRef_t(context, status, stack_ref);
@@ -539,15 +538,14 @@ namespace nixnetsocket_grpc {
         auto status = library_->IpStackCreate(stack_name, config, &stack_ref);
         return std::make_tuple(status, stack_ref);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (nxIpStackRef_t id) { library_->IpStackClear(id); };
-      int status = nx_ip_stack_ref_t_resource_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = nx_ip_stack_ref_t_resource_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNxSOCKET(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_stack_ref()->set_id(session_id);
+      response->mutable_stack_ref()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -603,7 +601,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto stack_ref_grpc_session = request->stack_ref();
-      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
+      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.name());
       auto info_id = nxIPSTACK_INFO_ID;
       auto virtual_interfaces = allocate_output_storage<nxVirtualInterface_t, google::protobuf::RepeatedPtrField<VirtualInterface>>(library_);
       auto status = library_->IpStackGetInfo(stack_ref, info_id, &virtual_interfaces);
@@ -634,15 +632,14 @@ namespace nixnetsocket_grpc {
         auto status = library_->IpStackOpen(stack_name, &stack_ref);
         return std::make_tuple(status, stack_ref);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (nxIpStackRef_t id) { library_->IpStackClear(id); };
-      int status = nx_ip_stack_ref_t_resource_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = nx_ip_stack_ref_t_resource_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNxSOCKET(context, status, 0);
       }
       response->set_status(status);
-      response->mutable_stack_ref()->set_id(session_id);
+      response->mutable_stack_ref()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
@@ -659,7 +656,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto stack_ref_grpc_session = request->stack_ref();
-      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
+      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.name());
       auto local_interface = request->local_interface().c_str();
       int32_t timeout_ms = request->timeout_ms();
       auto status = library_->IpStackWaitForInterface(stack_ref, local_interface, timeout_ms);
@@ -683,7 +680,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto socket_grpc_session = request->socket();
-      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.name());
       int32_t backlog = request->backlog();
       auto status = library_->Listen(socket, backlog);
       if (!status_ok(status)) {
@@ -706,7 +703,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto socket_grpc_session = request->socket();
-      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.name());
       int32_t size = request->size();
       const auto flags = nidevice_grpc::converters::convert_bitfield_as_enum_array_input(
         request->flags_array(),
@@ -735,7 +732,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto socket_grpc_session = request->socket();
-      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.name());
       int32_t size = request->size();
       const auto flags = nidevice_grpc::converters::convert_bitfield_as_enum_array_input(
         request->flags_array(),
@@ -792,7 +789,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto socket_grpc_session = request->socket();
-      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.name());
       char* data = (char*)request->data().c_str();
       int32_t size = static_cast<int32_t>(request->data().size());
       int32_t flags_raw = request->flags_raw();
@@ -817,7 +814,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto socket_grpc_session = request->socket();
-      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.name());
       char* data = (char*)request->data().c_str();
       int32_t size = static_cast<int32_t>(request->data().size());
       int32_t flags_raw = request->flags_raw();
@@ -844,7 +841,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto socket_grpc_session = request->socket();
-      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.name());
       int32_t level;
       switch (request->level_enum_case()) {
         case nixnetsocket_grpc::SetSockOptRequest::LevelEnumCase::kLevel: {
@@ -901,7 +898,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto socket_grpc_session = request->socket();
-      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.id(), socket_grpc_session.name());
+      nxSOCKET socket = session_repository_->access_session(socket_grpc_session.name());
       int32_t how;
       switch (request->how_enum_case()) {
         case nixnetsocket_grpc::ShutdownRequest::HowEnumCase::kHow: {
@@ -939,7 +936,7 @@ namespace nixnetsocket_grpc {
     }
     try {
       auto stack_ref_grpc_session = request->stack_ref();
-      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.id(), stack_ref_grpc_session.name());
+      nxIpStackRef_t stack_ref = nx_ip_stack_ref_t_resource_repository_->access_session(stack_ref_grpc_session.name());
       int32_t domain;
       switch (request->domain_enum_case()) {
         case nixnetsocket_grpc::SocketRequest::DomainEnumCase::kDomain: {
@@ -994,15 +991,14 @@ namespace nixnetsocket_grpc {
         auto status = socket == -1 ? -1 : 0;
         return std::make_tuple(status, socket);
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
+      std::string grpc_device_session_name = request->session_name();
       auto cleanup_lambda = [&] (nxSOCKET id) { library_->Close(id); };
-      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id);
+      int status = session_repository_->add_session(grpc_device_session_name, init_lambda, cleanup_lambda);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNxIpStackRef_t(context, status, stack_ref);
       }
       response->set_status(status);
-      response->mutable_socket()->set_id(session_id);
+      response->mutable_socket()->set_name(grpc_device_session_name);
       return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -19,11 +19,11 @@
 
   explicit_session_params = (common_helpers.get_cpp_local_name(param) for param in parameters if param.get('is_session_name', False))
   session_field_name = next(explicit_session_params, 'session_name')
-  add_session_snippet = 'add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id)'
+  add_session_snippet = 'add_session(grpc_device_session_name, init_lambda, cleanup_lambda)'
   if session_behavior_param and session_initialized_param:
       session_behavior_param_name = common_helpers.get_cpp_local_name(session_behavior_param)
       session_initialized_param_name = common_helpers.get_cpp_local_name(session_initialized_param)
-      add_session_snippet = f'add_session(grpc_device_session_name, init_lambda, cleanup_lambda, session_id, {session_behavior_param_name}, &{session_initialized_param_name})'
+      add_session_snippet = f'add_session(grpc_device_session_name, init_lambda, cleanup_lambda, {session_behavior_param_name}, &{session_initialized_param_name})'
 %>\
 ${initialize_input_params(function_name, parameters)}
 ${initialize_output_params(output_parameters_to_initialize)}\
@@ -41,8 +41,7 @@ ${call_library_method(
 }\
         return std::make_tuple(status, ${session_output_var_name});
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->${session_field_name}();
+      std::string grpc_device_session_name = request->${session_field_name}();
       auto cleanup_lambda = [&] (${resource_handle_type} id) { library_->${close_function_call}; };
       int status = ${service_helpers.session_repository_field_name(session_output_param, config)}->${add_session_snippet};
 ${populate_response(function_data=function_data, parameters=parameters, init_method=True)}\
@@ -64,18 +63,17 @@ ${populate_response(function_data=function_data, parameters=parameters, init_met
 %>\
 ${initialize_input_params(function_name, parameters)}
 ${initialize_output_params(output_parameters_to_initialize)}\
-      auto initiating_session_id = ${service_helpers.session_repository_field_name(initiating_driver_input_param, config)}->access_session_id(${initiating_driver_c_name}.id(), ${initiating_driver_c_name}.name());
+      auto initiating_session_name = ${initiating_driver_c_name}.name();
       auto init_lambda = [&] () {
         ${cross_driver_dep.resource_handle_type} ${session_output_var_name};
         int status = library_->${function_name}(${service_helpers.create_args(parameters)});
         return std::make_tuple(status, ${session_output_var_name});
       };
-      uint32_t session_id = 0;
-      const std::string& grpc_device_session_name = request->session_name();
-      int status = ${cross_driver_dep.field_name}->add_dependent_session(grpc_device_session_name, init_lambda, initiating_session_id, session_id);
+      std::string session_name;
+      int status = ${cross_driver_dep.field_name}->add_dependent_session(session_name, init_lambda, initiating_session_name);
       response->set_status(status);
       if (status == 0) {
-        response->mutable_${session_output_field_name}()->set_id(session_id);
+        response->mutable_${session_output_field_name}()->set_name(session_name);
       }
       return ::grpc::Status::OK;\
 </%def>
@@ -263,7 +261,7 @@ ${initialize_output_params(output_parameters)}\
   session_param = common_helpers.get_first_session_param(parameters)
   session_param_name = f'{common_helpers.get_cpp_local_name(session_param)}_grpc_session'
 %>\
-      ${service_helpers.session_repository_field_name(session_param, config)}->remove_session(${session_param_name}.id(), ${session_param_name}.name());
+      ${service_helpers.session_repository_field_name(session_param, config)}->remove_session(${session_param_name}.name());
 % endif
 ${call_library_method(
   function_name=function_name, 
@@ -579,7 +577,7 @@ ${initialize_standard_input_param(function_name, parameter)}
         ${parameter_name}_request.begin(),
         ${parameter_name}_request.end(),
         std::back_inserter(${parameter_name}),
-        [&](auto session) { return ${service_helpers.session_repository_field_name(parameter, config)}->access_session(session.id(), session.name()); }); \
+        [&](auto session) { return ${service_helpers.session_repository_field_name(parameter, config)}->access_session(session.name()); }); \
 % elif c_type == 'ViBoolean[]':
       auto ${parameter_name}_request = ${request_snippet};
       std::vector<${c_type_underlying_type}> ${parameter_name};
@@ -600,7 +598,7 @@ ${initialize_standard_input_param(function_name, parameter)}
       ${c_type} ${parameter_name} = (${c_type})${request_snippet};\
 % elif grpc_type == 'nidevice_grpc.Session':
       auto ${parameter_name}_grpc_session = ${request_snippet};
-      ${c_type} ${parameter_name} = ${service_helpers.session_repository_field_name(parameter, config)}->access_session(${parameter_name}_grpc_session.id(), ${parameter_name}_grpc_session.name());\
+      ${c_type} ${parameter_name} = ${service_helpers.session_repository_field_name(parameter, config)}->access_session(${parameter_name}_grpc_session.name());\
 % elif is_array and common_helpers.is_driver_typedef_with_same_size_but_different_qualifiers(c_type_underlying_type):
       auto ${parameter_name} = const_cast<${c_type_pointer}>(reinterpret_cast<const ${c_type_pointer}>(${request_snippet}.data()));\
 %elif c_type in ['const int32[]', 'const uInt32[]']:
@@ -862,9 +860,9 @@ ${copy_to_response_with_transform(source_buffer=parameter_name, parameter_name=p
       response->set_${field_name}(${parameter_name});
 %   elif parameter['grpc_type'] == 'nidevice_grpc.Session':
 %      if not init_method: # Non-init methods need to resolve the session ID from the out param.
-      auto session_id = ${service_helpers.session_repository_field_name(parameter, config)}->resolve_session_id(${parameter_name});
+      auto grpc_device_session_name = ${service_helpers.session_repository_field_name(parameter, config)}->resolve_session_name(${parameter_name});
 %      endif
-      response->mutable_${field_name}()->set_id(session_id);
+      response->mutable_${field_name}()->set_name(grpc_device_session_name);
 %   elif common_helpers.is_array(parameter['type']):
 %     if common_helpers.get_size_mechanism(parameter) == 'passed-in-by-ptr':
 ### size may have changed

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -69,7 +69,7 @@ ${initialize_output_params(output_parameters_to_initialize)}\
         int status = library_->${function_name}(${service_helpers.create_args(parameters)});
         return std::make_tuple(status, ${session_output_var_name});
       };
-      std::string session_name;
+      std::string session_name = request->session_name();
       int status = ${cross_driver_dep.field_name}->add_dependent_session(session_name, init_lambda, initiating_session_name);
       response->set_status(status);
       if (status == 0) {

--- a/source/custom/nidcpower_service.custom.cpp
+++ b/source/custom/nidcpower_service.custom.cpp
@@ -33,7 +33,7 @@ static void CheckStatus(int status)
   ViSession vi = VI_NULL;
   try {
     auto vi_grpc_session = request->vi();
-    vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+    vi = session_repository_->access_session(vi_grpc_session.name());
     ViConstString channel_name = request->channel_name().c_str();
 
     ViUInt32 number_of_channels;
@@ -72,7 +72,7 @@ static void CheckStatus(int status)
   ViSession vi = VI_NULL;
   try {
     auto vi_grpc_session = request->vi();
-    vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+    vi = session_repository_->access_session(vi_grpc_session.name());
     ViConstString channel_name = request->channel_name().c_str();
 
     ViUInt32 number_of_channels;

--- a/source/custom/nidigitalpattern_service.custom.cpp
+++ b/source/custom/nidigitalpattern_service.custom.cpp
@@ -34,7 +34,7 @@ inline bool status_ok(int32 status)
   }
   try {
     auto vi_grpc_session = request->vi();
-    ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+    ViSession vi = session_repository_->access_session(vi_grpc_session.name());
     auto site_list = request->site_list().c_str();
     auto waveform_name = request->waveform_name().c_str();
     ViInt32 samples_to_read = request->samples_to_read();

--- a/source/custom/nifgen_service.custom.cpp
+++ b/source/custom/nifgen_service.custom.cpp
@@ -13,7 +13,7 @@ namespace nifgen_grpc {
   }
   try {
     auto vi_grpc_session = request->vi();
-    ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+    ViSession vi = session_repository_->access_session(vi_grpc_session.name());
     ViInt32 sequence_length = request->waveform_handles_array().size();
     auto waveform_handles_array = const_cast<ViInt32*>(reinterpret_cast<const ViInt32*>(request->waveform_handles_array().data()));
     auto loop_counts_array = const_cast<ViInt32*>(reinterpret_cast<const ViInt32*>(request->loop_counts_array().data()));

--- a/source/custom/nimxlcterminaladaptor_restricted_service.custom.cpp
+++ b/source/custom/nimxlcterminaladaptor_restricted_service.custom.cpp
@@ -70,7 +70,7 @@ class TerminalContainerPtr {
   }
   try {
     auto grpc_session = request->session();
-    nimxlc_Session session = session_repository_->access_session(grpc_session.id(), grpc_session.name());
+    nimxlc_Session session = session_repository_->access_session(grpc_session.name());
 
     auto status = allocate_output_storage<nierr_Status, NIErrStatus>(context);
     DeviceContainerPtr deviceContainerPtr(library_, library_->getDeviceContainer(session, &status));

--- a/source/custom/nirfmxinstr_restricted_service.custom.cpp
+++ b/source/custom/nirfmxinstr_restricted_service.custom.cpp
@@ -35,7 +35,7 @@ inline bool status_ok(int32 status)
   }
   try {
     auto instrument_grpc_session = request->instrument();
-    niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+    niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
     uInt64 snapshot_info_cache_index{};
     int32 personality_id_array_actual_size{};
     int32 signal_names_actual_size{};
@@ -140,7 +140,7 @@ inline bool status_ok(int32 status)
   }
   try {
     auto instrument_grpc_session = request->instrument();
-    niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
+    niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
     uInt64 snapshot_info_cache_index{};
     int32 personality_id{};
     int32 signal_name_actual_size{};

--- a/source/custom/nirfmxinstr_service.custom.cpp
+++ b/source/custom/nirfmxinstr_service.custom.cpp
@@ -17,7 +17,7 @@ const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;
   try {
     auto instrument_grpc_session = request->instrument();
     auto instrument = session_repository_->access_session(instrument_grpc_session.name());
-    auto initiating_session_id = instrument_grpc_session.name();
+    auto initiating_session_name = instrument_grpc_session.name();
     auto nirfsa_sessions = std::vector<ViSession>{};
 
     int32 array_size{};
@@ -50,7 +50,7 @@ const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;
           return std::make_tuple(0, nirfsa_sessions[i]);
         };
         auto session_name = request->session_names_size() ? request->session_names(i) : "";
-        int status = vi_session_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_id);
+        int status = vi_session_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_name);
         auto session = response->add_nirfsa_sessions();
         session->set_name(session_name);
       }

--- a/source/custom/nirfmxinstr_service.custom.cpp
+++ b/source/custom/nirfmxinstr_service.custom.cpp
@@ -16,8 +16,8 @@ const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;
   }
   try {
     auto instrument_grpc_session = request->instrument();
-    auto instrument = session_repository_->access_session(instrument_grpc_session.id(), instrument_grpc_session.name());
-    auto initiating_session_id = session_repository_->access_session_id(instrument_grpc_session.id(), instrument_grpc_session.name());
+    auto instrument = session_repository_->access_session(instrument_grpc_session.name());
+    auto initiating_session_id = instrument_grpc_session.name();
     auto nirfsa_sessions = std::vector<ViSession>{};
 
     int32 array_size{};
@@ -49,11 +49,10 @@ const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;
         auto init_lambda = [&]() {
           return std::make_tuple(0, nirfsa_sessions[i]);
         };
-        uint32_t session_id = 0;
-        const auto session_name = request->session_names_size() ? request->session_names(i) : "";
-        int status = vi_session_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_id, session_id);
+        auto session_name = request->session_names_size() ? request->session_names(i) : "";
+        int status = vi_session_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_id);
         auto session = response->add_nirfsa_sessions();
-        session->set_id(session_id);
+        session->set_name(session_name);
       }
       return ::grpc::Status::OK;
     }

--- a/source/custom/niscope_service.custom.cpp
+++ b/source/custom/niscope_service.custom.cpp
@@ -31,7 +31,7 @@ void CheckStatus(int status)
   ViSession vi = VI_NULL;
   try {
     auto session = request->vi();
-    vi = session_repository_->access_session(session.id(), session.name());
+    vi = session_repository_->access_session(session.name());
     ViConstString channel_list = request->channel_list().c_str();
     ViReal64 timeout = request->timeout();
     ViInt32 num_samples = request->num_samples();
@@ -75,7 +75,7 @@ void CheckStatus(int status)
   ViSession vi = VI_NULL;
   try {
     auto session = request->vi();
-    vi = session_repository_->access_session(session.id(), session.name());
+    vi = session_repository_->access_session(session.name());
     ViConstString channel_list = request->channel_list().c_str();
     ViReal64 timeout = request->timeout();
     ViInt32 num_samples = request->num_samples();
@@ -119,7 +119,7 @@ void CheckStatus(int status)
   ViSession vi = VI_NULL;
   try {
     auto session = request->vi();
-    vi = session_repository_->access_session(session.id(), session.name());
+    vi = session_repository_->access_session(session.name());
     ViConstString channel_list = request->channel_list().c_str();
     ViReal64 timeout = request->timeout();
     ViInt32 num_samples = request->num_samples();
@@ -163,7 +163,7 @@ void CheckStatus(int status)
   ViSession vi = VI_NULL;
   try {
     auto session = request->vi();
-    vi = session_repository_->access_session(session.id(), session.name());
+    vi = session_repository_->access_session(session.name());
     ViConstString channel_list = request->channel_list().c_str();
     ViReal64 timeout = request->timeout();
     ViInt32 num_samples = request->num_samples();
@@ -207,7 +207,7 @@ void CheckStatus(int status)
   ViSession vi = VI_NULL;
   try {
     auto session = request->vi();
-    vi = session_repository_->access_session(session.id(), session.name());
+    vi = session_repository_->access_session(session.name());
     ViConstString channel_list = request->channel_list().c_str();
     ViReal64 timeout = request->timeout();
     ViInt32 array_meas_function;
@@ -262,7 +262,7 @@ void CheckStatus(int status)
   ViSession vi = VI_NULL;
   try {
     auto session = request->vi();
-    vi = session_repository_->access_session(session.id(), session.name());
+    vi = session_repository_->access_session(session.name());
     ViConstString channel_list = request->channel_list().c_str();
     ViReal64 timeout = request->timeout();
     ViInt32 scalar_meas_function;
@@ -322,7 +322,7 @@ void CheckStatus(int status)
   ViSession vi = VI_NULL;
   try {
     auto session = request->vi();
-    vi = session_repository_->access_session(session.id(), session.name());
+    vi = session_repository_->access_session(session.name());
     ViConstString channel_list = request->channel_list().c_str();
     ViReal64 timeout = request->timeout();
     ViInt32 num_samples = request->num_samples();
@@ -366,7 +366,7 @@ void CheckStatus(int status)
   ViSession vi = VI_NULL;
   try {
     auto session = request->vi();
-    vi = session_repository_->access_session(session.id(), session.name());
+    vi = session_repository_->access_session(session.name());
     ViConstString channel_list = request->channel_list().c_str();
     ViReal64 timeout = request->timeout();
     ViInt32 num_samples = request->num_samples();
@@ -410,7 +410,7 @@ void CheckStatus(int status)
   ViSession vi = VI_NULL;
   try {
     auto session = request->vi();
-    vi = session_repository_->access_session(session.id(), session.name());
+    vi = session_repository_->access_session(session.name());
     ViConstString channel_list = request->channel_list().c_str();
     ViReal64 timeout = request->timeout();
     ViInt32 num_samples = request->num_samples();
@@ -454,7 +454,7 @@ void CheckStatus(int status)
   ViSession vi = VI_NULL;
   try {
     auto session = request->vi();
-    vi = session_repository_->access_session(session.id(), session.name());
+    vi = session_repository_->access_session(session.name());
     ViConstString channel_list = request->channel_list().c_str();
     ViReal64 timeout = request->timeout();
     ViInt32 scalar_meas_function;
@@ -504,7 +504,7 @@ void CheckStatus(int status)
   ViSession vi = VI_NULL;
   try {
     auto session = request->vi();
-    vi = session_repository_->access_session(session.id(), session.name());
+    vi = session_repository_->access_session(session.name());
     ViConstString channel_list = request->channel_list().c_str();
     ViReal64 timeout = request->timeout();
     ViInt32 scalar_meas_function;

--- a/source/custom/nisync_service.custom.cpp
+++ b/source/custom/nisync_service.custom.cpp
@@ -11,7 +11,7 @@ namespace nisync_grpc {
   }
   try {
     auto vi_grpc_session = request->vi();
-    ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+    ViSession vi = session_repository_->access_session(vi_grpc_session.name());
     ViConstString terminal = request->terminal().c_str();
     ViUInt32 timestamps_to_read = request->timestamps_to_read();
     ViReal64 timeout = request->timeout();

--- a/source/custom/nixnet_service.custom.cpp
+++ b/source/custom/nixnet_service.custom.cpp
@@ -441,22 +441,22 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
         break;
       }
       case db_ref_: {
-        auto initiating_session_id = session_grpc_session.name();
+        auto initiating_session_name = session_grpc_session.name();
         auto init_lambda = [&]() {
           nxDatabaseRef_t property_value;
           status = library_->GetProperty(session, property_id, property_size, &property_value);
           return std::make_tuple(status, property_value);
         };
-        std::string session_id;
-        status = nx_database_ref_t_resource_repository_->add_dependent_session(session_id, init_lambda, initiating_session_id);
+        std::string session_name;
+        status = nx_database_ref_t_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_name);
         if (!status_ok(status)) {
           return ConvertApiErrorStatusForNxSessionRef_t(context, status, session);
         }
-        response->mutable_db_ref()->set_name(session_id);
+        response->mutable_db_ref()->set_name(session_name);
         break;
       }
       case db_ref_array_: {
-        auto initiating_session_id = session_grpc_session.name();
+        auto initiating_session_name = session_grpc_session.name();
         int32_t number_of_elements = property_size / sizeof(nxDatabaseRef_t);
         std::vector<nxDatabaseRef_t> property_value_vector(number_of_elements, 0U);
         nxDatabaseRef_t* property_value = static_cast<nxDatabaseRef_t*>(property_value_vector.data());
@@ -475,7 +475,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
                 return std::make_tuple(status, x);
               };
               std::string session_name;
-              status = nx_database_ref_t_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_id);
+              status = nx_database_ref_t_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_name);
               nidevice_grpc::Session dependent_session{};
               dependent_session.set_name(session_name);
               return dependent_session;
@@ -483,7 +483,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
         break;
       }
       case dev_ref_: {
-        auto initiating_session_id = session_grpc_session.name();
+        auto initiating_session_name = session_grpc_session.name();
         auto init_lambda = [&]() {
           nxSessionRef_t property_value;
           status = library_->GetProperty(session, property_id, property_size, &property_value);
@@ -492,7 +492,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
         std::string session_name;
         // We are adding it to session_repository_ and not to "device repository", because devices don't have a close API,
         // so it makes sense to tie their lifetime with session's lifetime.
-        status = session_repository_->add_dependent_session(session_name, init_lambda, initiating_session_id);
+        status = session_repository_->add_dependent_session(session_name, init_lambda, initiating_session_name);
         if (!status_ok(status)) {
           return ConvertApiErrorStatusForNxSessionRef_t(context, status, session);
         }
@@ -500,7 +500,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
         break;
       }
       case dev_ref_array_: {
-        auto initiating_session_id = session_grpc_session.name();
+        auto initiating_session_name = session_grpc_session.name();
         int32_t number_of_elements = property_size / sizeof(nxSessionRef_t);
         std::vector<nxSessionRef_t> property_value_vector(number_of_elements, 0U);
         nxSessionRef_t* property_value = property_value_vector.data();
@@ -521,7 +521,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
               std::string session_name;
               // We are adding it to session_repository_ and not to "device repository", because devices don't have a close API,
               // so it makes sense to tie their lifetime with session's lifetime.
-              status = session_repository_->add_dependent_session(session_name, init_lambda, initiating_session_id);
+              status = session_repository_->add_dependent_session(session_name, init_lambda, initiating_session_name);
               nidevice_grpc::Session dependent_session{};
               dependent_session.set_name(session_name);
               return dependent_session;
@@ -529,7 +529,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
         break;
       }
       case intf_ref_array_: {
-        auto initiating_session_id = session_grpc_session.name();
+        auto initiating_session_name = session_grpc_session.name();
         int32_t number_of_elements = property_size / sizeof(nxSessionRef_t);
         std::vector<nxSessionRef_t> property_value_vector(number_of_elements, 0U);
         nxSessionRef_t* property_value = property_value_vector.data();
@@ -550,7 +550,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
               std::string session_name;
               // We are adding it to session_repository_ and not to "interface repository", because interfaces don't have a close API,
               // so it makes sense to tie their lifetime with session's lifetime.
-              status = session_repository_->add_dependent_session(session_name, init_lambda, initiating_session_id);
+              status = session_repository_->add_dependent_session(session_name, init_lambda, initiating_session_name);
               nidevice_grpc::Session dependent_session{};
               dependent_session.set_name(session_name);
               return dependent_session;
@@ -756,14 +756,14 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
         response->set_u8_array(property_value);
       }
       case db_ref_: {
-        auto initiating_session_id = dbobject_grpc_session.name();
+        auto initiating_session_name = dbobject_grpc_session.name();
         auto init_lambda = [&]() {
           nxDatabaseRef_t property_value;
           status = library_->DbGetProperty(dbobject, property_id, property_size, &property_value);
           return std::make_tuple(status, property_value);
         };
         std::string session_name;
-        status = nx_database_ref_t_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_id);
+        status = nx_database_ref_t_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_name);
         if (!status_ok(status)) {
           return ConvertApiErrorStatusForNxDatabaseRef_t(context, status, dbobject);
         }
@@ -772,7 +772,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
       }
       case db_ref_array_: {
         int32_t number_of_elements = property_size / sizeof(nxDatabaseRef_t);
-        auto initiating_session_id = dbobject_grpc_session.name();
+        auto initiating_session_name = dbobject_grpc_session.name();
         std::vector<nxDatabaseRef_t> property_value_vector(number_of_elements, 0U);
         nxDatabaseRef_t* property_value = static_cast<nxDatabaseRef_t*>(property_value_vector.data());
         status = library_->DbGetProperty(dbobject, property_id, property_size, property_value);
@@ -790,7 +790,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
                 return std::make_tuple(status, x);
               };
               std::string session_name;
-              status = nx_database_ref_t_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_id);
+              status = nx_database_ref_t_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_name);
               nidevice_grpc::Session dependent_session{};
               dependent_session.set_name(session_name);
               return dependent_session;

--- a/source/custom/nixnet_service.custom.cpp
+++ b/source/custom/nixnet_service.custom.cpp
@@ -146,7 +146,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
   }
   try {
     auto session_grpc_session = request->session();
-    nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+    nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
     u32 state_id;
     switch (request->state_id_enum_case()) {
       case nixnet_grpc::ReadStateRequest::StateIdEnumCase::kStateId: {
@@ -247,7 +247,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
   }
   try {
     auto session_grpc_session = request->session();
-    nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+    nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
     u32 state_id;
     switch (request->state_id_enum_case()) {
       case nixnet_grpc::WriteStateRequest::StateIdEnumCase::kStateId: {
@@ -351,7 +351,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
     }
     // We store device, interface and session references in session_repository_ itself, either as owned session or
     // as dependent session. So we should always do a lookup in session_repository_.
-    nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+    nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
     u32 property_id;
     switch (request->property_id_enum_case()) {
       case nixnet_grpc::GetPropertyRequest::PropertyIdEnumCase::kPropertyId: {
@@ -441,22 +441,22 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
         break;
       }
       case db_ref_: {
-        auto initiating_session_id = session_repository_->access_session_id(session_grpc_session.id(), session_grpc_session.name());
+        auto initiating_session_id = session_grpc_session.name();
         auto init_lambda = [&]() {
           nxDatabaseRef_t property_value;
           status = library_->GetProperty(session, property_id, property_size, &property_value);
           return std::make_tuple(status, property_value);
         };
-        uint32_t session_id = 0;
-        status = nx_database_ref_t_resource_repository_->add_dependent_session("", init_lambda, initiating_session_id, session_id);
+        std::string session_id;
+        status = nx_database_ref_t_resource_repository_->add_dependent_session(session_id, init_lambda, initiating_session_id);
         if (!status_ok(status)) {
           return ConvertApiErrorStatusForNxSessionRef_t(context, status, session);
         }
-        response->mutable_db_ref()->set_id(session_id);
+        response->mutable_db_ref()->set_name(session_id);
         break;
       }
       case db_ref_array_: {
-        auto initiating_session_id = session_repository_->access_session_id(session_grpc_session.id(), session_grpc_session.name());
+        auto initiating_session_id = session_grpc_session.name();
         int32_t number_of_elements = property_size / sizeof(nxDatabaseRef_t);
         std::vector<nxDatabaseRef_t> property_value_vector(number_of_elements, 0U);
         nxDatabaseRef_t* property_value = static_cast<nxDatabaseRef_t*>(property_value_vector.data());
@@ -474,33 +474,33 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
               auto init_lambda = [&]() {
                 return std::make_tuple(status, x);
               };
-              uint32_t session_id{};
-              status = nx_database_ref_t_resource_repository_->add_dependent_session("", init_lambda, initiating_session_id, session_id);
+              std::string session_name;
+              status = nx_database_ref_t_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_id);
               nidevice_grpc::Session dependent_session{};
-              dependent_session.set_id(session_id);
+              dependent_session.set_name(session_name);
               return dependent_session;
             });
         break;
       }
       case dev_ref_: {
-        auto initiating_session_id = session_repository_->access_session_id(session_grpc_session.id(), session_grpc_session.name());
+        auto initiating_session_id = session_grpc_session.name();
         auto init_lambda = [&]() {
           nxSessionRef_t property_value;
           status = library_->GetProperty(session, property_id, property_size, &property_value);
           return std::make_tuple(status, property_value);
         };
-        uint32_t session_id = 0;
+        std::string session_name;
         // We are adding it to session_repository_ and not to "device repository", because devices don't have a close API,
         // so it makes sense to tie their lifetime with session's lifetime.
-        status = session_repository_->add_dependent_session("", init_lambda, initiating_session_id, session_id);
+        status = session_repository_->add_dependent_session(session_name, init_lambda, initiating_session_id);
         if (!status_ok(status)) {
           return ConvertApiErrorStatusForNxSessionRef_t(context, status, session);
         }
-        response->mutable_dev_ref()->set_id(session_id);
+        response->mutable_dev_ref()->set_name(session_name);
         break;
       }
       case dev_ref_array_: {
-        auto initiating_session_id = session_repository_->access_session_id(session_grpc_session.id(), session_grpc_session.name());
+        auto initiating_session_id = session_grpc_session.name();
         int32_t number_of_elements = property_size / sizeof(nxSessionRef_t);
         std::vector<nxSessionRef_t> property_value_vector(number_of_elements, 0U);
         nxSessionRef_t* property_value = property_value_vector.data();
@@ -518,18 +518,18 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
               auto init_lambda = [&]() {
                 return std::make_tuple(status, x);
               };
-              uint32_t session_id{};
+              std::string session_name;
               // We are adding it to session_repository_ and not to "device repository", because devices don't have a close API,
               // so it makes sense to tie their lifetime with session's lifetime.
-              status = session_repository_->add_dependent_session("", init_lambda, initiating_session_id, session_id);
+              status = session_repository_->add_dependent_session(session_name, init_lambda, initiating_session_id);
               nidevice_grpc::Session dependent_session{};
-              dependent_session.set_id(session_id);
+              dependent_session.set_name(session_name);
               return dependent_session;
             });
         break;
       }
       case intf_ref_array_: {
-        auto initiating_session_id = session_repository_->access_session_id(session_grpc_session.id(), session_grpc_session.name());
+        auto initiating_session_id = session_grpc_session.name();
         int32_t number_of_elements = property_size / sizeof(nxSessionRef_t);
         std::vector<nxSessionRef_t> property_value_vector(number_of_elements, 0U);
         nxSessionRef_t* property_value = property_value_vector.data();
@@ -547,12 +547,12 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
               auto init_lambda = [&]() {
                 return std::make_tuple(status, x);
               };
-              uint32_t session_id{};
+              std::string session_name;
               // We are adding it to session_repository_ and not to "interface repository", because interfaces don't have a close API,
               // so it makes sense to tie their lifetime with session's lifetime.
-              status = session_repository_->add_dependent_session("", init_lambda, initiating_session_id, session_id);
+              status = session_repository_->add_dependent_session(session_name, init_lambda, initiating_session_id);
               nidevice_grpc::Session dependent_session{};
-              dependent_session.set_id(session_id);
+              dependent_session.set_name(session_name);
               return dependent_session;
             });
         break;
@@ -591,7 +591,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
   }
   try {
     auto session_grpc_session = request->session();
-    nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+    nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
     u32 active_index = request->active_index();
     u32 property_id;
     switch (request->subproperty_id_enum_case()) {
@@ -666,7 +666,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
   }
   try {
     auto dbobject_grpc_session = request->dbobject();
-    nxDatabaseRef_t dbobject = nx_database_ref_t_resource_repository_->access_session(dbobject_grpc_session.id(), dbobject_grpc_session.name());
+    nxDatabaseRef_t dbobject = nx_database_ref_t_resource_repository_->access_session(dbobject_grpc_session.name());
     u32 property_id;
     switch (request->dbproperty_id_enum_case()) {
       case nixnet_grpc::DbGetPropertyRequest::DbpropertyIdEnumCase::kPropertyId: {
@@ -756,23 +756,23 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
         response->set_u8_array(property_value);
       }
       case db_ref_: {
-        auto initiating_session_id = nx_database_ref_t_resource_repository_->access_session_id(dbobject_grpc_session.id(), dbobject_grpc_session.name());
+        auto initiating_session_id = dbobject_grpc_session.name();
         auto init_lambda = [&]() {
           nxDatabaseRef_t property_value;
           status = library_->DbGetProperty(dbobject, property_id, property_size, &property_value);
           return std::make_tuple(status, property_value);
         };
-        uint32_t session_id = 0;
-        status = nx_database_ref_t_resource_repository_->add_dependent_session("", init_lambda, initiating_session_id, session_id);
+        std::string session_name;
+        status = nx_database_ref_t_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_id);
         if (!status_ok(status)) {
           return ConvertApiErrorStatusForNxDatabaseRef_t(context, status, dbobject);
         }
-        response->mutable_db_ref()->set_id(session_id);
+        response->mutable_db_ref()->set_name(session_name);
         break;
       }
       case db_ref_array_: {
         int32_t number_of_elements = property_size / sizeof(nxDatabaseRef_t);
-        auto initiating_session_id = nx_database_ref_t_resource_repository_->access_session_id(dbobject_grpc_session.id(), dbobject_grpc_session.name());
+        auto initiating_session_id = dbobject_grpc_session.name();
         std::vector<nxDatabaseRef_t> property_value_vector(number_of_elements, 0U);
         nxDatabaseRef_t* property_value = static_cast<nxDatabaseRef_t*>(property_value_vector.data());
         status = library_->DbGetProperty(dbobject, property_id, property_size, property_value);
@@ -789,10 +789,10 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
               auto init_lambda = [&]() {
                 return std::make_tuple(status, x);
               };
-              uint32_t session_id{};
-              status = nx_database_ref_t_resource_repository_->add_dependent_session("", init_lambda, initiating_session_id, session_id);
+              std::string session_name;
+              status = nx_database_ref_t_resource_repository_->add_dependent_session(session_name, init_lambda, initiating_session_id);
               nidevice_grpc::Session dependent_session{};
-              dependent_session.set_id(session_id);
+              dependent_session.set_name(session_name);
               return dependent_session;
             });
         break;
@@ -823,7 +823,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
   }
   try {
     auto session_grpc_session = request->session();
-    nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+    nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
     u32 property_id;
     switch (request->property_id_enum_case()) {
       case nixnet_grpc::SetPropertyRequest::PropertyIdEnumCase::kPropertyId: {
@@ -887,7 +887,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
       case db_ref_: {
         u32 property_size = sizeof(nxDatabaseRef_t);
         auto db_ref = request->db_ref();
-        nxDatabaseRef_t property_value = nx_database_ref_t_resource_repository_->access_session(db_ref.id(), db_ref.name());
+        nxDatabaseRef_t property_value = nx_database_ref_t_resource_repository_->access_session(db_ref.name());
         status = library_->SetProperty(session, property_id, property_size, &property_value);
         break;
       }
@@ -899,7 +899,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
             request->db_ref_array().db_ref().begin() + number_of_elements,
             property_value.end(),
             [&](auto x) {
-              nxDatabaseRef_t db_ref = nx_database_ref_t_resource_repository_->access_session(x.id(), x.name());
+              nxDatabaseRef_t db_ref = nx_database_ref_t_resource_repository_->access_session(x.name());
               return db_ref;
             });
         u32 property_size = number_of_elements * sizeof(nxDatabaseRef_t);
@@ -938,7 +938,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
   }
   try {
     auto session_grpc_session = request->session();
-    nxSessionRef_t session = session_repository_->access_session(session_grpc_session.id(), session_grpc_session.name());
+    nxSessionRef_t session = session_repository_->access_session(session_grpc_session.name());
     u32 active_index = request->active_index();
     u32 property_id;
     switch (request->subproperty_id_enum_case()) {
@@ -1002,7 +1002,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
   }
   try {
     auto dbobject_grpc_session = request->dbobject();
-    nxDatabaseRef_t dbobject = nx_database_ref_t_resource_repository_->access_session(dbobject_grpc_session.id(), dbobject_grpc_session.name());
+    nxDatabaseRef_t dbobject = nx_database_ref_t_resource_repository_->access_session(dbobject_grpc_session.name());
     u32 property_id;
     switch (request->dbproperty_id_enum_case()) {
       case nixnet_grpc::DbSetPropertyRequest::DbpropertyIdEnumCase::kPropertyId: {
@@ -1065,7 +1065,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
       case db_ref_: {
         u32 property_size = sizeof(nxDatabaseRef_t);
         auto db_ref = request->db_ref();
-        nxDatabaseRef_t property_value = nx_database_ref_t_resource_repository_->access_session(db_ref.id(), db_ref.name());
+        nxDatabaseRef_t property_value = nx_database_ref_t_resource_repository_->access_session(db_ref.name());
         status = library_->DbSetProperty(dbobject, property_id, property_size, &property_value);
         break;
       }
@@ -1077,7 +1077,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
             request->db_ref_array().db_ref().begin() + number_of_elements,
             property_value.end(),
             [&](auto x) {
-              nxDatabaseRef_t db_ref = nx_database_ref_t_resource_repository_->access_session(x.id(), x.name());
+              nxDatabaseRef_t db_ref = nx_database_ref_t_resource_repository_->access_session(x.name());
               return db_ref;
             });
         u32 property_size = number_of_elements * sizeof(nxDatabaseRef_t);
@@ -1144,7 +1144,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
   }
   try {
     auto db_object_grpc_session = request->db_object();
-    nxDatabaseRef_t dbobject = nx_database_ref_t_resource_repository_->access_session(db_object_grpc_session.id(), db_object_grpc_session.name());
+    nxDatabaseRef_t dbobject = nx_database_ref_t_resource_repository_->access_session(db_object_grpc_session.name());
     u32 mode;
     switch (request->mode_enum_case()) {
       case nixnet_grpc::DbGetDBCAttributeRequest::ModeEnumCase::kMode: {

--- a/source/custom/xnetsocket_converters.h
+++ b/source/custom/xnetsocket_converters.h
@@ -243,7 +243,7 @@ struct SetInputConverter {
   {
     nxFD_ZERO(&set);
     for (const auto& session : input) {
-      const auto socket = resource_repository->access_session(session.id(), session.name());
+      const auto socket = resource_repository->access_session(session.name());
       nxFD_SET(socket, &set);
     }
   }

--- a/source/protobuf/session.proto
+++ b/source/protobuf/session.proto
@@ -38,10 +38,7 @@ enum SessionInitializationBehavior {
 }
 
 message Session {
-  oneof session {
-    string name = 1;
-    uint32 id = 2;
-  }
+  string name = 1;
 }
 
 message DeviceProperties {

--- a/source/server/session_repository.cpp
+++ b/source/server/session_repository.cpp
@@ -20,7 +20,7 @@ SessionRepository::~SessionRepository()
   reset_server(/* cleanup_external_resources =*/false);
 }
 
-// Either returns (via session_id) an existing session with the specified name or initializes and
+// Either returns (via session_name) an existing session with the specified name or initializes and
 // adds a new session using the init_func provided. The init_func is only called when an existing
 // session with session_name is not found. It is expected to return a tuple, where the first value
 // is a status code, and the second value is the ID of a newly initialized session. The return

--- a/source/server/session_repository.cpp
+++ b/source/server/session_repository.cpp
@@ -26,17 +26,15 @@ SessionRepository::~SessionRepository()
 // is a status code, and the second value is the ID of a newly initialized session. The return
 // value is the status returned from the init_func, or 0 if an existing named session is found.
 int SessionRepository::add_session(
-    const std::string& session_name,
+    std::string& session_name,
     InitFunc init_func,
     CleanupSessionFunc cleanup_func,
-    uint32_t& session_id,
     SessionInitializationBehavior initialization_behavior,
     bool* initialized_new_session)
 {
   if (initialized_new_session) {
     *initialized_new_session = false;
   }
-  session_id = 0;
   std::unique_lock<std::shared_mutex> lock(repository_lock_);
   auto now = std::chrono::steady_clock::now();
   auto it = named_sessions_.find(session_name);
@@ -48,7 +46,6 @@ int SessionRepository::add_session(
   }
 
   if (it != named_sessions_.end()) {
-    session_id = it->second->id;
     it->second->last_access_time = now;
     return 0;
   }
@@ -57,15 +54,11 @@ int SessionRepository::add_session(
   if (status) {
     return status;
   }
-  session_id = next_id();
-  info->id = session_id;
+  session_name = next_id();
   info->cleanup_func = cleanup_func;
   info->last_access_time = now;
-  sessions_.emplace(session_id, info);
-  if (!session_name.empty()) {
-    info->name = session_name;
-    named_sessions_.emplace(session_name, info);
-  }
+  info->name = session_name;
+  named_sessions_.emplace(session_name, info);
   if (initialized_new_session) {
     *initialized_new_session = true;
   }
@@ -76,46 +69,37 @@ int SessionRepository::add_session(
 // the ID of the session that matches the given ID or name, or 0 if such a session is not found.
 // Only one of the two parameters needs to be specified.
 // Passing only a name returns the corresponding ID.
-uint32_t SessionRepository::access_session(uint32_t session_id, const std::string& session_name)
+std::string SessionRepository::access_session(const std::string& session_name)
 {
   std::unique_lock<std::shared_mutex> lock(repository_lock_);
   auto now = std::chrono::steady_clock::now();
   auto it = named_sessions_.find(session_name);
   if (it != named_sessions_.end()) {
     it->second->last_access_time = now;
-    return it->second->id;
-  }
-  auto sessions_it = sessions_.find(session_id);
-  if (sessions_it != sessions_.end()) {
-    sessions_it->second->last_access_time = now;
-    return session_id;
+    return it->second->name;
   }
   return 0;
 }
 
 // Removes a session by ID.
 // To remove a session by name, use access_session to get the session ID.
-void SessionRepository::remove_session(uint32_t id)
+void SessionRepository::remove_session(const std::string& name)
 {
   std::unique_lock<std::shared_mutex> lock(repository_lock_);
-  auto it = sessions_.find(id);
-  if (it != sessions_.end()) {
-    auto named_it = named_sessions_.find(it->second->name);
-    if (named_it != named_sessions_.end()) {
-      named_sessions_.erase(named_it);
-    }
-    sessions_.erase(it);
+  auto named_it = named_sessions_.find(name);
+  if (named_it != named_sessions_.end()) {
+    named_sessions_.erase(named_it);
   }
 }
 
-void SessionRepository::register_dependent_session(uint32_t id, uint32_t dependent_session_id, std::function<void()> cleanup)
+void SessionRepository::register_dependent_session(const std::string& name, const std::string& dependent_session_name, std::function<void()> cleanup)
 {
   std::unique_lock<std::shared_mutex> lock(repository_lock_);
-  auto it = sessions_.find(id);
-  if (it != sessions_.end()) {
-    auto remove_action = std::make_unique<RemoveAction>([dependent_session_id, cleanup, this]() {
+  auto it = named_sessions_.find(name);
+  if (it != named_sessions_.end()) {
+    auto remove_action = std::make_unique<RemoveAction>([dependent_session_name, cleanup, this]() {
       cleanup();
-      sessions_.erase(dependent_session_id);
+      named_sessions_.erase(dependent_session_name);
     });
     it->second->dependent_sessions.emplace_back(std::move(remove_action));
   }
@@ -257,31 +241,30 @@ bool SessionRepository::reset_server(bool cleanup_external_resources)
 
 bool SessionRepository::close_sessions(bool cleanup_external_resources)
 {
-  named_sessions_.clear();
   // Copy sessions for cleanup to avoid invalidating iterators when dependent sessions
   // are removed.
   auto sessions_cleanup = std::vector<std::shared_ptr<SessionInfo>>();
   std::transform(
-      sessions_.cbegin(),
-      sessions_.cend(),
+      named_sessions_.cbegin(),
+      named_sessions_.cend(),
       std::back_inserter(sessions_cleanup),
-      [](const SessionMap::value_type& entry) { return entry.second; });
+      [](const NamedSessionMap::value_type& entry) { return entry.second; });
 
-  sessions_.clear();
+  named_sessions_.clear();
   if (cleanup_external_resources) {
     for (auto session_info : sessions_cleanup) {
       cleanup_session(session_info);
     }
   }
   sessions_cleanup.clear();
-  return named_sessions_.empty() && sessions_.empty();
+  return named_sessions_.empty();
 }
 
 void SessionRepository::cleanup_session(const std::shared_ptr<SessionInfo>& session_info)
 {
   auto cleanup_process = session_info->cleanup_func;
   if (cleanup_process) {
-    cleanup_process(session_info->id);
+    cleanup_process(session_info->name);
   }
 }
 

--- a/source/server/session_repository.cpp
+++ b/source/server/session_repository.cpp
@@ -54,7 +54,9 @@ int SessionRepository::add_session(
   if (status) {
     return status;
   }
-  session_name = next_id();
+  if (session_name.length() == 0) {
+    session_name = next_id();
+  }
   info->cleanup_func = cleanup_func;
   info->last_access_time = now;
   info->name = session_name;
@@ -78,7 +80,7 @@ std::string SessionRepository::access_session(const std::string& session_name)
     it->second->last_access_time = now;
     return it->second->name;
   }
-  return 0;
+  return "";
 }
 
 // Removes a session by ID.

--- a/source/server/session_repository.h
+++ b/source/server/session_repository.h
@@ -35,7 +35,7 @@ class SessionRepository {
   std::string access_session(const std::string& session_name);
   void remove_session(const std::string& name);
 
-  void register_dependent_session(const std::string& id, const std::string& dependent_session_id, std::function<void()> cleanup);
+  void register_dependent_session(const std::string& name, const std::string& dependent_session_name, std::function<void()> cleanup);
 
   bool reserve(
       const ::grpc::ServerContext* context,

--- a/source/server/session_repository.h
+++ b/source/server/session_repository.h
@@ -24,19 +24,18 @@ class SessionRepository {
   ~SessionRepository();
 
   typedef std::function<int32_t()> InitFunc;
-  typedef std::function<void(uint32_t)> CleanupSessionFunc;
+  typedef std::function<void(const std::string&)> CleanupSessionFunc;
 
   int add_session(
-      const std::string& session_name,
+      std::string& session_name,
       InitFunc init_func,
       CleanupSessionFunc cleanup_func,
-      uint32_t& session_id,
       SessionInitializationBehavior initialization_behavior = SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED,
       bool* initialized_new_session = nullptr);
-  uint32_t access_session(uint32_t session_id, const std::string& session_name);
-  void remove_session(uint32_t id);
+  std::string access_session(const std::string& session_name);
+  void remove_session(const std::string& name);
 
-  void register_dependent_session(uint32_t id, uint32_t dependent_session_id, std::function<void()> cleanup);
+  void register_dependent_session(const std::string& id, const std::string& dependent_session_id, std::function<void()> cleanup);
 
   bool reserve(
       const ::grpc::ServerContext* context,
@@ -72,7 +71,6 @@ class SessionRepository {
   };
 
   struct SessionInfo {
-    uint32_t id;
     std::string name;
     std::chrono::steady_clock::time_point last_access_time;
     SessionRepository::CleanupSessionFunc cleanup_func;
@@ -80,7 +78,6 @@ class SessionRepository {
   };
 
   using NamedSessionMap = std::map<std::string, std::shared_ptr<SessionInfo>>;
-  using SessionMap = std::map<uint32_t, std::shared_ptr<SessionInfo>>;
   using ReservationMap = std::map<std::string, std::shared_ptr<ReservationInfo>>;
 
   std::shared_ptr<ReservationInfo> find_or_create_reservation(const std::string& reservation_id, const std::string& client_id);
@@ -88,11 +85,9 @@ class SessionRepository {
   bool close_sessions(bool cleanup);
   void cleanup_session(const std::shared_ptr<SessionInfo>& session_info);
   bool release_reservation(const ReservationInfo* reservation_info);
-  uint32_t next_id() { return ++_next_id; }
+  std::string next_id() { return "ni:generated:" + std::to_string(++_next_id); }
 
   std::shared_mutex repository_lock_;
-  // This map contains every session, including both named and unnamed ones.
-  SessionMap sessions_;
   // These entries point at SessionInfo objects that are also contained in sessions_.
   NamedSessionMap named_sessions_;
   ReservationMap reservations_;

--- a/source/server/session_resource_repository.h
+++ b/source/server/session_resource_repository.h
@@ -224,7 +224,7 @@ std::string SessionResourceRepository<TResourceHandle>::ResourceMap::get_session
   }
   // Note: failed resolve will ultimately be reported as a bad resource by the driver
   // on use.
-  return 0;
+  return "";
 }
 
 template <typename TResourceHandle>

--- a/source/server/session_resource_repository.h
+++ b/source/server/session_resource_repository.h
@@ -25,19 +25,17 @@ class SessionResourceRepository {
   }
 
   int add_session(
-      const std::string& session_name,
+      std::string& session_name,
       InitFunc init_func,
       CleanupSessionFunc cleanup_func,
-      uint32_t& session_id,
       SessionInitializationBehavior initialization_behavior = SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED,
       bool* initialized_new_session = nullptr,
       bool include_in_reverse_lookup = true);
 
-  TResourceHandle access_session(uint32_t session_id, const std::string& session_name) const;
-  uint32_t access_session_id(uint32_t session_id, const std::string& session_name) const;
-  uint32_t resolve_session_id(TResourceHandle handle) const;
-  int add_dependent_session(const std::string& session_name, InitFunc init_func, uint32_t initiating_session, uint32_t& session_id);
-  void remove_session(uint32_t session_id, const std::string& session_name);
+  TResourceHandle access_session(const std::string& session_name) const;
+  std::string resolve_session_name(TResourceHandle handle) const;
+  int add_dependent_session(std::string& session_name, InitFunc init_func, std::string& initiating_session);
+  void remove_session(const std::string& session_name);
 
  private:
   // Wraps init_func_ and caches the result as handle_.
@@ -60,17 +58,17 @@ class SessionResourceRepository {
   // A thread-safe bi-directional map of session_id to TResourceHandle.
   class ResourceMap {
    public:
-    void add(uint32_t session_id, TResourceHandle handle, bool include_in_reverse_lookup);
+    void add(const std::string& session_name, TResourceHandle handle, bool include_in_reverse_lookup);
 
-    bool contains(uint32_t session_id) const;
-    TResourceHandle get_handle(uint32_t session_id) const;
-    uint32_t get_session_id(TResourceHandle handle) const;
+    bool contains(const std::string& session_name) const;
+    TResourceHandle get_handle(const std::string& session_name) const;
+    std::string get_session_name(TResourceHandle handle) const;
 
-    TResourceHandle remove_session_id(uint32_t session_id);
+    TResourceHandle remove_session_name(const std::string& session_name);
 
    private:
-    using SessionToResourceMap = std::map<uint32_t, TResourceHandle>;
-    using ResourceToSessionMap = std::map<TResourceHandle, uint32_t>;
+    using SessionToResourceMap = std::map<std::string, TResourceHandle>;
+    using ResourceToSessionMap = std::map<TResourceHandle, std::string>;
     using MapLock = std::lock_guard<std::recursive_mutex>;
 
     SessionToResourceMap map_;
@@ -85,54 +83,48 @@ class SessionResourceRepository {
 
 template <typename TResourceHandle>
 int SessionResourceRepository<TResourceHandle>::add_session(
-    const std::string& session_name,
+    std::string& session_name,
     InitFunc init_func,
     CleanupSessionFunc cleanup_func,
-    uint32_t& session_id,
     SessionInitializationBehavior initialization_behavior,
     bool* initialized_new_session,
     bool include_in_reverse_lookup)
 {
-  uint32_t session_from_repository = 0;
-
   auto session_creator = SessionResourceCreator(init_func);
   auto resource_map = resource_map_;
   auto status = session_repository_->add_session(
       session_name,
       [&]() { return session_creator.init_resource_handle(); },
       // By val capture to keep cleanup_func in memory.
-      [resource_map, cleanup_func](uint32_t id) {
-        auto handle = resource_map->remove_session_id(id);
+      [resource_map, cleanup_func](const std::string& name) {
+        auto handle = resource_map->remove_session_name(name);
         return cleanup_func(handle);
       },
-      session_from_repository,
       initialization_behavior,
       initialized_new_session);
 
   if (status) {
-    session_id = 0;
+    session_name = std::string();
     return status;
   }
 
   if (session_creator.added_new_handle_) {
-    resource_map_->add(session_from_repository, session_creator.handle_, include_in_reverse_lookup);
+    resource_map_->add(session_name, session_creator.handle_, include_in_reverse_lookup);
   }
 
   // session_name resolves to a session in a different resource repository.
-  if (!resource_map_->contains(session_from_repository)) {
+  if (!resource_map_->contains(session_name)) {
     throw nidevice_grpc::SessionException("The session name \"" + session_name + "\" is being used by a different driver.");
   }
 
-  session_id = session_from_repository;
   return 0;
 }
 
 template <typename TResourceHandle>
 int SessionResourceRepository<TResourceHandle>::add_dependent_session(
-    const std::string& session_name,
+    std::string& session_name,
     InitFunc init_func,
-    uint32_t initiating_session,
-    uint32_t& session_id)
+    std::string& initiating_session)
 {
   // Register with no cleanup function.
   // ASSUMPTION: dependent sessions are owned by the initiating driver session and appropriate
@@ -141,45 +133,38 @@ int SessionResourceRepository<TResourceHandle>::add_dependent_session(
   auto status = add_session(
       session_name,
       init_func,
-      [](uint32_t id) {},
-      session_id,
+      [](TResourceHandle) {},
       /* initialization_behavior = */ SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED,
       /* initialized_new_session = */ nullptr,
       /* include_in_reverse_lookup = */ false);
   auto resource_map = resource_map_;
   session_repository_->register_dependent_session(
       initiating_session,
-      session_id,
-      [session_id, resource_map]() { resource_map->remove_session_id(session_id); });
+      session_name,
+      [session_name, resource_map]() { resource_map->remove_session_name(session_name); });
   return status;
 }
 
 template <typename TResourceHandle>
-TResourceHandle SessionResourceRepository<TResourceHandle>::access_session(uint32_t session_id, const std::string& session_name) const
+TResourceHandle SessionResourceRepository<TResourceHandle>::access_session(const std::string& session_name) const
 {
-  auto id = session_repository_->access_session(session_id, session_name);
-  return resource_map_->get_handle(id);
+  auto name = session_repository_->access_session(session_name);
+  return resource_map_->get_handle(name);
 }
 
 template <typename TResourceHandle>
-uint32_t SessionResourceRepository<TResourceHandle>::access_session_id(uint32_t session_id, const std::string& session_name) const
+std::string SessionResourceRepository<TResourceHandle>::resolve_session_name(TResourceHandle handle) const
 {
-  return session_repository_->access_session(session_id, session_name);
+  return resource_map_->get_session_name(handle);
 }
 
 template <typename TResourceHandle>
-uint32_t SessionResourceRepository<TResourceHandle>::resolve_session_id(TResourceHandle handle) const
+void SessionResourceRepository<TResourceHandle>::remove_session(const std::string& session_name)
 {
-  return resource_map_->get_session_id(handle);
-}
-
-template <typename TResourceHandle>
-void SessionResourceRepository<TResourceHandle>::remove_session(uint32_t session_id, const std::string& session_name)
-{
-  auto id = session_repository_->access_session(session_id, session_name);
-  if (id) {
-    resource_map_->remove_session_id(id);
-    session_repository_->remove_session(id);
+  auto name = session_repository_->access_session(session_name);
+  if (name.length()) {
+    resource_map_->remove_session_name(name);
+    session_repository_->remove_session(name);
   }
 }
 
@@ -199,28 +184,28 @@ uint32_t SessionResourceRepository<TResourceHandle>::SessionResourceCreator::ini
 }
 
 template <typename TResourceHandle>
-void SessionResourceRepository<TResourceHandle>::ResourceMap::add(uint32_t session_id, TResourceHandle handle, bool include_in_reverse_lookup)
+void SessionResourceRepository<TResourceHandle>::ResourceMap::add(const std::string& session_name, TResourceHandle handle, bool include_in_reverse_lookup)
 {
   MapLock lock(map_mutex_);
-  map_[session_id] = handle;
+  map_[session_name] = handle;
   if (include_in_reverse_lookup) {
-    reverse_map_[handle] = session_id;
+    reverse_map_[handle] = session_name;
   }
 }
 
 template <typename TResourceHandle>
-bool SessionResourceRepository<TResourceHandle>::ResourceMap::contains(uint32_t session_id) const
+bool SessionResourceRepository<TResourceHandle>::ResourceMap::contains(const std::string& session_name) const
 {
   MapLock lock(map_mutex_);
-  auto found = map_.find(session_id);
+  auto found = map_.find(session_name);
   return found != map_.end();
 }
 
 template <typename TResourceHandle>
-TResourceHandle SessionResourceRepository<TResourceHandle>::ResourceMap::get_handle(uint32_t session_id) const
+TResourceHandle SessionResourceRepository<TResourceHandle>::ResourceMap::get_handle(const std::string& session_name) const
 {
   MapLock lock(map_mutex_);
-  auto resource_it = map_.find(session_id);
+  auto resource_it = map_.find(session_name);
   if (resource_it != map_.end()) {
     return resource_it->second;
   }
@@ -230,7 +215,7 @@ TResourceHandle SessionResourceRepository<TResourceHandle>::ResourceMap::get_han
 }
 
 template <typename TResourceHandle>
-uint32_t SessionResourceRepository<TResourceHandle>::ResourceMap::get_session_id(TResourceHandle handle) const
+std::string SessionResourceRepository<TResourceHandle>::ResourceMap::get_session_name(TResourceHandle handle) const
 {
   MapLock lock(map_mutex_);
   auto session_it = reverse_map_.find(handle);
@@ -243,12 +228,12 @@ uint32_t SessionResourceRepository<TResourceHandle>::ResourceMap::get_session_id
 }
 
 template <typename TResourceHandle>
-TResourceHandle SessionResourceRepository<TResourceHandle>::ResourceMap::remove_session_id(uint32_t session_id)
+TResourceHandle SessionResourceRepository<TResourceHandle>::ResourceMap::remove_session_name(const std::string& session_name)
 {
   MapLock lock(map_mutex_);
-  auto handle = get_handle(session_id);
+  auto handle = get_handle(session_name);
   if (handle != TResourceHandle()) {
-    map_.erase(session_id);
+    map_.erase(session_name);
     reverse_map_.erase(handle);
   }
   return handle;

--- a/source/tests/integration/session_utilities_service_tests.cpp
+++ b/source/tests/integration/session_utilities_service_tests.cpp
@@ -450,7 +450,7 @@ TEST(SessionUtilitiesServiceTests, ReservationAndSession_ResetServer_UnreservesA
   EXPECT_TRUE(reset_response.is_server_reset());
   bool is_reserved = call_is_reserved(&service, session_name, "a");
   EXPECT_FALSE(is_reserved);
-  EXPECT_NE("", session_repository.access_session(session_name));
+  EXPECT_EQ("", session_repository.access_session(session_name));
 }
 
 TEST(SessionUtilitiesServiceTests, TwoReservations_ResetServer_Unreserves)

--- a/source/tests/integration/session_utilities_service_tests.cpp
+++ b/source/tests/integration/session_utilities_service_tests.cpp
@@ -437,12 +437,10 @@ TEST(SessionUtilitiesServiceTests, ReservationAndSession_ResetServer_UnreservesA
   nidevice_grpc::SoftwareEnumerator software_enumerator(&syscfg_mock_library);
   nidevice_grpc::SessionUtilitiesService service(&session_repository, &device_enumerator, &software_enumerator);
   std::string session_name = "session_name";
-  uint32_t named_session_id;
   int status = session_repository.add_session(
       session_name,
       []() { return 0; },
-      NULL,
-      named_session_id);
+      NULL);
   call_reserve(&service, session_name, "a");
 
   ::grpc::ServerContext context;
@@ -452,8 +450,7 @@ TEST(SessionUtilitiesServiceTests, ReservationAndSession_ResetServer_UnreservesA
   EXPECT_TRUE(reset_response.is_server_reset());
   bool is_reserved = call_is_reserved(&service, session_name, "a");
   EXPECT_FALSE(is_reserved);
-  EXPECT_FALSE(session_repository.access_session(named_session_id, ""));
-  EXPECT_FALSE(session_repository.access_session(0, session_name));
+  EXPECT_NE("", session_repository.access_session(session_name));
 }
 
 TEST(SessionUtilitiesServiceTests, TwoReservations_ResetServer_Unreserves)

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -615,7 +615,7 @@ class NiDAQmxDriverApiTests : public Test {
     request.set_session_name("saved_task");
     auto status = stub()->LoadTask(&context, request, &response);
     if (status.ok()) {
-      EXPECT_NE(driver_session_->id(), response.task().id());
+      EXPECT_NE(driver_session_->name(), response.task().name());
       driver_session_ = std::make_unique<nidevice_grpc::Session>(response.task());
     }
     return status;
@@ -705,7 +705,7 @@ class NiDAQmxDriverApiTests : public Test {
   template <typename TRequest>
   void set_request_session_id(TRequest& request, const nidevice_grpc::Session& session)
   {
-    request.mutable_task()->set_id(session.id());
+    request.mutable_task()->set_name(session.name());
   }
 
   template <typename TResponse>

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -132,7 +132,7 @@ class NiDAQmxDriverApiTests : public Test {
   CreateAIVoltageChanRequest create_ai_voltage_request(double min_val, double max_val, const std::string& custom_scale_name = "")
   {
     CreateAIVoltageChanRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_physical_channel("gRPCSystemTestDAQ/ai0");
     request.set_name_to_assign_to_channel("ai0");
     request.set_terminal_config(InputTermCfgWithDefault::INPUT_TERM_CFG_WITH_DEFAULT_CFG_DEFAULT);
@@ -163,7 +163,7 @@ class NiDAQmxDriverApiTests : public Test {
   CreateAOVoltageChanRequest create_ao_voltage_chan_request(double min_val, double max_val, const std::string& name = "ao0")
   {
     CreateAOVoltageChanRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
 
     request.set_physical_channel("gRPCSystemTestDAQ/ao0");
     request.set_name_to_assign_to_channel(name);
@@ -190,7 +190,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     CreateDIChanRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_lines("gRPCSystemTestDAQ/port0/line0");
     request.set_name_to_assign_to_lines("di");
     request.set_line_grouping(LineGrouping::LINE_GROUPING_CHAN_PER_LINE);
@@ -206,7 +206,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     CreateCIFreqChanRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_counter("gRPCSystemTestDAQ/ctr0");
     request.set_name_to_assign_to_channel("ctr");
     request.set_min_val(1.19209);
@@ -231,7 +231,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     StartTaskRequest request;
-    set_request_session_id(request, session);
+    set_request_session_name(request, session);
     return stub()->StartTask(&context, request, &response);
   }
 
@@ -244,7 +244,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     StopTaskRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     return stub()->StopTask(&context, request, &response);
   }
 
@@ -255,7 +255,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     ReadAnalogF64Request request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_num_samps_per_chan(samps_per_chan);
     request.set_array_size_in_samps(array_size_in_samps);
     request.set_fill_mode(GroupBy::GROUP_BY_GROUP_BY_CHANNEL);
@@ -269,7 +269,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     WriteAnalogF64Request request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_num_samps_per_chan(static_cast<int32_t>(data.size()));
     request.set_auto_start(false);
     request.mutable_write_array()->Add(data.cbegin(), data.cend());
@@ -283,7 +283,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     WriteDigitalU32Request request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_data_layout(GroupBy::GROUP_BY_GROUP_BY_CHANNEL);
     request.set_num_samps_per_chan(4);
     request.add_write_array(1000000);
@@ -297,7 +297,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     ReadDigitalU32Request request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_num_samps_per_chan(4);
     request.set_array_size_in_samps(4);
     request.set_fill_mode(GroupBy::GROUP_BY_GROUP_BY_CHANNEL);
@@ -308,7 +308,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     WriteDigitalU16Request request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_data_layout(GroupBy::GROUP_BY_GROUP_BY_CHANNEL);
     request.set_num_samps_per_chan(4);
     request.add_write_array(65535);
@@ -322,7 +322,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     ReadDigitalU16Request request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_num_samps_per_chan(4);
     request.set_array_size_in_samps(4);
     request.set_fill_mode(GroupBy::GROUP_BY_GROUP_BY_CHANNEL);
@@ -333,7 +333,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     WriteDigitalU8Request request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_data_layout(GroupBy::GROUP_BY_GROUP_BY_CHANNEL);
     request.set_num_samps_per_chan(4);
     uint8_t data[4] = {255, 10, 1, 0};
@@ -345,7 +345,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     ReadDigitalU8Request request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_num_samps_per_chan(4);
     request.set_array_size_in_samps(4);
     request.set_fill_mode(GroupBy::GROUP_BY_GROUP_BY_CHANNEL);
@@ -356,7 +356,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     WriteBinaryI16Request request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_num_samps_per_chan(static_cast<uint32>(data.size()));
     request.mutable_write_array()->CopyFrom({data.cbegin(), data.cend()});
     request.set_data_layout(GroupBy::GROUP_BY_GROUP_BY_CHANNEL);
@@ -367,7 +367,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     GetNthTaskDeviceRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_index(index);
 
     return stub()->GetNthTaskDevice(&context, request, &response);
@@ -377,7 +377,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     IsTaskDoneRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     IsTaskDoneResponse response;
     auto status = stub()->IsTaskDone(&context, request, &response);
     EXPECT_SUCCESS(status, response);
@@ -388,7 +388,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     TaskControlRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_action(action);
     return stub()->TaskControl(&context, request, &response);
   }
@@ -396,14 +396,14 @@ class NiDAQmxDriverApiTests : public Test {
   auto register_done_event(::grpc::ClientContext& context)
   {
     RegisterDoneEventRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     return stub()->RegisterDoneEvent(&context, request);
   }
 
   auto register_every_n_samples_event(::grpc::ClientContext& context, uint32 n_samples)
   {
     RegisterEveryNSamplesEventRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_n_samples(n_samples);
     request.set_every_n_samples_event_type(EveryNSamplesEventType::EVERY_N_SAMPLES_EVENT_TYPE_ACQUIRED_INTO_BUFFER);
     return stub()->RegisterEveryNSamplesEvent(&context, request);
@@ -412,7 +412,7 @@ class NiDAQmxDriverApiTests : public Test {
   auto register_signal_event(::grpc::ClientContext& context, Signal2 signal_id)
   {
     RegisterSignalEventRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_signal_id(Signal2::SIGNAL2_SAMPLE_CLOCK);
     return stub()->RegisterSignalEvent(&context, request);
   }
@@ -420,7 +420,7 @@ class NiDAQmxDriverApiTests : public Test {
   CfgSampClkTimingRequest create_cfg_samp_clk_timing_request(double rate, Edge1 active_edge, AcquisitionType sample_mode, uInt64 samples_per_chan)
   {
     CfgSampClkTimingRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_rate(rate);
     request.set_active_edge(active_edge);
     request.set_sample_mode(sample_mode);
@@ -443,7 +443,7 @@ class NiDAQmxDriverApiTests : public Test {
   CfgChangeDetectionTimingRequest create_cfg_change_detection_timing(const std::string& channel)
   {
     CfgChangeDetectionTimingRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_falling_edge_chan(channel);
     request.set_rising_edge_chan(channel);
     request.set_sample_mode(AcquisitionType::ACQUISITION_TYPE_HW_TIMED_SINGLE_POINT);
@@ -460,7 +460,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     CfgInputBufferRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_num_samps_per_chan(1024U);
     return stub()->CfgInputBuffer(&context, request, &response);
   }
@@ -469,7 +469,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     CfgOutputBufferRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_num_samps_per_chan(1024U);
     return stub()->CfgOutputBuffer(&context, request, &response);
   }
@@ -510,7 +510,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     CreateAIThrmcplChanRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_physical_channel("gRPCSystemTestDAQ/ai0");
     request.set_units(TemperatureUnits::TEMPERATURE_UNITS_DEG_C);
     request.set_min_val(min_val);
@@ -548,7 +548,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     ReadRawRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_num_samps_per_chan(samples_to_read);
     request.set_array_size_in_bytes(samples_to_read * sizeof(TRaw));
     request.set_timeout(1000.0);
@@ -560,7 +560,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     WriteRawRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     auto byte_data = reinterpret_cast<const char*>(data.data());
     auto write_data = request.mutable_write_array();
     write_data->insert(write_data->cbegin(), byte_data, byte_data + data.size() * sizeof(TRaw));
@@ -573,7 +573,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     WaitForValidTimestampRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_timestamp_event(TimestampEvent::TIMESTAMP_EVENT_FIRST_SAMPLE_TIMESTAMP);
     request.set_timeout(1.000);
     auto status = stub()->WaitForValidTimestamp(&context, request, &response);
@@ -585,7 +585,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     CfgTimeStartTrigRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     auto time = google::protobuf::util::TimeUtil::GetCurrentTime();
     auto duration = google::protobuf::Duration{};
     duration.set_seconds(10);
@@ -601,7 +601,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     SaveTaskRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_author("grpc.tester@ni.com");
     request.set_options_raw(SaveOptions::SAVE_OPTIONS_OVERWRITE | SaveOptions::SAVE_OPTIONS_ALLOW_INTERACTIVE_DELETION);
     request.set_save_as("saved_task");
@@ -643,7 +643,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     ::grpc::ClientContext context;
     WaitForNextSampleClockRequest request;
-    set_request_session_id(request);
+    set_request_session_name(request);
     request.set_timeout(10.0);
     auto status = stub()->WaitForNextSampleClock(&context, request, &response);
     nidevice_grpc::experimental::client::raise_if_error(status, context);
@@ -677,7 +677,7 @@ class NiDAQmxDriverApiTests : public Test {
     ::grpc::ClientContext context;
     CfgWatchdogDOExpirStatesRequest request;
 
-    set_request_session_id(request, watchdog_session);
+    set_request_session_name(request, watchdog_session);
     request.set_channel_names("gRPCSystemTestDAQ/port1/line0:1");
     auto expir_states = std::vector<DigitalLineState>{
         DigitalLineState::DIGITAL_LINE_STATE_HIGH,
@@ -697,13 +697,13 @@ class NiDAQmxDriverApiTests : public Test {
   }
 
   template <typename TRequest>
-  void set_request_session_id(TRequest& request)
+  void set_request_session_name(TRequest& request)
   {
-    set_request_session_id(request, *driver_session_);
+    set_request_session_name(request, *driver_session_);
   }
 
   template <typename TRequest>
-  void set_request_session_id(TRequest& request, const nidevice_grpc::Session& session)
+  void set_request_session_name(TRequest& request, const nidevice_grpc::Session& session)
   {
     request.mutable_task()->set_name(session.name());
   }

--- a/source/tests/system/nidaqmx_session_tests.cpp
+++ b/source/tests/system/nidaqmx_session_tests.cpp
@@ -28,15 +28,12 @@ class NiDAQmxSessionTests : public ::testing::Test {
     return stub()->CreateTask(&context, request, &response);
   }
 
-  ::grpc::Status clear_task(const std::string& name, uint32_t session_id, ClearTaskResponse& response)
+  ::grpc::Status clear_task(const std::string& name, ClearTaskResponse& response)
   {
     ::grpc::ClientContext context;
     ClearTaskRequest request;
     if (!name.empty()) {
       request.mutable_task()->set_name(name);
-    }
-    if (session_id) {
-      request.mutable_task()->set_id(session_id);
     }
     return stub()->ClearTask(&context, request, &response);
   }
@@ -55,13 +52,13 @@ TEST_F(NiDAQmxSessionTests, CreateTask_ClearTask_Succeeds)
   auto create_status = create_task("", create_response);
 
   ClearTaskResponse clear_response;
-  auto clear_status = clear_task("", create_response.task().id(), clear_response);
+  auto clear_status = clear_task("", clear_response);
 
   EXPECT_TRUE(create_status.ok());
   EXPECT_TRUE(clear_status.ok());
   EXPECT_EQ(DAQMX_SUCCESS, create_response.status());
   EXPECT_EQ(DAQMX_SUCCESS, clear_response.status());
-  EXPECT_NE(0, create_response.task().id());
+  EXPECT_NE("", create_response.task().name());
 }
 }  // namespace system
 }  // namespace tests

--- a/source/tests/system/nidcpower_driver_api_tests.cpp
+++ b/source/tests/system/nidcpower_driver_api_tests.cpp
@@ -44,9 +44,9 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
     return nidcpower_stub_;
   }
 
-  int GetSessionId()
+  std::string GetSessionName()
   {
-    return driver_session_->id();
+    return driver_session_->name();
   }
 
   void initialize_driver_session()
@@ -89,7 +89,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
     dcpower::InitiateRequest request;
     dcpower::InitiateResponse response;
     ::grpc::ClientContext context;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
 
     ::grpc::Status status = GetStub()->Initiate(&context, request, &response);
 
@@ -101,7 +101,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dcpower::CloseRequest request;
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     dcpower::CloseResponse response;
 
     ::grpc::Status status = GetStub()->Close(&context, request, &response);
@@ -114,7 +114,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dcpower::MeasureMultipleRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
 
     ::grpc::Status status = GetStub()->MeasureMultiple(&context, request, response);
@@ -126,7 +126,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dcpower::GetAttributeViBooleanRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_list);
     request.set_attribute_id(attribute_id);
     dcpower::GetAttributeViBooleanResponse response;
@@ -142,7 +142,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dcpower::GetAttributeViInt32Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_list);
     request.set_attribute_id(attribute_id);
     dcpower::GetAttributeViInt32Response response;
@@ -158,7 +158,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dcpower::GetAttributeViInt64Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_list);
     request.set_attribute_id(attribute_id);
     dcpower::GetAttributeViInt64Response response;
@@ -174,7 +174,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dcpower::GetAttributeViReal64Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_list);
     request.set_attribute_id(attribute_id);
     dcpower::GetAttributeViReal64Response response;
@@ -190,7 +190,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dcpower::GetAttributeViStringRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_list);
     request.set_attribute_id(attribute_id);
     dcpower::GetAttributeViStringResponse response;
@@ -207,7 +207,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
     ::grpc::ClientContext context;
     const dcpower::NiDCPowerAttribute attribute_to_set = attribute_id;
     dcpower::SetAttributeViInt32Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_list);
     request.set_attribute_id(attribute_to_set);
     request.set_attribute_value(attribute_value);
@@ -223,7 +223,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dcpower::ConfigureOutputFunctionRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_function(function);
     dcpower::ConfigureOutputFunctionResponse response;
@@ -238,7 +238,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dcpower::ConfigureVoltageLevelRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_level(level);
     dcpower::ConfigureVoltageLevelResponse response;
@@ -253,7 +253,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dcpower::ConfigureCurrentLevelRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_level(level);
     dcpower::ConfigureCurrentLevelResponse response;
@@ -268,7 +268,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dcpower::ExportAttributeConfigurationBufferRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     dcpower::ExportAttributeConfigurationBufferResponse response;
 
     ::grpc::Status status = GetStub()->ExportAttributeConfigurationBuffer(&context, request, &response);
@@ -282,7 +282,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dcpower::ResetWithChannelsRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     dcpower::ResetWithChannelsResponse response;
 
@@ -296,7 +296,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dcpower::FetchMultipleRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_timeout(5);
     request.set_count(20);
@@ -310,7 +310,7 @@ class NiDCPowerDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dcpower::ImportAttributeConfigurationBufferRequest import_request;
-    import_request.mutable_vi()->set_id(GetSessionId());
+    import_request.mutable_vi()->set_name(GetSessionName());
     auto exported_configuration = export_buffer_response.configuration();
     import_request.mutable_configuration()->append(exported_configuration.begin(), exported_configuration.end());
     dcpower::ImportAttributeConfigurationBufferResponse import_response;
@@ -338,7 +338,7 @@ TEST_F(NiDCPowerDriverApiTest, PerformSelfTest_CompletesSuccessfuly)
 {
   ::grpc::ClientContext context;
   dcpower::SelfTestRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   dcpower::SelfTestResponse response;
   ::grpc::Status status = GetStub()->SelfTest(&context, request, &response);
 
@@ -352,7 +352,7 @@ TEST_F(NiDCPowerDriverApiTest, PerformReset_CompletesSuccessfuly)
 {
   ::grpc::ClientContext context;
   dcpower::ResetRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   dcpower::ResetResponse response;
   ::grpc::Status status = GetStub()->Reset(&context, request, &response);
 
@@ -367,7 +367,7 @@ TEST_F(NiDCPowerDriverApiTest, SetAttributeViInt32_GetAttributeViInt32ReturnsSam
   const auto expected_value = dcpower::NiDCPowerInt32AttributeValues::NIDCPOWER_INT32_MEASURE_WHEN_VAL_AUTOMATICALLY_AFTER_SOURCE_COMPLETE;
   ::grpc::ClientContext context;
   dcpower::SetAttributeViInt32Request request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_name(channel_name);
   request.set_attribute_id(attribute_to_set);
   request.set_attribute_value(expected_value);
@@ -394,7 +394,7 @@ TEST_F(NiDCPowerDriverApiTest, SetAttributeViReal64_GetAttributeViReal64ReturnsS
   const double expected_value = 2.516;
   ::grpc::ClientContext context;
   dcpower::SetAttributeViReal64Request request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_name(channel_name);
   request.set_attribute_id(attribute_to_set);
   request.set_attribute_value_raw(expected_value);
@@ -421,7 +421,7 @@ TEST_F(NiDCPowerDriverApiTest, SetAttributeViBoolean_GetAttributeViBooleanReturn
   const bool expected_value = true;
   ::grpc::ClientContext context;
   dcpower::SetAttributeViBooleanRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_name(channel_name);
   request.set_attribute_id(attribute_to_set);
   request.set_attribute_value(expected_value);
@@ -442,7 +442,7 @@ TEST_F(NiDCPowerDriverApiTest, SetAttributeViString_GetAttributeViStringReturnsS
   const char* expected_value = "/Dev1/PXI_Trig0";
   ::grpc::ClientContext context;
   dcpower::SetAttributeViStringRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_name(channel_name);
   request.set_attribute_id(attribute_to_set);
   request.set_attribute_value_raw(expected_value);
@@ -462,7 +462,7 @@ TEST_F(NiDCPowerDriverApiTest, SetAttributeViInt64_GetAttributeViInt64ReturnsSam
   const int64 expected_value = 1;
   ::grpc::ClientContext context;
   dcpower::SetAttributeViInt64Request request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_name(channel_name);
   request.set_attribute_id(attribute_to_set);
   request.set_attribute_value_raw(expected_value);
@@ -560,7 +560,7 @@ TEST_F(NiDCPowerDriverApiTest, CalSelfCalibrate_CompletesSuccessfully)
   const char* channel_name = "";
   ::grpc::ClientContext context;
   dcpower::CalSelfCalibrateRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_name(channel_name);
   dcpower::CalSelfCalibrateResponse response;
   ::grpc::Status status = GetStub()->CalSelfCalibrate(&context, request, &response);

--- a/source/tests/system/nidcpower_session_tests.cpp
+++ b/source/tests/system/nidcpower_session_tests.cpp
@@ -72,7 +72,7 @@ class NiDCPowerSessionTest : public ::testing::Test {
 
     ::grpc::ClientContext context;
     dcpower::ErrorMessageRequest request;
-    request.mutable_vi()->set_id(session.id());
+    request.mutable_vi()->set_name(session.name());
     request.set_error_code(error_status);
     dcpower::ErrorMessageResponse error_response;
 
@@ -100,7 +100,7 @@ TEST_F(NiDCPowerSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDr
   GTEST_SKIP_IF_UNSUPPORTED(status);
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.vi().id());
+  EXPECT_NE("", response.vi().name());
   EXPECT_EQ("", response.error_message());
 }
 
@@ -112,7 +112,7 @@ TEST_F(NiDCPowerSessionTest, InitializeSessionWithDeviceAndNoSessionName_Creates
   GTEST_SKIP_IF_UNSUPPORTED(status);
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.vi().id());
+  EXPECT_NE("", response.vi().name());
   EXPECT_EQ("", response.error_message());
 }
 
@@ -139,7 +139,7 @@ TEST_F(NiDCPowerSessionTest, InitializedSession_CloseSession_ClosesDriverSession
 
   ::grpc::ClientContext context;
   dcpower::CloseRequest close_request;
-  close_request.mutable_vi()->set_id(session.id());
+  close_request.mutable_vi()->set_name(session.name());
   dcpower::CloseResponse close_response;
   status = GetStub()->Close(&context, close_request, &close_response);
 
@@ -150,12 +150,12 @@ TEST_F(NiDCPowerSessionTest, InitializedSession_CloseSession_ClosesDriverSession
 TEST_F(NiDCPowerSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
 {
   nidevice_grpc::Session session;
-  session.set_id(0UL);
+  session.set_name("");
 
   try {
     ::grpc::ClientContext context;
     dcpower::CloseRequest request;
-    request.mutable_vi()->set_id(session.id());
+    request.mutable_vi()->set_name(session.name());
     dcpower::CloseResponse response;
     auto status = GetStub()->Close(&context, request, &response);
     nidevice_grpc::experimental::client::raise_if_error(status, context);

--- a/source/tests/system/nidcpower_session_tests.cpp
+++ b/source/tests/system/nidcpower_session_tests.cpp
@@ -13,7 +13,7 @@ using namespace ::testing;
 
 const int kInvalidRsrc = -1074118656;
 const int kInvalidDCPowerSession = -1074130544;
-const char* kViErrorResourceNotFoundMessage = "Device was not recognized.  The device is not supported with this driver or version.\n\nInvalid Identifier: ";
+const char* kViErrorResourceNotFoundMessage = "Device was not recognized. The device is not supported with this driver or version.\n\nInvalid Identifier: ";
 const char* kInvalidDCPowerSessionMessage = "The session handle is not valid.";
 const char* kTestRsrc = "FakeDevice";
 const char* kOptionsString = "Simulate=1, DriverSetup=Model:4147; BoardType:PXIe";

--- a/source/tests/system/nidcpower_session_tests.cpp
+++ b/source/tests/system/nidcpower_session_tests.cpp
@@ -13,7 +13,7 @@ using namespace ::testing;
 
 const int kInvalidRsrc = -1074118656;
 const int kInvalidDCPowerSession = -1074130544;
-const char* kViErrorResourceNotFoundMessage = "Device was not recognized. The device is not supported with this driver or version.\n\nInvalid Identifier: ";
+const char* kViErrorResourceNotFoundMessage = "Device was not recognized.  The device is not supported with this driver or version.\n\nInvalid Identifier: ";
 const char* kInvalidDCPowerSessionMessage = "The session handle is not valid.";
 const char* kTestRsrc = "FakeDevice";
 const char* kOptionsString = "Simulate=1, DriverSetup=Model:4147; BoardType:PXIe";

--- a/source/tests/system/nidigital_driver_api_tests.cpp
+++ b/source/tests/system/nidigital_driver_api_tests.cpp
@@ -64,14 +64,14 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     return nidigital_stub_;
   }
 
-  int GetSessionId()
+  std::string GetSessionName()
   {
-    return driver_session_->id();
+    return driver_session_->name();
   }
 
-  int GetMultiInstrumentSessionId()
+  std::string GetMultiInstrumentSessionName()
   {
-    return multi_instrument_driver_session_->id();
+    return multi_instrument_driver_session_->name();
   }
 
   void initialize_driver_session()
@@ -117,7 +117,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     }
     ::grpc::ClientContext context;
     digital::CloseRequest request;
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     digital::CloseResponse response;
 
     ::grpc::Status status = GetStub()->Close(&context, request, &response);
@@ -133,7 +133,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     }
     ::grpc::ClientContext context;
     digital::CloseRequest request;
-    request.mutable_vi()->set_id(multi_instrument_driver_session_->id());
+    request.mutable_vi()->set_name(multi_instrument_driver_session_->name());
     digital::CloseResponse response;
 
     ::grpc::Status status = GetStub()->Close(&context, request, &response);
@@ -151,7 +151,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     digital::ErrorMessageRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_error_code(error_status);
     digital::ErrorMessageResponse response;
 
@@ -161,11 +161,11 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     return response.error_message();
   }
 
-  void load_pin_map(int session_id, const fs::path& file_path)
+  void load_pin_map(const std::string& session_name, const fs::path& file_path)
   {
     ::grpc::ClientContext context;
     digital::LoadPinMapRequest request;
-    request.mutable_vi()->set_id(session_id);
+    request.mutable_vi()->set_name(session_name);
     request.set_file_path(file_path.string());
     digital::LoadPinMapResponse response;
 
@@ -175,11 +175,11 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     EXPECT_EQ(kDigitalDriverApiSuccess, response.status());
   }
 
-  void load_specifications(int session_id, const fs::path& file_path)
+  void load_specifications(const std::string& session_name, const fs::path& file_path)
   {
     ::grpc::ClientContext context;
     digital::LoadSpecificationsRequest request;
-    request.mutable_vi()->set_id(session_id);
+    request.mutable_vi()->set_name(session_name);
     request.set_file_path(file_path.string());
     digital::LoadSpecificationsResponse response;
 
@@ -189,11 +189,11 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     EXPECT_EQ(kDigitalDriverApiSuccess, response.status());
   }
 
-  void load_levels(int session_id, const fs::path& file_path)
+  void load_levels(const std::string & session_name, const fs::path& file_path)
   {
     ::grpc::ClientContext context;
     digital::LoadLevelsRequest request;
-    request.mutable_vi()->set_id(session_id);
+    request.mutable_vi()->set_name(session_name);
     request.set_file_path(file_path.string());
     digital::LoadLevelsResponse response;
 
@@ -203,11 +203,11 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     EXPECT_EQ(kDigitalDriverApiSuccess, response.status());
   }
 
-  void load_timing(int session_id, const fs::path& file_path)
+  void load_timing(const std::string& session_name, const fs::path& file_path)
   {
     ::grpc::ClientContext context;
     digital::LoadTimingRequest request;
-    request.mutable_vi()->set_id(session_id);
+    request.mutable_vi()->set_name(session_name);
     request.set_file_path(file_path.string());
     digital::LoadTimingResponse response;
 
@@ -217,11 +217,11 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     EXPECT_EQ(kDigitalDriverApiSuccess, response.status());
   }
 
-  void apply_levels_and_timing(int session_id, const char* levels_sheet, const char* timing_sheet)
+  void apply_levels_and_timing(const std::string & session_name, const char* levels_sheet, const char* timing_sheet)
   {
     ::grpc::ClientContext context;
     digital::ApplyLevelsAndTimingRequest request;
-    request.mutable_vi()->set_id(session_id);
+    request.mutable_vi()->set_name(session_name);
     request.set_levels_sheet(levels_sheet);
     request.set_timing_sheet(timing_sheet);
     digital::ApplyLevelsAndTimingResponse response;
@@ -232,20 +232,20 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     EXPECT_EQ(kDigitalDriverApiSuccess, response.status());
   }
 
-  void configure_session(int session_id)
+  void configure_session(const std::string & session_name)
   {
-    load_pin_map(session_id, fs::absolute("test_create_capture_waveform_serial/pin_map.pinmap"));
-    load_specifications(session_id, fs::absolute("test_create_capture_waveform_serial/specifications.specs"));
-    load_levels(session_id, fs::absolute("test_create_capture_waveform_serial/pin_levels.digilevels"));
-    load_timing(session_id, fs::absolute("test_create_capture_waveform_serial/timing.digitiming"));
-    apply_levels_and_timing(session_id, "pin_levels", "timing");
+    load_pin_map(session_name, fs::absolute("test_create_capture_waveform_serial/pin_map.pinmap"));
+    load_specifications(session_name, fs::absolute("test_create_capture_waveform_serial/specifications.specs"));
+    load_levels(session_name, fs::absolute("test_create_capture_waveform_serial/pin_levels.digilevels"));
+    load_timing(session_name, fs::absolute("test_create_capture_waveform_serial/timing.digitiming"));
+    apply_levels_and_timing(session_name, "pin_levels", "timing");
   }
 
-  void load_pattern(int session_id, const fs::path& file_path)
+  void load_pattern(const std::string & session_name, const fs::path& file_path)
   {
     ::grpc::ClientContext context;
     digital::LoadPatternRequest request;
-    request.mutable_vi()->set_id(session_id);
+    request.mutable_vi()->set_name(session_name);
     request.set_file_path(file_path.string());
     digital::LoadPatternResponse response;
 
@@ -256,7 +256,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
   }
 
   void create_capture_waveform_serial(
-      int session_id,
+      const std::string & session_name,
       const char* pin_list,
       const char* waveform_name,
       int sample_width,
@@ -264,7 +264,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     digital::CreateCaptureWaveformSerialRequest request;
-    request.mutable_vi()->set_id(session_id);
+    request.mutable_vi()->set_name(session_name);
     request.set_pin_list(pin_list);
     request.set_waveform_name(waveform_name);
     request.set_sample_width(sample_width);
@@ -278,7 +278,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
   }
 
   void create_source_waveform_serial(
-      int session_id,
+      const std::string & session_name,
       const char* pin_list,
       const char* waveform_name,
       digital::SourceDataMapping data_mapping,
@@ -287,7 +287,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     digital::CreateSourceWaveformSerialRequest request;
-    request.mutable_vi()->set_id(session_id);
+    request.mutable_vi()->set_name(session_name);
     request.set_pin_list(pin_list);
     request.set_waveform_name(waveform_name);
     request.set_data_mapping(data_mapping);
@@ -301,11 +301,11 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     EXPECT_EQ(kDigitalDriverApiSuccess, response.status());
   }
 
-  void write_source_waveform_broadcast_u32(int session_id, const char* waveform_name, unsigned int* waveform_data, int num_samples)
+  void write_source_waveform_broadcast_u32(const std::string & session_name, const char* waveform_name, unsigned int* waveform_data, int num_samples)
   {
     ::grpc::ClientContext context;
     digital::WriteSourceWaveformBroadcastU32Request request;
-    request.mutable_vi()->set_id(session_id);
+    request.mutable_vi()->set_name(session_name);
     request.set_waveform_name(waveform_name);
     for (int i = 0; i < num_samples; ++i) {
       request.add_waveform_data(waveform_data[i]);
@@ -318,11 +318,11 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     EXPECT_EQ(kDigitalDriverApiSuccess, response.status());
   }
 
-  void burst_pattern(int session_id, const char* start_label)
+  void burst_pattern(const std::string & session_name, const char* start_label)
   {
     ::grpc::ClientContext context;
     digital::BurstPatternRequest request;
-    request.mutable_vi()->set_id(session_id);
+    request.mutable_vi()->set_name(session_name);
     request.set_start_label(start_label);
     digital::BurstPatternResponse response;
 
@@ -333,7 +333,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
   }
 
   void fetch_capture_waveform(
-      int session_id,
+      const std::string & session_name,
       const char* site_list,
       const char* waveform_name,
       int samples_to_read,
@@ -341,7 +341,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     digital::FetchCaptureWaveformU32Request request;
-    request.mutable_vi()->set_id(session_id);
+    request.mutable_vi()->set_name(session_name);
     request.set_site_list(site_list);
     request.set_waveform_name(waveform_name);
     request.set_samples_to_read(samples_to_read);
@@ -356,7 +356,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     digital::SetAttributeViBooleanRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute(attribute);
     request.set_value(value);
@@ -372,7 +372,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     digital::SetAttributeViInt32Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute(attribute);
     request.set_value(value);
@@ -388,7 +388,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     digital::SetAttributeViInt64Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute(attribute);
     request.set_value_raw(value);
@@ -404,7 +404,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     digital::SetAttributeViStringRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute(attribute);
     request.set_value_raw(value);
@@ -420,7 +420,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     digital::GetAttributeViBooleanRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute(attribute);
     digital::GetAttributeViBooleanResponse response;
@@ -436,7 +436,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     digital::GetAttributeViInt32Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute(attribute);
     digital::GetAttributeViInt32Response response;
@@ -452,7 +452,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     digital::GetAttributeViInt64Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute(attribute);
     digital::GetAttributeViInt64Response response;
@@ -468,7 +468,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     digital::GetAttributeViStringRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute(attribute);
     digital::GetAttributeViStringResponse response;
@@ -484,7 +484,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     digital::FrequencyCounterConfigureMeasurementTimeRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_list(channel_list);
     request.set_measurement_time(value);
     digital::FrequencyCounterConfigureMeasurementTimeResponse response;
@@ -499,7 +499,7 @@ class NiDigitalDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     digital::SelectFunctionRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_list(channel_list);
     request.set_function(function_type);
     digital::SelectFunctionResponse response;
@@ -523,7 +523,7 @@ TEST_F(NiDigitalDriverApiTest, PerformReadStatic_CompletesSuccessfully)
   ::grpc::ClientContext context;
   select_function(channel_name, digital::SelectedFunction::SELECTED_FUNCTION_NIDIGITAL_VAL_DIGITAL);
   digital::ReadStaticRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_list(channel_name);
   digital::ReadStaticResponse response;
   ::grpc::Status status = GetStub()->ReadStatic(&context, request, &response);
@@ -538,7 +538,7 @@ TEST_F(NiDigitalDriverApiTest, PerformWriteStatic_CompletesSuccessfully)
   ::grpc::ClientContext context;
   select_function(channel_name, digital::SelectedFunction::SELECTED_FUNCTION_NIDIGITAL_VAL_DIGITAL);
   digital::WriteStaticRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_list(channel_name);
   request.set_state(digital::WriteStaticPinState::WRITE_STATIC_PIN_STATE_NIDIGITAL_VAL_0);
   digital::WriteStaticResponse response;
@@ -556,7 +556,7 @@ TEST_F(NiDigitalDriverApiTest, PerformFrequencyCounterMeasureFrequency_Completes
   select_function(channel_name, digital::SelectedFunction::SELECTED_FUNCTION_NIDIGITAL_VAL_DIGITAL);
   configure_frequency_counter_measurement_time(channel_name, measurement_time);
   digital::FrequencyCounterMeasureFrequencyRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_list(channel_name);
   digital::FrequencyCounterMeasureFrequencyResponse response;
   ::grpc::Status status = GetStub()->FrequencyCounterMeasureFrequency(&context, request, &response);
@@ -567,21 +567,21 @@ TEST_F(NiDigitalDriverApiTest, PerformFrequencyCounterMeasureFrequency_Completes
 
 TEST_F(NiDigitalDriverApiTest, CreateCaptureWaveformSerial_FetchCaptureWaveform_ReturnsReasonableData)
 {
-  int session_id = GetMultiInstrumentSessionId();
-  configure_session(session_id);
-  load_pattern(session_id, fs::absolute("test_create_capture_waveform_serial/pattern.digipat"));
+  const std::string& session_name = GetMultiInstrumentSessionName();
+  configure_session(session_name);
+  load_pattern(session_name, fs::absolute("test_create_capture_waveform_serial/pattern.digipat"));
   auto bit_order = digital::BitOrder::BIT_ORDER_NIDIGITAL_VAL_LSB_FIRST;
-  create_capture_waveform_serial(session_id, "HI0", "capt_wfm", 2, bit_order);
+  create_capture_waveform_serial(session_name, "HI0", "capt_wfm", 2, bit_order);
   // The pattern references a wfm "src_wfm", so we have to load it before we can burst
   auto source_data_mapping = digital::SourceDataMapping::SOURCE_DATA_MAPPING_NIDIGITAL_VAL_BROADCAST;
-  create_source_waveform_serial(session_id, "LO0", "src_wfm", source_data_mapping, 2, bit_order);
+  create_source_waveform_serial(session_name, "LO0", "src_wfm", source_data_mapping, 2, bit_order);
   unsigned int waveform_data[] = {1, 2};
-  write_source_waveform_broadcast_u32(session_id, "src_wfm", waveform_data, sizeof(waveform_data) / sizeof(unsigned int));
-  burst_pattern(session_id, "new_pattern");
+  write_source_waveform_broadcast_u32(session_name, "src_wfm", waveform_data, sizeof(waveform_data) / sizeof(unsigned int));
+  burst_pattern(session_name, "new_pattern");
 
   int num_samples = 2;
   digital::FetchCaptureWaveformU32Response response;
-  fetch_capture_waveform(session_id, "site0,site1", "capt_wfm", num_samples, &response);
+  fetch_capture_waveform(session_name, "site0,site1", "capt_wfm", num_samples, &response);
 
   int num_sites = 2;
   expect_api_success(response.status());
@@ -592,7 +592,7 @@ TEST_F(NiDigitalDriverApiTest, SelfTest_SelfTestCompletesSuccessfully)
 {
   ::grpc::ClientContext context;
   digital::SelfTestRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   digital::SelfTestResponse response;
   ::grpc::Status status = GetStub()->SelfTest(&context, request, &response);
 
@@ -606,7 +606,7 @@ TEST_F(NiDigitalDriverApiTest, Reset_ResetCompletesSuccessfully)
 {
   ::grpc::ClientContext context;
   digital::ResetRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   digital::ResetResponse response;
   ::grpc::Status status = GetStub()->Reset(&context, request, &response);
 
@@ -666,7 +666,7 @@ TEST_F(NiDigitalDriverApiTest, SelfCalibrate_CompletesSuccessfully)
 {
   ::grpc::ClientContext context;
   digital::SelfCalibrateRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   digital::SelfCalibrateResponse response;
   ::grpc::Status status = GetStub()->SelfCalibrate(&context, request, &response);
 
@@ -679,7 +679,7 @@ TEST_F(NiDigitalDriverApiTest, ClockGeneratorInitiate_ClockGenerationInitiated)
   std::string channel_list = "0";
   ::grpc::ClientContext context;
   digital::ClockGeneratorInitiateRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_list(channel_list);
   digital::ClockGeneratorInitiateResponse response;
   ::grpc::Status status = GetStub()->ClockGeneratorInitiate(&context, request, &response);
@@ -693,7 +693,7 @@ TEST_F(NiDigitalDriverApiTest, ConfigureSoftwareEdgeStartTrigger_StartTriggerTyp
 {
   ::grpc::ClientContext context;
   digital::ConfigureSoftwareEdgeStartTriggerRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   digital::ConfigureSoftwareEdgeStartTriggerResponse response;
   ::grpc::Status status = GetStub()->ConfigureSoftwareEdgeStartTrigger(&context, request, &response);
 
@@ -708,7 +708,7 @@ TEST_F(NiDigitalDriverApiTest, ConfigureStartLabel_StartLabelConfigured)
   const char* start_label = "abcde";
   ::grpc::ClientContext context;
   digital::ConfigureStartLabelRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_label(start_label);
   digital::ConfigureStartLabelResponse response;
   ::grpc::Status status = GetStub()->ConfigureStartLabel(&context, request, &response);

--- a/source/tests/system/nidigital_session_tests.cpp
+++ b/source/tests/system/nidigital_session_tests.cpp
@@ -65,7 +65,7 @@ TEST_F(NiDigitalSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDr
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.vi().id());
+  EXPECT_NE("", response.vi().name());
   EXPECT_EQ("", response.error_message());
 }
 
@@ -76,7 +76,7 @@ TEST_F(NiDigitalSessionTest, InitializeSessionWithDeviceAndNoSessionName_Creates
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.vi().id());
+  EXPECT_NE("", response.vi().name());
   EXPECT_EQ("", response.error_message());
 }
 
@@ -88,7 +88,7 @@ TEST_F(NiDigitalSessionTest, InitializedSession_CloseSession_ClosesDriverSession
   nidevice_grpc::Session session = init_response.vi();
   ::grpc::ClientContext context;
   digital::CloseRequest close_request;
-  close_request.mutable_vi()->set_id(session.id());
+  close_request.mutable_vi()->set_name(session.name());
   digital::CloseResponse close_response;
   ::grpc::Status status = GetStub()->Close(&context, close_request, &close_response);
 

--- a/source/tests/system/nidmm_driver_api_tests.cpp
+++ b/source/tests/system/nidmm_driver_api_tests.cpp
@@ -38,9 +38,9 @@ class NiDmmDriverApiTest : public ::testing::Test {
     return nidmm_stub_;
   }
 
-  int GetSessionId()
+  std::string GetSessionName()
   {
-    return driver_session_->id();
+    return driver_session_->name();
   }
 
   void expect_api_success(int error_status)
@@ -70,7 +70,7 @@ class NiDmmDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dmm::CloseRequest request;
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     dmm::CloseResponse response;
 
     ::grpc::Status status = GetStub()->Close(&context, request, &response);
@@ -83,7 +83,7 @@ class NiDmmDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dmm::GetErrorMessageRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_error_code(error_status);
     dmm::GetErrorMessageResponse response;
     ::grpc::Status status = GetStub()->GetErrorMessage(&context, request, &response);
@@ -98,7 +98,7 @@ class NiDmmDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dmm::GetAttributeViBooleanRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute_id(attribute_id);
     dmm::GetAttributeViBooleanResponse response;
@@ -114,7 +114,7 @@ class NiDmmDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dmm::GetAttributeViInt32Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute_id(attribute_id);
     dmm::GetAttributeViInt32Response response;
@@ -130,7 +130,7 @@ class NiDmmDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dmm::GetAttributeViReal64Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute_id(attribute_id);
     dmm::GetAttributeViReal64Response response;
@@ -146,7 +146,7 @@ class NiDmmDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dmm::ConfigureCurrentSourceRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_current_source(value);
     dmm::ConfigureCurrentSourceResponse response;
     ::grpc::Status status = GetStub()->ConfigureCurrentSource(&context, request, &response);
@@ -159,7 +159,7 @@ class NiDmmDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dmm::ExportAttributeConfigurationBufferRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     dmm::ExportAttributeConfigurationBufferResponse response;
     ::grpc::Status status = GetStub()->ExportAttributeConfigurationBuffer(&context, request, &response);
 
@@ -173,7 +173,7 @@ class NiDmmDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dmm::ResetRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     dmm::ResetResponse response;
     ::grpc::Status status = GetStub()->Reset(&context, request, &response);
 
@@ -185,7 +185,7 @@ class NiDmmDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     dmm::ImportAttributeConfigurationBufferRequest import_request;
-    import_request.mutable_vi()->set_id(GetSessionId());
+    import_request.mutable_vi()->set_name(GetSessionName());
     auto exported_configuration = exported_configuration_response.configuration();
     import_request.mutable_configuration()->append(exported_configuration.begin(), exported_configuration.end());
     dmm::ImportAttributeConfigurationBufferResponse import_response;
@@ -205,7 +205,7 @@ TEST_F(NiDmmDriverApiTest, SelfTest_CompletesSuccessfully)
 {
   ::grpc::ClientContext context;
   dmm::SelfTestRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   dmm::SelfTestResponse response;
   ::grpc::Status status = GetStub()->SelfTest(&context, request, &response);
 
@@ -219,7 +219,7 @@ TEST_F(NiDmmDriverApiTest, Reset_CompletesSuccessfully)
 {
   ::grpc::ClientContext context;
   dmm::ResetRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   dmm::ResetResponse response;
   ::grpc::Status status = GetStub()->Reset(&context, request, &response);
 
@@ -234,7 +234,7 @@ TEST_F(NiDmmDriverApiTest, SetViReal64Attribute_GetViReal64Attribute_ValueMatche
   const ViReal64 expected_value = 42.24;
   ::grpc::ClientContext context;
   dmm::SetAttributeViReal64Request request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_name(channel_name);
   request.set_attribute_id(attribute_to_set);
   request.set_attribute_value_raw(expected_value);
@@ -254,7 +254,7 @@ TEST_F(NiDmmDriverApiTest, SetViInt32Attribute_GetViInt32Attribute_ValueMatchesS
   const ViInt32 expected_value = 4;
   ::grpc::ClientContext context;
   dmm::SetAttributeViInt32Request request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_name(channel_name);
   request.set_attribute_id(attribute_to_set);
   request.set_attribute_value_raw(expected_value);
@@ -274,7 +274,7 @@ TEST_F(NiDmmDriverApiTest, SetViBooleanAttribute_GetViBooleanAttribute_ValueMatc
   const ViBoolean expected_value = true;
   ::grpc::ClientContext context;
   dmm::SetAttributeViBooleanRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_name(channel_name);
   request.set_attribute_id(attribute_to_set);
   request.set_attribute_value(expected_value);
@@ -291,7 +291,7 @@ TEST_F(NiDmmDriverApiTest, ConfigureMeasurementAbsolute_CompletesSuccessfully)
 {
   ::grpc::ClientContext context;
   dmm::ConfigureMeasurementAbsoluteRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_measurement_function(dmm::Function::FUNCTION_NIDMM_VAL_DC_VOLTS);
   request.set_range(10);
   request.set_resolution_absolute(5.5);
@@ -306,7 +306,7 @@ TEST_F(NiDmmDriverApiTest, ConfigureCurrentSourse_CompletesSuccessfully)
 {
   ::grpc::ClientContext context;
   dmm::ConfigureCurrentSourceRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_current_source(0.0001);
   dmm::ConfigureCurrentSourceResponse response;
   ::grpc::Status status = GetStub()->ConfigureCurrentSource(&context, request, &response);
@@ -332,7 +332,7 @@ TEST_F(NiDmmDriverApiTest, ConfiguredTrigger_ConfiguresSuccessfully)
 {
   ::grpc::ClientContext context;
   dmm::ConfigureTriggerRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_trigger_source(dmm::TriggerSource::TRIGGER_SOURCE_NIDMM_VAL_SOFTWARE_TRIG);
   request.set_trigger_delay(dmm::TriggerDelays::TRIGGER_DELAYS_NIDMM_VAL_AUTO_DELAY_ON);
   dmm::ConfigureTriggerResponse response;
@@ -346,7 +346,7 @@ TEST_F(NiDmmDriverApiTest, AcquireMeasurement_CompletesSuccesfully)
 {
   ::grpc::ClientContext context;
   dmm::ReadRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_maximum_time_raw(1000);
   dmm::ReadResponse response;
   ::grpc::Status status = GetStub()->Read(&context, request, &response);
@@ -360,7 +360,7 @@ TEST_F(NiDmmDriverApiTest, SelfCalibrate_CompletesSuccessfully)
 {
   ::grpc::ClientContext context;
   dmm::SelfCalRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   dmm::SelfCalResponse response;
   ::grpc::Status status = GetStub()->SelfCal(&context, request, &response);
 

--- a/source/tests/system/nidmm_session_tests.cpp
+++ b/source/tests/system/nidmm_session_tests.cpp
@@ -65,7 +65,7 @@ class NiDmmSessionTest : public ::testing::Test {
 
     ::grpc::ClientContext context;
     dmm::GetErrorMessageRequest error_request;
-    error_request.mutable_vi()->set_id(session.id());
+    error_request.mutable_vi()->set_name(session.name());
     error_request.set_error_code(error_status);
     dmm::GetErrorMessageResponse error_response;
 
@@ -87,7 +87,7 @@ TEST_F(NiDmmSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDriver
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.vi().id());
+  EXPECT_NE("", response.vi().name());
   EXPECT_EQ("", response.error_message());
 }
 
@@ -98,7 +98,7 @@ TEST_F(NiDmmSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesDriv
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.vi().id());
+  EXPECT_NE("", response.vi().name());
   EXPECT_EQ("", response.error_message());
 }
 
@@ -110,7 +110,7 @@ TEST_F(NiDmmSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
 
   ::grpc::ClientContext context;
   dmm::CloseRequest close_request;
-  close_request.mutable_vi()->set_id(session.id());
+  close_request.mutable_vi()->set_name(session.name());
   dmm::CloseResponse close_response;
   ::grpc::Status status = GetStub()->Close(&context, close_request, &close_response);
 
@@ -121,12 +121,12 @@ TEST_F(NiDmmSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
 TEST_F(NiDmmSessionTest, InvalidSession_CloseSession_ReturnsInvalidSesssionError)
 {
   nidevice_grpc::Session session;
-  session.set_id(NULL);
+  session.set_name("");
 
   try {
     ::grpc::ClientContext context;
     dmm::CloseRequest request;
-    request.mutable_vi()->set_id(session.id());
+    request.mutable_vi()->set_name(session.name());
     dmm::CloseResponse response;
     ::grpc::Status status = GetStub()->Close(&context, request, &response);
     nidevice_grpc::experimental::client::raise_if_error(status, context);

--- a/source/tests/system/nifgen_driver_api_tests.cpp
+++ b/source/tests/system/nifgen_driver_api_tests.cpp
@@ -48,9 +48,9 @@ class NiFgenDriverApiTest : public ::testing::Test {
     return nifgen_stub_;
   }
 
-  int GetSessionId()
+  std::string GetSessionName()
   {
-    return driver_session_->id();
+    return driver_session_->name();
   }
 
   void expect_api_success(int error_status)
@@ -80,7 +80,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
     fgen::InitiateGenerationRequest request;
     fgen::InitiateGenerationResponse response;
     ::grpc::ClientContext context;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
 
     ::grpc::Status status = GetStub()->InitiateGeneration(&context, request, &response);
 
@@ -96,7 +96,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
 
     ::grpc::ClientContext context;
     fgen::CloseRequest request;
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     fgen::CloseResponse response;
 
     ::grpc::Status status = GetStub()->Close(&context, request, &response);
@@ -109,7 +109,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::ErrorHandlerRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_error_code(error_status);
     fgen::ErrorHandlerResponse response;
     ::grpc::Status status = GetStub()->ErrorHandler(&context, request, &response);
@@ -124,7 +124,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::GetAttributeViBooleanRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_list);
     request.set_attribute_id(attribute_id);
     fgen::GetAttributeViBooleanResponse response;
@@ -140,7 +140,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::GetAttributeViInt32Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_list);
     request.set_attribute_id(attribute_id);
     fgen::GetAttributeViInt32Response response;
@@ -156,7 +156,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::GetAttributeViInt64Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_list);
     request.set_attribute_id(attribute_id);
     fgen::GetAttributeViInt64Response response;
@@ -172,7 +172,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::GetAttributeViReal64Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_list);
     request.set_attribute_id(attribute_id);
     fgen::GetAttributeViReal64Response response;
@@ -188,7 +188,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::GetAttributeViStringRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_list);
     request.set_attribute_id(attribute_id);
     fgen::GetAttributeViStringResponse response;
@@ -204,7 +204,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::SetAttributeViInt32Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_list);
     request.set_attribute_id(attribute_id);
     request.set_attribute_value(attribute_value);
@@ -220,7 +220,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::SetAttributeViBooleanRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute_id(attribute);
     request.set_attribute_value(value);
@@ -236,7 +236,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::ConfigureTriggerModeRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_trigger_mode(trigger_mode);
     fgen::ConfigureTriggerModeResponse response;
@@ -251,7 +251,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::ExportAttributeConfigurationBufferRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     fgen::ExportAttributeConfigurationBufferResponse response;
 
     ::grpc::Status status = GetStub()->ExportAttributeConfigurationBuffer(&context, request, &response);
@@ -265,7 +265,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::ImportAttributeConfigurationBufferRequest import_request;
-    import_request.mutable_vi()->set_id(GetSessionId());
+    import_request.mutable_vi()->set_name(GetSessionName());
     auto exported_configuration = export_buffer_response.configuration();
     import_request.mutable_configuration()->append(exported_configuration.begin(), exported_configuration.end());
     fgen::ImportAttributeConfigurationBufferResponse import_response;
@@ -280,7 +280,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::ResetRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     fgen::ResetResponse response;
 
     ::grpc::Status status = GetStub()->Reset(&context, request, &response);
@@ -293,7 +293,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::ConfigureOutputModeRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_output_mode(output_mode);
     fgen::ConfigureOutputModeResponse response;
 
@@ -308,7 +308,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
     ::grpc::ClientContext context;
     fgen::CreateWaveformF64Request request;
     const double waveform_data_array[] = {1, 0, 0, 1};
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     for (double waveform_data : waveform_data_array) {
       request.add_waveform_data_array(waveform_data);
@@ -326,7 +326,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::CreateAdvancedArbSequenceRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.mutable_waveform_handles_array()->Add(waveform_handles_array, waveform_handles_array + sequence_length);
     request.mutable_loop_counts_array()->Add(loop_counts_array, loop_counts_array + sequence_length);
     request.mutable_marker_location_array()->Add(marker_location_array, marker_location_array + sequence_length);
@@ -342,7 +342,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::AllocateNamedWaveformRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_waveform_name(waveform_name);
     request.set_waveform_size(waveform_size);
@@ -358,7 +358,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::WriteNamedWaveformF64Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_waveform_name(waveform_name);
     request.mutable_data()->CopyFrom(google::protobuf::RepeatedField<double>(waveform, waveform + waveform_size));
@@ -374,7 +374,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::AllocateWaveformRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_waveform_size(waveform_size);
     fgen::AllocateWaveformResponse response;
@@ -390,7 +390,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     fgen::WriteWaveformComplexF64Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_waveform_handle(waveform_handle);
     for (int i = 0; i < waveform_size; i++) {
@@ -423,7 +423,7 @@ TEST_F(NiFgenDriverApiTest, PerformSelfTest_CompletesSuccessfuly)
 {
   ::grpc::ClientContext context;
   fgen::SelfTestRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   fgen::SelfTestResponse response;
   ::grpc::Status status = GetStub()->SelfTest(&context, request, &response);
 
@@ -437,7 +437,7 @@ TEST_F(NiFgenDriverApiTest, PerformReset_CompletesSuccessfuly)
 {
   ::grpc::ClientContext context;
   fgen::ResetRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   fgen::ResetResponse response;
   ::grpc::Status status = GetStub()->Reset(&context, request, &response);
 
@@ -452,7 +452,7 @@ TEST_F(NiFgenDriverApiTest, SetAttributeViInt32_GetAttributeViInt32_ValueMatches
   const auto expected_value = fgen::NiFgenInt32AttributeValues::NIFGEN_INT32_OUTPUT_MODE_VAL_OUTPUT_ARB;
   ::grpc::ClientContext context;
   fgen::SetAttributeViInt32Request request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_name(channel_name);
   request.set_attribute_id(attribute_to_set);
   request.set_attribute_value(expected_value);
@@ -473,7 +473,7 @@ TEST_F(NiFgenDriverApiTest, SetAttributeViReal64_GetAttributeViReal64_ValueMatch
   const double expected_value = -1.0;
   ::grpc::ClientContext context;
   fgen::SetAttributeViReal64Request request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_name(channel_name);
   request.set_attribute_id(attribute_to_set);
   request.set_attribute_value_raw(expected_value);
@@ -506,7 +506,7 @@ TEST_F(NiFgenDriverApiTest, SetAttributeViString_GetAttributeViString_ValueMatch
   const std::string expected_value = "sample";
   ::grpc::ClientContext context;
   fgen::SetAttributeViStringRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_name(channel_name);
   request.set_attribute_id(attribute_to_set);
   request.set_attribute_value_raw(expected_value);
@@ -536,7 +536,7 @@ TEST_F(NiFgenDriverApiTest, ResetInterchangeCheck_ResetsSuccessfully)
   double expected_current_level = 3.0;
   ::grpc::ClientContext context;
   fgen::ResetInterchangeCheckRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   fgen::ResetInterchangeCheckResponse response;
   ::grpc::Status status = GetStub()->ResetInterchangeCheck(&context, request, &response);
 
@@ -548,7 +548,7 @@ TEST_F(NiFgenDriverApiTest, SendSoftwareEdgeTrigger_TriggersSuccessfully)
 {
   ::grpc::ClientContext context;
   fgen::SendSoftwareEdgeTriggerRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_trigger(fgen::Trigger::TRIGGER_NIFGEN_VAL_SCRIPT_TRIGGER);
   request.set_trigger_id("ScriptTrigger0");
   fgen::SendSoftwareEdgeTriggerResponse response;
@@ -623,7 +623,7 @@ TEST_F(NiFgenDriverApiTest, OutputModeConfiguredToArb_CreateWaveformI16_CreatesS
 
   ::grpc::ClientContext context;
   fgen::CreateWaveformI16Request request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_name(channel_name);
   for (auto waveform_data : waveform_data_array) {
     request.add_waveform_data_array(waveform_data);

--- a/source/tests/system/nifgen_session_tests.cpp
+++ b/source/tests/system/nifgen_session_tests.cpp
@@ -67,7 +67,7 @@ class NiFgenSessionTest : public ::testing::Test {
 
     ::grpc::ClientContext context;
     fgen::ErrorMessageRequest request;
-    request.mutable_vi()->set_id(session.id());
+    request.mutable_vi()->set_name(session.name());
     request.set_error_code(error_status);
     fgen::ErrorMessageResponse error_response;
 
@@ -88,7 +88,7 @@ TEST_F(NiFgenSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDrive
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.vi().id());
+  EXPECT_NE("", response.vi().name());
   EXPECT_EQ("", response.error_message());
 }
 
@@ -99,7 +99,7 @@ TEST_F(NiFgenSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesDri
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.vi().id());
+  EXPECT_NE("", response.vi().name());
   EXPECT_EQ("", response.error_message());
 }
 
@@ -111,7 +111,7 @@ TEST_F(NiFgenSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
 
   ::grpc::ClientContext context;
   fgen::CloseRequest close_request;
-  close_request.mutable_vi()->set_id(session.id());
+  close_request.mutable_vi()->set_name(session.name());
   fgen::CloseResponse close_response;
   ::grpc::Status status = GetStub()->Close(&context, close_request, &close_response);
 
@@ -122,12 +122,12 @@ TEST_F(NiFgenSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
 TEST_F(NiFgenSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
 {
   nidevice_grpc::Session session;
-  session.set_id(NULL);
+  session.set_name("");
 
   try {
     ::grpc::ClientContext context;
     fgen::CloseRequest request;
-    request.mutable_vi()->set_id(session.id());
+    request.mutable_vi()->set_name(session.name());
     fgen::CloseResponse response;
     auto status = GetStub()->Close(&context, request, &response);
     nidevice_grpc::experimental::client::raise_if_error(status, context);

--- a/source/tests/system/nirfmxbluetooth_session_tests.cpp
+++ b/source/tests/system/nirfmxbluetooth_session_tests.cpp
@@ -50,7 +50,7 @@ class NiRFmxBluetoothSessionTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     rfmxbluetooth::CloseRequest request;
-    request.mutable_instrument()->set_id(session.id());
+    request.mutable_instrument()->set_name(session.name());
     request.set_force_destroy(force_destroy);
 
     ::grpc::Status status = GetStub()->Close(&context, request, response);
@@ -70,7 +70,7 @@ TEST_F(NiRFmxBluetoothSessionTest, InitializeSessionWithDeviceAndSessionName_Cre
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.instrument().id());
+  EXPECT_NE("", response.instrument().name());
 }
 
 TEST_F(NiRFmxBluetoothSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesDriverSession)
@@ -80,7 +80,7 @@ TEST_F(NiRFmxBluetoothSessionTest, InitializeSessionWithDeviceAndNoSessionName_C
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.instrument().id());
+  EXPECT_NE("", response.instrument().name());
 }
 
 TEST_F(NiRFmxBluetoothSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
@@ -103,7 +103,7 @@ TEST_F(NiRFmxBluetoothSessionTest, InitializedSession_CloseSession_ClosesDriverS
   nidevice_grpc::Session session = init_response.instrument();
   ::grpc::ClientContext context;
   rfmxbluetooth::CloseRequest close_request;
-  close_request.mutable_instrument()->set_id(session.id());
+  close_request.mutable_instrument()->set_name(session.name());
   close_request.set_force_destroy(false);
   rfmxbluetooth::CloseResponse close_response;
   ::grpc::Status status = GetStub()->Close(&context, close_request, &close_response);
@@ -121,7 +121,7 @@ TEST_F(NiRFmxBluetoothSessionTest, TwoInitializedSessionsOnSameDevice_CloseSessi
   EXPECT_EQ(0, init_response_one.status());
   EXPECT_TRUE(status_two.ok());
   EXPECT_EQ(0, init_response_two.status());
-  EXPECT_NE(init_response_one.instrument().id(), init_response_two.instrument().id());
+  EXPECT_NE(init_response_one.instrument().name(), init_response_two.instrument().name());
 
   nidevice_grpc::Session session_one = init_response_one.instrument();
   nidevice_grpc::Session session_two = init_response_two.instrument();
@@ -144,7 +144,7 @@ TEST_F(NiRFmxBluetoothSessionTest, CallInitializeTwiceWithSameSessionNameOnSameD
   EXPECT_EQ(0, init_response_one.status());
   EXPECT_TRUE(status_two.ok());
   EXPECT_EQ(0, init_response_two.status());
-  EXPECT_EQ(init_response_one.instrument().id(), init_response_two.instrument().id());
+  EXPECT_EQ(init_response_one.instrument().name(), init_response_two.instrument().name());
 
   nidevice_grpc::Session session_one = init_response_one.instrument();
   nidevice_grpc::Session session_two = init_response_two.instrument();
@@ -167,7 +167,7 @@ TEST_F(NiRFmxBluetoothSessionTest, CallInitializeTwiceWithSameSessionNameOnSameD
 TEST_F(NiRFmxBluetoothSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
 {
   nidevice_grpc::Session session;
-  session.set_id(0UL);
+  session.set_name("");
 
   try {
     rfmxbluetooth::CloseResponse response;

--- a/source/tests/system/nirfmxlte_session_tests.cpp
+++ b/source/tests/system/nirfmxlte_session_tests.cpp
@@ -50,7 +50,7 @@ class NiRFmxLTESessionTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     rfmxlte::CloseRequest request;
-    request.mutable_instrument()->set_id(session.id());
+    request.mutable_instrument()->set_name(session.name());
     request.set_force_destroy(force_destroy);
 
     ::grpc::Status status = GetStub()->Close(&context, request, response);
@@ -70,7 +70,7 @@ TEST_F(NiRFmxLTESessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDr
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.instrument().id());
+  EXPECT_NE("", response.instrument().name());
 }
 
 TEST_F(NiRFmxLTESessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesDriverSession)
@@ -80,7 +80,7 @@ TEST_F(NiRFmxLTESessionTest, InitializeSessionWithDeviceAndNoSessionName_Creates
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.instrument().id());
+  EXPECT_NE("", response.instrument().name());
 }
 
 TEST_F(NiRFmxLTESessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
@@ -103,7 +103,7 @@ TEST_F(NiRFmxLTESessionTest, InitializedSession_CloseSession_ClosesDriverSession
   nidevice_grpc::Session session = init_response.instrument();
   ::grpc::ClientContext context;
   rfmxlte::CloseRequest close_request;
-  close_request.mutable_instrument()->set_id(session.id());
+  close_request.mutable_instrument()->set_name(session.name());
   close_request.set_force_destroy(false);
   rfmxlte::CloseResponse close_response;
   ::grpc::Status status = GetStub()->Close(&context, close_request, &close_response);
@@ -121,7 +121,7 @@ TEST_F(NiRFmxLTESessionTest, TwoInitializedSessionsOnSameDevice_CloseSessions_Cl
   EXPECT_EQ(0, init_response_one.status());
   EXPECT_TRUE(status_two.ok());
   EXPECT_EQ(0, init_response_two.status());
-  EXPECT_NE(init_response_one.instrument().id(), init_response_two.instrument().id());
+  EXPECT_NE(init_response_one.instrument().name(), init_response_two.instrument().name());
 
   nidevice_grpc::Session session_one = init_response_one.instrument();
   nidevice_grpc::Session session_two = init_response_two.instrument();
@@ -144,7 +144,7 @@ TEST_F(NiRFmxLTESessionTest, CallInitializeTwiceWithSameSessionNameOnSameDevice_
   EXPECT_EQ(0, init_response_one.status());
   EXPECT_TRUE(status_two.ok());
   EXPECT_EQ(0, init_response_two.status());
-  EXPECT_EQ(init_response_one.instrument().id(), init_response_two.instrument().id());
+  EXPECT_EQ(init_response_one.instrument().name(), init_response_two.instrument().name());
 
   nidevice_grpc::Session session_one = init_response_one.instrument();
   nidevice_grpc::Session session_two = init_response_two.instrument();
@@ -167,7 +167,7 @@ TEST_F(NiRFmxLTESessionTest, CallInitializeTwiceWithSameSessionNameOnSameDevice_
 TEST_F(NiRFmxLTESessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
 {
   nidevice_grpc::Session session;
-  session.set_id(0UL);
+  session.set_name("");
 
   try {
     rfmxlte::CloseResponse response;

--- a/source/tests/system/nirfmxnr_session_tests.cpp
+++ b/source/tests/system/nirfmxnr_session_tests.cpp
@@ -50,7 +50,7 @@ class NiRFmxNRSessionTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     rfmxnr::CloseRequest request;
-    request.mutable_instrument()->set_id(session.id());
+    request.mutable_instrument()->set_name(session.name());
     request.set_force_destroy(force_destroy);
 
     ::grpc::Status status = GetStub()->Close(&context, request, response);
@@ -70,7 +70,7 @@ TEST_F(NiRFmxNRSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDri
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.instrument().id());
+  EXPECT_NE("", response.instrument().name());
 }
 
 TEST_F(NiRFmxNRSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesDriverSession)
@@ -80,7 +80,7 @@ TEST_F(NiRFmxNRSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesD
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.instrument().id());
+  EXPECT_NE("", response.instrument().name());
 }
 
 TEST_F(NiRFmxNRSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
@@ -103,7 +103,7 @@ TEST_F(NiRFmxNRSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
   nidevice_grpc::Session session = init_response.instrument();
   ::grpc::ClientContext context;
   rfmxnr::CloseRequest close_request;
-  close_request.mutable_instrument()->set_id(session.id());
+  close_request.mutable_instrument()->set_name(session.name());
   close_request.set_force_destroy(false);
   rfmxnr::CloseResponse close_response;
   ::grpc::Status status = GetStub()->Close(&context, close_request, &close_response);
@@ -121,7 +121,7 @@ TEST_F(NiRFmxNRSessionTest, TwoInitializedSessionsOnSameDevice_CloseSessions_Clo
   EXPECT_EQ(0, init_response_one.status());
   EXPECT_TRUE(status_two.ok());
   EXPECT_EQ(0, init_response_two.status());
-  EXPECT_NE(init_response_one.instrument().id(), init_response_two.instrument().id());
+  EXPECT_NE(init_response_one.instrument().name(), init_response_two.instrument().name());
 
   nidevice_grpc::Session session_one = init_response_one.instrument();
   nidevice_grpc::Session session_two = init_response_two.instrument();
@@ -144,7 +144,7 @@ TEST_F(NiRFmxNRSessionTest, CallInitializeTwiceWithSameSessionNameOnSameDevice_C
   EXPECT_EQ(0, init_response_one.status());
   EXPECT_TRUE(status_two.ok());
   EXPECT_EQ(0, init_response_two.status());
-  EXPECT_EQ(init_response_one.instrument().id(), init_response_two.instrument().id());
+  EXPECT_EQ(init_response_one.instrument().name(), init_response_two.instrument().name());
 
   nidevice_grpc::Session session_one = init_response_one.instrument();
   nidevice_grpc::Session session_two = init_response_two.instrument();
@@ -167,7 +167,7 @@ TEST_F(NiRFmxNRSessionTest, CallInitializeTwiceWithSameSessionNameOnSameDevice_C
 TEST_F(NiRFmxNRSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
 {
   nidevice_grpc::Session session;
-  session.set_id(0UL);
+  session.set_name("");
 
   try {
     rfmxnr::CloseResponse response;

--- a/source/tests/system/nirfmxspecan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxspecan_driver_api_tests.cpp
@@ -558,7 +558,7 @@ TEST_P(NiRFmxSpecAnDriverApiCompatibleResourceInitTests, InitializeTwoCompatible
 {
   const auto session1 = init_session(stub(), PXI_5663, std::get<0>(GetParam()));
   const auto session2 = init_session(stub(), PXI_5663, std::get<1>(GetParam()));
-  EXPECT_NE(session1.id(), session2.id());
+  EXPECT_NE(session1.name(), session2.name());
   EXPECT_VALID_DRIVER_SESSION(session1);
   EXPECT_VALID_DRIVER_SESSION(session2);
 
@@ -575,9 +575,9 @@ TEST_F(NiRFmxSpecAnDriverApiTests, InitializeThreeIdenticalResourcesAsSeparateSe
   const auto session1 = init_session(stub(), PXI_5663, "specan1,specan2");
   const auto session2 = init_session(stub(), PXI_5663, "specan2,specan1");
   const auto session3 = init_session(stub(), PXI_5663, "specan1,specan2");
-  EXPECT_NE(session1.id(), session2.id());
-  EXPECT_NE(session1.id(), session3.id());
-  EXPECT_NE(session2.id(), session3.id());
+  EXPECT_NE(session1.name(), session2.name());
+  EXPECT_NE(session1.name(), session3.name());
+  EXPECT_NE(session2.name(), session3.name());
   EXPECT_VALID_DRIVER_SESSION(session1);
   EXPECT_VALID_DRIVER_SESSION(session2);
   EXPECT_VALID_DRIVER_SESSION(session3);
@@ -604,7 +604,7 @@ TEST_P(NiRFmxSpecAnDriverApiIndependentResourceInitTests, InitializeTwoSessionsW
 {
   const auto session1 = init_session(stub(), PXI_5663, std::get<0>(GetParam()));
   const auto session2 = init_session(stub(), PXI_5663, std::get<1>(GetParam()));
-  EXPECT_NE(session1.id(), session2.id());
+  EXPECT_NE(session1.name(), session2.name());
   EXPECT_VALID_DRIVER_SESSION(session1);
   EXPECT_VALID_DRIVER_SESSION(session2);
 
@@ -625,7 +625,7 @@ TEST_P(NiRFmxSpecAnDriverApiSameUnderlyingResourceInitTests, InitializeTwoSessio
 {
   const auto session1 = init_session(stub(), PXI_5663, std::get<0>(GetParam()));
   const auto session2 = init_session(stub(), PXI_5663, std::get<1>(GetParam()));
-  EXPECT_NE(session1.id(), session2.id());
+  EXPECT_NE(session1.name(), session2.name());
   EXPECT_VALID_DRIVER_SESSION(session1);
   EXPECT_VALID_DRIVER_SESSION(session2);
 

--- a/source/tests/system/nirfmxspecan_session_tests.cpp
+++ b/source/tests/system/nirfmxspecan_session_tests.cpp
@@ -60,7 +60,7 @@ TEST_F(NiRFmxSpecAnSessionTest, InitializeSessionWithDeviceAndSessionName_Create
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.instrument().id());
+  EXPECT_NE("", response.instrument().name());
 }
 
 TEST_F(NiRFmxSpecAnSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesDriverSession)
@@ -70,7 +70,7 @@ TEST_F(NiRFmxSpecAnSessionTest, InitializeSessionWithDeviceAndNoSessionName_Crea
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.instrument().id());
+  EXPECT_NE("", response.instrument().name());
 }
 
 TEST_F(NiRFmxSpecAnSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
@@ -81,7 +81,7 @@ TEST_F(NiRFmxSpecAnSessionTest, InitializedSession_CloseSession_ClosesDriverSess
   nidevice_grpc::Session session = init_response.instrument();
   ::grpc::ClientContext context;
   rfmxspecan::CloseRequest close_request;
-  close_request.mutable_instrument()->set_id(session.id());
+  close_request.mutable_instrument()->set_name(session.name());
   close_request.set_force_destroy(false);
   rfmxspecan::CloseResponse close_response;
   ::grpc::Status status = GetStub()->Close(&context, close_request, &close_response);
@@ -129,12 +129,12 @@ TEST_F(NiRFmxSpecAnSessionTest, InitWithErrorFromDriver_ReinitSuccessfully_Error
 TEST_F(NiRFmxSpecAnSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
 {
   nidevice_grpc::Session session;
-  session.set_id(0UL);
+  session.set_name("");
 
   try {
     ::grpc::ClientContext context;
     rfmxspecan::CloseRequest request;
-    request.mutable_instrument()->set_id(session.id());
+    request.mutable_instrument()->set_name(session.name());
     request.set_force_destroy(false);
     rfmxspecan::CloseResponse response;
     ::grpc::Status status = GetStub()->Close(&context, request, &response);

--- a/source/tests/system/nirfmxwlan_session_tests.cpp
+++ b/source/tests/system/nirfmxwlan_session_tests.cpp
@@ -50,7 +50,7 @@ class NiRFmxWLANSessionTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     rfmxwlan::CloseRequest request;
-    request.mutable_instrument()->set_id(session.id());
+    request.mutable_instrument()->set_name(session.name());
     request.set_force_destroy(force_destroy);
 
     ::grpc::Status status = GetStub()->Close(&context, request, response);
@@ -70,7 +70,7 @@ TEST_F(NiRFmxWLANSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesD
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.instrument().id());
+  EXPECT_NE("", response.instrument().name());
 }
 
 TEST_F(NiRFmxWLANSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesDriverSession)
@@ -80,7 +80,7 @@ TEST_F(NiRFmxWLANSessionTest, InitializeSessionWithDeviceAndNoSessionName_Create
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.instrument().id());
+  EXPECT_NE("", response.instrument().name());
 }
 
 TEST_F(NiRFmxWLANSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
@@ -103,7 +103,7 @@ TEST_F(NiRFmxWLANSessionTest, InitializedSession_CloseSession_ClosesDriverSessio
   nidevice_grpc::Session session = init_response.instrument();
   ::grpc::ClientContext context;
   rfmxwlan::CloseRequest close_request;
-  close_request.mutable_instrument()->set_id(session.id());
+  close_request.mutable_instrument()->set_name(session.name());
   close_request.set_force_destroy(false);
   rfmxwlan::CloseResponse close_response;
   ::grpc::Status status = GetStub()->Close(&context, close_request, &close_response);
@@ -121,7 +121,7 @@ TEST_F(NiRFmxWLANSessionTest, TwoInitializedSessionsOnSameDevice_CloseSessions_C
   EXPECT_EQ(0, init_response_one.status());
   EXPECT_TRUE(status_two.ok());
   EXPECT_EQ(0, init_response_two.status());
-  EXPECT_NE(init_response_one.instrument().id(), init_response_two.instrument().id());
+  EXPECT_NE(init_response_one.instrument().name(), init_response_two.instrument().name());
 
   nidevice_grpc::Session session_one = init_response_one.instrument();
   nidevice_grpc::Session session_two = init_response_two.instrument();
@@ -138,7 +138,7 @@ TEST_F(NiRFmxWLANSessionTest, TwoInitializedSessionsOnSameDevice_CloseSessions_C
 TEST_F(NiRFmxWLANSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
 {
   nidevice_grpc::Session session;
-  session.set_id(0UL);
+  session.set_name("");
 
   try {
     rfmxwlan::CloseResponse response;
@@ -159,7 +159,7 @@ TEST_F(NiRFmxWLANSessionTest, CallInitializeTwiceWithSameSessionNameOnSameDevice
   EXPECT_EQ(0, init_response_one.status());
   EXPECT_TRUE(status_two.ok());
   EXPECT_EQ(0, init_response_two.status());
-  EXPECT_EQ(init_response_one.instrument().id(), init_response_two.instrument().id());
+  EXPECT_EQ(init_response_one.instrument().name(), init_response_two.instrument().name());
 
   nidevice_grpc::Session session_one = init_response_one.instrument();
   nidevice_grpc::Session session_two = init_response_two.instrument();

--- a/source/tests/system/nirfsg_session_tests.cpp
+++ b/source/tests/system/nirfsg_session_tests.cpp
@@ -51,7 +51,7 @@ class NiRFSGSessionTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     rfsg::GetErrorRequest error_request;
-    error_request.mutable_vi()->set_id(session.id());
+    error_request.mutable_vi()->set_name(session.name());
     rfsg::GetErrorResponse error_response;
     ::grpc::Status status = GetStub()->GetError(&context, error_request, &error_response);
     EXPECT_TRUE(status.ok());
@@ -71,7 +71,7 @@ TEST_F(NiRFSGSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDrive
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.vi().id());
+  EXPECT_NE("", response.vi().name());
   EXPECT_EQ("", response.error_message());
 }
 
@@ -82,7 +82,7 @@ TEST_F(NiRFSGSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesDri
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.vi().id());
+  EXPECT_NE("", response.vi().name());
   EXPECT_EQ("", response.error_message());
 }
 
@@ -94,7 +94,7 @@ TEST_F(NiRFSGSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
   nidevice_grpc::Session session = init_response.vi();
   ::grpc::ClientContext context;
   rfsg::CloseRequest close_request;
-  close_request.mutable_vi()->set_id(session.id());
+  close_request.mutable_vi()->set_name(session.name());
   rfsg::CloseResponse close_response;
   ::grpc::Status status = GetStub()->Close(&context, close_request, &close_response);
 
@@ -118,12 +118,12 @@ TEST_F(NiRFSGSessionTest, InitWithErrorFromDriver_ReturnsDriverErrorWithUserErro
 TEST_F(NiRFSGSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
 {
   nidevice_grpc::Session session;
-  session.set_id(0UL);
+  session.set_name("");
 
   try {
     ::grpc::ClientContext context;
     rfsg::CloseRequest request;
-    request.mutable_vi()->set_id(session.id());
+    request.mutable_vi()->set_name(session.name());
     rfsg::CloseResponse response;
     auto status = GetStub()->Close(&context, request, &response);
     nidevice_grpc::experimental::client::raise_if_error(status, context);

--- a/source/tests/system/niscope_driver_api_tests.cpp
+++ b/source/tests/system/niscope_driver_api_tests.cpp
@@ -44,9 +44,9 @@ class NiScopeDriverApiTest : public ::testing::Test {
     return niscope_stub_;
   }
 
-  int GetSessionId()
+  std::string GetSessionName()
   {
-    return driver_session_->id();
+    return driver_session_->name();
   }
 
   void initialize_driver_session()
@@ -71,7 +71,7 @@ class NiScopeDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     scope::CloseRequest request;
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     scope::CloseResponse response;
 
     ::grpc::Status status = GetStub()->Close(&context, request, &response);
@@ -84,7 +84,7 @@ class NiScopeDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     scope::ActualNumWfmsRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_list(channel_list);
     scope::ActualNumWfmsResponse response;
     auto status = GetStub()->ActualNumWfms(&context, request, &response);
@@ -98,7 +98,7 @@ class NiScopeDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     scope::ActualMeasWfmSizeRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_array_meas_function(array_measurement);
     scope::ActualMeasWfmSizeResponse response;
     auto status = GetStub()->ActualMeasWfmSize(&context, request, &response);
@@ -111,7 +111,7 @@ class NiScopeDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     scope::InitiateAcquisitionRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     scope::InitiateAcquisitionResponse response;
     auto status = GetStub()->InitiateAcquisition(&context, request, &response);
     EXPECT_TRUE(status.ok());
@@ -127,7 +127,7 @@ class NiScopeDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     scope::GetErrorMessageRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_error_code(error_status);
     scope::GetErrorMessageResponse response;
 
@@ -141,7 +141,7 @@ class NiScopeDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     scope::AutoSetupRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     scope::AutoSetupResponse response;
 
     ::grpc::Status status = GetStub()->AutoSetup(&context, request, &response);
@@ -153,7 +153,7 @@ class NiScopeDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     scope::GetAttributeViBooleanRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_list(channel_list);
     request.set_attribute_id(attribute_id);
     scope::GetAttributeViBooleanResponse response;
@@ -167,7 +167,7 @@ class NiScopeDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     scope::GetAttributeViInt32Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_list(channel_list);
     request.set_attribute_id(attribute_id);
     scope::GetAttributeViInt32Response response;
@@ -181,7 +181,7 @@ class NiScopeDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     scope::GetAttributeViInt64Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_list(channel_list);
     request.set_attribute_id(attribute_id);
     scope::GetAttributeViInt64Response response;
@@ -195,7 +195,7 @@ class NiScopeDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     scope::GetAttributeViReal64Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_list(channel_list);
     request.set_attribute_id(attribute_id);
     scope::GetAttributeViReal64Response response;
@@ -209,7 +209,7 @@ class NiScopeDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     scope::GetAttributeViStringRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_list(channel_list);
     request.set_attribute_id(attribute_id);
     scope::GetAttributeViStringResponse response;
@@ -229,7 +229,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeSelfTest_SendRequest_SelfTestCompletesSucces
 {
   ::grpc::ClientContext context;
   scope::SelfTestRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   scope::SelfTestResponse response;
 
   ::grpc::Status status = GetStub()->SelfTest(&context, request, &response);
@@ -244,7 +244,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeReset_SendRequest_ResetCompletesSuccessfully
 {
   ::grpc::ClientContext context;
   scope::ResetRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   scope::ResetResponse response;
 
   ::grpc::Status status = GetStub()->Reset(&context, request, &response);
@@ -260,7 +260,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeRead_SendRequest_ReadCompletesWithCorrectSiz
   const int32 expected_num_waveforms = get_actual_num_wfms(channel_list);
   ::grpc::ClientContext context;
   scope::ReadRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_list(channel_list);
   request.set_timeout(10000);
   request.set_num_samples(expected_num_samples);
@@ -285,7 +285,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeFetchArrayMeasurement_SendRequest_FetchCompl
   const int32 expected_waveform_size = get_actual_measurement_waveform_size(measurement_func);
   ::grpc::ClientContext context;
   scope::FetchArrayMeasurementRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_list(channel_list);
   request.set_timeout(10000);
   request.set_array_meas_function(measurement_func);
@@ -308,7 +308,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeFetchBinary16_SendRequest_FetchCompletesWith
   const int32 expected_num_waveforms = get_actual_num_wfms(channel_list);
   ::grpc::ClientContext context;
   scope::FetchBinary16Request request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_list(channel_list);
   request.set_timeout(10000);
   request.set_num_samples(expected_num_samples);
@@ -331,7 +331,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeFetchBinary8_SendRequest_FetchCompletesWithC
   const int32 expected_num_waveforms = get_actual_num_wfms(channel_list);
   ::grpc::ClientContext context;
   scope::FetchBinary8Request request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_list(channel_list);
   request.set_timeout(10000);
   request.set_num_samples(expected_num_samples);
@@ -352,7 +352,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeSetViInt32Attribute_SendRequest_GetViInt32At
   const int32 expected_value = 4;
   ::grpc::ClientContext context;
   scope::SetAttributeViInt32Request request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_list(channel_list);
   request.set_attribute_id(attribute_to_set);
   request.set_value_raw(expected_value);
@@ -375,7 +375,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeSetViInt64Attribute_SendRequest_GetViInt64At
   const int64 expected_value = 4;
   ::grpc::ClientContext context;
   scope::SetAttributeViInt64Request request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_list(channel_list);
   request.set_attribute_id(attribute_to_set);
   request.set_value_raw(expected_value);
@@ -396,7 +396,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeSetViReal64Attribute_SendRequest_GetViReal64
   const double expected_value = 42.24;
   ::grpc::ClientContext context;
   scope::SetAttributeViReal64Request request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_list(channel_list);
   request.set_attribute_id(attribute_to_set);
   request.set_value_raw(expected_value);
@@ -417,7 +417,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeSetViStringAttribute_SendRequest_GetViString
   const std::string expected_value = "Hello world!";
   ::grpc::ClientContext context;
   scope::SetAttributeViStringRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_list(channel_list);
   request.set_attribute_id(attribute_to_set);
   request.set_value_raw(expected_value);
@@ -438,7 +438,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeSetBoolAttribute_SendRequest_GetBoolAttribut
   const bool expected_value = true;
   ::grpc::ClientContext context;
   scope::SetAttributeViBooleanRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_list(channel_list);
   request.set_attribute_id(attribute_to_set);
   request.set_value(expected_value);
@@ -456,7 +456,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeConfigureHorizontalTiming_SendRequest_Config
 {
   ::grpc::ClientContext context;
   scope::ConfigureHorizontalTimingRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_min_sample_rate(1000000);
   request.set_min_num_pts(100000);
   request.set_ref_position(50);
@@ -474,7 +474,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeConfigureVertical_SendRequest_ConfigureCompl
 {
   ::grpc::ClientContext context;
   scope::ConfigureVerticalRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_list("0");
   request.set_range(30.0);
   request.set_offset(0);
@@ -494,7 +494,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeGetScalingCoefficients_SendRequest_NonZeroCo
   auto_setup();
   ::grpc::ClientContext context;
   scope::GetScalingCoefficientsRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_list("0, 1");
   scope::GetScalingCoefficientsResponse response;
 
@@ -512,7 +512,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeGetNormalizationCoefficients_SendRequest_Non
   auto_setup();
   ::grpc::ClientContext context;
   scope::GetNormalizationCoefficientsRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_list("0, 1");
   scope::GetNormalizationCoefficientsResponse response;
 

--- a/source/tests/system/niscope_session_tests.cpp
+++ b/source/tests/system/niscope_session_tests.cpp
@@ -56,7 +56,7 @@ class NiScopeSessionTest : public ::testing::Test {
 
     ::grpc::ClientContext context;
     scope::GetErrorMessageRequest request;
-    request.mutable_vi()->set_id(session.id());
+    request.mutable_vi()->set_name(session.name());
     request.set_error_code(error_status);
     scope::GetErrorMessageResponse error_response;
 
@@ -77,7 +77,7 @@ TEST_F(NiScopeSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDriv
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.vi().id());
+  EXPECT_NE("", response.vi().name());
   EXPECT_EQ("", response.error_message());
 }
 
@@ -88,7 +88,7 @@ TEST_F(NiScopeSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesDr
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.vi().id());
+  EXPECT_NE("", response.vi().name());
   EXPECT_EQ("", response.error_message());
 }
 
@@ -100,7 +100,7 @@ TEST_F(NiScopeSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
 
   ::grpc::ClientContext context;
   scope::CloseRequest close_request;
-  close_request.mutable_vi()->set_id(session.id());
+  close_request.mutable_vi()->set_name(session.name());
   scope::CloseResponse close_response;
   ::grpc::Status status = GetStub()->Close(&context, close_request, &close_response);
 
@@ -111,12 +111,12 @@ TEST_F(NiScopeSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
 TEST_F(NiScopeSessionTest, InvalidSession_CloseSession_ReturnsInvalidSesssionError)
 {
   nidevice_grpc::Session session;
-  session.set_id(NULL);
+  session.set_name("");
 
   try {
     ::grpc::ClientContext context;
     scope::CloseRequest request;
-    request.mutable_vi()->set_id(session.id());
+    request.mutable_vi()->set_name(session.name());
     scope::CloseResponse response;
     ::grpc::Status status = GetStub()->Close(&context, request, &response);
     nidevice_grpc::experimental::client::raise_if_error(status, context);

--- a/source/tests/system/niswitch_driver_api_tests.cpp
+++ b/source/tests/system/niswitch_driver_api_tests.cpp
@@ -48,9 +48,9 @@ class NiSwitchDriverApiTest : public ::testing::Test {
     return niswitch_stub_;
   }
 
-  int GetSessionId()
+  std::string GetSessionName()
   {
-    return driver_session_->id();
+    return driver_session_->name();
   }
 
   void expect_api_success(int error_status)
@@ -62,7 +62,7 @@ class NiSwitchDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     niswitch::ErrorMessageRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_error_code(error_status);
     niswitch::ErrorMessageResponse response;
 
@@ -95,7 +95,7 @@ class NiSwitchDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     niswitch::CloseRequest request;
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     niswitch::CloseResponse response;
 
     ::grpc::Status status = GetStub()->Close(&context, request, &response);
@@ -108,7 +108,7 @@ class NiSwitchDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     niswitch::WaitForDebounceRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_maximum_time_ms(kWaitForDebounceMaxTime);
     niswitch::WaitForDebounceResponse response;
 
@@ -122,7 +122,7 @@ class NiSwitchDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     niswitch::CanConnectRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel1(channel1);
     request.set_channel2(channel2);
     niswitch::CanConnectResponse response;
@@ -138,7 +138,7 @@ class NiSwitchDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     niswitch::ConnectRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel1(channel1);
     request.set_channel2(channel2);
     niswitch::ConnectResponse response;
@@ -153,7 +153,7 @@ class NiSwitchDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     niswitch::DisconnectAllRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     niswitch::DisconnectAllResponse response;
 
     ::grpc::Status status = GetStub()->DisconnectAll(&context, request, &response);
@@ -166,7 +166,7 @@ class NiSwitchDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     niswitch::GetRelayPositionRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_relay_name(relay_name);
     niswitch::GetRelayPositionResponse response;
 
@@ -181,7 +181,7 @@ class NiSwitchDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     niswitch::GetAttributeViReal64Request request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute_id(attribute_id);
     niswitch::GetAttributeViReal64Response response;
@@ -197,7 +197,7 @@ class NiSwitchDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     niswitch::GetAttributeViStringRequest request;
-    request.mutable_vi()->set_id(GetSessionId());
+    request.mutable_vi()->set_name(GetSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute_id(attribute_id);
     niswitch::GetAttributeViStringResponse response;
@@ -219,7 +219,7 @@ TEST_F(NiSwitchDriverApiTest, NiSwitchSelfTest_SendRequest_SelfTestCompletesSucc
 {
   ::grpc::ClientContext context;
   niswitch::SelfTestRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   niswitch::SelfTestResponse response;
 
   ::grpc::Status status = GetStub()->SelfTest(&context, request, &response);
@@ -234,7 +234,7 @@ TEST_F(NiSwitchDriverApiTest, NiSwitchReset_SendRequest_ResetCompletesSuccessful
 {
   ::grpc::ClientContext context;
   niswitch::ResetRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   niswitch::ResetResponse response;
 
   ::grpc::Status status = GetStub()->Reset(&context, request, &response);
@@ -250,7 +250,7 @@ TEST_F(NiSwitchDriverApiTest, NiSwitchSetViReal64Attribute_SendRequest_GetViReal
   const double expected_value = 402.24;
   ::grpc::ClientContext context;
   niswitch::SetAttributeViReal64Request request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_name(channel_name);
   request.set_attribute_id(attribute_to_set);
   request.set_attribute_value_raw(expected_value);
@@ -271,7 +271,7 @@ TEST_F(NiSwitchDriverApiTest, NiSwitchSetViStringAttribute_SendRequest_GetViStri
   const std::string expected_value = "b0r1->b0c1;b0r1->b0c2;b0r2->b0c3";
   ::grpc::ClientContext context;
   niswitch::SetAttributeViStringRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_channel_name(channel_name);
   request.set_attribute_id(attribute_to_set);
   request.set_attribute_value_raw(expected_value);
@@ -291,7 +291,7 @@ TEST_F(NiSwitchDriverApiTest, NiSwitchRelayControl_SendRequest_RelayPositionMatc
   const niswitch::RelayPosition expected_value = niswitch::RelayPosition::RELAY_POSITION_NISWITCH_VAL_CLOSED;
   ::grpc::ClientContext context;
   niswitch::RelayControlRequest request;
-  request.mutable_vi()->set_id(GetSessionId());
+  request.mutable_vi()->set_name(GetSessionName());
   request.set_relay_name(kRelayName);
   request.set_relay_action(relay_action);
   niswitch::RelayControlResponse response;

--- a/source/tests/system/niswitch_session_tests.cpp
+++ b/source/tests/system/niswitch_session_tests.cpp
@@ -58,7 +58,7 @@ class NiSwitchSessionTest : public ::testing::Test {
 
     ::grpc::ClientContext context;
     niswitch::ErrorMessageRequest error_request;
-    error_request.mutable_vi()->set_id(session.id());
+    error_request.mutable_vi()->set_name(session.name());
     error_request.set_error_code(error_status);
     niswitch::ErrorMessageResponse error_response;
 
@@ -79,7 +79,7 @@ TEST_F(NiSwitchSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDri
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.vi().id());
+  EXPECT_NE("", response.vi().name());
   EXPECT_EQ("", response.error_message());
 }
 
@@ -90,7 +90,7 @@ TEST_F(NiSwitchSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesD
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.vi().id());
+  EXPECT_NE("", response.vi().name());
   EXPECT_EQ("", response.error_message());
 }
 
@@ -102,7 +102,7 @@ TEST_F(NiSwitchSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
 
   ::grpc::ClientContext context;
   niswitch::CloseRequest close_request;
-  close_request.mutable_vi()->set_id(session.id());
+  close_request.mutable_vi()->set_name(session.name());
   niswitch::CloseResponse close_response;
   ::grpc::Status status = GetStub()->Close(&context, close_request, &close_response);
 
@@ -113,12 +113,12 @@ TEST_F(NiSwitchSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
 TEST_F(NiSwitchSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
 {
   nidevice_grpc::Session session;
-  session.set_id(NULL);
+  session.set_name("");
 
   try {
     ::grpc::ClientContext context;
     niswitch::CloseRequest request;
-    request.mutable_vi()->set_id(session.id());
+    request.mutable_vi()->set_name(session.name());
     niswitch::CloseResponse response;
     auto status = GetStub()->Close(&context, request, &response);
     nidevice_grpc::experimental::client::raise_if_error(status, context);

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -107,7 +107,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
 
     ::grpc::ClientContext context;
     nisync::CloseRequest request;
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     nisync::CloseResponse response;
 
     ::grpc::Status status = GetStub()->Close(&context, request, &response);
@@ -121,7 +121,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     ::grpc::ClientContext clientContext;
     nisync::RevisionQueryRequest request;
     nisync::RevisionQueryResponse response;
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->RevisionQuery(&clientContext, request, &response);
     *driverRevision = response.driver_revision();
     *firmwareRevision = response.firmware_revision();
@@ -135,7 +135,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     nisync::SendSoftwareTriggerRequest request;
     nisync::SendSoftwareTriggerResponse response;
     request.set_src_terminal(srcTerminal);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->SendSoftwareTrigger(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -148,7 +148,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     nisync::ConnectClkTerminalsResponse response;
     request.set_src_terminal(srcTerminal);
     request.set_dest_terminal(destTerminal);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->ConnectClkTerminals(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -161,7 +161,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     nisync::DisconnectClkTerminalsResponse response;
     request.set_src_terminal(srcTerminal);
     request.set_dest_terminal(destTerminal);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->DisconnectClkTerminals(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -185,7 +185,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     request.set_invert(invert);
     request.set_update_edge(updateEdge);
     request.set_delay(delay);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->ConnectSWTrigToTerminal(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -198,7 +198,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     nisync::DisconnectSWTrigFromTerminalResponse response;
     request.set_src_terminal(srcTerminal);
     request.set_dest_terminal(destTerminal);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->DisconnectSWTrigFromTerminal(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -220,7 +220,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     request.set_sync_clock(syncClock);
     request.set_invert(invert);
     request.set_update_edge(updateEdge);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->ConnectTrigTerminals(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -233,7 +233,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     nisync::DisconnectTrigTerminalsResponse response;
     request.set_src_terminal(srcTerminal);
     request.set_dest_terminal(destTerminal);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->DisconnectTrigTerminals(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -247,7 +247,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     request.set_active_item(activeItem);
     request.set_attribute(static_cast<nisync::NiSyncAttribute>(attribute));
     request.set_value_raw(value);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->SetAttributeViInt32(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -260,7 +260,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     nisync::GetAttributeViInt32Response response;
     request.set_active_item(activeItem);
     request.set_attribute(static_cast<nisync::NiSyncAttribute>(attribute));
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->GetAttributeViInt32(&clientContext, request, &response);
     *valueOut = response.value();
     *viStatusOut = response.status();
@@ -275,7 +275,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     request.set_active_item(activeItem);
     request.set_attribute(static_cast<nisync::NiSyncAttribute>(attribute));
     request.set_value_raw(value);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->SetAttributeViString(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -288,7 +288,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     nisync::GetAttributeViStringResponse response;
     request.set_active_item(activeItem);
     request.set_attribute(static_cast<nisync::NiSyncAttribute>(attribute));
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->GetAttributeViString(&clientContext, request, &response);
     *valueOut = response.value();
     *viStatusOut = response.status();
@@ -303,7 +303,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     request.set_active_item(activeItem);
     request.set_attribute(static_cast<nisync::NiSyncAttribute>(attribute));
     request.set_value(value);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->SetAttributeViBoolean(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -316,7 +316,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     nisync::GetAttributeViBooleanResponse response;
     request.set_active_item(activeItem);
     request.set_attribute(static_cast<nisync::NiSyncAttribute>(attribute));
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->GetAttributeViBoolean(&clientContext, request, &response);
     *valueOut = response.value();
     *viStatusOut = response.status();
@@ -331,7 +331,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     request.set_active_item(activeItem);
     request.set_attribute(static_cast<nisync::NiSyncAttribute>(attribute));
     request.set_value_raw(value);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->SetAttributeViReal64(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -344,7 +344,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     nisync::GetAttributeViReal64Response response;
     request.set_active_item(activeItem);
     request.set_attribute(static_cast<nisync::NiSyncAttribute>(attribute));
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->GetAttributeViReal64(&clientContext, request, &response);
     *valueOut = response.value();
     *viStatusOut = response.status();
@@ -366,7 +366,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     request.set_src_terminal(srcTerminal);
     request.set_duration(duration);
     request.set_decimation_count(decimationCount);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->MeasureFrequencyEx(&clientContext, request, &response);
     *actualDurationOut = response.actual_duration();
     *frequencyOut = response.frequency();
@@ -384,7 +384,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     ::grpc::ClientContext clientContext;
     nisync::GetTimeRequest request;
     nisync::GetTimeResponse response;
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->GetTime(&clientContext, request, &response);
     *timeSeconds = response.time_seconds();
     *timeNanoseconds = response.time_nanoseconds();
@@ -398,7 +398,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     ::grpc::ClientContext clientContext;
     nisync::SetTimeReferenceFreeRunningRequest request;
     nisync::SetTimeReferenceFreeRunningResponse response;
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->SetTimeReferenceFreeRunning(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -409,7 +409,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     ::grpc::ClientContext clientContext;
     nisync::SetTimeReferenceGPSRequest request;
     nisync::SetTimeReferenceGPSResponse response;
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->SetTimeReferenceGPS(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -425,7 +425,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     nisync::SetTimeReferenceIRIGResponse response;
     request.set_irig_type(irigType);
     request.set_terminal_name(terminalName);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->SetTimeReferenceIRIG(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -447,7 +447,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     request.set_initial_time_seconds(initialTimeSeconds);
     request.set_initial_time_nanoseconds(initialTimeNanoseconds);
     request.set_initial_time_fractional_nanoseconds(initialTimeFractionalNanoseconds);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->SetTimeReferencePPS(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -458,7 +458,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     ::grpc::ClientContext clientContext;
     nisync::SetTimeReference1588OrdinaryClockRequest request;
     nisync::SetTimeReference1588OrdinaryClockResponse response;
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->SetTimeReference1588OrdinaryClock(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -469,7 +469,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     ::grpc::ClientContext clientContext;
     nisync::SetTimeReference8021ASRequest request;
     nisync::SetTimeReference8021ASResponse response;
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->SetTimeReference8021AS(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -491,7 +491,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     request.set_time_seconds(timeSeconds);
     request.set_time_nanoseconds(timeNanoseconds);
     request.set_time_fractional_nanoseconds(timeFractionalNanoseconds);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->CreateFutureTimeEvent(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -524,7 +524,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     nisync::ClearFutureTimeEventsRequest request;
     nisync::ClearFutureTimeEventsResponse response;
     request.set_terminal(terminal);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->ClearFutureTimeEvents(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -554,7 +554,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     request.set_stop_time_seconds(stopTimeSeconds);
     request.set_stop_time_nanoseconds(stopTimeNanoseconds);
     request.set_stop_time_fractional_nanoseconds(stopTimeFractionalNanoseconds);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->CreateClock(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -568,7 +568,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     nisync::ClearClockRequest request;
     nisync::ClearClockResponse response;
     request.set_terminal(terminal);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->ClearClock(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -580,7 +580,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext clientContext;
     nisync::GetTimeReferenceNamesRequest request;
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     nisync::GetTimeReferenceNamesResponse response;
     auto grpcStatus = GetStub()->GetTimeReferenceNames(&clientContext, request, &response);
     *valueOut = response.time_reference_names();
@@ -598,7 +598,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     nisync::EnableTimeStampTriggerResponse response;
     request.set_terminal(terminal);
     request.set_active_edge(activeEdge);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->EnableTimeStampTrigger(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;
@@ -628,7 +628,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     nisync::ReadTriggerTimeStampResponse response;
     request.set_terminal(terminal);
     request.set_timeout(timeout);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->ReadTriggerTimeStamp(&clientContext, request, &response);
     *timeSeconds = response.time_seconds();
     *timeNanoseconds = response.time_nanoseconds();
@@ -655,7 +655,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     request.set_terminal(terminal);
     request.set_timeout(timeout);
     request.set_timestamps_to_read(timestampsToRead);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->ReadMultipleTriggerTimeStamp(&clientContext, request, &response);
     *timestampsRead = response.timestamps_read();
     std::copy(response.time_seconds_buffer().begin(), response.time_seconds_buffer().end(), timeSecondsBuffer);
@@ -674,7 +674,7 @@ class NiSyncDriverApiTest : public ::testing::Test {
     nisync::DisableTimeStampTriggerRequest request;
     nisync::DisableTimeStampTriggerResponse response;
     request.set_terminal(terminal);
-    request.mutable_vi()->set_id(driver_session_->id());
+    request.mutable_vi()->set_name(driver_session_->name());
     auto grpcStatus = GetStub()->DisableTimeStampTrigger(&clientContext, request, &response);
     *viStatusOut = response.status();
     return grpcStatus;

--- a/source/tests/system/nisync_session_tests.cpp
+++ b/source/tests/system/nisync_session_tests.cpp
@@ -71,7 +71,7 @@ TEST_F(NiSyncSessionTest, InitializeSessionWithDeviceAndSessionName_CreatesDrive
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.vi().id());
+  EXPECT_NE("", response.vi().name());
 }
 
 TEST_F(NiSyncSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesDriverSession)
@@ -81,7 +81,7 @@ TEST_F(NiSyncSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesDri
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(0, response.status());
-  EXPECT_NE(0, response.vi().id());
+  EXPECT_NE("", response.vi().name());
 }
 
 TEST_F(NiSyncSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
@@ -91,7 +91,7 @@ TEST_F(NiSyncSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kSyncDeviceNotFound, response.status());
-  EXPECT_EQ(0, response.vi().id());
+  EXPECT_EQ("", response.vi().name());
 }
 
 TEST_F(NiSyncSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
@@ -103,7 +103,7 @@ TEST_F(NiSyncSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
 
   ::grpc::ClientContext context;
   nisync::CloseRequest close_request;
-  close_request.mutable_vi()->set_id(session.id());
+  close_request.mutable_vi()->set_name(session.name());
   nisync::CloseResponse close_response;
   ::grpc::Status status = GetStub()->Close(&context, close_request, &close_response);
 
@@ -114,11 +114,11 @@ TEST_F(NiSyncSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
 TEST_F(NiSyncSessionTest, InvalidSession_CloseSession_NoErrorReported)
 {
   nidevice_grpc::Session session;
-  session.set_id(NULL);
+  session.set_name("");
 
   ::grpc::ClientContext context;
   nisync::CloseRequest request;
-  request.mutable_vi()->set_id(session.id());
+  request.mutable_vi()->set_name(session.name());
   nisync::CloseResponse response;
   ::grpc::Status status = GetStub()->Close(&context, request, &response);
 

--- a/source/tests/system/nitclk_driver_api_tests.cpp
+++ b/source/tests/system/nitclk_driver_api_tests.cpp
@@ -51,9 +51,9 @@ class NiTClkDriverApiTest : public ::testing::Test {
     return nitclk_stub_;
   }
 
-  int GetScopeSessionId()
+  std::string GetScopeSessionName()
   {
-    return scope_session_->id();
+    return scope_session_->name();
   }
 
   void initialize_scope_session()
@@ -78,7 +78,7 @@ class NiTClkDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     scope::CloseRequest request;
-    request.mutable_vi()->set_id(scope_session_->id());
+    request.mutable_vi()->set_name(scope_session_->name());
     scope::CloseResponse response;
 
     ::grpc::Status status = GetScopeStub()->Close(&context, request, &response);
@@ -91,7 +91,7 @@ class NiTClkDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     tclk::GetAttributeViReal64Request request;
-    request.mutable_session()->set_id(GetScopeSessionId());
+    request.mutable_session()->set_name(GetScopeSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute_id(attribute_id);
     tclk::GetAttributeViReal64Response response;
@@ -103,11 +103,11 @@ class NiTClkDriverApiTest : public ::testing::Test {
     return response.value();
   }
 
-  int get_session_id_from_attribute(const char* channel_name, tclk::NiTClkAttribute attribute_id)
+  std::string get_session_id_from_attribute(const char* channel_name, tclk::NiTClkAttribute attribute_id)
   {
     ::grpc::ClientContext context;
     tclk::GetAttributeViSessionRequest request;
-    request.mutable_session()->set_id(GetScopeSessionId());
+    request.mutable_session()->set_name(GetScopeSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute_id(attribute_id);
     tclk::GetAttributeViSessionResponse response;
@@ -116,14 +116,14 @@ class NiTClkDriverApiTest : public ::testing::Test {
 
     EXPECT_TRUE(status.ok());
     EXPECT_EQ(kTClkDriverApiSuccess, response.status());
-    return response.value().id();
+    return response.value().name();
   }
 
   std::string get_string_attribute(const char* channel_name, tclk::NiTClkAttribute attribute_id)
   {
     ::grpc::ClientContext context;
     tclk::GetAttributeViStringRequest request;
-    request.mutable_session()->set_id(GetScopeSessionId());
+    request.mutable_session()->set_name(GetScopeSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute_id(attribute_id);
     tclk::GetAttributeViStringResponse response;
@@ -139,7 +139,7 @@ class NiTClkDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     tclk::SetAttributeViReal64Request request;
-    request.mutable_session()->set_id(GetScopeSessionId());
+    request.mutable_session()->set_name(GetScopeSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute_id(attribute_id);
     request.set_value_raw(attribute_value);
@@ -151,14 +151,14 @@ class NiTClkDriverApiTest : public ::testing::Test {
     EXPECT_EQ(kTClkDriverApiSuccess, response.status());
   }
 
-  void set_session_attribute(const char* channel_name, tclk::NiTClkAttribute attribute_id, const int session_id)
+  void set_session_attribute(const char* channel_name, tclk::NiTClkAttribute attribute_id, const std::string& session_id)
   {
     ::grpc::ClientContext context;
     tclk::SetAttributeViSessionRequest request;
-    request.mutable_session()->set_id(GetScopeSessionId());
+    request.mutable_session()->set_name(GetScopeSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute_id(attribute_id);
-    request.mutable_value()->set_id(session_id);
+    request.mutable_value()->set_name(session_id);
     tclk::SetAttributeViSessionResponse response;
 
     ::grpc::Status status = GetTClkStub()->SetAttributeViSession(&context, request, &response);
@@ -171,7 +171,7 @@ class NiTClkDriverApiTest : public ::testing::Test {
   {
     ::grpc::ClientContext context;
     tclk::SetAttributeViStringRequest request;
-    request.mutable_session()->set_id(GetScopeSessionId());
+    request.mutable_session()->set_name(GetScopeSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute_id(attribute_id);
     request.set_value_raw(attribute_value);
@@ -194,7 +194,7 @@ TEST_F(NiTClkDriverApiTest, ConfigureForHomogeneousTriggers_ReturnsStatusAsSucce
 {
   ::grpc::ClientContext context;
   tclk::ConfigureForHomogeneousTriggersRequest request;
-  request.add_sessions()->set_id(GetScopeSessionId());
+  request.add_sessions()->set_name(GetScopeSessionName());
   tclk::ConfigureForHomogeneousTriggersResponse response;
   ::grpc::Status status = GetTClkStub()->ConfigureForHomogeneousTriggers(&context, request, &response);
 
@@ -206,7 +206,7 @@ TEST_F(NiTClkDriverApiTest, SetupForSyncPulseSenderSynchronize_ReturnsStatusAsSu
 {
   ::grpc::ClientContext context;
   tclk::SetupForSyncPulseSenderSynchronizeRequest request;
-  request.add_sessions()->set_id(GetScopeSessionId());
+  request.add_sessions()->set_name(GetScopeSessionName());
   tclk::SetupForSyncPulseSenderSynchronizeResponse response;
   ::grpc::Status status = GetTClkStub()->SetupForSyncPulseSenderSynchronize(&context, request, &response);
 
@@ -230,10 +230,10 @@ TEST_F(NiTClkDriverApiTest, SetAttributeViSession_CallGetAttributeViSession_Valu
 {
   const char* channel_name = "";
   const tclk::NiTClkAttribute attribute_to_set = tclk::NiTClkAttribute::NITCLK_ATTRIBUTE_START_TRIGGER_MASTER_SESSION;
-  int expected_value = GetScopeSessionId();
+  auto expected_value = GetScopeSessionName();
   set_session_attribute(channel_name, attribute_to_set, expected_value);
 
-  int get_attribute_value = get_session_id_from_attribute(channel_name, attribute_to_set);
+  auto get_attribute_value = get_session_id_from_attribute(channel_name, attribute_to_set);
 
   EXPECT_EQ(expected_value, get_attribute_value);
 }

--- a/source/tests/system/nitclk_driver_api_tests.cpp
+++ b/source/tests/system/nitclk_driver_api_tests.cpp
@@ -103,7 +103,7 @@ class NiTClkDriverApiTest : public ::testing::Test {
     return response.value();
   }
 
-  std::string get_session_id_from_attribute(const char* channel_name, tclk::NiTClkAttribute attribute_id)
+  std::string get_session_name_from_attribute(const char* channel_name, tclk::NiTClkAttribute attribute_id)
   {
     ::grpc::ClientContext context;
     tclk::GetAttributeViSessionRequest request;
@@ -151,14 +151,14 @@ class NiTClkDriverApiTest : public ::testing::Test {
     EXPECT_EQ(kTClkDriverApiSuccess, response.status());
   }
 
-  void set_session_attribute(const char* channel_name, tclk::NiTClkAttribute attribute_id, const std::string& session_id)
+  void set_session_attribute(const char* channel_name, tclk::NiTClkAttribute attribute_id, const std::string& session_name)
   {
     ::grpc::ClientContext context;
     tclk::SetAttributeViSessionRequest request;
     request.mutable_session()->set_name(GetScopeSessionName());
     request.set_channel_name(channel_name);
     request.set_attribute_id(attribute_id);
-    request.mutable_value()->set_name(session_id);
+    request.mutable_value()->set_name(session_name);
     tclk::SetAttributeViSessionResponse response;
 
     ::grpc::Status status = GetTClkStub()->SetAttributeViSession(&context, request, &response);
@@ -233,7 +233,7 @@ TEST_F(NiTClkDriverApiTest, SetAttributeViSession_CallGetAttributeViSession_Valu
   auto expected_value = GetScopeSessionName();
   set_session_attribute(channel_name, attribute_to_set, expected_value);
 
-  auto get_attribute_value = get_session_id_from_attribute(channel_name, attribute_to_set);
+  auto get_attribute_value = get_session_name_from_attribute(channel_name, attribute_to_set);
 
   EXPECT_EQ(expected_value, get_attribute_value);
 }

--- a/source/tests/system/nixnetsocket_driver_api_tests.cpp
+++ b/source/tests/system/nixnetsocket_driver_api_tests.cpp
@@ -285,7 +285,7 @@ SocketResponse socket(client::StubPtr& stub)
 TEST_F(NiXnetSocketNoHardwareTests, InitWithInvalidIpStack_Close_ReturnsAndSetsExpectedErrors)
 {
   SocketResponse invalid_socket;
-  invalid_socket.mutable_socket()->set_id(static_cast<uint32_t>(INVALID_XNET_SOCKET));
+  invalid_socket.mutable_socket()->set_name("");
 
   try {
     client::close(stub(), invalid_socket.socket());
@@ -301,7 +301,7 @@ TEST_F(NiXnetSocketNoHardwareTests, InitWithInvalidIpStack_Close_ReturnsAndSetsE
 TEST_F(NiXnetSocketNoHardwareTests, InitWithInvalidIpStack_Bind_ReturnsAndSetsExpectedErrors)
 {
   SocketResponse invalid_socket;
-  invalid_socket.mutable_socket()->set_id(static_cast<uint32_t>(INVALID_XNET_SOCKET));
+  invalid_socket.mutable_socket()->set_name("");
   auto sock_addr = SockAddr{};
   sock_addr.mutable_ipv4()->mutable_addr()->set_addr(0x7F000001);
   sock_addr.mutable_ipv4()->set_port(31764);
@@ -320,7 +320,7 @@ TEST_F(NiXnetSocketNoHardwareTests, InitWithInvalidIpStack_Bind_ReturnsAndSetsEx
 TEST_F(NiXnetSocketNoHardwareTests, SocketAndEmptySet_IsSet_ReturnsFalse)
 {
   SocketResponse invalid_socket;
-  invalid_socket.mutable_socket()->set_id(static_cast<uint32_t>(INVALID_XNET_SOCKET));
+  invalid_socket.mutable_socket()->set_name("");
 
   auto is_set_response = client::fd_is_set(stub(), invalid_socket.socket(), {});
 
@@ -331,7 +331,7 @@ TEST_F(NiXnetSocketNoHardwareTests, SocketAndEmptySet_IsSet_ReturnsFalse)
 TEST_F(NiXnetSocketNoHardwareTests, SocketAndSetContainingSocket_IsSet_ReturnsTrue)
 {
   SocketResponse invalid_socket;
-  invalid_socket.mutable_socket()->set_id(static_cast<uint32_t>(INVALID_XNET_SOCKET));
+  invalid_socket.mutable_socket()->set_name("");
 
   auto is_set_response = client::fd_is_set(stub(), invalid_socket.socket(), {invalid_socket.socket()});
 
@@ -342,7 +342,7 @@ TEST_F(NiXnetSocketNoHardwareTests, SocketAndSetContainingSocket_IsSet_ReturnsTr
 TEST_F(NiXnetSocketNoHardwareTests, InvalidSocket_Select_ReturnsAndSetsExpectedErrors)
 {
   SocketResponse invalid_socket;
-  invalid_socket.mutable_socket()->set_id(static_cast<uint32_t>(INVALID_XNET_SOCKET));
+  invalid_socket.mutable_socket()->set_name("");
   auto duration = pb::Duration{};
   duration.set_seconds(1);
   duration.set_nanos(500000);

--- a/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
+++ b/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
@@ -197,7 +197,7 @@ class NiFakeNonIviServiceTests : public ::testing::Test {
 
     ::grpc::ServerContext context;
     InitRequest request;
-    request.set_session_name(session_name.c_str());
+    request.set_session_name(session_name);
     InitResponse response;
 
     service_.Init(&context, &request, &response);

--- a/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
+++ b/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
@@ -190,7 +190,7 @@ class NiFakeNonIviServiceTests : public ::testing::Test {
 
   virtual ~NiFakeNonIviServiceTests() {}
 
-  uint32_t init(const std::string& session_name, FakeHandle handle)
+  std::string init(const std::string& session_name, FakeHandle handle)
   {
     EXPECT_CALL(library_, Init(StrEq(session_name.c_str()), _))
         .WillOnce(DoAll(SetArgPointee<1>(handle), Return(kDriverSuccess)));
@@ -202,10 +202,10 @@ class NiFakeNonIviServiceTests : public ::testing::Test {
 
     service_.Init(&context, &request, &response);
 
-    return response.handle().id();
+    return response.handle().name();
   }
 
-  uint32_t init_secondary_session(const std::string& session_name, SecondarySessionHandle handle)
+  std::string init_secondary_session(const std::string& session_name, SecondarySessionHandle handle)
   {
     EXPECT_CALL(library_, InitSecondarySession(_))
         .WillOnce(DoAll(SetArgPointee<0>(handle), Return(kDriverSuccess)));
@@ -217,10 +217,10 @@ class NiFakeNonIviServiceTests : public ::testing::Test {
 
     service_.InitSecondarySession(&context, &request, &response);
 
-    return response.secondary_session_handle().id();
+    return response.secondary_session_handle().name();
   }
 
-  uint32_t init_with_handle_name_as_session_name(const std::string& handle_name, FakeHandle handle)
+  std::string init_with_handle_name_as_session_name(const std::string& handle_name, FakeHandle handle)
   {
     EXPECT_CALL(library_, InitWithHandleNameAsSessionName(StrEq(handle_name.c_str()), _))
         .WillOnce(DoAll(SetArgPointee<1>(handle), Return(kDriverSuccess)));
@@ -232,29 +232,29 @@ class NiFakeNonIviServiceTests : public ::testing::Test {
 
     service_.InitWithHandleNameAsSessionName(&context, &request, &response);
 
-    return response.handle().id();
+    return response.handle().name();
   }
 
-  int32 close_secondary_session_with_expected_handle(uint32_t session_id, SecondarySessionHandle expected_closed_handle)
+  int32 close_secondary_session_with_expected_handle(std::string session_id, SecondarySessionHandle expected_closed_handle)
   {
     EXPECT_CALL(library_, CloseSecondarySession(expected_closed_handle))
         .WillOnce(Return(kDriverSuccess));
     ::grpc::ServerContext context;
     CloseSecondarySessionRequest request;
-    request.mutable_secondary_session_handle()->set_id(session_id);
+    request.mutable_secondary_session_handle()->set_name(session_id);
     CloseSecondarySessionResponse response;
     service_.CloseSecondarySession(&context, &request, &response);
 
     return response.status();
   }
 
-  int32 close_with_expected_handle(uint32_t session_id, FakeHandle expected_closed_handle)
+  int32 close_with_expected_handle(std::string session_id, FakeHandle expected_closed_handle)
   {
     EXPECT_CALL(library_, Close(expected_closed_handle))
         .WillOnce(Return(kDriverSuccess));
     ::grpc::ServerContext context;
     CloseRequest request;
-    request.mutable_handle()->set_id(session_id);
+    request.mutable_handle()->set_name(session_id);
     CloseResponse response;
     service_.Close(&context, &request, &response);
 
@@ -288,8 +288,8 @@ TEST_F(NiFakeNonIviServiceTests, InitSecondarySession_AddsSessionHandleToSeconda
   const SecondarySessionHandle kHandle = 1234UL;
   auto session = init_secondary_session("test", kHandle);
 
-  EXPECT_NE(0, session);
-  EXPECT_EQ(kHandle, secondary_resource_repository_->access_session(session, ""));
+  EXPECT_NE("", session);
+  EXPECT_EQ(kHandle, secondary_resource_repository_->access_session(session));
 }
 
 TEST_F(NiFakeNonIviServiceTests, InitSecondarySession_CloseSecondarySession_ClosesSecondarySession)
@@ -297,7 +297,7 @@ TEST_F(NiFakeNonIviServiceTests, InitSecondarySession_CloseSecondarySession_Clos
   const SecondarySessionHandle kHandle = 1234UL;
   auto session = init_secondary_session("test", kHandle);
 
-  EXPECT_NE(0, session);
+  EXPECT_NE("", session);
   EXPECT_EQ(kDriverSuccess, close_secondary_session_with_expected_handle(session, kHandle));
 }
 
@@ -305,7 +305,7 @@ TEST_F(NiFakeNonIviServiceTests, InitSession_CloseSession_ClosesHandleAndSucceed
 {
   const FakeHandle kHandle = 1234UL;
   auto session = init("test", kHandle);
-  EXPECT_NE(0, session);
+  EXPECT_NE("", session);
 
   auto status = close_with_expected_handle(session, kHandle);
 
@@ -316,7 +316,7 @@ TEST_F(NiFakeNonIviServiceTests, InitWithHandleNameAsSessionName_CloseSession_Cl
 {
   const FakeHandle kHandle = 99999UL;
   auto session = init_with_handle_name_as_session_name("test", kHandle);
-  EXPECT_NE(0, session);
+  EXPECT_NE("", session);
 
   auto status = close_with_expected_handle(session, kHandle);
 
@@ -1540,12 +1540,11 @@ TEST_F(NiFakeNonIviServiceTests, WriteBooleanArray_PassesBooleansAsInt32s)
 template <typename TSessionRepository, typename TResource>
 void add_session(TSessionRepository& repository, TResource resource_handle, const std::string name)
 {
-  uint32_t session_id;
+  std::string session_name = name;
   repository->add_session(
-      name,
+      session_name,
       [resource_handle]() { return std::make_tuple(0, resource_handle); },
-      [](TResource handle) {},
-      session_id);
+      [](TResource handle) {});
 }
 
 TEST_F(NiFakeNonIviServiceTests, InitFromCrossDriverSession_PassesSessionResourcesAndSucceeds)
@@ -1565,7 +1564,7 @@ TEST_F(NiFakeNonIviServiceTests, InitFromCrossDriverSession_PassesSessionResourc
   service_.InitFromCrossDriverSession(&context, &request, &response);
 
   EXPECT_EQ(kDriverSuccess, response.status());
-  EXPECT_EQ(DRIVER_SESSION, resource_repository_->access_session(response.handle().id(), ""));
+  EXPECT_EQ(DRIVER_SESSION, resource_repository_->access_session(response.handle().name()));
 }
 
 template <size_t N>
@@ -1597,7 +1596,7 @@ TEST_F(NiFakeNonIviServiceTests, InitFromCrossDriverSessionArray_PassesSessionRe
   service_.InitFromCrossDriverSessionArray(&context, &request, &response);
 
   EXPECT_EQ(kDriverSuccess, response.status());
-  EXPECT_EQ(DRIVER_SESSION, resource_repository_->access_session(response.handle().id(), ""));
+  EXPECT_EQ(DRIVER_SESSION, resource_repository_->access_session(response.handle().name()));
 }
 
 TEST_F(NiFakeNonIviServiceTests, GetCrossDriverSession_CloseInitiatingSession_RemovesBothSessions)
@@ -1617,11 +1616,11 @@ TEST_F(NiFakeNonIviServiceTests, GetCrossDriverSession_CloseInitiatingSession_Re
   request.set_session_name(CROSS_DRIVER_SESSION_NAME);
   service_.GetCrossDriverSession(&context, &request, &response);
   EXPECT_EQ(kDriverSuccess, response.status());
-  EXPECT_EQ(cross_driver_resource_repository_->access_session(0, CROSS_DRIVER_SESSION_NAME), CROSS_DRIVER_HANDLE);
+  EXPECT_EQ(cross_driver_resource_repository_->access_session(CROSS_DRIVER_SESSION_NAME), CROSS_DRIVER_HANDLE);
 
   close_with_expected_handle(initiating_session_id, INITIATING_DRIVER_HANDLE);
 
-  EXPECT_EQ(cross_driver_resource_repository_->access_session(0, CROSS_DRIVER_SESSION_NAME), 0);
+  EXPECT_EQ(cross_driver_resource_repository_->access_session(CROSS_DRIVER_SESSION_NAME), 0);
 }
 
 TEST_F(NiFakeNonIviServiceTests, GetCrossDriverSession_ResetServer_RemovesBothSessions)
@@ -1643,8 +1642,8 @@ TEST_F(NiFakeNonIviServiceTests, GetCrossDriverSession_ResetServer_RemovesBothSe
 
   session_repository_.reset_server();
 
-  EXPECT_EQ(cross_driver_resource_repository_->access_session(0, CROSS_DRIVER_SESSION_NAME), 0);
-  EXPECT_EQ(resource_repository_->access_session(0, INITIATING_SESSION_NAME), 0);
+  EXPECT_EQ(cross_driver_resource_repository_->access_session(CROSS_DRIVER_SESSION_NAME), 0);
+  EXPECT_EQ(resource_repository_->access_session(INITIATING_SESSION_NAME), 0);
 }
 
 TEST_F(NiFakeNonIviServiceTests, SessionAlreadyInCrossDriverSessionRepository_GetCrossDriverSessionForSameResourceHandle_ReverseLookupStillReturnsOriginalSession)
@@ -1654,12 +1653,12 @@ TEST_F(NiFakeNonIviServiceTests, SessionAlreadyInCrossDriverSessionRepository_Ge
   constexpr auto INITIATING_SESSION_NAME = "initiating_session";
   constexpr auto CROSS_DRIVER_SESSION_NAME = "cross_driver_session";
   constexpr auto ORIGINAL_NAME_FOR_CROSS_DRIVER_RESOURCE = "original_cross_driver_resource_name";
-  uint32_t original_session_id;
+
+  std::string session_name = ORIGINAL_NAME_FOR_CROSS_DRIVER_RESOURCE;
   cross_driver_resource_repository_->add_session(
-      ORIGINAL_NAME_FOR_CROSS_DRIVER_RESOURCE,
+      session_name,
       [&]() { return std::make_tuple(0, CROSS_DRIVER_HANDLE); },
-      [](FakeCrossDriverHandle handle) {},
-      original_session_id);
+      [](FakeCrossDriverHandle handle) {});
 
   const auto initiating_session_id = init(INITIATING_SESSION_NAME, INITIATING_DRIVER_HANDLE);
   EXPECT_CALL(library_, GetCrossDriverSession(INITIATING_DRIVER_HANDLE, _))
@@ -1672,7 +1671,7 @@ TEST_F(NiFakeNonIviServiceTests, SessionAlreadyInCrossDriverSessionRepository_Ge
   request.set_session_name(CROSS_DRIVER_SESSION_NAME);
   service_.GetCrossDriverSession(&context, &request, &response);
 
-  EXPECT_EQ(original_session_id, cross_driver_resource_repository_->resolve_session_id(CROSS_DRIVER_HANDLE));
+  EXPECT_EQ(session_name, cross_driver_resource_repository_->resolve_session_name(CROSS_DRIVER_HANDLE));
 }
 
 TEST_F(NiFakeNonIviServiceTests, InitWithReturnedSession_AccessSession_ReturnsInitializeSessionHandle)
@@ -1687,7 +1686,7 @@ TEST_F(NiFakeNonIviServiceTests, InitWithReturnedSession_AccessSession_ReturnsIn
   request.set_handle_name(SESSION_NAME);
   service_.InitWithReturnedSession(&context, &request, &response);
 
-  const auto accessed_handle = resource_repository_->access_session(response.handle().id(), "");
+  const auto accessed_handle = resource_repository_->access_session(response.handle().name());
 
   EXPECT_EQ(kDriverSuccess, response.status());
   EXPECT_EQ(SESSION_HANDLE, accessed_handle);
@@ -1706,7 +1705,7 @@ TEST_F(NiFakeNonIviServiceTests, InitWithReturnedSessionFailsInit_AccessSession_
   request.set_handle_name(SESSION_NAME);
   auto status = service_.InitWithReturnedSession(&context, &request, &response);
 
-  const auto accessed_handle = resource_repository_->access_session(response.handle().id(), "");
+  const auto accessed_handle = resource_repository_->access_session(response.handle().name());
 
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(::grpc::StatusCode::UNKNOWN, status.error_code());

--- a/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
+++ b/source/tests/unit/ni_fake_non_ivi_service_tests.cpp
@@ -235,26 +235,26 @@ class NiFakeNonIviServiceTests : public ::testing::Test {
     return response.handle().name();
   }
 
-  int32 close_secondary_session_with_expected_handle(std::string session_id, SecondarySessionHandle expected_closed_handle)
+  int32 close_secondary_session_with_expected_handle(std::string session_name, SecondarySessionHandle expected_closed_handle)
   {
     EXPECT_CALL(library_, CloseSecondarySession(expected_closed_handle))
         .WillOnce(Return(kDriverSuccess));
     ::grpc::ServerContext context;
     CloseSecondarySessionRequest request;
-    request.mutable_secondary_session_handle()->set_name(session_id);
+    request.mutable_secondary_session_handle()->set_name(session_name);
     CloseSecondarySessionResponse response;
     service_.CloseSecondarySession(&context, &request, &response);
 
     return response.status();
   }
 
-  int32 close_with_expected_handle(std::string session_id, FakeHandle expected_closed_handle)
+  int32 close_with_expected_handle(std::string session_name, FakeHandle expected_closed_handle)
   {
     EXPECT_CALL(library_, Close(expected_closed_handle))
         .WillOnce(Return(kDriverSuccess));
     ::grpc::ServerContext context;
     CloseRequest request;
-    request.mutable_handle()->set_name(session_id);
+    request.mutable_handle()->set_name(session_name);
     CloseResponse response;
     service_.Close(&context, &request, &response);
 
@@ -1605,7 +1605,7 @@ TEST_F(NiFakeNonIviServiceTests, GetCrossDriverSession_CloseInitiatingSession_Re
   constexpr auto CROSS_DRIVER_HANDLE = 1234;
   constexpr auto INITIATING_SESSION_NAME = "initiating_session";
   constexpr auto CROSS_DRIVER_SESSION_NAME = "cross_driver_session";
-  const auto initiating_session_id = init(INITIATING_SESSION_NAME, INITIATING_DRIVER_HANDLE);
+  const auto initiating_session_name = init(INITIATING_SESSION_NAME, INITIATING_DRIVER_HANDLE);
   EXPECT_CALL(library_, GetCrossDriverSession(INITIATING_DRIVER_HANDLE, _))
       .WillOnce(DoAll(
           SetArgPointee<1, FakeCrossDriverHandle>(CROSS_DRIVER_HANDLE), Return(kDriverSuccess)));
@@ -1618,7 +1618,7 @@ TEST_F(NiFakeNonIviServiceTests, GetCrossDriverSession_CloseInitiatingSession_Re
   EXPECT_EQ(kDriverSuccess, response.status());
   EXPECT_EQ(cross_driver_resource_repository_->access_session(CROSS_DRIVER_SESSION_NAME), CROSS_DRIVER_HANDLE);
 
-  close_with_expected_handle(initiating_session_id, INITIATING_DRIVER_HANDLE);
+  close_with_expected_handle(initiating_session_name, INITIATING_DRIVER_HANDLE);
 
   EXPECT_EQ(cross_driver_resource_repository_->access_session(CROSS_DRIVER_SESSION_NAME), 0);
 }
@@ -1629,7 +1629,7 @@ TEST_F(NiFakeNonIviServiceTests, GetCrossDriverSession_ResetServer_RemovesBothSe
   constexpr auto CROSS_DRIVER_HANDLE = 1234;
   constexpr auto INITIATING_SESSION_NAME = "initiating_session";
   constexpr auto CROSS_DRIVER_SESSION_NAME = "cross_driver_session";
-  const auto initiating_session_id = init(INITIATING_SESSION_NAME, INITIATING_DRIVER_HANDLE);
+  const auto initiating_session_name = init(INITIATING_SESSION_NAME, INITIATING_DRIVER_HANDLE);
   EXPECT_CALL(library_, GetCrossDriverSession(INITIATING_DRIVER_HANDLE, _))
       .WillOnce(DoAll(
           SetArgPointee<1, FakeCrossDriverHandle>(CROSS_DRIVER_HANDLE), Return(kDriverSuccess)));
@@ -1660,7 +1660,7 @@ TEST_F(NiFakeNonIviServiceTests, SessionAlreadyInCrossDriverSessionRepository_Ge
       [&]() { return std::make_tuple(0, CROSS_DRIVER_HANDLE); },
       [](FakeCrossDriverHandle handle) {});
 
-  const auto initiating_session_id = init(INITIATING_SESSION_NAME, INITIATING_DRIVER_HANDLE);
+  const auto initiating_session_name = init(INITIATING_SESSION_NAME, INITIATING_DRIVER_HANDLE);
   EXPECT_CALL(library_, GetCrossDriverSession(INITIATING_DRIVER_HANDLE, _))
       .WillOnce(DoAll(
           SetArgPointee<1, FakeCrossDriverHandle>(CROSS_DRIVER_HANDLE), Return(kDriverSuccess)));

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -118,8 +118,8 @@ std::string create_session(
   const char* resource_name = "Dev0";
   const char* option_string = "Simulate = 1";
   bool id_query = false, reset_device = true;
-  //EXPECT_CALL(library, InitWithOptions(Pointee(*resource_name), id_query, reset_device, Pointee(*option_string), _))
-  //    .WillOnce(DoAll(SetArgPointee<4>(session_name), Return(kDriverSuccess)));
+  EXPECT_CALL(library, InitWithOptions(Pointee(*resource_name), id_query, reset_device, Pointee(*option_string), _))
+      .WillOnce(DoAll(SetArgPointee<4>(std::atoi(session_name.c_str())), Return(kDriverSuccess)));
 
   ::grpc::ServerContext context;
   nifake_grpc::InitWithOptionsRequest request;
@@ -1995,15 +1995,15 @@ TEST(NiFakeServiceTests, NiFakeService_AcceptViSessionArray_CallsAcceptViSession
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  std::array<std::string, 3> vi_session_array{"12345671", "12345672", "12345673"};
+  std::array<std::uint32_t, 3> vi_session_array{12345671, 12345672, 12345673};
   auto session_id1 = create_session(library, service, vi_session_array[0]);
   auto session_id2 = create_session(library, service, vi_session_array[1]);
   auto session_id3 = create_session(library, service, vi_session_array[2]);
 
   std::uint32_t session_count = 3;
-  //EXPECT_CALL(library, AcceptViSessionArray(session_count, _))
-  //    .With(Args<1, 0>(ElementsAreArray(vi_session_array)))
-  //    .WillOnce(Return(kDriverSuccess));
+  EXPECT_CALL(library, AcceptViSessionArray(session_count, _))
+      .With(Args<1, 0>(ElementsAreArray(vi_session_array)))
+      .WillOnce(Return(kDriverSuccess));
 
   ::grpc::ServerContext context;
   nifake_grpc::AcceptViSessionArrayRequest request;

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -137,9 +137,9 @@ std::string create_session(
 std::string create_session(
     NiFakeMockLibrary& library,
     nifake_grpc::NiFakeService& service,
-    std::uint32_t session_id)
+    std::uint32_t session_name)
 {
-  return create_session(library, service, std::to_string(session_id));
+  return create_session(library, service, std::to_string(session_name));
 }
 
 // Init and Close function tests
@@ -242,8 +242,8 @@ TEST(NiFakeServiceTests, NiFakeServiceWithSession_InitWithOptionsWithInitializeB
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  const char* session_name = "sessionName";
-  auto session_id = create_session(library, service, session_name);
+  const char* default_session_name = "sessionName";
+  auto session_name = create_session(library, service, default_session_name);
   const char* resource_name = "Dev0";
   const char* option_string = "Simulate = 1";
   bool id_query = false, reset_device = true;
@@ -273,8 +273,8 @@ TEST(NiFakeServiceTests, NiFakeServiceWithSession_InitWithOptionsWithAttachBehav
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  const char* session_name = "sessionName";
-  auto session_id = create_session(library, service, session_name);
+  const char* default_session_name = "sessionName";
+  auto session_name = create_session(library, service, default_session_name);
   const char* resource_name = "Dev0";
   const char* option_string = "Simulate = 1";
   bool id_query = false, reset_device = true;
@@ -564,14 +564,14 @@ TEST(NiFakeServiceTests, NiFakeService_FunctionNotFound_DoesNotCallFunction)
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const char* message = "Exception!";
   EXPECT_CALL(library, GetABoolean)
       .WillOnce(Throw(nidevice_grpc::LibraryLoadException(message)));
 
   ::grpc::ServerContext context;
   nifake_grpc::GetABooleanRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetABooleanResponse response;
   ::grpc::Status status = service.GetABoolean(&context, &request, &response);
 
@@ -585,14 +585,14 @@ TEST(NiFakeServiceTests, NiFakeService_FunctionCallErrors_ResponseValuesNotSet)
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   bool a_boolean = true;
   EXPECT_CALL(library, GetABoolean(kTestViSession, _))
       .WillOnce(DoAll(SetArgPointee<1>(a_boolean), Return(kDriverFailure)));
 
   ::grpc::ServerContext context;
   nifake_grpc::GetABooleanRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetABooleanResponse response;
   ::grpc::Status status = service.GetABoolean(&context, &request, &response);
 
@@ -608,14 +608,14 @@ TEST(NiFakeServiceTests, NiFakeService_FunctionCallReturnsWarning_ResponseValueS
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   bool a_boolean = true;
   EXPECT_CALL(library, GetABoolean(kTestViSession, _))
       .WillOnce(DoAll(SetArgPointee<1>(a_boolean), Return(kDriverWarning)));
 
   ::grpc::ServerContext context;
   nifake_grpc::GetABooleanRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetABooleanResponse response;
   ::grpc::Status status = service.GetABoolean(&context, &request, &response);
 
@@ -630,14 +630,14 @@ TEST(NiFakeServiceTests, NiFakeService_GetABoolean_CallsGetABoolean)
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   bool a_boolean = true;
   EXPECT_CALL(library, GetABoolean(kTestViSession, _))
       .WillOnce(DoAll(SetArgPointee<1>(a_boolean), Return(kDriverSuccess)));
 
   ::grpc::ServerContext context;
   nifake_grpc::GetABooleanRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetABooleanResponse response;
   ::grpc::Status status = service.GetABoolean(&context, &request, &response);
 
@@ -653,13 +653,13 @@ TEST(NiFakeServiceTests, NiFakeService_Abort_CallsAbort)
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   EXPECT_CALL(library, Abort(kTestViSession))
       .WillOnce(Return(kDriverSuccess));
 
   ::grpc::ServerContext context;
   nifake_grpc::AbortRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::AbortResponse response;
   ::grpc::Status status = service.Abort(&context, &request, &response);
 
@@ -673,14 +673,14 @@ TEST(NiFakeServiceTests, NiFakeService_GetANumber_CallsGetANumber)
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   std::int16_t a_number = 15;
   EXPECT_CALL(library, GetANumber(kTestViSession, _))
       .WillOnce(DoAll(SetArgPointee<1>(a_number), Return(kDriverSuccess)));
 
   ::grpc::ServerContext context;
   nifake_grpc::GetANumberRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetANumberResponse response;
   ::grpc::Status status = service.GetANumber(&context, &request, &response);
 
@@ -695,14 +695,14 @@ TEST(NiFakeServiceTests, NiFakeService_GetArraySizeForCustomCode_CallsGetArraySi
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   std::int32_t array_size = 1000;
   EXPECT_CALL(library, GetArraySizeForCustomCode(kTestViSession, _))
       .WillOnce(DoAll(SetArgPointee<1>(array_size), Return(kDriverSuccess)));
 
   ::grpc::ServerContext context;
   nifake_grpc::GetArraySizeForCustomCodeRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetArraySizeForCustomCodeResponse response;
   ::grpc::Status status = service.GetArraySizeForCustomCode(&context, &request, &response);
 
@@ -717,7 +717,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViBoolean_CallsGetAttributeVi
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   nifake_grpc::NiFakeAttribute attribute_id = nifake_grpc::NIFAKE_ATTRIBUTE_READ_WRITE_BOOL;
   bool attribute_value = true;
   EXPECT_CALL(library, GetAttributeViBoolean(kTestViSession, Pointee(*kTestChannelName), attribute_id, _))
@@ -725,7 +725,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViBoolean_CallsGetAttributeVi
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAttributeViBooleanRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_channel_name(kTestChannelName);
   request.set_attribute_id(attribute_id);
   nifake_grpc::GetAttributeViBooleanResponse response;
@@ -742,7 +742,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViInt32_CallsGetAttributeViIn
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   nifake_grpc::NiFakeAttribute attribute_id = nifake_grpc::NIFAKE_ATTRIBUTE_READ_WRITE_INTEGER;
   std::int32_t attribute_value = 12345;
   EXPECT_CALL(library, GetAttributeViInt32(kTestViSession, Pointee(*kTestChannelName), attribute_id, _))
@@ -750,7 +750,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViInt32_CallsGetAttributeViIn
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAttributeViInt32Request request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_channel_name(kTestChannelName);
   request.set_attribute_id(attribute_id);
   nifake_grpc::GetAttributeViInt32Response response;
@@ -767,7 +767,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViInt64_CallsGetAttributeViIn
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   nifake_grpc::NiFakeAttribute attribute_id = nifake_grpc::NIFAKE_ATTRIBUTE_READ_WRITE_INT64;
   std::int64_t attribute_value = -12345;
   EXPECT_CALL(library, GetAttributeViInt64(kTestViSession, Pointee(*kTestChannelName), attribute_id, _))
@@ -775,7 +775,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViInt64_CallsGetAttributeViIn
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAttributeViInt64Request request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_channel_name(kTestChannelName);
   request.set_attribute_id(attribute_id);
   nifake_grpc::GetAttributeViInt64Response response;
@@ -792,7 +792,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViReal64_CallsGetAttributeViR
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   nifake_grpc::NiFakeAttribute attribute_id = nifake_grpc::NIFAKE_ATTRIBUTE_READ_WRITE_DOUBLE;
   double attribute_value = 12.345;
   EXPECT_CALL(library, GetAttributeViReal64(kTestViSession, Pointee(*kTestChannelName), attribute_id, _))
@@ -800,7 +800,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViReal64_CallsGetAttributeViR
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAttributeViReal64Request request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_channel_name(kTestChannelName);
   request.set_attribute_id(attribute_id);
   nifake_grpc::GetAttributeViReal64Response response;
@@ -817,7 +817,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetCalDateAndTime_CallsGetCalDateAndTime)
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   std::int32_t cal_type = 0;
   std::int32_t month = 1, day = 17, year = 2021, hour = 0, minute = 0;
   EXPECT_CALL(library, GetCalDateAndTime(kTestViSession, cal_type, _, _, _, _, _))
@@ -831,7 +831,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetCalDateAndTime_CallsGetCalDateAndTime)
 
   ::grpc::ServerContext context;
   nifake_grpc::GetCalDateAndTimeRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_cal_type(cal_type);
   nifake_grpc::GetCalDateAndTimeResponse response;
   ::grpc::Status status = service.GetCalDateAndTime(&context, &request, &response);
@@ -851,7 +851,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetCalInterval_CallsGetCalInterval)
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   nifake_grpc::NiFakeAttribute attribute_id = nifake_grpc::NIFAKE_ATTRIBUTE_READ_WRITE_DOUBLE;
   std::int32_t months = 24;
   EXPECT_CALL(library, GetCalInterval(kTestViSession, _))
@@ -859,7 +859,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetCalInterval_CallsGetCalInterval)
 
   ::grpc::ServerContext context;
   nifake_grpc::GetCalIntervalRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetCalIntervalResponse response;
   ::grpc::Status status = service.GetCalInterval(&context, &request, &response);
 
@@ -874,7 +874,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetEnumValue_CallsGetEnumValue)
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   std::int32_t a_quantity = 123;
   std::int16_t a_turtle = NIFAKE_VAL_LEONARDO;
   EXPECT_CALL(library, GetEnumValue(kTestViSession, _, _))
@@ -882,7 +882,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetEnumValue_CallsGetEnumValue)
 
   ::grpc::ServerContext context;
   nifake_grpc::GetEnumValueRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetEnumValueResponse response;
   ::grpc::Status status = service.GetEnumValue(&context, &request, &response);
 
@@ -899,7 +899,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetEnumValueNotInEnum_CallsGetEnumValue)
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   std::int32_t a_quantity = 123;
   std::int16_t a_turtle = 5;
   EXPECT_CALL(library, GetEnumValue(kTestViSession, _, _))
@@ -907,7 +907,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetEnumValueNotInEnum_CallsGetEnumValue)
 
   ::grpc::ServerContext context;
   nifake_grpc::GetEnumValueRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetEnumValueResponse response;
   ::grpc::Status status = service.GetEnumValue(&context, &request, &response);
 
@@ -925,7 +925,7 @@ TEST(NiFakeServiceTests, NiFakeService_AcceptListOfDurationsInSeconds_CallsAccep
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const double delays[] = {1, 2, 3, 4, 5};
   std::int32_t expected_size = 5;
   EXPECT_CALL(library, AcceptListOfDurationsInSeconds(kTestViSession, expected_size, _))
@@ -934,7 +934,7 @@ TEST(NiFakeServiceTests, NiFakeService_AcceptListOfDurationsInSeconds_CallsAccep
 
   ::grpc::ServerContext context;
   nifake_grpc::AcceptListOfDurationsInSecondsRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   for (double delay : delays) {
     request.add_delays(delay);
   }
@@ -951,7 +951,7 @@ TEST(NiFakeServiceTests, NiFakeService_BoolArrayOutputFunction_CallsBoolArrayOut
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViInt32 number_of_elements = 3;
   ViBoolean an_array[] = {VI_FALSE, VI_TRUE, VI_TRUE};
   EXPECT_CALL(library, BoolArrayOutputFunction(kTestViSession, number_of_elements, _))
@@ -961,7 +961,7 @@ TEST(NiFakeServiceTests, NiFakeService_BoolArrayOutputFunction_CallsBoolArrayOut
 
   ::grpc::ServerContext context;
   nifake_grpc::BoolArrayOutputFunctionRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_number_of_elements(number_of_elements);
   nifake_grpc::BoolArrayOutputFunctionResponse response;
   ::grpc::Status status = service.BoolArrayOutputFunction(&context, &request, &response);
@@ -979,7 +979,7 @@ TEST(NiFakeServiceTests, NiFakeService_BoolArrayInputFunction_CallsBoolArrayInpu
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViInt32 number_of_elements = 3;
   ViBoolean expected_array[] = {VI_FALSE, VI_TRUE, VI_TRUE};
   EXPECT_CALL(library, BoolArrayInputFunction(kTestViSession, number_of_elements, _))
@@ -988,7 +988,7 @@ TEST(NiFakeServiceTests, NiFakeService_BoolArrayInputFunction_CallsBoolArrayInpu
 
   ::grpc::ServerContext context;
   nifake_grpc::BoolArrayInputFunctionRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_number_of_elements(number_of_elements);
   request.add_an_array(false);
   request.add_an_array(true);
@@ -1006,7 +1006,7 @@ TEST(NiFakeServiceTests, NiFakeService_DoubleAllTheNums_CallsDoubleAllTheNums)
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const double numbers[] = {1, 2, 3, 4, 5};
   std::int32_t expected_size = 5;
   EXPECT_CALL(library, DoubleAllTheNums(kTestViSession, expected_size, _))
@@ -1015,7 +1015,7 @@ TEST(NiFakeServiceTests, NiFakeService_DoubleAllTheNums_CallsDoubleAllTheNums)
 
   ::grpc::ServerContext context;
   nifake_grpc::DoubleAllTheNumsRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   for (double number : numbers) {
     request.add_numbers(number);
   }
@@ -1032,7 +1032,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAStringOfFixedMaximumSize_CallsGetAStr
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   char output_string[256] = "Hello World!";
   EXPECT_CALL(library, GetAStringOfFixedMaximumSize(kTestViSession, _))
       .WillOnce(DoAll(
@@ -1041,7 +1041,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAStringOfFixedMaximumSize_CallsGetAStr
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAStringOfFixedMaximumSizeRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetAStringOfFixedMaximumSizeResponse response;
   ::grpc::Status status = service.GetAStringOfFixedMaximumSize(&context, &request, &response);
 
@@ -1056,7 +1056,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetCustomTypeArray_CallsGetCustomTypeArra
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViInt32 number_of_elements = 3;
   std::vector<CustomStruct> cs(number_of_elements);
   EXPECT_CALL(library, GetCustomTypeArray(kTestViSession, number_of_elements, _))
@@ -1064,7 +1064,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetCustomTypeArray_CallsGetCustomTypeArra
 
   ::grpc::ServerContext context;
   nifake_grpc::GetCustomTypeArrayRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_number_of_elements(3);
   nifake_grpc::GetCustomTypeArrayResponse response;
   ::grpc::Status status = service.GetCustomTypeArray(&context, &request, &response);
@@ -1080,7 +1080,7 @@ TEST(NiFakeServiceTests, NiFakeService_ImportAttributeConfigurationBuffer_CallsI
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const std::int8_t char_array[] = {'a', 'b', 'c'};
   std::int32_t expected_size = 3;
   EXPECT_CALL(library, ImportAttributeConfigurationBuffer(kTestViSession, expected_size, _))
@@ -1089,7 +1089,7 @@ TEST(NiFakeServiceTests, NiFakeService_ImportAttributeConfigurationBuffer_CallsI
 
   ::grpc::ServerContext context;
   nifake_grpc::ImportAttributeConfigurationBufferRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   for (std::int8_t character : char_array) {
     request.mutable_configuration()->push_back(character);
   }
@@ -1102,14 +1102,14 @@ TEST(NiFakeServiceTests, NiFakeService_ImportAttributeConfigurationBuffer_CallsI
 
 template <typename TRequest>
 TRequest create_linked_array_request(
-    std::string session_id,
+    std::string session_name,
     const std::vector<double>& values1,
     const std::vector<double>& values2,
     const std::vector<double>& values3,
     const std::vector<double>& values4)
 {
   auto request = TRequest{};
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.mutable_values1()->CopyFrom({values1.cbegin(), values1.cend()});
   request.mutable_values2()->CopyFrom({values2.cbegin(), values2.cend()});
   request.mutable_values3()->CopyFrom({values3.cbegin(), values3.cend()});
@@ -1123,7 +1123,7 @@ TEST(NiFakeServiceTests, NiFakeService_MultipleArraysSameSize_CallsMultipleArray
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const std::vector<double> doubles = {0.2, -2.3, 4.5};
   const auto expected_size = static_cast<std::int32_t>(doubles.size());
   EXPECT_CALL(library, MultipleArraysSameSize(kTestViSession, _, _, _, _, expected_size))
@@ -1135,7 +1135,7 @@ TEST(NiFakeServiceTests, NiFakeService_MultipleArraysSameSize_CallsMultipleArray
       .WillOnce(Return(kDriverSuccess));
 
   ::grpc::ServerContext context;
-  auto request = create_linked_array_request<MultipleArraysSameSizeRequest>(session_id, doubles, doubles, doubles, doubles);
+  auto request = create_linked_array_request<MultipleArraysSameSizeRequest>(session_name, doubles, doubles, doubles, doubles);
   nifake_grpc::MultipleArraysSameSizeResponse response;
   ::grpc::Status status = service.MultipleArraysSameSize(&context, &request, &response);
 
@@ -1149,13 +1149,13 @@ TEST(NiFakeServiceTests, NiFakeService_MultipleArraysSameSize_OneArrayDifferentS
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const std::vector<double> doubles = {0.2, -2.3, 4.5};
   EXPECT_CALL(library, MultipleArraysSameSize)
       .Times(0);
 
   ::grpc::ServerContext context;
-  const auto request = create_linked_array_request<MultipleArraysSameSizeRequest>(session_id, doubles, {doubles.begin() + 1, doubles.end()}, doubles, doubles);
+  const auto request = create_linked_array_request<MultipleArraysSameSizeRequest>(session_name, doubles, {doubles.begin() + 1, doubles.end()}, doubles, doubles);
   nifake_grpc::MultipleArraysSameSizeResponse response;
   ::grpc::Status status = service.MultipleArraysSameSize(&context, &request, &response);
 
@@ -1168,13 +1168,13 @@ TEST(NiFakeServiceTests, NiFakeService_MultipleArraysSameSize_OneArrayWithZeroSi
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const std::vector<double> doubles = {0.2, -2.3, 4.5};
   EXPECT_CALL(library, MultipleArraysSameSize)
       .Times(0);
 
   ::grpc::ServerContext context;
-  const auto request = create_linked_array_request<MultipleArraysSameSizeRequest>(session_id, {}, doubles, doubles, doubles);
+  const auto request = create_linked_array_request<MultipleArraysSameSizeRequest>(session_name, {}, doubles, doubles, doubles);
   nifake_grpc::MultipleArraysSameSizeResponse response;
   ::grpc::Status status = service.MultipleArraysSameSize(&context, &request, &response);
 
@@ -1195,7 +1195,7 @@ TEST(NiFakeServiceTests, NiFakeService_MultipleArraysSameSizeWithOptionals_OneAr
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const auto doubles = std::vector<double>{0.2, -2.3, 4.5};
   const auto fake_structs = std::vector<FakeCustomStruct>{
       create_custom_struct(1, 3.2),
@@ -1211,7 +1211,7 @@ TEST(NiFakeServiceTests, NiFakeService_MultipleArraysSameSizeWithOptionals_OneAr
       .WillOnce(Return(kDriverSuccess));
 
   ::grpc::ServerContext context;
-  auto request = create_linked_array_request<MultipleArraysSameSizeWithOptionalRequest>(session_id, doubles, doubles, doubles, {});
+  auto request = create_linked_array_request<MultipleArraysSameSizeWithOptionalRequest>(session_name, doubles, doubles, doubles, {});
   request.mutable_values5()->CopyFrom({fake_structs.cbegin(), fake_structs.cend()});
   nifake_grpc::MultipleArraysSameSizeWithOptionalResponse response;
   ::grpc::Status status = service.MultipleArraysSameSizeWithOptional(&context, &request, &response);
@@ -1226,7 +1226,7 @@ TEST(NiFakeServiceTests, NiFakeService_MultipleArraysSameSizeWithOptionals_TwoZe
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const std::vector<double> doubles = {0.2, -2.3, 4.5};
   const auto expected_size = static_cast<std::int32_t>(doubles.size());
   EXPECT_CALL(library, MultipleArraysSameSizeWithOptional(kTestViSession, _, nullptr, nullptr, _, nullptr, expected_size))
@@ -1236,7 +1236,7 @@ TEST(NiFakeServiceTests, NiFakeService_MultipleArraysSameSizeWithOptionals_TwoZe
       .WillOnce(Return(kDriverSuccess));
 
   ::grpc::ServerContext context;
-  const auto request = create_linked_array_request<MultipleArraysSameSizeWithOptionalRequest>(session_id, doubles, {}, {}, doubles);
+  const auto request = create_linked_array_request<MultipleArraysSameSizeWithOptionalRequest>(session_name, doubles, {}, {}, doubles);
   nifake_grpc::MultipleArraysSameSizeWithOptionalResponse response;
   ::grpc::Status status = service.MultipleArraysSameSizeWithOptional(&context, &request, &response);
 
@@ -1250,14 +1250,14 @@ TEST(NiFakeServiceTests, NiFakeService_MultipleArraysSameSizeWithOptionals_Diffe
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const std::vector<double> doubles = {1.2, 2.3, 4.5, 6};
   const auto expected_size = static_cast<std::int32_t>(doubles.size());
   EXPECT_CALL(library, MultipleArraysSameSize)
       .Times(0);
 
   ::grpc::ServerContext context;
-  const auto request = create_linked_array_request<MultipleArraysSameSizeWithOptionalRequest>(session_id, {}, doubles, {}, {doubles.begin() + 1, doubles.end()});
+  const auto request = create_linked_array_request<MultipleArraysSameSizeWithOptionalRequest>(session_name, {}, doubles, {}, {doubles.begin() + 1, doubles.end()});
   nifake_grpc::MultipleArraysSameSizeWithOptionalResponse response;
   ::grpc::Status status = service.MultipleArraysSameSizeWithOptional(&context, &request, &response);
 
@@ -1270,7 +1270,7 @@ TEST(NiFakeServiceTests, NiFakeService_MultipleArraysSameSizeWithOptionals_AllEm
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const std::vector<double> empty_doubles = {};
   const auto expected_size = static_cast<std::int32_t>(empty_doubles.size());
   EXPECT_CALL(library, MultipleArraysSameSizeWithOptional(kTestViSession, _, _, _, _, nullptr, expected_size))
@@ -1282,7 +1282,7 @@ TEST(NiFakeServiceTests, NiFakeService_MultipleArraysSameSizeWithOptionals_AllEm
       .WillOnce(Return(kDriverSuccess));
 
   ::grpc::ServerContext context;
-  const auto request = create_linked_array_request<MultipleArraysSameSizeWithOptionalRequest>(session_id, empty_doubles, empty_doubles, empty_doubles, empty_doubles);
+  const auto request = create_linked_array_request<MultipleArraysSameSizeWithOptionalRequest>(session_name, empty_doubles, empty_doubles, empty_doubles, empty_doubles);
   nifake_grpc::MultipleArraysSameSizeWithOptionalResponse response;
   ::grpc::Status status = service.MultipleArraysSameSizeWithOptional(&context, &request, &response);
 
@@ -1296,7 +1296,7 @@ TEST(NiFakeServiceTests, NiFakeService_ParametersAreMultipleTypes_CallsParameter
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   bool a_boolean = true;
   std::int32_t an_int_32 = 35;
   std::int64_t an_int_64 = 42;
@@ -1323,7 +1323,7 @@ TEST(NiFakeServiceTests, NiFakeService_ParametersAreMultipleTypes_CallsParameter
 
   ::grpc::ServerContext context;
   nifake_grpc::ParametersAreMultipleTypesRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_a_boolean(a_boolean);
   request.set_an_int32(an_int_32);
   request.set_an_int64(an_int_64);
@@ -1344,7 +1344,7 @@ TEST(NiFakeServiceTests, NiFakeService_ParametersAreMultipleTypesWithRawValues_C
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   bool a_boolean = true;
   std::int32_t an_int_32 = 35;
   std::int64_t an_int_64 = 42;
@@ -1370,7 +1370,7 @@ TEST(NiFakeServiceTests, NiFakeService_ParametersAreMultipleTypesWithRawValues_C
 
   ::grpc::ServerContext context;
   nifake_grpc::ParametersAreMultipleTypesRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_a_boolean(a_boolean);
   request.set_an_int32(an_int_32);
   request.set_an_int64(an_int_64);
@@ -1391,7 +1391,7 @@ TEST(NiFakeServiceTests, NiFakeService_ParametersAreMultipleTypesWithRawValuesNo
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   bool a_boolean = true;
   std::int32_t an_int_32 = 35;
   std::int64_t an_int_64 = 42;
@@ -1417,7 +1417,7 @@ TEST(NiFakeServiceTests, NiFakeService_ParametersAreMultipleTypesWithRawValuesNo
 
   ::grpc::ServerContext context;
   nifake_grpc::ParametersAreMultipleTypesRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_a_boolean(a_boolean);
   request.set_an_int32(an_int_32);
   request.set_an_int64(an_int_64);
@@ -1438,7 +1438,7 @@ TEST(NiFakeServiceTests, NiFakeService_ReturnANumberAndAString_CallsReturnANumbe
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   std::int16_t a_number = 42;
   char a_string[256] = "Hello World!";
   EXPECT_CALL(library, ReturnANumberAndAString(kTestViSession, _, _))
@@ -1449,7 +1449,7 @@ TEST(NiFakeServiceTests, NiFakeService_ReturnANumberAndAString_CallsReturnANumbe
 
   ::grpc::ServerContext context;
   nifake_grpc::ReturnANumberAndAStringRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::ReturnANumberAndAStringResponse response;
   ::grpc::Status status = service.ReturnANumberAndAString(&context, &request, &response);
 
@@ -1465,7 +1465,7 @@ TEST(NiFakeServiceTests, NiFakeService_ReturnListOfDurationsInSeconds_CallsRetur
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViInt32 number_of_elements = 3;
   ViReal64 timedeltas[] = {1.0, 2, -3.0};
   EXPECT_CALL(library, ReturnListOfDurationsInSeconds(kTestViSession, number_of_elements, _))
@@ -1475,7 +1475,7 @@ TEST(NiFakeServiceTests, NiFakeService_ReturnListOfDurationsInSeconds_CallsRetur
 
   ::grpc::ServerContext context;
   nifake_grpc::ReturnListOfDurationsInSecondsRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_number_of_elements(3);
   nifake_grpc::ReturnListOfDurationsInSecondsResponse response;
   ::grpc::Status status = service.ReturnListOfDurationsInSeconds(&context, &request, &response);
@@ -1493,7 +1493,7 @@ TEST(NiFakeServiceTests, NiFakeService_ReturnMultipleTypes_CallsReturnMultipleTy
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViInt32 array_size = 3;
   ViBoolean a_boolean = false;
   ViInt32 an_int32 = 4;
@@ -1521,7 +1521,7 @@ TEST(NiFakeServiceTests, NiFakeService_ReturnMultipleTypes_CallsReturnMultipleTy
 
   ::grpc::ServerContext context;
   nifake_grpc::ReturnMultipleTypesRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_array_size(3);
   nifake_grpc::ReturnMultipleTypesResponse response;
   ::grpc::Status status = service.ReturnMultipleTypes(&context, &request, &response);
@@ -1547,7 +1547,7 @@ TEST(NiFakeServiceTests, NiFakeService_WriteWaveform_CallsWriteWaveform)
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViReal64 waveforms[] = {53.4, 42, -120.3};
   std::int32_t expected_number_of_samples = 3;
   EXPECT_CALL(library, WriteWaveform(kTestViSession, expected_number_of_samples, _))
@@ -1556,7 +1556,7 @@ TEST(NiFakeServiceTests, NiFakeService_WriteWaveform_CallsWriteWaveform)
 
   ::grpc::ServerContext context;
   nifake_grpc::WriteWaveformRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   for (double waveform : waveforms) {
     request.add_waveform(waveform);
   }
@@ -1573,7 +1573,7 @@ TEST(NiFakeServiceTests, NiFakeService_FetchWaveform_CallsFetchWaveform)
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViInt32 request_number_of_samples = 4;
   ViReal64 actual_doubles[] = {53.4, 42, -120.3};
   ViInt32 actual_number_of_samples = 3;
@@ -1585,7 +1585,7 @@ TEST(NiFakeServiceTests, NiFakeService_FetchWaveform_CallsFetchWaveform)
 
   ::grpc::ServerContext context;
   nifake_grpc::FetchWaveformRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_number_of_samples(request_number_of_samples);
   nifake_grpc::FetchWaveformResponse response;
   ::grpc::Status status = service.FetchWaveform(&context, &request, &response);
@@ -1605,14 +1605,14 @@ TEST(NiFakeServiceTests, NiFakeService_StringValuedEnumInputFunctionWithDefaults
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   nifake_grpc::MobileOSNames a_mobile_o_s_name = nifake_grpc::MOBILE_OS_NAMES_UNSPECIFIED;
   EXPECT_CALL(library, StringValuedEnumInputFunctionWithDefaults)
       .Times(0);
 
   ::grpc::ServerContext context;
   nifake_grpc::StringValuedEnumInputFunctionWithDefaultsRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_a_mobile_os_name_mapped(a_mobile_o_s_name);
   nifake_grpc::StringValuedEnumInputFunctionWithDefaultsResponse response;
   ::grpc::Status status = service.StringValuedEnumInputFunctionWithDefaults(&context, &request, &response);
@@ -1627,7 +1627,7 @@ TEST(NiFakeServiceTests, NiFakeService_StringValuedEnumInputFunctionWithDefaults
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   nifake_grpc::MobileOSNames a_mobile_o_s_name = nifake_grpc::MOBILE_OS_NAMES_ANDROID;
   const char* expected_enum_value = NIFAKE_VAL_ANDROID;
   EXPECT_CALL(library, StringValuedEnumInputFunctionWithDefaults(kTestViSession, Pointee(*expected_enum_value)))
@@ -1635,7 +1635,7 @@ TEST(NiFakeServiceTests, NiFakeService_StringValuedEnumInputFunctionWithDefaults
 
   ::grpc::ServerContext context;
   nifake_grpc::StringValuedEnumInputFunctionWithDefaultsRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_a_mobile_os_name_mapped(a_mobile_o_s_name);
   nifake_grpc::StringValuedEnumInputFunctionWithDefaultsResponse response;
   ::grpc::Status status = service.StringValuedEnumInputFunctionWithDefaults(&context, &request, &response);
@@ -1651,7 +1651,7 @@ TEST(NiFakeServiceTests, NiFakeService_ExportAttributeConfigurationBuffer_CallsE
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViInt8 config_buffer[] = {'A', 'B', 'C'};
   ViInt32 expected_size = 3;
   // ivi-dance call
@@ -1665,7 +1665,7 @@ TEST(NiFakeServiceTests, NiFakeService_ExportAttributeConfigurationBuffer_CallsE
 
   ::grpc::ServerContext context;
   nifake_grpc::ExportAttributeConfigurationBufferRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::ExportAttributeConfigurationBufferResponse response;
   ::grpc::Status status = service.ExportAttributeConfigurationBuffer(&context, &request, &response);
 
@@ -1680,7 +1680,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceString_CallsGetAnIviDanceStr
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViChar char_array[] = {'H', 'E', 'L', 'L', 'O', '\0'};
   ViInt32 expected_size = sizeof(char_array);
   // ivi-dance call
@@ -1694,7 +1694,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceString_CallsGetAnIviDanceStr
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAnIviDanceStringRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetAnIviDanceStringResponse response;
   ::grpc::Status status = service.GetAnIviDanceString(&context, &request, &response);
 
@@ -1710,7 +1710,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetArrayUsingIviDance_CallsGetArrayUsingI
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViReal64 doubles[] = {53.4, 42, -120.3};
   ViInt32 expected_size = 3;
   // ivi-dance call
@@ -1724,7 +1724,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetArrayUsingIviDance_CallsGetArrayUsingI
 
   ::grpc::ServerContext context;
   nifake_grpc::GetArrayUsingIviDanceRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetArrayUsingIviDanceResponse response;
   ::grpc::Status status = service.GetArrayUsingIviDance(&context, &request, &response);
 
@@ -1739,7 +1739,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetArrayUsingIviDanceWithChangingSizesByR
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViReal64 doubles[] = {53.4, 42, -120.3};
   ViInt32 expected_old_size = 2;
   ViInt32 expected_new_size = 3;
@@ -1760,7 +1760,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetArrayUsingIviDanceWithChangingSizesByR
 
   ::grpc::ServerContext context;
   nifake_grpc::GetArrayUsingIviDanceRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetArrayUsingIviDanceResponse response;
   ::grpc::Status status = service.GetArrayUsingIviDance(&context, &request, &response);
 
@@ -1775,7 +1775,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetArrayUsingIviDanceWithChangingSizesByE
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViReal64 doubles[] = {53.4, 42, -120.3};
   ViInt32 expected_old_size = 2;
   ViInt32 expected_new_size = 3;
@@ -1797,7 +1797,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetArrayUsingIviDanceWithChangingSizesByE
 
   ::grpc::ServerContext context;
   nifake_grpc::GetArrayUsingIviDanceRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetArrayUsingIviDanceResponse response;
   ::grpc::Status status = service.GetArrayUsingIviDance(&context, &request, &response);
 
@@ -1812,7 +1812,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViString_CallsGetAttributeViS
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   nifake_grpc::NiFakeAttribute attributeId = nifake_grpc::NIFAKE_ATTRIBUTE_READ_WRITE_DOUBLE;
   ViChar attribute_char_array[] = {'H', 'E', 'L', 'L', 'O', '\0'};
   ViInt32 expected_size = sizeof(attribute_char_array);
@@ -1827,7 +1827,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViString_CallsGetAttributeViS
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAttributeViStringRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_channel_name(kTestChannelName);
   request.set_attribute_id(attributeId);
   nifake_grpc::GetAttributeViStringResponse response;
@@ -1845,14 +1845,14 @@ TEST(NiFakeServiceTests, NiFakeService_GetViUInt8_CallsGetViUInt8)
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViUInt8 a_ViUInt8_number = 0xFF;
   EXPECT_CALL(library, GetViUInt8(kTestViSession, _))
       .WillOnce(DoAll(SetArgPointee<1>(a_ViUInt8_number), Return(kDriverSuccess)));
 
   ::grpc::ServerContext context;
   nifake_grpc::GetViUInt8Request request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetViUInt8Response response;
   ::grpc::Status status = service.GetViUInt8(&context, &request, &response);
 
@@ -1867,7 +1867,7 @@ TEST(NiFakeServiceTests, NiFakeService_ViUInt8ArrayInputFunction_CallsViUInt8Arr
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViInt32 number_of_elements = 3;
   ViUInt8 expected_array[] = {0, 127, 0xFF};
   EXPECT_CALL(library, ViUInt8ArrayInputFunction(kTestViSession, number_of_elements, _))
@@ -1876,7 +1876,7 @@ TEST(NiFakeServiceTests, NiFakeService_ViUInt8ArrayInputFunction_CallsViUInt8Arr
 
   ::grpc::ServerContext context;
   nifake_grpc::ViUInt8ArrayInputFunctionRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_number_of_elements(number_of_elements);
   std::string input_array;
   input_array.push_back(0);
@@ -1896,7 +1896,7 @@ TEST(NiFakeServiceTests, NiFakeService_ViUInt8ArrayOutputFunction_CallsViUInt8Ar
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViInt32 number_of_elements = 3;
   ViUInt8 an_array[] = {0, 127, 0xFF};
   EXPECT_CALL(library, ViUInt8ArrayOutputFunction(kTestViSession, number_of_elements, _))
@@ -1906,7 +1906,7 @@ TEST(NiFakeServiceTests, NiFakeService_ViUInt8ArrayOutputFunction_CallsViUInt8Ar
 
   ::grpc::ServerContext context;
   nifake_grpc::ViUInt8ArrayOutputFunctionRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_number_of_elements(number_of_elements);
   nifake_grpc::ViUInt8ArrayOutputFunctionResponse response;
   ::grpc::Status status = service.ViUInt8ArrayOutputFunction(&context, &request, &response);
@@ -1923,7 +1923,7 @@ TEST(NiFakeServiceTests, NiFakeService_AcceptViUInt32Array_CallsAcceptViUInt32Ar
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   std::uint32_t uint32_array[] = {0, 1, 0xFFFFFFFD, 0xFFFFFFFE, 0xFFFFFFFF};
   std::int32_t array_len = 5;
   EXPECT_CALL(library, AcceptViUInt32Array(kTestViSession, array_len, _))
@@ -1932,7 +1932,7 @@ TEST(NiFakeServiceTests, NiFakeService_AcceptViUInt32Array_CallsAcceptViUInt32Ar
 
   ::grpc::ServerContext context;
   nifake_grpc::AcceptViUInt32ArrayRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.mutable_u_int32_array()->CopyFrom(google::protobuf::RepeatedField<google::protobuf::uint32>(uint32_array, uint32_array + 5));
   nifake_grpc::AcceptViUInt32ArrayResponse response;
   ::grpc::Status status = service.AcceptViUInt32Array(&context, &request, &response);
@@ -1947,7 +1947,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetViInt32Array_CallsGetViInt32Array)
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   int array_len = 4;
   std::int32_t int32_array[] = {-2147483646, -2147483645, 2147483646, 2147483647};
   EXPECT_CALL(library, GetViInt32Array(kTestViSession, array_len, _))
@@ -1955,7 +1955,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetViInt32Array_CallsGetViInt32Array)
 
   ::grpc::ServerContext context;
   nifake_grpc::GetViInt32ArrayRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_array_len(array_len);
   nifake_grpc::GetViInt32ArrayResponse response;
   ::grpc::Status status = service.GetViInt32Array(&context, &request, &response);
@@ -1971,7 +1971,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetViUInt32Array_CallsGetViUInt32Array)
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   int array_len = 4;
   std::uint32_t uint32_array[] = {0, 1, 0xFFFFFFFE, 0xFFFFFFFF};
   EXPECT_CALL(library, GetViUInt32Array(kTestViSession, array_len, _))
@@ -1979,7 +1979,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetViUInt32Array_CallsGetViUInt32Array)
 
   ::grpc::ServerContext context;
   nifake_grpc::GetViUInt32ArrayRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_array_len(array_len);
   nifake_grpc::GetViUInt32ArrayResponse response;
   ::grpc::Status status = service.GetViUInt32Array(&context, &request, &response);
@@ -1996,9 +1996,9 @@ TEST(NiFakeServiceTests, NiFakeService_AcceptViSessionArray_CallsAcceptViSession
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
   std::array<std::uint32_t, 3> vi_session_array{12345671, 12345672, 12345673};
-  auto session_id1 = create_session(library, service, vi_session_array[0]);
-  auto session_id2 = create_session(library, service, vi_session_array[1]);
-  auto session_id3 = create_session(library, service, vi_session_array[2]);
+  auto session_name1 = create_session(library, service, vi_session_array[0]);
+  auto session_name2 = create_session(library, service, vi_session_array[1]);
+  auto session_name3 = create_session(library, service, vi_session_array[2]);
 
   std::uint32_t session_count = 3;
   EXPECT_CALL(library, AcceptViSessionArray(session_count, _))
@@ -2008,9 +2008,9 @@ TEST(NiFakeServiceTests, NiFakeService_AcceptViSessionArray_CallsAcceptViSession
   ::grpc::ServerContext context;
   nifake_grpc::AcceptViSessionArrayRequest request;
   request.set_session_count(session_count);
-  request.add_session_array()->set_name(session_id1);
-  request.add_session_array()->set_name(session_id2);
-  request.add_session_array()->set_name(session_id3);
+  request.add_session_array()->set_name(session_name1);
+  request.add_session_array()->set_name(session_name2);
+  request.add_session_array()->set_name(session_name3);
   nifake_grpc::AcceptViSessionArrayResponse response;
   ::grpc::Status status = service.AcceptViSessionArray(&context, &request, &response);
 
@@ -2035,7 +2035,7 @@ TEST(NiFakeServiceTests, NiFakeService_UseTwoDimensionWithCorrectSize_CallsUseAT
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViInt32 array[] = {1, 2, 2, 3, 3, 3};
   ViInt32 array_lengths[] = {1, 2, 3};
   ViInt32 array_size = 3;
@@ -2046,7 +2046,7 @@ TEST(NiFakeServiceTests, NiFakeService_UseTwoDimensionWithCorrectSize_CallsUseAT
 
   ::grpc::ServerContext context;
   nifake_grpc::UseATwoDimensionParameterRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   for (int arrayval : array) {
     request.add_array(arrayval);
   }
@@ -2067,7 +2067,7 @@ TEST(NiFakeServiceTests, NiFakeService_UseTwoDimensionWithIncorrectSize_FailsUse
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViInt32 array[] = {1, 2, 2, 3, 3, 3};
   ViInt32 array_lengths[] = {2, 5, 6};
 
@@ -2076,7 +2076,7 @@ TEST(NiFakeServiceTests, NiFakeService_UseTwoDimensionWithIncorrectSize_FailsUse
 
   ::grpc::ServerContext context;
   nifake_grpc::UseATwoDimensionParameterRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   for (int arrayval : array) {
     request.add_array(arrayval);
   }
@@ -2098,7 +2098,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArray_CallsGetAnIv
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const char* a_string = "abc";
   ViInt32 array_out[] = {1, 2, 3};
   ViInt32 expected_size = 3;
@@ -2116,7 +2116,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArray_CallsGetAnIv
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAnIviDanceWithATwistArrayRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_a_string(a_string);
   nifake_grpc::GetAnIviDanceWithATwistArrayResponse response;
   ::grpc::Status status = service.GetAnIviDanceWithATwistArray(&context, &request, &response);
@@ -2133,7 +2133,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArrayWithWarning_C
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const char* a_string = "abc";
   const auto data_in = std::array<ViInt32, 4>{0, -1, 100, 5};
   ViInt32 input_size = 2;
@@ -2154,7 +2154,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArrayWithWarning_C
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAnIviDanceWithATwistArrayRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_a_string(a_string);
   nifake_grpc::GetAnIviDanceWithATwistArrayResponse response;
   ::grpc::Status status = service.GetAnIviDanceWithATwistArray(&context, &request, &response);
@@ -2206,7 +2206,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArrayWithBiggerSiz
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const char* a_string = "abc";
   ViInt32 array_out[] = {1, 2, 3};
   ViInt32 expected_old_size = 2;
@@ -2234,7 +2234,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArrayWithBiggerSiz
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAnIviDanceWithATwistArrayRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_a_string(a_string);
   nifake_grpc::GetAnIviDanceWithATwistArrayResponse response;
   ::grpc::Status status = service.GetAnIviDanceWithATwistArray(&context, &request, &response);
@@ -2251,7 +2251,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArrayWithSmallerSi
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const char* a_string = "abc";
   ViInt32 array_out[] = {1, 2, 3};
   ViInt32 expected_old_size = 3;
@@ -2270,7 +2270,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArrayWithSmallerSi
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAnIviDanceWithATwistArrayRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_a_string(a_string);
   nifake_grpc::GetAnIviDanceWithATwistArrayResponse response;
   ::grpc::Status status = service.GetAnIviDanceWithATwistArray(&context, &request, &response);
@@ -2287,7 +2287,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistByteArrayWithSmall
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const auto DATA = std::vector<char>{'a', 'b'};
   const auto NEW_SIZE = static_cast<ViInt32>(DATA.size());
   const auto OLD_SIZE = NEW_SIZE + 1;
@@ -2322,7 +2322,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistStringWithSmallerS
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const auto DATA = std::string("ab");
   // +1 to include null terminator.
   const auto NEW_SIZE = static_cast<ViInt32>(DATA.size() + 1);
@@ -2341,7 +2341,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistStringWithSmallerS
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAnIviDanceWithATwistStringRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetAnIviDanceWithATwistStringResponse response;
   ::grpc::Status status = service.GetAnIviDanceWithATwistString(&context, &request, &response);
 
@@ -2417,7 +2417,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArrayWithChangingS
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const char* a_string = "abc";
   ViInt32 array_out[] = {1, 2, 3};
   ViInt32 expected_old_size = 2;
@@ -2445,7 +2445,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArrayWithChangingS
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAnIviDanceWithATwistArrayRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_a_string(a_string);
   nifake_grpc::GetAnIviDanceWithATwistArrayResponse response;
   ::grpc::Status status = service.GetAnIviDanceWithATwistArray(&context, &request, &response);
@@ -2463,7 +2463,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArrayOfCustomType_
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   CustomStruct array_out[] = {{-1, -2.0}, {0, 0.5}, {70000, 32768.0}};
   ViInt32 expected_size = 3;
   // ivi-dance-with-a-twist call
@@ -2480,7 +2480,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArrayOfCustomType_
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAnIviDanceWithATwistArrayOfCustomTypeRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetAnIviDanceWithATwistArrayOfCustomTypeResponse response;
   ::grpc::Status status = service.GetAnIviDanceWithATwistArrayOfCustomType(&context, &request, &response);
 
@@ -2496,7 +2496,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArrayOfCustomTypeW
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   CustomStruct array_out[] = {{-1, -2.0}, {0, 0.5}, {70000, 32768.0}};
   ViInt32 expected_old_size = 2;
   ViInt32 expected_new_size = 3;
@@ -2523,7 +2523,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArrayOfCustomTypeW
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAnIviDanceWithATwistArrayOfCustomTypeRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetAnIviDanceWithATwistArrayOfCustomTypeResponse response;
   ::grpc::Status status = service.GetAnIviDanceWithATwistArrayOfCustomType(&context, &request, &response);
 
@@ -2539,7 +2539,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArrayOfCustomTypeW
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   CustomStruct array_out[] = {{-1, -2.0}, {0, 0.5}};
   ViInt32 expected_old_size = 3;
   ViInt32 expected_new_size = 2;
@@ -2557,7 +2557,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAnIviDanceWithATwistArrayOfCustomTypeW
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAnIviDanceWithATwistArrayOfCustomTypeRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::GetAnIviDanceWithATwistArrayOfCustomTypeResponse response;
   ::grpc::Status status = service.GetAnIviDanceWithATwistArrayOfCustomType(&context, &request, &response);
 
@@ -2573,7 +2573,7 @@ TEST(NiFakeServiceTests, NiFakeService_AcceptViInt16Array_CallsAcceptViInt16Arra
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   std::int16_t int16_array[] = {0, 1, -0x8000, 0x7FFF};
   std::int32_t array_len = 4;
   EXPECT_CALL(library, ViInt16ArrayInputFunction(kTestViSession, array_len, _))
@@ -2582,7 +2582,7 @@ TEST(NiFakeServiceTests, NiFakeService_AcceptViInt16Array_CallsAcceptViInt16Arra
 
   ::grpc::ServerContext context;
   nifake_grpc::ViInt16ArrayInputFunctionRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.mutable_an_array()->CopyFrom(google::protobuf::RepeatedField<google::protobuf::int32>(int16_array, int16_array + 4));
   nifake_grpc::ViInt16ArrayInputFunctionResponse response;
   ::grpc::Status status = service.ViInt16ArrayInputFunction(&context, &request, &response);
@@ -2597,7 +2597,7 @@ TEST(NiFakeServiceTests, NiFakeService_SetCustomTypeArray_CallsSetCustomTypeArra
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   ViInt32 number_of_elements = 2;
   CustomStruct cs_array[] = {{5, 8.0}, {15, 19.7}};
   EXPECT_CALL(library, SetCustomTypeArray(kTestViSession, number_of_elements, _))
@@ -2606,7 +2606,7 @@ TEST(NiFakeServiceTests, NiFakeService_SetCustomTypeArray_CallsSetCustomTypeArra
 
   ::grpc::ServerContext context;
   nifake_grpc::SetCustomTypeArrayRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   for (int i = 0; i < number_of_elements; i++) {
     request.add_cs();
     request.mutable_cs(i)->set_struct_int(cs_array[i].structInt);
@@ -2625,7 +2625,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetArrayViUInt8WithEnum_CallsGetArrayViUI
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   int array_len = 3;
   ViUInt8 uint8_array[] = {
       nifake_grpc::GrpcColorOverride::GRPC_COLOR_OVERRIDE_RED,
@@ -2645,7 +2645,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetArrayViUInt8WithEnum_CallsGetArrayViUI
 
   ::grpc::ServerContext context;
   nifake_grpc::GetArrayViUInt8WithEnumRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_array_len(array_len);
   nifake_grpc::GetArrayViUInt8WithEnumResponse response;
   ::grpc::Status status = service.GetArrayViUInt8WithEnum(&context, &request, &response);
@@ -2662,7 +2662,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViSession_ReturnsSessionId)
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   nifake_grpc::NiFakeAttribute attribute_id = nifake_grpc::NIFAKE_ATTRIBUTE_READ_WRITE_STRING;
   EXPECT_CALL(library, GetAttributeViSession(kTestViSession, Pointee(*kTestChannelName), attribute_id, _))
       .WillOnce(
@@ -2672,7 +2672,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViSession_ReturnsSessionId)
 
   ::grpc::ServerContext context;
   nifake_grpc::GetAttributeViSessionRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_attribute_id(attribute_id);
   request.set_channel_name(kTestChannelName);
   nifake_grpc::GetAttributeViSessionResponse response;
@@ -2680,7 +2680,7 @@ TEST(NiFakeServiceTests, NiFakeService_GetAttributeViSession_ReturnsSessionId)
 
   EXPECT_TRUE(status.ok());
   EXPECT_EQ(kDriverSuccess, response.status());
-  EXPECT_EQ(session_id, response.attribute_value().name());
+  EXPECT_EQ(session_name, response.attribute_value().name());
 }
 
 TEST(NiFakeServiceTests, NiFakeExtensionService_CallMethodWithSesionStartedByNIFakeService_PassesThroughSession)
@@ -2691,7 +2691,7 @@ TEST(NiFakeServiceTests, NiFakeExtensionService_CallMethodWithSesionStartedByNIF
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
   nifake_extension_grpc::NiFakeExtensionService extension_service(&extension_library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   const ViInt32 kParam = 1234;
   EXPECT_CALL(extension_library, AddCoolFunctionality(kTestViSession, kParam))
       .WillOnce(
@@ -2700,7 +2700,7 @@ TEST(NiFakeServiceTests, NiFakeExtensionService_CallMethodWithSesionStartedByNIF
 
   ::grpc::ServerContext context;
   nifake_extension_grpc::AddCoolFunctionalityRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   request.set_param(kParam);
   nifake_extension_grpc::AddCoolFunctionalityResponse response;
   auto status = extension_service.AddCoolFunctionality(&context, &request, &response);
@@ -2715,7 +2715,7 @@ TEST(NiFakeServiceTests, NiFakeService_CallMethodWithReservedPassNullParam_Passe
   NiFakeMockLibrary library;
   auto resource_repository = std::make_shared<FakeResourceRepository>(&session_repository);
   nifake_grpc::NiFakeService service(&library, resource_repository);
-  auto session_id = create_session(library, service, kTestViSession);
+  auto session_name = create_session(library, service, kTestViSession);
   EXPECT_CALL(library, CommandWithReservedParam(kTestViSession, nullptr))
       .WillOnce(
           DoAll(
@@ -2723,7 +2723,7 @@ TEST(NiFakeServiceTests, NiFakeService_CallMethodWithReservedPassNullParam_Passe
 
   ::grpc::ServerContext context;
   nifake_grpc::CommandWithReservedParamRequest request;
-  request.mutable_vi()->set_name(session_id);
+  request.mutable_vi()->set_name(session_name);
   nifake_grpc::CommandWithReservedParamResponse response;
   auto status = service.CommandWithReservedParam(&context, &request, &response);
 

--- a/source/tests/unit/session_repository_tests.cpp
+++ b/source/tests/unit/session_repository_tests.cpp
@@ -14,27 +14,25 @@ constexpr auto EXPECTED_FIRST_SESSION_ID = 1;
 TEST(SessionRepositoryTests, AddSessionWithNonZeroStatus_ReturnsStatusAndDoesNotStoreSession)
 {
   nidevice_grpc::SessionRepository session_repository;
-  uint32_t session_id = 42;
+  std::string session_id = "42";
   int status = session_repository.add_session(
-      "",
+      session_id,
       [session_id]() { return 1; },
-      NULL,
-      session_id);
+      NULL);
 
   EXPECT_EQ(status, 1);
-  EXPECT_FALSE(session_repository.access_session(session_id, ""));
+  EXPECT_EQ("" , session_repository.access_session(session_id));
 }
 
 TEST(SessionRepositoryTests, AddSessionWithNonZeroStatus_InitializedNewSessionIsFalse)
 {
   nidevice_grpc::SessionRepository session_repository;
-  uint32_t session_id = 42;
+  std::string session_id = "42";
   bool initialized_new_session;
   int status = session_repository.add_session(
-      "",
+      session_id,
       [session_id]() { return 1; },
       NULL,
-      session_id,
       nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED,
       &initialized_new_session);
 
@@ -44,19 +42,17 @@ TEST(SessionRepositoryTests, AddSessionWithNonZeroStatus_InitializedNewSessionIs
 TEST(SessionRepositoryTests, AddSession_StoresSessionWithGivenId)
 {
   nidevice_grpc::SessionRepository session_repository;
-  uint32_t session_id;
+  std::string session_id;
   bool initialized_new_session;
   int status = session_repository.add_session(
-      "",
+      session_id,
       []() { return 0; },
       NULL,
-      session_id,
       nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED,
       &initialized_new_session);
 
   EXPECT_EQ(status, 0);
-  EXPECT_EQ(session_id, EXPECTED_FIRST_SESSION_ID);
-  EXPECT_EQ(session_repository.access_session(session_id, ""), session_id);
+  EXPECT_EQ(session_repository.access_session(session_id), session_id);
   EXPECT_TRUE(initialized_new_session);
 }
 
@@ -64,7 +60,6 @@ TEST(SessionRepositoryTests, NoSessions_AddSessionWithAttachToExistingBehavior_E
 {
   std::string session_name = "session_name";
   nidevice_grpc::SessionRepository session_repository;
-  uint32_t first_session_id;
 
   EXPECT_THROW(
       {
@@ -73,7 +68,6 @@ TEST(SessionRepositoryTests, NoSessions_AddSessionWithAttachToExistingBehavior_E
               session_name,
               []() { return 0; },
               NULL,
-              first_session_id,
               nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_ATTACH_TO_EXISTING);
         }
         catch (const nidevice_grpc::NonDriverException& e) {
@@ -89,67 +83,56 @@ TEST(SessionRepositoryTests, AddNamedSession_StoresSessionWithGivenIdAndName)
 {
   std::string session_name = "session_name";
   nidevice_grpc::SessionRepository session_repository;
-  uint32_t session_id;
   bool initialized_new_session;
   int status = session_repository.add_session(
       session_name,
       []() { return 0; },
       NULL,
-      session_id,
       nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED,
       &initialized_new_session);
 
   EXPECT_EQ(status, 0);
-  EXPECT_EQ(session_id, EXPECTED_FIRST_SESSION_ID);
-  EXPECT_EQ(session_repository.access_session(session_id, ""), session_id);
-  EXPECT_EQ(session_repository.access_session(0, session_name), session_id);
+  EXPECT_EQ(session_repository.access_session(session_name), session_name);
   EXPECT_TRUE(initialized_new_session);
 }
 
 TEST(SessionRepositoryTests, UnnamedSessionAdded_RemoveSession_RemovesSession)
 {
   nidevice_grpc::SessionRepository session_repository;
-  uint32_t session_id;
+  std::string session_id;
   session_repository.add_session(
-      "",
+      session_id,
       []() { return 0; },
-      NULL,
-      session_id);
+      NULL);
 
   session_repository.remove_session(session_id);
 
-  EXPECT_FALSE(session_repository.access_session(session_id, ""));
+  EXPECT_EQ("",  session_repository.access_session(session_id));
 }
 
 TEST(SessionRepositoryTests, NamedSessionAdded_RemoveSession_RemovesSession)
 {
   std::string session_name = "session_name";
   nidevice_grpc::SessionRepository session_repository;
-  uint32_t session_id;
   int status = session_repository.add_session(
       session_name,
       []() { return 0; },
-      NULL,
-      session_id);
+      NULL);
 
-  session_repository.remove_session(session_id);
+  session_repository.remove_session(session_name);
 
-  EXPECT_FALSE(session_repository.access_session(session_id, ""));
-  EXPECT_FALSE(session_repository.access_session(0, session_name));
+  EXPECT_EQ("", session_repository.access_session(session_name));
 }
 
 TEST(SessionRepositoryTests, NamedSessionAdded_AddSessionWithSameName_ReturnsFirstSessionIdAndDoesNotCallInit)
 {
   std::string session_name = "session_name";
   nidevice_grpc::SessionRepository session_repository;
-  uint32_t first_session_id;
   session_repository.add_session(
       session_name,
       []() { return 0; },
-      NULL,
-      first_session_id);
+      NULL);
 
-  uint32_t second_session_id;
   bool init_called = false;
   bool initialized_new_session;
   session_repository.add_session(
@@ -159,27 +142,22 @@ TEST(SessionRepositoryTests, NamedSessionAdded_AddSessionWithSameName_ReturnsFir
         return 0;
       },
       NULL,
-      second_session_id,
       nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED,
       &initialized_new_session);
 
   EXPECT_FALSE(init_called);
   EXPECT_FALSE(initialized_new_session);
-  EXPECT_EQ(first_session_id, second_session_id);
 }
 
 TEST(SessionRepositoryTests, NamedSessionAdded_AddSessionWithSameNameWithInitializeNewBehavior_ExceptionThrown)
 {
   std::string session_name = "session_name";
   nidevice_grpc::SessionRepository session_repository;
-  uint32_t first_session_id;
   session_repository.add_session(
       session_name,
       []() { return 0; },
-      NULL,
-      first_session_id);
+      NULL);
 
-  uint32_t second_session_id;
   bool init_called = false;
   EXPECT_THROW(
       {
@@ -191,7 +169,6 @@ TEST(SessionRepositoryTests, NamedSessionAdded_AddSessionWithSameNameWithInitial
                 return 0;
               },
               NULL,
-              second_session_id,
               nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_INITIALIZE_NEW);
         }
         catch (const nidevice_grpc::NonDriverException& e) {
@@ -207,33 +184,29 @@ TEST(SessionRepositoryTests, NamedSessionAdded_ResetServer_RemovesSession)
 {
   std::string session_name = "session_name";
   nidevice_grpc::SessionRepository session_repository;
-  uint32_t session_id;
   int status = session_repository.add_session(
       session_name,
       []() { return 0; },
-      NULL,
-      session_id);
+      NULL);
 
   bool is_server_reset = session_repository.reset_server();
 
-  EXPECT_FALSE(session_repository.access_session(session_id, ""));
-  EXPECT_FALSE(session_repository.access_session(0, session_name));
+  EXPECT_EQ("", session_repository.access_session(session_name));
   EXPECT_TRUE(is_server_reset);
 }
 
 TEST(SessionRepositoryTests, UnnamedSessionAdded_ResetServer_RemovesSession)
 {
   nidevice_grpc::SessionRepository session_repository;
-  uint32_t session_id;
+  std::string session_id;
   session_repository.add_session(
-      "",
+      session_id,
       []() { return 0; },
-      NULL,
-      session_id);
+      NULL);
 
   bool is_server_reset = session_repository.reset_server();
 
-  EXPECT_FALSE(session_repository.access_session(session_id, ""));
+  EXPECT_EQ("", session_repository.access_session(session_id));
   EXPECT_TRUE(is_server_reset);
 }
 
@@ -241,24 +214,20 @@ TEST(SessionRepositoryTests, NamedAndUnnamedSessionsAdded_ResetServer_RemovesBot
 {
   std::string session_name = "session_name";
   nidevice_grpc::SessionRepository session_repository;
-  uint32_t named_session_id;
   int status = session_repository.add_session(
       session_name,
       []() { return 0; },
-      NULL,
-      named_session_id);
-  uint32_t unnamed_session_id;
+      NULL);
+  std::string unnamed_session_id;
   session_repository.add_session(
-      "",
+      unnamed_session_id,
       []() { return 0; },
-      NULL,
-      unnamed_session_id);
+      NULL);
 
   bool is_server_reset = session_repository.reset_server();
 
-  EXPECT_FALSE(session_repository.access_session(named_session_id, ""));
-  EXPECT_FALSE(session_repository.access_session(0, session_name));
-  EXPECT_FALSE(session_repository.access_session(unnamed_session_id, ""));
+  EXPECT_EQ("", session_repository.access_session(session_name));
+  EXPECT_EQ("", session_repository.access_session(unnamed_session_id));
   EXPECT_TRUE(is_server_reset);
 }
 

--- a/source/tests/unit/session_repository_tests.cpp
+++ b/source/tests/unit/session_repository_tests.cpp
@@ -7,31 +7,31 @@ namespace ni {
 namespace tests {
 namespace unit {
 
-// Starting with session_id 1 isn't functionally important, but we want to start with
+// Starting with session_name 1 isn't functionally important, but we want to start with
 // something intentional. NOT an uninitialized uint.
 constexpr auto EXPECTED_FIRST_SESSION_ID = 1;
 
 TEST(SessionRepositoryTests, AddSessionWithNonZeroStatus_ReturnsStatusAndDoesNotStoreSession)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::string session_id = "42";
+  std::string session_name = "42";
   int status = session_repository.add_session(
-      session_id,
-      [session_id]() { return 1; },
+      session_name,
+      [session_name]() { return 1; },
       NULL);
 
   EXPECT_EQ(status, 1);
-  EXPECT_EQ("" , session_repository.access_session(session_id));
+  EXPECT_EQ("" , session_repository.access_session(session_name));
 }
 
 TEST(SessionRepositoryTests, AddSessionWithNonZeroStatus_InitializedNewSessionIsFalse)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::string session_id = "42";
+  std::string session_name = "42";
   bool initialized_new_session;
   int status = session_repository.add_session(
-      session_id,
-      [session_id]() { return 1; },
+      session_name,
+      [session_name]() { return 1; },
       NULL,
       nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED,
       &initialized_new_session);
@@ -42,17 +42,17 @@ TEST(SessionRepositoryTests, AddSessionWithNonZeroStatus_InitializedNewSessionIs
 TEST(SessionRepositoryTests, AddSession_StoresSessionWithGivenId)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::string session_id;
+  std::string session_name;
   bool initialized_new_session;
   int status = session_repository.add_session(
-      session_id,
+      session_name,
       []() { return 0; },
       NULL,
       nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED,
       &initialized_new_session);
 
   EXPECT_EQ(status, 0);
-  EXPECT_EQ(session_repository.access_session(session_id), session_id);
+  EXPECT_EQ(session_repository.access_session(session_name), session_name);
   EXPECT_TRUE(initialized_new_session);
 }
 
@@ -99,15 +99,15 @@ TEST(SessionRepositoryTests, AddNamedSession_StoresSessionWithGivenIdAndName)
 TEST(SessionRepositoryTests, UnnamedSessionAdded_RemoveSession_RemovesSession)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::string session_id;
+  std::string session_name;
   session_repository.add_session(
-      session_id,
+      session_name,
       []() { return 0; },
       NULL);
 
-  session_repository.remove_session(session_id);
+  session_repository.remove_session(session_name);
 
-  EXPECT_EQ("",  session_repository.access_session(session_id));
+  EXPECT_EQ("",  session_repository.access_session(session_name));
 }
 
 TEST(SessionRepositoryTests, NamedSessionAdded_RemoveSession_RemovesSession)
@@ -198,15 +198,15 @@ TEST(SessionRepositoryTests, NamedSessionAdded_ResetServer_RemovesSession)
 TEST(SessionRepositoryTests, UnnamedSessionAdded_ResetServer_RemovesSession)
 {
   nidevice_grpc::SessionRepository session_repository;
-  std::string session_id;
+  std::string session_name;
   session_repository.add_session(
-      session_id,
+      session_name,
       []() { return 0; },
       NULL);
 
   bool is_server_reset = session_repository.reset_server();
 
-  EXPECT_EQ("", session_repository.access_session(session_id));
+  EXPECT_EQ("", session_repository.access_session(session_name));
   EXPECT_TRUE(is_server_reset);
 }
 
@@ -218,16 +218,16 @@ TEST(SessionRepositoryTests, NamedAndUnnamedSessionsAdded_ResetServer_RemovesBot
       session_name,
       []() { return 0; },
       NULL);
-  std::string unnamed_session_id;
+  std::string unnamed_session_name;
   session_repository.add_session(
-      unnamed_session_id,
+      unnamed_session_name,
       []() { return 0; },
       NULL);
 
   bool is_server_reset = session_repository.reset_server();
 
   EXPECT_EQ("", session_repository.access_session(session_name));
-  EXPECT_EQ("", session_repository.access_session(unnamed_session_id));
+  EXPECT_EQ("", session_repository.access_session(unnamed_session_name));
   EXPECT_TRUE(is_server_reset);
 }
 

--- a/source/tests/unit/session_resource_repository_tests.cpp
+++ b/source/tests/unit/session_resource_repository_tests.cpp
@@ -34,23 +34,23 @@ TEST(SessionResourceRepositoryTests, AddSessionResource_ResourceIsAdded)
       &repository);
 
   const uint64_t kResourceHandle = 0x1111222233334444;
-  std::string session_id("session");
+  std::string session_name("session");
   auto result = resource_repository.add_session(
-      session_id,
+      session_name,
       [=]() { return std::make_tuple(kNoError, kResourceHandle); },
       [](uint64_t handle) {});
 
   EXPECT_EQ(kNoError, result);
-  EXPECT_NE(kNoSessionName, session_id);
+  EXPECT_NE(kNoSessionName, session_name);
   EXPECT_EQ(
       kResourceHandle,
-      resource_repository.access_session(session_id));
+      resource_repository.access_session(session_name));
   EXPECT_EQ(
       kResourceHandle,
-      resource_repository.access_session(session_id));
+      resource_repository.access_session(session_name));
   EXPECT_EQ(
-      session_id,
-      repository.access_session(session_id));
+      session_name,
+      repository.access_session(session_name));
 }
 
 TEST(SessionResourceRepositoryTests, AddTwoSessionsWithSameResourceHandle_RemoveOneSession_ResourceStillAccessible)
@@ -59,24 +59,24 @@ TEST(SessionResourceRepositoryTests, AddTwoSessionsWithSameResourceHandle_Remove
   SessionResourceRepository<uint64_t> resource_repository(
       &repository);
   const uint64_t kResourceHandle = 0x1234;
-  auto session_id_one = add_session_resource(resource_repository, kResourceHandle);
-  auto session_id_two = add_session_resource(resource_repository, kResourceHandle);
-  EXPECT_NE(session_id_one, session_id_two);
+  auto session_name_one = add_session_resource(resource_repository, kResourceHandle);
+  auto session_name_two = add_session_resource(resource_repository, kResourceHandle);
+  EXPECT_NE(session_name_one, session_name_two);
   EXPECT_EQ(
       kResourceHandle,
-      resource_repository.access_session(session_id_one));
+      resource_repository.access_session(session_name_one));
   EXPECT_EQ(
       kResourceHandle,
-      resource_repository.access_session(session_id_two));
+      resource_repository.access_session(session_name_two));
 
-  resource_repository.remove_session(session_id_one);
+  resource_repository.remove_session(session_name_one);
 
   EXPECT_EQ(
       kNoSession,
-      resource_repository.access_session(session_id_one));
+      resource_repository.access_session(session_name_one));
   EXPECT_EQ(
       kResourceHandle,
-      resource_repository.access_session(session_id_two));
+      resource_repository.access_session(session_name_two));
 }
 
 TEST(SessionResourceRepositoryTests, SessionResource_RemoveSession_ResourceIsRemoved)
@@ -85,16 +85,16 @@ TEST(SessionResourceRepositoryTests, SessionResource_RemoveSession_ResourceIsRem
   SessionResourceRepository<uint16_t> resource_repository(
       &repository);
   const uint16_t kResourceHandle = 0x1234;
-  auto session_id = add_session_resource(resource_repository, kResourceHandle);
+  auto session_name = add_session_resource(resource_repository, kResourceHandle);
 
-  repository.remove_session(session_id);
+  repository.remove_session(session_name);
 
   EXPECT_EQ(
       kNoSession,
-      resource_repository.access_session(session_id));
+      resource_repository.access_session(session_name));
   EXPECT_EQ(
       kNoSessionName,
-      repository.access_session(session_id));
+      repository.access_session(session_name));
 }
 
 TEST(SessionResourceRepositoryTests, SessionResource_RemoveFromResourceRepository_ResourceIsRemoved)
@@ -103,18 +103,18 @@ TEST(SessionResourceRepositoryTests, SessionResource_RemoveFromResourceRepositor
   SessionResourceRepository<int64_t> resource_repository(
       &repository);
   const int64_t kResourceHandle = 68686868;
-  auto session_id = add_session_resource(resource_repository, kResourceHandle);
+  auto session_name = add_session_resource(resource_repository, kResourceHandle);
 
   // Remove from the SessionResourceRepository and ensure that it removes from the
   // SessionRepository and SessionResourceRepository.
-  resource_repository.remove_session(session_id);
+  resource_repository.remove_session(session_name);
 
   EXPECT_EQ(
       kNoSessionName,
-      repository.access_session(session_id));
+      repository.access_session(session_name));
   EXPECT_EQ(
       0,
-      resource_repository.access_session(session_id));
+      resource_repository.access_session(session_name));
   EXPECT_EQ(
       kNoSessionName,
       resource_repository.resolve_session_name(kResourceHandle));
@@ -126,13 +126,13 @@ TEST(SessionResourceRepositoryTests, SessionResource_ResetServer_ResourceIsRemov
   SessionResourceRepository<int64_t> resource_repository(
       &repository);
   const int64_t kResourceHandle = -9847465247263584;
-  auto session_id = add_session_resource(resource_repository, kResourceHandle);
+  auto session_name = add_session_resource(resource_repository, kResourceHandle);
 
   repository.reset_server();
 
   EXPECT_EQ(
       kNoSession,
-      resource_repository.access_session(session_id));
+      resource_repository.access_session(session_name));
 }
 
 TEST(SessionResourceRepositoryTests, SessionResource_ResetServer_CleanupIsCalled)
@@ -179,20 +179,20 @@ TEST(SessionResourceRepositoryTests, MultipleResourceRepositories_AddResourceToE
       &repository);
 
   const int32_t kIntResourceHandle = -123456;
-  auto int_session_id = add_session_resource(
+  auto int_session_name = add_session_resource(
       int_resource_repository,
       kIntResourceHandle);
   const std::string kStringResourceHandle("RESOURCE_HANDLE");
-  auto string_session_id = add_session_resource(
+  auto string_session_name = add_session_resource(
       string_resource_repository,
       kStringResourceHandle);
 
   EXPECT_EQ(
       kIntResourceHandle,
-      int_resource_repository.access_session(int_session_id));
+      int_resource_repository.access_session(int_session_name));
   EXPECT_EQ(
       kStringResourceHandle,
-      string_resource_repository.access_session(string_session_id));
+      string_resource_repository.access_session(string_session_name));
 }
 
 TEST(SessionResourceRepositoryTests, AddMultipleResources_ResourcesAreAdded)
@@ -202,20 +202,20 @@ TEST(SessionResourceRepositoryTests, AddMultipleResources_ResourcesAreAdded)
       &repository);
 
   const int32_t kResourceHandle1 = -123456;
-  auto session_id_1 = add_session_resource(
+  auto session_name_1 = add_session_resource(
       resource_repository,
       kResourceHandle1);
   const int32_t kResourceHandle2 = 654321;
-  auto session_id_2 = add_session_resource(
+  auto session_name_2 = add_session_resource(
       resource_repository,
       kResourceHandle2);
 
   EXPECT_EQ(
       kResourceHandle1,
-      resource_repository.access_session(session_id_1));
+      resource_repository.access_session(session_name_1));
   EXPECT_EQ(
       kResourceHandle2,
-      resource_repository.access_session(session_id_2));
+      resource_repository.access_session(session_name_2));
 }
 
 TEST(SessionResourceRepositoryTests, AddSessionResource_AccessFromDifferentRepository_DoesNotReturnSession)
@@ -226,12 +226,12 @@ TEST(SessionResourceRepositoryTests, AddSessionResource_AccessFromDifferentRepos
   SessionResourceRepository<int32_t> other_resource_repository(
       &repository);
   const int32_t kResourceHandle1 = -123456;
-  auto session_id = add_session_resource(
+  auto session_name = add_session_resource(
       resource_repository,
       kResourceHandle1);
 
   auto session_from_other_repository =
-      other_resource_repository.access_session(session_id);
+      other_resource_repository.access_session(session_name);
 
   EXPECT_EQ(kNoSession, session_from_other_repository);
 }
@@ -273,30 +273,30 @@ TEST(SessionResourceRepositoryTests, AddSessionResource_AddSessionWithSameNameFr
 template <typename TResource>
 std::string simple_add_session(SessionResourceRepository<TResource> resource_repository, const std::string& session_name, TResource new_resource_handle)
 {
-  std::string session_id = session_name;
+  std::string mutable_session_name = session_name;
   const auto status = resource_repository.add_session(
-      session_id,
+      mutable_session_name,
       [new_resource_handle]() { return std::make_tuple(0, new_resource_handle); },
       [](TResource handle) {});
   EXPECT_EQ(0, status);
-  return session_id;
+  return mutable_session_name;
 }
 
 template <typename TResource>
 std::string simple_add_dependent_session(
     SessionResourceRepository<TResource> resource_repository,
     const std::string& session_name,
-    const std::string& initiating_session_id,
+    const std::string& initiating_session_name,
     TResource new_resource_handle)
 {
-  std::string session_id = session_name;
-  std::string initiating_session_name = initiating_session_id;
+  std::string mutable_session_name = session_name;
+  std::string mutable_initiating_session_name = initiating_session_name;
   const auto status = resource_repository.add_dependent_session(
-      session_id,
+      mutable_session_name,
       [new_resource_handle]() { return std::make_tuple(0, new_resource_handle); },
-      initiating_session_name);
+      mutable_initiating_session_name);
   EXPECT_EQ(0, status);
-  return session_id;
+  return mutable_session_name;
 }
 
 // Note: this is the key functional criteria. Make sure that dependent sessions can't "overwrite" primary sessions in the reverse lookup.
@@ -307,12 +307,12 @@ TEST(SessionResourceRepositoryTests, SessionAlreadyInResourceRepository_AddDepen
   constexpr auto INITIATING_SESSION_HANDLE = 5678U;
   SessionRepository repository;
   SessionResourceRepository<uint32_t> resource_repository(&repository);
-  const auto initiating_session_id = simple_add_session(resource_repository, "initiating_session", INITIATING_SESSION_HANDLE);
-  const auto primary_with_dupe_session_id = simple_add_session(resource_repository, "primary_session_with_dupe_handle", DUPE_SESSION_HANDLE);
+  const auto initiating_session_name = simple_add_session(resource_repository, "initiating_session", INITIATING_SESSION_HANDLE);
+  const auto primary_with_dupe_session_name = simple_add_session(resource_repository, "primary_session_with_dupe_handle", DUPE_SESSION_HANDLE);
 
-  const auto dupe_dependent_session_id = simple_add_dependent_session(resource_repository, "dependent_session", initiating_session_id, DUPE_SESSION_HANDLE);
+  const auto dupe_dependent_session_name = simple_add_dependent_session(resource_repository, "dependent_session", initiating_session_name, DUPE_SESSION_HANDLE);
 
-  EXPECT_EQ(primary_with_dupe_session_id, resource_repository.resolve_session_name(DUPE_SESSION_HANDLE));
+  EXPECT_EQ(primary_with_dupe_session_name, resource_repository.resolve_session_name(DUPE_SESSION_HANDLE));
 }
 
 // Note: This is how the above criteria (SessionAlreadyInResourceRepository_AddDependentSessionWithSameHandle_ResolveSessionByHandleGivesOriginalSession)
@@ -325,8 +325,8 @@ TEST(SessionResourceRepositoryTests, AddDependentSession_DependentSessionIsNotRe
   constexpr auto INITIATING_SESSION_HANDLE = 5678U;
   SessionRepository repository;
   SessionResourceRepository<uint32_t> resource_repository(&repository);
-  const auto initiating_session_id = simple_add_session(resource_repository, "initiating_session", INITIATING_SESSION_HANDLE);
-  const auto dupe_dependent_session_id = simple_add_dependent_session(resource_repository, "dependent_session", initiating_session_id, DEPENDENT_SESSION_HANDLE);
+  const auto initiating_session_name = simple_add_session(resource_repository, "initiating_session", INITIATING_SESSION_HANDLE);
+  const auto dupe_dependent_session_name = simple_add_dependent_session(resource_repository, "dependent_session", initiating_session_name, DEPENDENT_SESSION_HANDLE);
 
   EXPECT_EQ("", resource_repository.resolve_session_name(DEPENDENT_SESSION_HANDLE));
 }
@@ -337,12 +337,12 @@ TEST(SessionResourceRepositoryTests, AddDependentSession_RemoveDependentSession_
   constexpr auto INITIATING_SESSION_HANDLE = 5678U;
   SessionRepository repository;
   SessionResourceRepository<uint32_t> resource_repository(&repository);
-  const auto initiating_session_id = simple_add_session(resource_repository, "initiating_session", INITIATING_SESSION_HANDLE);
-  const auto dependent_session_id = simple_add_dependent_session(resource_repository, "dependent_session", initiating_session_id, DEPENDENT_SESSION_HANDLE);
+  const auto initiating_session_name = simple_add_session(resource_repository, "initiating_session", INITIATING_SESSION_HANDLE);
+  const auto dependent_session_name = simple_add_dependent_session(resource_repository, "dependent_session", initiating_session_name, DEPENDENT_SESSION_HANDLE);
 
-  resource_repository.remove_session(dependent_session_id);
+  resource_repository.remove_session(dependent_session_name);
 
-  EXPECT_EQ(0, resource_repository.access_session(dependent_session_id));
+  EXPECT_EQ(0, resource_repository.access_session(dependent_session_name));
 }
 
 TEST(SessionResourceRepositoryTests, AddDependentSession_RemoveInitiatingSession_BothSessionsAreRemoved)
@@ -351,13 +351,13 @@ TEST(SessionResourceRepositoryTests, AddDependentSession_RemoveInitiatingSession
   constexpr auto INITIATING_SESSION_HANDLE = 5678U;
   SessionRepository repository;
   SessionResourceRepository<uint32_t> resource_repository(&repository);
-  const auto initiating_session_id = simple_add_session(resource_repository, "initiating_session", INITIATING_SESSION_HANDLE);
-  const auto dependent_session_id = simple_add_dependent_session(resource_repository, "dependent_session", initiating_session_id, DEPENDENT_SESSION_HANDLE);
+  const auto initiating_session_name = simple_add_session(resource_repository, "initiating_session", INITIATING_SESSION_HANDLE);
+  const auto dependent_session_name = simple_add_dependent_session(resource_repository, "dependent_session", initiating_session_name, DEPENDENT_SESSION_HANDLE);
 
-  resource_repository.remove_session(initiating_session_id);
+  resource_repository.remove_session(initiating_session_name);
 
-  EXPECT_EQ(0, resource_repository.access_session(initiating_session_id));
-  EXPECT_EQ(0, resource_repository.access_session(dependent_session_id));
+  EXPECT_EQ(0, resource_repository.access_session(initiating_session_name));
+  EXPECT_EQ(0, resource_repository.access_session(dependent_session_name));
 }
 
 }  // namespace unit

--- a/source/tests/unit/xnet_socket_converters_tests.cpp
+++ b/source/tests/unit/xnet_socket_converters_tests.cpp
@@ -142,9 +142,9 @@ ResourceRepositoryHolder create_resource_repository(std::unordered_map<std::stri
 {
   auto repository = ResourceRepositoryHolder{};
   for (const auto pair : socket_sessions) {
-    uint32_t session_id;
+    std::string session_name = pair.first;
     repository.resource_repository->add_session(
-        pair.first, [pair]() { return std::make_tuple(0, pair.second); }, nullptr, session_id);
+        session_name, [pair]() { return std::make_tuple(0, pair.second); }, nullptr);
   }
 
   return repository;


### PR DESCRIPTION
### What does this Pull Request accomplish?

* Having both name and id is somewhat confusing
* It makes using the session in interactive tools like bloom RPC difficult, since oneof is a little complex to use.

I don't think ID should ever be used.  There are a lot of advantages to keeping the data on the wire "time invariant" or independent on server state.  For example, we are trying to do batching to improve throughput when doing "cloud-based measurements" as part of various LTIs and hopefully products.

Even if we remove id we can still maintain the current behavior by generating a name if the client does not specify. Clients who use name should not need to make any changes to their code. The wire format does not break for clients who use name, so we don't even need to require clients change. The wire format does not really break for clients that use id since they can't set it and our server will stop setting it. Clients who use id should be treating Session as an opaque structure since there is nothing they can do with name.

### Why should this Pull Request be merged?

General improvement to grpc-device.

### What testing has been done?

Existing test suite updated.
