### PR TITLE
[RFC] Expose GetStartTimestampInformation in niscope.proto

### DIFF
--- a/generated/niscope/niscope.proto
+++ b/generated/niscope/niscope.proto
@@ -1707,10 +1707,10 @@ message GetStartTimestampInformationRequest {
 
 message GetStartTimestampInformationResponse {
   int32 status = 1;
-  uint32 sys_time_in128_bits_t1 = 2;
-  uint32 sys_time_in128_bits_t2 = 3;
-  uint32 sys_time_in128_bits_t3 = 4;
-  uint32 sys_time_in128_bits_t4 = 5;
+  uint32 sys_time_in_128_bits_t1 = 2;
+  uint32 sys_time_in_128_bits_t2 = 3;
+  uint32 sys_time_in_128_bits_t3 = 4;
+  uint32 sys_time_in_128_bits_t4 = 5;
   double device_time_in_absolute_time_units = 6;
 }
 

--- a/generated/niscope/niscope.proto
+++ b/generated/niscope/niscope.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SCOPE API metadata version 23.0.0f168
+// This file is generated from NI-SCOPE API metadata version 23.3.0d9999
 //---------------------------------------------------------------------
 // Proto file for the NI-SCOPE Metadata
 //---------------------------------------------------------------------
@@ -84,6 +84,7 @@ service NiScope {
   rpc GetFrequencyResponse(GetFrequencyResponseRequest) returns (GetFrequencyResponseResponse);
   rpc GetNormalizationCoefficients(GetNormalizationCoefficientsRequest) returns (GetNormalizationCoefficientsResponse);
   rpc GetScalingCoefficients(GetScalingCoefficientsRequest) returns (GetScalingCoefficientsResponse);
+  rpc GetStartTimestampInformation(GetStartTimestampInformationRequest) returns (GetStartTimestampInformationResponse);
   rpc GetStreamEndpointHandle(GetStreamEndpointHandleRequest) returns (GetStreamEndpointHandleResponse);
   rpc ImportAttributeConfigurationBuffer(ImportAttributeConfigurationBufferRequest) returns (ImportAttributeConfigurationBufferResponse);
   rpc ImportAttributeConfigurationFile(ImportAttributeConfigurationFileRequest) returns (ImportAttributeConfigurationFileResponse);
@@ -473,8 +474,8 @@ enum ExportableSignals {
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_ADVANCE_EVENT = 6;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_START_EVENT = 7;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_REF_EVENT = 10;
-  EXPORTABLE_SIGNALS_NISCOPE_VAL_REF_CLOCK = 100;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_5V_OUT = 13;
+  EXPORTABLE_SIGNALS_NISCOPE_VAL_REF_CLOCK = 100;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_SAMPLE_CLOCK = 101;
 }
 
@@ -1698,6 +1699,19 @@ message GetScalingCoefficientsResponse {
   int32 status = 1;
   repeated CoefficientInfo coefficient_info = 2;
   sint32 number_of_coefficient_sets = 3;
+}
+
+message GetStartTimestampInformationRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetStartTimestampInformationResponse {
+  int32 status = 1;
+  uint32 sys_time_in128_bits_t1 = 2;
+  uint32 sys_time_in128_bits_t2 = 3;
+  uint32 sys_time_in128_bits_t3 = 4;
+  uint32 sys_time_in128_bits_t4 = 5;
+  double device_time_in_absolute_time_units = 6;
 }
 
 message GetStreamEndpointHandleRequest {

--- a/generated/niscope/niscope_client.cpp
+++ b/generated/niscope/niscope_client.cpp
@@ -1579,6 +1579,23 @@ get_scaling_coefficients(const StubPtr& stub, const nidevice_grpc::Session& vi, 
   return response;
 }
 
+GetStartTimestampInformationResponse
+get_start_timestamp_information(const StubPtr& stub, const nidevice_grpc::Session& vi)
+{
+  ::grpc::ClientContext context;
+
+  auto request = GetStartTimestampInformationRequest{};
+  request.mutable_vi()->CopyFrom(vi);
+
+  auto response = GetStartTimestampInformationResponse{};
+
+  raise_if_error(
+      stub->GetStartTimestampInformation(&context, request, &response),
+      context);
+
+  return response;
+}
+
 GetStreamEndpointHandleResponse
 get_stream_endpoint_handle(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& stream_name)
 {

--- a/generated/niscope/niscope_client.h
+++ b/generated/niscope/niscope_client.h
@@ -89,6 +89,7 @@ GetErrorMessageResponse get_error_message(const StubPtr& stub, const nidevice_gr
 GetFrequencyResponseResponse get_frequency_response(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel, const pb::int32& buffer_size);
 GetNormalizationCoefficientsResponse get_normalization_coefficients(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list);
 GetScalingCoefficientsResponse get_scaling_coefficients(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list);
+GetStartTimestampInformationResponse get_start_timestamp_information(const StubPtr& stub, const nidevice_grpc::Session& vi);
 GetStreamEndpointHandleResponse get_stream_endpoint_handle(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& stream_name);
 ImportAttributeConfigurationBufferResponse import_attribute_configuration_buffer(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& configuration);
 ImportAttributeConfigurationFileResponse import_attribute_configuration_file(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& file_path);

--- a/generated/niscope/niscope_compilation_test.cpp
+++ b/generated/niscope/niscope_compilation_test.cpp
@@ -342,6 +342,11 @@ ViStatus GetScalingCoefficients(ViSession vi, ViConstString channelList, ViInt32
   return niScope_GetScalingCoefficients(vi, channelList, bufferSize, coefficientInfo, numberOfCoefficientSets);
 }
 
+ViStatus GetStartTimestampInformation(ViSession vi, ViUInt32* sysTimeIn128BitsT1, ViUInt32* sysTimeIn128BitsT2, ViUInt32* sysTimeIn128BitsT3, ViUInt32* sysTimeIn128BitsT4, ViReal64* deviceTimeInAbsoluteTimeUnits)
+{
+  return niScope_GetStartTimestampInformation(vi, sysTimeIn128BitsT1, sysTimeIn128BitsT2, sysTimeIn128BitsT3, sysTimeIn128BitsT4, deviceTimeInAbsoluteTimeUnits);
+}
+
 ViStatus GetStreamEndpointHandle(ViSession vi, ViConstString streamName, ViUInt32* writerHandle)
 {
   return niScope_GetStreamEndpointHandle(vi, streamName, writerHandle);

--- a/generated/niscope/niscope_library.cpp
+++ b/generated/niscope/niscope_library.cpp
@@ -88,6 +88,7 @@ NiScopeLibrary::NiScopeLibrary() : shared_library_(kLibraryName)
   function_pointers_.GetFrequencyResponse = reinterpret_cast<GetFrequencyResponsePtr>(shared_library_.get_function_pointer("niScope_GetFrequencyResponse"));
   function_pointers_.GetNormalizationCoefficients = reinterpret_cast<GetNormalizationCoefficientsPtr>(shared_library_.get_function_pointer("niScope_GetNormalizationCoefficients"));
   function_pointers_.GetScalingCoefficients = reinterpret_cast<GetScalingCoefficientsPtr>(shared_library_.get_function_pointer("niScope_GetScalingCoefficients"));
+  function_pointers_.GetStartTimestampInformation = reinterpret_cast<GetStartTimestampInformationPtr>(shared_library_.get_function_pointer("niScope_GetStartTimestampInformation"));
   function_pointers_.GetStreamEndpointHandle = reinterpret_cast<GetStreamEndpointHandlePtr>(shared_library_.get_function_pointer("niScope_GetStreamEndpointHandle"));
   function_pointers_.ImportAttributeConfigurationBuffer = reinterpret_cast<ImportAttributeConfigurationBufferPtr>(shared_library_.get_function_pointer("niScope_ImportAttributeConfigurationBuffer"));
   function_pointers_.ImportAttributeConfigurationFile = reinterpret_cast<ImportAttributeConfigurationFilePtr>(shared_library_.get_function_pointer("niScope_ImportAttributeConfigurationFile"));
@@ -660,6 +661,14 @@ ViStatus NiScopeLibrary::GetScalingCoefficients(ViSession vi, ViConstString chan
     throw nidevice_grpc::LibraryLoadException("Could not find niScope_GetScalingCoefficients.");
   }
   return function_pointers_.GetScalingCoefficients(vi, channelList, bufferSize, coefficientInfo, numberOfCoefficientSets);
+}
+
+ViStatus NiScopeLibrary::GetStartTimestampInformation(ViSession vi, ViUInt32* sysTimeIn128BitsT1, ViUInt32* sysTimeIn128BitsT2, ViUInt32* sysTimeIn128BitsT3, ViUInt32* sysTimeIn128BitsT4, ViReal64* deviceTimeInAbsoluteTimeUnits)
+{
+  if (!function_pointers_.GetStartTimestampInformation) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niScope_GetStartTimestampInformation.");
+  }
+  return function_pointers_.GetStartTimestampInformation(vi, sysTimeIn128BitsT1, sysTimeIn128BitsT2, sysTimeIn128BitsT3, sysTimeIn128BitsT4, deviceTimeInAbsoluteTimeUnits);
 }
 
 ViStatus NiScopeLibrary::GetStreamEndpointHandle(ViSession vi, ViConstString streamName, ViUInt32* writerHandle)

--- a/generated/niscope/niscope_library.h
+++ b/generated/niscope/niscope_library.h
@@ -85,6 +85,7 @@ class NiScopeLibrary : public niscope_grpc::NiScopeLibraryInterface {
   ViStatus GetFrequencyResponse(ViSession vi, ViConstString channel, ViInt32 bufferSize, ViReal64 frequencies[], ViReal64 amplitudes[], ViReal64 phases[], ViInt32* numberOfFrequencies);
   ViStatus GetNormalizationCoefficients(ViSession vi, ViConstString channelList, ViInt32 bufferSize, niScope_coefficientInfo coefficientInfo[], ViInt32* numberOfCoefficientSets);
   ViStatus GetScalingCoefficients(ViSession vi, ViConstString channelList, ViInt32 bufferSize, niScope_coefficientInfo coefficientInfo[], ViInt32* numberOfCoefficientSets);
+  ViStatus GetStartTimestampInformation(ViSession vi, ViUInt32* sysTimeIn128BitsT1, ViUInt32* sysTimeIn128BitsT2, ViUInt32* sysTimeIn128BitsT3, ViUInt32* sysTimeIn128BitsT4, ViReal64* deviceTimeInAbsoluteTimeUnits);
   ViStatus GetStreamEndpointHandle(ViSession vi, ViConstString streamName, ViUInt32* writerHandle);
   ViStatus ImportAttributeConfigurationBuffer(ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[]);
   ViStatus ImportAttributeConfigurationFile(ViSession vi, ViConstString filePath);
@@ -179,6 +180,7 @@ class NiScopeLibrary : public niscope_grpc::NiScopeLibraryInterface {
   using GetFrequencyResponsePtr = decltype(&niScope_GetFrequencyResponse);
   using GetNormalizationCoefficientsPtr = decltype(&niScope_GetNormalizationCoefficients);
   using GetScalingCoefficientsPtr = decltype(&niScope_GetScalingCoefficients);
+  using GetStartTimestampInformationPtr = decltype(&niScope_GetStartTimestampInformation);
   using GetStreamEndpointHandlePtr = decltype(&niScope_GetStreamEndpointHandle);
   using ImportAttributeConfigurationBufferPtr = decltype(&niScope_ImportAttributeConfigurationBuffer);
   using ImportAttributeConfigurationFilePtr = decltype(&niScope_ImportAttributeConfigurationFile);
@@ -273,6 +275,7 @@ class NiScopeLibrary : public niscope_grpc::NiScopeLibraryInterface {
     GetFrequencyResponsePtr GetFrequencyResponse;
     GetNormalizationCoefficientsPtr GetNormalizationCoefficients;
     GetScalingCoefficientsPtr GetScalingCoefficients;
+    GetStartTimestampInformationPtr GetStartTimestampInformation;
     GetStreamEndpointHandlePtr GetStreamEndpointHandle;
     ImportAttributeConfigurationBufferPtr ImportAttributeConfigurationBuffer;
     ImportAttributeConfigurationFilePtr ImportAttributeConfigurationFile;

--- a/generated/niscope/niscope_library_interface.h
+++ b/generated/niscope/niscope_library_interface.h
@@ -8,6 +8,7 @@
 
 #include <grpcpp/grpcpp.h>
 #include <niScopeCal.h>
+#include "niScopePrivate.h"
 
 namespace niscope_grpc {
 
@@ -82,6 +83,7 @@ class NiScopeLibraryInterface {
   virtual ViStatus GetFrequencyResponse(ViSession vi, ViConstString channel, ViInt32 bufferSize, ViReal64 frequencies[], ViReal64 amplitudes[], ViReal64 phases[], ViInt32* numberOfFrequencies) = 0;
   virtual ViStatus GetNormalizationCoefficients(ViSession vi, ViConstString channelList, ViInt32 bufferSize, niScope_coefficientInfo coefficientInfo[], ViInt32* numberOfCoefficientSets) = 0;
   virtual ViStatus GetScalingCoefficients(ViSession vi, ViConstString channelList, ViInt32 bufferSize, niScope_coefficientInfo coefficientInfo[], ViInt32* numberOfCoefficientSets) = 0;
+  virtual ViStatus GetStartTimestampInformation(ViSession vi, ViUInt32* sysTimeIn128BitsT1, ViUInt32* sysTimeIn128BitsT2, ViUInt32* sysTimeIn128BitsT3, ViUInt32* sysTimeIn128BitsT4, ViReal64* deviceTimeInAbsoluteTimeUnits) = 0;
   virtual ViStatus GetStreamEndpointHandle(ViSession vi, ViConstString streamName, ViUInt32* writerHandle) = 0;
   virtual ViStatus ImportAttributeConfigurationBuffer(ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[]) = 0;
   virtual ViStatus ImportAttributeConfigurationFile(ViSession vi, ViConstString filePath) = 0;

--- a/generated/niscope/niscope_mock_library.h
+++ b/generated/niscope/niscope_mock_library.h
@@ -84,6 +84,7 @@ class NiScopeMockLibrary : public niscope_grpc::NiScopeLibraryInterface {
   MOCK_METHOD(ViStatus, GetFrequencyResponse, (ViSession vi, ViConstString channel, ViInt32 bufferSize, ViReal64 frequencies[], ViReal64 amplitudes[], ViReal64 phases[], ViInt32* numberOfFrequencies), (override));
   MOCK_METHOD(ViStatus, GetNormalizationCoefficients, (ViSession vi, ViConstString channelList, ViInt32 bufferSize, niScope_coefficientInfo coefficientInfo[], ViInt32* numberOfCoefficientSets), (override));
   MOCK_METHOD(ViStatus, GetScalingCoefficients, (ViSession vi, ViConstString channelList, ViInt32 bufferSize, niScope_coefficientInfo coefficientInfo[], ViInt32* numberOfCoefficientSets), (override));
+  MOCK_METHOD(ViStatus, GetStartTimestampInformation, (ViSession vi, ViUInt32* sysTimeIn128BitsT1, ViUInt32* sysTimeIn128BitsT2, ViUInt32* sysTimeIn128BitsT3, ViUInt32* sysTimeIn128BitsT4, ViReal64* deviceTimeInAbsoluteTimeUnits), (override));
   MOCK_METHOD(ViStatus, GetStreamEndpointHandle, (ViSession vi, ViConstString streamName, ViUInt32* writerHandle), (override));
   MOCK_METHOD(ViStatus, ImportAttributeConfigurationBuffer, (ViSession vi, ViInt32 sizeInBytes, ViInt8 configuration[]), (override));
   MOCK_METHOD(ViStatus, ImportAttributeConfigurationFile, (ViSession vi, ViConstString filePath), (override));

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -2256,6 +2256,38 @@ namespace niscope_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiScopeService::GetStartTimestampInformation(::grpc::ServerContext* context, const GetStartTimestampInformationRequest* request, GetStartTimestampInformationResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto vi_grpc_session = request->vi();
+      ViSession vi = session_repository_->access_session(vi_grpc_session.name());
+      ViUInt32 sys_time_in128_bits_t1 {};
+      ViUInt32 sys_time_in128_bits_t2 {};
+      ViUInt32 sys_time_in128_bits_t3 {};
+      ViUInt32 sys_time_in128_bits_t4 {};
+      ViReal64 device_time_in_absolute_time_units {};
+      auto status = library_->GetStartTimestampInformation(vi, &sys_time_in128_bits_t1, &sys_time_in128_bits_t2, &sys_time_in128_bits_t3, &sys_time_in128_bits_t4, &device_time_in_absolute_time_units);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForViSession(context, status, vi);
+      }
+      response->set_status(status);
+      response->set_sys_time_in128_bits_t1(sys_time_in128_bits_t1);
+      response->set_sys_time_in128_bits_t2(sys_time_in128_bits_t2);
+      response->set_sys_time_in128_bits_t3(sys_time_in128_bits_t3);
+      response->set_sys_time_in128_bits_t4(sys_time_in128_bits_t4);
+      response->set_device_time_in_absolute_time_units(device_time_in_absolute_time_units);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiScopeService::GetStreamEndpointHandle(::grpc::ServerContext* context, const GetStreamEndpointHandleRequest* request, GetStreamEndpointHandleResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/niscope/niscope_service.cpp
+++ b/generated/niscope/niscope_service.cpp
@@ -2264,20 +2264,20 @@ namespace niscope_grpc {
     try {
       auto vi_grpc_session = request->vi();
       ViSession vi = session_repository_->access_session(vi_grpc_session.name());
-      ViUInt32 sys_time_in128_bits_t1 {};
-      ViUInt32 sys_time_in128_bits_t2 {};
-      ViUInt32 sys_time_in128_bits_t3 {};
-      ViUInt32 sys_time_in128_bits_t4 {};
+      ViUInt32 sys_time_in_128_bits_t1 {};
+      ViUInt32 sys_time_in_128_bits_t2 {};
+      ViUInt32 sys_time_in_128_bits_t3 {};
+      ViUInt32 sys_time_in_128_bits_t4 {};
       ViReal64 device_time_in_absolute_time_units {};
-      auto status = library_->GetStartTimestampInformation(vi, &sys_time_in128_bits_t1, &sys_time_in128_bits_t2, &sys_time_in128_bits_t3, &sys_time_in128_bits_t4, &device_time_in_absolute_time_units);
+      auto status = library_->GetStartTimestampInformation(vi, &sys_time_in_128_bits_t1, &sys_time_in_128_bits_t2, &sys_time_in_128_bits_t3, &sys_time_in_128_bits_t4, &device_time_in_absolute_time_units);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForViSession(context, status, vi);
       }
       response->set_status(status);
-      response->set_sys_time_in128_bits_t1(sys_time_in128_bits_t1);
-      response->set_sys_time_in128_bits_t2(sys_time_in128_bits_t2);
-      response->set_sys_time_in128_bits_t3(sys_time_in128_bits_t3);
-      response->set_sys_time_in128_bits_t4(sys_time_in128_bits_t4);
+      response->set_sys_time_in_128_bits_t1(sys_time_in_128_bits_t1);
+      response->set_sys_time_in_128_bits_t2(sys_time_in_128_bits_t2);
+      response->set_sys_time_in_128_bits_t3(sys_time_in_128_bits_t3);
+      response->set_sys_time_in_128_bits_t4(sys_time_in_128_bits_t4);
       response->set_device_time_in_absolute_time_units(device_time_in_absolute_time_units);
       return ::grpc::Status::OK;
     }

--- a/generated/niscope/niscope_service.h
+++ b/generated/niscope/niscope_service.h
@@ -108,6 +108,7 @@ public:
   ::grpc::Status GetFrequencyResponse(::grpc::ServerContext* context, const GetFrequencyResponseRequest* request, GetFrequencyResponseResponse* response) override;
   ::grpc::Status GetNormalizationCoefficients(::grpc::ServerContext* context, const GetNormalizationCoefficientsRequest* request, GetNormalizationCoefficientsResponse* response) override;
   ::grpc::Status GetScalingCoefficients(::grpc::ServerContext* context, const GetScalingCoefficientsRequest* request, GetScalingCoefficientsResponse* response) override;
+  ::grpc::Status GetStartTimestampInformation(::grpc::ServerContext* context, const GetStartTimestampInformationRequest* request, GetStartTimestampInformationResponse* response) override;
   ::grpc::Status GetStreamEndpointHandle(::grpc::ServerContext* context, const GetStreamEndpointHandleRequest* request, GetStreamEndpointHandleResponse* response) override;
   ::grpc::Status ImportAttributeConfigurationBuffer(::grpc::ServerContext* context, const ImportAttributeConfigurationBufferRequest* request, ImportAttributeConfigurationBufferResponse* response) override;
   ::grpc::Status ImportAttributeConfigurationFile(::grpc::ServerContext* context, const ImportAttributeConfigurationFileRequest* request, ImportAttributeConfigurationFileResponse* response) override;

--- a/imports/include/niScopePrivate.h
+++ b/imports/include/niScopePrivate.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#define IVI_DO_NOT_INCLUDE_VISA_HEADERS
+#include "ivi.h"
+#undef IVI_DO_NOT_INCLUDE_VISA_HEADERS
+#include "niScope.h"
+
+// explicitly tell the make files what functions to export
+extern "C"
+{
+ViStatus _VI_FUNC niScope_GetStartTimestampInformation(
+   ViSession vi,
+   ViUInt32* sysTimeIn128BitsT1,
+   ViUInt32* sysTimeIn128BitsT2,
+   ViUInt32* sysTimeIn128BitsT3,
+   ViUInt32* sysTimeIn128BitsT4,
+   ViReal64* deviceTimeInAbsoluteTimeUnits);
+}

--- a/source/codegen/metadata/niscope/attributes.py
+++ b/source/codegen/metadata/niscope/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0f168
+# This file is generated from NI-SCOPE API metadata version 23.3.0d9999
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niscope/config.py
+++ b/source/codegen/metadata/niscope/config.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0f168
+# This file is generated from NI-SCOPE API metadata version 23.3.0d9999
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
-        ]
+        ],
+        'niScopePrivate.h': [
+            'library_interface.h'
+        ],
     },
-    'api_version': '23.0.0f168',
+    'api_version': '23.3.0d9999',
     'c_function_prefix': 'niScope_',
     'c_header': 'niScopeCal.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/niscope/config.py
+++ b/source/codegen/metadata/niscope/config.py
@@ -7,7 +7,7 @@ config = {
         ],
         'niScopePrivate.h': [
             'library_interface.h'
-        ],
+        ]
     },
     'api_version': '23.3.0d9999',
     'c_function_prefix': 'niScope_',

--- a/source/codegen/metadata/niscope/enums.py
+++ b/source/codegen/metadata/niscope/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0f168
+# This file is generated from NI-SCOPE API metadata version 23.3.0d9999
 enums = {
     'AcquisitionStatus': {
         'codegen_method': 'public',
@@ -583,12 +583,12 @@ enums = {
                 'value': 10
             },
             {
-                'name': 'NISCOPE_VAL_REF_CLOCK',
-                'value': 100
-            },
-            {
                 'name': 'NISCOPE_VAL_5V_OUT',
                 'value': 13
+            },
+            {
+                'name': 'NISCOPE_VAL_REF_CLOCK',
+                'value': 100
             },
             {
                 'name': 'NISCOPE_VAL_SAMPLE_CLOCK',

--- a/source/codegen/metadata/niscope/functions.py
+++ b/source/codegen/metadata/niscope/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0f168
+# This file is generated from NI-SCOPE API metadata version 23.3.0d9999
 functions = {
     'Abort': {
         'codegen_method': 'public',
@@ -2668,6 +2668,54 @@ functions = {
                 'grpc_type': 'sint32',
                 'name': 'numberOfCoefficientSets',
                 'type': 'ViInt32'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
+    'GetStartTimestampInformation': {
+        'codegen_method': 'public',
+        'parameters': [
+            {
+                'cppName': 'vi',
+                'direction': 'in',
+                'grpc_type': 'nidevice_grpc.Session',
+                'name': 'vi',
+                'type': 'ViSession'
+            },
+            {
+                'cppName': 'sysTimeIn128BitsT1',
+                'direction': 'out',
+                'grpc_type': 'uint32',
+                'name': 'sysTimeIn128BitsT1',
+                'type': 'ViUInt32'
+            },
+            {
+                'cppName': 'sysTimeIn128BitsT2',
+                'direction': 'out',
+                'grpc_type': 'uint32',
+                'name': 'sysTimeIn128BitsT2',
+                'type': 'ViUInt32'
+            },
+            {
+                'cppName': 'sysTimeIn128BitsT3',
+                'direction': 'out',
+                'grpc_type': 'uint32',
+                'name': 'sysTimeIn128BitsT3',
+                'type': 'ViUInt32'
+            },
+            {
+                'cppName': 'sysTimeIn128BitsT4',
+                'direction': 'out',
+                'grpc_type': 'uint32',
+                'name': 'sysTimeIn128BitsT4',
+                'type': 'ViUInt32'
+            },
+            {
+                'cppName': 'deviceTimeInAbsoluteTimeUnits',
+                'direction': 'out',
+                'grpc_type': 'double',
+                'name': 'deviceTimeInAbsoluteTimeUnits',
+                'type': 'ViReal64'
             }
         ],
         'returns': 'ViStatus'

--- a/source/codegen/metadata/niscope/functions.py
+++ b/source/codegen/metadata/niscope/functions.py
@@ -2685,6 +2685,7 @@ functions = {
             {
                 'cppName': 'sysTimeIn128BitsT1',
                 'direction': 'out',
+                'grpc_name': 'sys_time_in_128_bits_t1',
                 'grpc_type': 'uint32',
                 'name': 'sysTimeIn128BitsT1',
                 'type': 'ViUInt32'
@@ -2692,6 +2693,7 @@ functions = {
             {
                 'cppName': 'sysTimeIn128BitsT2',
                 'direction': 'out',
+                'grpc_name': 'sys_time_in_128_bits_t2',
                 'grpc_type': 'uint32',
                 'name': 'sysTimeIn128BitsT2',
                 'type': 'ViUInt32'
@@ -2699,6 +2701,7 @@ functions = {
             {
                 'cppName': 'sysTimeIn128BitsT3',
                 'direction': 'out',
+                'grpc_name': 'sys_time_in_128_bits_t3',
                 'grpc_type': 'uint32',
                 'name': 'sysTimeIn128BitsT3',
                 'type': 'ViUInt32'
@@ -2706,6 +2709,7 @@ functions = {
             {
                 'cppName': 'sysTimeIn128BitsT4',
                 'direction': 'out',
+                'grpc_name': 'sys_time_in_128_bits_t4',
                 'grpc_type': 'uint32',
                 'name': 'sysTimeIn128BitsT4',
                 'type': 'ViUInt32'

--- a/source/codegen/metadata/niscope/niscope.proto
+++ b/source/codegen/metadata/niscope/niscope.proto
@@ -1707,10 +1707,10 @@ message GetStartTimestampInformationRequest {
 
 message GetStartTimestampInformationResponse {
   int32 status = 1;
-  uint32 sys_time_in128_bits_t1 = 2;
-  uint32 sys_time_in128_bits_t2 = 3;
-  uint32 sys_time_in128_bits_t3 = 4;
-  uint32 sys_time_in128_bits_t4 = 5;
+  uint32 sys_time_in_128_bits_t1 = 2;
+  uint32 sys_time_in_128_bits_t2 = 3;
+  uint32 sys_time_in_128_bits_t3 = 4;
+  uint32 sys_time_in_128_bits_t4 = 5;
   double device_time_in_absolute_time_units = 6;
 }
 

--- a/source/codegen/metadata/niscope/niscope.proto
+++ b/source/codegen/metadata/niscope/niscope.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SCOPE API metadata version 23.0.0f168
+// This file is generated from NI-SCOPE API metadata version 23.3.0d9999
 //---------------------------------------------------------------------
 // Proto file for the NI-SCOPE Metadata
 //---------------------------------------------------------------------
@@ -84,6 +84,7 @@ service NiScope {
   rpc GetFrequencyResponse(GetFrequencyResponseRequest) returns (GetFrequencyResponseResponse);
   rpc GetNormalizationCoefficients(GetNormalizationCoefficientsRequest) returns (GetNormalizationCoefficientsResponse);
   rpc GetScalingCoefficients(GetScalingCoefficientsRequest) returns (GetScalingCoefficientsResponse);
+  rpc GetStartTimestampInformation(GetStartTimestampInformationRequest) returns (GetStartTimestampInformationResponse);
   rpc GetStreamEndpointHandle(GetStreamEndpointHandleRequest) returns (GetStreamEndpointHandleResponse);
   rpc ImportAttributeConfigurationBuffer(ImportAttributeConfigurationBufferRequest) returns (ImportAttributeConfigurationBufferResponse);
   rpc ImportAttributeConfigurationFile(ImportAttributeConfigurationFileRequest) returns (ImportAttributeConfigurationFileResponse);
@@ -473,8 +474,8 @@ enum ExportableSignals {
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_ADVANCE_EVENT = 6;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_START_EVENT = 7;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_REF_EVENT = 10;
-  EXPORTABLE_SIGNALS_NISCOPE_VAL_REF_CLOCK = 100;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_5V_OUT = 13;
+  EXPORTABLE_SIGNALS_NISCOPE_VAL_REF_CLOCK = 100;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_SAMPLE_CLOCK = 101;
 }
 
@@ -1698,6 +1699,19 @@ message GetScalingCoefficientsResponse {
   int32 status = 1;
   repeated CoefficientInfo coefficient_info = 2;
   sint32 number_of_coefficient_sets = 3;
+}
+
+message GetStartTimestampInformationRequest {
+  nidevice_grpc.Session vi = 1;
+}
+
+message GetStartTimestampInformationResponse {
+  int32 status = 1;
+  uint32 sys_time_in128_bits_t1 = 2;
+  uint32 sys_time_in128_bits_t2 = 3;
+  uint32 sys_time_in128_bits_t3 = 4;
+  uint32 sys_time_in128_bits_t4 = 5;
+  double device_time_in_absolute_time_units = 6;
 }
 
 message GetStreamEndpointHandleRequest {

--- a/source/tests/system/niscope_driver_api_tests.cpp
+++ b/source/tests/system/niscope_driver_api_tests.cpp
@@ -558,10 +558,10 @@ TEST_F(NiScopeDriverApiTest, NiScopeGetStartTimestampInformation_SendRequest_Non
 
   EXPECT_TRUE(status.ok());
   expect_api_success(response.status());
-  EXPECT_NE(0, response.sys_time_in128_bits_t1());
-  EXPECT_NE(0, response.sys_time_in128_bits_t2());
-  EXPECT_NE(0, response.sys_time_in128_bits_t3());
-  EXPECT_EQ(0, response.sys_time_in128_bits_t4()); // Not sure why this is always 0, may be because it's on a simulated device.
+  EXPECT_NE(0, response.sys_time_in_128_bits_t1());
+  EXPECT_NE(0, response.sys_time_in_128_bits_t2());
+  EXPECT_NE(0, response.sys_time_in_128_bits_t3());
+  EXPECT_EQ(0, response.sys_time_in_128_bits_t4()); // Not sure why this is always 0, may be because it's on a simulated device.
   EXPECT_EQ(0, response.device_time_in_absolute_time_units()); // Not sure why this is always 0, may be because it's on a simulated device.
 }
 

--- a/source/tests/system/niscope_driver_api_tests.cpp
+++ b/source/tests/system/niscope_driver_api_tests.cpp
@@ -546,6 +546,25 @@ TEST_F(NiScopeDriverApiTest, NiScopeGetNormalizationCoefficients_SendRequest_Non
   EXPECT_NE(0, response.coefficient_info(0).gain());
 }
 
+TEST_F(NiScopeDriverApiTest, NiScopeGetStartTimestampInformation_SendRequest_NonZeroTimestampsReturned)
+{
+  auto_setup();
+  ::grpc::ClientContext context;
+  scope::GetStartTimestampInformationRequest request;
+  request.mutable_vi()->set_name(GetSessionName());
+  scope::GetStartTimestampInformationResponse response;
+
+  ::grpc::Status status = GetStub()->GetStartTimestampInformation(&context, request, &response);
+
+  EXPECT_TRUE(status.ok());
+  expect_api_success(response.status());
+  EXPECT_NE(0, response.sys_time_in128_bits_t1());
+  EXPECT_NE(0, response.sys_time_in128_bits_t2());
+  EXPECT_NE(0, response.sys_time_in128_bits_t3());
+  EXPECT_EQ(0, response.sys_time_in128_bits_t4()); // Not sure why this is always 0, may be because it's on a simulated device.
+  EXPECT_EQ(0, response.device_time_in_absolute_time_units()); // Not sure why this is always 0, may be because it's on a simulated device.
+}
+
 }  // namespace system
 }  // namespace tests
 }  // namespace ni


### PR DESCRIPTION
### What does this Pull Request accomplish?

Exposes the private niScope_GetStartTimestampInformation in niscope.proto

### Why should this Pull Request be merged?

[AB#2267151](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2267151)

While developing the grpc-device DVL plugin for LabVIEW calls, it was noted that other plugins call a private `niScope_GetStartTimestampInformation` to populate some of the return info for their WDT methods like `niScope_LVGenericFetchWDT_Info`. And currently, that method isn't exposed in grpc-device.

Still trying to determine if it makes sense to try to put this in the regular niscope.proto or if it warrants something more akin to the restricted services and the DVL plugin for grpc-device will have to pull that in as well for these WDT methods to work. Or some other option I'm not thinking of / prompting a discussion about if exposing a private method like this is appropriate at all.

### What testing has been done?

Build passes and new system test for GetStartTimestampInformation succeeds.
