### PR TITLE
Avoid including README in artifacts.

### DIFF
--- a/source/codegen/stage_client_files.py
+++ b/source/codegen/stage_client_files.py
@@ -106,10 +106,10 @@ def stage_client_files(output_path: Path, ignore_release_readiness: bool):
     proto_path = output_path / "proto"
     proto_path.mkdir(parents=True)
 
-    for file in artifact_locations.shared_source_protos.iterdir():
+    for file in artifact_locations.shared_source_protos.glob("*.proto"):
         copy2(file, proto_path)
 
-    for file in artifact_locations.shared_imported_protos.iterdir():
+    for file in artifact_locations.shared_imported_protos.glob("*.proto"):
         copy2(file, proto_path)
 
     for file in _get_release_proto_files(artifact_locations, readiness):


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update `stage_client_files.py` to just pull in `.proto` files from the shared spots.

### Why should this Pull Request be merged?

Slight mess up in my recent submission #814 

I added a README.md file to the imports/protobuf folder to clarify where they were coming from. That's all good and well, but I failed to notice that when I updated the `stage_client_artifacts.py` file that it would pull this new README into the artifacts.

See the most recent export [here](https://p4.natinst.com/browser/perforce/build/exports/adhoc/ni-g/ni-grpc-device-main-desktop/official/export/1.2/1.2.0d460/proto/) with that README.md file present

### What testing has been done?

Ran a dry run of `py stage_client_files.py` to confirm what the export was showing; that it was including the README.md file.

Ran again after the updates in this PR and it lists all the expected paths and leaves out the README.md one so it should be rectified.
