### PR TITLE
Cherry-pick from main: "Bump to version 2.0.0 in main. (#824)"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12.0)
 
 project(ni_grpc_device_server
   LANGUAGES C CXX
-  VERSION 1.5.2)
+  VERSION 2.0.0)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(CreateVirtualEnvironment)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Cherry-pick commit from main (#824) which updated CMAKE project version to 2.0.0 (used to show the executable version on Windows).

### Why should this Pull Request be merged?

Releases branch should also update to 2.0.0

There was discussion in my first attempt to change the version in the releases branch directly (#823 ) about how to distinguish it in the main branch. Up to this point, we haven't had a distinction between the released 1.5.1 version and the version in main also showing 1.5.1 for this project / executable version. So I think for the release it should be fine to bump both to 2.0.0.

I think there should be an extra effort / investigation to figure out in main how to distinguish an executable coming from there, possibly with specifying `DESCRIPTION` on the CMAKE project and incorporating that in the executable details.

### What testing has been done?

Confirmed the update updates the version shown with ni_grpc_device_server.exe
