### PR TITLE
Update MI metadata to match version in nimi-python.

### DIFF
--- a/generated/nidcpower/nidcpower.proto
+++ b/generated/nidcpower/nidcpower.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-DCPower API metadata version 23.0.0d288
+// This file is generated from NI-DCPower API metadata version 23.0.0d318
 //---------------------------------------------------------------------
 // Proto file for the NI-DCPower Metadata
 //---------------------------------------------------------------------
@@ -43,7 +43,6 @@ service NiDCPower {
   rpc ConfigureDigitalEdgeSourceTriggerWithChannels(ConfigureDigitalEdgeSourceTriggerWithChannelsRequest) returns (ConfigureDigitalEdgeSourceTriggerWithChannelsResponse);
   rpc ConfigureDigitalEdgeStartTrigger(ConfigureDigitalEdgeStartTriggerRequest) returns (ConfigureDigitalEdgeStartTriggerResponse);
   rpc ConfigureDigitalEdgeStartTriggerWithChannels(ConfigureDigitalEdgeStartTriggerWithChannelsRequest) returns (ConfigureDigitalEdgeStartTriggerWithChannelsResponse);
-  rpc ConfigureLCRCompensation(ConfigureLCRCompensationRequest) returns (ConfigureLCRCompensationResponse);
   rpc ConfigureLCRCustomCableCompensation(ConfigureLCRCustomCableCompensationRequest) returns (ConfigureLCRCustomCableCompensationResponse);
   rpc ConfigureOutputEnabled(ConfigureOutputEnabledRequest) returns (ConfigureOutputEnabledResponse);
   rpc ConfigureOutputFunction(ConfigureOutputFunctionRequest) returns (ConfigureOutputFunctionResponse);
@@ -118,7 +117,6 @@ service NiDCPower {
   rpc GetExtCalLastDateAndTime(GetExtCalLastDateAndTimeRequest) returns (GetExtCalLastDateAndTimeResponse);
   rpc GetExtCalLastTemp(GetExtCalLastTempRequest) returns (GetExtCalLastTempResponse);
   rpc GetExtCalRecommendedInterval(GetExtCalRecommendedIntervalRequest) returns (GetExtCalRecommendedIntervalResponse);
-  rpc GetLCRCompensationData(GetLCRCompensationDataRequest) returns (GetLCRCompensationDataResponse);
   rpc GetLCRCompensationLastDateAndTime(GetLCRCompensationLastDateAndTimeRequest) returns (GetLCRCompensationLastDateAndTimeResponse);
   rpc GetLCRCustomCableCompensationData(GetLCRCustomCableCompensationDataRequest) returns (GetLCRCustomCableCompensationDataResponse);
   rpc GetNextCoercionRecord(GetNextCoercionRecordRequest) returns (GetNextCoercionRecordResponse);
@@ -943,16 +941,6 @@ message ConfigureDigitalEdgeStartTriggerWithChannelsResponse {
   int32 status = 1;
 }
 
-message ConfigureLCRCompensationRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  bytes compensation_data = 3;
-}
-
-message ConfigureLCRCompensationResponse {
-  int32 status = 1;
-}
-
 message ConfigureLCRCustomCableCompensationRequest {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
@@ -1698,16 +1686,6 @@ message GetExtCalRecommendedIntervalRequest {
 message GetExtCalRecommendedIntervalResponse {
   int32 status = 1;
   sint32 months = 2;
-}
-
-message GetLCRCompensationDataRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-}
-
-message GetLCRCompensationDataResponse {
-  int32 status = 1;
-  bytes compensation_data = 2;
 }
 
 message GetLCRCompensationLastDateAndTimeRequest {

--- a/generated/nidcpower/nidcpower_client.cpp
+++ b/generated/nidcpower/nidcpower_client.cpp
@@ -611,25 +611,6 @@ configure_digital_edge_start_trigger_with_channels(const StubPtr& stub, const ni
   return response;
 }
 
-ConfigureLCRCompensationResponse
-configure_lcr_compensation(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const pb::string& compensation_data)
-{
-  ::grpc::ClientContext context;
-
-  auto request = ConfigureLCRCompensationRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-  request.set_channel_name(channel_name);
-  request.set_compensation_data(compensation_data);
-
-  auto response = ConfigureLCRCompensationResponse{};
-
-  raise_if_error(
-      stub->ConfigureLCRCompensation(&context, request, &response),
-      context);
-
-  return response;
-}
-
 ConfigureLCRCustomCableCompensationResponse
 configure_lcr_custom_cable_compensation(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const pb::string& custom_cable_compensation_data)
 {
@@ -2039,24 +2020,6 @@ get_ext_cal_recommended_interval(const StubPtr& stub, const nidevice_grpc::Sessi
 
   raise_if_error(
       stub->GetExtCalRecommendedInterval(&context, request, &response),
-      context);
-
-  return response;
-}
-
-GetLCRCompensationDataResponse
-get_lcr_compensation_data(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name)
-{
-  ::grpc::ClientContext context;
-
-  auto request = GetLCRCompensationDataRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-  request.set_channel_name(channel_name);
-
-  auto response = GetLCRCompensationDataResponse{};
-
-  raise_if_error(
-      stub->GetLCRCompensationData(&context, request, &response),
       context);
 
   return response;

--- a/generated/nidcpower/nidcpower_client.h
+++ b/generated/nidcpower/nidcpower_client.h
@@ -48,7 +48,6 @@ ConfigureDigitalEdgeSourceTriggerResponse configure_digital_edge_source_trigger(
 ConfigureDigitalEdgeSourceTriggerWithChannelsResponse configure_digital_edge_source_trigger_with_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const pb::string& input_terminal, const simple_variant<DigitalEdge, pb::int32>& edge);
 ConfigureDigitalEdgeStartTriggerResponse configure_digital_edge_start_trigger(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& input_terminal, const simple_variant<DigitalEdge, pb::int32>& edge);
 ConfigureDigitalEdgeStartTriggerWithChannelsResponse configure_digital_edge_start_trigger_with_channels(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const pb::string& input_terminal, const simple_variant<DigitalEdge, pb::int32>& edge);
-ConfigureLCRCompensationResponse configure_lcr_compensation(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const pb::string& compensation_data);
 ConfigureLCRCustomCableCompensationResponse configure_lcr_custom_cable_compensation(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const pb::string& custom_cable_compensation_data);
 ConfigureOutputEnabledResponse configure_output_enabled(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const bool& enabled);
 ConfigureOutputFunctionResponse configure_output_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const simple_variant<OutputFunction, pb::int32>& function);
@@ -123,7 +122,6 @@ GetErrorResponse get_error(const StubPtr& stub, const nidevice_grpc::Session& vi
 GetExtCalLastDateAndTimeResponse get_ext_cal_last_date_and_time(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetExtCalLastTempResponse get_ext_cal_last_temp(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetExtCalRecommendedIntervalResponse get_ext_cal_recommended_interval(const StubPtr& stub, const nidevice_grpc::Session& vi);
-GetLCRCompensationDataResponse get_lcr_compensation_data(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name);
 GetLCRCompensationLastDateAndTimeResponse get_lcr_compensation_last_date_and_time(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const simple_variant<LCRCompensationType, pb::int32>& compensation_type);
 GetLCRCustomCableCompensationDataResponse get_lcr_custom_cable_compensation_data(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name);
 GetNextCoercionRecordResponse get_next_coercion_record(const StubPtr& stub, const nidevice_grpc::Session& vi);

--- a/generated/nidcpower/nidcpower_compilation_test.cpp
+++ b/generated/nidcpower/nidcpower_compilation_test.cpp
@@ -137,11 +137,6 @@ ViStatus ConfigureDigitalEdgeStartTriggerWithChannels(ViSession vi, ViConstStrin
   return niDCPower_ConfigureDigitalEdgeStartTriggerWithChannels(vi, channelName, inputTerminal, edge);
 }
 
-ViStatus ConfigureLCRCompensation(ViSession vi, ViConstString channelName, ViInt32 compensationDataSize, ViInt8 compensationData[])
-{
-  return niDCPower_ConfigureLCRCompensation(vi, channelName, compensationDataSize, compensationData);
-}
-
 ViStatus ConfigureLCRCustomCableCompensation(ViSession vi, ViConstString channelName, ViInt32 customCableCompensationDataSize, ViInt8 customCableCompensationData[])
 {
   return niDCPower_ConfigureLCRCustomCableCompensation(vi, channelName, customCableCompensationDataSize, customCableCompensationData);
@@ -510,11 +505,6 @@ ViStatus GetExtCalLastTemp(ViSession vi, ViReal64* temperature)
 ViStatus GetExtCalRecommendedInterval(ViSession vi, ViInt32* months)
 {
   return niDCPower_GetExtCalRecommendedInterval(vi, months);
-}
-
-ViStatus GetLCRCompensationData(ViSession vi, ViConstString channelName, ViInt32 compensationDataSize, ViInt8 compensationData[])
-{
-  return niDCPower_GetLCRCompensationData(vi, channelName, compensationDataSize, compensationData);
 }
 
 ViStatus GetLCRCompensationLastDateAndTime(ViSession vi, ViConstString channelName, ViInt32 compensationType, ViInt32* year, ViInt32* month, ViInt32* day, ViInt32* hour, ViInt32* minute)

--- a/generated/nidcpower/nidcpower_library.cpp
+++ b/generated/nidcpower/nidcpower_library.cpp
@@ -47,7 +47,6 @@ NiDCPowerLibrary::NiDCPowerLibrary() : shared_library_(kLibraryName)
   function_pointers_.ConfigureDigitalEdgeSourceTriggerWithChannels = reinterpret_cast<ConfigureDigitalEdgeSourceTriggerWithChannelsPtr>(shared_library_.get_function_pointer("niDCPower_ConfigureDigitalEdgeSourceTriggerWithChannels"));
   function_pointers_.ConfigureDigitalEdgeStartTrigger = reinterpret_cast<ConfigureDigitalEdgeStartTriggerPtr>(shared_library_.get_function_pointer("niDCPower_ConfigureDigitalEdgeStartTrigger"));
   function_pointers_.ConfigureDigitalEdgeStartTriggerWithChannels = reinterpret_cast<ConfigureDigitalEdgeStartTriggerWithChannelsPtr>(shared_library_.get_function_pointer("niDCPower_ConfigureDigitalEdgeStartTriggerWithChannels"));
-  function_pointers_.ConfigureLCRCompensation = reinterpret_cast<ConfigureLCRCompensationPtr>(shared_library_.get_function_pointer("niDCPower_ConfigureLCRCompensation"));
   function_pointers_.ConfigureLCRCustomCableCompensation = reinterpret_cast<ConfigureLCRCustomCableCompensationPtr>(shared_library_.get_function_pointer("niDCPower_ConfigureLCRCustomCableCompensation"));
   function_pointers_.ConfigureOutputEnabled = reinterpret_cast<ConfigureOutputEnabledPtr>(shared_library_.get_function_pointer("niDCPower_ConfigureOutputEnabled"));
   function_pointers_.ConfigureOutputFunction = reinterpret_cast<ConfigureOutputFunctionPtr>(shared_library_.get_function_pointer("niDCPower_ConfigureOutputFunction"));
@@ -122,7 +121,6 @@ NiDCPowerLibrary::NiDCPowerLibrary() : shared_library_(kLibraryName)
   function_pointers_.GetExtCalLastDateAndTime = reinterpret_cast<GetExtCalLastDateAndTimePtr>(shared_library_.get_function_pointer("niDCPower_GetExtCalLastDateAndTime"));
   function_pointers_.GetExtCalLastTemp = reinterpret_cast<GetExtCalLastTempPtr>(shared_library_.get_function_pointer("niDCPower_GetExtCalLastTemp"));
   function_pointers_.GetExtCalRecommendedInterval = reinterpret_cast<GetExtCalRecommendedIntervalPtr>(shared_library_.get_function_pointer("niDCPower_GetExtCalRecommendedInterval"));
-  function_pointers_.GetLCRCompensationData = reinterpret_cast<GetLCRCompensationDataPtr>(shared_library_.get_function_pointer("niDCPower_GetLCRCompensationData"));
   function_pointers_.GetLCRCompensationLastDateAndTime = reinterpret_cast<GetLCRCompensationLastDateAndTimePtr>(shared_library_.get_function_pointer("niDCPower_GetLCRCompensationLastDateAndTime"));
   function_pointers_.GetLCRCustomCableCompensationData = reinterpret_cast<GetLCRCustomCableCompensationDataPtr>(shared_library_.get_function_pointer("niDCPower_GetLCRCustomCableCompensationData"));
   function_pointers_.GetNextCoercionRecord = reinterpret_cast<GetNextCoercionRecordPtr>(shared_library_.get_function_pointer("niDCPower_GetNextCoercionRecord"));
@@ -391,14 +389,6 @@ ViStatus NiDCPowerLibrary::ConfigureDigitalEdgeStartTriggerWithChannels(ViSessio
     throw nidevice_grpc::LibraryLoadException("Could not find niDCPower_ConfigureDigitalEdgeStartTriggerWithChannels.");
   }
   return function_pointers_.ConfigureDigitalEdgeStartTriggerWithChannels(vi, channelName, inputTerminal, edge);
-}
-
-ViStatus NiDCPowerLibrary::ConfigureLCRCompensation(ViSession vi, ViConstString channelName, ViInt32 compensationDataSize, ViInt8 compensationData[])
-{
-  if (!function_pointers_.ConfigureLCRCompensation) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niDCPower_ConfigureLCRCompensation.");
-  }
-  return function_pointers_.ConfigureLCRCompensation(vi, channelName, compensationDataSize, compensationData);
 }
 
 ViStatus NiDCPowerLibrary::ConfigureLCRCustomCableCompensation(ViSession vi, ViConstString channelName, ViInt32 customCableCompensationDataSize, ViInt8 customCableCompensationData[])
@@ -991,14 +981,6 @@ ViStatus NiDCPowerLibrary::GetExtCalRecommendedInterval(ViSession vi, ViInt32* m
     throw nidevice_grpc::LibraryLoadException("Could not find niDCPower_GetExtCalRecommendedInterval.");
   }
   return function_pointers_.GetExtCalRecommendedInterval(vi, months);
-}
-
-ViStatus NiDCPowerLibrary::GetLCRCompensationData(ViSession vi, ViConstString channelName, ViInt32 compensationDataSize, ViInt8 compensationData[])
-{
-  if (!function_pointers_.GetLCRCompensationData) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niDCPower_GetLCRCompensationData.");
-  }
-  return function_pointers_.GetLCRCompensationData(vi, channelName, compensationDataSize, compensationData);
 }
 
 ViStatus NiDCPowerLibrary::GetLCRCompensationLastDateAndTime(ViSession vi, ViConstString channelName, ViInt32 compensationType, ViInt32* year, ViInt32* month, ViInt32* day, ViInt32* hour, ViInt32* minute)

--- a/generated/nidcpower/nidcpower_library.h
+++ b/generated/nidcpower/nidcpower_library.h
@@ -44,7 +44,6 @@ class NiDCPowerLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
   ViStatus ConfigureDigitalEdgeSourceTriggerWithChannels(ViSession vi, ViConstString channelName, ViConstString inputTerminal, ViInt32 edge);
   ViStatus ConfigureDigitalEdgeStartTrigger(ViSession vi, ViConstString inputTerminal, ViInt32 edge);
   ViStatus ConfigureDigitalEdgeStartTriggerWithChannels(ViSession vi, ViConstString channelName, ViConstString inputTerminal, ViInt32 edge);
-  ViStatus ConfigureLCRCompensation(ViSession vi, ViConstString channelName, ViInt32 compensationDataSize, ViInt8 compensationData[]);
   ViStatus ConfigureLCRCustomCableCompensation(ViSession vi, ViConstString channelName, ViInt32 customCableCompensationDataSize, ViInt8 customCableCompensationData[]);
   ViStatus ConfigureOutputEnabled(ViSession vi, ViConstString channelName, ViBoolean enabled);
   ViStatus ConfigureOutputFunction(ViSession vi, ViConstString channelName, ViInt32 function);
@@ -119,7 +118,6 @@ class NiDCPowerLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
   ViStatus GetExtCalLastDateAndTime(ViSession vi, ViInt32* year, ViInt32* month, ViInt32* day, ViInt32* hour, ViInt32* minute);
   ViStatus GetExtCalLastTemp(ViSession vi, ViReal64* temperature);
   ViStatus GetExtCalRecommendedInterval(ViSession vi, ViInt32* months);
-  ViStatus GetLCRCompensationData(ViSession vi, ViConstString channelName, ViInt32 compensationDataSize, ViInt8 compensationData[]);
   ViStatus GetLCRCompensationLastDateAndTime(ViSession vi, ViConstString channelName, ViInt32 compensationType, ViInt32* year, ViInt32* month, ViInt32* day, ViInt32* hour, ViInt32* minute);
   ViStatus GetLCRCustomCableCompensationData(ViSession vi, ViConstString channelName, ViInt32 customCableCompensationDataSize, ViInt8 customCableCompensationData[]);
   ViStatus GetNextCoercionRecord(ViSession vi, ViInt32 bufferSize, ViChar coercionRecord[]);
@@ -197,7 +195,6 @@ class NiDCPowerLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
   using ConfigureDigitalEdgeSourceTriggerWithChannelsPtr = decltype(&niDCPower_ConfigureDigitalEdgeSourceTriggerWithChannels);
   using ConfigureDigitalEdgeStartTriggerPtr = decltype(&niDCPower_ConfigureDigitalEdgeStartTrigger);
   using ConfigureDigitalEdgeStartTriggerWithChannelsPtr = decltype(&niDCPower_ConfigureDigitalEdgeStartTriggerWithChannels);
-  using ConfigureLCRCompensationPtr = decltype(&niDCPower_ConfigureLCRCompensation);
   using ConfigureLCRCustomCableCompensationPtr = decltype(&niDCPower_ConfigureLCRCustomCableCompensation);
   using ConfigureOutputEnabledPtr = decltype(&niDCPower_ConfigureOutputEnabled);
   using ConfigureOutputFunctionPtr = decltype(&niDCPower_ConfigureOutputFunction);
@@ -272,7 +269,6 @@ class NiDCPowerLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
   using GetExtCalLastDateAndTimePtr = decltype(&niDCPower_GetExtCalLastDateAndTime);
   using GetExtCalLastTempPtr = decltype(&niDCPower_GetExtCalLastTemp);
   using GetExtCalRecommendedIntervalPtr = decltype(&niDCPower_GetExtCalRecommendedInterval);
-  using GetLCRCompensationDataPtr = decltype(&niDCPower_GetLCRCompensationData);
   using GetLCRCompensationLastDateAndTimePtr = decltype(&niDCPower_GetLCRCompensationLastDateAndTime);
   using GetLCRCustomCableCompensationDataPtr = decltype(&niDCPower_GetLCRCustomCableCompensationData);
   using GetNextCoercionRecordPtr = decltype(&niDCPower_GetNextCoercionRecord);
@@ -350,7 +346,6 @@ class NiDCPowerLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
     ConfigureDigitalEdgeSourceTriggerWithChannelsPtr ConfigureDigitalEdgeSourceTriggerWithChannels;
     ConfigureDigitalEdgeStartTriggerPtr ConfigureDigitalEdgeStartTrigger;
     ConfigureDigitalEdgeStartTriggerWithChannelsPtr ConfigureDigitalEdgeStartTriggerWithChannels;
-    ConfigureLCRCompensationPtr ConfigureLCRCompensation;
     ConfigureLCRCustomCableCompensationPtr ConfigureLCRCustomCableCompensation;
     ConfigureOutputEnabledPtr ConfigureOutputEnabled;
     ConfigureOutputFunctionPtr ConfigureOutputFunction;
@@ -425,7 +420,6 @@ class NiDCPowerLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
     GetExtCalLastDateAndTimePtr GetExtCalLastDateAndTime;
     GetExtCalLastTempPtr GetExtCalLastTemp;
     GetExtCalRecommendedIntervalPtr GetExtCalRecommendedInterval;
-    GetLCRCompensationDataPtr GetLCRCompensationData;
     GetLCRCompensationLastDateAndTimePtr GetLCRCompensationLastDateAndTime;
     GetLCRCustomCableCompensationDataPtr GetLCRCustomCableCompensationData;
     GetNextCoercionRecordPtr GetNextCoercionRecord;

--- a/generated/nidcpower/nidcpower_library_interface.h
+++ b/generated/nidcpower/nidcpower_library_interface.h
@@ -41,7 +41,6 @@ class NiDCPowerLibraryInterface {
   virtual ViStatus ConfigureDigitalEdgeSourceTriggerWithChannels(ViSession vi, ViConstString channelName, ViConstString inputTerminal, ViInt32 edge) = 0;
   virtual ViStatus ConfigureDigitalEdgeStartTrigger(ViSession vi, ViConstString inputTerminal, ViInt32 edge) = 0;
   virtual ViStatus ConfigureDigitalEdgeStartTriggerWithChannels(ViSession vi, ViConstString channelName, ViConstString inputTerminal, ViInt32 edge) = 0;
-  virtual ViStatus ConfigureLCRCompensation(ViSession vi, ViConstString channelName, ViInt32 compensationDataSize, ViInt8 compensationData[]) = 0;
   virtual ViStatus ConfigureLCRCustomCableCompensation(ViSession vi, ViConstString channelName, ViInt32 customCableCompensationDataSize, ViInt8 customCableCompensationData[]) = 0;
   virtual ViStatus ConfigureOutputEnabled(ViSession vi, ViConstString channelName, ViBoolean enabled) = 0;
   virtual ViStatus ConfigureOutputFunction(ViSession vi, ViConstString channelName, ViInt32 function) = 0;
@@ -116,7 +115,6 @@ class NiDCPowerLibraryInterface {
   virtual ViStatus GetExtCalLastDateAndTime(ViSession vi, ViInt32* year, ViInt32* month, ViInt32* day, ViInt32* hour, ViInt32* minute) = 0;
   virtual ViStatus GetExtCalLastTemp(ViSession vi, ViReal64* temperature) = 0;
   virtual ViStatus GetExtCalRecommendedInterval(ViSession vi, ViInt32* months) = 0;
-  virtual ViStatus GetLCRCompensationData(ViSession vi, ViConstString channelName, ViInt32 compensationDataSize, ViInt8 compensationData[]) = 0;
   virtual ViStatus GetLCRCompensationLastDateAndTime(ViSession vi, ViConstString channelName, ViInt32 compensationType, ViInt32* year, ViInt32* month, ViInt32* day, ViInt32* hour, ViInt32* minute) = 0;
   virtual ViStatus GetLCRCustomCableCompensationData(ViSession vi, ViConstString channelName, ViInt32 customCableCompensationDataSize, ViInt8 customCableCompensationData[]) = 0;
   virtual ViStatus GetNextCoercionRecord(ViSession vi, ViInt32 bufferSize, ViChar coercionRecord[]) = 0;

--- a/generated/nidcpower/nidcpower_mock_library.h
+++ b/generated/nidcpower/nidcpower_mock_library.h
@@ -43,7 +43,6 @@ class NiDCPowerMockLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
   MOCK_METHOD(ViStatus, ConfigureDigitalEdgeSourceTriggerWithChannels, (ViSession vi, ViConstString channelName, ViConstString inputTerminal, ViInt32 edge), (override));
   MOCK_METHOD(ViStatus, ConfigureDigitalEdgeStartTrigger, (ViSession vi, ViConstString inputTerminal, ViInt32 edge), (override));
   MOCK_METHOD(ViStatus, ConfigureDigitalEdgeStartTriggerWithChannels, (ViSession vi, ViConstString channelName, ViConstString inputTerminal, ViInt32 edge), (override));
-  MOCK_METHOD(ViStatus, ConfigureLCRCompensation, (ViSession vi, ViConstString channelName, ViInt32 compensationDataSize, ViInt8 compensationData[]), (override));
   MOCK_METHOD(ViStatus, ConfigureLCRCustomCableCompensation, (ViSession vi, ViConstString channelName, ViInt32 customCableCompensationDataSize, ViInt8 customCableCompensationData[]), (override));
   MOCK_METHOD(ViStatus, ConfigureOutputEnabled, (ViSession vi, ViConstString channelName, ViBoolean enabled), (override));
   MOCK_METHOD(ViStatus, ConfigureOutputFunction, (ViSession vi, ViConstString channelName, ViInt32 function), (override));
@@ -118,7 +117,6 @@ class NiDCPowerMockLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
   MOCK_METHOD(ViStatus, GetExtCalLastDateAndTime, (ViSession vi, ViInt32* year, ViInt32* month, ViInt32* day, ViInt32* hour, ViInt32* minute), (override));
   MOCK_METHOD(ViStatus, GetExtCalLastTemp, (ViSession vi, ViReal64* temperature), (override));
   MOCK_METHOD(ViStatus, GetExtCalRecommendedInterval, (ViSession vi, ViInt32* months), (override));
-  MOCK_METHOD(ViStatus, GetLCRCompensationData, (ViSession vi, ViConstString channelName, ViInt32 compensationDataSize, ViInt8 compensationData[]), (override));
   MOCK_METHOD(ViStatus, GetLCRCompensationLastDateAndTime, (ViSession vi, ViConstString channelName, ViInt32 compensationType, ViInt32* year, ViInt32* month, ViInt32* day, ViInt32* hour, ViInt32* minute), (override));
   MOCK_METHOD(ViStatus, GetLCRCustomCableCompensationData, (ViSession vi, ViConstString channelName, ViInt32 customCableCompensationDataSize, ViInt8 customCableCompensationData[]), (override));
   MOCK_METHOD(ViStatus, GetNextCoercionRecord, (ViSession vi, ViInt32 bufferSize, ViChar coercionRecord[]), (override));

--- a/generated/nidcpower/nidcpower_service.h
+++ b/generated/nidcpower/nidcpower_service.h
@@ -67,7 +67,6 @@ public:
   ::grpc::Status ConfigureDigitalEdgeSourceTriggerWithChannels(::grpc::ServerContext* context, const ConfigureDigitalEdgeSourceTriggerWithChannelsRequest* request, ConfigureDigitalEdgeSourceTriggerWithChannelsResponse* response) override;
   ::grpc::Status ConfigureDigitalEdgeStartTrigger(::grpc::ServerContext* context, const ConfigureDigitalEdgeStartTriggerRequest* request, ConfigureDigitalEdgeStartTriggerResponse* response) override;
   ::grpc::Status ConfigureDigitalEdgeStartTriggerWithChannels(::grpc::ServerContext* context, const ConfigureDigitalEdgeStartTriggerWithChannelsRequest* request, ConfigureDigitalEdgeStartTriggerWithChannelsResponse* response) override;
-  ::grpc::Status ConfigureLCRCompensation(::grpc::ServerContext* context, const ConfigureLCRCompensationRequest* request, ConfigureLCRCompensationResponse* response) override;
   ::grpc::Status ConfigureLCRCustomCableCompensation(::grpc::ServerContext* context, const ConfigureLCRCustomCableCompensationRequest* request, ConfigureLCRCustomCableCompensationResponse* response) override;
   ::grpc::Status ConfigureOutputEnabled(::grpc::ServerContext* context, const ConfigureOutputEnabledRequest* request, ConfigureOutputEnabledResponse* response) override;
   ::grpc::Status ConfigureOutputFunction(::grpc::ServerContext* context, const ConfigureOutputFunctionRequest* request, ConfigureOutputFunctionResponse* response) override;
@@ -142,7 +141,6 @@ public:
   ::grpc::Status GetExtCalLastDateAndTime(::grpc::ServerContext* context, const GetExtCalLastDateAndTimeRequest* request, GetExtCalLastDateAndTimeResponse* response) override;
   ::grpc::Status GetExtCalLastTemp(::grpc::ServerContext* context, const GetExtCalLastTempRequest* request, GetExtCalLastTempResponse* response) override;
   ::grpc::Status GetExtCalRecommendedInterval(::grpc::ServerContext* context, const GetExtCalRecommendedIntervalRequest* request, GetExtCalRecommendedIntervalResponse* response) override;
-  ::grpc::Status GetLCRCompensationData(::grpc::ServerContext* context, const GetLCRCompensationDataRequest* request, GetLCRCompensationDataResponse* response) override;
   ::grpc::Status GetLCRCompensationLastDateAndTime(::grpc::ServerContext* context, const GetLCRCompensationLastDateAndTimeRequest* request, GetLCRCompensationLastDateAndTimeResponse* response) override;
   ::grpc::Status GetLCRCustomCableCompensationData(::grpc::ServerContext* context, const GetLCRCustomCableCompensationDataRequest* request, GetLCRCustomCableCompensationDataResponse* response) override;
   ::grpc::Status GetNextCoercionRecord(::grpc::ServerContext* context, const GetNextCoercionRecordRequest* request, GetNextCoercionRecordResponse* response) override;

--- a/generated/nidigitalpattern/nidigitalpattern.proto
+++ b/generated/nidigitalpattern/nidigitalpattern.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d48
+// This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d57
 //---------------------------------------------------------------------
 // Proto file for the NI-Digital Pattern Driver Metadata
 //---------------------------------------------------------------------

--- a/generated/nidmm/nidmm.proto
+++ b/generated/nidmm/nidmm.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-DMM API metadata version 23.0.0
+// This file is generated from NI-DMM API metadata version 23.0.0d85
 //---------------------------------------------------------------------
 // Proto file for the NI-DMM Metadata
 //---------------------------------------------------------------------

--- a/generated/nifake/nifake.proto
+++ b/generated/nifake/nifake.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-FAKE API metadata version 23.0.0
+// This file is generated from NI-FAKE API metadata version 23.0.0d96
 //---------------------------------------------------------------------
 // Proto file for the NI-FAKE Metadata
 //---------------------------------------------------------------------
@@ -25,6 +25,7 @@ service NiFake {
   rpc Close(CloseRequest) returns (CloseResponse);
   rpc CloseExtCal(CloseExtCalRequest) returns (CloseExtCalResponse);
   rpc CommandWithReservedParam(CommandWithReservedParamRequest) returns (CommandWithReservedParamResponse);
+  rpc ConfigureAbc(ConfigureAbcRequest) returns (ConfigureAbcResponse);
   rpc Control4022(Control4022Request) returns (Control4022Response);
   rpc CreateConfigurationList(CreateConfigurationListRequest) returns (CreateConfigurationListResponse);
   rpc CustomNestedStructRoundtrip(CustomNestedStructRoundtripRequest) returns (CustomNestedStructRoundtripResponse);
@@ -307,6 +308,14 @@ message CommandWithReservedParamRequest {
 }
 
 message CommandWithReservedParamResponse {
+  int32 status = 1;
+}
+
+message ConfigureAbcRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ConfigureAbcResponse {
   int32 status = 1;
 }
 

--- a/generated/nifake/nifake_client.cpp
+++ b/generated/nifake/nifake_client.cpp
@@ -177,6 +177,23 @@ command_with_reserved_param(const StubPtr& stub, const nidevice_grpc::Session& v
   return response;
 }
 
+ConfigureAbcResponse
+configure_abc(const StubPtr& stub, const nidevice_grpc::Session& vi)
+{
+  ::grpc::ClientContext context;
+
+  auto request = ConfigureAbcRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+
+  auto response = ConfigureAbcResponse{};
+
+  raise_if_error(
+      stub->ConfigureAbc(&context, request, &response),
+      context);
+
+  return response;
+}
+
 Control4022Response
 control4022(const StubPtr& stub, const pb::string& resource_name, const pb::int32& configuration)
 {

--- a/generated/nifake/nifake_client.h
+++ b/generated/nifake/nifake_client.h
@@ -31,6 +31,7 @@ BoolArrayOutputFunctionResponse bool_array_output_function(const StubPtr& stub, 
 CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& vi);
 CloseExtCalResponse close_ext_cal(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& action);
 CommandWithReservedParamResponse command_with_reserved_param(const StubPtr& stub, const nidevice_grpc::Session& vi);
+ConfigureAbcResponse configure_abc(const StubPtr& stub, const nidevice_grpc::Session& vi);
 Control4022Response control4022(const StubPtr& stub, const pb::string& resource_name, const pb::int32& configuration);
 CreateConfigurationListResponse create_configuration_list(const StubPtr& stub, const std::vector<NiFakeAttribute>& list_attribute_ids);
 CustomNestedStructRoundtripResponse custom_nested_struct_roundtrip(const StubPtr& stub, const CustomStructNestedTypedef& nested_custom_type_in);

--- a/generated/nifake/nifake_compilation_test.cpp
+++ b/generated/nifake/nifake_compilation_test.cpp
@@ -52,6 +52,11 @@ ViStatus CommandWithReservedParam(ViSession vi, ViBoolean* reserved)
   return niFake_CommandWithReservedParam(vi, reserved);
 }
 
+ViStatus ConfigureAbc(ViSession vi)
+{
+  return niFake_ConfigureABC(vi);
+}
+
 ViStatus Control4022(ViString resourceName, ViInt32 configuration)
 {
   return niFake_4022Control(resourceName, configuration);
@@ -317,9 +322,9 @@ ViStatus OneInputFunction(ViSession vi, ViInt32 aNumber)
   return niFake_OneInputFunction(vi, aNumber);
 }
 
-ViStatus ParametersAreMultipleTypes(ViSession vi, ViBoolean aBoolean, ViInt32 anInt32, ViInt64 anInt64, ViInt16 anIntEnum, ViReal64 aFloat, ViReal64 aFloatEnum, ViInt32 stringSize, ViConstString aString)
+ViStatus ParametersAreMultipleTypes(ViSession vi, ViBoolean aBoolean, ViInt32 anInt32, ViInt64 anInt64, ViInt16 anIntEnum, ViReal64 aFloat, ViReal64 aFloatEnum, ViConstString aString)
 {
-  return niFake_ParametersAreMultipleTypes(vi, aBoolean, anInt32, anInt64, anIntEnum, aFloat, aFloatEnum, stringSize, aString);
+  return niFake_ParametersAreMultipleTypes(vi, aBoolean, anInt32, anInt64, anIntEnum, aFloat, aFloatEnum, aString);
 }
 
 ViStatus PoorlyNamedSimpleFunction(ViSession vi)

--- a/generated/nifake/nifake_library.cpp
+++ b/generated/nifake/nifake_library.cpp
@@ -30,6 +30,7 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.Close = reinterpret_cast<ClosePtr>(shared_library_.get_function_pointer("niFake_close"));
   function_pointers_.CloseExtCal = reinterpret_cast<CloseExtCalPtr>(shared_library_.get_function_pointer("niFake_CloseExtCal"));
   function_pointers_.CommandWithReservedParam = reinterpret_cast<CommandWithReservedParamPtr>(shared_library_.get_function_pointer("niFake_CommandWithReservedParam"));
+  function_pointers_.ConfigureAbc = reinterpret_cast<ConfigureAbcPtr>(shared_library_.get_function_pointer("niFake_ConfigureABC"));
   function_pointers_.Control4022 = reinterpret_cast<Control4022Ptr>(shared_library_.get_function_pointer("niFake_4022Control"));
   function_pointers_.CreateConfigurationList = reinterpret_cast<CreateConfigurationListPtr>(shared_library_.get_function_pointer("niFake_CreateConfigurationList"));
   function_pointers_.CustomNestedStructRoundtrip = reinterpret_cast<CustomNestedStructRoundtripPtr>(shared_library_.get_function_pointer("niFake_CustomNestedStructRoundtrip"));
@@ -193,6 +194,14 @@ ViStatus NiFakeLibrary::CommandWithReservedParam(ViSession vi, ViBoolean* reserv
     throw nidevice_grpc::LibraryLoadException("Could not find niFake_CommandWithReservedParam.");
   }
   return function_pointers_.CommandWithReservedParam(vi, reserved);
+}
+
+ViStatus NiFakeLibrary::ConfigureAbc(ViSession vi)
+{
+  if (!function_pointers_.ConfigureAbc) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_ConfigureABC.");
+  }
+  return function_pointers_.ConfigureAbc(vi);
 }
 
 ViStatus NiFakeLibrary::Control4022(ViString resourceName, ViInt32 configuration)
@@ -627,12 +636,12 @@ ViStatus NiFakeLibrary::OneInputFunction(ViSession vi, ViInt32 aNumber)
   return function_pointers_.OneInputFunction(vi, aNumber);
 }
 
-ViStatus NiFakeLibrary::ParametersAreMultipleTypes(ViSession vi, ViBoolean aBoolean, ViInt32 anInt32, ViInt64 anInt64, ViInt16 anIntEnum, ViReal64 aFloat, ViReal64 aFloatEnum, ViInt32 stringSize, ViConstString aString)
+ViStatus NiFakeLibrary::ParametersAreMultipleTypes(ViSession vi, ViBoolean aBoolean, ViInt32 anInt32, ViInt64 anInt64, ViInt16 anIntEnum, ViReal64 aFloat, ViReal64 aFloatEnum, ViConstString aString)
 {
   if (!function_pointers_.ParametersAreMultipleTypes) {
     throw nidevice_grpc::LibraryLoadException("Could not find niFake_ParametersAreMultipleTypes.");
   }
-  return function_pointers_.ParametersAreMultipleTypes(vi, aBoolean, anInt32, anInt64, anIntEnum, aFloat, aFloatEnum, stringSize, aString);
+  return function_pointers_.ParametersAreMultipleTypes(vi, aBoolean, anInt32, anInt64, anIntEnum, aFloat, aFloatEnum, aString);
 }
 
 ViStatus NiFakeLibrary::PoorlyNamedSimpleFunction(ViSession vi)

--- a/generated/nifake/nifake_library.h
+++ b/generated/nifake/nifake_library.h
@@ -27,6 +27,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus Close(ViSession vi);
   ViStatus CloseExtCal(ViSession vi, ViInt32 action);
   ViStatus CommandWithReservedParam(ViSession vi, ViBoolean* reserved);
+  ViStatus ConfigureAbc(ViSession vi);
   ViStatus Control4022(ViString resourceName, ViInt32 configuration);
   ViStatus CreateConfigurationList(ViInt32 numberOfListAttributes, ViAttr listAttributeIds[]);
   ViStatus CustomNestedStructRoundtrip(CustomStructNestedTypedef_struct nestedCustomTypeIn, CustomStructNestedTypedef_struct* nestedCustomTypeOut);
@@ -81,7 +82,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus MultipleArraysSameSize(ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], ViInt32 size);
   ViStatus MultipleArraysSameSizeWithOptional(ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], CustomStruct values5[], ViInt32 size);
   ViStatus OneInputFunction(ViSession vi, ViInt32 aNumber);
-  ViStatus ParametersAreMultipleTypes(ViSession vi, ViBoolean aBoolean, ViInt32 anInt32, ViInt64 anInt64, ViInt16 anIntEnum, ViReal64 aFloat, ViReal64 aFloatEnum, ViInt32 stringSize, ViConstString aString);
+  ViStatus ParametersAreMultipleTypes(ViSession vi, ViBoolean aBoolean, ViInt32 anInt32, ViInt64 anInt64, ViInt16 anIntEnum, ViReal64 aFloat, ViReal64 aFloatEnum, ViConstString aString);
   ViStatus PoorlyNamedSimpleFunction(ViSession vi);
   ViStatus Read(ViSession vi, ViReal64 maximumTime, ViReal64* reading);
   ViStatus ReadDataWithInOutIviTwist(ViInt32 data[], ViInt32* bufferSize);
@@ -118,6 +119,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using ClosePtr = decltype(&niFake_close);
   using CloseExtCalPtr = decltype(&niFake_CloseExtCal);
   using CommandWithReservedParamPtr = decltype(&niFake_CommandWithReservedParam);
+  using ConfigureAbcPtr = decltype(&niFake_ConfigureABC);
   using Control4022Ptr = decltype(&niFake_4022Control);
   using CreateConfigurationListPtr = decltype(&niFake_CreateConfigurationList);
   using CustomNestedStructRoundtripPtr = decltype(&niFake_CustomNestedStructRoundtrip);
@@ -209,6 +211,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     ClosePtr Close;
     CloseExtCalPtr CloseExtCal;
     CommandWithReservedParamPtr CommandWithReservedParam;
+    ConfigureAbcPtr ConfigureAbc;
     Control4022Ptr Control4022;
     CreateConfigurationListPtr CreateConfigurationList;
     CustomNestedStructRoundtripPtr CustomNestedStructRoundtrip;

--- a/generated/nifake/nifake_library_interface.h
+++ b/generated/nifake/nifake_library_interface.h
@@ -24,6 +24,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus Close(ViSession vi) = 0;
   virtual ViStatus CloseExtCal(ViSession vi, ViInt32 action) = 0;
   virtual ViStatus CommandWithReservedParam(ViSession vi, ViBoolean* reserved) = 0;
+  virtual ViStatus ConfigureAbc(ViSession vi) = 0;
   virtual ViStatus Control4022(ViString resourceName, ViInt32 configuration) = 0;
   virtual ViStatus CreateConfigurationList(ViInt32 numberOfListAttributes, ViAttr listAttributeIds[]) = 0;
   virtual ViStatus CustomNestedStructRoundtrip(CustomStructNestedTypedef_struct nestedCustomTypeIn, CustomStructNestedTypedef_struct* nestedCustomTypeOut) = 0;
@@ -78,7 +79,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus MultipleArraysSameSize(ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], ViInt32 size) = 0;
   virtual ViStatus MultipleArraysSameSizeWithOptional(ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], CustomStruct values5[], ViInt32 size) = 0;
   virtual ViStatus OneInputFunction(ViSession vi, ViInt32 aNumber) = 0;
