### PR TITLE
Skip converter namespace if no custom types

### DIFF
--- a/examples/session/session-reservation.py
+++ b/examples/session/session-reservation.py
@@ -80,7 +80,7 @@ try:
         )
     )
     vi = init_with_options_response.vi
-    print(f"Session initialized with name {session_name} and id {vi.id}.\n")
+    print(f"Session initialized with name {session_name}.\n")
 
     # Check if session is reserved by client 1.
     # Note: The reservation_id is defined by and has meaning only for the client + Session

--- a/generated/nifgen/nifgen_service.h
+++ b/generated/nifgen/nifgen_service.h
@@ -184,9 +184,4 @@ private:
 
 } // namespace nifgen_grpc
 
-namespace nidevice_grpc {
-namespace converters {
-} // namespace converters
-} // namespace nidevice_grpc
-
 #endif  // NIFGEN_GRPC_SERVICE_H

--- a/source/codegen/templates/service.h.mako
+++ b/source/codegen/templates/service.h.mako
@@ -125,7 +125,14 @@ private:
 
 } // namespace ${config["namespace_component"]}_grpc
 
-% if any(input_custom_types) or any(output_custom_types):
+<%
+has_custom_types = False
+for custom_type in custom_types:
+  if custom_type["name"] in output_custom_types or custom_type["name"] in input_custom_types:
+    has_custom_types = True
+    break
+%>\
+% if has_custom_types:
 namespace nidevice_grpc {
 namespace converters {
 %   for custom_type in custom_types:


### PR DESCRIPTION
### What does this Pull Request accomplish?

In some cases, we were generating an empty namespace at the bottom of the service header. This PR now avoids doing that.

### Why should this Pull Request be merged?

[Technical Debt 2192495](https://ni.visualstudio.com/DevCentral/_workitems/edit/2192495): [gRPC] Fix issue with empty namespace generating at bottom of _service.h

### What testing has been done?

Built locally. Verified that the only generated change was this one for FGEN.