### PR TITLE
Change code readiness on restricted services from RestrictedNextRelease to RestrictedRelease

### DIFF
--- a/generated/nimxlcterminaladaptor_restricted/nimxlcterminaladaptor_restricted_service.cpp
+++ b/generated/nimxlcterminaladaptor_restricted/nimxlcterminaladaptor_restricted_service.cpp
@@ -180,7 +180,7 @@ namespace nimxlcterminaladaptor_restricted_grpc {
   NimxlcTerminalAdaptorRestrictedFeatureToggles::NimxlcTerminalAdaptorRestrictedFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("nimxlcterminaladaptor_restricted", CodeReadiness::kRestrictedNextRelease))
+        feature_toggles.is_feature_enabled("nimxlcterminaladaptor_restricted", CodeReadiness::kRestrictedRelease))
   {
   }
 } // namespace nimxlcterminaladaptor_restricted_grpc

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
@@ -1026,7 +1026,7 @@ namespace nirfmxinstr_restricted_grpc {
   NiRFmxInstrRestrictedFeatureToggles::NiRFmxInstrRestrictedFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("nirfmxinstr_restricted", CodeReadiness::kRestrictedNextRelease))
+        feature_toggles.is_feature_enabled("nirfmxinstr_restricted", CodeReadiness::kRestrictedRelease))
   {
   }
 } // namespace nirfmxinstr_restricted_grpc

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_service.cpp
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_service.cpp
@@ -146,7 +146,7 @@ namespace nirfmxspecan_restricted_grpc {
   NiRFmxSpecAnRestrictedFeatureToggles::NiRFmxSpecAnRestrictedFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("nirfmxspecan_restricted", CodeReadiness::kRestrictedNextRelease))
+        feature_toggles.is_feature_enabled("nirfmxspecan_restricted", CodeReadiness::kRestrictedRelease))
   {
   }
 } // namespace nirfmxspecan_restricted_grpc

--- a/source/codegen/metadata/nimxlcterminaladaptor_restricted/config.py
+++ b/source/codegen/metadata/nimxlcterminaladaptor_restricted/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 config = {
-    "code_readiness": "RestrictedNextRelease",
+    "code_readiness": "RestrictedRelease",
     'api_version': '21.0.0',
     'c_header': 'TerminalAdaptorTypes.h',
     'c_function_prefix': 'nimxlc_ta_nimxlc_',

--- a/source/codegen/metadata/nirfmxinstr_restricted/config.py
+++ b/source/codegen/metadata/nirfmxinstr_restricted/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 config = {
-    "code_readiness": "RestrictedNextRelease",
+    "code_readiness": "RestrictedRelease",
     'api_version': '21.0.0',
     'c_header': 'niRFmxInstr.h',
     'c_function_prefix': 'RFmxInstr_',

--- a/source/codegen/metadata/nirfmxspecan_restricted/config.py
+++ b/source/codegen/metadata/nirfmxspecan_restricted/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 config = {
-    "code_readiness": "RestrictedNextRelease",
+    "code_readiness": "RestrictedRelease",
     "api_version": "21.0.0",
     "c_header": "niRFmxSpecAn.h",
     "c_function_prefix": "RFmxSpecAn_",

--- a/source/server/debug_session_properties_restricted_service.cpp
+++ b/source/server/debug_session_properties_restricted_service.cpp
@@ -7,7 +7,7 @@ namespace nidevice_restricted_grpc {
 DebugSessionPropertiesRestrictedFeatureToggles::DebugSessionPropertiesRestrictedFeatureToggles(
   const nidevice_grpc::FeatureToggles& feature_toggles)
   : is_enabled(
-      feature_toggles.is_feature_enabled("debugsessionproperties_restricted", CodeReadiness::kRestrictedNextRelease))
+      feature_toggles.is_feature_enabled("debugsessionproperties_restricted", CodeReadiness::kRestrictedRelease))
 {
 }
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Changes the code readiness of restricted services.

### Why should this Pull Request be merged?

InstrumentStudio remote SFPs for RFmxSpecAn requires the functionality from the restricted services to function. The code readiness of those services should reflect this.

### What testing has been done?

Ran automated tests locally and verified manually that remotability still works.
