### PR TITLE
Pull in 23.0 finals of MI driver grpc-device metadata

### DIFF
--- a/generated/nidcpower/nidcpower.proto
+++ b/generated/nidcpower/nidcpower.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-DCPower API metadata version 23.0.0d446
+// This file is generated from NI-DCPower API metadata version 23.0.0f517
 //---------------------------------------------------------------------
 // Proto file for the NI-DCPower Metadata
 //---------------------------------------------------------------------

--- a/generated/nidigitalpattern/nidigitalpattern.proto
+++ b/generated/nidigitalpattern/nidigitalpattern.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d94
+// This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0f112
 //---------------------------------------------------------------------
 // Proto file for the NI-Digital Pattern Driver Metadata
 //---------------------------------------------------------------------

--- a/generated/nidmm/nidmm.proto
+++ b/generated/nidmm/nidmm.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-DMM API metadata version 23.0.0d127
+// This file is generated from NI-DMM API metadata version 23.0.0f147
 //---------------------------------------------------------------------
 // Proto file for the NI-DMM Metadata
 //---------------------------------------------------------------------

--- a/generated/nifake/nifake.proto
+++ b/generated/nifake/nifake.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-FAKE API metadata version 23.0.0d142
+// This file is generated from NI-FAKE API metadata version 23.0.0f157
 //---------------------------------------------------------------------
 // Proto file for the NI-FAKE Metadata
 //---------------------------------------------------------------------

--- a/generated/nifgen/nifgen.proto
+++ b/generated/nifgen/nifgen.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-FGEN API metadata version 23.0.0d57
+// This file is generated from NI-FGEN API metadata version 23.0.0f157
 //---------------------------------------------------------------------
 // Proto file for the NI-FGEN Metadata
 //---------------------------------------------------------------------

--- a/generated/nifgen/nifgen_compilation_test.cpp
+++ b/generated/nifgen/nifgen_compilation_test.cpp
@@ -562,7 +562,7 @@ ViStatus SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[
   return niFgen_self_test(vi, selfTestResult, selfTestMessage);
 }
 
-ViStatus SendSoftwareEdgeTrigger(ViSession vi, ViInt32 trigger, ViString triggerId)
+ViStatus SendSoftwareEdgeTrigger(ViSession vi, ViInt32 trigger, ViConstString triggerId)
 {
   return niFgen_SendSoftwareEdgeTrigger(vi, trigger, triggerId);
 }

--- a/generated/nifgen/nifgen_library.cpp
+++ b/generated/nifgen/nifgen_library.cpp
@@ -1063,7 +1063,7 @@ ViStatus NiFgenLibrary::SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar s
   return function_pointers_.SelfTest(vi, selfTestResult, selfTestMessage);
 }
 
-ViStatus NiFgenLibrary::SendSoftwareEdgeTrigger(ViSession vi, ViInt32 trigger, ViString triggerId)
+ViStatus NiFgenLibrary::SendSoftwareEdgeTrigger(ViSession vi, ViInt32 trigger, ViConstString triggerId)
 {
   if (!function_pointers_.SendSoftwareEdgeTrigger) {
     throw nidevice_grpc::LibraryLoadException("Could not find niFgen_SendSoftwareEdgeTrigger.");

--- a/generated/nifgen/nifgen_library.h
+++ b/generated/nifgen/nifgen_library.h
@@ -130,7 +130,7 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   ViStatus RouteSignalOut(ViSession vi, ViConstString channelName, ViInt32 routeSignalFrom, ViInt32 routeSignalTo);
   ViStatus SelfCal(ViSession vi);
   ViStatus SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]);
-  ViStatus SendSoftwareEdgeTrigger(ViSession vi, ViInt32 trigger, ViString triggerId);
+  ViStatus SendSoftwareEdgeTrigger(ViSession vi, ViInt32 trigger, ViConstString triggerId);
   ViStatus SetAttributeViBoolean(ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean attributeValue);
   ViStatus SetAttributeViInt32(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 attributeValue);
   ViStatus SetAttributeViInt64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64 attributeValue);

