### PR TITLE
Fix example mypy type violations.

### DIFF
--- a/.github/workflows/validate_python.yml
+++ b/.github/workflows/validate_python.yml
@@ -29,7 +29,7 @@ jobs:
       with:
         poetry-version: 1.1.5
 
-    - name: Validate RFmx, XNET, and session examples
+    - name: Validate examples (except DAQmx)
       run: |
         python source/codegen/validate_examples.py -p "*dcpower*"
         python source/codegen/validate_examples.py -p "*digital*"

--- a/.github/workflows/validate_python.yml
+++ b/.github/workflows/validate_python.yml
@@ -31,6 +31,13 @@ jobs:
 
     - name: Validate RFmx, XNET, and session examples
       run: |
-        python source/codegen/validate_examples.py -p "*rfmx*"
+        python source/codegen/validate_examples.py -p "*dcpower*"
+        python source/codegen/validate_examples.py -p "*digital*"
+        python source/codegen/validate_examples.py -p "*dmm*"
+        python source/codegen/validate_examples.py -p "*fgen*"
+        python source/codegen/validate_examples.py -p "*rf*"
+        python source/codegen/validate_examples.py -p "*scope*"
+        python source/codegen/validate_examples.py -p "*switch*"
+        python source/codegen/validate_examples.py -p "*tclk*"
         python source/codegen/validate_examples.py -p "*xnet*"
         python source/codegen/validate_examples.py -p "session"

--- a/.github/workflows/validate_python.yml
+++ b/.github/workflows/validate_python.yml
@@ -31,13 +31,4 @@ jobs:
 
     - name: Validate examples (except DAQmx)
       run: |
-        python source/codegen/validate_examples.py -p "*dcpower*"
-        python source/codegen/validate_examples.py -p "*digital*"
-        python source/codegen/validate_examples.py -p "*dmm*"
-        python source/codegen/validate_examples.py -p "*fgen*"
-        python source/codegen/validate_examples.py -p "*rf*"
-        python source/codegen/validate_examples.py -p "*scope*"
-        python source/codegen/validate_examples.py -p "*switch*"
-        python source/codegen/validate_examples.py -p "*tclk*"
-        python source/codegen/validate_examples.py -p "*xnet*"
-        python source/codegen/validate_examples.py -p "session"
+        python source/codegen/validate_examples.py -e "nidaqmx"

--- a/examples/nidcpower/measure-record.py
+++ b/examples/nidcpower/measure-record.py
@@ -105,7 +105,7 @@ try:
         nidcpower_types.SetAttributeViInt32Request(
             vi=vi,
             attribute_id=nidcpower_types.NiDCPowerAttribute.NIDCPOWER_ATTRIBUTE_MEASURE_RECORD_LENGTH,
-            attribute_value=RECORD_LENGTH,
+            attribute_value_raw=RECORD_LENGTH,
         )
     )
 
@@ -180,11 +180,11 @@ try:
 
             # Updating the precision of the fetched values.
             y_axis_new = []
-            for value in y_axis:
-                if value < VOLTAGE_LEVEL:
-                    y_axis_new.append(math.floor(value * 100) / 100)
+            for y_value in y_axis:
+                if y_value < VOLTAGE_LEVEL:
+                    y_axis_new.append(math.floor(y_value * 100) / 100)
                 else:
-                    y_axis_new.append(math.ceil(value * 100) / 100)
+                    y_axis_new.append(math.ceil(y_value * 100) / 100)
 
             # Plotting
             y_axis = y_axis_new
@@ -216,6 +216,6 @@ except grpc.RpcError as rpc_error:
     print(f"{error_message}")
 
 finally:
-    if "vi" in vars() and vi.id != 0:
+    if "vi" in vars() and vi.name != "":
         # Close the session.
         client.Close(nidcpower_types.CloseRequest(vi=vi))

--- a/examples/nidigitalpattern/configure-voltage-levels-and-termination-voltage.py
+++ b/examples/nidigitalpattern/configure-voltage-levels-and-termination-voltage.py
@@ -253,6 +253,6 @@ except grpc.RpcError as rpc_error:
         )
     print(f"{error_message}")
 finally:
