### PR TITLE
Move SessionUtilities service to session_utilities.proto file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -612,7 +612,7 @@ set(system_test_runner_sources
   ${session_grpc_srcs}
   ${session_utilities_proto_srcs}
   ${session_utilities_grpc_srcs}
-${debugsessionproperties_restricted_proto_srcs}
+  ${debugsessionproperties_restricted_proto_srcs}
   ${debugsessionproperties_restricted_grpc_srcs}
   ${nidriver_service_srcs}
   ${nidriver_client_srcs}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,6 +227,7 @@ set(nidriver_service_srcs
 # Proto file
 #----------------------------------------------------------------------
 get_filename_component(session_proto "source/protobuf/session.proto" ABSOLUTE)
+get_filename_component(session_utilities_proto "source/protobuf/session_utilities.proto" ABSOLUTE)
 get_filename_component(nidevice_proto "source/protobuf/nidevice.proto" ABSOLUTE)
 get_filename_component(debugsessionproperties_restricted_proto "source/protobuf_restricted/debugsessionproperties_restricted.proto" ABSOLUTE)
 get_filename_component(session_proto_path "${session_proto}" PATH)
@@ -262,6 +263,10 @@ set(session_proto_srcs "${proto_srcs_dir}/session.pb.cc")
 set(session_proto_hdrs "${proto_srcs_dir}/session.pb.h")
 set(session_grpc_srcs "${proto_srcs_dir}/session.grpc.pb.cc")
 set(session_grpc_hdrs "${proto_srcs_dir}/session.grpc.pb.h")
+set(session_utilities_proto_srcs "${proto_srcs_dir}/session_utilities.pb.cc")
+set(session_utilities_proto_hdrs "${proto_srcs_dir}/session_utilities.pb.h")
+set(session_utilities_grpc_srcs "${proto_srcs_dir}/session_utilities.grpc.pb.cc")
+set(session_utilities_grpc_hdrs "${proto_srcs_dir}/session_utilities.grpc.pb.h")
 set(nidevice_proto_srcs "${proto_srcs_dir}/nidevice.pb.cc")
 set(nidevice_proto_hdrs "${proto_srcs_dir}/nidevice.pb.h")
 set(debugsessionproperties_restricted_proto_srcs "${proto_srcs_dir}/debugsessionproperties_restricted.pb.cc")
@@ -278,6 +283,16 @@ GenerateGrpcSources(
     "${session_proto_hdrs}"
     "${session_grpc_srcs}"
     "${session_grpc_hdrs}"
+)
+
+GenerateGrpcSources(
+  PROTO
+    ${session_utilities_proto}
+  OUTPUT
+    "${session_utilities_proto_srcs}"
+    "${session_utilities_proto_hdrs}"
+    "${session_utilities_grpc_srcs}"
+    "${session_utilities_grpc_hdrs}"
 )
 
 GenerateGrpcSources(
@@ -338,6 +353,8 @@ add_executable(ni_grpc_device_server
    ${nidevice_proto_srcs}
    ${session_proto_srcs}
    ${session_grpc_srcs}
+   ${session_utilities_proto_srcs}
+   ${session_utilities_grpc_srcs}
    ${debugsessionproperties_restricted_proto_srcs}
    ${debugsessionproperties_restricted_grpc_srcs}
    ${nidriver_service_srcs})
@@ -428,6 +445,8 @@ add_executable(IntegrationTestsRunner
     ${nidevice_proto_srcs}
     ${session_proto_srcs}
     ${session_grpc_srcs}
+    ${session_utilities_proto_srcs}
+    ${session_utilities_grpc_srcs}
     ${debugsessionproperties_restricted_proto_srcs}
     ${debugsessionproperties_restricted_grpc_srcs}
     "${proto_srcs_dir}/nifake.pb.cc"
@@ -491,6 +510,8 @@ add_executable(UnitTestsRunner
     ${nidevice_proto_srcs}
     ${session_proto_srcs}
     ${session_grpc_srcs}
+    ${session_utilities_proto_srcs}
+    ${session_utilities_grpc_srcs}
     ${debugsessionproperties_restricted_proto_srcs}
     ${debugsessionproperties_restricted_grpc_srcs}
     "${proto_srcs_dir}/nifake.pb.cc"
@@ -589,7 +610,9 @@ set(system_test_runner_sources
   ${nidevice_proto_srcs}
   ${session_proto_srcs}
   ${session_grpc_srcs}
-  ${debugsessionproperties_restricted_proto_srcs}
+  ${session_utilities_proto_srcs}
+  ${session_utilities_grpc_srcs}
+${debugsessionproperties_restricted_proto_srcs}
   ${debugsessionproperties_restricted_grpc_srcs}
   ${nidriver_service_srcs}
   ${nidriver_client_srcs}

--- a/examples/session/session-reservation.py
+++ b/examples/session/session-reservation.py
@@ -36,8 +36,8 @@ import sys
 import grpc
 import niscope_pb2 as niscope_types
 import niscope_pb2_grpc as grpc_niscope
-import session_pb2 as session_types
-import session_pb2_grpc as grpc_session
+import session_utilities_pb2 as session_types
+import session_utilities_pb2_grpc as grpc_session
 
 SERVER_ADDRESS = "localhost"
 SERVER_PORT = "31763"

--- a/examples/session/session-utilities.py
+++ b/examples/session/session-utilities.py
@@ -31,8 +31,8 @@ subcommands:
 import argparse
 
 import grpc
-import session_pb2 as session_types
-import session_pb2_grpc as grpc_session
+import session_utilities_pb2 as session_types
+import session_utilities_pb2_grpc as grpc_session
 
 
 def main(args):

--- a/source/protobuf/session.proto
+++ b/source/protobuf/session.proto
@@ -7,30 +7,6 @@ option csharp_namespace = "NationalInstruments.Grpc.Device";
 
 package nidevice_grpc;
 
-service SessionUtilities {
-  // Provides a list of devices or chassis connected to server under localhost
-  rpc EnumerateDevices(EnumerateDevicesRequest)
-      returns (EnumerateDevicesResponse);
-
-  // Provides a list of NI software installed on server under localhost
-  rpc EnumerateInstalledSoftware(EnumerateInstalledSoftwareRequest)
-      returns (EnumerateInstalledSoftwareResponse);
-
-  // Reserve a set of client defined resources for exclusive use
-  rpc Reserve(ReserveRequest) returns (ReserveResponse);
-
-  // Determines if a set of client defined resources is currently reserved by a
-  // specific client
-  rpc IsReservedByClient(IsReservedByClientRequest)
-      returns (IsReservedByClientResponse);
-
-  // Unreserves a previously reserved resource
-  rpc Unreserve(UnreserveRequest) returns (UnreserveResponse);
-
-  // Resets the server to a default state with no open sessions
-  rpc ResetServer(ResetServerRequest) returns (ResetServerResponse);
-}
-
 enum SessionInitializationBehavior {
   SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED = 0;
   SESSION_INITIALIZATION_BEHAVIOR_INITIALIZE_NEW = 1;
@@ -39,71 +15,4 @@ enum SessionInitializationBehavior {
 
 message Session {
   string name = 1;
-}
-
-message DeviceProperties {
-  string name = 1;
-  string model = 2;
-  string vendor = 3;
-  string serial_number = 4;
-  uint32 product_id = 5;
-}
-
-message EnumerateDevicesRequest {}
-
-message EnumerateDevicesResponse {
-  repeated DeviceProperties devices = 1;
-}
-
-message SoftwareProperties {
-  string package_id = 1;
-  string package_version = 2;
-  string product_name = 3;
-}
-
-message EnumerateInstalledSoftwareRequest {
-  bool include_hidden_packages = 1;
-}
-
-message EnumerateInstalledSoftwareResponse {
-  repeated SoftwareProperties software = 1;
-}
-
-message ReserveRequest {
-  // client defined string representing a set of reservable resources
-  string reservation_id = 1;
-  // client defined identifier for a specific client
-  string client_id = 2;
-}
-
-message ReserveResponse {
-  bool is_reserved = 1;
-}
-
-message IsReservedByClientRequest {
-  // client defined string representing a set of reservable resources
-  string reservation_id = 1;
-  // client defined identifier for a specific client
-  string client_id = 2;
-}
-
-message IsReservedByClientResponse {
-  bool is_reserved = 1;
-}
-
-message UnreserveRequest {
-  // client defined string representing a set of reservable resources
-  string reservation_id = 1;
-  // client defined identifier for a specific client
-  string client_id = 2;
-}
-
-message UnreserveResponse {
-  bool is_unreserved = 1;
-}
-
-message ResetServerRequest {}
-
-message ResetServerResponse {
-  bool is_server_reset = 1;
 }

--- a/source/protobuf/session_utilities.proto
+++ b/source/protobuf/session_utilities.proto
@@ -1,0 +1,99 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "com.ni.grpc.device";
+option java_outer_classname = "NiDevice";
+option csharp_namespace = "NationalInstruments.Grpc.Device";
+
+package nidevice_grpc;
+
+service SessionUtilities {
+  // Provides a list of devices or chassis connected to server under localhost
+  rpc EnumerateDevices(EnumerateDevicesRequest)
+      returns (EnumerateDevicesResponse);
+
+  // Provides a list of NI software installed on server under localhost
+  rpc EnumerateInstalledSoftware(EnumerateInstalledSoftwareRequest)
+      returns (EnumerateInstalledSoftwareResponse);
+
+  // Reserve a set of client defined resources for exclusive use
+  rpc Reserve(ReserveRequest) returns (ReserveResponse);
+
+  // Determines if a set of client defined resources is currently reserved by a
+  // specific client
+  rpc IsReservedByClient(IsReservedByClientRequest)
+      returns (IsReservedByClientResponse);
+
+  // Unreserves a previously reserved resource
+  rpc Unreserve(UnreserveRequest) returns (UnreserveResponse);
+
+  // Resets the server to a default state with no open sessions
+  rpc ResetServer(ResetServerRequest) returns (ResetServerResponse);
+}
+
+message DeviceProperties {
+  string name = 1;
+  string model = 2;
+  string vendor = 3;
+  string serial_number = 4;
+  uint32 product_id = 5;
+}
+
+message EnumerateDevicesRequest {}
+
+message EnumerateDevicesResponse {
+  repeated DeviceProperties devices = 1;
+}
+
+message SoftwareProperties {
+  string package_id = 1;
+  string package_version = 2;
+  string product_name = 3;
+}
+
+message EnumerateInstalledSoftwareRequest {
+  bool include_hidden_packages = 1;
+}
+
+message EnumerateInstalledSoftwareResponse {
+  repeated SoftwareProperties software = 1;
+}
+
+message ReserveRequest {
+  // client defined string representing a set of reservable resources
+  string reservation_id = 1;
+  // client defined identifier for a specific client
+  string client_id = 2;
+}
+
+message ReserveResponse {
+  bool is_reserved = 1;
+}
+
+message IsReservedByClientRequest {
+  // client defined string representing a set of reservable resources
+  string reservation_id = 1;
+  // client defined identifier for a specific client
+  string client_id = 2;
+}
+
+message IsReservedByClientResponse {
+  bool is_reserved = 1;
+}
+
+message UnreserveRequest {
+  // client defined string representing a set of reservable resources
+  string reservation_id = 1;
+  // client defined identifier for a specific client
+  string client_id = 2;
+}
+
+message UnreserveResponse {
+  bool is_unreserved = 1;
+}
+
+message ResetServerRequest {}
+
+message ResetServerResponse {
+  bool is_server_reset = 1;
+}

--- a/source/server/device_enumerator.h
+++ b/source/server/device_enumerator.h
@@ -4,6 +4,7 @@
 #include <grpcpp/grpcpp.h>
 #include <nisyscfg.h>
 #include <session.grpc.pb.h>
+#include <session_utilities.grpc.pb.h>
 #include <shared_mutex>
 
 #include "syscfg_library_interface.h"

--- a/source/server/software_enumerator.h
+++ b/source/server/software_enumerator.h
@@ -4,6 +4,7 @@
 #include <grpcpp/grpcpp.h>
 #include <nisyscfg.h>
 #include <session.grpc.pb.h>
+#include <session_utilities.grpc.pb.h>
 
 #include <shared_mutex>
 

--- a/source/tests/system/device_server.cpp
+++ b/source/tests/system/device_server.cpp
@@ -4,6 +4,7 @@
 #include <register_all_services.h>
 #include <server/feature_toggles.h>
 #include <session.grpc.pb.h>
+#include <session_utilities.grpc.pb.h>
 
 namespace ni {
 namespace tests {


### PR DESCRIPTION
### What does this Pull Request accomplish?

We want to use the session message definition in other projects but do not want to include SessionUtilities.  SessionUtilities is not heavily used and moving to another proto file should not be disruptive to many users.

### Why should this Pull Request be merged?

General improvement to the organization of the services and messages of this project.

### What testing has been done?

No behavioral changes.
