### PR TITLE
Fix sizing of waveform_info array returned from NI-SCOPE's FetchArrayMeasurement.

### DIFF
--- a/source/custom/niscope_service.custom.cpp
+++ b/source/custom/niscope_service.custom.cpp
@@ -231,7 +231,7 @@ void CheckStatus(int status)
 
     response->mutable_meas_wfm()->Resize(num_waveforms * measurement_waveform_size, 0);
     ViReal64* meas_wfm = response->mutable_meas_wfm()->mutable_data();
-    std::vector<niScope_wfmInfo> waveform_info(measurement_waveform_size, niScope_wfmInfo());
+    std::vector<niScope_wfmInfo> waveform_info(num_waveforms, niScope_wfmInfo());
     auto status = library_->FetchArrayMeasurement(vi, channel_list, timeout, array_meas_function, measurement_waveform_size, meas_wfm, waveform_info.data());
     if (status < VI_SUCCESS) {
       return ConvertApiErrorStatusForViSession(context, status, vi);

--- a/source/tests/system/niscope_driver_api_tests.cpp
+++ b/source/tests/system/niscope_driver_api_tests.cpp
@@ -296,7 +296,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeFetchArrayMeasurement_SendRequest_FetchCompl
   EXPECT_TRUE(status.ok());
   expect_api_success(response.status());
   EXPECT_EQ(expected_num_waveforms * expected_waveform_size, response.meas_wfm_size());
-  EXPECT_EQ(expected_waveform_size, response.wfm_info_size());
+  EXPECT_EQ(expected_num_waveforms, response.wfm_info_size());
 }
 
 TEST_F(NiScopeDriverApiTest, NiScopeFetchBinary16_SendRequest_FetchCompletesWithCorrectSizes)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes an issue in the custom implementation for NI-SCOPE's FetchArrayMeasurement where it was using the wrong size for the returned waveform_info array.

### Why should this Pull Request be merged?

Fixes [AB#2220088](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2220088)

Found during testing this method in nimi-python against grpc-device that there was something wrong on the grpc-device end. Comparing the nimi-python implementation and the custom implementation here revealed the discrepancy.

This update aligns with nimi-python and the [documentation for the method](https://github.com/ni/grpc-device/wiki/NI-SCOPE-Measurement-Functions#niscope_fetcharraymeasurement)

### What testing has been done?

Updated and ran system test that was asserting the wrong expected array size before for this method.