-    if "vi" in vars() and vi.id != 0:
+    if "vi" in vars() and vi.name != "":
         # Close NI-Digital Pattern Driver session
         nidigital_client.Close(nidigital_types.CloseRequest(vi=vi))

--- a/examples/nidmm/continuous-acquire-graph-multiple-points.py
+++ b/examples/nidmm/continuous-acquire-graph-multiple-points.py
@@ -162,7 +162,7 @@ try:
                 fetch_multipoints_response = nidmm_client.FetchMultiPoint(
                     nidmm_types.FetchMultiPointRequest(
                         vi=vi,
-                        maximum_time=-1,
+                        maximum_time_raw=-1,
                         array_size=pts_available,
                     )
                 )
@@ -209,6 +209,6 @@ except grpc.RpcError as rpc_error:
         )
     print(f"{error_message}")
 finally:
-    if "vi" in vars() and vi.id != 0:
+    if "vi" in vars() and vi.name != "":
         # Close NI-DMM session
         nidmm_client.Close(nidmm_types.CloseRequest(vi=vi))

--- a/examples/nifgen/basic-arbitrary-waveform.py
+++ b/examples/nifgen/basic-arbitrary-waveform.py
@@ -168,6 +168,6 @@ except grpc.RpcError as rpc_error:
         )
     print(f"{error_message}")
 finally:
-    if "vi" in vars() and vi.id != 0:
+    if "vi" in vars() and vi.name != "":
         # Close NI-FGEN session
         nifgen_client.Close(nifgen_types.CloseRequest(vi=vi))

--- a/examples/nirfsa/getting-started-iq.py
+++ b/examples/nirfsa/getting-started-iq.py
@@ -64,7 +64,7 @@ def check_for_warning(response, vi):
     """Print to console if the status indicates a warning."""
     if response.status > 0:
         warning_message = client.ErrorMessage(
-            nirfsa_types.ErrorMessageRequest(vi=vi, error_code=response.status)
+            nirfsa_types.ErrorMessageRequest(vi=vi, status_code=response.status)
         )
         sys.stderr.write(f"{warning_message.error_message}\nWarning status: {response.status}\n")
 

--- a/examples/nirfsa/getting-started-spectrum.py
+++ b/examples/nirfsa/getting-started-spectrum.py
@@ -68,7 +68,7 @@ def check_for_warning(response, vi):
     """Print to console if the status indicates a warning."""
     if response.status > 0:
         warning_message = client.ErrorMessage(
-            nirfsa_types.ErrorMessageRequest(vi=vi, error_code=response.status)
+            nirfsa_types.ErrorMessageRequest(vi=vi, status_code=response.status)
         )
         sys.stderr.write(f"{warning_message.error_message}\nWarning status: {response.status}\n")
 

--- a/examples/niscope/fetch-continuous.py
+++ b/examples/niscope/fetch-continuous.py
@@ -180,6 +180,6 @@ except grpc.RpcError as rpc_error:
     print(f"{error_message}")
 
 finally:
-    if "vi" in vars() and vi.id != 0:
+    if "vi" in vars() and vi.name != "":
         # close the session.
         niscope_client.Close(niscope_types.CloseRequest(vi=vi))

--- a/examples/niscope/fetch.py
+++ b/examples/niscope/fetch.py
@@ -140,6 +140,6 @@ except grpc.RpcError as rpc_error:
     print(f"{error_message}")
 
 finally:
-    if "vi" in vars() and vi.id != 0:
+    if "vi" in vars() and vi.name != "":
         # close the session.
         niscope_client.Close(niscope_types.CloseRequest(vi=vi))

--- a/examples/niscope/graph-measurement.py
+++ b/examples/niscope/graph-measurement.py
@@ -199,6 +199,6 @@ except grpc.RpcError as rpc_error:
     print(f"{error_message}")
 
 finally:
-    if "vi" in vars() and vi.id != 0:
+    if "vi" in vars() and vi.name != "":
         # close the session.
         niscope_client.Close(niscope_types.CloseRequest(vi=vi))

