### PR TITLE
Latest niscope d87 metadata with new methods.

### DIFF
--- a/generated/niscope/niscope.proto
+++ b/generated/niscope/niscope.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SCOPE API metadata version 23.0.0
+// This file is generated from NI-SCOPE API metadata version 23.0.0d87
 //---------------------------------------------------------------------
 // Proto file for the NI-SCOPE Metadata
 //---------------------------------------------------------------------
@@ -27,6 +27,8 @@ service NiScope {
   rpc AutoSetup(AutoSetupRequest) returns (AutoSetupResponse);
   rpc CableSenseSignalStart(CableSenseSignalStartRequest) returns (CableSenseSignalStartResponse);
   rpc CableSenseSignalStop(CableSenseSignalStopRequest) returns (CableSenseSignalStopResponse);
+  rpc CalFetchDate(CalFetchDateRequest) returns (CalFetchDateResponse);
+  rpc CalFetchTemperature(CalFetchTemperatureRequest) returns (CalFetchTemperatureResponse);
   rpc CalSelfCalibrate(CalSelfCalibrateRequest) returns (CalSelfCalibrateResponse);
   rpc CheckAttributeViBoolean(CheckAttributeViBooleanRequest) returns (CheckAttributeViBooleanResponse);
   rpc CheckAttributeViInt32(CheckAttributeViInt32Request) returns (CheckAttributeViInt32Response);
@@ -365,6 +367,12 @@ enum ArrayMeasurement {
   ARRAY_MEASUREMENT_NISCOPE_VAL_ARRAY_GAIN = 4026;
 }
 
+enum CalibrationTypes {
+  CALIBRATION_TYPES_NISCOPE_VAL_CAL_EXTERNAL = 0;
+  CALIBRATION_TYPES_NISCOPE_VAL_CAL_SELF = 1;
+  CALIBRATION_TYPES_NISCOPE_VAL_CAL_MANUFACTURE = 2;
+}
+
 enum ClearableMeasurement {
   CLEARABLE_MEASUREMENT_NISCOPE_VAL_RISE_TIME = 0;
   CLEARABLE_MEASUREMENT_NISCOPE_VAL_ALL_MEASUREMENTS = 10000;
@@ -465,8 +473,8 @@ enum ExportableSignals {
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_ADVANCE_EVENT = 6;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_START_EVENT = 7;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_REF_EVENT = 10;
-  EXPORTABLE_SIGNALS_NISCOPE_VAL_5V_OUT = 13;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_REF_CLOCK = 100;
+  EXPORTABLE_SIGNALS_NISCOPE_VAL_5V_OUT = 13;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_SAMPLE_CLOCK = 101;
 }
 
@@ -922,6 +930,34 @@ message CableSenseSignalStopRequest {
 
 message CableSenseSignalStopResponse {
   int32 status = 1;
+}
+
+message CalFetchDateRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof which_one_enum {
+    CalibrationTypes which_one = 2;
+    sint32 which_one_raw = 3;
+  }
+}
+
+message CalFetchDateResponse {
+  int32 status = 1;
+  sint32 year = 2;
+  sint32 month = 3;
+  sint32 day = 4;
+}
+
+message CalFetchTemperatureRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof which_one_enum {
+    CalibrationTypes which_one = 2;
+    sint32 which_one_raw = 3;
+  }
+}
+
+message CalFetchTemperatureResponse {
+  int32 status = 1;
+  double temperature = 2;
 }
 
 message CalSelfCalibrateRequest {

--- a/generated/niscope/niscope_client.cpp
+++ b/generated/niscope/niscope_client.cpp
@@ -206,6 +206,56 @@ cable_sense_signal_stop(const StubPtr& stub, const nidevice_grpc::Session& vi)
   return response;
 }
 
+CalFetchDateResponse
+cal_fetch_date(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<CalibrationTypes, pb::int32>& which_one)
+{
+  ::grpc::ClientContext context;
+
+  auto request = CalFetchDateRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+  const auto which_one_ptr = which_one.get_if<CalibrationTypes>();
+  const auto which_one_raw_ptr = which_one.get_if<pb::int32>();
+  if (which_one_ptr) {
+    request.set_which_one(*which_one_ptr);
+  }
+  else if (which_one_raw_ptr) {
+    request.set_which_one_raw(*which_one_raw_ptr);
+  }
+
+  auto response = CalFetchDateResponse{};
+
+  raise_if_error(
+      stub->CalFetchDate(&context, request, &response),
+      context);
+
+  return response;
+}
+
+CalFetchTemperatureResponse
+cal_fetch_temperature(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<CalibrationTypes, pb::int32>& which_one)
+{
+  ::grpc::ClientContext context;
+
+  auto request = CalFetchTemperatureRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+  const auto which_one_ptr = which_one.get_if<CalibrationTypes>();
+  const auto which_one_raw_ptr = which_one.get_if<pb::int32>();
+  if (which_one_ptr) {
+    request.set_which_one(*which_one_ptr);
+  }
+  else if (which_one_raw_ptr) {
+    request.set_which_one_raw(*which_one_raw_ptr);
+  }
+
+  auto response = CalFetchTemperatureResponse{};
+
+  raise_if_error(
+      stub->CalFetchTemperature(&context, request, &response),
+      context);
+
+  return response;
+}
+
 CalSelfCalibrateResponse
 cal_self_calibrate(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_list, const simple_variant<Option, pb::int32>& option)
 {

--- a/generated/niscope/niscope_client.h
+++ b/generated/niscope/niscope_client.h
@@ -32,6 +32,8 @@ AdjustSampleClockRelativeDelayResponse adjust_sample_clock_relative_delay(const 
 AutoSetupResponse auto_setup(const StubPtr& stub, const nidevice_grpc::Session& vi);
 CableSenseSignalStartResponse cable_sense_signal_start(const StubPtr& stub, const nidevice_grpc::Session& vi);
 CableSenseSignalStopResponse cable_sense_signal_stop(const StubPtr& stub, const nidevice_grpc::Session& vi);
+CalFetchDateResponse cal_fetch_date(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<CalibrationTypes, pb::int32>& which_one);
+CalFetchTemperatureResponse cal_fetch_temperature(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<CalibrationTypes, pb::int32>& which_one);
 CalSelfCalibrateResponse cal_self_calibrate(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_list, const simple_variant<Option, pb::int32>& option);
 CheckAttributeViBooleanResponse check_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_list, const NiScopeAttribute& attribute_id, const bool& value);
 CheckAttributeViInt32Response check_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_list, const NiScopeAttribute& attribute_id, const simple_variant<NiScopeInt32AttributeValues, pb::int32>& value);

--- a/generated/niscope/niscope_library.cpp
+++ b/generated/niscope/niscope_library.cpp
@@ -31,6 +31,8 @@ NiScopeLibrary::NiScopeLibrary() : shared_library_(kLibraryName)
   function_pointers_.AutoSetup = reinterpret_cast<AutoSetupPtr>(shared_library_.get_function_pointer("niScope_AutoSetup"));
   function_pointers_.CableSenseSignalStart = reinterpret_cast<CableSenseSignalStartPtr>(shared_library_.get_function_pointer("niScope_CableSenseSignalStart"));
   function_pointers_.CableSenseSignalStop = reinterpret_cast<CableSenseSignalStopPtr>(shared_library_.get_function_pointer("niScope_CableSenseSignalStop"));
+  function_pointers_.CalFetchDate = reinterpret_cast<CalFetchDatePtr>(shared_library_.get_function_pointer("niScope_CalFetchDate"));
+  function_pointers_.CalFetchTemperature = reinterpret_cast<CalFetchTemperaturePtr>(shared_library_.get_function_pointer("niScope_CalFetchTemperature"));
   function_pointers_.CalSelfCalibrate = reinterpret_cast<CalSelfCalibratePtr>(shared_library_.get_function_pointer("niScope_CalSelfCalibrate"));
   function_pointers_.CheckAttributeViBoolean = reinterpret_cast<CheckAttributeViBooleanPtr>(shared_library_.get_function_pointer("niScope_CheckAttributeViBoolean"));
   function_pointers_.CheckAttributeViInt32 = reinterpret_cast<CheckAttributeViInt32Ptr>(shared_library_.get_function_pointer("niScope_CheckAttributeViInt32"));
@@ -241,6 +243,30 @@ ViStatus NiScopeLibrary::CableSenseSignalStop(ViSession vi)
   return niScope_CableSenseSignalStop(vi);
 #else
   return function_pointers_.CableSenseSignalStop(vi);
+#endif
+}
+
+ViStatus NiScopeLibrary::CalFetchDate(ViSession vi, ViInt32 whichOne, ViInt32* year, ViInt32* month, ViInt32* day)
+{
+  if (!function_pointers_.CalFetchDate) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niScope_CalFetchDate.");
+  }
+#if defined(_MSC_VER)
+  return niScope_CalFetchDate(vi, whichOne, year, month, day);
+#else
+  return function_pointers_.CalFetchDate(vi, whichOne, year, month, day);
+#endif
+}
+
+ViStatus NiScopeLibrary::CalFetchTemperature(ViSession vi, ViInt32 whichOne, ViReal64* temperature)
+{
+  if (!function_pointers_.CalFetchTemperature) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niScope_CalFetchTemperature.");
+  }
+#if defined(_MSC_VER)
+  return niScope_CalFetchTemperature(vi, whichOne, temperature);
+#else
+  return function_pointers_.CalFetchTemperature(vi, whichOne, temperature);
 #endif
 }
 

