### PR TITLE
CMakeLists.txt: Hardcode the version instead of using tags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.12.0)
 
-project(ni_grpc_device_server C CXX
+project(ni_grpc_device_server
+  LANGUAGES C CXX
   VERSION 1.5.2)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.12.0)
 
-project(ni_grpc_device_server C CXX)
+project(ni_grpc_device_server C CXX
+  VERSION 1.5.2)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(CreateVirtualEnvironment)
@@ -8,34 +9,6 @@ include(CreateVirtualEnvironment)
 # Workaround for: https://bugs.chromium.org/p/boringssl/issues/detail?id=423
 if (CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64")
   set(CMAKE_SYSTEM_PROCESSOR "amd64")
-endif()
-
-#----------------------------------------------------------------------
-# Determine version using current branch Git tag (e.g. v1.5.2)
-#----------------------------------------------------------------------
-if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
-  execute_process(
-    COMMAND git describe --tags
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    OUTPUT_VARIABLE GIT_TAG
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-  )
-else(EXISTS "${CMAKE_SOURCE_DIR}/.git")
-  set(GIT_TAG "v0.0.0")
-endif(EXISTS "${CMAKE_SOURCE_DIR}/.git")
-
-message(STATUS "Parsing Git tag ${GIT_TAG}.")
-
-if(GIT_TAG MATCHES "^v([0-9]+)\\.([0-9]+)\\.?([0-9]+)?")
-  set(GIT_TAG_MAJOR ${CMAKE_MATCH_1})
-  set(GIT_TAG_MINOR ${CMAKE_MATCH_2})
-  if(CMAKE_MATCH_3)
-    set(GIT_TAG_PATCH ${CMAKE_MATCH_3})
-  else()
-    set(GIT_TAG_PATCH "0")
-  endif()
-else()
-  message(FATAL_ERROR "Unable to parse Git tag. Tag must contain major and minor version with optional patch. e.g. \"v1.33.7\"")
 endif()
 
 #----------------------------------------------------------------------

--- a/source/server/version.rc.in
+++ b/source/server/version.rc.in
@@ -15,8 +15,8 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 #pragma code_page(1252)
 
 VS_VERSION_INFO VERSIONINFO
-    FILEVERSION @GIT_TAG_MAJOR@,@GIT_TAG_MINOR@,@GIT_TAG_PATCH@,0
-    PRODUCTVERSION @GIT_TAG_MAJOR@,@GIT_TAG_MINOR@,0,0
+    FILEVERSION @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,@PROJECT_VERSION_PATCH@,0
+    PRODUCTVERSION @PROJECT_VERSION_MAJOR@,@PROJECT_VERSION_MINOR@,0,0
     FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
     FILEFLAGS 0x1L
@@ -33,12 +33,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "NI"
             VALUE "FileDescription", ""
-            VALUE "FileVersion", "@GIT_TAG_MAJOR@.@GIT_TAG_MINOR@.@GIT_TAG_PATCH@.0"
+            VALUE "FileVersion", "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@.0"
             VALUE "InternalName", ""
             VALUE "LegalCopyright", "Copyright (C) 2021 - 2022"
             VALUE "OriginalFilename", "ni_grpc_device_server.exe"
             VALUE "ProductName", "NI gRPC Device Server"
-            VALUE "ProductVersion", "@GIT_TAG_MAJOR@.@GIT_TAG_MINOR@"
+            VALUE "ProductVersion", "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@"
         END
     END
     BLOCK "VarFileInfo"


### PR DESCRIPTION
### What does this Pull Request accomplish?

#782 

Using git tags to parse the version used for Windows builds was causing builds without access to those tags to fail. Specifically, this caused the NI Linux RT OpenEmbedded build to fail. This change switches to a hard-coded value for now until a better automated solution can be determined.

Signed-off-by: Charlie Johnston <charlie.johnston@ni.com>

### Why should this Pull Request be merged?

In order to ensure that the automated builds used for the version in the NI Linux RT feeds continue to work.

### What testing has been done?

The actual functionality only affects Windows systems (though it was breaking NI Linux RT builds), so a pass of the Windows build should indicate everything is working. 
