### PR TITLE
Update using latest metadata exports

### DIFF
--- a/generated/nidcpower/nidcpower.proto
+++ b/generated/nidcpower/nidcpower.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-DCPower API metadata version 23.0.0d318
+// This file is generated from NI-DCPower API metadata version 23.0.0d446
 //---------------------------------------------------------------------
 // Proto file for the NI-DCPower Metadata
 //---------------------------------------------------------------------
@@ -46,7 +46,6 @@ service NiDCPower {
   rpc ConfigureLCRCustomCableCompensation(ConfigureLCRCustomCableCompensationRequest) returns (ConfigureLCRCustomCableCompensationResponse);
   rpc ConfigureOutputEnabled(ConfigureOutputEnabledRequest) returns (ConfigureOutputEnabledResponse);
   rpc ConfigureOutputFunction(ConfigureOutputFunctionRequest) returns (ConfigureOutputFunctionResponse);
-  rpc ConfigureOutputRange(ConfigureOutputRangeRequest) returns (ConfigureOutputRangeResponse);
   rpc ConfigureOutputResistance(ConfigureOutputResistanceRequest) returns (ConfigureOutputResistanceResponse);
   rpc ConfigureOvp(ConfigureOvpRequest) returns (ConfigureOvpResponse);
   rpc ConfigurePowerLineFrequency(ConfigurePowerLineFrequencyRequest) returns (ConfigurePowerLineFrequencyResponse);
@@ -971,17 +970,6 @@ message ConfigureOutputFunctionRequest {
 }
 
 message ConfigureOutputFunctionResponse {
-  int32 status = 1;
-}
-
-message ConfigureOutputRangeRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 range_type = 3;
-  double range = 4;
-}
-
-message ConfigureOutputRangeResponse {
   int32 status = 1;
 }
 

--- a/generated/nidcpower/nidcpower_client.cpp
+++ b/generated/nidcpower/nidcpower_client.cpp
@@ -675,26 +675,6 @@ configure_output_function(const StubPtr& stub, const nidevice_grpc::Session& vi,
   return response;
 }
 