--- a/generated/niscope/niscope_library.h
+++ b/generated/niscope/niscope_library.h
@@ -28,6 +28,8 @@ class NiScopeLibrary : public niscope_grpc::NiScopeLibraryInterface {
   ViStatus AutoSetup(ViSession vi);
   ViStatus CableSenseSignalStart(ViSession vi);
   ViStatus CableSenseSignalStop(ViSession vi);
+  ViStatus CalFetchDate(ViSession vi, ViInt32 whichOne, ViInt32* year, ViInt32* month, ViInt32* day);
+  ViStatus CalFetchTemperature(ViSession vi, ViInt32 whichOne, ViReal64* temperature);
   ViStatus CalSelfCalibrate(ViSession vi, ViConstString channelList, ViInt32 option);
   ViStatus CheckAttributeViBoolean(ViSession vi, ViConstString channelList, ViAttr attributeId, ViBoolean value);
   ViStatus CheckAttributeViInt32(ViSession vi, ViConstString channelList, ViAttr attributeId, ViInt32 value);
@@ -120,6 +122,8 @@ class NiScopeLibrary : public niscope_grpc::NiScopeLibraryInterface {
   using AutoSetupPtr = decltype(&niScope_AutoSetup);
   using CableSenseSignalStartPtr = decltype(&niScope_CableSenseSignalStart);
   using CableSenseSignalStopPtr = decltype(&niScope_CableSenseSignalStop);
+  using CalFetchDatePtr = decltype(&niScope_CalFetchDate);
+  using CalFetchTemperaturePtr = decltype(&niScope_CalFetchTemperature);
   using CalSelfCalibratePtr = decltype(&niScope_CalSelfCalibrate);
   using CheckAttributeViBooleanPtr = decltype(&niScope_CheckAttributeViBoolean);
   using CheckAttributeViInt32Ptr = decltype(&niScope_CheckAttributeViInt32);
@@ -212,6 +216,8 @@ class NiScopeLibrary : public niscope_grpc::NiScopeLibraryInterface {
     AutoSetupPtr AutoSetup;
     CableSenseSignalStartPtr CableSenseSignalStart;
     CableSenseSignalStopPtr CableSenseSignalStop;
+    CalFetchDatePtr CalFetchDate;
+    CalFetchTemperaturePtr CalFetchTemperature;
     CalSelfCalibratePtr CalSelfCalibrate;
     CheckAttributeViBooleanPtr CheckAttributeViBoolean;
     CheckAttributeViInt32Ptr CheckAttributeViInt32;

--- a/generated/niscope/niscope_library_interface.h
+++ b/generated/niscope/niscope_library_interface.h
@@ -7,7 +7,7 @@
 #define NISCOPE_GRPC_LIBRARY_WRAPPER_H
 
 #include <grpcpp/grpcpp.h>
-#include <niScope.h>
+#include <niScopeCal.h>
 
 namespace niscope_grpc {
 
@@ -25,6 +25,8 @@ class NiScopeLibraryInterface {
   virtual ViStatus AutoSetup(ViSession vi) = 0;
   virtual ViStatus CableSenseSignalStart(ViSession vi) = 0;
   virtual ViStatus CableSenseSignalStop(ViSession vi) = 0;
+  virtual ViStatus CalFetchDate(ViSession vi, ViInt32 whichOne, ViInt32* year, ViInt32* month, ViInt32* day) = 0;
+  virtual ViStatus CalFetchTemperature(ViSession vi, ViInt32 whichOne, ViReal64* temperature) = 0;
   virtual ViStatus CalSelfCalibrate(ViSession vi, ViConstString channelList, ViInt32 option) = 0;
   virtual ViStatus CheckAttributeViBoolean(ViSession vi, ViConstString channelList, ViAttr attributeId, ViBoolean value) = 0;
   virtual ViStatus CheckAttributeViInt32(ViSession vi, ViConstString channelList, ViAttr attributeId, ViInt32 value) = 0;

--- a/generated/niscope/niscope_mock_library.h
+++ b/generated/niscope/niscope_mock_library.h
@@ -27,6 +27,8 @@ class NiScopeMockLibrary : public niscope_grpc::NiScopeLibraryInterface {
   MOCK_METHOD(ViStatus, AutoSetup, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, CableSenseSignalStart, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, CableSenseSignalStop, (ViSession vi), (override));
+  MOCK_METHOD(ViStatus, CalFetchDate, (ViSession vi, ViInt32 whichOne, ViInt32* year, ViInt32* month, ViInt32* day), (override));
+  MOCK_METHOD(ViStatus, CalFetchTemperature, (ViSession vi, ViInt32 whichOne, ViReal64* temperature), (override));
   MOCK_METHOD(ViStatus, CalSelfCalibrate, (ViSession vi, ViConstString channelList, ViInt32 option), (override));
   MOCK_METHOD(ViStatus, CheckAttributeViBoolean, (ViSession vi, ViConstString channelList, ViAttr attributeId, ViBoolean value), (override));
   MOCK_METHOD(ViStatus, CheckAttributeViInt32, (ViSession vi, ViConstString channelList, ViAttr attributeId, ViInt32 value), (override));

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -311,6 +311,90 @@ namespace niscope_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiScopeService::CalFetchDate(::grpc::ServerContext* context, const CalFetchDateRequest* request, CalFetchDateResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViInt32 which_one;
+      switch (request->which_one_enum_case()) {
+        case niscope_grpc::CalFetchDateRequest::WhichOneEnumCase::kWhichOne: {
+          which_one = static_cast<ViInt32>(request->which_one());
+          break;
+        }
+        case niscope_grpc::CalFetchDateRequest::WhichOneEnumCase::kWhichOneRaw: {
+          which_one = static_cast<ViInt32>(request->which_one_raw());
+          break;
+        }
+        case niscope_grpc::CalFetchDateRequest::WhichOneEnumCase::WHICH_ONE_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for which_one was not specified or out of range");
+          break;
+        }
+      }
+
+      ViInt32 year {};
+      ViInt32 month {};
+      ViInt32 day {};
+      auto status = library_->CalFetchDate(vi, which_one, &year, &month, &day);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      response->set_year(year);
+      response->set_month(month);
+      response->set_day(day);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiScopeService::CalFetchTemperature(::grpc::ServerContext* context, const CalFetchTemperatureRequest* request, CalFetchTemperatureResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.id(), vi_grpc_session.name());
+      ViInt32 which_one;
+      switch (request->which_one_enum_case()) {
+        case niscope_grpc::CalFetchTemperatureRequest::WhichOneEnumCase::kWhichOne: {
+          which_one = static_cast<ViInt32>(request->which_one());
+          break;
+        }
+        case niscope_grpc::CalFetchTemperatureRequest::WhichOneEnumCase::kWhichOneRaw: {
+          which_one = static_cast<ViInt32>(request->which_one_raw());
+          break;
+        }
+        case niscope_grpc::CalFetchTemperatureRequest::WhichOneEnumCase::WHICH_ONE_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for which_one was not specified or out of range");
+          break;
+        }
+      }
+
+      ViReal64 temperature {};
+      auto status = library_->CalFetchTemperature(vi, which_one, &temperature);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      response->set_temperature(temperature);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::CalSelfCalibrate(::grpc::ServerContext* context, const CalSelfCalibrateRequest* request, CalSelfCalibrateResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/niscope/niscope_service.h
+++ b/generated/niscope/niscope_service.h
@@ -51,6 +51,8 @@ public:
   ::grpc::Status AutoSetup(::grpc::ServerContext* context, const AutoSetupRequest* request, AutoSetupResponse* response) override;
   ::grpc::Status CableSenseSignalStart(::grpc::ServerContext* context, const CableSenseSignalStartRequest* request, CableSenseSignalStartResponse* response) override;
   ::grpc::Status CableSenseSignalStop(::grpc::ServerContext* context, const CableSenseSignalStopRequest* request, CableSenseSignalStopResponse* response) override;
+  ::grpc::Status CalFetchDate(::grpc::ServerContext* context, const CalFetchDateRequest* request, CalFetchDateResponse* response) override;
+  ::grpc::Status CalFetchTemperature(::grpc::ServerContext* context, const CalFetchTemperatureRequest* request, CalFetchTemperatureResponse* response) override;
   ::grpc::Status CalSelfCalibrate(::grpc::ServerContext* context, const CalSelfCalibrateRequest* request, CalSelfCalibrateResponse* response) override;
   ::grpc::Status CheckAttributeViBoolean(::grpc::ServerContext* context, const CheckAttributeViBooleanRequest* request, CheckAttributeViBooleanResponse* response) override;
   ::grpc::Status CheckAttributeViInt32(::grpc::ServerContext* context, const CheckAttributeViInt32Request* request, CheckAttributeViInt32Response* response) override;

--- a/generated/niscope/niscope_service_registrar.h
+++ b/generated/niscope/niscope_service_registrar.h
@@ -11,7 +11,7 @@
 
 #include <memory>
 
-#include <niScope.h> // for ViSession
+#include <niScopeCal.h> // for ViSession
 
 namespace grpc {
 class ServerBuilder;

--- a/imports/include/niScope.h
+++ b/imports/include/niScope.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  *                                niScope                                   *
  *--------------------------------------------------------------------------*
- *   Copyright (c) National Instruments 2004-2021.  All Rights Reserved.    *
+ *   Copyright (c) National Instruments 2004-2022.  All Rights Reserved.    *
  *--------------------------------------------------------------------------*
  *                                                                          *
  * Title:    niScope.h                                                      *
@@ -9,26 +9,35 @@
  *           instrument driver declarations.                                *
  *                                                                          *
  ****************************************************************************/
+
 #ifndef __NISCOPE_HEADER
 #define __NISCOPE_HEADER
+
 #define IVI_DO_NOT_INCLUDE_VISA_HEADERS
 #include "ivi.h"
 #include "IviScope.h"
 #undef IVI_DO_NOT_INCLUDE_VISA_HEADERS
 #include <string.h>
+
+
 #if defined(__cplusplus) || defined(__cplusplus__)
 extern "C" {
 #endif
+
 /* Pragma used in CVI to indicate that functions in this file have
  * user protection associated with them */
 #ifdef _CVI_
  #pragma EnableLibraryRuntimeChecking
 #endif
+
+
 /****************************************************************************
  *----------------- Instrument Driver Revision Information -----------------*
  ****************************************************************************/
-#define NISCOPE_MAJOR_VERSION                                                  20                                                            // Instrument driver major version
-#define NISCOPE_MINOR_VERSION                                                  700                                                           // Instrument driver minor version
+#define NISCOPE_MAJOR_VERSION                                                  22                                                            // Instrument driver major version
+#define NISCOPE_MINOR_VERSION                                                  500                                                           // Instrument driver minor version
+
+
 /****************************************************************************
  *---------------------- Useful Macros and Defines -------------------------*
  ****************************************************************************/
@@ -36,6 +45,7 @@ extern "C" {
 #define MAX_FUNCTION_NAME_SIZE      55
 /* Maximum size of an error message returned from niScope_errorHandler */
 #define MAX_ERROR_DESCRIPTION       (IVI_MAX_MESSAGE_BUF_SIZE * 2 + MAX_FUNCTION_NAME_SIZE + 75)
+
 /* This macro handles all errors and warnings returned from NI SCOPE.
    It requires two variables be declared:
       ViStatus error
@@ -62,6 +72,7 @@ extern "C" {
               error = code;                                          \
               strncpy(errorSource, funcName, funcNameLen);           \
               errorSource[funcNameLen] = '\0'; } } }
+
 /* Use this macro to set a customized error elaboration for a particular function
    call.  The overwrite parameter in Ivi_SetErrorInfo is set to VI_TRUE so this
    macro will overwrite the default error elaboration that is on the error queue. */
@@ -69,6 +80,7 @@ extern "C" {
         if (error = (fCall), (error = (error < 0) ? (error) : VI_SUCCESS))              \
            {Ivi_SetErrorInfo(vi, VI_TRUE, error, Ivi_ParamPositionError(paramPosition), \
            errorElaboration); goto Error;} else
+
 /* Use this macro in the same manner as above but for cases where it is not a user
    set parameter that is in error
    Let errors over-ride warnings, but if there's no error or warning don't clear the
@@ -87,6 +99,7 @@ extern "C" {
          error = tempErrorForElab;                                   \
       }                                                              \
    }
+
 /* WARNING: These are overrides of some of the IVI macros to preserve warnings.
    These changes should ONLY affect the way warnings are dealt with.  However,
    there are other functions that may erase warning messages. */
@@ -108,6 +121,8 @@ extern "C" {
       }                                                        \
    }
 #endif
+
+
 /* checkErr shouldn't ignore warning messages, so this is an override of the IVI version. */
 #ifdef checkErr
 #undef checkErr
@@ -124,6 +139,8 @@ extern "C" {
       }                                                        \
    }
 #endif
+
+
 #ifdef viCheckErr
 #undef viCheckErr
 #define viCheckErr(fCall)                                      \
@@ -142,10 +159,13 @@ extern "C" {
       }                                                        \
    }
 #endif
+
+
 /****************************************************************************
  *---------------------------- Attribute Defines ---------------------------*
  ****************************************************************************/
  /*- NOTE: multi channel denotes an attribute specified on a per channel basis -*/
+
 // -- User Options --
 #define NISCOPE_ATTR_CACHE                                                     IVI_ATTR_CACHE                                                // 1050004 (0x100594), ViBoolean
 #define NISCOPE_ATTR_RANGE_CHECK                                               IVI_ATTR_RANGE_CHECK                                          // 1050002 (0x100592), ViBoolean
@@ -153,11 +173,13 @@ extern "C" {
 #define NISCOPE_ATTR_RECORD_COERCIONS                                          IVI_ATTR_RECORD_COERCIONS                                     // 1050006 (0x100596), ViBoolean
 #define NISCOPE_ATTR_SIMULATE                                                  IVI_ATTR_SIMULATE                                             // 1050005 (0x100595), ViBoolean
 #define NISCOPE_ATTR_INTERCHANGE_CHECK                                         IVI_ATTR_INTERCHANGE_CHECK                                    // 1050021 (0x1005a5), ViBoolean
+
 // -- Instrument Capabilities --
 #define NISCOPE_ATTR_CHANNEL_COUNT                                             IVI_ATTR_CHANNEL_COUNT                                        // 1050203 (0x10065b), ViInt32,    read-only
 #define NISCOPE_ATTR_SUPPORTED_INSTRUMENT_MODELS                               IVI_ATTR_SUPPORTED_INSTRUMENT_MODELS                          // 1050327 (0x1006d7), ViString,   read-only
 #define NISCOPE_ATTR_GROUP_CAPABILITIES                                        IVI_ATTR_GROUP_CAPABILITIES                                   // 1050401 (0x100721), ViString,   read-only
-// -- Instrument Version and Identification --
+
+// -- Instrument Version And Identification --
 #define NISCOPE_ATTR_SPECIFIC_DRIVER_DESCRIPTION                               IVI_ATTR_SPECIFIC_DRIVER_DESCRIPTION                          // 1050514 (0x100792), ViString,   read-only
 #define NISCOPE_ATTR_SPECIFIC_DRIVER_PREFIX                                    IVI_ATTR_SPECIFIC_DRIVER_PREFIX                               // 1050302 (0x1006be), ViString,   read-only
 #define NISCOPE_ATTR_SPECIFIC_DRIVER_VENDOR                                    IVI_ATTR_SPECIFIC_DRIVER_VENDOR                               // 1050513 (0x100791), ViString,   read-only
@@ -167,13 +189,16 @@ extern "C" {
 #define NISCOPE_ATTR_INSTRUMENT_MANUFACTURER                                   IVI_ATTR_INSTRUMENT_MANUFACTURER                              // 1050511 (0x10078f), ViString,   read-only
 #define NISCOPE_ATTR_INSTRUMENT_MODEL                                          IVI_ATTR_INSTRUMENT_MODEL                                     // 1050512 (0x100790), ViString,   read-only
 #define NISCOPE_ATTR_INSTRUMENT_FIRMWARE_REVISION                              IVI_ATTR_INSTRUMENT_FIRMWARE_REVISION                         // 1050510 (0x10078e), ViString,   read-only
+
 // -- Advanced Session Information --
 #define NISCOPE_ATTR_IO_RESOURCE_DESCRIPTOR                                    IVI_ATTR_IO_RESOURCE_DESCRIPTOR                               // 1050304 (0x1006c0), ViString,   read-only
 #define NISCOPE_ATTR_LOGICAL_NAME                                              IVI_ATTR_LOGICAL_NAME                                         // 1050305 (0x1006c1), ViString,   read-only
 #define NISCOPE_ATTR_DRIVER_SETUP                                              IVI_ATTR_DRIVER_SETUP                                         // 1050007 (0x100597), ViString,   read-only
+
 // -- Acquisition Subsystem --
 #define NISCOPE_ATTR_ACQUISITION_TYPE                                          IVISCOPE_ATTR_ACQUISITION_TYPE                                // 1250101 (0x131335), ViInt32
 #define NISCOPE_ATTR_SAMPLE_MODE                                               IVISCOPE_ATTR_SAMPLE_MODE                                     // 1250106 (0x13133a), ViInt32,    read-only
+
 // -- Vertical Subsystem --
 #define NISCOPE_ATTR_CHANNEL_ENABLED                                           IVISCOPE_ATTR_CHANNEL_ENABLED                                 // 1250005 (0x1312d5), ViBoolean,  multi-channel
 #define NISCOPE_ATTR_PROBE_ATTENUATION                                         IVISCOPE_ATTR_PROBE_ATTENUATION                               // 1250004 (0x1312d4), ViReal64,   multi-channel
@@ -182,6 +207,7 @@ extern "C" {
 #define NISCOPE_ATTR_VERTICAL_COUPLING                                         IVISCOPE_ATTR_VERTICAL_COUPLING                               // 1250003 (0x1312d3), ViInt32,    multi-channel
 #define NISCOPE_ATTR_MAX_INPUT_FREQUENCY                                       IVISCOPE_ATTR_MAX_INPUT_FREQUENCY                             // 1250006 (0x1312d6), ViReal64,   multi-channel
 #define NISCOPE_ATTR_INPUT_IMPEDANCE                                           IVISCOPE_ATTR_INPUT_IMPEDANCE                                 // 1250103 (0x131337), ViReal64,   multi-channel
+
 // -- Horizontal Subsystem --
 #define NISCOPE_ATTR_HORZ_TIME_PER_RECORD                                      IVISCOPE_ATTR_HORZ_TIME_PER_RECORD                            // 1250007 (0x1312d7), ViReal64
 #define NISCOPE_ATTR_ACQUISITION_START_TIME                                    IVISCOPE_ATTR_ACQUISITION_START_TIME                          // 1250109 (0x13133d), ViReal64
@@ -189,6 +215,7 @@ extern "C" {
 #define NISCOPE_ATTR_HORZ_RECORD_LENGTH                                        IVISCOPE_ATTR_HORZ_RECORD_LENGTH                              // 1250008 (0x1312d8), ViInt32,    read-only
 #define NISCOPE_ATTR_HORZ_RECORD_REF_POSITION                                  (IVI_CLASS_PUBLIC_ATTR_BASE + 11L)                            // 1250011 (0x1312db), ViReal64
 #define NISCOPE_ATTR_HORZ_SAMPLE_RATE                                          IVISCOPE_ATTR_HORZ_SAMPLE_RATE                                // 1250010 (0x1312da), ViReal64,   read-only
+
 // -- Trigger Subsystem --
 #define NISCOPE_ATTR_TRIGGER_TYPE                                              IVISCOPE_ATTR_TRIGGER_TYPE                                    // 1250012 (0x1312dc), ViInt32
 #define NISCOPE_ATTR_TRIGGER_SOURCE                                            IVISCOPE_ATTR_TRIGGER_SOURCE                                  // 1250013 (0x1312dd), ViString
@@ -197,28 +224,34 @@ extern "C" {
 #define NISCOPE_ATTR_TRIGGER_HOLDOFF                                           IVISCOPE_ATTR_TRIGGER_HOLDOFF                                 // 1250016 (0x1312e0), ViReal64
 #define NISCOPE_ATTR_TRIGGER_COUPLING                                          IVISCOPE_ATTR_TRIGGER_COUPLING                                // 1250014 (0x1312de), ViInt32
 #define NISCOPE_ATTR_TRIGGER_SLOPE                                             IVISCOPE_ATTR_TRIGGER_SLOPE                                   // 1250018 (0x1312e2), ViInt32
-// -- IviScopeTVTrigger Extension --
+
+// -- Iviscopetvtrigger Extension --
 #define NISCOPE_ATTR_TV_TRIGGER_EVENT                                          IVISCOPE_ATTR_TV_TRIGGER_EVENT                                // 1250205 (0x13139d), ViInt32
 #define NISCOPE_ATTR_TV_TRIGGER_LINE_NUMBER                                    IVISCOPE_ATTR_TV_TRIGGER_LINE_NUMBER                          // 1250206 (0x13139e), ViInt32
 #define NISCOPE_ATTR_TV_TRIGGER_SIGNAL_FORMAT                                  IVISCOPE_ATTR_TV_TRIGGER_SIGNAL_FORMAT                        // 1250201 (0x131399), ViInt32
 #define NISCOPE_ATTR_TV_TRIGGER_POLARITY                                       IVISCOPE_ATTR_TV_TRIGGER_POLARITY                             // 1250204 (0x13139c), ViInt32
-// -- IviScopeGlitchTrigger Extension --
+
+// -- Iviscopeglitchtrigger Extension --
 #define NISCOPE_ATTR_GLITCH_CONDITION                                          IVISCOPE_ATTR_GLITCH_CONDITION                                // 1250403 (0x131463), ViInt32
 #define NISCOPE_ATTR_GLITCH_WIDTH                                              IVISCOPE_ATTR_GLITCH_WIDTH                                    // 1250401 (0x131461), ViReal64
 #define NISCOPE_ATTR_GLITCH_POLARITY                                           IVISCOPE_ATTR_GLITCH_POLARITY                                 // 1250402 (0x131462), ViInt32
-// -- IviScopeWidthTrigger Extension --
+
+// -- Iviscopewidthtrigger Extension --
 #define NISCOPE_ATTR_WIDTH_CONDITION                                           IVISCOPE_ATTR_WIDTH_CONDITION                                 // 1250504 (0x1314c8), ViInt32
 #define NISCOPE_ATTR_WIDTH_LOW_THRESHOLD                                       IVISCOPE_ATTR_WIDTH_LOW_THRESHOLD                             // 1250501 (0x1314c5), ViReal64
 #define NISCOPE_ATTR_WIDTH_HIGH_THRESHOLD                                      IVISCOPE_ATTR_WIDTH_HIGH_THRESHOLD                            // 1250502 (0x1314c6), ViReal64
 #define NISCOPE_ATTR_WIDTH_POLARITY                                            IVISCOPE_ATTR_WIDTH_POLARITY                                  // 1250503 (0x1314c7), ViInt32
-// -- IviScopeRuntTrigger Extension --
+
+// -- Iviscoperunttrigger Extension --
 #define NISCOPE_ATTR_RUNT_POLARITY                                             IVISCOPE_ATTR_RUNT_POLARITY                                   // 1250303 (0x1313ff), ViInt32
 #define NISCOPE_ATTR_RUNT_LOW_THRESHOLD                                        IVISCOPE_ATTR_RUNT_LOW_THRESHOLD                              // 1250302 (0x1313fe), ViReal64
 #define NISCOPE_ATTR_RUNT_HIGH_THRESHOLD                                       IVISCOPE_ATTR_RUNT_HIGH_THRESHOLD                             // 1250301 (0x1313fd), ViReal64
+
 // -- Measurement Functions --
 #define NISCOPE_ATTR_MEAS_HIGH_REF                                             IVISCOPE_ATTR_MEAS_HIGH_REF                                   // 1250607 (0x13152f), ViReal64
 #define NISCOPE_ATTR_MEAS_LOW_REF                                              IVISCOPE_ATTR_MEAS_LOW_REF                                    // 1250608 (0x131530), ViReal64
 #define NISCOPE_ATTR_MEAS_MID_REF                                              IVISCOPE_ATTR_MEAS_MID_REF                                    // 1250609 (0x131531), ViReal64
+
 // -- Additional Instrument-Specific Attributes --
 #define NISCOPE_ATTR_HORZ_NUM_RECORDS                                          (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 1L)                          // 1150001 (0x118c31), ViInt32
 #define NISCOPE_ATTR_INPUT_CLOCK_SOURCE                                        (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 2L)                          // 1150002 (0x118c32), ViString
@@ -261,7 +294,8 @@ extern "C" {
 #define NISCOPE_ATTR_MEAS_ARRAY_GAIN                                           (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 43L)                         // 1150043 (0x118c5b), ViReal64,   multi-channel
 #define NISCOPE_ATTR_MEAS_ARRAY_OFFSET                                         (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 44L)                         // 1150044 (0x118c5c), ViReal64,   multi-channel
 #define NISCOPE_ATTR_MEAS_PERCENTAGE_METHOD                                    (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 45L)                         // 1150045 (0x118c5d), ViInt32,    multi-channel
-// -- Advanced synchronization attributes --
+
+// -- Advanced Synchronization Attributes --
 #define NISCOPE_ATTR_ACQ_ARM_SOURCE                                            (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 53L)                         // 1150053 (0x118c65), ViString
 #define NISCOPE_ATTR_IS_PROBE_COMP_ON                                          (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 66L)                         // 1150066 (0x118c72), ViBoolean,  read-only
 #define NISCOPE_ATTR_USE_SPEC_INITIAL_X                                        (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 67L)                         // 1150067 (0x118c73), ViBoolean
@@ -284,7 +318,8 @@ extern "C" {
 #define NISCOPE_ATTR_BACKLOG                                                   (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 84L)                         // 1150084 (0x118c84), ViReal64,   read-only
 #define NISCOPE_ATTR_POLL_INTERVAL                                             (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 100L)                        // 1150100 (0x118c94), ViInt32
 #define NISCOPE_ATTR_PLL_LOCK_STATUS                                           (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 1303L)                       // 1151303 (0x119147), ViBoolean,  read-only
-// -- New attributes for NI-SCOPE 2.5 --
+
+// -- New Attributes For Ni-Scope 2.5 --
 #define NISCOPE_ATTR_DEVICE_TEMPERATURE                                        (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 86L)                         // 1150086 (0x118c86), ViReal64,   read-only
 #define NISCOPE_ATTR_SAMP_CLK_TIMEBASE_SRC                                     (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 87L)                         // 1150087 (0x118c87), ViString
 #define NISCOPE_ATTR_SAMP_CLK_TIMEBASE_RATE                                    (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 88L)                         // 1150088 (0x118c88), ViReal64
@@ -296,21 +331,26 @@ extern "C" {
 #define NISCOPE_ATTR_ARM_REF_TRIG_SRC                                          (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 95L)                         // 1150095 (0x118c8f), ViString
 #define NISCOPE_ATTR_REF_TRIG_TDC_ENABLE                                       (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 96L)                         // 1150096 (0x118c90), ViBoolean
 #define NISCOPE_ATTR_RESOLUTION                                                (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 102L)                        // 1150102 (0x118c96), ViInt32,    read-only
-// -- New attributes for NI-SCOPE 2.6 --
+
+// -- New Attributes For Ni-Scope 2.6 --
 #define NISCOPE_ATTR_START_TO_REF_TRIGGER_HOLDOFF                              (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 103L)                        // 1150103 (0x118c97), ViReal64
-// -- New attributes for NI-SCOPE 2.7 --
+
+// -- New Attributes For Ni-Scope 2.7 --
 #define NISCOPE_ATTR_SERIAL_NUMBER                                             (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 104L)                        // 1150104 (0x118c98), ViString,   read-only
 #define NISCOPE_ATTR_OSCILLATOR_PHASE_DAC_VALUE                                (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 105L)                        // 1150105 (0x118c99), ViInt32
-// -- New attributes for NI-SCOPE 2.8 --
+
+// -- New Attributes For Ni-Scope 2.8 --
 #define NISCOPE_ATTR_RIS_IN_AUTO_SETUP_ENABLE                                  (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 106L)                        // 1150106 (0x118c9a), ViBoolean
 #define NISCOPE_ATTR_CHANNEL_TERMINAL_CONFIGURATION                            (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 107L)                        // 1150107 (0x118c9b), ViInt32,    multi-channel
 #define NISCOPE_ATTR_EXPORTED_ADVANCE_TRIGGER_OUTPUT_TERMINAL                  (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 109L)                        // 1150109 (0x118c9d), ViString
 #define NISCOPE_ATTR_READY_FOR_START_EVENT_OUTPUT_TERMINAL                     (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 110L)                        // 1150110 (0x118c9e), ViString
 #define NISCOPE_ATTR_READY_FOR_REF_EVENT_OUTPUT_TERMINAL                       (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 111L)                        // 1150111 (0x118c9f), ViString
 #define NISCOPE_ATTR_READY_FOR_ADVANCE_EVENT_OUTPUT_TERMINAL                   (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 112L)                        // 1150112 (0x118ca0), ViString
-// -- New attributes for NI-SCOPE 2.9.1 --
+
+// -- New Attributes For Ni-Scope 2.9.1 --
 #define NISCOPE_ATTR_FLEX_FIR_ANTIALIAS_FILTER_TYPE                            (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 271L)                        // 1150271 (0x118d3f), ViInt32,    multi-channel
-// -- New attributes for NI-SCOPE 3.0. Attributes for the NI 5142 & 5622 OSP functionality. --
+
+// -- New Attributes For Ni-Scope 3.0. Attributes For The Ni 5142 & 5622 Osp Functionality. --
 #define NISCOPE_ATTR_DDC_ENABLED                                               (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 300L)                        // 1150300 (0x118d5c), ViBoolean,  multi-channel
 #define NISCOPE_ATTR_DDC_FREQUENCY_TRANSLATION_ENABLED                         (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 302L)                        // 1150302 (0x118d5e), ViBoolean,  multi-channel
 #define NISCOPE_ATTR_DDC_CENTER_FREQUENCY                                      (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 303L)                        // 1150303 (0x118d5f), ViReal64,   multi-channel
@@ -322,16 +362,20 @@ extern "C" {
 #define NISCOPE_ATTR_OVERFLOW_ERROR_REPORTING                                  (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 309L)                        // 1150309 (0x118d65), ViInt32
 #define NISCOPE_ATTR_DDC_Q_SOURCE                                              (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 310L)                        // 1150310 (0x118d66), ViString,   multi-channel
 #define NISCOPE_ATTR_FETCH_INTERLEAVED_IQ_DATA                                 (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 311L)                        // 1150311 (0x118d67), ViBoolean
-// -- New attributes for NI-SCOPE 3.1. --
+
+// -- New Attributes For Ni-Scope 3.1. --
 #define NISCOPE_ATTR_EQUALIZATION_NUM_COEFFICIENTS                             (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 312L)                        // 1150312 (0x118d68), ViInt32,    multi-channel, read-only
 #define NISCOPE_ATTR_EQUALIZATION_FILTER_ENABLED                               (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 313L)                        // 1150313 (0x118d69), ViBoolean,  multi-channel
 #define NISCOPE_ATTR_REF_TRIGGER_DETECTOR_LOCATION                             (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 314L)                        // 1150314 (0x118d6a), ViInt32
 #define NISCOPE_ATTR_REF_TRIGGER_MINIMUM_QUIET_TIME                            (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 315L)                        // 1150315 (0x118d6b), ViReal64
-// -- New attributes for NI-SCOPE 3.2 --
+
+// -- New Attributes For Ni-Scope 3.2 --
 #define NISCOPE_ATTR_ENABLE_TIME_INTERLEAVED_SAMPLING                          (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 128L)                        // 1150128 (0x118cb0), ViBoolean,  multi-channel
-// -- New attributes for NI-SCOPE 3.3 --
+
+// -- New Attributes For Ni-Scope 3.3 --
 #define NISCOPE_ATTR_DATA_TRANSFER_BLOCK_SIZE                                  (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 316L)                        // 1150316 (0x118d6c), ViInt32
-// -- New attributes for NI-SCOPE 3.4 --
+
+// -- New Attributes For Ni-Scope 3.4 --
 #define NISCOPE_ATTR_TRIGGER_MODIFIER                                          IVISCOPE_ATTR_TRIGGER_MODIFIER                                // 1250102 (0x131336), ViInt32
 #define NISCOPE_ATTR_TRIGGER_AUTO_TRIGGERED                                    (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 278L)                        // 1150278 (0x118d46), ViBoolean,  read-only
 #define NISCOPE_ATTR_EXPORTED_START_TRIGGER_OUTPUT_TERMINAL                    (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 97L)                         // 1150097 (0x118c91), ViString
@@ -339,16 +383,19 @@ extern "C" {
 #define NISCOPE_ATTR_END_OF_RECORD_EVENT_OUTPUT_TERMINAL                       (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 99L)                         // 1150099 (0x118c93), ViString
 #define NISCOPE_ATTR_END_OF_ACQUISITION_EVENT_OUTPUT_TERMINAL                  (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 101L)                        // 1150101 (0x118c95), ViString
 #define NISCOPE_ATTR_5V_OUT_OUTPUT_TERMINAL                                    (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 129L)                        // 1150129 (0x118cb1), ViString
-// -- New attributes for NI-SCOPE 3.5 --
+
+// -- New Attributes For Ni-Scope 3.5 --
 #define NISCOPE_ATTR_BANDPASS_FILTER_ENABLED                                   (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 318L)                        // 1150318 (0x118d6e), ViBoolean,  multi-channel
 #define NISCOPE_ATTR_DITHER_ENABLED                                            (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 319L)                        // 1150319 (0x118d6f), ViBoolean,  multi-channel
 #define NISCOPE_ATTR_FRACTIONAL_RESAMPLE_ENABLED                               (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 320L)                        // 1150320 (0x118d70), ViBoolean
 #define NISCOPE_ATTR_DATA_TRANSFER_MAXIMUM_BANDWIDTH                           (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 321L)                        // 1150321 (0x118d71), ViReal64
 #define NISCOPE_ATTR_DATA_TRANSFER_PREFERRED_PACKET_SIZE                       (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 322L)                        // 1150322 (0x118d72), ViInt32
-// -- NI-5900 specific definitions --
+
+// -- Ni-5900 Specific Definitions --
 #define NISCOPE_ATTR_SIGNAL_COND_GAIN                                          (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 279L)                        // 1150279 (0x118d47), ViReal64,   multi-channel, read-only
 #define NISCOPE_ATTR_SIGNAL_COND_OFFSET                                        (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 280L)                        // 1150280 (0x118d48), ViReal64,   multi-channel, read-only
-// -- New attributes for NI-SCOPE 3.6, Peer-to-Peer --
+
+// -- New Attributes For Ni-Scope 3.6, Peer-To-Peer --
 #define NISCOPE_ATTR_P2P_ENABLED                                               (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 338L)                        // 1150338 (0x118d82), ViBoolean
 #define NISCOPE_ATTR_P2P_CHANNELS_TO_STREAM                                    (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 339L)                        // 1150339 (0x118d83), ViString
 #define NISCOPE_ATTR_P2P_ENDPOINT_SIZE                                         (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 342L)                        // 1150342 (0x118d86), ViInt32,    read-only
@@ -368,30 +415,39 @@ extern "C" {
 #define NISCOPE_ATTR_P2P_NOTIFY_MESSAGE_PUSH_ADDR                              (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 335L)                        // 1150335 (0x118d7f), ViInt64
 #define NISCOPE_ATTR_P2P_NOTIFY_MESSAGE_PUSH_ADDR_TYPE                         (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 336L)                        // 1150336 (0x118d80), ViInt32
 #define NISCOPE_ATTR_P2P_NOTIFY_MESSAGE_PUSH_VALUE                             (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 337L)                        // 1150337 (0x118d81), ViInt64
-// -- New attributes for NI-SCOPE 3.8 --
+
+// -- New Attributes For Ni-Scope 3.8 --
 #define NISCOPE_ATTR_SAMP_CLK_TIMEBASE_MULT                                    (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 367L)                        // 1150367 (0x118d9f), ViInt32
-// -- New attributes for NI-SCOPE 4.0, Peer-to-Peer --
+
+// -- New Attributes For Ni-Scope 4.0, Peer-To-Peer --
 #define NISCOPE_ATTR_P2P_STREAM_RELATIVE_TO                                    (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 373L)                        // 1150373 (0x118da5), ViInt32
 #define NISCOPE_ATTR_P2P_SAMPLES_TRANSFERRED_PER_RECORD                        (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 380L)                        // 1150380 (0x118dac), ViInt32,    read-only
-// -- New attributes for NI-SCOPE 4.2 --
+
+// -- New Attributes For Ni-Scope 4.2 --
 #define NISCOPE_ATTR_END_OF_RECORD_TO_ADVANCE_TRIGGER_HOLDOFF                  (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 366L)                        // 1150366 (0x118d9e), ViReal64
-// -- New attributes for NI-SCOPE 15.1 --
+
+// -- New Attributes For Ni-Scope 15.1 --
 #define NISCOPE_ATTR_ABSOLUTE_SAMPLE_CLOCK_OFFSET                              (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 374L)                        // 1150374 (0x118da6), ViReal64
 #define NISCOPE_ATTR_FPGA_BITFILE_PATH                                         (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 375L)                        // 1150375 (0x118da7), ViString,   read-only
-// -- New attributes for NI-SCOPE 16.1 --
+
+// -- New Attributes For Ni-Scope 16.1 --
 #define NISCOPE_ATTR_INTERLEAVING_OFFSET_CORRECTION_ENABLED                    (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 376L)                        // 1150376 (0x118da8), ViBoolean,  multi-channel
 #define NISCOPE_ATTR_HIGH_PASS_FILTER_FREQUENCY                                (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 377L)                        // 1150377 (0x118da9), ViReal64,   multi-channel
-// -- New attributes for NI-SCOPE 18.6 --
+
+// -- New Attributes For Ni-Scope 18.6 --
 #define NISCOPE_ATTR_RUNT_TIME_CONDITION                                       (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 132L)                        // 1150132 (0x118cb4), ViInt32
 #define NISCOPE_ATTR_RUNT_TIME_LOW_LIMIT                                       (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 133L)                        // 1150133 (0x118cb5), ViReal64
 #define NISCOPE_ATTR_RUNT_TIME_HIGH_LIMIT                                      (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 134L)                        // 1150134 (0x118cb6), ViReal64
-// -- New attributes for NI-SCOPE 18.7 --
+
+// -- New Attributes For Ni-Scope 18.7 --
 #define NISCOPE_ATTR_CABLE_SENSE_VOLTAGE                                       (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 137L)                        // 1150137 (0x118cb9), ViReal64
 #define NISCOPE_ATTR_CABLE_SENSE_MODE                                          (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 138L)                        // 1150138 (0x118cba), ViReal64
 #define NISCOPE_ATTR_CABLE_SENSE_SIGNAL_ENABLE                                 (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 139L)                        // 1150139 (0x118cbb), ViBoolean
-// -- New attributes for NI-SCOPE 19.0 --
+
+// -- New Attributes For Ni-Scope 19.0 --
 #define NISCOPE_ATTR_ENABLED_CHANNELS                                          (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 140L)                        // 1150140 (0x118cbc), ViString,   read-only
-// -- New attributes for NI-SCOPE 20.0 --
+
+// -- New Attributes For Ni-Scope 20.0 --
 #define NISCOPE_ATTR_END_OF_ACQUISITION_EVENT_TERMINAL_NAME                    (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 141L)                        // 1150141 (0x118cbd), ViString,   read-only
 #define NISCOPE_ATTR_END_OF_RECORD_EVENT_TERMINAL_NAME                         (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 142L)                        // 1150142 (0x118cbe), ViString,   read-only
 #define NISCOPE_ATTR_ADVANCE_TRIGGER_TERMINAL_NAME                             (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 143L)                        // 1150143 (0x118cbf), ViString,   read-only
@@ -400,6 +456,8 @@ extern "C" {
 #define NISCOPE_ATTR_READY_FOR_ADVANCE_EVENT_TERMINAL_NAME                     (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 146L)                        // 1150146 (0x118cc2), ViString,   read-only
 #define NISCOPE_ATTR_READY_FOR_REF_EVENT_TERMINAL_NAME                         (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 147L)                        // 1150147 (0x118cc3), ViString,   read-only
 #define NISCOPE_ATTR_READY_FOR_START_EVENT_TERMINAL_NAME                       (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 148L)                        // 1150148 (0x118cc4), ViString,   read-only
+
+
 /****************************************************************************
  *------------------ Attribute and Parameter Value Defines -----------------*
  ****************************************************************************/
@@ -409,17 +467,20 @@ extern "C" {
 #define NISCOPE_VAL_RIS_MIN_NUM_AVERAGES                                       2                                                             // 2 (0x2)
 #define NISCOPE_VAL_RIS_INCOMPLETE                                             3                                                             // 3 (0x3)
 #define NISCOPE_VAL_RIS_LIMITED_BIN_WIDTH                                      5                                                             // 5 (0x5)
+
 // Values used in
 //     niScope_SendSoftwareTriggerEdge
 #define NISCOPE_VAL_SOFTWARE_TRIGGER_START                                     0                                                             // 0 (0x0)
 #define NISCOPE_VAL_SOFTWARE_TRIGGER_ARM_REFERENCE                             1                                                             // 1 (0x1)
 #define NISCOPE_VAL_SOFTWARE_TRIGGER_REFERENCE                                 2                                                             // 2 (0x2)
 #define NISCOPE_VAL_SOFTWARE_TRIGGER_ADVANCE                                   3                                                             // 3 (0x3)
+
 // Values used in
 //     NISCOPE_ATTR_VERTICAL_COUPLING, niScope_ConfigureVertical
 #define NISCOPE_VAL_AC                                                         IVISCOPE_VAL_AC                                               // 0 (0x0)
 #define NISCOPE_VAL_DC                                                         IVISCOPE_VAL_DC                                               // 1 (0x1)
 #define NISCOPE_VAL_GND                                                        IVISCOPE_VAL_GND                                              // 2 (0x2)
+
 // Values used in
 //     NISCOPE_ATTR_MAX_INPUT_FREQUENCY
 #define NISCOPE_VAL_BANDWIDTH_FULL                                             -1.0
@@ -428,11 +489,13 @@ extern "C" {
 #define NISCOPE_VAL_100MHZ_BANDWIDTH                                           100000000.0
 #define NISCOPE_VAL_20MHZ_MAX_INPUT_FREQUENCY                                  20000000.0
 #define NISCOPE_VAL_100MHZ_MAX_INPUT_FREQUENCY                                 100000000.0
+
 // Values used in
 //     NISCOPE_ATTR_INPUT_IMPEDANCE
 #define NISCOPE_VAL_50_OHMS                                                    50.0
 #define NISCOPE_VAL_75_OHMS                                                    75.0
 #define NISCOPE_VAL_1_MEG_OHM                                                  1000000.0
+
 // Values used in
 //     NISCOPE_ATTR_TRIGGER_TYPE
 #define NISCOPE_VAL_EDGE_TRIGGER                                               IVISCOPE_VAL_EDGE_TRIGGER                                     // 1 (0x1)
@@ -445,6 +508,7 @@ extern "C" {
 #define NISCOPE_VAL_WIDTH_TRIGGER                                              IVISCOPE_VAL_WIDTH_TRIGGER                                    // 2 (0x2)
 #define NISCOPE_VAL_RUNT_TRIGGER                                               IVISCOPE_VAL_RUNT_TRIGGER                                     // 3 (0x3)
 #define NISCOPE_VAL_IMMEDIATE_TRIGGER                                          IVISCOPE_VAL_IMMEDIATE_TRIGGER                                // 6 (0x6)
+
 // Values used in
 //     NISCOPE_ATTR_TRIGGER_SOURCE
 #define NISCOPE_VAL_IMMEDIATE                                                  "VAL_IMMEDIATE"
@@ -485,6 +549,7 @@ extern "C" {
 #define NISCOPE_VAL_AUX_0_PFI_6                                                "VAL_AUX_0_PFI_6"
 #define NISCOPE_VAL_AUX_0_PFI_7                                                "VAL_AUX_0_PFI_7"
 #define NISCOPE_VAL_AUX_0_PFI_2                                                "VAL_AUX_0_PFI_2"
+
 // Values used in
 //     NISCOPE_ATTR_FETCH_RELATIVE_TO
 #define NISCOPE_VAL_READ_POINTER                                               388                                                           // 388 (0x184)
@@ -492,11 +557,13 @@ extern "C" {
 #define NISCOPE_VAL_NOW                                                        481                                                           // 481 (0x1e1)
 #define NISCOPE_VAL_START                                                      482                                                           // 482 (0x1e2)
 #define NISCOPE_VAL_TRIGGER                                                    483                                                           // 483 (0x1e3)
+
 // Values used in
 //     NISCOPE_ATTR_TRIGGER_MODIFIER
 #define NISCOPE_VAL_NO_TRIGGER_MOD                                             IVISCOPE_VAL_NO_TRIGGER_MOD                                   // 1 (0x1)
 #define NISCOPE_VAL_AUTO                                                       IVISCOPE_VAL_AUTO                                             // 2 (0x2)
 #define NISCOPE_VAL_AUTO_LEVEL                                                 IVISCOPE_VAL_AUTO_LEVEL                                       // 3 (0x3)
+
 // Values used in
 //     NISCOPE_ATTR_TRIGGER_COUPLING, niScope_ConfigureTriggerEdge, niScope_ConfigureTriggerGlitch,
 //     niScope_ConfigureTriggerHysteresis, niScope_ConfigureTriggerRunt, niScope_ConfigureTriggerVideo,
@@ -506,21 +573,25 @@ extern "C" {
 #define NISCOPE_VAL_HF_REJECT                                                  IVISCOPE_VAL_HF_REJECT                                        // 3 (0x3)
 #define NISCOPE_VAL_LF_REJECT                                                  IVISCOPE_VAL_LF_REJECT                                        // 4 (0x4)
 #define NISCOPE_VAL_AC_PLUS_HF_REJECT                                          (IVISCOPE_VAL_TRIGGER_COUPLING_SPECIFIC_EXT_BASE + 1L)        // 1001 (0x3e9)
+
 // Values used in
 //     NISCOPE_ATTR_TRIGGER_SLOPE, niScope_ConfigureTriggerDigital, niScope_ConfigureTriggerEdge,
 //     niScope_ConfigureTriggerHysteresis
 #define NISCOPE_VAL_NEGATIVE                                                   IVISCOPE_VAL_NEGATIVE                                         // 0 (0x0)
 #define NISCOPE_VAL_POSITIVE                                                   IVISCOPE_VAL_POSITIVE                                         // 1 (0x1)
 #define NISCOPE_VAL_SLOPE_EITHER                                               3                                                             // 3 (0x3)
+
 // Values used in
 //     NISCOPE_ATTR_ACQUISITION_TYPE
 #define NISCOPE_VAL_NORMAL                                                     IVISCOPE_VAL_NORMAL                                           // 0 (0x0)
 #define NISCOPE_VAL_FLEXRES                                                    (IVISCOPE_VAL_ACQUISITION_TYPE_SPECIFIC_EXT_BASE + 1L)        // 1001 (0x3e9)
 #define NISCOPE_VAL_DDC                                                        (IVISCOPE_VAL_ACQUISITION_TYPE_SPECIFIC_EXT_BASE + 2L)        // 1002 (0x3ea)
+
 // Interpolation
 #define NISCOPE_VAL_NO_INTERPOLATION                                           IVISCOPE_VAL_NO_INTERPOLATION                                 // 1 (0x1)
 #define NISCOPE_VAL_SINE_X                                                     IVISCOPE_VAL_SINE_X                                           // 2 (0x2)
 #define NISCOPE_VAL_LINEAR                                                     IVISCOPE_VAL_LINEAR                                           // 3 (0x3)
+
 // Values used in
 //     NISCOPE_ATTR_TV_TRIGGER_SIGNAL_FORMAT
 #define NISCOPE_VAL_NTSC                                                       IVISCOPE_VAL_NTSC                                             // 1 (0x1)
@@ -540,10 +611,12 @@ extern "C" {
 #define NISCOPE_VAL_1080I_59_94_FIELDS_PER_SECOND                              (IVISCOPE_VAL_TV_SIGNAL_FORMAT_SPECIFIC_EXT_BASE + 41L)       // 1041 (0x411)
 #define NISCOPE_VAL_1080I_60_FIELDS_PER_SECOND                                 (IVISCOPE_VAL_TV_SIGNAL_FORMAT_SPECIFIC_EXT_BASE + 42L)       // 1042 (0x412)
 #define NISCOPE_VAL_1080P_24_FRAMES_PER_SECOND                                 (IVISCOPE_VAL_TV_SIGNAL_FORMAT_SPECIFIC_EXT_BASE + 45L)       // 1045 (0x415)
+
 // Values used in
 //     NISCOPE_ATTR_TV_TRIGGER_POLARITY, niScope_ConfigureTriggerVideo
 #define NISCOPE_VAL_TV_POSITIVE                                                IVISCOPE_VAL_TV_POSITIVE                                      // 1 (0x1)
 #define NISCOPE_VAL_TV_NEGATIVE                                                IVISCOPE_VAL_TV_NEGATIVE                                      // 2 (0x2)
+
 // Values used in
 //     NISCOPE_ATTR_TV_TRIGGER_EVENT, niScope_ConfigureTriggerVideo
 #define NISCOPE_VAL_TV_EVENT_FIELD1                                            IVISCOPE_VAL_TV_EVENT_FIELD1                                  // 1 (0x1)
@@ -551,50 +624,59 @@ extern "C" {
 #define NISCOPE_VAL_TV_EVENT_ANY_FIELD                                         IVISCOPE_VAL_TV_EVENT_ANY_FIELD                               // 3 (0x3)
 #define NISCOPE_VAL_TV_EVENT_ANY_LINE                                          IVISCOPE_VAL_TV_EVENT_ANY_LINE                                // 4 (0x4)
 #define NISCOPE_VAL_TV_EVENT_LINE_NUMBER                                       IVISCOPE_VAL_TV_EVENT_LINE_NUMBER                             // 5 (0x5)
+
 // Values used in
 //     NISCOPE_ATTR_GLITCH_CONDITION, niScope_ConfigureTriggerGlitch
 #define NISCOPE_VAL_GLITCH_GREATER_THAN                                        IVISCOPE_VAL_GLITCH_GREATER_THAN                              // 2 (0x2)
 #define NISCOPE_VAL_GLITCH_LESS_THAN                                           IVISCOPE_VAL_GLITCH_LESS_THAN                                 // 1 (0x1)
+
 // Values used in
 //     NISCOPE_ATTR_GLITCH_POLARITY, niScope_ConfigureTriggerGlitch
 #define NISCOPE_VAL_GLITCH_POSITIVE                                            IVISCOPE_VAL_GLITCH_POSITIVE                                  // 1 (0x1)
 #define NISCOPE_VAL_GLITCH_NEGATIVE                                            IVISCOPE_VAL_GLITCH_NEGATIVE                                  // 2 (0x2)
 #define NISCOPE_VAL_GLITCH_EITHER                                              IVISCOPE_VAL_GLITCH_EITHER                                    // 3 (0x3)
+
 // Values used in
 //     NISCOPE_ATTR_WIDTH_CONDITION, niScope_ConfigureTriggerWidth
 #define NISCOPE_VAL_WIDTH_WITHIN                                               IVISCOPE_VAL_WIDTH_WITHIN                                     // 1 (0x1)
 #define NISCOPE_VAL_WIDTH_OUTSIDE                                              IVISCOPE_VAL_WIDTH_OUTSIDE                                    // 2 (0x2)
+
 // Values used in
 //     NISCOPE_ATTR_WIDTH_POLARITY, niScope_ConfigureTriggerWidth
 #define NISCOPE_VAL_WIDTH_POSITIVE                                             IVISCOPE_VAL_WIDTH_POSITIVE                                   // 1 (0x1)
 #define NISCOPE_VAL_WIDTH_NEGATIVE                                             IVISCOPE_VAL_WIDTH_NEGATIVE                                   // 2 (0x2)
 #define NISCOPE_VAL_WIDTH_EITHER                                               IVISCOPE_VAL_WIDTH_EITHER                                     // 3 (0x3)
+
 // Values used in
 //     NISCOPE_ATTR_RUNT_POLARITY, niScope_ConfigureTriggerRunt
 #define NISCOPE_VAL_RUNT_POSITIVE                                              IVISCOPE_VAL_RUNT_POSITIVE                                    // 1 (0x1)
 #define NISCOPE_VAL_RUNT_NEGATIVE                                              IVISCOPE_VAL_RUNT_NEGATIVE                                    // 2 (0x2)
 #define NISCOPE_VAL_RUNT_EITHER                                                IVISCOPE_VAL_RUNT_EITHER                                      // 3 (0x3)
+
 // Values used in
 //     NISCOPE_ATTR_RUNT_TIME_CONDITION
 #define NISCOPE_VAL_RUNT_TIME_CONDITION_NONE                                   0                                                             // 0 (0x0)
 #define NISCOPE_VAL_RUNT_TIME_CONDITION_WITHIN                                 1                                                             // 1 (0x1)
 #define NISCOPE_VAL_RUNT_TIME_CONDITION_OUTSIDE                                2                                                             // 2 (0x2)
+
 // Values used in
 //     NISCOPE_ATTR_CABLE_SENSE_MODE
 #define NISCOPE_VAL_CABLE_SENSE_MODE_DISABLED                                  0                                                             // 0 (0x0)
 #define NISCOPE_VAL_CABLE_SENSE_MODE_ON_DEMAND                                 1                                                             // 1 (0x1)
+
 // Values used in
 //     NISCOPE_ATTR_SAMPLE_MODE
 #define NISCOPE_VAL_REAL_TIME                                                  IVISCOPE_VAL_REAL_TIME                                        // 0 (0x0)
 #define NISCOPE_VAL_EQUIVALENT_TIME                                            IVISCOPE_VAL_EQUIVALENT_TIME                                  // 1 (0x1)
+
 // Values used in
 //     niScope_ConfigureClock, niScope_ExportSignal
 #define NISCOPE_VAL_NO_SOURCE                                                  "VAL_NO_SOURCE"
 #define NISCOPE_VAL_RTSI_CLOCK                                                 "VAL_RTSI_CLOCK"
-// #define NISCOPE_VAL_EXTERNAL                                                DEFINED ABOVE (IVISCOPE_VAL_EXTERNAL)
-// #define NISCOPE_VAL_PFI_0                                                   DEFINED ABOVE ("VAL_PFI_0")
-// #define NISCOPE_VAL_PFI_1                                                   DEFINED ABOVE ("VAL_PFI_1")
-// #define NISCOPE_VAL_PFI_2                                                   DEFINED ABOVE ("VAL_PFI_2")
+// #define NISCOPE_VAL_EXTERNAL                                                DEFINED ABOVE (IVISCOPE_VAL_EXTERNAL)                        
+// #define NISCOPE_VAL_PFI_0                                                   DEFINED ABOVE ("VAL_PFI_0")                                  
+// #define NISCOPE_VAL_PFI_1                                                   DEFINED ABOVE ("VAL_PFI_1")                                  
+// #define NISCOPE_VAL_PFI_2                                                   DEFINED ABOVE ("VAL_PFI_2")                                  
 #define NISCOPE_VAL_CLK_IN                                                     "VAL_CLK_IN"
 #define NISCOPE_VAL_CLK_OUT                                                    "VAL_CLK_OUT"
 #define NISCOPE_VAL_INTERNAL10MHZ_OSC                                          "VAL_INTERNAL10MHZ_OSC"
@@ -605,14 +687,16 @@ extern "C" {
 #define NISCOPE_VAL_AUX_0_CLK_IN                                               "VAL_AUX_0_CLK_IN"
 #define NISCOPE_VAL_AUX_0_CLK_OUT                                              "VAL_AUX_0_CLK_OUT"
 #define NISCOPE_VAL_ONBOARD_CONFIGURABLE_RATE_CLK                              "VAL_ONBOARD_CONFIGURABLE_RATE_CLK"
+
 // Values used in
 //     NISCOPE_ATTR_SAMP_CLK_TIMEBASE_SRC
-// #define NISCOPE_VAL_CLK_IN                                                  DEFINED ABOVE ("VAL_CLK_IN")
-// #define NISCOPE_VAL_NO_SOURCE                                               DEFINED ABOVE ("VAL_NO_SOURCE")
-// #define NISCOPE_VAL_PXI_STAR                                                DEFINED ABOVE (IVISCOPE_VAL_PXI_STAR)
-// #define NISCOPE_VAL_PXIE_DSTAR_A                                            DEFINED ABOVE ("VAL_PXIE_DSTAR_A")
-// #define NISCOPE_VAL_AUX_0_CLK_IN                                            DEFINED ABOVE ("VAL_AUX_0_CLK_IN")
-// #define NISCOPE_VAL_ONBOARD_CONFIGURABLE_RATE_CLK                           DEFINED ABOVE ("VAL_ONBOARD_CONFIGURABLE_RATE_CLK")
+// #define NISCOPE_VAL_CLK_IN                                                  DEFINED ABOVE ("VAL_CLK_IN")                                 
+// #define NISCOPE_VAL_NO_SOURCE                                               DEFINED ABOVE ("VAL_NO_SOURCE")                              
+// #define NISCOPE_VAL_PXI_STAR                                                DEFINED ABOVE (IVISCOPE_VAL_PXI_STAR)                        
+// #define NISCOPE_VAL_PXIE_DSTAR_A                                            DEFINED ABOVE ("VAL_PXIE_DSTAR_A")                           
+// #define NISCOPE_VAL_AUX_0_CLK_IN                                            DEFINED ABOVE ("VAL_AUX_0_CLK_IN")                           
+// #define NISCOPE_VAL_ONBOARD_CONFIGURABLE_RATE_CLK                           DEFINED ABOVE ("VAL_ONBOARD_CONFIGURABLE_RATE_CLK")          
+
 // Values used in
 //     niScope_ExportSignal
 #define NISCOPE_VAL_REF_TRIGGER                                                1                                                             // 1 (0x1)
@@ -623,38 +707,45 @@ extern "C" {
 #define NISCOPE_VAL_READY_FOR_ADVANCE_EVENT                                    6                                                             // 6 (0x6)
 #define NISCOPE_VAL_READY_FOR_START_EVENT                                      7                                                             // 7 (0x7)
 #define NISCOPE_VAL_READY_FOR_REF_EVENT                                        10                                                            // 10 (0xa)
-#define NISCOPE_VAL_REF_CLOCK                                                  100                                                           // 100 (0x64)
 #define NISCOPE_VAL_5V_OUT                                                     13                                                            // 13 (0xd)
+#define NISCOPE_VAL_REF_CLOCK                                                  100                                                           // 100 (0x64)
 #define NISCOPE_VAL_SAMPLE_CLOCK                                               101                                                           // 101 (0x65)
+
 // Values used in
 //     NISCOPE_ATTR_TRIGGER_WINDOW_MODE, niScope_ConfigureTriggerWindow
 #define NISCOPE_VAL_ENTERING_WINDOW                                            0                                                             // 0 (0x0)
 #define NISCOPE_VAL_LEAVING_WINDOW                                             1                                                             // 1 (0x1)
 #define NISCOPE_VAL_ENTERING_OR_LEAVING_WINDOW                                 2                                                             // 2 (0x2)
+
 // Max Time
 #define NISCOPE_VAL_MAX_TIME_INFINITE                                          0xFFFFFFFFUL                                                  // 4294967295 (0xffffffff)
 #define NISCOPE_VAL_MAX_TIME_IMMEDIATE                                         0                                                             // 0 (0x0)
 #define NISCOPE_VAL_MAX_TIME_NONE                                              0                                                             // 0 (0x0)
+
 // Values used in
 //     niScope_AcquisitionStatus
 #define NISCOPE_VAL_ACQ_COMPLETE                                               IVISCOPE_VAL_ACQ_COMPLETE                                     // 1 (0x1)
 #define NISCOPE_VAL_ACQ_IN_PROGRESS                                            IVISCOPE_VAL_ACQ_IN_PROGRESS                                  // 0 (0x0)
 #define NISCOPE_VAL_ACQ_STATUS_UNKNOWN                                         IVISCOPE_VAL_ACQ_STATUS_UNKNOWN                               // -1 (-0x1)
+
 // Values used in
 //     NISCOPE_ATTR_MEAS_FILTER_TYPE
 #define NISCOPE_VAL_MEAS_LOWPASS                                               0                                                             // 0 (0x0)
 #define NISCOPE_VAL_MEAS_HIGHPASS                                              1                                                             // 1 (0x1)
 #define NISCOPE_VAL_MEAS_BANDPASS                                              2                                                             // 2 (0x2)
 #define NISCOPE_VAL_MEAS_BANDSTOP                                              3                                                             // 3 (0x3)
+
 // Values used in
 //     NISCOPE_ATTR_MEAS_PERCENTAGE_METHOD
 #define NISCOPE_VAL_MEAS_LOW_HIGH                                              0                                                             // 0 (0x0)
 #define NISCOPE_VAL_MEAS_MIN_MAX                                               1                                                             // 1 (0x1)
 #define NISCOPE_VAL_MEAS_BASE_TOP                                              2                                                             // 2 (0x2)
+
 // Values used in
 //     NISCOPE_ATTR_MEAS_REF_LEVEL_UNITS
 #define NISCOPE_VAL_MEAS_VOLTAGE                                               0                                                             // 0 (0x0)
 #define NISCOPE_VAL_MEAS_PERCENTAGE                                            1                                                             // 1 (0x1)
+
 // Values used in
 //     niScope_FetchMeasurement, niScope_FetchMeasurementStats, niScope_ReadMeasurement
 #define NISCOPE_VAL_NO_MEASUREMENT                                             4000                                                          // 4000 (0xfa0)
@@ -697,6 +788,7 @@ extern "C" {
 #define NISCOPE_VAL_AVERAGE_FREQUENCY                                          (IVISCOPE_VAL_MEASUREMENT_FUNCTION_SPECIFIC_EXT_BASE + 16L)   // 1016 (0x3f8)
 #define NISCOPE_VAL_VOLTAGE_BASE_TO_TOP                                        (IVISCOPE_VAL_MEASUREMENT_FUNCTION_SPECIFIC_EXT_BASE + 17L)   // 1017 (0x3f9)
 #define NISCOPE_VAL_PHASE_DELAY                                                (IVISCOPE_VAL_MEASUREMENT_FUNCTION_SPECIFIC_EXT_BASE + 18L)   // 1018 (0x3fa)
+
 // Voltage Histogram
 #define NISCOPE_VAL_VOLTAGE_HISTOGRAM_MEAN                                     (IVISCOPE_VAL_MEASUREMENT_FUNCTION_SPECIFIC_EXT_BASE + 1000L) // 2000 (0x7d0)
 #define NISCOPE_VAL_VOLTAGE_HISTOGRAM_STDEV                                    (IVISCOPE_VAL_MEASUREMENT_FUNCTION_SPECIFIC_EXT_BASE + 1001L) // 2001 (0x7d1)
@@ -710,6 +802,7 @@ extern "C" {
 #define NISCOPE_VAL_VOLTAGE_HISTOGRAM_MEAN_PLUS_3_STDEV                        (IVISCOPE_VAL_MEASUREMENT_FUNCTION_SPECIFIC_EXT_BASE + 1009L) // 2009 (0x7d9)
 #define NISCOPE_VAL_VOLTAGE_HISTOGRAM_MODE                                     (IVISCOPE_VAL_MEASUREMENT_FUNCTION_SPECIFIC_EXT_BASE + 1010L) // 2010 (0x7da)
 #define NISCOPE_VAL_VOLTAGE_HISTOGRAM_NEW_HITS                                 (IVISCOPE_VAL_MEASUREMENT_FUNCTION_SPECIFIC_EXT_BASE + 1011L) // 2011 (0x7db)
+
 // Time Histogram
 #define NISCOPE_VAL_TIME_HISTOGRAM_MEAN                                        (IVISCOPE_VAL_MEASUREMENT_FUNCTION_SPECIFIC_EXT_BASE + 2000L) // 3000 (0xbb8)
 #define NISCOPE_VAL_TIME_HISTOGRAM_STDEV                                       (IVISCOPE_VAL_MEASUREMENT_FUNCTION_SPECIFIC_EXT_BASE + 2001L) // 3001 (0xbb9)
@@ -723,6 +816,7 @@ extern "C" {
 #define NISCOPE_VAL_TIME_HISTOGRAM_MEAN_PLUS_3_STDEV                           (IVISCOPE_VAL_MEASUREMENT_FUNCTION_SPECIFIC_EXT_BASE + 2009L) // 3009 (0xbc1)
 #define NISCOPE_VAL_TIME_HISTOGRAM_MODE                                        (IVISCOPE_VAL_MEASUREMENT_FUNCTION_SPECIFIC_EXT_BASE + 2010L) // 3010 (0xbc2)
 #define NISCOPE_VAL_TIME_HISTOGRAM_NEW_HITS                                    (IVISCOPE_VAL_MEASUREMENT_FUNCTION_SPECIFIC_EXT_BASE + 2011L) // 3011 (0xbc3)
+
 // Values used in
 //     niScope_ActualMeasWfmSize, niScope_AddWaveformProcessing, niScope_FetchArrayMeasurement
 // #define NISCOPE_VAL_NO_MEASUREMENT                                          DEFINED ABOVE (4000)                                          // 4000 (0xfa0)
@@ -752,43 +846,53 @@ extern "C" {
 #define NISCOPE_VAL_BLACKMAN_WINDOW                                            4024                                                          // 4024 (0xfb8)
 #define NISCOPE_VAL_ARRAY_OFFSET                                               4025                                                          // 4025 (0xfb9)
 #define NISCOPE_VAL_ARRAY_GAIN                                                 4026                                                          // 4026 (0xfba)
+
 // Values used in
 //     NISCOPE_ATTR_DDC_DATA_PROCESSING_MODE
 #define NISCOPE_VAL_REAL                                                       0                                                             // 0 (0x0)
 #define NISCOPE_VAL_COMPLEX                                                    1                                                             // 1 (0x1)
+
 // Values used in
 //     NISCOPE_ATTR_CHANNEL_TERMINAL_CONFIGURATION
 #define NISCOPE_VAL_SINGLE_ENDED                                               0                                                             // 0 (0x0)
 #define NISCOPE_VAL_UNBALANCED_DIFFERENTIAL                                    1                                                             // 1 (0x1)
 #define NISCOPE_VAL_DIFFERENTIAL                                               2                                                             // 2 (0x2)
+
 // Values used in
 //     NISCOPE_ATTR_FLEX_FIR_ANTIALIAS_FILTER_TYPE
 #define NISCOPE_VAL_48_TAP_STANDARD                                            0                                                             // 0 (0x0)
 #define NISCOPE_VAL_48_TAP_HANNING                                             1                                                             // 1 (0x1)
 #define NISCOPE_VAL_16_TAP_HANNING                                             2                                                             // 2 (0x2)
 #define NISCOPE_VAL_8_TAP_HANNING                                              3                                                             // 3 (0x3)
+
 // Values used in
 //     NISCOPE_ATTR_OVERFLOW_ERROR_REPORTING
 #define NISCOPE_VAL_ERROR_REPORTING_ERROR                                      0                                                             // 0 (0x0)
 #define NISCOPE_VAL_ERROR_REPORTING_WARNING                                    1                                                             // 1 (0x1)
 #define NISCOPE_VAL_ERROR_REPORTING_DISABLED                                   2                                                             // 2 (0x2)
+
 // Values used in
 //     NISCOPE_ATTR_REF_TRIGGER_DETECTOR_LOCATION
 #define NISCOPE_VAL_ANALOG_DETECTION_CIRCUIT                                   0                                                             // 0 (0x0)
 #define NISCOPE_VAL_DDC_OUTPUT                                                 1                                                             // 1 (0x1)
+
 // Values used in
 //     NISCOPE_ATTR_P2P_DATA_TRANS_PERMISSION_ADDR_TYPE, NISCOPE_ATTR_P2P_DESTINATION_WINDOW_ADDR_TYPE,
 //     NISCOPE_ATTR_P2P_NOTIFY_MESSAGE_PUSH_ADDR_TYPE
 #define NISCOPE_VAL_ADDR_PHYSICAL                                              0                                                             // 0 (0x0)
 #define NISCOPE_VAL_ADDR_VIRTUAL                                               1                                                             // 1 (0x1)
+
 // Values used in
 //     NISCOPE_ATTR_P2P_NOTIFY_PUSH_MESSAGE_ON
 #define NISCOPE_VAL_NOTIFY_NEVER                                               0                                                             // 0 (0x0)
 #define NISCOPE_VAL_NOTIFY_DONE                                                1                                                             // 1 (0x1)
+
 // P2P Stream Relative To
 #define NISCOPE_VAL_STREAM_RELATIVE_TO_START_TRIGGER                           0                                                             // 0 (0x0)
 #define NISCOPE_VAL_STREAM_RELATIVE_TO_REFERENCE_TRIGGER                       1                                                             // 1 (0x1)
 #define NISCOPE_VAL_STREAM_RELATIVE_TO_SYNC_TRIGGER                            2                                                             // 2 (0x2)
+
+
 /****************************************************************************
  *-------------------------------- Constants -------------------------------*
  ****************************************************************************/
@@ -802,6 +906,8 @@ extern "C" {
 #define NISCOPE_VAL_RESTORE_FACTORY_CALIBRATION                                2                                                             // 2 (0x2)
 #define NISCOPE_VAL_CAL_RESTORE_EXTERNAL_CALIBRATION                           NISCOPE_VAL_RESTORE_FACTORY_CALIBRATION                       // 2 (0x2)
 #define NISCOPE_VAL_ALL_MEASUREMENTS                                           10000                                                         // 10000 (0x2710)
+
+
 /****************************************************************************
  *----------------------------- Type Definitions ---------------------------*
  ****************************************************************************/
@@ -817,6 +923,7 @@ struct niScope_wfmInfo
     ViReal64 reserved1;
     ViReal64 reserved2;
 };
+
 struct niScope_coefficientInfo
 {
     ViReal64 offset;
@@ -824,6 +931,7 @@ struct niScope_coefficientInfo
     ViReal64 reserved1;
     ViReal64 reserved2;
 };
+
 #if !defined(_NIComplexNumber)
 #define _NIComplexNumber
 typedef struct NIComplexNumber_struct
@@ -832,6 +940,7 @@ typedef struct NIComplexNumber_struct
     ViReal64 imaginary;
 } NIComplexNumber;
 #endif // !defined(_NIComplexNumber)
+
 #if !defined(_NIComplexI16)
 #define _NIComplexI16
 typedef struct NIComplexI16_struct
@@ -840,27 +949,34 @@ typedef struct NIComplexI16_struct
     ViInt16 imaginary;
 } NIComplexI16;
 #endif // !defined(_NIComplexI16)
+
 #pragma pack(pop)
+
+
 /****************************************************************************
  *---------------- Instrument Driver Function Declarations -----------------*
  ****************************************************************************/
-// -- Init and Close Functions --
+// -- Init And Close Functions --
 ViStatus _VI_FUNC niScope_init(
    ViRsrc resourceName,
    ViBoolean idQuery,
    ViBoolean resetDevice,
    ViSession* vi);
+
 ViStatus _VI_FUNC niScope_InitWithOptions(
    ViRsrc resourceName,
    ViBoolean idQuery,
    ViBoolean resetDevice,
    ViConstString optionString,
    ViSession* vi);
+
 ViStatus _VI_FUNC niScope_close(
    ViSession vi);
-// -- AutoSetup Functions --
+
+// -- Autosetup Functions --
 ViStatus _VI_FUNC niScope_AutoSetup(
    ViSession vi);
+
 // -- Vertical Subsystem Configuration --
 ViStatus _VI_FUNC niScope_ConfigureVertical(
    ViSession vi,
@@ -870,11 +986,13 @@ ViStatus _VI_FUNC niScope_ConfigureVertical(
    ViInt32 coupling,
    ViReal64 probeAttenuation,
    ViBoolean enabled);
+
 ViStatus _VI_FUNC niScope_ConfigureChanCharacteristics(
    ViSession vi,
    ViConstString channelList,
    ViReal64 inputImpedance,
    ViReal64 maxInputFrequency);
+
 // -- Horizontal Subsystem Configuration --
 ViStatus _VI_FUNC niScope_ConfigureHorizontalTiming(
    ViSession vi,
@@ -883,6 +1001,7 @@ ViStatus _VI_FUNC niScope_ConfigureHorizontalTiming(
    ViReal64 refPosition,
    ViInt32 numRecords,
    ViBoolean enforceRealtime);
+
 // -- Synchronization Configuration --
 ViStatus _VI_FUNC niScope_ConfigureClock(
    ViSession vi,
@@ -890,14 +1009,17 @@ ViStatus _VI_FUNC niScope_ConfigureClock(
    ViConstString outputClockSource,
    ViConstString clockSyncPulseSource,
    ViBoolean masterEnabled);
+
 ViStatus _VI_FUNC niScope_ExportSignal(
    ViSession vi,
    ViInt32 signal,
    ViConstString signalIdentifier,
    ViConstString outputTerminal);
+
 ViStatus _VI_FUNC niScope_AdjustSampleClockRelativeDelay(
    ViSession vi,
    ViReal64 delay);
+
 // -- Triggering Subsystem Configuration --
 ViStatus _VI_FUNC niScope_ConfigureTriggerEdge(
    ViSession vi,
@@ -907,6 +1029,7 @@ ViStatus _VI_FUNC niScope_ConfigureTriggerEdge(
    ViInt32 triggerCoupling,
    ViReal64 holdoff,
    ViReal64 delay);
+
 ViStatus _VI_FUNC niScope_ConfigureTriggerGlitch(
    ViSession vi,
    ViConstString triggerSource,
@@ -917,6 +1040,7 @@ ViStatus _VI_FUNC niScope_ConfigureTriggerGlitch(
    ViInt32 triggerCoupling,
    ViReal64 holdoff,
    ViReal64 delay);
+
 ViStatus _VI_FUNC niScope_ConfigureTriggerHysteresis(
    ViSession vi,
    ViConstString triggerSource,
@@ -926,6 +1050,7 @@ ViStatus _VI_FUNC niScope_ConfigureTriggerHysteresis(
    ViInt32 triggerCoupling,
    ViReal64 holdoff,
    ViReal64 delay);
+
 ViStatus _VI_FUNC niScope_ConfigureTriggerWindow(
    ViSession vi,
    ViConstString triggerSource,
@@ -935,15 +1060,19 @@ ViStatus _VI_FUNC niScope_ConfigureTriggerWindow(
    ViInt32 triggerCoupling,
    ViReal64 holdoff,
    ViReal64 delay);
+
 ViStatus _VI_FUNC niScope_ConfigureTriggerSoftware(
    ViSession vi,
    ViReal64 holdoff,
    ViReal64 delay);
+
 ViStatus _VI_FUNC niScope_SendSoftwareTriggerEdge(
    ViSession vi,
    ViInt32 whichTrigger);
+
 ViStatus _VI_FUNC niScope_ConfigureTriggerImmediate(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_ConfigureTriggerRunt(
    ViSession vi,
    ViConstString triggerSource,
@@ -953,12 +1082,14 @@ ViStatus _VI_FUNC niScope_ConfigureTriggerRunt(
    ViInt32 triggerCoupling,
    ViReal64 holdoff,
    ViReal64 delay);
+
 ViStatus _VI_FUNC niScope_ConfigureTriggerDigital(
    ViSession vi,
    ViConstString triggerSource,
    ViInt32 slope,
    ViReal64 holdoff,
    ViReal64 delay);
+
 ViStatus _VI_FUNC niScope_ConfigureTriggerVideo(
    ViSession vi,
    ViConstString triggerSource,
@@ -970,6 +1101,7 @@ ViStatus _VI_FUNC niScope_ConfigureTriggerVideo(
    ViInt32 triggerCoupling,
    ViReal64 holdoff,
    ViReal64 delay);
+
 ViStatus _VI_FUNC niScope_ConfigureTriggerWidth(
    ViSession vi,
    ViConstString triggerSource,
@@ -981,17 +1113,20 @@ ViStatus _VI_FUNC niScope_ConfigureTriggerWidth(
    ViInt32 triggerCoupling,
    ViReal64 holdoff,
    ViReal64 delay);
+
 // -- Onboard Signal Processing Subsystem Configuration --
 ViStatus _VI_FUNC niScope_ConfigureEqualizationFilterCoefficients(
    ViSession vi,
    ViConstString channelList,
    ViInt32 numberOfCoefficients,
    ViReal64 coefficients[]);
+
 ViStatus _VI_FUNC niScope_GetEqualizationFilterCoefficients(
    ViSession vi,
    ViConstString channel,
    ViInt32 numberOfCoefficients,
    ViReal64 coefficients[]);
+
 ViStatus _VI_FUNC niScope_GetFrequencyResponse(
    ViSession vi,
    ViConstString channel,
@@ -1000,16 +1135,21 @@ ViStatus _VI_FUNC niScope_GetFrequencyResponse(
    ViReal64 amplitudes[],
    ViReal64 phases[],
    ViInt32* numberOfFrequencies);
+
 // -- Waveform Acquisition Subsystem --
 ViStatus _VI_FUNC niScope_ConfigureAcquisition(
    ViSession vi,
    ViInt32 acquisitionType);
+
 ViStatus _VI_FUNC niScope_InitiateAcquisition(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_Abort(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_Commit(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_Read(
    ViSession vi,
    ViConstString channelList,
@@ -1017,6 +1157,7 @@ ViStatus _VI_FUNC niScope_Read(
    ViInt32 numSamples,
    ViReal64 waveform[],
    struct niScope_wfmInfo wfmInfo[]);
+
 ViStatus _VI_FUNC niScope_Fetch(
    ViSession vi,
    ViConstString channelList,
@@ -1024,6 +1165,7 @@ ViStatus _VI_FUNC niScope_Fetch(
    ViInt32 numSamples,
    ViReal64 waveform[],
    struct niScope_wfmInfo wfmInfo[]);
+
 ViStatus _VI_FUNC niScope_FetchBinary8(
    ViSession vi,
    ViConstString channelList,
@@ -1031,6 +1173,7 @@ ViStatus _VI_FUNC niScope_FetchBinary8(
    ViInt32 numSamples,
    ViInt8 waveform[],
    struct niScope_wfmInfo wfmInfo[]);
+
 ViStatus _VI_FUNC niScope_FetchBinary16(
    ViSession vi,
    ViConstString channelList,
@@ -1038,6 +1181,7 @@ ViStatus _VI_FUNC niScope_FetchBinary16(
    ViInt32 numSamples,
    ViInt16 waveform[],
    struct niScope_wfmInfo wfmInfo[]);
+
 ViStatus _VI_FUNC niScope_FetchBinary32(
    ViSession vi,
    ViConstString channelList,
@@ -1045,6 +1189,7 @@ ViStatus _VI_FUNC niScope_FetchBinary32(
    ViInt32 numSamples,
    ViInt32 waveform[],
    struct niScope_wfmInfo wfmInfo[]);
+
 ViStatus _VI_FUNC niScope_FetchComplex(
    ViSession vi,
    ViConstString channelList,
@@ -1052,6 +1197,7 @@ ViStatus _VI_FUNC niScope_FetchComplex(
    ViInt32 numSamples,
    NIComplexNumber wfm[],
    struct niScope_wfmInfo wfmInfo[]);
+
 ViStatus _VI_FUNC niScope_FetchComplexBinary16(
    ViSession vi,
    ViConstString channelList,
@@ -1059,52 +1205,64 @@ ViStatus _VI_FUNC niScope_FetchComplexBinary16(
    ViInt32 numSamples,
    NIComplexI16 wfm[],
    struct niScope_wfmInfo wfmInfo[]);
+
 // -- Status --
 ViStatus _VI_FUNC niScope_AcquisitionStatus(
    ViSession vi,
    ViInt32* acquisitionStatus);
+
 // -- Actual Values --
 ViStatus _VI_FUNC niScope_ActualNumWfms(
    ViSession vi,
    ViConstString channelList,
    ViInt32* numWfms);
+
 ViStatus _VI_FUNC niScope_ActualMeasWfmSize(
    ViSession vi,
    ViInt32 arrayMeasFunction,
    ViInt32* measWaveformSize);
+
 ViStatus _VI_FUNC niScope_ActualRecordLength(
    ViSession vi,
    ViInt32* recordLength);
+
 ViStatus _VI_FUNC niScope_SampleRate(
    ViSession vi,
    ViReal64* sampleRate);
+
 ViStatus _VI_FUNC niScope_SampleMode(
    ViSession vi,
    ViInt32* sampleMode);
+
 // -- Waveform Measurement Functions --
 ViStatus _VI_FUNC niScope_AddWaveformProcessing(
    ViSession vi,
    ViConstString channelList,
    ViInt32 measFunction);
+
 ViStatus _VI_FUNC niScope_ClearWaveformProcessing(
    ViSession vi,
    ViConstString channelList);
+
 ViStatus _VI_FUNC niScope_ClearWaveformMeasurementStats(
    ViSession vi,
    ViConstString channelList,
    ViInt32 clearableMeasurementFunction);
+
 ViStatus _VI_FUNC niScope_ReadMeasurement(
    ViSession vi,
    ViConstString channelList,
    ViReal64 timeout,
    ViInt32 scalarMeasFunction,
    ViReal64 result[]);
+
 ViStatus _VI_FUNC niScope_FetchMeasurement(
    ViSession vi,
    ViConstString channelList,
    ViReal64 timeout,
    ViInt32 scalarMeasFunction,
    ViReal64 result[]);
+
 ViStatus _VI_FUNC niScope_FetchMeasurementStats(
    ViSession vi,
    ViConstString channelList,
@@ -1116,6 +1274,7 @@ ViStatus _VI_FUNC niScope_FetchMeasurementStats(
    ViReal64 min[],
    ViReal64 max[],
    ViInt32 numInStats[]);
+
 ViStatus _VI_FUNC niScope_FetchArrayMeasurement(
    ViSession vi,
    ViConstString channelList,
@@ -1124,201 +1283,249 @@ ViStatus _VI_FUNC niScope_FetchArrayMeasurement(
    ViInt32 measWfmSize,
    ViReal64 measWfm[],
    struct niScope_wfmInfo wfmInfo[]);
+
 // -- Utility Functions --
 ViStatus _VI_FUNC niScope_reset(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_self_test(
    ViSession vi,
    ViInt16* selfTestResult,
    ViChar selfTestMessage[IVI_MAX_MESSAGE_BUF_SIZE]);
+
 ViStatus _VI_FUNC niScope_Disable(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_ResetDevice(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_CalSelfCalibrate(
    ViSession vi,
    ViConstString channelList,
    ViInt32 option);
+
 ViStatus _VI_FUNC niScope_revision_query(
    ViSession vi,
    ViChar driverRevision[IVI_MAX_MESSAGE_BUF_SIZE],
    ViChar firmwareRevision[IVI_MAX_MESSAGE_BUF_SIZE]);
+
 ViStatus _VI_FUNC niScope_ProbeCompensationSignalStart(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_ProbeCompensationSignalStop(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_CableSenseSignalStart(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_CableSenseSignalStop(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_IsDeviceReady(
    ViRsrc resourceName,
    ViConstString channelList,
    ViBoolean* deviceReady);
+
 ViStatus _VI_FUNC niScope_GetChannelName(
    ViSession vi,
    ViInt32 index,
    ViInt32 bufferSize,
    ViChar channelString[]);
+
 ViStatus _VI_FUNC niScope_GetChannelNameFromString(
    ViSession vi,
    ViConstString index,
    ViInt32 bufferSize,
    ViChar name[]);
+
 // -- Error Functions --
 ViStatus _VI_FUNC niScope_errorHandler(
    ViSession vi,
    ViStatus errorCode,
    const ViChar errorSource[MAX_FUNCTION_NAME_SIZE],
    ViChar errorDescription[MAX_ERROR_DESCRIPTION]);
+
 ViStatus _VI_FUNC niScope_GetError(
    ViSession vi,
    ViStatus* errorCode,
    ViInt32 bufferSize,
    ViChar description[]);
+
 ViStatus _VI_FUNC niScope_GetErrorMessage(
    ViSession vi,
    ViStatus errorCode,
    ViInt32 bufferSize,
    ViChar errorMessage[]);
+
 // -- Session Locking Functions --
 ViStatus _VI_FUNC niScope_LockSession(
    ViSession vi,
    ViBoolean* callerHasLock);
+
 ViStatus _VI_FUNC niScope_UnlockSession(
    ViSession vi,
    ViBoolean* callerHasLock);
-// -- Typesafe Get, Set, and Check Attribute Functions --
+
+// -- Typesafe Get, Set, And Check Attribute Functions --
 ViStatus _VI_FUNC niScope_GetAttributeViInt32(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViInt32* value);
+
 ViStatus _VI_FUNC niScope_SetAttributeViInt32(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViInt32 value);
+
 ViStatus _VI_FUNC niScope_CheckAttributeViInt32(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViInt32 value);
+
 ViStatus _VI_FUNC niScope_GetAttributeViInt64(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViInt64* value);
+
 ViStatus _VI_FUNC niScope_SetAttributeViInt64(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViInt64 value);
+
 ViStatus _VI_FUNC niScope_CheckAttributeViInt64(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViInt64 value);
+
 ViStatus _VI_FUNC niScope_GetAttributeViReal64(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViReal64* value);
+
 ViStatus _VI_FUNC niScope_SetAttributeViReal64(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViReal64 value);
+
 ViStatus _VI_FUNC niScope_CheckAttributeViReal64(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViReal64 value);
+
 ViStatus _VI_FUNC niScope_GetAttributeViString(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViInt32 bufSize,
    ViChar value[]);
+
 ViStatus _VI_FUNC niScope_SetAttributeViString(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViConstString value);
+
 ViStatus _VI_FUNC niScope_CheckAttributeViString(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViConstString value);
+
 ViStatus _VI_FUNC niScope_GetAttributeViSession(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViSession* value);
+
 ViStatus _VI_FUNC niScope_SetAttributeViSession(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViSession value);
+
 ViStatus _VI_FUNC niScope_CheckAttributeViSession(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViSession value);
+
 ViStatus _VI_FUNC niScope_GetAttributeViBoolean(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViBoolean* value);
+
 ViStatus _VI_FUNC niScope_SetAttributeViBoolean(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViBoolean value);
+
 ViStatus _VI_FUNC niScope_CheckAttributeViBoolean(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId,
    ViBoolean value);
+
 ViStatus _VI_FUNC niScope_ResetAttribute(
    ViSession vi,
    ViConstString channelList,
    ViAttr attributeId);
+
 ViStatus _VI_FUNC niScope_ResetAllAttributes(
    ViSession vi);
-// -- Import and Export Attribute Configuration Functions --
+
+// -- Import And Export Attribute Configuration Functions --
 ViStatus _VI_FUNC niScope_ImportAttributeConfigurationBuffer(
    ViSession vi,
    ViInt32 sizeInBytes,
    ViInt8 configuration[]);
+
 ViStatus _VI_FUNC niScope_ExportAttributeConfigurationBuffer(
    ViSession vi,
    ViInt32 sizeInBytes,
    ViInt8 configuration[]);
+
 ViStatus _VI_FUNC niScope_ImportAttributeConfigurationFile(
    ViSession vi,
    ViConstString filePath);
+
 ViStatus _VI_FUNC niScope_ExportAttributeConfigurationFile(
    ViSession vi,
    ViConstString filePath);
-// -- Scaling and Normalization Functions --
+
+// -- Scaling And Normalization Functions --
 ViStatus _VI_FUNC niScope_GetScalingCoefficients(
    ViSession vi,
    ViConstString channelList,
    ViInt32 bufferSize,
    struct niScope_coefficientInfo coefficientInfo[],
    ViInt32* numberOfCoefficientSets);
+
 ViStatus _VI_FUNC niScope_GetNormalizationCoefficients(
    ViSession vi,
    ViConstString channelList,
    ViInt32 bufferSize,
    struct niScope_coefficientInfo coefficientInfo[],
    ViInt32* numberOfCoefficientSets);
-// -- Peer-to-Peer Streaming Functions --
+
+// -- Peer-To-Peer Streaming Functions --
 ViStatus _VI_FUNC niScope_GetStreamEndpointHandle(
    ViSession vi,
    ViConstString streamName,
    ViUInt32* writerHandle);
+
+
+
 /****************************************************************************
  *------------------------ Error And Completion Codes ----------------------*
  ****************************************************************************/
@@ -1403,11 +1610,15 @@ ViStatus _VI_FUNC niScope_GetStreamEndpointHandle(
 #define NISCOPE_ERROR_OFFSET_DAC_CAL_FAILURE                                   (IVI_SPECIFIC_ERROR_BASE + 68L)                               // 3220848708 (0xbffa4044)
 #define NISCOPE_ERROR_INVALID_FETCH_POSITION                                   (IVI_SPECIFIC_ERROR_BASE + 69L)                               // 3220848709 (0xbffa4045)
 #define NISCOPE_ERROR_RIS_MODE_NOT_SUPPORTED_WITH_P2P                          (IVI_SPECIFIC_ERROR_BASE + 70L)                               // 3220848710 (0xbffa4046)
+
+
 /*- niScopeObsolete.h included for backwards compatibility -*/
 #include "niScopeObsolete.h"
+
 /****************************************************************************
  *---------------------------- End Include File ----------------------------*
  ****************************************************************************/
+
 #if defined(__cplusplus) || defined(__cplusplus__)
 }
 #endif

--- a/imports/include/niScopeCal.h
+++ b/imports/include/niScopeCal.h
@@ -1,0 +1,190 @@
+#ifndef ___niScopeCal_h___
+#define ___niScopeCal_h___
+
+#ifndef ___niScope_h___
+#include "niScope.h"
+#endif
+
+/* Pragma used in CVI to indicate that functions in this file have
+ * user protection associated with them */
+#ifdef _CVI_
+ #pragma EnableLibraryRuntimeChecking
+#endif
+
+// Values used in
+//     niScope_CalEnd
+#define NISCOPE_VAL_CAL_ACTION_STORE                                           0                                                             // 0 (0x0)
+#define NISCOPE_VAL_CAL_ACTION_ABORT                                           1                                                             // 1 (0x1)
+#define NISCOPE_VAL_CAL_ACTION_RESET                                           101                                                           // 101 (0x65)
+
+// Options For Error Handling
+#define NISCOPE_VAL_CAL_ABORT_ON_ERR                                           0                                                             // 0 (0x0)
+#define NISCOPE_VAL_CAL_ABORT_ON_MAJOR_ERR                                     1                                                             // 1 (0x1)
+#define NISCOPE_VAL_CAL_SKIP_BAD_SECTIONS                                      2                                                             // 2 (0x2)
+#define NISCOPE_VAL_CAL_RESET_BAD_SECTIONS                                     3                                                             // 3 (0x3)
+
+// Values used in
+//     niScope_CalFetchCount, niScope_CalFetchDate
+#define NISCOPE_VAL_CAL_SELF                                                   1                                                             // 1 (0x1)
+#define NISCOPE_VAL_CAL_EXTERNAL                                               0                                                             // 0 (0x0)
+#define NISCOPE_VAL_CAL_MANUFACTURE                                            2                                                             // 2 (0x2)
+
+// Values used in
+//     niScope_CalRouteInternalReference
+#define NISCOPE_VAL_CAL_UNROUTE_SIGNAL                                         (ViUInt32)0xfffffff
+#define NISCOPE_VAL_CAL_POSITIVE                                               (ViUInt32)0xffff
+#define NISCOPE_VAL_CAL_NEGATIVE                                               0                                                             // 0 (0x0)
+
+// Values used in
+//     niScope_CalSetAccessorySource
+#define NISCOPE_VAL_CAL_SOURCE_GROUND                                          0                                                             // 0 (0x0)
+#define NISCOPE_VAL_CAL_SOURCE_POSITIVEFS                                      1                                                             // 1 (0x1)
+#define NISCOPE_VAL_CAL_SOURCE_NEGATIVEFS                                      2                                                             // 2 (0x2)
+
+// Reference Parameter For Routing And Storing And Fetching Int Ref
+#define NISCOPE_VAL_CAL_10V_CH0                                                0                                                             // 0 (0x0)
+
+
+#if defined(__cplusplus) || defined(__cplusplus__)
+extern "C" {
+#endif
+
+// -- Open / Close / Change Password --
+// Gives calibration session handle
+ViStatus _VI_FUNC niScope_CalStart(
+   ViRsrc resourceName,             // e.g. "DAQ:1"
+   ViConstString password,          // pointer to 4 bytes for password, 0 or "" by default
+   ViSession* newSessionHandle);    // returns this session handle
+
+// Either store constants in eeprom or abort.
+ViStatus _VI_FUNC niScope_CalEnd(
+   ViSession vi,                    // session handle from CalStart
+   ViInt32 action);                 // see defined "action" constants above
+
+// If the old password is correct, the new password is stored in eeprom
+ViStatus _VI_FUNC niScope_CalChangePassword(
+   ViSession vi,                    // session handle from CalStart or niScope_init
+   ViConstString oldPassword,       // previous password is verfied (pointer to 4 bytes)
+   ViConstString newPassword);      // new password is written to eeprom (pointer to 4 bytes)
+
+// -- Fetch --
+ViStatus _VI_FUNC niScope_CalFetchCount(
+   ViSession vi,                    // session handle from CalStart or niScope_init
+   ViInt32 whichOne,                // internal or external count: see defines
+   ViInt32* calibrationCount);      // number of calibrations peformed
+
+ViStatus _VI_FUNC niScope_CalFetchDate(
+   ViSession vi,                    // session handle from CalStart or niScope_init
+   ViInt32 whichOne,                // internal or external cal date, or manufacture date
+   ViInt32* year,                   // year of last calibration from eeprom
+   ViInt32* month,                  // month of last calibration from eeprom
+   ViInt32* day);                   // day of last calibration from eeprom
+
+// Not supported yet, but will be for temperature sensing devices
+ViStatus _VI_FUNC niScope_CalFetchTemperature(
+   ViSession vi,                    // session handle from CalStart or niScope_init
+   ViInt32 whichOne,                // internal or external cal temperature
+   ViReal64* temperature);          // temperature in degrees C
+
+ViStatus _VI_FUNC niScope_CalFetchMiscInfo(
+   ViSession vi,                    // session handle from CalStart or niScope_init
+   ViChar miscInfo[5]);             // pointer to 5 bytes; returned from eeprom
+
+// Return the last stored internal reference value.
+// This value is not used during device operation.
+ViStatus _VI_FUNC niScope_CalFetchInternalReference(
+   ViSession vi,                    // session handle from CalStart or niScope_init
+   ViInt32 whichReference,          // see defines
+   ViReal64* internalRefValue);     // last stored internal reference measurement
+
+// -- Store --
+ViStatus _VI_FUNC niScope_CalStoreMiscInfo(
+   ViSession vi,                    // session handle from CalStart
+   ViConstString miscInfo);         // pointer to 4 characters to store in eeprom (operator id?)
+
+// For verification, store the internal reference. This value is not
+// used during device operation.
+ViStatus _VI_FUNC niScope_CalStoreInternalReference(
+   ViSession vi,                    // session handle from CalStart
+   ViInt32 whichReference,          // see defines
+   ViReal64 internalRefValue);      // last stored internal reference measurement
+
+// -- Adjustment --
+ViStatus _VI_FUNC niScope_CalAdjustRange(
+   ViSession vi,                    // session handle from CalStart
+   ViConstString channelName,       // e.g. "0" or "1"
+   ViReal64 range,                  // see niscope calibration document
+   ViReal64 stimulus);              // peak voltage of applied signal
+
+ViStatus _VI_FUNC niScope_CalAdjustVCXO(
+   ViSession vi,                    // session handle from CalStart
+   ViReal64 stimulusFreq);          // frequency of applied signal
+
+ViStatus _VI_FUNC niScope_CalAdjustDCM(
+   ViSession vi,                    // session handle from CalStart
+   ViConstString channelName,       // e.g. "0" or "1"
+   ViReal64 stimulusFreq);          // frequency of applied signal
+
+ViStatus _VI_FUNC niScope_CalAdjustOffset(
+   ViSession vi,                    // session handle from CalStart
+   ViConstString channelName,       // e.g. "0" or "1"
+   ViReal64 range);                 // see niscope calibration document
+
+ViStatus _VI_FUNC niScope_CalAdjustOffsetRange(
+   ViSession vi,                    // session handle from CalStart
+   ViConstString channelName,       // e.g. "0" or "1"
+   ViReal64 range,                  // see niscope calibration document
+   ViReal64 stimulus);              // peak voltage of applied signal
+
+ViStatus _VI_FUNC niScope_CalAdjustCompensationAttenuator(
+   ViSession vi,                    // session handle from CalStart
+   ViConstString channelName,       // e.g. "0" or "1"
+   ViReal64 range);                 // see niscope calibration document
+
+ViStatus _VI_FUNC niScope_CalAdjustFrequencyResponse(
+   ViSession vi,                    // session handle from CalStart
+   ViConstString channelName,       // e.g. "0" or "1"
+   ViReal64 range,                  // see niscope calibration document
+   ViReal64 stimulusFreq,           // frequency of applied signal
+   ViReal64 stimulusAmp);           // peak voltage of applied signal
+
+// For the 5911 external calibration with a single DC external voltage source
+ViStatus _VI_FUNC niScope_CalAdjustInternalReference(
+   ViSession vi,                    // session handle from CalStart
+   ViInt32 option,                  // use VI_NULL
+   ViReal64 stimulus);              // voltage of applied signal
+
+// For 5112 verification, this routes the internal reference out the
+// front BNC connector for measurement.
+ViStatus _VI_FUNC niScope_CalRouteInternalReference(
+   ViSession vi,                    // session handle from CalStart
+   ViInt32 option,                  // see defines
+   ViInt32 whichReference);         // see constants
+
+// For the 5900 external calibration
+ViStatus _VI_FUNC niScope_CalAdjustAccessoryGainAndOffset(
+   ViSession vi,                    // session handle from CalStart
+   ViConstString channelName,       // e.g. "0" or "1"
+   ViReal64 posFs,
+   ViReal64 gnd,
+   ViReal64 negFs);
+
+ViStatus _VI_FUNC niScope_CalSetAccessorySource(
+   ViSession vi,
+   ViConstString channelName,
+   ViInt32 calSource);
+
+// -- Verification --
+ViStatus _VI_FUNC niScope_CalMeasureRISDistribution(
+   ViSession vi,                    // session handle from CalStart or niScope_init
+   ViConstString channelName,       // e.g. "0" or "1"
+   ViInt32 maxTime,                 // max time in ms for each acquisition
+   ViReal64* minBinPercent,         // percent (0-1) of trigers in the least full bin
+   ViInt32 distributionSize,        // number of bins for distribution
+   ViInt32* distribution);          // array for distribution, NULL for "do not return it"
+
+
+#if defined(__cplusplus) || defined(__cplusplus__)
+}
+#endif
+#endif /* ___niScopeCal_h___ */

--- a/imports/include/niScopeObsolete.h
+++ b/imports/include/niScopeObsolete.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  *                                niScope                                   *
  *--------------------------------------------------------------------------*
- *   Copyright (c) National Instruments 2001-2021.  All Rights Reserved.    *
+ *   Copyright (c) National Instruments 2001-2022.  All Rights Reserved.    *
  *--------------------------------------------------------------------------*
  *                                                                          *
  * Title:    niScopeObsolete.h                                              *
@@ -14,25 +14,32 @@
  *              the current niScope.h header file.                          *
  *                                                                          *
  ****************************************************************************/
+
 #ifndef __NISCOPE_HEADER_OBSOLETE
 #define __NISCOPE_HEADER_OBSOLETE
+
 #define IVI_DO_NOT_INCLUDE_VISA_HEADERS
 #include "ivi.h"
 #undef IVI_DO_NOT_INCLUDE_VISA_HEADERS
+
+
 /* Pragma used in CVI to indicate that functions in this file have
  * user protection associated with them */
 #ifdef _CVI_
  #pragma EnableLibraryRuntimeChecking
 #endif
+
 #if defined(__cplusplus) || defined(__cplusplus__)
 extern "C" {
 #endif
+
 /****************************************************************************
  *----------------------- Obsolete Attribute Defines -----------------------*
  ****************************************************************************/
 // Obsolete Inherent Instrument Attributes and functions.
 // These attributes and functions have been deprecated and may not
 // be supported in future versions of this driver.
+
 // -- Obsolete Specific Attributes. --
 #define NISCOPE_ATTR_SLAVE_TRIGGER_DELAY                                       (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 46L)                         // 1150046 (0x118c5e), ViReal64
 #define NISCOPE_ATTR_TRIGGER_TO_STAR_DELAY                                     (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 47L)                         // 1150047 (0x118c5f), ViReal64,   read-only
@@ -43,7 +50,8 @@ extern "C" {
 #define NISCOPE_ATTR_TRIGGER_FROM_PFI_DELAY                                    (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 52L)                         // 1150052 (0x118c64), ViReal64,   read-only
 #define NISCOPE_ATTR_RECORD_ARM_SOURCE                                         (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 65L)                         // 1150065 (0x118c71), ViString
 #define NISCOPE_ATTR_5102_ADJUST_PRETRIGGER_SAMPLES                            (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 85L)                         // 1150085 (0x118c85), ViBoolean
-// -- Attributes for the 5620 Digital Down Converter --
+
+// -- Attributes For The 5620 Digital Down Converter --
 #define NISCOPE_ATTR_DDC_NCO_FREQUENCY                                         (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 1000L)                       // 1151000 (0x119018), ViReal64,   multi-channel
 #define NISCOPE_ATTR_DDC_NCO_PHASE                                             (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 1001L)                       // 1151001 (0x119019), ViReal64,   multi-channel
 #define NISCOPE_ATTR_DDC_ENABLE                                                (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 1003L)                       // 1151003 (0x11901b), ViBoolean
@@ -99,9 +107,12 @@ extern "C" {
 #define NISCOPE_ATTR_DELAY_BEFORE_INITIATE                                     (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 1304L)                       // 1151304 (0x119148), ViReal64
 #define NISCOPE_ATTR_DDC_DIRECT_REGISTER_ADDRESS                               (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 1305L)                       // 1151305 (0x119149), ViInt32
 #define NISCOPE_ATTR_DDC_DIRECT_REGISTER_DATA                                  (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 1306L)                       // 1151306 (0x11914a), ViInt32
+
+
 /****************************************************************************
  *-------------------------- Other Obsolete Values -------------------------*
  ****************************************************************************/
+
 // -- Deprecated --
 // use NISCOPE_ATTR_QUERY_INSTRUMENT_STATUS instead
 #define NISCOPE_ATTR_QUERY_INSTR_STATUS                                        NISCOPE_ATTR_QUERY_INSTRUMENT_STATUS                          // 1050003 (0x100593)
@@ -113,7 +124,8 @@ extern "C" {
 #define NISCOPE_ATTR_DRIVER_REVISION                                           NISCOPE_ATTR_SPECIFIC_DRIVER_REVISION                         // 1050551 (0x1007b7)
 // use NISCOPE_ATTR_IO_RESOURCE_DESCRIPTOR instead
 #define NISCOPE_ATTR_RESOURCE_DESCRIPTOR                                       NISCOPE_ATTR_IO_RESOURCE_DESCRIPTOR                           // 1050304 (0x1006c0)
-// -- Do not use --
+
+// -- Do Not Use --
 #define NISCOPE_ATTR_DRIVER_MAJOR_VERSION                                      IVISCOPE_ATTR_DRIVER_MAJOR_VERSION                            // 1050503 (0x100787)
 #define NISCOPE_ATTR_DRIVER_MINOR_VERSION                                      IVISCOPE_ATTR_DRIVER_MINOR_VERSION                            // 1050504 (0x100788)
 #define NISCOPE_ATTR_ENGINE_MAJOR_VERSION                                      IVISCOPE_ATTR_ENGINE_MAJOR_VERSION                            // 1050501 (0x100785)
@@ -125,13 +137,15 @@ extern "C" {
 #define NISCOPE_ATTR_PRIMARY_ERROR                                             IVISCOPE_ATTR_PRIMARY_ERROR                                   // 1050101 (0x1005f5)
 #define NISCOPE_ATTR_SECONDARY_ERROR                                           IVISCOPE_ATTR_SECONDARY_ERROR                                 // 1050102 (0x1005f6)
 #define NISCOPE_ATTR_ERROR_ELABORATION                                         IVISCOPE_ATTR_ERROR_ELABORATION                               // 1050103 (0x1005f7)
+
 // -- Obsolete Specific Attributes --
 // use NISCOPE_ATTR_MAX_INPUT_FREQUENCY instead
 #define NISCOPE_ATTR_BANDWIDTH                                                 IVISCOPE_ATTR_MAX_INPUT_FREQUENCY                             // 1250006 (0x1312d6)
 #define NISCOPE_ATTR_TRIGGER_OUTPUT_EVENT                                      (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 10L)                         // 1150010 (0x118c3a)
 #define NISCOPE_ATTR_TRIGGER_OUTPUT_SOURCE                                     (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 11L)                         // 1150011 (0x118c3b)
 #define NISCOPE_ATTR_EXPORT_SAMP_CLK_OUTPUT_TERM                               NISCOPE_ATTR_EXPORTED_SAMPLE_CLOCK_OUTPUT_TERMINAL            // 1150091 (0x118c8b)
-// -- Every line called by configure trigger output can have a different event --
+
+// -- Every Line Called By Configure Trigger Output Can Have A Different Event --
 #define NISCOPE_ATTR_RTSI0_TRIGGER_OUTPUT_EVENT                                (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 54L)                         // 1150054 (0x118c66)
 #define NISCOPE_ATTR_RTSI1_TRIGGER_OUTPUT_EVENT                                (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 55L)                         // 1150055 (0x118c67)
 #define NISCOPE_ATTR_RTSI2_TRIGGER_OUTPUT_EVENT                                (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 56L)                         // 1150056 (0x118c68)
@@ -142,28 +156,35 @@ extern "C" {
 #define NISCOPE_ATTR_PFI1_TRIGGER_OUTPUT_EVENT                                 (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 61L)                         // 1150061 (0x118c6d)
 #define NISCOPE_ATTR_PFI2_TRIGGER_OUTPUT_EVENT                                 (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 62L)                         // 1150062 (0x118c6e)
 #define NISCOPE_ATTR_STAR_TRIGGER_OUTPUT_EVENT                                 (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 63L)                         // 1150063 (0x118c6f)
-// -- NISCOPE_ATTR_TRIGGER_OUTPUT_EVENT / ConfigureTriggerOutput values --
+
+// -- Niscope_Attr_Trigger_Output_Event / Configuretriggeroutput Values --
 #define NISCOPE_VAL_NO_EVENT                                                   0                                                             // 0 (0x0)
 #define NISCOPE_VAL_STOP_TRIGGER_EVENT                                         1                                                             // 1 (0x1)
 #define NISCOPE_VAL_START_TRIGGER_EVENT                                        2                                                             // 2 (0x2)
-// -- NISCOPE_ATTR_TRIGGER_TYPE Values --
+
+// -- Niscope_Attr_Trigger_Type Values --
 #define NISCOPE_VAL_EDGE                                                       IVISCOPE_VAL_EDGE_TRIGGER                                     // 1 (0x1)
 #define NISCOPE_VAL_HYSTERESIS                                                 (IVISCOPE_VAL_TRIGGER_TYPE_SPECIFIC_EXT_BASE + 1L)            // 1001 (0x3e9)
 #define NISCOPE_VAL_DIGITAL                                                    (IVISCOPE_VAL_TRIGGER_TYPE_SPECIFIC_EXT_BASE + 2L)            // 1002 (0x3ea)
 #define NISCOPE_VAL_WINDOW                                                     (IVISCOPE_VAL_TRIGGER_TYPE_SPECIFIC_EXT_BASE + 3L)            // 1003 (0x3eb)
-// -- NISCOPE_ATTR_MAX_INPUT_FREQUENCY Values --
+
+// -- Niscope_Attr_Max_Input_Frequency Values --
 #define NISCOPE_VAL_FULL_BANDWIDTH                                             0.0
-// -- NISCOPE_ATTR_DDC_PFIR_SYMMETRY_TYPE and NISCOPE_ATTR_DDC_DISCRIMINATOR_FIR_SYMMETRY_TYPE Values --
+
+// -- Niscope_Attr_Ddc_Pfir_Symmetry_Type And Niscope_Attr_Ddc_Discriminator_Fir_Symmetry_Type Values --
 #define NISCOPE_VAL_EVEN                                                       0                                                             // 0 (0x0)
 #define NISCOPE_VAL_ODD                                                        1                                                             // 1 (0x1)
-// -- NISCOPE_ATTR_DDC_PFIR_SYMMETRY and NISCOPE_ATTR_DDC_DISCRIMINATOR_FIR_SYMMETRY Values --
+
+// -- Niscope_Attr_Ddc_Pfir_Symmetry And Niscope_Attr_Ddc_Discriminator_Fir_Symmetry Values --
 #define NISCOPE_VAL_SYMMETRIC                                                  0                                                             // 0 (0x0)
 #define NISCOPE_VAL_ASYMMETRIC                                                 1                                                             // 1 (0x1)
-// -- NISCOPE_ATTR_DDC_DISCRIMINATOR_FIR_INPUT_SOURCE Values --
+
+// -- Niscope_Attr_Ddc_Discriminator_Fir_Input_Source Values --
 #define NISCOPE_VAL_PHASE                                                      0                                                             // 0 (0x0)
 #define NISCOPE_VAL_MAGNITUDE                                                  1                                                             // 1 (0x1)
 #define NISCOPE_VAL_RESAMPLER                                                  2                                                             // 2 (0x2)
-// -- NISCOPE_ATTR_DDC_AOUT_PARALLEL_OUTPUT_SOURCE and NISCOPE_ATTR_DDC_BOUT_PARALLEL_OUTPUT_SOURCE Values --
+
+// -- Niscope_Attr_Ddc_Aout_Parallel_Output_Source And Niscope_Attr_Ddc_Bout_Parallel_Output_Source Values --
 // Valid for AOUT only
 #define NISCOPE_VAL_I_DATA                                                     0                                                             // 0 (0x0)
 // Valid for both AOUT and BOUT
@@ -174,44 +195,57 @@ extern "C" {
 #define NISCOPE_VAL_Q_DATA                                                     3                                                             // 3 (0x3)
 // Valid for BOUT only
 #define NISCOPE_VAL_PHASE_DATA                                                 4                                                             // 4 (0x4)
-// -- Older programs only --
+
+// -- Older Programs Only --
 // The driver now uses an IEEE defined Nan (Not a Number) value to indicate an empty
 // point in the waveform. Use the niScope_IsInvalidWfmElement function to determine
 // if an element of a waveform array is invalid.
 #define NISCOPE_MAX_VALID_WFM_VOLTAGE                                          1e+300
 #define NISCOPE_INVALID_WFM_VOLTAGE                                            1e+301
+
 // -- Clocking Terminal Values --
 #define NISCOPE_VAL_PXI_CLOCK                                                  "VAL_PXI_CLOCK"
-// -- NI-SCOPE 3.7 changed the name of the Advanced P2P attribute --
+
+// -- Ni-Scope 3.7 Changed The Name Of The Advanced P2P Attribute --
 #define NISCOPE_ATTR_P2P_ADVANCED_ATTRIBUTES_ENABLED                           NISCOPE_ATTR_P2P_MANUAL_CONFIGURATION_ENABLED                 // 1150343 (0x118d87)
-// -- NI-Scope 3.9.1 - PCIe-5155 --
+
+// -- Ni-Scope 3.9.1 - Pcie-5155 --
 #define NISCOPE_ATTR_FETCH_DATA_JUSTIFICATION                                  (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 233L)                        // 1150233 (0x118d19)
+
 // -- Justification --
 #define NISCOPE_VAL_JUSTIFY_LEFT                                               1                                                             // 1 (0x1)
 #define NISCOPE_VAL_JUSTIFY_RIGHT                                              2                                                             // 2 (0x2)
-// -- Level sensitive start trigger.  Added for PCIe-5155 --
+
+// -- Level Sensitive Start Trigger.  Added For Pcie-5155 --
 #define NISCOPE_ATTR_ENABLE_LEVEL_ACQ_ARM                                      (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 410L)                        // 1150410 (0x118dca)
+
 // -- Sync Trigger --
 #define NISCOPE_ATTR_SYNC_TRIG_OUT_SOURCE                                      (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 411L)                        // 1150411 (0x118dcb)
 #define NISCOPE_ATTR_SYNC_TRIG_OUT_PULSE_WIDTH                                 (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 412L)                        // 1150412 (0x118dcc)
 #define NISCOPE_ATTR_SYNC_TRIG_OUT_PERIOD                                      (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 413L)                        // 1150413 (0x118dcd)
+
 // -- Sync Trigger Values --
 #define NISCOPE_VAL_SYNC_TRIG_NONE                                             0                                                             // 0 (0x0)
 #define NISCOPE_VAL_SYNC_TRIG_REFERENCE                                        1                                                             // 1 (0x1)
 #define NISCOPE_VAL_SYNC_TRIG_TIMER                                            2                                                             // 2 (0x2)
+
 // -- Self Calibration --
 #define NISCOPE_ATTR_NO_RESET_DURING_SELF_CAL                                  (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 415L)                        // 1150415 (0x118dcf)
-// -- OSP --
+
+// -- Osp --
 #define NISCOPE_ATTR_ENABLE_PATTERN_NOISE_OSP                                  (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 418L)                        // 1150418 (0x118dd2)
 #define NISCOPE_ATTR_PATTERN_NOISE_OSP_OFFSET                                  (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 419L)                        // 1150419 (0x118dd3)
+
 // -- Synchronization Events --
 #define NISCOPE_ATTR_ACQUISITION_ACTIVE_EVENT_OUTPUT_TERMINAL                  (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 381L)                        // 1150381 (0x118dad)
 #define NISCOPE_ATTR_END_OF_WAVEFORM_EVENT_OUTPUT_TERMINAL                     (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 417L)                        // 1150417 (0x118dd1)
+
 // -- Waveform Averaging --
 #define NISCOPE_ATTR_WFM_AVG_ENABLED                                           (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 383L)                        // 1150383 (0x118daf)
 #define NISCOPE_ATTR_WFM_AVG_NUMBER_OF_WAVEFORMS                               (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 384L)                        // 1150384 (0x118db0)
 #define NISCOPE_ATTR_OSP_TRIGGER_DELAY_TIME                                    (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 416L)                        // 1150416 (0x118dd0)
 #define NISCOPE_ATTR_ACCUM_SAMPLES_TO_DISCARD                                  (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 421L)                        // 1150421 (0x118dd5)
+
 // -- Thresholding --
 #define NISCOPE_ATTR_THRESHOLD_ENABLED                                         (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 385L)                        // 1150385 (0x118db1)
 #define NISCOPE_ATTR_THRESHOLD_LEVEL                                           (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 386L)                        // 1150386 (0x118db2)
@@ -219,30 +253,38 @@ extern "C" {
 #define NISCOPE_ATTR_THRESHOLD_OFFSET                                          (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 388L)                        // 1150388 (0x118db4)
 #define NISCOPE_ATTR_THRESHOLD_POLARITY                                        (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 389L)                        // 1150389 (0x118db5)
 #define NISCOPE_ATTR_THRESHOLD_VALUE_TYPE                                      (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 420L)                        // 1150420 (0x118dd4)
-// -- NISCOPE_ATTR_THRESHOLD_POLARITY Values --
+
+// -- Niscope_Attr_Threshold_Polarity Values --
 #define NISCOPE_VAL_THRESHOLD_SUPPRESS_BELOW                                   0                                                             // 0 (0x0)
 #define NISCOPE_VAL_THRESHOLD_SUPPRESS_ABOVE                                   1                                                             // 1 (0x1)
-// -- NISCOPE_ATTR_THRESHOLD_VALUE_TYPE Values --
+
+// -- Niscope_Attr_Threshold_Value_Type Values --
 #define NISCOPE_VAL_THRESHOLD_VALUE_TYPE_VOLTS                                 0                                                             // 0 (0x0)
 #define NISCOPE_VAL_THRESHOLD_VALUE_TYPE_CODES                                 1                                                             // 1 (0x1)
+
 // -- Local Peak Detection --
 #define NISCOPE_ATTR_LOCAL_PEAK_DETECTION_ENABLED                              (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 390L)                        // 1150390 (0x118db6)
 #define NISCOPE_ATTR_LOCAL_PEAK_DETECTION_ALGORITHM                            (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 391L)                        // 1150391 (0x118db7)
 #define NISCOPE_ATTR_LOCAL_PEAK_DETECTION_FLOOR                                (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 392L)                        // 1150392 (0x118db8)
 #define NISCOPE_ATTR_LOCAL_PEAK_DETECTION_MODE                                 (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 393L)                        // 1150393 (0x118db9)
-// -- NISCOPE_ATTR_LOCAL_PEAK_DETECTION_ALGORITHM Values --
+
+// -- Niscope_Attr_Local_Peak_Detection_Algorithm Values --
 #define NISCOPE_VAL_PEAKS                                                      0                                                             // 0 (0x0)
 #define NISCOPE_VAL_VALLEYS                                                    1                                                             // 1 (0x1)
-// -- NISCOPE_ATTR_LOCAL_PEAK_DETECTION_MODE Values --
+
+// -- Niscope_Attr_Local_Peak_Detection_Mode Values --
 #define NISCOPE_VAL_MODE_GREATER_THAN                                          1                                                             // 1 (0x1)
+
 // -- Array --
 #define NISCOPE_ATTR_PEAK_ARRAY_DETECTION_WINDOW                               (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 430L)                        // 1150430 (0x118dde)
 #define NISCOPE_ATTR_PEAK_ARRAY_INTERPOLATION_WINDOW                           (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 431L)                        // 1150431 (0x118ddf)
-// -- Other OSP --
+
+// -- Other Osp --
 #define NISCOPE_ATTR_INVERT_DATA_ENABLED                                       (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 414L)                        // 1150414 (0x118dce)
 #define NISCOPE_ATTR_UNSIGNED_FETCH_ENABLED                                    (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 422L)                        // 1150422 (0x118dd6)
 #define NISCOPE_ATTR_ACQUISITION_STATE                                         (IVI_SPECIFIC_PUBLIC_ATTR_BASE + 442L)                        // 1150442 (0x118dea)
-// -- NISCOPE_ATTR_ACQUISITION_STATE value --
+
+// -- Niscope_Attr_Acquisition_State Value --
 #define NISCOPE_VAL_ACQUISITION_STATE_UNKNOWN                                  0                                                             // 0 (0x0)
 #define NISCOPE_VAL_ACQUISITION_STATE_IDLE                                     2                                                             // 2 (0x2)
 #define NISCOPE_VAL_ACQUISITION_STATE_WAIT_FOR_START_TRIGGER                   3                                                             // 3 (0x3)
@@ -252,12 +294,14 @@ extern "C" {
 #define NISCOPE_VAL_ACQUISITION_STATE_WAIT_FOR_REFERENCE_TRIGGER               7                                                             // 7 (0x7)
 #define NISCOPE_VAL_ACQUISITION_STATE_POSTTRIG_SAMPLING                        8                                                             // 8 (0x8)
 #define NISCOPE_VAL_ACQUISITION_STATE_WAIT_FOR_ADVANCE_TRIGGER                 9                                                             // 9 (0x9)
+
 // We use native packing on Windows x64, which is on 8 byte boundaries
 #if defined(_WIN64)
 #define NISCOPE_STRUCT_PACK_SIZE 8
 #else
 #define NISCOPE_STRUCT_PACK_SIZE 1
 #endif
+
 /****************************************************************************
  *------------------------ Obsolete Type Definitions -----------------------*
  ****************************************************************************/
@@ -273,6 +317,7 @@ typedef struct tWfmInfo_struct
     ViReal64 reserved1;
     ViReal64 reserved2;
 } tWfmInfo;
+
 #pragma pack(pop)
 #pragma pack(push,8)
 struct niScope_PeakArrayInfo
@@ -283,32 +328,43 @@ struct niScope_PeakArrayInfo
     ViReal64 triggerDelay;
     ViReal64 xIncrement;
 };
+
 #pragma pack(pop)
+
+
 /****************************************************************************
  *---- Obsolete functions and functions used for class driver compliance ---*
  ****************************************************************************/
 // -- Deprecated --
 ViStatus _VI_FUNC niScope_ClearError(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_GetNextInterchangeWarning(
    ViSession vi,
    ViInt32 bufferSize,
    ViChar interchangeWarning[]);
+
 ViStatus _VI_FUNC niScope_ResetInterchangeCheck(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_ClearInterchangeWarnings(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_GetNextCoercionRecord(
    ViSession vi,
    ViInt32 bufferSize,
    ViChar record[]);
+
 ViStatus _VI_FUNC niScope_InvalidateAllAttributes(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_ResetWithDefaults(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_ConfigureAcquisitionType(
    ViSession vi,
    ViInt32 acquisitionType);
+
 // -- Vertical --
 ViStatus _VI_FUNC niScope_ConfigureChannel(
    ViSession vi,
@@ -318,34 +374,40 @@ ViStatus _VI_FUNC niScope_ConfigureChannel(
    ViInt32 coupling,
    ViReal64 probeAttenuation,
    ViBoolean enabled);
+
 // -- Horizontal --
 ViStatus _VI_FUNC niScope_ConfigureHorizontal(
    ViSession vi,
    ViReal64 timePerRecord,
    ViInt32 minNumPts,
    ViReal64 refPosition);
+
 ViStatus _VI_FUNC niScope_ConfigureAcquisitionRecord(
    ViSession vi,
    ViReal64 timePerRecord,
    ViInt32 minNumPoints,
    ViReal64 acquisitionStartTime);
+
 ViStatus _VI_FUNC niScope_ConfigureHorizontalRate(
    ViSession vi,
    ViReal64 minSampleRate,
    ViInt32 minNumPts,
    ViReal64 refPosition);
+
 ViStatus _VI_FUNC niScope_ConfigureMultiHorizontal(
    ViSession vi,
    ViReal64 timePerRecord,
    ViInt32 minNumPts,
    ViReal64 refPosition,
    ViInt32 numRecords);
+
 ViStatus _VI_FUNC niScope_ConfigureMultiHorizontalRate(
    ViSession vi,
    ViReal64 minSampleRate,
    ViInt32 minNumPts,
    ViReal64 refPosition,
    ViInt32 numRecords);
+
 // -- Triggering --
 ViStatus _VI_FUNC niScope_ConfigureTriggerSource(
    ViSession vi,
@@ -353,40 +415,49 @@ ViStatus _VI_FUNC niScope_ConfigureTriggerSource(
    ViInt32 triggerType,
    ViReal64 triggerDelay,
    ViReal64 holdoff);
+
 ViStatus _VI_FUNC niScope_ConfigureTrigger(
    ViSession vi,
    ViInt32 triggerType,
    ViReal64 holdoff);
+
 ViStatus _VI_FUNC niScope_ConfigureTriggerCoupling(
    ViSession vi,
    ViInt32 coupling);
+
 ViStatus _VI_FUNC niScope_ConfigureEdgeTrigger(
    ViSession vi,
    ViReal64 level,
    ViInt32 triggerCoupling,
    ViInt32 slope);
+
 ViStatus _VI_FUNC niScope_ConfigureEdgeTriggerSource(
    ViSession vi,
    ViConstString source,
    ViReal64 level,
    ViInt32 slope);
+
 ViStatus _VI_FUNC niScope_ConfigureHysteresisTrigger(
    ViSession vi,
    ViReal64 level,
    ViReal64 hysteresis,
    ViInt32 triggerCoupling,
    ViInt32 slope);
+
 ViStatus _VI_FUNC niScope_ConfigureWindowTrigger(
    ViSession vi,
    ViReal64 lowLevel,
    ViReal64 highLevel,
    ViInt32 triggerCoupling,
    ViInt32 windowMode);
+
 ViStatus _VI_FUNC niScope_ConfigureDigitalTrigger(
    ViSession vi,
    ViInt32 slope);
+
 ViStatus _VI_FUNC niScope_SendSWTrigger(
    ViSession vi);
+
 // -- Fetch Functions --
 ViStatus _VI_FUNC niScope_ReadWaveform(
    ViSession vi,
@@ -397,6 +468,7 @@ ViStatus _VI_FUNC niScope_ReadWaveform(
    ViInt32* actualPoints,
    ViReal64* initialX,
    ViReal64* xIncrement);
+
 ViStatus _VI_FUNC niScope_FetchWaveform(
    ViSession vi,
    ViConstString channel,
@@ -405,6 +477,7 @@ ViStatus _VI_FUNC niScope_FetchWaveform(
    ViInt32* actualPoints,
    ViReal64* initialX,
    ViReal64* xIncrement);
+
 ViStatus _VI_FUNC niScope_FetchWaveformFromOffset(
    ViSession vi,
    ViConstString channelName,
@@ -414,6 +487,7 @@ ViStatus _VI_FUNC niScope_FetchWaveformFromOffset(
    ViInt32* actualPoints,
    ViReal64* initialX,
    ViReal64* xIncrement);
+
 ViStatus _VI_FUNC niScope_FetchBinary8Waveform(
    ViSession vi,
    ViConstString channelName,
@@ -425,6 +499,7 @@ ViStatus _VI_FUNC niScope_FetchBinary8Waveform(
    ViReal64* xIncrement,
    ViReal64* gainFactor,
    ViReal64* verticalOffset);
+
 ViStatus _VI_FUNC niScope_FetchBinary16Waveform(
    ViSession vi,
    ViConstString channelName,
@@ -436,6 +511,7 @@ ViStatus _VI_FUNC niScope_FetchBinary16Waveform(
    ViReal64* xIncrement,
    ViReal64* gainFactor,
    ViReal64* verticalOffset);
+
 ViStatus _VI_FUNC niScope_FetchBinary32Waveform(
    ViSession vi,
    ViConstString channelName,
@@ -447,6 +523,7 @@ ViStatus _VI_FUNC niScope_FetchBinary32Waveform(
    ViReal64* xIncrement,
    ViReal64* gainFactor,
    ViReal64* verticalOffset);
+
 ViStatus _VI_FUNC niScope_FetchMultiWaveform(
    ViSession vi,
    ViConstString channelName,
@@ -457,6 +534,7 @@ ViStatus _VI_FUNC niScope_FetchMultiWaveform(
    ViInt32* actualPoints,
    ViReal64* initialX,
    ViReal64* xIncrement);
+
 ViStatus _VI_FUNC niScope_FetchMultiBinary8Waveform(
    ViSession vi,
    ViConstString channelName,
@@ -469,6 +547,7 @@ ViStatus _VI_FUNC niScope_FetchMultiBinary8Waveform(
    ViReal64* xIncrement,
    ViReal64* gainFactor,
    ViReal64* verticalOffset);
+
 ViStatus _VI_FUNC niScope_FetchMultiBinary16Waveform(
    ViSession vi,
    ViConstString channelName,
@@ -481,6 +560,7 @@ ViStatus _VI_FUNC niScope_FetchMultiBinary16Waveform(
    ViReal64* xIncrement,
    ViReal64* gainFactor,
    ViReal64* verticalOffset);
+
 ViStatus _VI_FUNC niScope_FetchMultiBinary32Waveform(
    ViSession vi,
    ViConstString channelName,
@@ -493,6 +573,7 @@ ViStatus _VI_FUNC niScope_FetchMultiBinary32Waveform(
    ViReal64* xIncrement,
    ViReal64* gainFactor,
    ViReal64* verticalOffset);
+
 ViStatus _VI_FUNC niScope_FetchMinMaxWaveform(
    ViSession vi,
    ViConstString channelName,
@@ -502,6 +583,7 @@ ViStatus _VI_FUNC niScope_FetchMinMaxWaveform(
    ViInt32* actualPoints,
    ViReal64* initialX,
    ViReal64* xIncrement);
+
 ViStatus _VI_FUNC niScope_ReadMinMaxWaveform(
    ViSession vi,
    ViConstString channelName,
@@ -512,6 +594,7 @@ ViStatus _VI_FUNC niScope_ReadMinMaxWaveform(
    ViInt32* actualPoints,
    ViReal64* initialX,
    ViReal64* xIncrement);
+
 ViStatus _VI_FUNC niScope_FetchMultiMinMaxWaveform(
    ViSession vi,
    ViConstString channelName,
@@ -523,10 +606,12 @@ ViStatus _VI_FUNC niScope_FetchMultiMinMaxWaveform(
    ViInt32* actualPoints,
    ViReal64* initialX,
    ViReal64* xIncrement);
+
 ViStatus _VI_FUNC niScope_IsInvalidWfmElement(
    ViSession vi,
    ViReal64 elementValue,
    ViBoolean* isInvalid);
+
 // -- Wavefom Measurement Functions --
 ViStatus _VI_FUNC niScope_FetchWaveformMeasurementStats(
    ViSession vi,
@@ -539,6 +624,7 @@ ViStatus _VI_FUNC niScope_FetchWaveformMeasurementStats(
    ViReal64* min,
    ViReal64* max,
    ViInt32* numInStats);
+
 ViStatus _VI_FUNC niScope_FetchWaveformMeasurementArray(
    ViSession vi,
    ViConstString channel,
@@ -549,46 +635,55 @@ ViStatus _VI_FUNC niScope_FetchWaveformMeasurementArray(
    ViInt32* actualPoints,
    ViReal64* initialX,
    ViReal64* xIncrement);
+
 ViStatus _VI_FUNC niScope_ConfigureRefLevels(
    ViSession vi,
    ViReal64 low,
    ViReal64 mid,
    ViReal64 high);
+
 ViStatus _VI_FUNC niScope_ReadWaveformMeasurement(
    ViSession vi,
    ViConstString channel,
    ViInt32 measFunction,
    ViInt32 maxTime,
    ViReal64* measurement);
+
 ViStatus _VI_FUNC niScope_FetchWaveformMeasurement(
    ViSession vi,
    ViConstString channel,
    ViInt32 measFunction,
    ViReal64* measurement);
+
 ViStatus _VI_FUNC niScope_FetchMultiWaveformMeasurement(
    ViSession vi,
    ViConstString channel,
    ViInt32 recordNumber,
    ViInt32 measFunction,
    ViReal64* measurement);
+
 ViStatus _VI_FUNC niScope_WaitForAcquisitionToFinish(
    ViSession vi,
    ViInt32 maxTime);
+
 ViStatus _VI_FUNC niScope_ConfigureTriggerOutput(
    ViSession vi,
    ViInt32 triggerEvent,
    ViConstString triggerOutput);
-// -- IviScopeTVTrigger Extension --
+
+// -- Iviscopetvtrigger Extension --
 ViStatus _VI_FUNC niScope_ConfigureTVTriggerSource(
    ViSession vi,
    ViConstString source,
    ViInt32 signalFormat,
    ViInt32 event,
    ViInt32 polarity);
+
 ViStatus _VI_FUNC niScope_ConfigureTVTriggerLineNumber(
    ViSession vi,
    ViInt32 lineNumber);
-// -- IviScopeGlitchTrigger Extension --
+
+// -- Iviscopeglitchtrigger Extension --
 ViStatus _VI_FUNC niScope_ConfigureGlitchTriggerSource(
    ViSession vi,
    ViConstString triggerSource,
@@ -596,7 +691,8 @@ ViStatus _VI_FUNC niScope_ConfigureGlitchTriggerSource(
    ViReal64 glitchWidth,
    ViInt32 glitchPolarity,
    ViInt32 glitchCondition);
-// -- IviScopeWidthTrigger Extension --
+
+// -- Iviscopewidthtrigger Extension --
 ViStatus _VI_FUNC niScope_ConfigureWidthTriggerSource(
    ViSession vi,
    ViConstString triggerSource,
@@ -605,36 +701,43 @@ ViStatus _VI_FUNC niScope_ConfigureWidthTriggerSource(
    ViReal64 widthHighTreshold,
    ViInt32 widthPolarity,
    ViInt32 widthCondition);
-// -- IviScopeRuntTrigger Extension --
+
+// -- Iviscoperunttrigger Extension --
 ViStatus _VI_FUNC niScope_ConfigureRuntTriggerSource(
    ViSession vi,
    ViConstString triggerSource,
    ViReal64 runtLowThreshold,
    ViReal64 runtHighTreshold,
    ViInt32 runtPolarity);
+
 // -- Calibrate --
 ViStatus _VI_FUNC niScope_Calibrate(
    ViSession vi,
    ViConstString channel,
    ViInt32 calibrationOperation,
    ViReal64 referenceVoltage);
-// -- Error handlers --
+
+// -- Error Handlers --
 ViStatus _VI_FUNC niScope_error_query(
    ViSession vi,
    ViInt32* errCode,
    ViChar errMessage[256]);
+
 ViStatus _VI_FUNC niScope_GetErrorInfo(
    ViSession vi,
    ViStatus* primaryError,
    ViStatus* secondaryError,
    ViChar errorElaboration[IVI_MAX_MESSAGE_BUF_SIZE]);
+
 ViStatus _VI_FUNC niScope_ClearErrorInfo(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_error_message(
    ViSession vi,
    ViStatus errorCode,
    ViChar errorMessage[256]);
-// -- Experimental prototypes, subject to change --
+
+// -- Experimental Prototypes, Subject To Change --
 // use niScope_FetchBinary instead
 ViStatus _VI_FUNC niScope_DirectDMAFetchBinary(
    ViSession vi,
@@ -645,29 +748,36 @@ ViStatus _VI_FUNC niScope_DirectDMAFetchBinary(
    void* bufferAddress,
    struct niScope_wfmInfo* wfmInfo,
    ViUInt32* offsetToFirstSample);
+
 ViStatus _VI_FUNC niScope_ExportAttributes(
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_ImportAttributes(
    ViSession vi);
+
 // -- Register Access Functions --
 ViStatus _VI_FUNC niScope_ReadRegister(
    ViSession vi,
    ViInt32 size,
    ViInt32 offset,
    ViUInt32* value);
+
 ViStatus _VI_FUNC niScope_WriteRegister(
    ViSession vi,
    ViInt32 size,
    ViInt32 offset,
    ViUInt32 value);
-// -- Functions reserved for class driver use only. End-users should not call these. --
+
+// -- Functions Reserved For Class Driver Use Only. End-Users Should Not Call These. --
 ViStatus _VI_FUNC niScope_IviInit(
    ViRsrc resourceName,
    ViBoolean idQuery,
    ViBoolean reset,
    ViSession vi);
+
 ViStatus _VI_FUNC niScope_IviClose(
    ViSession vi);
+
 // -- Peak --
 ViStatus _VI_FUNC niScope_FetchPeakArrayTime32Ampl16(
    ViSession vi,
@@ -676,35 +786,45 @@ ViStatus _VI_FUNC niScope_FetchPeakArrayTime32Ampl16(
    struct niScope_PeakArrayInfo* info,
    ViUInt32* peakTimes,
    ViUInt16* peakAmplitudes);
-// -- NI-5620 Specific Functions --
+
+// -- Ni-5620 Specific Functions --
 ViStatus _VI_FUNC niScope_SetDDCFilterCoefficients(
    ViSession vi,
    ViConstString channel,
    ViInt32 coefficientType,
    ViInt32 numCoefficients,
    ViInt32* coefficients);
+
 ViStatus _VI_FUNC niScope_CalSetSerialDACVoltageEeprom(
    ViSession vi,
    ViReal32 serialDACVolts);
+
 ViStatus _VI_FUNC niScope_CalSetADCVoltageEeprom(
    ViSession vi,
    ViReal32 adcVoltageGain,
    ViReal32 adcVoltageOffset);
+
 ViStatus _VI_FUNC niScope_CalSetFREeprom(
    ViSession vi,
    ViInt32 numCoefficients,
    ViReal32* polynomialFitCoefficients);
+
 ViStatus _VI_FUNC niScope_CalGetSerialDACVoltageEeprom(
    ViSession vi,
    ViReal32* serialDACVolts);
+
 ViStatus _VI_FUNC niScope_CalGetADCVoltageEeprom(
    ViSession vi,
    ViReal32* adcVoltageGain,
    ViReal32* adcVoltageOffset);
+
 ViStatus _VI_FUNC niScope_CalGetFREeprom(
    ViSession vi,
    ViInt32 numCoefficients,
    ViReal32* polynomialFitCoefficients);
+
+
+
 /****************************************************************************
  *--- Not Recommended error strings (these strings are subject to change) --*
  ****************************************************************************/
@@ -769,6 +889,7 @@ To use a DAQmx device with a DAQ::N style name (e.g. DAQ::1), rename the device 
 Verify that all necessary steps are performed before closing the external calibration session."
 #define NISCOPE_ERRMSG_EXT_CAL_CONSTS_INVALID          "External calibration constants are invalid.  Perform an external calibration. Contact National Instruments if you need additional information."
 #define NISCOPE_ERRMSG_INVALID_NUM_WAVEFORMS           "This function may not be used for fetching multiple waveforms."
+
 /* Not recommended */
 #define NISCOPE_ERROR_CODES_AND_MSGS \
 {NISCOPE_WARN_HEATER_CIRCUIT_TEMPERATURE,          NISCOPE_WARNMSG_HEATER_CIRCUIT_TEMPERATURE},    \
@@ -830,9 +951,11 @@ Verify that all necessary steps are performed before closing the external calibr
 {NISCOPE_ERROR_INVALID_NUM_WAVEFORMS,              NISCOPE_ERRMSG_INVALID_NUM_WAVEFORMS},          \
 {NISCOPE_ERROR_EXT_CAL_NOT_COMPLETE,               NISCOPE_ERRMSG_EXT_CAL_NOT_COMPLETE},           \
 {NISCOPE_ERROR_EXT_CAL_CONSTS_INVALID,             NISCOPE_ERRMSG_EXT_CAL_CONSTS_INVALID}
+
 /****************************************************************************
  *---------------------------- End Include File ----------------------------*
  ****************************************************************************/
+
 #if defined(__cplusplus) || defined(__cplusplus__)
 }
 #endif

--- a/source/codegen/metadata/niscope/attributes.py
+++ b/source/codegen/metadata/niscope/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0d58
+# This file is generated from NI-SCOPE API metadata version 23.0.0d87
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niscope/config.py
+++ b/source/codegen/metadata/niscope/config.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0d58
+# This file is generated from NI-SCOPE API metadata version 23.0.0d87
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0',
+    'api_version': '23.0.0d87',
     'c_function_prefix': 'niScope_',
-    'c_header': 'niScope.h',
+    'c_header': 'niScopeCal.h',
     'close_function': 'Close',
     'csharp_namespace': 'NationalInstruments.Grpc.Scope',
     'custom_types': [

--- a/source/codegen/metadata/niscope/enums.py
+++ b/source/codegen/metadata/niscope/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0d58
+# This file is generated from NI-SCOPE API metadata version 23.0.0d87
 enums = {
     'AcquisitionStatus': {
         'codegen_method': 'public',
@@ -171,6 +171,23 @@ enums = {
             {
                 'name': 'NISCOPE_VAL_CABLE_SENSE_MODE_ON_DEMAND',
                 'value': 1
+            }
+        ]
+    },
+    'CalibrationTypes': {
+        'codegen_method': 'public',
+        'values': [
+            {
+                'name': 'NISCOPE_VAL_CAL_EXTERNAL',
+                'value': 0
+            },
+            {
+                'name': 'NISCOPE_VAL_CAL_SELF',
+                'value': 1
+            },
+            {
+                'name': 'NISCOPE_VAL_CAL_MANUFACTURE',
+                'value': 2
             }
         ]
     },
@@ -566,12 +583,12 @@ enums = {
                 'value': 10
             },
             {
-                'name': 'NISCOPE_VAL_5V_OUT',
-                'value': 13
-            },
-            {
                 'name': 'NISCOPE_VAL_REF_CLOCK',
                 'value': 100
+            },
+            {
+                'name': 'NISCOPE_VAL_5V_OUT',
+                'value': 13
             },
             {
                 'name': 'NISCOPE_VAL_SAMPLE_CLOCK',

--- a/source/codegen/metadata/niscope/functions.py
+++ b/source/codegen/metadata/niscope/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0d58
+# This file is generated from NI-SCOPE API metadata version 23.0.0d87
 functions = {
     'Abort': {
         'codegen_method': 'public',
@@ -193,6 +193,76 @@ functions = {
                 'grpc_type': 'nidevice_grpc.Session',
                 'name': 'vi',
                 'type': 'ViSession'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'CalFetchDate': {
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'cppName': 'vi',
+                'direction': 'in',
+                'grpc_type': 'nidevice_grpc.Session',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'cppName': 'whichOne',
+                'direction': 'in',
+                'enum': 'CalibrationTypes',
+                'grpc_type': 'sint32',
+                'name': 'whichOne',
+                'type': 'ViInt32'
+            },
+            {
+                'cppName': 'year',
+                'direction': 'out',
+                'grpc_type': 'sint32',
+                'name': 'year',
+                'type': 'ViInt32'
+            },
+            {
+                'cppName': 'month',
+                'direction': 'out',
+                'grpc_type': 'sint32',
+                'name': 'month',
+                'type': 'ViInt32'
+            },
+            {
+                'cppName': 'day',
+                'direction': 'out',
+                'grpc_type': 'sint32',
+                'name': 'day',
+                'type': 'ViInt32'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'CalFetchTemperature': {
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'cppName': 'vi',
+                'direction': 'in',
+                'grpc_type': 'nidevice_grpc.Session',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'cppName': 'whichOne',
+                'direction': 'in',
+                'enum': 'CalibrationTypes',
+                'grpc_type': 'sint32',
+                'name': 'whichOne',
+                'type': 'ViInt32'
+            },
+            {
+                'cppName': 'temperature',
+                'direction': 'out',
+                'grpc_type': 'double',
+                'name': 'temperature',
+                'type': 'ViReal64'
             }
         ],
         'returns': 'ViStatus'

--- a/source/codegen/metadata/niscope/niscope.proto
+++ b/source/codegen/metadata/niscope/niscope.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SCOPE API metadata version 23.0.0
+// This file is generated from NI-SCOPE API metadata version 23.0.0d87
 //---------------------------------------------------------------------
 // Proto file for the NI-SCOPE Metadata
 //---------------------------------------------------------------------
@@ -27,6 +27,8 @@ service NiScope {
   rpc AutoSetup(AutoSetupRequest) returns (AutoSetupResponse);
   rpc CableSenseSignalStart(CableSenseSignalStartRequest) returns (CableSenseSignalStartResponse);
   rpc CableSenseSignalStop(CableSenseSignalStopRequest) returns (CableSenseSignalStopResponse);
+  rpc CalFetchDate(CalFetchDateRequest) returns (CalFetchDateResponse);
+  rpc CalFetchTemperature(CalFetchTemperatureRequest) returns (CalFetchTemperatureResponse);
   rpc CalSelfCalibrate(CalSelfCalibrateRequest) returns (CalSelfCalibrateResponse);
   rpc CheckAttributeViBoolean(CheckAttributeViBooleanRequest) returns (CheckAttributeViBooleanResponse);
   rpc CheckAttributeViInt32(CheckAttributeViInt32Request) returns (CheckAttributeViInt32Response);
@@ -365,6 +367,12 @@ enum ArrayMeasurement {
   ARRAY_MEASUREMENT_NISCOPE_VAL_ARRAY_GAIN = 4026;
 }
 
+enum CalibrationTypes {
+  CALIBRATION_TYPES_NISCOPE_VAL_CAL_EXTERNAL = 0;
+  CALIBRATION_TYPES_NISCOPE_VAL_CAL_SELF = 1;
+  CALIBRATION_TYPES_NISCOPE_VAL_CAL_MANUFACTURE = 2;
+}
+
 enum ClearableMeasurement {
   CLEARABLE_MEASUREMENT_NISCOPE_VAL_RISE_TIME = 0;
   CLEARABLE_MEASUREMENT_NISCOPE_VAL_ALL_MEASUREMENTS = 10000;
@@ -465,8 +473,8 @@ enum ExportableSignals {
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_ADVANCE_EVENT = 6;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_START_EVENT = 7;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_REF_EVENT = 10;
-  EXPORTABLE_SIGNALS_NISCOPE_VAL_5V_OUT = 13;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_REF_CLOCK = 100;
+  EXPORTABLE_SIGNALS_NISCOPE_VAL_5V_OUT = 13;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_SAMPLE_CLOCK = 101;
 }
 
@@ -922,6 +930,34 @@ message CableSenseSignalStopRequest {
 
 message CableSenseSignalStopResponse {
   int32 status = 1;
+}
+
+message CalFetchDateRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof which_one_enum {
+    CalibrationTypes which_one = 2;
+    sint32 which_one_raw = 3;
+  }
+}
+
+message CalFetchDateResponse {
+  int32 status = 1;
+  sint32 year = 2;
+  sint32 month = 3;
+  sint32 day = 4;
+}
+
+message CalFetchTemperatureRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof which_one_enum {
+    CalibrationTypes which_one = 2;
+    sint32 which_one_raw = 3;
+  }
+}
+
+message CalFetchTemperatureResponse {
+  int32 status = 1;
+  double temperature = 2;
 }
 
 message CalSelfCalibrateRequest {


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Adds `CalFetchDate` and `CalFetchTemperature` methods.
- Updates niscope headers to those exported from the 22.5 release.

### Why should this Pull Request be merged?

Using a newer export is better.

### What testing has been done?

Built locally.