-  virtual ViStatus ParametersAreMultipleTypes(ViSession vi, ViBoolean aBoolean, ViInt32 anInt32, ViInt64 anInt64, ViInt16 anIntEnum, ViReal64 aFloat, ViReal64 aFloatEnum, ViInt32 stringSize, ViConstString aString) = 0;
+  virtual ViStatus ParametersAreMultipleTypes(ViSession vi, ViBoolean aBoolean, ViInt32 anInt32, ViInt64 anInt64, ViInt16 anIntEnum, ViReal64 aFloat, ViReal64 aFloatEnum, ViConstString aString) = 0;
   virtual ViStatus PoorlyNamedSimpleFunction(ViSession vi) = 0;
   virtual ViStatus Read(ViSession vi, ViReal64 maximumTime, ViReal64* reading) = 0;
   virtual ViStatus ReadDataWithInOutIviTwist(ViInt32 data[], ViInt32* bufferSize) = 0;

--- a/generated/nifake/nifake_mock_library.h
+++ b/generated/nifake/nifake_mock_library.h
@@ -26,6 +26,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, Close, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, CloseExtCal, (ViSession vi, ViInt32 action), (override));
   MOCK_METHOD(ViStatus, CommandWithReservedParam, (ViSession vi, ViBoolean* reserved), (override));