-ConfigureOutputRangeResponse
-configure_output_range(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const pb::int32& range_type, const double& range)
-{
-  ::grpc::ClientContext context;
-
-  auto request = ConfigureOutputRangeRequest{};
-  request.mutable_vi()->CopyFrom(vi);
-  request.set_channel_name(channel_name);
-  request.set_range_type(range_type);
-  request.set_range(range);
-
-  auto response = ConfigureOutputRangeResponse{};
-
-  raise_if_error(
-      stub->ConfigureOutputRange(&context, request, &response),
-      context);
-
-  return response;
-}
-
 ConfigureOutputResistanceResponse
 configure_output_resistance(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const double& resistance)
 {

--- a/generated/nidcpower/nidcpower_client.h
+++ b/generated/nidcpower/nidcpower_client.h
@@ -51,7 +51,6 @@ ConfigureDigitalEdgeStartTriggerWithChannelsResponse configure_digital_edge_star
 ConfigureLCRCustomCableCompensationResponse configure_lcr_custom_cable_compensation(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const pb::string& custom_cable_compensation_data);
 ConfigureOutputEnabledResponse configure_output_enabled(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const bool& enabled);
 ConfigureOutputFunctionResponse configure_output_function(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const simple_variant<OutputFunction, pb::int32>& function);
-ConfigureOutputRangeResponse configure_output_range(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const pb::int32& range_type, const double& range);
 ConfigureOutputResistanceResponse configure_output_resistance(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const double& resistance);
 ConfigureOvpResponse configure_ovp(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const bool& enabled, const double& limit);
 ConfigurePowerLineFrequencyResponse configure_power_line_frequency(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<PowerLineFrequencies, double>& powerline_frequency);

--- a/generated/nidcpower/nidcpower_compilation_test.cpp
+++ b/generated/nidcpower/nidcpower_compilation_test.cpp
@@ -152,11 +152,6 @@ ViStatus ConfigureOutputFunction(ViSession vi, ViConstString channelName, ViInt3
   return niDCPower_ConfigureOutputFunction(vi, channelName, function);
 }
 
-ViStatus ConfigureOutputRange(ViSession vi, ViConstString channelName, ViInt32 rangeType, ViReal64 range)
-{
-  return niDCPower_ConfigureOutputRange(vi, channelName, rangeType, range);
-}
-
 ViStatus ConfigureOutputResistance(ViSession vi, ViConstString channelName, ViReal64 resistance)
 {
   return niDCPower_ConfigureOutputResistance(vi, channelName, resistance);

--- a/generated/nidcpower/nidcpower_library.cpp
+++ b/generated/nidcpower/nidcpower_library.cpp
@@ -50,7 +50,6 @@ NiDCPowerLibrary::NiDCPowerLibrary() : shared_library_(kLibraryName)
   function_pointers_.ConfigureLCRCustomCableCompensation = reinterpret_cast<ConfigureLCRCustomCableCompensationPtr>(shared_library_.get_function_pointer("niDCPower_ConfigureLCRCustomCableCompensation"));
   function_pointers_.ConfigureOutputEnabled = reinterpret_cast<ConfigureOutputEnabledPtr>(shared_library_.get_function_pointer("niDCPower_ConfigureOutputEnabled"));
   function_pointers_.ConfigureOutputFunction = reinterpret_cast<ConfigureOutputFunctionPtr>(shared_library_.get_function_pointer("niDCPower_ConfigureOutputFunction"));
-  function_pointers_.ConfigureOutputRange = reinterpret_cast<ConfigureOutputRangePtr>(shared_library_.get_function_pointer("niDCPower_ConfigureOutputRange"));
   function_pointers_.ConfigureOutputResistance = reinterpret_cast<ConfigureOutputResistancePtr>(shared_library_.get_function_pointer("niDCPower_ConfigureOutputResistance"));
   function_pointers_.ConfigureOvp = reinterpret_cast<ConfigureOvpPtr>(shared_library_.get_function_pointer("niDCPower_ConfigureOVP"));
   function_pointers_.ConfigurePowerLineFrequency = reinterpret_cast<ConfigurePowerLineFrequencyPtr>(shared_library_.get_function_pointer("niDCPower_ConfigurePowerLineFrequency"));
@@ -413,14 +412,6 @@ ViStatus NiDCPowerLibrary::ConfigureOutputFunction(ViSession vi, ViConstString c
     throw nidevice_grpc::LibraryLoadException("Could not find niDCPower_ConfigureOutputFunction.");
   }
   return function_pointers_.ConfigureOutputFunction(vi, channelName, function);
-}
-
-ViStatus NiDCPowerLibrary::ConfigureOutputRange(ViSession vi, ViConstString channelName, ViInt32 rangeType, ViReal64 range)
-{
-  if (!function_pointers_.ConfigureOutputRange) {
-    throw nidevice_grpc::LibraryLoadException("Could not find niDCPower_ConfigureOutputRange.");
-  }
-  return function_pointers_.ConfigureOutputRange(vi, channelName, rangeType, range);
 }
 
 ViStatus NiDCPowerLibrary::ConfigureOutputResistance(ViSession vi, ViConstString channelName, ViReal64 resistance)

--- a/generated/nidcpower/nidcpower_library.h
+++ b/generated/nidcpower/nidcpower_library.h
@@ -47,7 +47,6 @@ class NiDCPowerLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
   ViStatus ConfigureLCRCustomCableCompensation(ViSession vi, ViConstString channelName, ViInt32 customCableCompensationDataSize, ViInt8 customCableCompensationData[]);
   ViStatus ConfigureOutputEnabled(ViSession vi, ViConstString channelName, ViBoolean enabled);
   ViStatus ConfigureOutputFunction(ViSession vi, ViConstString channelName, ViInt32 function);
-  ViStatus ConfigureOutputRange(ViSession vi, ViConstString channelName, ViInt32 rangeType, ViReal64 range);
   ViStatus ConfigureOutputResistance(ViSession vi, ViConstString channelName, ViReal64 resistance);
   ViStatus ConfigureOvp(ViSession vi, ViConstString channelName, ViBoolean enabled, ViReal64 limit);
   ViStatus ConfigurePowerLineFrequency(ViSession vi, ViReal64 powerlineFrequency);
@@ -198,7 +197,6 @@ class NiDCPowerLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
   using ConfigureLCRCustomCableCompensationPtr = decltype(&niDCPower_ConfigureLCRCustomCableCompensation);
   using ConfigureOutputEnabledPtr = decltype(&niDCPower_ConfigureOutputEnabled);
   using ConfigureOutputFunctionPtr = decltype(&niDCPower_ConfigureOutputFunction);
-  using ConfigureOutputRangePtr = decltype(&niDCPower_ConfigureOutputRange);
   using ConfigureOutputResistancePtr = decltype(&niDCPower_ConfigureOutputResistance);
   using ConfigureOvpPtr = decltype(&niDCPower_ConfigureOVP);
   using ConfigurePowerLineFrequencyPtr = decltype(&niDCPower_ConfigurePowerLineFrequency);
@@ -349,7 +347,6 @@ class NiDCPowerLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
     ConfigureLCRCustomCableCompensationPtr ConfigureLCRCustomCableCompensation;
     ConfigureOutputEnabledPtr ConfigureOutputEnabled;
     ConfigureOutputFunctionPtr ConfigureOutputFunction;
-    ConfigureOutputRangePtr ConfigureOutputRange;
     ConfigureOutputResistancePtr ConfigureOutputResistance;
     ConfigureOvpPtr ConfigureOvp;
     ConfigurePowerLineFrequencyPtr ConfigurePowerLineFrequency;

--- a/generated/nidcpower/nidcpower_library_interface.h
+++ b/generated/nidcpower/nidcpower_library_interface.h
@@ -44,7 +44,6 @@ class NiDCPowerLibraryInterface {
   virtual ViStatus ConfigureLCRCustomCableCompensation(ViSession vi, ViConstString channelName, ViInt32 customCableCompensationDataSize, ViInt8 customCableCompensationData[]) = 0;
   virtual ViStatus ConfigureOutputEnabled(ViSession vi, ViConstString channelName, ViBoolean enabled) = 0;
   virtual ViStatus ConfigureOutputFunction(ViSession vi, ViConstString channelName, ViInt32 function) = 0;
-  virtual ViStatus ConfigureOutputRange(ViSession vi, ViConstString channelName, ViInt32 rangeType, ViReal64 range) = 0;
   virtual ViStatus ConfigureOutputResistance(ViSession vi, ViConstString channelName, ViReal64 resistance) = 0;
   virtual ViStatus ConfigureOvp(ViSession vi, ViConstString channelName, ViBoolean enabled, ViReal64 limit) = 0;
   virtual ViStatus ConfigurePowerLineFrequency(ViSession vi, ViReal64 powerlineFrequency) = 0;

--- a/generated/nidcpower/nidcpower_mock_library.h
+++ b/generated/nidcpower/nidcpower_mock_library.h
@@ -46,7 +46,6 @@ class NiDCPowerMockLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
   MOCK_METHOD(ViStatus, ConfigureLCRCustomCableCompensation, (ViSession vi, ViConstString channelName, ViInt32 customCableCompensationDataSize, ViInt8 customCableCompensationData[]), (override));
   MOCK_METHOD(ViStatus, ConfigureOutputEnabled, (ViSession vi, ViConstString channelName, ViBoolean enabled), (override));
   MOCK_METHOD(ViStatus, ConfigureOutputFunction, (ViSession vi, ViConstString channelName, ViInt32 function), (override));
-  MOCK_METHOD(ViStatus, ConfigureOutputRange, (ViSession vi, ViConstString channelName, ViInt32 rangeType, ViReal64 range), (override));
   MOCK_METHOD(ViStatus, ConfigureOutputResistance, (ViSession vi, ViConstString channelName, ViReal64 resistance), (override));
   MOCK_METHOD(ViStatus, ConfigureOvp, (ViSession vi, ViConstString channelName, ViBoolean enabled, ViReal64 limit), (override));
   MOCK_METHOD(ViStatus, ConfigurePowerLineFrequency, (ViSession vi, ViReal64 powerlineFrequency), (override));

--- a/generated/nidcpower/nidcpower_service.cpp
+++ b/generated/nidcpower/nidcpower_service.cpp
@@ -1010,32 +1010,6 @@ namespace nidcpower_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiDCPowerService::ConfigureOutputRange(::grpc::ServerContext* context, const ConfigureOutputRangeRequest* request, ConfigureOutputRangeResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto vi_grpc_session = request->vi();
-      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
-      auto channel_name_mbcs = convert_from_grpc<std::string>(request->channel_name());
-      auto channel_name = channel_name_mbcs.c_str();
-      ViInt32 range_type = request->range_type();
-      ViReal64 range = request->range();
-      auto status = library_->ConfigureOutputRange(vi, channel_name, range_type, range);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForViSession(context, status, vi);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
   ::grpc::Status NiDCPowerService::ConfigureOutputResistance(::grpc::ServerContext* context, const ConfigureOutputResistanceRequest* request, ConfigureOutputResistanceResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nidcpower/nidcpower_service.h
+++ b/generated/nidcpower/nidcpower_service.h
@@ -70,7 +70,6 @@ public:
   ::grpc::Status ConfigureLCRCustomCableCompensation(::grpc::ServerContext* context, const ConfigureLCRCustomCableCompensationRequest* request, ConfigureLCRCustomCableCompensationResponse* response) override;
   ::grpc::Status ConfigureOutputEnabled(::grpc::ServerContext* context, const ConfigureOutputEnabledRequest* request, ConfigureOutputEnabledResponse* response) override;
   ::grpc::Status ConfigureOutputFunction(::grpc::ServerContext* context, const ConfigureOutputFunctionRequest* request, ConfigureOutputFunctionResponse* response) override;
-  ::grpc::Status ConfigureOutputRange(::grpc::ServerContext* context, const ConfigureOutputRangeRequest* request, ConfigureOutputRangeResponse* response) override;
   ::grpc::Status ConfigureOutputResistance(::grpc::ServerContext* context, const ConfigureOutputResistanceRequest* request, ConfigureOutputResistanceResponse* response) override;
   ::grpc::Status ConfigureOvp(::grpc::ServerContext* context, const ConfigureOvpRequest* request, ConfigureOvpResponse* response) override;
   ::grpc::Status ConfigurePowerLineFrequency(::grpc::ServerContext* context, const ConfigurePowerLineFrequencyRequest* request, ConfigurePowerLineFrequencyResponse* response) override;

--- a/generated/nidigitalpattern/nidigitalpattern.proto
+++ b/generated/nidigitalpattern/nidigitalpattern.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d57
+// This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d94
 //---------------------------------------------------------------------
 // Proto file for the NI-Digital Pattern Driver Metadata
 //---------------------------------------------------------------------

--- a/generated/nidmm/nidmm.proto
+++ b/generated/nidmm/nidmm.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-DMM API metadata version 23.0.0d85
+// This file is generated from NI-DMM API metadata version 23.0.0d127
 //---------------------------------------------------------------------
 // Proto file for the NI-DMM Metadata
 //---------------------------------------------------------------------

--- a/generated/nifake/nifake.proto
+++ b/generated/nifake/nifake.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-FAKE API metadata version 23.0.0d96
+// This file is generated from NI-FAKE API metadata version 23.0.0d142
 //---------------------------------------------------------------------
 // Proto file for the NI-FAKE Metadata
 //---------------------------------------------------------------------
@@ -26,6 +26,7 @@ service NiFake {
   rpc CloseExtCal(CloseExtCalRequest) returns (CloseExtCalResponse);
   rpc CommandWithReservedParam(CommandWithReservedParamRequest) returns (CommandWithReservedParamResponse);
   rpc ConfigureAbc(ConfigureAbcRequest) returns (ConfigureAbcResponse);
+  rpc ConfigureEnums(ConfigureEnumsRequest) returns (ConfigureEnumsResponse);
   rpc Control4022(Control4022Request) returns (Control4022Response);
   rpc CreateConfigurationList(CreateConfigurationListRequest) returns (CreateConfigurationListResponse);
   rpc CustomNestedStructRoundtrip(CustomNestedStructRoundtripRequest) returns (CustomNestedStructRoundtripResponse);
@@ -34,6 +35,7 @@ service NiFake {
   rpc EnumInputFunctionWithDefaults(EnumInputFunctionWithDefaultsRequest) returns (EnumInputFunctionWithDefaultsResponse);
   rpc ErrorMessage(ErrorMessageRequest) returns (ErrorMessageResponse);
   rpc ExportAttributeConfigurationBuffer(ExportAttributeConfigurationBufferRequest) returns (ExportAttributeConfigurationBufferResponse);
+  rpc ExportAttributeConfigurationBufferEx(ExportAttributeConfigurationBufferExRequest) returns (ExportAttributeConfigurationBufferExResponse);
   rpc FetchWaveform(FetchWaveformRequest) returns (FetchWaveformResponse);
   rpc GetABoolean(GetABooleanRequest) returns (GetABooleanResponse);
   rpc GetANumber(GetANumberRequest) returns (GetANumberResponse);
@@ -65,6 +67,7 @@ service NiFake {
   rpc GetViUInt32Array(GetViUInt32ArrayRequest) returns (GetViUInt32ArrayResponse);
   rpc GetViUInt8(GetViUInt8Request) returns (GetViUInt8Response);
   rpc ImportAttributeConfigurationBuffer(ImportAttributeConfigurationBufferRequest) returns (ImportAttributeConfigurationBufferResponse);
+  rpc ImportAttributeConfigurationBufferEx(ImportAttributeConfigurationBufferExRequest) returns (ImportAttributeConfigurationBufferExResponse);
   rpc InitExtCal(InitExtCalRequest) returns (InitExtCalResponse);
   rpc InitWithOptions(InitWithOptionsRequest) returns (InitWithOptionsResponse);
   rpc InitWithVarArgs(InitWithVarArgsRequest) returns (InitWithVarArgsResponse);
@@ -119,6 +122,8 @@ enum NiFakeAttribute {
   NIFAKE_ATTRIBUTE_READ_WRITE_INTEGER_WITH_CONVERTER = 1000008;
   NIFAKE_ATTRIBUTE_READ_WRITE_DOUBLE_WITH_REPEATED_CAPABILITY = 1000009;
   NIFAKE_ATTRIBUTE_READ_WRITE_STRING_REPEATED_CAPABILITY = 1000010;
+  NIFAKE_ATTRIBUTE_SAMPLE_COUNT = 1000012;
+  NIFAKE_ATTRIBUTE_SAMPLE_INTERVAL = 1000013;
 }
 
 enum Bitfield {
@@ -184,11 +189,18 @@ enum MobileOSNames {
 }
 
 enum NiFakeInt32AttributeValues {
+  option allow_alias = true;
   NIFAKE_INT32_UNSPECIFIED = 0;
   NIFAKE_INT32_GRPC_COLOR_OVERRIDE_RED = 1;
   NIFAKE_INT32_GRPC_COLOR_OVERRIDE_BLUE = 2;
   NIFAKE_INT32_GRPC_COLOR_OVERRIDE_YELLOW = 5;
   NIFAKE_INT32_GRPC_COLOR_OVERRIDE_BLACK = 42;
+  NIFAKE_INT32_SAMPLE_COUNT_SAMPLE_COUNT_INFINITE = 0;
+}
+
+enum NiFakeReal64AttributeValues {
+  NIFAKE_REAL64_UNSPECIFIED = 0;
+  NIFAKE_REAL64_SAMPLE_INTERVAL_AUTO_DELAY = -1;
 }
 
 enum NiFakeReal64AttributeValuesMapped {
@@ -198,6 +210,15 @@ enum NiFakeReal64AttributeValuesMapped {
   NIFAKE_REAL64_FLOAT_ENUM_FIVE_POINT_FIVE = 3;
   NIFAKE_REAL64_FLOAT_ENUM_SIX_POINT_FIVE = 4;
   NIFAKE_REAL64_FLOAT_ENUM_SEVEN_POINT_FIVE = 5;
+}
+
+enum SampleCount {
+  SAMPLE_COUNT_SAMPLE_COUNT_INFINITE = 0;
+}
+
+enum SampleInterval {
+  SAMPLE_INTERVAL_UNSPECIFIED = 0;
+  SAMPLE_INTERVAL_AUTO_DELAY = -1;
 }
 
 enum Turtle {
@@ -319,6 +340,22 @@ message ConfigureAbcResponse {
   int32 status = 1;
 }
 
+message ConfigureEnumsRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof sample_count_enum {
+    SampleCount sample_count = 2;
+    sint32 sample_count_raw = 3;
+  }
+  oneof sample_interval_enum {
+    SampleInterval sample_interval = 4;
+    double sample_interval_raw = 5;
+  }
+}
+
+message ConfigureEnumsResponse {
+  int32 status = 1;
+}
+
 message Control4022Request {
   string resource_name = 1;
   sint32 configuration = 2;
@@ -392,6 +429,15 @@ message ExportAttributeConfigurationBufferRequest {
 }
 
 message ExportAttributeConfigurationBufferResponse {
+  int32 status = 1;
+  bytes configuration = 2;
+}
+
+message ExportAttributeConfigurationBufferExRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ExportAttributeConfigurationBufferExResponse {
   int32 status = 1;
   bytes configuration = 2;
 }
@@ -707,6 +753,15 @@ message ImportAttributeConfigurationBufferResponse {
   int32 status = 1;
 }
 
+message ImportAttributeConfigurationBufferExRequest {
+  nidevice_grpc.Session vi = 1;
+  bytes configuration = 2;
+}
+
+message ImportAttributeConfigurationBufferExResponse {
+  int32 status = 1;
+}
+
 message InitExtCalRequest {
   string session_name = 1;
   string resource_name = 2;
@@ -1014,8 +1069,9 @@ message SetAttributeViReal64Request {
   string channel_name = 2;
   NiFakeAttribute attribute_id = 3;
   oneof attribute_value_enum {
-    NiFakeReal64AttributeValuesMapped attribute_value_mapped = 4;
-    double attribute_value_raw = 5;
+    NiFakeReal64AttributeValues attribute_value = 4;
+    NiFakeReal64AttributeValuesMapped attribute_value_mapped = 5;
+    double attribute_value_raw = 6;
   }
 }
 

--- a/generated/nifake/nifake_client.cpp
+++ b/generated/nifake/nifake_client.cpp
@@ -194,6 +194,39 @@ configure_abc(const StubPtr& stub, const nidevice_grpc::Session& vi)
   return response;
 }
 
+ConfigureEnumsResponse
+configure_enums(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<SampleCount, pb::int32>& sample_count, const simple_variant<SampleInterval, double>& sample_interval)
+{
+  ::grpc::ClientContext context;
+
+  auto request = ConfigureEnumsRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+  const auto sample_count_ptr = sample_count.get_if<SampleCount>();
+  const auto sample_count_raw_ptr = sample_count.get_if<pb::int32>();
+  if (sample_count_ptr) {
+    request.set_sample_count(*sample_count_ptr);
+  }
+  else if (sample_count_raw_ptr) {
+    request.set_sample_count_raw(*sample_count_raw_ptr);
+  }
+  const auto sample_interval_ptr = sample_interval.get_if<SampleInterval>();
+  const auto sample_interval_raw_ptr = sample_interval.get_if<double>();
+  if (sample_interval_ptr) {
+    request.set_sample_interval(*sample_interval_ptr);
+  }
+  else if (sample_interval_raw_ptr) {
+    request.set_sample_interval_raw(*sample_interval_raw_ptr);
+  }
+
+  auto response = ConfigureEnumsResponse{};
+
+  raise_if_error(
+      stub->ConfigureEnums(&context, request, &response),
+      context);
+
+  return response;
+}
+
 Control4022Response
 control4022(const StubPtr& stub, const pb::string& resource_name, const pb::int32& configuration)
 {
@@ -337,6 +370,23 @@ export_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::
 
   raise_if_error(
       stub->ExportAttributeConfigurationBuffer(&context, request, &response),
+      context);
+
+  return response;
+}
+
+ExportAttributeConfigurationBufferExResponse
+export_attribute_configuration_buffer_ex(const StubPtr& stub, const nidevice_grpc::Session& vi)
+{
+  ::grpc::ClientContext context;
+
+  auto request = ExportAttributeConfigurationBufferExRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+
+  auto response = ExportAttributeConfigurationBufferExResponse{};
+
+  raise_if_error(
+      stub->ExportAttributeConfigurationBufferEx(&context, request, &response),
       context);
 
   return response;
@@ -886,6 +936,24 @@ import_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::
   return response;
 }
 
+ImportAttributeConfigurationBufferExResponse
+import_attribute_configuration_buffer_ex(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& configuration)
+{
+  ::grpc::ClientContext context;
+
+  auto request = ImportAttributeConfigurationBufferExRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+  request.set_configuration(configuration);
+
+  auto response = ImportAttributeConfigurationBufferExResponse{};
+
+  raise_if_error(
+      stub->ImportAttributeConfigurationBufferEx(&context, request, &response),
+      context);
+
+  return response;
+}
+
 InitExtCalResponse
 init_ext_cal(const StubPtr& stub, const pb::string& resource_name, const pb::string& calibration_password)
 {
@@ -1409,7 +1477,7 @@ set_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, co
 }
 
 SetAttributeViReal64Response
-set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const simple_variant<NiFakeReal64AttributeValuesMapped, double>& attribute_value)
+set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const simple_variant<NiFakeReal64AttributeValues, double>& attribute_value)
 {
   ::grpc::ClientContext context;
 
@@ -1417,10 +1485,10 @@ set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   request.mutable_vi()->CopyFrom(vi);
   request.set_channel_name(channel_name);
   request.set_attribute_id(attribute_id);
-  const auto attribute_value_ptr = attribute_value.get_if<NiFakeReal64AttributeValuesMapped>();
+  const auto attribute_value_ptr = attribute_value.get_if<NiFakeReal64AttributeValues>();
   const auto attribute_value_raw_ptr = attribute_value.get_if<double>();
   if (attribute_value_ptr) {
-    request.set_attribute_value_mapped(*attribute_value_ptr);
+    request.set_attribute_value(*attribute_value_ptr);
   }
   else if (attribute_value_raw_ptr) {
     request.set_attribute_value_raw(*attribute_value_raw_ptr);

--- a/generated/nifake/nifake_client.h
+++ b/generated/nifake/nifake_client.h
@@ -32,6 +32,7 @@ CloseResponse close(const StubPtr& stub, const nidevice_grpc::Session& vi);
 CloseExtCalResponse close_ext_cal(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& action);
 CommandWithReservedParamResponse command_with_reserved_param(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ConfigureAbcResponse configure_abc(const StubPtr& stub, const nidevice_grpc::Session& vi);
+ConfigureEnumsResponse configure_enums(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<SampleCount, pb::int32>& sample_count, const simple_variant<SampleInterval, double>& sample_interval);
 Control4022Response control4022(const StubPtr& stub, const pb::string& resource_name, const pb::int32& configuration);
 CreateConfigurationListResponse create_configuration_list(const StubPtr& stub, const std::vector<NiFakeAttribute>& list_attribute_ids);
 CustomNestedStructRoundtripResponse custom_nested_struct_roundtrip(const StubPtr& stub, const CustomStructNestedTypedef& nested_custom_type_in);
@@ -40,6 +41,7 @@ EnumArrayOutputFunctionResponse enum_array_output_function(const StubPtr& stub, 
 EnumInputFunctionWithDefaultsResponse enum_input_function_with_defaults(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<Turtle, pb::int32>& a_turtle);
 ErrorMessageResponse error_message(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& error_code);
 ExportAttributeConfigurationBufferResponse export_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::Session& vi);
+ExportAttributeConfigurationBufferExResponse export_attribute_configuration_buffer_ex(const StubPtr& stub, const nidevice_grpc::Session& vi);
 FetchWaveformResponse fetch_waveform(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& number_of_samples);
 GetABooleanResponse get_a_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetANumberResponse get_a_number(const StubPtr& stub, const nidevice_grpc::Session& vi);
@@ -71,6 +73,7 @@ GetViInt32ArrayResponse get_vi_int32_array(const StubPtr& stub, const nidevice_g
 GetViUInt32ArrayResponse get_vi_uint32_array(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::int32& array_len);
 GetViUInt8Response get_vi_uint8(const StubPtr& stub, const nidevice_grpc::Session& vi);
 ImportAttributeConfigurationBufferResponse import_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& configuration);
+ImportAttributeConfigurationBufferExResponse import_attribute_configuration_buffer_ex(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& configuration);
 InitExtCalResponse init_ext_cal(const StubPtr& stub, const pb::string& resource_name, const pb::string& calibration_password);
 InitWithOptionsResponse init_with_options(const StubPtr& stub, const pb::string& resource_name, const bool& id_query, const bool& reset_device, const pb::string& option_string, const nidevice_grpc::SessionInitializationBehavior& initialization_behavior = nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED);
 InitWithVarArgsResponse init_with_var_args(const StubPtr& stub, const pb::string& resource_name, const std::vector<StringAndTurtle>& name_and_turtle);
@@ -98,7 +101,7 @@ ReturnMultipleTypesResponse return_multiple_types(const StubPtr& stub, const nid
 SetAttributeViBooleanResponse set_attribute_vi_boolean(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const bool& attribute_value);
 SetAttributeViInt32Response set_attribute_vi_int32(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const simple_variant<NiFakeInt32AttributeValues, pb::int32>& attribute_value);
 SetAttributeViInt64Response set_attribute_vi_int64(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const pb::int64& attribute_value);
-SetAttributeViReal64Response set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const simple_variant<NiFakeReal64AttributeValuesMapped, double>& attribute_value);
+SetAttributeViReal64Response set_attribute_vi_real64(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const simple_variant<NiFakeReal64AttributeValues, double>& attribute_value);
 SetAttributeViStringResponse set_attribute_vi_string(const StubPtr& stub, const nidevice_grpc::Session& vi, const pb::string& channel_name, const NiFakeAttribute& attribute_id, const pb::string& attribute_value);
 SetCustomTypeResponse set_custom_type(const StubPtr& stub, const nidevice_grpc::Session& vi, const FakeCustomStruct& cs);
 SetCustomTypeArrayResponse set_custom_type_array(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::vector<FakeCustomStruct>& cs);

--- a/generated/nifake/nifake_compilation_test.cpp
+++ b/generated/nifake/nifake_compilation_test.cpp
@@ -57,6 +57,11 @@ ViStatus ConfigureAbc(ViSession vi)
   return niFake_ConfigureABC(vi);
 }
 
+ViStatus ConfigureEnums(ViSession vi, ViInt32 sampleCount, ViReal64 sampleInterval)
+{
+  return niFake_ConfigureEnums(vi, sampleCount, sampleInterval);
+}
+
 ViStatus Control4022(ViString resourceName, ViInt32 configuration)
 {
   return niFake_4022Control(resourceName, configuration);
@@ -95,6 +100,11 @@ ViStatus ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]
 ViStatus ExportAttributeConfigurationBuffer(ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[])
 {
   return niFake_ExportAttributeConfigurationBuffer(vi, sizeInBytes, configuration);
+}
+
+ViStatus ExportAttributeConfigurationBufferEx(ViSession vi, ViInt32 size, ViInt8 configuration[])
+{
+  return niFake_ExportAttributeConfigurationBufferEx(vi, size, configuration);
 }
 
 ViStatus FetchWaveform(ViSession vi, ViInt32 numberOfSamples, ViReal64 waveformData[], ViInt32* actualNumberOfSamples)
@@ -250,6 +260,11 @@ ViStatus GetViUInt8(ViSession vi, ViUInt8* aUint8Number)
 ViStatus ImportAttributeConfigurationBuffer(ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[])
 {
   return niFake_ImportAttributeConfigurationBuffer(vi, sizeInBytes, configuration);
+}
+
+ViStatus ImportAttributeConfigurationBufferEx(ViSession vi, ViInt32 size, ViInt8 configuration[])
+{
+  return niFake_ImportAttributeConfigurationBufferEx(vi, size, configuration);
 }
 
 ViStatus InitExtCal(ViRsrc resourceName, ViString calibrationPassword, ViSession* vi)

--- a/generated/nifake/nifake_library.cpp
+++ b/generated/nifake/nifake_library.cpp
@@ -31,6 +31,7 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.CloseExtCal = reinterpret_cast<CloseExtCalPtr>(shared_library_.get_function_pointer("niFake_CloseExtCal"));
   function_pointers_.CommandWithReservedParam = reinterpret_cast<CommandWithReservedParamPtr>(shared_library_.get_function_pointer("niFake_CommandWithReservedParam"));
   function_pointers_.ConfigureAbc = reinterpret_cast<ConfigureAbcPtr>(shared_library_.get_function_pointer("niFake_ConfigureABC"));
+  function_pointers_.ConfigureEnums = reinterpret_cast<ConfigureEnumsPtr>(shared_library_.get_function_pointer("niFake_ConfigureEnums"));
   function_pointers_.Control4022 = reinterpret_cast<Control4022Ptr>(shared_library_.get_function_pointer("niFake_4022Control"));
   function_pointers_.CreateConfigurationList = reinterpret_cast<CreateConfigurationListPtr>(shared_library_.get_function_pointer("niFake_CreateConfigurationList"));
   function_pointers_.CustomNestedStructRoundtrip = reinterpret_cast<CustomNestedStructRoundtripPtr>(shared_library_.get_function_pointer("niFake_CustomNestedStructRoundtrip"));
@@ -39,6 +40,7 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.EnumInputFunctionWithDefaults = reinterpret_cast<EnumInputFunctionWithDefaultsPtr>(shared_library_.get_function_pointer("niFake_EnumInputFunctionWithDefaults"));
   function_pointers_.ErrorMessage = reinterpret_cast<ErrorMessagePtr>(shared_library_.get_function_pointer("niFake_error_message"));
   function_pointers_.ExportAttributeConfigurationBuffer = reinterpret_cast<ExportAttributeConfigurationBufferPtr>(shared_library_.get_function_pointer("niFake_ExportAttributeConfigurationBuffer"));
+  function_pointers_.ExportAttributeConfigurationBufferEx = reinterpret_cast<ExportAttributeConfigurationBufferExPtr>(shared_library_.get_function_pointer("niFake_ExportAttributeConfigurationBufferEx"));
   function_pointers_.FetchWaveform = reinterpret_cast<FetchWaveformPtr>(shared_library_.get_function_pointer("niFake_FetchWaveform"));
   function_pointers_.GetABoolean = reinterpret_cast<GetABooleanPtr>(shared_library_.get_function_pointer("niFake_GetABoolean"));
   function_pointers_.GetANumber = reinterpret_cast<GetANumberPtr>(shared_library_.get_function_pointer("niFake_GetANumber"));
@@ -70,6 +72,7 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.GetViUInt32Array = reinterpret_cast<GetViUInt32ArrayPtr>(shared_library_.get_function_pointer("niFake_GetViUInt32Array"));
   function_pointers_.GetViUInt8 = reinterpret_cast<GetViUInt8Ptr>(shared_library_.get_function_pointer("niFake_GetViUInt8"));
   function_pointers_.ImportAttributeConfigurationBuffer = reinterpret_cast<ImportAttributeConfigurationBufferPtr>(shared_library_.get_function_pointer("niFake_ImportAttributeConfigurationBuffer"));
+  function_pointers_.ImportAttributeConfigurationBufferEx = reinterpret_cast<ImportAttributeConfigurationBufferExPtr>(shared_library_.get_function_pointer("niFake_ImportAttributeConfigurationBufferEx"));
   function_pointers_.InitExtCal = reinterpret_cast<InitExtCalPtr>(shared_library_.get_function_pointer("niFake_InitExtCal"));
   function_pointers_.InitWithOptions = reinterpret_cast<InitWithOptionsPtr>(shared_library_.get_function_pointer("niFake_InitWithOptions"));
   function_pointers_.InitWithVarArgs = reinterpret_cast<InitWithVarArgsPtr>(shared_library_.get_function_pointer("niFake_InitWithVarArgs"));
@@ -204,6 +207,14 @@ ViStatus NiFakeLibrary::ConfigureAbc(ViSession vi)
   return function_pointers_.ConfigureAbc(vi);
 }
 
+ViStatus NiFakeLibrary::ConfigureEnums(ViSession vi, ViInt32 sampleCount, ViReal64 sampleInterval)
+{
+  if (!function_pointers_.ConfigureEnums) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_ConfigureEnums.");
+  }
+  return function_pointers_.ConfigureEnums(vi, sampleCount, sampleInterval);
+}
+
 ViStatus NiFakeLibrary::Control4022(ViString resourceName, ViInt32 configuration)
 {
   if (!function_pointers_.Control4022) {
@@ -266,6 +277,14 @@ ViStatus NiFakeLibrary::ExportAttributeConfigurationBuffer(ViSession vi, ViInt32
     throw nidevice_grpc::LibraryLoadException("Could not find niFake_ExportAttributeConfigurationBuffer.");
   }
   return function_pointers_.ExportAttributeConfigurationBuffer(vi, sizeInBytes, configuration);
+}
+
+ViStatus NiFakeLibrary::ExportAttributeConfigurationBufferEx(ViSession vi, ViInt32 size, ViInt8 configuration[])
+{
+  if (!function_pointers_.ExportAttributeConfigurationBufferEx) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_ExportAttributeConfigurationBufferEx.");
+  }
+  return function_pointers_.ExportAttributeConfigurationBufferEx(vi, size, configuration);
 }
 
 ViStatus NiFakeLibrary::FetchWaveform(ViSession vi, ViInt32 numberOfSamples, ViReal64 waveformData[], ViInt32* actualNumberOfSamples)
@@ -514,6 +533,14 @@ ViStatus NiFakeLibrary::ImportAttributeConfigurationBuffer(ViSession vi, ViInt32
     throw nidevice_grpc::LibraryLoadException("Could not find niFake_ImportAttributeConfigurationBuffer.");
   }
   return function_pointers_.ImportAttributeConfigurationBuffer(vi, sizeInBytes, configuration);
+}
+
+ViStatus NiFakeLibrary::ImportAttributeConfigurationBufferEx(ViSession vi, ViInt32 size, ViInt8 configuration[])
+{
+  if (!function_pointers_.ImportAttributeConfigurationBufferEx) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_ImportAttributeConfigurationBufferEx.");
+  }
+  return function_pointers_.ImportAttributeConfigurationBufferEx(vi, size, configuration);
 }
 
 ViStatus NiFakeLibrary::InitExtCal(ViRsrc resourceName, ViString calibrationPassword, ViSession* vi)

--- a/generated/nifake/nifake_library.h
+++ b/generated/nifake/nifake_library.h
@@ -28,6 +28,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus CloseExtCal(ViSession vi, ViInt32 action);
   ViStatus CommandWithReservedParam(ViSession vi, ViBoolean* reserved);
   ViStatus ConfigureAbc(ViSession vi);
+  ViStatus ConfigureEnums(ViSession vi, ViInt32 sampleCount, ViReal64 sampleInterval);
   ViStatus Control4022(ViString resourceName, ViInt32 configuration);
   ViStatus CreateConfigurationList(ViInt32 numberOfListAttributes, ViAttr listAttributeIds[]);
   ViStatus CustomNestedStructRoundtrip(CustomStructNestedTypedef_struct nestedCustomTypeIn, CustomStructNestedTypedef_struct* nestedCustomTypeOut);
@@ -36,6 +37,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus EnumInputFunctionWithDefaults(ViSession vi, ViInt16 aTurtle);
   ViStatus ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]);
   ViStatus ExportAttributeConfigurationBuffer(ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[]);
+  ViStatus ExportAttributeConfigurationBufferEx(ViSession vi, ViInt32 size, ViInt8 configuration[]);
   ViStatus FetchWaveform(ViSession vi, ViInt32 numberOfSamples, ViReal64 waveformData[], ViInt32* actualNumberOfSamples);
   ViStatus GetABoolean(ViSession vi, ViBoolean* aBoolean);
   ViStatus GetANumber(ViSession vi, ViInt16* aNumber);
@@ -67,6 +69,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus GetViUInt32Array(ViSession vi, ViInt32 arrayLen, ViUInt32 uInt32Array[]);
   ViStatus GetViUInt8(ViSession vi, ViUInt8* aUint8Number);
   ViStatus ImportAttributeConfigurationBuffer(ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[]);
+  ViStatus ImportAttributeConfigurationBufferEx(ViSession vi, ViInt32 size, ViInt8 configuration[]);
   ViStatus InitExtCal(ViRsrc resourceName, ViString calibrationPassword, ViSession* vi);
   ViStatus InitWithOptions(ViString resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViConstString optionString, ViSession* vi);
   ViStatus InitWithVarArgs(ViRsrc resourceName, ViSession* vi, ViConstString stringArg, ViInt16 turtle, ViConstString stringArg0, ViInt16 turtle0, ViConstString stringArg1, ViInt16 turtle1, ViConstString stringArg2, ViInt16 turtle2);
@@ -120,6 +123,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using CloseExtCalPtr = decltype(&niFake_CloseExtCal);
   using CommandWithReservedParamPtr = decltype(&niFake_CommandWithReservedParam);
   using ConfigureAbcPtr = decltype(&niFake_ConfigureABC);
+  using ConfigureEnumsPtr = decltype(&niFake_ConfigureEnums);
   using Control4022Ptr = decltype(&niFake_4022Control);
   using CreateConfigurationListPtr = decltype(&niFake_CreateConfigurationList);
   using CustomNestedStructRoundtripPtr = decltype(&niFake_CustomNestedStructRoundtrip);
@@ -128,6 +132,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using EnumInputFunctionWithDefaultsPtr = decltype(&niFake_EnumInputFunctionWithDefaults);
   using ErrorMessagePtr = decltype(&niFake_error_message);
   using ExportAttributeConfigurationBufferPtr = decltype(&niFake_ExportAttributeConfigurationBuffer);
+  using ExportAttributeConfigurationBufferExPtr = decltype(&niFake_ExportAttributeConfigurationBufferEx);
   using FetchWaveformPtr = decltype(&niFake_FetchWaveform);
   using GetABooleanPtr = decltype(&niFake_GetABoolean);
   using GetANumberPtr = decltype(&niFake_GetANumber);
@@ -159,6 +164,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using GetViUInt32ArrayPtr = decltype(&niFake_GetViUInt32Array);
   using GetViUInt8Ptr = decltype(&niFake_GetViUInt8);
   using ImportAttributeConfigurationBufferPtr = decltype(&niFake_ImportAttributeConfigurationBuffer);
+  using ImportAttributeConfigurationBufferExPtr = decltype(&niFake_ImportAttributeConfigurationBufferEx);
   using InitExtCalPtr = decltype(&niFake_InitExtCal);
   using InitWithOptionsPtr = decltype(&niFake_InitWithOptions);
   using InitWithVarArgsPtr = decltype(&niFake_InitWithVarArgs);
@@ -212,6 +218,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     CloseExtCalPtr CloseExtCal;
     CommandWithReservedParamPtr CommandWithReservedParam;
     ConfigureAbcPtr ConfigureAbc;
+    ConfigureEnumsPtr ConfigureEnums;
     Control4022Ptr Control4022;
     CreateConfigurationListPtr CreateConfigurationList;
     CustomNestedStructRoundtripPtr CustomNestedStructRoundtrip;
@@ -220,6 +227,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     EnumInputFunctionWithDefaultsPtr EnumInputFunctionWithDefaults;
     ErrorMessagePtr ErrorMessage;
     ExportAttributeConfigurationBufferPtr ExportAttributeConfigurationBuffer;
+    ExportAttributeConfigurationBufferExPtr ExportAttributeConfigurationBufferEx;
     FetchWaveformPtr FetchWaveform;
     GetABooleanPtr GetABoolean;
     GetANumberPtr GetANumber;
@@ -251,6 +259,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     GetViUInt32ArrayPtr GetViUInt32Array;
     GetViUInt8Ptr GetViUInt8;
     ImportAttributeConfigurationBufferPtr ImportAttributeConfigurationBuffer;
+    ImportAttributeConfigurationBufferExPtr ImportAttributeConfigurationBufferEx;
     InitExtCalPtr InitExtCal;
     InitWithOptionsPtr InitWithOptions;
     InitWithVarArgsPtr InitWithVarArgs;

--- a/generated/nifake/nifake_library_interface.h
+++ b/generated/nifake/nifake_library_interface.h
@@ -25,6 +25,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus CloseExtCal(ViSession vi, ViInt32 action) = 0;
   virtual ViStatus CommandWithReservedParam(ViSession vi, ViBoolean* reserved) = 0;
   virtual ViStatus ConfigureAbc(ViSession vi) = 0;
+  virtual ViStatus ConfigureEnums(ViSession vi, ViInt32 sampleCount, ViReal64 sampleInterval) = 0;
   virtual ViStatus Control4022(ViString resourceName, ViInt32 configuration) = 0;
   virtual ViStatus CreateConfigurationList(ViInt32 numberOfListAttributes, ViAttr listAttributeIds[]) = 0;
   virtual ViStatus CustomNestedStructRoundtrip(CustomStructNestedTypedef_struct nestedCustomTypeIn, CustomStructNestedTypedef_struct* nestedCustomTypeOut) = 0;
@@ -33,6 +34,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus EnumInputFunctionWithDefaults(ViSession vi, ViInt16 aTurtle) = 0;
   virtual ViStatus ErrorMessage(ViSession vi, ViStatus errorCode, ViChar errorMessage[256]) = 0;
   virtual ViStatus ExportAttributeConfigurationBuffer(ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[]) = 0;
+  virtual ViStatus ExportAttributeConfigurationBufferEx(ViSession vi, ViInt32 size, ViInt8 configuration[]) = 0;
   virtual ViStatus FetchWaveform(ViSession vi, ViInt32 numberOfSamples, ViReal64 waveformData[], ViInt32* actualNumberOfSamples) = 0;
   virtual ViStatus GetABoolean(ViSession vi, ViBoolean* aBoolean) = 0;
   virtual ViStatus GetANumber(ViSession vi, ViInt16* aNumber) = 0;
@@ -64,6 +66,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus GetViUInt32Array(ViSession vi, ViInt32 arrayLen, ViUInt32 uInt32Array[]) = 0;
   virtual ViStatus GetViUInt8(ViSession vi, ViUInt8* aUint8Number) = 0;
   virtual ViStatus ImportAttributeConfigurationBuffer(ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[]) = 0;
+  virtual ViStatus ImportAttributeConfigurationBufferEx(ViSession vi, ViInt32 size, ViInt8 configuration[]) = 0;
   virtual ViStatus InitExtCal(ViRsrc resourceName, ViString calibrationPassword, ViSession* vi) = 0;
   virtual ViStatus InitWithOptions(ViString resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViConstString optionString, ViSession* vi) = 0;
   virtual ViStatus InitWithVarArgs(ViRsrc resourceName, ViSession* vi, ViConstString stringArg, ViInt16 turtle, ViConstString stringArg0, ViInt16 turtle0, ViConstString stringArg1, ViInt16 turtle1, ViConstString stringArg2, ViInt16 turtle2) = 0;

--- a/generated/nifake/nifake_mock_library.h
+++ b/generated/nifake/nifake_mock_library.h
@@ -27,6 +27,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, CloseExtCal, (ViSession vi, ViInt32 action), (override));
   MOCK_METHOD(ViStatus, CommandWithReservedParam, (ViSession vi, ViBoolean* reserved), (override));
   MOCK_METHOD(ViStatus, ConfigureAbc, (ViSession vi), (override));
+  MOCK_METHOD(ViStatus, ConfigureEnums, (ViSession vi, ViInt32 sampleCount, ViReal64 sampleInterval), (override));
   MOCK_METHOD(ViStatus, Control4022, (ViString resourceName, ViInt32 configuration), (override));
   MOCK_METHOD(ViStatus, CreateConfigurationList, (ViInt32 numberOfListAttributes, ViAttr listAttributeIds[]), (override));
   MOCK_METHOD(ViStatus, CustomNestedStructRoundtrip, (CustomStructNestedTypedef_struct nestedCustomTypeIn, CustomStructNestedTypedef_struct* nestedCustomTypeOut), (override));
@@ -35,6 +36,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, EnumInputFunctionWithDefaults, (ViSession vi, ViInt16 aTurtle), (override));
   MOCK_METHOD(ViStatus, ErrorMessage, (ViSession vi, ViStatus errorCode, ViChar errorMessage[256]), (override));
   MOCK_METHOD(ViStatus, ExportAttributeConfigurationBuffer, (ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[]), (override));
+  MOCK_METHOD(ViStatus, ExportAttributeConfigurationBufferEx, (ViSession vi, ViInt32 size, ViInt8 configuration[]), (override));
   MOCK_METHOD(ViStatus, FetchWaveform, (ViSession vi, ViInt32 numberOfSamples, ViReal64 waveformData[], ViInt32* actualNumberOfSamples), (override));
   MOCK_METHOD(ViStatus, GetABoolean, (ViSession vi, ViBoolean* aBoolean), (override));
   MOCK_METHOD(ViStatus, GetANumber, (ViSession vi, ViInt16* aNumber), (override));
@@ -66,6 +68,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, GetViUInt32Array, (ViSession vi, ViInt32 arrayLen, ViUInt32 uInt32Array[]), (override));
   MOCK_METHOD(ViStatus, GetViUInt8, (ViSession vi, ViUInt8* aUint8Number), (override));
   MOCK_METHOD(ViStatus, ImportAttributeConfigurationBuffer, (ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[]), (override));
+  MOCK_METHOD(ViStatus, ImportAttributeConfigurationBufferEx, (ViSession vi, ViInt32 size, ViInt8 configuration[]), (override));
   MOCK_METHOD(ViStatus, InitExtCal, (ViRsrc resourceName, ViString calibrationPassword, ViSession* vi), (override));
   MOCK_METHOD(ViStatus, InitWithOptions, (ViString resourceName, ViBoolean idQuery, ViBoolean resetDevice, ViConstString optionString, ViSession* vi), (override));
   MOCK_METHOD(ViStatus, InitWithVarArgs, (ViRsrc resourceName, ViSession* vi, ViConstString stringArg, ViInt16 turtle, ViConstString stringArg0, ViInt16 turtle0, ViConstString stringArg1, ViInt16 turtle1, ViConstString stringArg2, ViInt16 turtle2), (override));

--- a/generated/nifake/nifake_service.cpp
+++ b/generated/nifake/nifake_service.cpp
@@ -295,6 +295,60 @@ namespace nifake_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::ConfigureEnums(::grpc::ServerContext* context, const ConfigureEnumsRequest* request, ConfigureEnumsResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      ViInt32 sample_count;
+      switch (request->sample_count_enum_case()) {
+        case nifake_grpc::ConfigureEnumsRequest::SampleCountEnumCase::kSampleCount: {
+          sample_count = static_cast<ViInt32>(request->sample_count());
+          break;
+        }
+        case nifake_grpc::ConfigureEnumsRequest::SampleCountEnumCase::kSampleCountRaw: {
+          sample_count = static_cast<ViInt32>(request->sample_count_raw());
+          break;
+        }
+        case nifake_grpc::ConfigureEnumsRequest::SampleCountEnumCase::SAMPLE_COUNT_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for sample_count was not specified or out of range");
+          break;
+        }
+      }
+
+      ViReal64 sample_interval;
+      switch (request->sample_interval_enum_case()) {
+        case nifake_grpc::ConfigureEnumsRequest::SampleIntervalEnumCase::kSampleInterval: {
+          sample_interval = static_cast<ViReal64>(request->sample_interval());
+          break;
+        }
+        case nifake_grpc::ConfigureEnumsRequest::SampleIntervalEnumCase::kSampleIntervalRaw: {
+          sample_interval = static_cast<ViReal64>(request->sample_interval_raw());
+          break;
+        }
+        case nifake_grpc::ConfigureEnumsRequest::SampleIntervalEnumCase::SAMPLE_INTERVAL_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for sample_interval was not specified or out of range");
+          break;
+        }
+      }
+
+      auto status = library_->ConfigureEnums(vi, sample_count, sample_interval);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::Control4022(::grpc::ServerContext* context, const Control4022Request* request, Control4022Response* response)
   {
     if (context->IsCancelled()) {
@@ -487,6 +541,43 @@ namespace nifake_grpc {
         std::string configuration(size_in_bytes, '\0');
         status = library_->ExportAttributeConfigurationBuffer(vi, size_in_bytes, (ViInt8*)configuration.data());
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(size_in_bytes)) {
+          // buffer is now too small, try again
+          continue;
+        }
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForViSession(context, status, vi);
+        }
+        response->set_status(status);
+        response->set_configuration(configuration);
+        return ::grpc::Status::OK;
+      }
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::ExportAttributeConfigurationBufferEx(::grpc::ServerContext* context, const ExportAttributeConfigurationBufferExRequest* request, ExportAttributeConfigurationBufferExResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+
+      while (true) {
+        auto status = library_->ExportAttributeConfigurationBufferEx(vi, 0, nullptr);
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForViSession(context, status, vi);
+        }
+        ViInt32 size = status;
+
+        std::string configuration(size, '\0');
+        status = library_->ExportAttributeConfigurationBufferEx(vi, size, (ViInt8*)configuration.data());
+        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer || status > static_cast<decltype(status)>(size)) {
           // buffer is now too small, try again
           continue;
         }