--- a/generated/nifgen/nifgen_library_interface.h
+++ b/generated/nifgen/nifgen_library_interface.h
@@ -127,7 +127,7 @@ class NiFgenLibraryInterface {
   virtual ViStatus RouteSignalOut(ViSession vi, ViConstString channelName, ViInt32 routeSignalFrom, ViInt32 routeSignalTo) = 0;
   virtual ViStatus SelfCal(ViSession vi) = 0;
   virtual ViStatus SelfTest(ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]) = 0;
-  virtual ViStatus SendSoftwareEdgeTrigger(ViSession vi, ViInt32 trigger, ViString triggerId) = 0;
+  virtual ViStatus SendSoftwareEdgeTrigger(ViSession vi, ViInt32 trigger, ViConstString triggerId) = 0;
   virtual ViStatus SetAttributeViBoolean(ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean attributeValue) = 0;
   virtual ViStatus SetAttributeViInt32(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 attributeValue) = 0;
   virtual ViStatus SetAttributeViInt64(ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64 attributeValue) = 0;

--- a/generated/nifgen/nifgen_mock_library.h
+++ b/generated/nifgen/nifgen_mock_library.h
@@ -129,7 +129,7 @@ class NiFgenMockLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   MOCK_METHOD(ViStatus, RouteSignalOut, (ViSession vi, ViConstString channelName, ViInt32 routeSignalFrom, ViInt32 routeSignalTo), (override));
   MOCK_METHOD(ViStatus, SelfCal, (ViSession vi), (override));
   MOCK_METHOD(ViStatus, SelfTest, (ViSession vi, ViInt16* selfTestResult, ViChar selfTestMessage[256]), (override));
-  MOCK_METHOD(ViStatus, SendSoftwareEdgeTrigger, (ViSession vi, ViInt32 trigger, ViString triggerId), (override));
+  MOCK_METHOD(ViStatus, SendSoftwareEdgeTrigger, (ViSession vi, ViInt32 trigger, ViConstString triggerId), (override));
   MOCK_METHOD(ViStatus, SetAttributeViBoolean, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViBoolean attributeValue), (override));
   MOCK_METHOD(ViStatus, SetAttributeViInt32, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt32 attributeValue), (override));
   MOCK_METHOD(ViStatus, SetAttributeViInt64, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViInt64 attributeValue), (override));

--- a/generated/nifgen/nifgen_service.cpp
+++ b/generated/nifgen/nifgen_service.cpp
@@ -3315,7 +3315,7 @@ namespace nifgen_grpc {
       }
 
       auto trigger_id_mbcs = convert_from_grpc<std::string>(request->trigger_id());
-      ViString trigger_id = (ViString)trigger_id_mbcs.c_str();
+      auto trigger_id = trigger_id_mbcs.c_str();
       auto status = library_->SendSoftwareEdgeTrigger(vi, trigger, trigger_id);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);

--- a/generated/niscope/niscope.proto
+++ b/generated/niscope/niscope.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SCOPE API metadata version 23.0.0d152
+// This file is generated from NI-SCOPE API metadata version 23.0.0f168
 //---------------------------------------------------------------------
 // Proto file for the NI-SCOPE Metadata
 //---------------------------------------------------------------------
@@ -473,8 +473,8 @@ enum ExportableSignals {
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_ADVANCE_EVENT = 6;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_START_EVENT = 7;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_REF_EVENT = 10;
-  EXPORTABLE_SIGNALS_NISCOPE_VAL_5V_OUT = 13;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_REF_CLOCK = 100;
+  EXPORTABLE_SIGNALS_NISCOPE_VAL_5V_OUT = 13;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_SAMPLE_CLOCK = 101;
 }
 

--- a/generated/niswitch/niswitch.proto
+++ b/generated/niswitch/niswitch.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SWITCH API metadata version 23.0.0d149
+// This file is generated from NI-SWITCH API metadata version 23.0.0f167
 //---------------------------------------------------------------------
 // Proto file for the NI-SWITCH Metadata
 //---------------------------------------------------------------------

--- a/generated/nitclk/nitclk.proto
+++ b/generated/nitclk/nitclk.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-TClk API metadata version 23.0.0d64
+// This file is generated from NI-TClk API metadata version 23.0.0f77
 //---------------------------------------------------------------------
 // Proto file for the NI-TClk Metadata
 //---------------------------------------------------------------------