--- a/examples/niscope/plot-read-waveform.py
+++ b/examples/niscope/plot-read-waveform.py
@@ -147,6 +147,6 @@ except grpc.RpcError as rpc_error:
     print(f"{error_message}")
 
 finally:
-    if "vi" in vars() and vi.id != 0:
+    if "vi" in vars() and vi.name != "":
         # close the session.
         niscope_client.Close(niscope_types.CloseRequest(vi=vi))

--- a/examples/niswitch/controlling-an-individual-relay.py
+++ b/examples/niswitch/controlling-an-individual-relay.py
@@ -108,5 +108,5 @@ except grpc.RpcError as rpc_error:
 
 finally:
     # Close the session.
-    if "vi" in vars() and vi.id != 0:
+    if "vi" in vars() and vi.name != "":
         niswitch_client.Close(niswitch_types.CloseRequest(vi=vi))

--- a/examples/niswitch/software-scanning.py
+++ b/examples/niswitch/software-scanning.py
@@ -142,5 +142,5 @@ except grpc.RpcError as rpc_error:
 
 finally:
     # Close the session.
-    if "vi" in vars() and vi.id != 0:
+    if "vi" in vars() and vi.name != "":
         niswitch_client.Close(niswitch_types.CloseRequest(vi=vi))

--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -46,7 +46,11 @@ def _stage_client_files(artifact_location: Optional[str], staging_dir: Path) -> 
 
 
 def _validate_examples(
-    driver_glob_expression: str, ip_address: str, device_name: str, artifact_location: Optional[str]
+    driver_glob_expression: str,
+    driver_exclusions: List[str],
+    ip_address: str,
+    device_name: str,
+    artifact_location: Optional[str],
 ) -> None:
     staging_dir = Path(__file__).parent.parent.parent / "build" / "validate_examples"
     staging_dir = staging_dir.resolve()
@@ -72,6 +76,8 @@ def _validate_examples(
             rf"poetry run python -m grpc_tools.protoc -I{proto_dir} --python_out=. --grpc_python_out=. --mypy_out=. --mypy_grpc_out=. {proto_files_str}"
         )
         for dir in examples_dir.glob(driver_glob_expression):
+            if dir.name in driver_exclusions:
+                continue
             print()
             print(f"-- Validating: {dir.name}")
 
@@ -94,6 +100,14 @@ if __name__ == "__main__":
         "-p",
         "--pattern",
         help="Glob expression for scrapigen driver names to validate (i.e., *rfmx*).",
+        default="*",
+    )
+
+    parser.add_argument(
+        "-e",
+        "--exclusions",
+        help='Space delimited list of driver names to exclude from validation (e.g., "nidaqmx nidcpower").',
+        default="",
     )
 
     parser.add_argument(
@@ -118,7 +132,8 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    _validate_examples(args.pattern, args.server, args.device, args.artifacts)
+    exclusions = args.exclusions.split(" ")
+    _validate_examples(args.pattern, exclusions, args.server, args.device, args.artifacts)
 
     if any(_FAILED_COMMANDS):
         for code, command in _FAILED_COMMANDS:

--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -79,7 +79,7 @@ def _validate_examples(
             _system(f"poetry run black --check --line-length 100 {dir}")
 
             print(f" -> Running mypy")
-            _system(f"poetry run mypy {dir} --check-untyped-defs")
+            _system(f"poetry run mypy {dir} --check-untyped-defs --ignore-missing-imports")
 
             if ip_address:
                 for file in dir.glob("*.py"):


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Fixes mypy violations on all examples except DAQmx
- Primarily focused on avoiding referencing removed `id` field on `Session` message

### Why should this Pull Request be merged?

Fixes #793 

Related AzDo Bug: [AB#2222316](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2222316)

Recently, a change went in to remove `id` from the `Session` message. We don't run validation on all the examples so there were a handful still trying to reference this `id` field.

### What testing has been done?

Ran validate_examples.py against all examples with `--ignore-missing-imports` to avoid any errors related to numpy or matplotlib. All passed with updates except DAQmx which I'm not attempting to fix with this change.