@@ -1467,6 +1558,30 @@ namespace nifake_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiFakeService::ImportAttributeConfigurationBufferEx(::grpc::ServerContext* context, const ImportAttributeConfigurationBufferExRequest* request, ImportAttributeConfigurationBufferExResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      ViInt32 size = static_cast<ViInt32>(request->configuration().size());
+      ViInt8* configuration = (ViInt8*)request->configuration().c_str();
+      auto status = library_->ImportAttributeConfigurationBufferEx(vi, size, configuration);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiFakeService::InitExtCal(::grpc::ServerContext* context, const InitExtCalRequest* request, InitExtCalResponse* response)
   {
     if (context->IsCancelled()) {
@@ -2387,6 +2502,10 @@ namespace nifake_grpc {
       ViAttr attribute_id = request->attribute_id();
       ViReal64 attribute_value;
       switch (request->attribute_value_enum_case()) {
+        case nifake_grpc::SetAttributeViReal64Request::AttributeValueEnumCase::kAttributeValue: {
+          attribute_value = static_cast<ViReal64>(request->attribute_value());
+          break;
+        }
         case nifake_grpc::SetAttributeViReal64Request::AttributeValueEnumCase::kAttributeValueMapped: {
           auto attribute_value_imap_it = nifakereal64attributevaluesmapped_input_map_.find(request->attribute_value_mapped());
           if (attribute_value_imap_it == nifakereal64attributevaluesmapped_input_map_.end()) {

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -51,6 +51,7 @@ public:
   ::grpc::Status CloseExtCal(::grpc::ServerContext* context, const CloseExtCalRequest* request, CloseExtCalResponse* response) override;
   ::grpc::Status CommandWithReservedParam(::grpc::ServerContext* context, const CommandWithReservedParamRequest* request, CommandWithReservedParamResponse* response) override;
   ::grpc::Status ConfigureAbc(::grpc::ServerContext* context, const ConfigureAbcRequest* request, ConfigureAbcResponse* response) override;
+  ::grpc::Status ConfigureEnums(::grpc::ServerContext* context, const ConfigureEnumsRequest* request, ConfigureEnumsResponse* response) override;
   ::grpc::Status Control4022(::grpc::ServerContext* context, const Control4022Request* request, Control4022Response* response) override;
   ::grpc::Status CreateConfigurationList(::grpc::ServerContext* context, const CreateConfigurationListRequest* request, CreateConfigurationListResponse* response) override;
   ::grpc::Status CustomNestedStructRoundtrip(::grpc::ServerContext* context, const CustomNestedStructRoundtripRequest* request, CustomNestedStructRoundtripResponse* response) override;
@@ -59,6 +60,7 @@ public:
   ::grpc::Status EnumInputFunctionWithDefaults(::grpc::ServerContext* context, const EnumInputFunctionWithDefaultsRequest* request, EnumInputFunctionWithDefaultsResponse* response) override;
   ::grpc::Status ErrorMessage(::grpc::ServerContext* context, const ErrorMessageRequest* request, ErrorMessageResponse* response) override;
   ::grpc::Status ExportAttributeConfigurationBuffer(::grpc::ServerContext* context, const ExportAttributeConfigurationBufferRequest* request, ExportAttributeConfigurationBufferResponse* response) override;
+  ::grpc::Status ExportAttributeConfigurationBufferEx(::grpc::ServerContext* context, const ExportAttributeConfigurationBufferExRequest* request, ExportAttributeConfigurationBufferExResponse* response) override;
   ::grpc::Status FetchWaveform(::grpc::ServerContext* context, const FetchWaveformRequest* request, FetchWaveformResponse* response) override;
   ::grpc::Status GetABoolean(::grpc::ServerContext* context, const GetABooleanRequest* request, GetABooleanResponse* response) override;
   ::grpc::Status GetANumber(::grpc::ServerContext* context, const GetANumberRequest* request, GetANumberResponse* response) override;
@@ -90,6 +92,7 @@ public:
   ::grpc::Status GetViUInt32Array(::grpc::ServerContext* context, const GetViUInt32ArrayRequest* request, GetViUInt32ArrayResponse* response) override;
   ::grpc::Status GetViUInt8(::grpc::ServerContext* context, const GetViUInt8Request* request, GetViUInt8Response* response) override;
   ::grpc::Status ImportAttributeConfigurationBuffer(::grpc::ServerContext* context, const ImportAttributeConfigurationBufferRequest* request, ImportAttributeConfigurationBufferResponse* response) override;
+  ::grpc::Status ImportAttributeConfigurationBufferEx(::grpc::ServerContext* context, const ImportAttributeConfigurationBufferExRequest* request, ImportAttributeConfigurationBufferExResponse* response) override;
   ::grpc::Status InitExtCal(::grpc::ServerContext* context, const InitExtCalRequest* request, InitExtCalResponse* response) override;
   ::grpc::Status InitWithOptions(::grpc::ServerContext* context, const InitWithOptionsRequest* request, InitWithOptionsResponse* response) override;
   ::grpc::Status InitWithVarArgs(::grpc::ServerContext* context, const InitWithVarArgsRequest* request, InitWithVarArgsResponse* response) override;

--- a/generated/niscope/niscope.proto
+++ b/generated/niscope/niscope.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SCOPE API metadata version 23.0.0d95
+// This file is generated from NI-SCOPE API metadata version 23.0.0d152
 //---------------------------------------------------------------------
 // Proto file for the NI-SCOPE Metadata
 //---------------------------------------------------------------------

--- a/generated/niswitch/niswitch.proto
+++ b/generated/niswitch/niswitch.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SWITCH API metadata version 23.0.0d75
+// This file is generated from NI-SWITCH API metadata version 23.0.0d149
 //---------------------------------------------------------------------
 // Proto file for the NI-SWITCH Metadata
 //---------------------------------------------------------------------

--- a/generated/nitclk/nitclk.proto
+++ b/generated/nitclk/nitclk.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-TClk API metadata version 23.0.0
+// This file is generated from NI-TClk API metadata version 23.0.0d64
 //---------------------------------------------------------------------
 // Proto file for the NI-TClk Metadata
 //---------------------------------------------------------------------

--- a/source/codegen/metadata/nidcpower/attributes.py
+++ b/source/codegen/metadata/nidcpower/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 23.0.0d318
+# This file is generated from NI-DCPower API metadata version 23.0.0d446
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidcpower/config.py
+++ b/source/codegen/metadata/nidcpower/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 23.0.0d318
+# This file is generated from NI-DCPower API metadata version 23.0.0d446
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0d318',
+    'api_version': '23.0.0d446',
     'c_function_prefix': 'niDCPower_',
     'c_header': 'nidcpower.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/nidcpower/enums.py
+++ b/source/codegen/metadata/nidcpower/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 23.0.0d318
+# This file is generated from NI-DCPower API metadata version 23.0.0d446
 enums = {
     'ApertureTimeAutoMode': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidcpower/functions.py
+++ b/source/codegen/metadata/nidcpower/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 23.0.0d318
+# This file is generated from NI-DCPower API metadata version 23.0.0d446
 functions = {
     'Abort': {
         'codegen_method': 'public',
@@ -779,40 +779,6 @@ functions = {
                 'grpc_type': 'sint32',
                 'name': 'function',
                 'type': 'ViInt32'
-            }
-        ],
-        'returns': 'ViStatus'
-    },
-    'ConfigureOutputRange': {
-        'codegen_method': 'public',
-        'parameters': [
-            {
-                'cppName': 'vi',
-                'direction': 'in',
-                'grpc_type': 'nidevice_grpc.Session',
-                'name': 'vi',
-                'type': 'ViSession'
-            },
-            {
-                'cppName': 'channelName',
-                'direction': 'in',
-                'grpc_type': 'string',
-                'name': 'channelName',
-                'type': 'ViConstString'
-            },
-            {
-                'cppName': 'rangeType',
-                'direction': 'in',
-                'grpc_type': 'sint32',
-                'name': 'rangeType',
-                'type': 'ViInt32'
-            },
-            {
-                'cppName': 'range',
-                'direction': 'in',
-                'grpc_type': 'double',
-                'name': 'range',
-                'type': 'ViReal64'
             }
         ],
         'returns': 'ViStatus'

--- a/source/codegen/metadata/nidcpower/nidcpower.proto
+++ b/source/codegen/metadata/nidcpower/nidcpower.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-DCPower API metadata version 23.0.0d318
+// This file is generated from NI-DCPower API metadata version 23.0.0d446
 //---------------------------------------------------------------------
 // Proto file for the NI-DCPower Metadata
 //---------------------------------------------------------------------
@@ -46,7 +46,6 @@ service NiDCPower {
   rpc ConfigureLCRCustomCableCompensation(ConfigureLCRCustomCableCompensationRequest) returns (ConfigureLCRCustomCableCompensationResponse);
   rpc ConfigureOutputEnabled(ConfigureOutputEnabledRequest) returns (ConfigureOutputEnabledResponse);
   rpc ConfigureOutputFunction(ConfigureOutputFunctionRequest) returns (ConfigureOutputFunctionResponse);
-  rpc ConfigureOutputRange(ConfigureOutputRangeRequest) returns (ConfigureOutputRangeResponse);
   rpc ConfigureOutputResistance(ConfigureOutputResistanceRequest) returns (ConfigureOutputResistanceResponse);
   rpc ConfigureOvp(ConfigureOvpRequest) returns (ConfigureOvpResponse);
   rpc ConfigurePowerLineFrequency(ConfigurePowerLineFrequencyRequest) returns (ConfigurePowerLineFrequencyResponse);
@@ -971,17 +970,6 @@ message ConfigureOutputFunctionRequest {
 }
 
 message ConfigureOutputFunctionResponse {
-  int32 status = 1;
-}
-
-message ConfigureOutputRangeRequest {
-  nidevice_grpc.Session vi = 1;
-  string channel_name = 2;
-  sint32 range_type = 3;
-  double range = 4;
-}
-
-message ConfigureOutputRangeResponse {
   int32 status = 1;
 }
 

--- a/source/codegen/metadata/nidigitalpattern/attributes.py
+++ b/source/codegen/metadata/nidigitalpattern/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d57
+# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d94
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidigitalpattern/config.py
+++ b/source/codegen/metadata/nidigitalpattern/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d57
+# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d94
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0d57',
+    'api_version': '23.0.0d94',
     'c_function_prefix': 'niDigital_',
     'c_header': 'niDigital.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/nidigitalpattern/enums.py
+++ b/source/codegen/metadata/nidigitalpattern/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d57
+# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d94
 enums = {
     'BitOrder': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidigitalpattern/functions.py
+++ b/source/codegen/metadata/nidigitalpattern/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d57
+# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d94
 functions = {
     'Abort': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidigitalpattern/nidigitalpattern.proto
+++ b/source/codegen/metadata/nidigitalpattern/nidigitalpattern.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d57
+// This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d94
 //---------------------------------------------------------------------
 // Proto file for the NI-Digital Pattern Driver Metadata
 //---------------------------------------------------------------------

--- a/source/codegen/metadata/nidmm/attributes.py
+++ b/source/codegen/metadata/nidmm/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DMM API metadata version 23.0.0d85
+# This file is generated from NI-DMM API metadata version 23.0.0d127
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidmm/config.py
+++ b/source/codegen/metadata/nidmm/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DMM API metadata version 23.0.0d85
+# This file is generated from NI-DMM API metadata version 23.0.0d127
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0d85',
+    'api_version': '23.0.0d127',
     'c_function_prefix': 'niDMM_',
     'c_header': 'nidmm.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/nidmm/enums.py
+++ b/source/codegen/metadata/nidmm/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DMM API metadata version 23.0.0d85
+# This file is generated from NI-DMM API metadata version 23.0.0d127
 enums = {
     'AcquisitionStatus': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidmm/functions.py
+++ b/source/codegen/metadata/nidmm/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DMM API metadata version 23.0.0d85
+# This file is generated from NI-DMM API metadata version 23.0.0d127
 functions = {
     'Abort': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidmm/nidmm.proto
+++ b/source/codegen/metadata/nidmm/nidmm.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-DMM API metadata version 23.0.0d85
+// This file is generated from NI-DMM API metadata version 23.0.0d127
 //---------------------------------------------------------------------
 // Proto file for the NI-DMM Metadata
 //---------------------------------------------------------------------

--- a/source/codegen/metadata/nifake/attributes.py
+++ b/source/codegen/metadata/nifake/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 23.0.0d96
+# This file is generated from NI-FAKE API metadata version 23.0.0d142
 attributes = {
     1000000: {
         'codegen_method': 'public',
@@ -79,5 +79,21 @@ attributes = {
         'name': 'READ_WRITE_STRING_REPEATED_CAPABILITY',
         'resettable': False,
         'type': 'ViString'
+    },
+    1000012: {
+        'codegen_method': 'public',
+        'enum': 'SampleCount',
+        'grpc_type': 'sint32',
+        'name': 'SAMPLE_COUNT',
+        'resettable': False,
+        'type': 'ViInt32'
+    },
+    1000013: {
+        'codegen_method': 'public',
+        'enum': 'SampleInterval',
+        'grpc_type': 'double',
+        'name': 'SAMPLE_INTERVAL',
+        'resettable': False,
+        'type': 'ViReal64'
     }
 }

--- a/source/codegen/metadata/nifake/config.py
+++ b/source/codegen/metadata/nifake/config.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 23.0.0d96
+# This file is generated from NI-FAKE API metadata version 23.0.0d142
 config = {
     'additional_headers': {
     },
-    'api_version': '23.0.0d96',
+    'api_version': '23.0.0d142',
     'c_function_prefix': 'niFake_',
     'c_header': 'niFake.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/nifake/enums.py
+++ b/source/codegen/metadata/nifake/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 23.0.0d96
+# This file is generated from NI-FAKE API metadata version 23.0.0d142
 enums = {
     'Bitfield': {
         'codegen_method': 'public',
@@ -188,6 +188,20 @@ enums = {
             {
                 'name': 'GRPC_COLOR_OVERRIDE_BLACK',
                 'value': 42
+            },
+            {
+                'name': 'SAMPLE_COUNT_SAMPLE_COUNT_INFINITE',
+                'value': 0
+            }
+        ]
+    },
+    'NiFakeReal64AttributeValues': {
+        'enum-value-prefix': 'NIFAKE_REAL64',
+        'generate-mappings': False,
+        'values': [
+            {
+                'name': 'SAMPLE_INTERVAL_AUTO_DELAY',
+                'value': -1
             }
         ]
     },
@@ -214,6 +228,24 @@ enums = {
             {
                 'name': 'FLOAT_ENUM_SEVEN_POINT_FIVE',
                 'value': 7.5
+            }
+        ]
+    },
+    'SampleCount': {
+        'codegen_method': 'public',
+        'values': [
+            {
+                'name': 'SAMPLE_COUNT_INFINITE',
+                'value': 0
+            }
+        ]
+    },
+    'SampleInterval': {
+        'codegen_method': 'public',
+        'values': [
+            {
+                'name': 'AUTO_DELAY',
+                'value': -1
             }
         ]
     },

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 23.0.0d96
+# This file is generated from NI-FAKE API metadata version 23.0.0d142
 functions = {
     'Abort': {
         'codegen_method': 'public',
@@ -249,6 +249,35 @@ functions = {
         ],
         'returns': 'ViStatus'
     },
+    'ConfigureEnums': {
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'cppName': 'vi',
+                'direction': 'in',
+                'grpc_type': 'nidevice_grpc.Session',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'cppName': 'sampleCount',
+                'direction': 'in',
+                'enum': 'SampleCount',
+                'grpc_type': 'sint32',
+                'name': 'sampleCount',
+                'type': 'ViInt32'
+            },
+            {
+                'cppName': 'sampleInterval',
+                'direction': 'in',
+                'enum': 'SampleInterval',
+                'grpc_type': 'double',
+                'name': 'sampleInterval',
+                'type': 'ViReal64'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
     'Control4022': {
         'cname': 'niFake_4022Control',
         'codegen_method': 'public',
@@ -471,6 +500,39 @@ functions = {
                 'size': {
                     'mechanism': 'ivi-dance',
                     'value': 'sizeInBytes'
+                },
+                'type': 'ViInt8[]'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'ExportAttributeConfigurationBufferEx': {
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'cppName': 'vi',
+                'direction': 'in',
+                'grpc_type': 'nidevice_grpc.Session',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'cppName': 'size',
+                'direction': 'in',
+                'grpc_type': 'sint32',
+                'include_in_proto': False,
+                'is_size_param': True,
+                'name': 'size',
+                'type': 'ViInt32'
+            },
+            {
+                'cppName': 'configuration',
+                'direction': 'out',
+                'grpc_type': 'bytes',
+                'name': 'configuration',
+                'size': {
+                    'mechanism': 'ivi-dance',
+                    'value': 'size'
                 },
                 'type': 'ViInt8[]'
             }
@@ -1500,6 +1562,43 @@ functions = {
                 'size': {
                     'mechanism': 'len',
                     'value': 'sizeInBytes'
+                },
+                'type': 'ViInt8[]'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'ImportAttributeConfigurationBufferEx': {
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'cppName': 'vi',
+                'direction': 'in',
+                'grpc_type': 'nidevice_grpc.Session',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'cppName': 'size',
+                'determine_size_from': [
+                    'configuration'
+                ],
+                'direction': 'in',
+                'grpc_type': 'sint32',
+                'include_in_proto': False,
+                'is_size_param': True,
+                'linked_params_are_optional': False,
+                'name': 'size',
+                'type': 'ViInt32'
+            },
+            {
+                'cppName': 'configuration',
+                'direction': 'in',
+                'grpc_type': 'bytes',
+                'name': 'configuration',
+                'size': {
+                    'mechanism': 'len',
+                    'value': 'size'
                 },
                 'type': 'ViInt8[]'
             }
@@ -2609,6 +2708,7 @@ functions = {
             {
                 'cppName': 'attributeValue',
                 'direction': 'in',
+                'enum': 'NiFakeReal64AttributeValues',
                 'grpc_type': 'double',
                 'mapped-enum': 'NiFakeReal64AttributeValuesMapped',
                 'name': 'attributeValue',

--- a/source/codegen/metadata/nifake/nifake.proto
+++ b/source/codegen/metadata/nifake/nifake.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-FAKE API metadata version 23.0.0d96
+// This file is generated from NI-FAKE API metadata version 23.0.0d142
 //---------------------------------------------------------------------
 // Proto file for the NI-FAKE Metadata
 //---------------------------------------------------------------------
@@ -26,6 +26,7 @@ service NiFake {
   rpc CloseExtCal(CloseExtCalRequest) returns (CloseExtCalResponse);
   rpc CommandWithReservedParam(CommandWithReservedParamRequest) returns (CommandWithReservedParamResponse);
   rpc ConfigureAbc(ConfigureAbcRequest) returns (ConfigureAbcResponse);
+  rpc ConfigureEnums(ConfigureEnumsRequest) returns (ConfigureEnumsResponse);
   rpc Control4022(Control4022Request) returns (Control4022Response);
   rpc CreateConfigurationList(CreateConfigurationListRequest) returns (CreateConfigurationListResponse);
   rpc CustomNestedStructRoundtrip(CustomNestedStructRoundtripRequest) returns (CustomNestedStructRoundtripResponse);
@@ -34,6 +35,7 @@ service NiFake {
   rpc EnumInputFunctionWithDefaults(EnumInputFunctionWithDefaultsRequest) returns (EnumInputFunctionWithDefaultsResponse);
   rpc ErrorMessage(ErrorMessageRequest) returns (ErrorMessageResponse);
   rpc ExportAttributeConfigurationBuffer(ExportAttributeConfigurationBufferRequest) returns (ExportAttributeConfigurationBufferResponse);
+  rpc ExportAttributeConfigurationBufferEx(ExportAttributeConfigurationBufferExRequest) returns (ExportAttributeConfigurationBufferExResponse);
   rpc FetchWaveform(FetchWaveformRequest) returns (FetchWaveformResponse);
   rpc GetABoolean(GetABooleanRequest) returns (GetABooleanResponse);
   rpc GetANumber(GetANumberRequest) returns (GetANumberResponse);
@@ -65,6 +67,7 @@ service NiFake {
   rpc GetViUInt32Array(GetViUInt32ArrayRequest) returns (GetViUInt32ArrayResponse);
   rpc GetViUInt8(GetViUInt8Request) returns (GetViUInt8Response);
   rpc ImportAttributeConfigurationBuffer(ImportAttributeConfigurationBufferRequest) returns (ImportAttributeConfigurationBufferResponse);
+  rpc ImportAttributeConfigurationBufferEx(ImportAttributeConfigurationBufferExRequest) returns (ImportAttributeConfigurationBufferExResponse);
   rpc InitExtCal(InitExtCalRequest) returns (InitExtCalResponse);
   rpc InitWithOptions(InitWithOptionsRequest) returns (InitWithOptionsResponse);
   rpc InitWithVarArgs(InitWithVarArgsRequest) returns (InitWithVarArgsResponse);
@@ -119,6 +122,8 @@ enum NiFakeAttribute {
   NIFAKE_ATTRIBUTE_READ_WRITE_INTEGER_WITH_CONVERTER = 1000008;
   NIFAKE_ATTRIBUTE_READ_WRITE_DOUBLE_WITH_REPEATED_CAPABILITY = 1000009;
   NIFAKE_ATTRIBUTE_READ_WRITE_STRING_REPEATED_CAPABILITY = 1000010;
+  NIFAKE_ATTRIBUTE_SAMPLE_COUNT = 1000012;
+  NIFAKE_ATTRIBUTE_SAMPLE_INTERVAL = 1000013;
 }
 
 enum Bitfield {
@@ -184,11 +189,18 @@ enum MobileOSNames {
 }
 
 enum NiFakeInt32AttributeValues {
+  option allow_alias = true;
   NIFAKE_INT32_UNSPECIFIED = 0;
   NIFAKE_INT32_GRPC_COLOR_OVERRIDE_RED = 1;
   NIFAKE_INT32_GRPC_COLOR_OVERRIDE_BLUE = 2;
   NIFAKE_INT32_GRPC_COLOR_OVERRIDE_YELLOW = 5;
   NIFAKE_INT32_GRPC_COLOR_OVERRIDE_BLACK = 42;
+  NIFAKE_INT32_SAMPLE_COUNT_SAMPLE_COUNT_INFINITE = 0;
+}
+
+enum NiFakeReal64AttributeValues {
+  NIFAKE_REAL64_UNSPECIFIED = 0;
+  NIFAKE_REAL64_SAMPLE_INTERVAL_AUTO_DELAY = -1;
 }
 
 enum NiFakeReal64AttributeValuesMapped {
@@ -198,6 +210,15 @@ enum NiFakeReal64AttributeValuesMapped {
   NIFAKE_REAL64_FLOAT_ENUM_FIVE_POINT_FIVE = 3;
   NIFAKE_REAL64_FLOAT_ENUM_SIX_POINT_FIVE = 4;
   NIFAKE_REAL64_FLOAT_ENUM_SEVEN_POINT_FIVE = 5;
+}
+
+enum SampleCount {
+  SAMPLE_COUNT_SAMPLE_COUNT_INFINITE = 0;
+}
+
+enum SampleInterval {
+  SAMPLE_INTERVAL_UNSPECIFIED = 0;
+  SAMPLE_INTERVAL_AUTO_DELAY = -1;
 }
 
 enum Turtle {
@@ -319,6 +340,22 @@ message ConfigureAbcResponse {
   int32 status = 1;
 }
 
+message ConfigureEnumsRequest {
+  nidevice_grpc.Session vi = 1;
+  oneof sample_count_enum {
+    SampleCount sample_count = 2;
+    sint32 sample_count_raw = 3;
+  }
+  oneof sample_interval_enum {
+    SampleInterval sample_interval = 4;
+    double sample_interval_raw = 5;
+  }
+}
+
+message ConfigureEnumsResponse {
+  int32 status = 1;
+}
+
 message Control4022Request {
   string resource_name = 1;
   sint32 configuration = 2;
@@ -392,6 +429,15 @@ message ExportAttributeConfigurationBufferRequest {
 }
 
 message ExportAttributeConfigurationBufferResponse {
+  int32 status = 1;
+  bytes configuration = 2;
+}
+
+message ExportAttributeConfigurationBufferExRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message ExportAttributeConfigurationBufferExResponse {
   int32 status = 1;
   bytes configuration = 2;
 }
@@ -707,6 +753,15 @@ message ImportAttributeConfigurationBufferResponse {
   int32 status = 1;
 }
 
+message ImportAttributeConfigurationBufferExRequest {
+  nidevice_grpc.Session vi = 1;
+  bytes configuration = 2;
+}
+
+message ImportAttributeConfigurationBufferExResponse {
+  int32 status = 1;
+}
+
 message InitExtCalRequest {
   string session_name = 1;
   string resource_name = 2;
@@ -1014,8 +1069,9 @@ message SetAttributeViReal64Request {
   string channel_name = 2;
   NiFakeAttribute attribute_id = 3;
   oneof attribute_value_enum {
-    NiFakeReal64AttributeValuesMapped attribute_value_mapped = 4;
-    double attribute_value_raw = 5;
+    NiFakeReal64AttributeValues attribute_value = 4;
+    NiFakeReal64AttributeValuesMapped attribute_value_mapped = 5;
+    double attribute_value_raw = 6;
   }
 }
 

--- a/source/codegen/metadata/niscope/attributes.py
+++ b/source/codegen/metadata/niscope/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0d95
+# This file is generated from NI-SCOPE API metadata version 23.0.0d152
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niscope/config.py
+++ b/source/codegen/metadata/niscope/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0d95
+# This file is generated from NI-SCOPE API metadata version 23.0.0d152
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0d95',
+    'api_version': '23.0.0d152',
     'c_function_prefix': 'niScope_',
     'c_header': 'niScopeCal.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/niscope/enums.py
+++ b/source/codegen/metadata/niscope/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0d95
+# This file is generated from NI-SCOPE API metadata version 23.0.0d152
 enums = {
     'AcquisitionStatus': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niscope/functions.py
+++ b/source/codegen/metadata/niscope/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0d95
+# This file is generated from NI-SCOPE API metadata version 23.0.0d152
 functions = {
     'Abort': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niscope/niscope.proto
+++ b/source/codegen/metadata/niscope/niscope.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SCOPE API metadata version 23.0.0d95
+// This file is generated from NI-SCOPE API metadata version 23.0.0d152
 //---------------------------------------------------------------------
 // Proto file for the NI-SCOPE Metadata
 //---------------------------------------------------------------------

--- a/source/codegen/metadata/niswitch/attributes.py
+++ b/source/codegen/metadata/niswitch/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SWITCH API metadata version 23.0.0d75
+# This file is generated from NI-SWITCH API metadata version 23.0.0d149
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niswitch/config.py
+++ b/source/codegen/metadata/niswitch/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SWITCH API metadata version 23.0.0d75
+# This file is generated from NI-SWITCH API metadata version 23.0.0d149
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0d75',
+    'api_version': '23.0.0d149',
     'c_function_prefix': 'niSwitch_',
     'c_header': 'niswitch.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/niswitch/enums.py
+++ b/source/codegen/metadata/niswitch/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SWITCH API metadata version 23.0.0d75
+# This file is generated from NI-SWITCH API metadata version 23.0.0d149
 enums = {
     'HandshakingInitiation': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niswitch/functions.py
+++ b/source/codegen/metadata/niswitch/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SWITCH API metadata version 23.0.0d75
+# This file is generated from NI-SWITCH API metadata version 23.0.0d149
 functions = {
     'AbortScan': {
         'codegen_method': 'public',
@@ -148,7 +148,7 @@ functions = {
                 'cppName': 'attributeValue',
                 'direction': 'in',
                 'grpc_type': 'double',
-                'name': 'attributeValue_raw',
+                'name': 'attribute_value_raw',
                 'type': 'ViReal64'
             }
         ],
@@ -216,7 +216,7 @@ functions = {
                 'cppName': 'attributeValue',
                 'direction': 'in',
                 'grpc_type': 'string',
-                'name': 'attributeValue_raw',
+                'name': 'attribute_value_raw',
                 'type': 'ViString'
             }
         ],
@@ -1623,7 +1623,7 @@ functions = {
                 'cppName': 'attributeValue',
                 'direction': 'in',
                 'grpc_type': 'double',
-                'name': 'attributeValue_raw',
+                'name': 'attribute_value_raw',
                 'type': 'ViReal64'
             }
         ],
@@ -1691,7 +1691,7 @@ functions = {
                 'cppName': 'attributeValue',
                 'direction': 'in',
                 'grpc_type': 'string',
-                'name': 'attributeValue_raw',
+                'name': 'attribute_value_raw',
                 'type': 'ViString'
             }
         ],

--- a/source/codegen/metadata/niswitch/niswitch.proto
+++ b/source/codegen/metadata/niswitch/niswitch.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SWITCH API metadata version 23.0.0d75
+// This file is generated from NI-SWITCH API metadata version 23.0.0d149
 //---------------------------------------------------------------------
 // Proto file for the NI-SWITCH Metadata
 //---------------------------------------------------------------------

--- a/source/codegen/metadata/nitclk/attributes.py
+++ b/source/codegen/metadata/nitclk/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-TClk API metadata version 23.0.0d7
+# This file is generated from NI-TClk API metadata version 23.0.0d64
 attributes = {
     1: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nitclk/config.py
+++ b/source/codegen/metadata/nitclk/config.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-TClk API metadata version 23.0.0d7
+# This file is generated from NI-TClk API metadata version 23.0.0d64
 config = {
     'additional_headers': {
     },
-    'api_version': '23.0.0',
+    'api_version': '23.0.0d64',
     'c_function_prefix': 'niTClk_',
     'c_header': 'niTClk.h',
     'close_function': None,

--- a/source/codegen/metadata/nitclk/enums.py
+++ b/source/codegen/metadata/nitclk/enums.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-TClk API metadata version 23.0.0d7
+# This file is generated from NI-TClk API metadata version 23.0.0d64
 enums = {
 }

--- a/source/codegen/metadata/nitclk/functions.py
+++ b/source/codegen/metadata/nitclk/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-TClk API metadata version 23.0.0d7
+# This file is generated from NI-TClk API metadata version 23.0.0d64
 functions = {
     'ConfigureForHomogeneousTriggers': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nitclk/nitclk.proto
+++ b/source/codegen/metadata/nitclk/nitclk.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-TClk API metadata version 23.0.0
+// This file is generated from NI-TClk API metadata version 23.0.0d64
 //---------------------------------------------------------------------
 // Proto file for the NI-TClk Metadata
 //---------------------------------------------------------------------


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Update to nidcpower `23.0.0d446`
  -  This removes the method `ConfigureOutputRange` which was not in the previous release, so it's not "breaking"
- Update to nidigitalpattern `23.0.0d94`
- Update to nidmm `23.0.0d127`
- Update to nifake `23.0.0d142`
- Update to niscope `23.0.0d152`
- Update to niswitch `23.0.0d149`
- Update to nitclk `23.0.0d64`

**Note** that this PR does not include nifgen because there are other discussions about whether metadata changes that have been submitted were appropriate.

### Why should this Pull Request be merged?

Make sure we get as close to final exports as possible, and ensure there are no breaking changes.

### What testing has been done?

Built locally.