### PR TITLE
Fix intermittent LTE test.

### DIFF
--- a/source/tests/system/nirfmxlte_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxlte_driver_api_tests.cpp
@@ -1110,6 +1110,7 @@ TEST_F(NiRFmxLTEDriverApiTests, ULModAccSingleCarrierFromExample_FetchData_DataL
     EXPECT_SUCCESS(session, client::initiate(stub(), session, "", ""));
 
     // Intermittently gives "374603: Unable to synchronize." and outputs nan values
+    mod_acc_fetch_composite_evm_response = client::mod_acc_fetch_composite_evm(stub(), session, "", 10.0);
     if (mod_acc_fetch_composite_evm_response.status() == SYNC_FAILURE_WARNING && attempts < 5) {
       TearDown();
       SetUp();


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes the intermittent LTE test by actually making a call that was missing.

### Why should this Pull Request be merged?

Fixes #791 

### What testing has been done?

Ran test in a loop for 500 times with `SetUp`/`TearDown` call at beginning/end of loop.
Without changes failed consistently within 100 iterations.
After change it's passed consistently.