### PR TITLE
Bump project version in main to 2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.12.0)
 
 project(ni_grpc_device_server
   LANGUAGES C CXX
-  VERSION 2.0.0)
+  VERSION 2.1.0)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(CreateVirtualEnvironment)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Bumps project version in main to 2.1 (anticipating 2.1 release in the future).

### Why should this Pull Request be merged?

We want to start making the next version dev exports in AzDo (see [this PR](https://dev.azure.com/ni/DevCentral/_git/ni-central/pullrequest/426490) leading up to the next release instead of continuing to build 2.0 dev exports when it's gone final.

### What testing has been done?

Built and verified version in ni_grpc_device_server.exe details on Windows shows 2.1.0.