--- a/source/codegen/metadata/nidcpower/attributes.py
+++ b/source/codegen/metadata/nidcpower/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 23.0.0d446
+# This file is generated from NI-DCPower API metadata version 23.0.0f517
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidcpower/config.py
+++ b/source/codegen/metadata/nidcpower/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 23.0.0d446
+# This file is generated from NI-DCPower API metadata version 23.0.0f517
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0d446',
+    'api_version': '23.0.0f517',
     'c_function_prefix': 'niDCPower_',
     'c_header': 'nidcpower.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/nidcpower/enums.py
+++ b/source/codegen/metadata/nidcpower/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 23.0.0d446
+# This file is generated from NI-DCPower API metadata version 23.0.0f517
 enums = {
     'ApertureTimeAutoMode': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidcpower/functions.py
+++ b/source/codegen/metadata/nidcpower/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DCPower API metadata version 23.0.0d446
+# This file is generated from NI-DCPower API metadata version 23.0.0f517
 functions = {
     'Abort': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidcpower/nidcpower.proto
+++ b/source/codegen/metadata/nidcpower/nidcpower.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-DCPower API metadata version 23.0.0d446
+// This file is generated from NI-DCPower API metadata version 23.0.0f517
 //---------------------------------------------------------------------
 // Proto file for the NI-DCPower Metadata
 //---------------------------------------------------------------------

--- a/source/codegen/metadata/nidigitalpattern/attributes.py
+++ b/source/codegen/metadata/nidigitalpattern/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d94
+# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0f112
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidigitalpattern/config.py
+++ b/source/codegen/metadata/nidigitalpattern/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d94
+# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0f112
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0d94',
+    'api_version': '23.0.0f112',
     'c_function_prefix': 'niDigital_',
     'c_header': 'niDigital.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/nidigitalpattern/enums.py
+++ b/source/codegen/metadata/nidigitalpattern/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d94
+# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0f112
 enums = {
     'BitOrder': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidigitalpattern/functions.py
+++ b/source/codegen/metadata/nidigitalpattern/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d94
+# This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0f112
 functions = {
     'Abort': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidigitalpattern/nidigitalpattern.proto
+++ b/source/codegen/metadata/nidigitalpattern/nidigitalpattern.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0d94
+// This file is generated from NI-Digital Pattern Driver API metadata version 23.0.0f112
 //---------------------------------------------------------------------
 // Proto file for the NI-Digital Pattern Driver Metadata
 //---------------------------------------------------------------------

--- a/source/codegen/metadata/nidmm/attributes.py
+++ b/source/codegen/metadata/nidmm/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DMM API metadata version 23.0.0d127
+# This file is generated from NI-DMM API metadata version 23.0.0f147
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidmm/config.py
+++ b/source/codegen/metadata/nidmm/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DMM API metadata version 23.0.0d127
+# This file is generated from NI-DMM API metadata version 23.0.0f147
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0d127',
+    'api_version': '23.0.0f147',
     'c_function_prefix': 'niDMM_',
     'c_header': 'nidmm.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/nidmm/enums.py
+++ b/source/codegen/metadata/nidmm/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DMM API metadata version 23.0.0d127
+# This file is generated from NI-DMM API metadata version 23.0.0f147
 enums = {
     'AcquisitionStatus': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidmm/functions.py
+++ b/source/codegen/metadata/nidmm/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-DMM API metadata version 23.0.0d127
+# This file is generated from NI-DMM API metadata version 23.0.0f147
 functions = {
     'Abort': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nidmm/nidmm.proto
+++ b/source/codegen/metadata/nidmm/nidmm.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-DMM API metadata version 23.0.0d127
+// This file is generated from NI-DMM API metadata version 23.0.0f147
 //---------------------------------------------------------------------
 // Proto file for the NI-DMM Metadata
 //---------------------------------------------------------------------

--- a/source/codegen/metadata/nifake/attributes.py
+++ b/source/codegen/metadata/nifake/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 23.0.0d142
+# This file is generated from NI-FAKE API metadata version 23.0.0f157
 attributes = {
     1000000: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nifake/config.py
+++ b/source/codegen/metadata/nifake/config.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 23.0.0d142
+# This file is generated from NI-FAKE API metadata version 23.0.0f157
 config = {
     'additional_headers': {
     },
-    'api_version': '23.0.0d142',
+    'api_version': '23.0.0f157',
     'c_function_prefix': 'niFake_',
     'c_header': 'niFake.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/nifake/enums.py
+++ b/source/codegen/metadata/nifake/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 23.0.0d142
+# This file is generated from NI-FAKE API metadata version 23.0.0f157
 enums = {
     'Bitfield': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nifake/functions.py
+++ b/source/codegen/metadata/nifake/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FAKE API metadata version 23.0.0d142
+# This file is generated from NI-FAKE API metadata version 23.0.0f157
 functions = {
     'Abort': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nifake/nifake.proto
+++ b/source/codegen/metadata/nifake/nifake.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-FAKE API metadata version 23.0.0d142
+// This file is generated from NI-FAKE API metadata version 23.0.0f157
 //---------------------------------------------------------------------
 // Proto file for the NI-FAKE Metadata
 //---------------------------------------------------------------------

--- a/source/codegen/metadata/nifgen/attributes.py
+++ b/source/codegen/metadata/nifgen/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 23.0.0d57
+# This file is generated from NI-FGEN API metadata version 23.0.0f157
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nifgen/config.py
+++ b/source/codegen/metadata/nifgen/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 23.0.0d57
+# This file is generated from NI-FGEN API metadata version 23.0.0f157
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0d57',
+    'api_version': '23.0.0f157',
     'c_function_prefix': 'niFgen_',
     'c_header': 'niFgen.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/nifgen/enums.py
+++ b/source/codegen/metadata/nifgen/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 23.0.0d57
+# This file is generated from NI-FGEN API metadata version 23.0.0f157
 enums = {
     'AddressType': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nifgen/functions.py
+++ b/source/codegen/metadata/nifgen/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-FGEN API metadata version 23.0.0d57
+# This file is generated from NI-FGEN API metadata version 23.0.0f157
 functions = {
     'AbortGeneration': {
         'codegen_method': 'public',
@@ -3457,7 +3457,7 @@ functions = {
                 'direction': 'in',
                 'grpc_type': 'string',
                 'name': 'triggerId',
-                'type': 'ViString'
+                'type': 'ViConstString'
             }
         ],
         'returns': 'ViStatus'

--- a/source/codegen/metadata/nifgen/nifgen.proto
+++ b/source/codegen/metadata/nifgen/nifgen.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-FGEN API metadata version 23.0.0d57
+// This file is generated from NI-FGEN API metadata version 23.0.0f157
 //---------------------------------------------------------------------
 // Proto file for the NI-FGEN Metadata
 //---------------------------------------------------------------------

--- a/source/codegen/metadata/niscope/attributes.py
+++ b/source/codegen/metadata/niscope/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0d152
+# This file is generated from NI-SCOPE API metadata version 23.0.0f168
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niscope/config.py
+++ b/source/codegen/metadata/niscope/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0d152
+# This file is generated from NI-SCOPE API metadata version 23.0.0f168
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0d152',
+    'api_version': '23.0.0f168',
     'c_function_prefix': 'niScope_',
     'c_header': 'niScopeCal.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/niscope/enums.py
+++ b/source/codegen/metadata/niscope/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0d152
+# This file is generated from NI-SCOPE API metadata version 23.0.0f168
 enums = {
     'AcquisitionStatus': {
         'codegen_method': 'public',
@@ -583,12 +583,12 @@ enums = {
                 'value': 10
             },
             {
-                'name': 'NISCOPE_VAL_5V_OUT',
-                'value': 13
-            },
-            {
                 'name': 'NISCOPE_VAL_REF_CLOCK',
                 'value': 100
+            },
+            {
+                'name': 'NISCOPE_VAL_5V_OUT',
+                'value': 13
             },
             {
                 'name': 'NISCOPE_VAL_SAMPLE_CLOCK',

--- a/source/codegen/metadata/niscope/functions.py
+++ b/source/codegen/metadata/niscope/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0d152
+# This file is generated from NI-SCOPE API metadata version 23.0.0f168
 functions = {
     'Abort': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niscope/niscope.proto
+++ b/source/codegen/metadata/niscope/niscope.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SCOPE API metadata version 23.0.0d152
+// This file is generated from NI-SCOPE API metadata version 23.0.0f168
 //---------------------------------------------------------------------
 // Proto file for the NI-SCOPE Metadata
 //---------------------------------------------------------------------
@@ -473,8 +473,8 @@ enum ExportableSignals {
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_ADVANCE_EVENT = 6;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_START_EVENT = 7;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_REF_EVENT = 10;
-  EXPORTABLE_SIGNALS_NISCOPE_VAL_5V_OUT = 13;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_REF_CLOCK = 100;
+  EXPORTABLE_SIGNALS_NISCOPE_VAL_5V_OUT = 13;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_SAMPLE_CLOCK = 101;
 }
 

--- a/source/codegen/metadata/niswitch/attributes.py
+++ b/source/codegen/metadata/niswitch/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SWITCH API metadata version 23.0.0d149
+# This file is generated from NI-SWITCH API metadata version 23.0.0f167
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niswitch/config.py
+++ b/source/codegen/metadata/niswitch/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SWITCH API metadata version 23.0.0d149
+# This file is generated from NI-SWITCH API metadata version 23.0.0f167
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0d149',
+    'api_version': '23.0.0f167',
     'c_function_prefix': 'niSwitch_',
     'c_header': 'niswitch.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/niswitch/enums.py
+++ b/source/codegen/metadata/niswitch/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SWITCH API metadata version 23.0.0d149
+# This file is generated from NI-SWITCH API metadata version 23.0.0f167
 enums = {
     'HandshakingInitiation': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niswitch/functions.py
+++ b/source/codegen/metadata/niswitch/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SWITCH API metadata version 23.0.0d149
+# This file is generated from NI-SWITCH API metadata version 23.0.0f167
 functions = {
     'AbortScan': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niswitch/niswitch.proto
+++ b/source/codegen/metadata/niswitch/niswitch.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SWITCH API metadata version 23.0.0d149
+// This file is generated from NI-SWITCH API metadata version 23.0.0f167
 //---------------------------------------------------------------------
 // Proto file for the NI-SWITCH Metadata
 //---------------------------------------------------------------------

--- a/source/codegen/metadata/nitclk/attributes.py
+++ b/source/codegen/metadata/nitclk/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-TClk API metadata version 23.0.0d64
+# This file is generated from NI-TClk API metadata version 23.0.0f77
 attributes = {
     1: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nitclk/config.py
+++ b/source/codegen/metadata/nitclk/config.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-TClk API metadata version 23.0.0d64
+# This file is generated from NI-TClk API metadata version 23.0.0f77
 config = {
     'additional_headers': {
     },
-    'api_version': '23.0.0d64',
+    'api_version': '23.0.0f77',
     'c_function_prefix': 'niTClk_',
     'c_header': 'niTClk.h',
     'close_function': None,

--- a/source/codegen/metadata/nitclk/enums.py
+++ b/source/codegen/metadata/nitclk/enums.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-TClk API metadata version 23.0.0d64
+# This file is generated from NI-TClk API metadata version 23.0.0f77
 enums = {
 }

--- a/source/codegen/metadata/nitclk/functions.py
+++ b/source/codegen/metadata/nitclk/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-TClk API metadata version 23.0.0d64
+# This file is generated from NI-TClk API metadata version 23.0.0f77
 functions = {
     'ConfigureForHomogeneousTriggers': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/nitclk/nitclk.proto
+++ b/source/codegen/metadata/nitclk/nitclk.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-TClk API metadata version 23.0.0d64
+// This file is generated from NI-TClk API metadata version 23.0.0f77
 //---------------------------------------------------------------------
 // Proto file for the NI-TClk Metadata
 //---------------------------------------------------------------------


### PR DESCRIPTION
### What does this Pull Request accomplish?

Pulls in the 23.0 final grpc-device metadata for the MI drivers.

### Why should this Pull Request be merged?

We should transition to the final metadata before making a grpc-device release.

### What testing has been done?

Build should suffice.