+  MOCK_METHOD(ViStatus, ConfigureAbc, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, Control4022, (ViString resourceName, ViInt32 configuration), (override));
   MOCK_METHOD(ViStatus, CreateConfigurationList, (ViInt32 numberOfListAttributes, ViAttr listAttributeIds[]), (override));
   MOCK_METHOD(ViStatus, CustomNestedStructRoundtrip, (CustomStructNestedTypedef_struct nestedCustomTypeIn, CustomStructNestedTypedef_struct* nestedCustomTypeOut), (override));
@@ -80,7 +81,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, MultipleArraysSameSize, (ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], ViInt32 size), (override));
   MOCK_METHOD(ViStatus, MultipleArraysSameSizeWithOptional, (ViSession vi, ViReal64 values1[], ViReal64 values2[], ViReal64 values3[], ViReal64 values4[], CustomStruct values5[], ViInt32 size), (override));
   MOCK_METHOD(ViStatus, OneInputFunction, (ViSession vi, ViInt32 aNumber), (override));
-  MOCK_METHOD(ViStatus, ParametersAreMultipleTypes, (ViSession vi, ViBoolean aBoolean, ViInt32 anInt32, ViInt64 anInt64, ViInt16 anIntEnum, ViReal64 aFloat, ViReal64 aFloatEnum, ViInt32 stringSize, ViConstString aString), (override));
+  MOCK_METHOD(ViStatus, ParametersAreMultipleTypes, (ViSession vi, ViBoolean aBoolean, ViInt32 anInt32, ViInt64 anInt64, ViInt16 anIntEnum, ViReal64 aFloat, ViReal64 aFloatEnum, ViConstString aString), (override));
   MOCK_METHOD(ViStatus, PoorlyNamedSimpleFunction, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, Read, (ViSession vi, ViReal64 maximumTime, ViReal64* reading), (override));
   MOCK_METHOD(ViStatus, ReadDataWithInOutIviTwist, (ViInt32 data[], ViInt32* bufferSize), (override));

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -273,6 +273,28 @@ namespace nifake_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::ConfigureAbc(::grpc::ServerContext* context, const ConfigureAbcRequest* request, ConfigureAbcResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      auto status = library_->ConfigureAbc(vi);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::Control4022(::grpc::ServerContext* context, const Control4022Request* request, Control4022Response* response)
   {
     if (context->IsCancelled()) {
@@ -1951,10 +1973,9 @@ namespace nifake_grpc {
         }
       }
 
-      ViInt32 string_size = static_cast<ViInt32>(convert_from_grpc<std::string>(request->a_string()).size());
       auto a_string_mbcs = convert_from_grpc<std::string>(request->a_string());
       auto a_string = a_string_mbcs.c_str();
-      auto status = library_->ParametersAreMultipleTypes(vi, a_boolean, an_int32, an_int64, an_int_enum, a_float, a_float_enum, string_size, a_string);
+      auto status = library_->ParametersAreMultipleTypes(vi, a_boolean, an_int32, an_int64, an_int_enum, a_float, a_float_enum, a_string);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
       }

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -50,6 +50,7 @@ public:
   ::grpc::Status Close(::grpc::ServerContext* context, const CloseRequest* request, CloseResponse* response) override;
   ::grpc::Status CloseExtCal(::grpc::ServerContext* context, const CloseExtCalRequest* request, CloseExtCalResponse* response) override;
   ::grpc::Status CommandWithReservedParam(::grpc::ServerContext* context, const CommandWithReservedParamRequest* request, CommandWithReservedParamResponse* response) override;
+  ::grpc::Status ConfigureAbc(::grpc::ServerContext* context, const ConfigureAbcRequest* request, ConfigureAbcResponse* response) override;
   ::grpc::Status Control4022(::grpc::ServerContext* context, const Control4022Request* request, Control4022Response* response) override;
   ::grpc::Status CreateConfigurationList(::grpc::ServerContext* context, const CreateConfigurationListRequest* request, CreateConfigurationListResponse* response) override;
   ::grpc::Status CustomNestedStructRoundtrip(::grpc::ServerContext* context, const CustomNestedStructRoundtripRequest* request, CustomNestedStructRoundtripResponse* response) override;

--- a/generated/nifgen/nifgen.proto
+++ b/generated/nifgen/nifgen.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-FGEN API metadata version 23.0.0
+// This file is generated from NI-FGEN API metadata version 23.0.0d57
 //---------------------------------------------------------------------
 // Proto file for the NI-FGEN Metadata
 //---------------------------------------------------------------------

--- a/generated/niscope/niscope.proto
+++ b/generated/niscope/niscope.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SCOPE API metadata version 23.0.0d87
+// This file is generated from NI-SCOPE API metadata version 23.0.0d95
 //---------------------------------------------------------------------
 // Proto file for the NI-SCOPE Metadata
 //---------------------------------------------------------------------
@@ -473,8 +473,8 @@ enum ExportableSignals {
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_ADVANCE_EVENT = 6;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_START_EVENT = 7;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_REF_EVENT = 10;
-  EXPORTABLE_SIGNALS_NISCOPE_VAL_REF_CLOCK = 100;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_5V_OUT = 13;
+  EXPORTABLE_SIGNALS_NISCOPE_VAL_REF_CLOCK = 100;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_SAMPLE_CLOCK = 101;
 }
 

--- a/generated/niswitch/niswitch.proto
+++ b/generated/niswitch/niswitch.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SWITCH API metadata version 23.0.0d58
+// This file is generated from NI-SWITCH API metadata version 23.0.0d75
 //---------------------------------------------------------------------
 // Proto file for the NI-SWITCH Metadata
 //---------------------------------------------------------------------

--- a/source/codegen/metadata/nidcpower/attributes.py
+++ b/source/codegen/metadata/nidcpower/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 23.0.0d288
+# This file is generated from NI-DCPower API metadata version 23.0.0d318
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidcpower/config.py
+++ b/source/codegen/metadata/nidcpower/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 23.0.0d288
+# This file is generated from NI-DCPower API metadata version 23.0.0d318
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0d288',
+    'api_version': '23.0.0d318',
     'c_function_prefix': 'niDCPower_',
     'c_header': 'nidcpower.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/nidcpower/enums.py
+++ b/source/codegen/metadata/nidcpower/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 23.0.0d288
+# This file is generated from NI-DCPower API metadata version 23.0.0d318
 enums = {
     'ApertureTimeAutoMode': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidcpower/functions.py
+++ b/source/codegen/metadata/nidcpower/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 23.0.0d288
+# This file is generated from NI-DCPower API metadata version 23.0.0d318
 functions = {
     'Abort': {
         'codegen_method': 'public',
@@ -680,50 +680,6 @@ functions = {
                 'grpc_type': 'sint32',
                 'name': 'edge',
                 'type': 'ViInt32'
-            }
-        ],
-        'returns': 'ViStatus'
-    },
-    'ConfigureLCRCompensation': {
-        'codegen_method': 'public',
-        'parameters': [
-            {
-                'cppName': 'vi',
-                'direction': 'in',
-                'grpc_type': 'nidevice_grpc.Session',
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'cppName': 'channelName',
-                'direction': 'in',
-                'grpc_type': 'string',
-                'name': 'channelName',
-                'type': 'ViConstString'
-            },
-            {
-                'cppName': 'compensationDataSize',
-                'determine_size_from': [
-                    'compensationData'
-                ],
-                'direction': 'in',
-                'grpc_type': 'sint32',
-                'include_in_proto': False,
-                'is_size_param': True,
-                'linked_params_are_optional': False,
-                'name': 'compensationDataSize',
-                'type': 'ViInt32'
-            },
-            {
-                'cppName': 'compensationData',
-                'direction': 'in',
-                'grpc_type': 'bytes',
-                'name': 'compensationData',
-                'size': {
-                    'mechanism': 'len',
-                    'value': 'compensationDataSize'
-                },
-                'type': 'ViInt8[]'
             }
         ],
         'returns': 'ViStatus'
@@ -2778,46 +2734,6 @@ functions = {
                 'grpc_type': 'sint32',
                 'name': 'months',
                 'type': 'ViInt32'
-            }
-        ],
-        'returns': 'ViStatus'
-    },
-    'GetLCRCompensationData': {
-        'codegen_method': 'public',
-        'parameters': [
-            {
-                'cppName': 'vi',
-                'direction': 'in',
-                'grpc_type': 'nidevice_grpc.Session',
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'cppName': 'channelName',
-                'direction': 'in',
-                'grpc_type': 'string',
-                'name': 'channelName',
-                'type': 'ViConstString'
-            },
-            {
-                'cppName': 'compensationDataSize',
-                'direction': 'in',
-                'grpc_type': 'sint32',
-                'include_in_proto': False,
-                'is_size_param': True,
-                'name': 'compensationDataSize',
-                'type': 'ViInt32'
-            },
-            {
-                'cppName': 'compensationData',
-                'direction': 'out',
-                'grpc_type': 'bytes',
-                'name': 'compensationData',
-                'size': {
-                    'mechanism': 'ivi-dance',
-                    'value': 'compensationDataSize'
-                },
-                'type': 'ViInt8[]'
             }
         ],
         'returns': 'ViStatus'

--- a/source/codegen/metadata/nidcpower/nidcpower.proto
+++ b/source/codegen/metadata/nidcpower/nidcpower.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-DCPower API metadata version 23.0.0d288
+// This file is generated from NI-DCPower API metadata version 23.0.0d318
 //---------------------------------------------------------------------
 // Proto file for the NI-DCPower Metadata
 //---------------------------------------------------------------------
@@ -43,7 +43,6 @@ service NiDCPower {
   rpc ConfigureDigitalEdgeSourceTriggerWithChannels(ConfigureDigitalEdgeSourceTriggerWithChannelsRequest) returns (ConfigureDigitalEdgeSourceTriggerWithChannelsResponse);
   rpc ConfigureDigitalEdgeStartTrigger(ConfigureDigitalEdgeStartTriggerRequest) returns (ConfigureDigitalEdgeStartTriggerResponse);
   rpc ConfigureDigitalEdgeStartTriggerWithChannels(ConfigureDigitalEdgeStartTriggerWithChannelsRequest) returns (ConfigureDigitalEdgeStartTriggerWithChannelsResponse);
-  rpc ConfigureLCRCompensation(ConfigureLCRCompensationRequest) returns (ConfigureLCRCompensationResponse);
   rpc ConfigureLCRCustomCableCompensation(ConfigureLCRCustomCableCompensationRequest) returns (ConfigureLCRCustomCableCompensationResponse);
   rpc ConfigureOutputEnabled(ConfigureOutputEnabledRequest) returns (ConfigureOutputEnabledResponse);
   rpc ConfigureOutputFunction(ConfigureOutputFunctionRequest) returns (ConfigureOutputFunctionResponse);
@@ -118,7 +117,6 @@ service NiDCPower {
   rpc GetExtCalLastDateAndTime(GetExtCalLastDateAndTimeRequest) returns (GetExtCalLastDateAndTimeResponse);
   rpc GetExtCalLastTemp(GetExtCalLastTempRequest) returns (GetExtCalLastTempResponse);
   rpc GetExtCalRecommendedInterval(GetExtCalRecommendedIntervalRequest) returns (GetExtCalRecommendedIntervalResponse);
-  rpc GetLCRCompensationData(GetLCRCompensationDataRequest) returns (GetLCRCompensationDataResponse);
   rpc GetLCRCompensationLastDateAndTime(GetLCRCompensationLastDateAndTimeRequest) returns (GetLCRCompensationLastDateAndTimeResponse);
   rpc GetLCRCustomCableCompensationData(GetLCRCustomCableCompensationDataRequest) returns (GetLCRCustomCableCompensationDataResponse);
   rpc GetNextCoercionRecord(GetNextCoercionRecordRequest) returns (GetNextCoercionRecordResponse);
@@ -943,16 +941,6 @@ message ConfigureDigitalEdgeStartTriggerWithChannelsResponse {
   int32 status = 1;
 }
 
-message ConfigureLCRCompensationRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  bytes compensation_data = 3;
-}
-
-message ConfigureLCRCompensationResponse {
-  int32 status = 1;
-}
-
 message ConfigureLCRCustomCableCompensationRequest {
   nidevice_grpc.Session vi = 1;
   string channel_name = 2;
@@ -1698,16 +1686,6 @@ message GetExtCalRecommendedIntervalRequest {
 message GetExtCalRecommendedIntervalResponse {
   int32 status = 1;
   sint32 months = 2;
-}
-
-message GetLCRCompensationDataRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-}
-
-message GetLCRCompensationDataResponse {
-  int32 status = 1;
-  bytes compensation_data = 2;
 }
 
 message GetLCRCompensationLastDateAndTimeRequest {

--- a/source/codegen/metadata/nidigitalpattern/attributes.py
+++ b/source/codegen/metadata/nidigitalpattern/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d48
+# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d57
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidigitalpattern/config.py
+++ b/source/codegen/metadata/nidigitalpattern/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d48
+# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d57
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0d48',
+    'api_version': '23.0.0d57',
     'c_function_prefix': 'niDigital_',
     'c_header': 'niDigital.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/nidigitalpattern/enums.py
+++ b/source/codegen/metadata/nidigitalpattern/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d48
+# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d57
 enums = {
     'BitOrder': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidigitalpattern/functions.py
+++ b/source/codegen/metadata/nidigitalpattern/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d48
+# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d57
 functions = {
     'Abort': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidigitalpattern/nidigitalpattern.proto
+++ b/source/codegen/metadata/nidigitalpattern/nidigitalpattern.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d48
+// This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d57
 //---------------------------------------------------------------------
 // Proto file for the NI-Digital Pattern Driver Metadata
 //---------------------------------------------------------------------

--- a/source/codegen/metadata/nidmm/attributes.py
+++ b/source/codegen/metadata/nidmm/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DMM API metadata version 23.0.0d46
+# This file is generated from NI-DMM API metadata version 23.0.0d85
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidmm/config.py
+++ b/source/codegen/metadata/nidmm/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DMM API metadata version 23.0.0d46
+# This file is generated from NI-DMM API metadata version 23.0.0d85
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0',
+    'api_version': '23.0.0d85',
     'c_function_prefix': 'niDMM_',
     'c_header': 'nidmm.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/nidmm/enums.py
+++ b/source/codegen/metadata/nidmm/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DMM API metadata version 23.0.0d46
+# This file is generated from NI-DMM API metadata version 23.0.0d85
 enums = {
     'AcquisitionStatus': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidmm/functions.py
+++ b/source/codegen/metadata/nidmm/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DMM API metadata version 23.0.0d46
+# This file is generated from NI-DMM API metadata version 23.0.0d85
 functions = {
     'Abort': {
         'codegen_method': 'public',
@@ -184,7 +184,7 @@ functions = {
                 'cppName': 'attributeValue',
                 'direction': 'in',
                 'grpc_type': 'string',
-                'name': 'attributeValue_raw',
+                'name': 'attribute_value_raw',
                 'type': 'ViString'
             }
         ],
@@ -2517,7 +2517,7 @@ functions = {
                 'cppName': 'attributeValue',
                 'direction': 'in',
                 'grpc_type': 'string',
-                'name': 'attributeValue_raw',
+                'name': 'attribute_value_raw',
                 'type': 'ViString'
             }
         ],

--- a/source/codegen/metadata/nidmm/nidmm.proto
+++ b/source/codegen/metadata/nidmm/nidmm.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-DMM API metadata version 23.0.0
+// This file is generated from NI-DMM API metadata version 23.0.0d85
 //---------------------------------------------------------------------
 // Proto file for the NI-DMM Metadata
 //---------------------------------------------------------------------

--- a/source/codegen/metadata/nifake/attributes.py
+++ b/source/codegen/metadata/nifake/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 23.0.0d49
+# This file is generated from NI-FAKE API metadata version 23.0.0d96
 attributes = {
     1000000: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nifake/config.py
+++ b/source/codegen/metadata/nifake/config.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 23.0.0d49
+# This file is generated from NI-FAKE API metadata version 23.0.0d96
 config = {
     'additional_headers': {
     },
-    'api_version': '23.0.0',
+    'api_version': '23.0.0d96',
     'c_function_prefix': 'niFake_',
     'c_header': 'niFake.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/nifake/enums.py
+++ b/source/codegen/metadata/nifake/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 23.0.0d49
+# This file is generated from NI-FAKE API metadata version 23.0.0d96
 enums = {
     'Bitfield': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 23.0.0d49
+# This file is generated from NI-FAKE API metadata version 23.0.0d96
 functions = {
     'Abort': {
         'codegen_method': 'public',
@@ -231,6 +231,20 @@ functions = {
                 'name': 'reserved',
                 'pointer': True,
                 'type': 'ViBoolean'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'ConfigureAbc': {
+        'cname': 'niFake_ConfigureABC',
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'cppName': 'vi',
+                'direction': 'in',
+                'grpc_type': 'nidevice_grpc.Session',
+                'name': 'vi',
+                'type': 'ViSession'
             }
         ],
         'returns': 'ViStatus'
@@ -2083,27 +2097,10 @@ functions = {
                 'type': 'ViReal64'
             },
             {
-                'cppName': 'stringSize',
-                'determine_size_from': [
-                    'aString'
-                ],
-                'direction': 'in',
-                'grpc_type': 'sint32',
-                'include_in_proto': False,
-                'is_size_param': True,
-                'linked_params_are_optional': False,
-                'name': 'stringSize',
-                'type': 'ViInt32'
-            },
-            {
                 'cppName': 'aString',
                 'direction': 'in',
                 'grpc_type': 'string',
                 'name': 'aString',
-                'size': {
-                    'mechanism': 'len',
-                    'value': 'stringSize'
-                },
                 'type': 'ViConstString'
             }
         ],
@@ -2579,7 +2576,7 @@ functions = {
                 'cppName': 'attributeValue',
                 'direction': 'in',
                 'grpc_type': 'int64',
-                'name': 'attributeValue_raw',
+                'name': 'attribute_value_raw',
                 'type': 'ViInt64'
             }
         ],
@@ -2648,7 +2645,7 @@ functions = {
                 'cppName': 'attributeValue',
                 'direction': 'in',
                 'grpc_type': 'string',
-                'name': 'attributeValue_raw',
+                'name': 'attribute_value_raw',
                 'type': 'ViConstString'
             }
         ],

--- a/source/codegen/metadata/nifake/nifake.proto
+++ b/source/codegen/metadata/nifake/nifake.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-FAKE API metadata version 23.0.0
+// This file is generated from NI-FAKE API metadata version 23.0.0d96
 //---------------------------------------------------------------------
 // Proto file for the NI-FAKE Metadata
 //---------------------------------------------------------------------
@@ -25,6 +25,7 @@ service NiFake {
   rpc Close(CloseRequest) returns (CloseResponse);
   rpc CloseExtCal(CloseExtCalRequest) returns (CloseExtCalResponse);
   rpc CommandWithReservedParam(CommandWithReservedParamRequest) returns (CommandWithReservedParamResponse);
+  rpc ConfigureAbc(ConfigureAbcRequest) returns (ConfigureAbcResponse);
   rpc Control4022(Control4022Request) returns (Control4022Response);
   rpc CreateConfigurationList(CreateConfigurationListRequest) returns (CreateConfigurationListResponse);
   rpc CustomNestedStructRoundtrip(CustomNestedStructRoundtripRequest) returns (CustomNestedStructRoundtripResponse);
@@ -307,6 +308,14 @@ message CommandWithReservedParamRequest {
 }
 
 message CommandWithReservedParamResponse {
+  int32 status = 1;
+}
+
+message ConfigureAbcRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ConfigureAbcResponse {
   int32 status = 1;
 }
 

--- a/source/codegen/metadata/nifgen/attributes.py
+++ b/source/codegen/metadata/nifgen/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 23.0.0d39
+# This file is generated from NI-FGEN API metadata version 23.0.0d57
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nifgen/config.py
+++ b/source/codegen/metadata/nifgen/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 23.0.0d39
+# This file is generated from NI-FGEN API metadata version 23.0.0d57
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0',
+    'api_version': '23.0.0d57',
     'c_function_prefix': 'niFgen_',
     'c_header': 'niFgen.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/nifgen/enums.py
+++ b/source/codegen/metadata/nifgen/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 23.0.0d39
+# This file is generated from NI-FGEN API metadata version 23.0.0d57
 enums = {
     'AddressType': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nifgen/functions.py
+++ b/source/codegen/metadata/nifgen/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 23.0.0d39
+# This file is generated from NI-FGEN API metadata version 23.0.0d57
 functions = {
     'AbortGeneration': {
         'codegen_method': 'public',
@@ -199,7 +199,7 @@ functions = {
                 'cppName': 'attributeValue',
                 'direction': 'in',
                 'grpc_type': 'int64',
-                'name': 'attributeValue_raw',
+                'name': 'attribute_value_raw',
                 'type': 'ViInt64'
             }
         ],
@@ -3559,7 +3559,7 @@ functions = {
                 'cppName': 'attributeValue',
                 'direction': 'in',
                 'grpc_type': 'int64',
-                'name': 'attributeValue_raw',
+                'name': 'attribute_value_raw',
                 'type': 'ViInt64'
             }
         ],

--- a/source/codegen/metadata/nifgen/nifgen.proto
+++ b/source/codegen/metadata/nifgen/nifgen.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-FGEN API metadata version 23.0.0
+// This file is generated from NI-FGEN API metadata version 23.0.0d57
 //---------------------------------------------------------------------
 // Proto file for the NI-FGEN Metadata
 //---------------------------------------------------------------------

--- a/source/codegen/metadata/niscope/attributes.py
+++ b/source/codegen/metadata/niscope/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0d87
+# This file is generated from NI-SCOPE API metadata version 23.0.0d95
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niscope/config.py
+++ b/source/codegen/metadata/niscope/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0d87
+# This file is generated from NI-SCOPE API metadata version 23.0.0d95
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0d87',
+    'api_version': '23.0.0d95',
     'c_function_prefix': 'niScope_',
     'c_header': 'niScopeCal.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/niscope/enums.py
+++ b/source/codegen/metadata/niscope/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0d87
+# This file is generated from NI-SCOPE API metadata version 23.0.0d95
 enums = {
     'AcquisitionStatus': {
         'codegen_method': 'public',
@@ -583,12 +583,12 @@ enums = {
                 'value': 10
             },
             {
-                'name': 'NISCOPE_VAL_REF_CLOCK',
-                'value': 100
-            },
-            {
                 'name': 'NISCOPE_VAL_5V_OUT',
                 'value': 13
+            },
+            {
+                'name': 'NISCOPE_VAL_REF_CLOCK',
+                'value': 100
             },
             {
                 'name': 'NISCOPE_VAL_SAMPLE_CLOCK',

--- a/source/codegen/metadata/niscope/functions.py
+++ b/source/codegen/metadata/niscope/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0d87
+# This file is generated from NI-SCOPE API metadata version 23.0.0d95
 functions = {
     'Abort': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niscope/niscope.proto
+++ b/source/codegen/metadata/niscope/niscope.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SCOPE API metadata version 23.0.0d87
+// This file is generated from NI-SCOPE API metadata version 23.0.0d95
 //---------------------------------------------------------------------
 // Proto file for the NI-SCOPE Metadata
 //---------------------------------------------------------------------
@@ -473,8 +473,8 @@ enum ExportableSignals {
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_ADVANCE_EVENT = 6;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_START_EVENT = 7;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_REF_EVENT = 10;
-  EXPORTABLE_SIGNALS_NISCOPE_VAL_REF_CLOCK = 100;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_5V_OUT = 13;
+  EXPORTABLE_SIGNALS_NISCOPE_VAL_REF_CLOCK = 100;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_SAMPLE_CLOCK = 101;
 }
 

--- a/source/codegen/metadata/niswitch/attributes.py
+++ b/source/codegen/metadata/niswitch/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SWITCH API metadata version 23.0.0d58
+# This file is generated from NI-SWITCH API metadata version 23.0.0d75
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niswitch/config.py
+++ b/source/codegen/metadata/niswitch/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SWITCH API metadata version 23.0.0d58
+# This file is generated from NI-SWITCH API metadata version 23.0.0d75
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0d58',
+    'api_version': '23.0.0d75',
     'c_function_prefix': 'niSwitch_',
     'c_header': 'niswitch.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/niswitch/enums.py
+++ b/source/codegen/metadata/niswitch/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SWITCH API metadata version 23.0.0d58
+# This file is generated from NI-SWITCH API metadata version 23.0.0d75
 enums = {
     'HandshakingInitiation': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niswitch/functions.py
+++ b/source/codegen/metadata/niswitch/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SWITCH API metadata version 23.0.0d58
+# This file is generated from NI-SWITCH API metadata version 23.0.0d75
 functions = {
     'AbortScan': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niswitch/niswitch.proto
+++ b/source/codegen/metadata/niswitch/niswitch.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SWITCH API metadata version 23.0.0d58
+// This file is generated from NI-SWITCH API metadata version 23.0.0d75
 //---------------------------------------------------------------------
 // Proto file for the NI-SWITCH Metadata
 //---------------------------------------------------------------------

--- a/source/tests/unit/ni_fake_service_tests.cpp
+++ b/source/tests/unit/ni_fake_service_tests.cpp
@@ -1316,9 +1316,7 @@ TEST(NiFakeServiceTests, NiFakeService_ParametersAreMultipleTypes_CallsParameter
           an_int_enum,
           a_float,
           expected_float_enum_value,
-          expected_string_size,
-          _))
-      .With(Args<8, 7>(ElementsAreArray(a_string, expected_string_size)))
+          StrEq(a_string)))
       .WillOnce(Return(kDriverSuccess));
 
   ::grpc::ServerContext context;
@@ -1363,9 +1361,7 @@ TEST(NiFakeServiceTests, NiFakeService_ParametersAreMultipleTypesWithRawValues_C
           an_int_enum,
           a_float,
           expected_float_enum_value,
-          expected_string_size,
-          _))
-      .With(Args<8, 7>(ElementsAreArray(a_string, expected_string_size)))
+          StrEq(a_string)))
       .WillOnce(Return(kDriverSuccess));
 
   ::grpc::ServerContext context;
@@ -1410,9 +1406,7 @@ TEST(NiFakeServiceTests, NiFakeService_ParametersAreMultipleTypesWithRawValuesNo
           expected_int_enum_value,
           a_float,
           expected_float_enum_value,
-          expected_string_size,
-          _))
-      .With(Args<8, 7>(ElementsAreArray(a_string, expected_string_size)))
+          StrEq(a_string)))
       .WillOnce(Return(kDriverSuccess));
 
   ::grpc::ServerContext context;


### PR DESCRIPTION
### What does this Pull Request accomplish?

For all the MI drivers in nimi-python, update the grpc-device metadata to be sourced from the same hapigen metadata as what the corresponding nimi-python metadata is based on.

In other words, nimi-python has NI-DCPower's metadata/proto sourced from the d318 version of the hapigen metadata (see [here](https://github.com/ni/nimi-python/blob/master/src/nidcpower/metadata/nidcpower.proto)) so we should align with that and pull in the same version of the metadata to grpc-device. Same goes for all the MI drivers.

### Why should this Pull Request be merged?

Was looking at nimi-python metadata and noticed that it was working off a different version of the hapigen metadata (and resulting .proto file) than grpc-device was pulling in.

I think in general these should be in sync (since nimi-python metadata takes into account grpc-device metadata). I'm not sure if it practically matters at this point but thought we should get them on the same page.

### What testing has been done?

Reviewed generated changes and they seem reasonable.
Unit and Integration tests pass locally. Relying on System Tests for everything else.
