### PR TITLE
Include meas_wfm_size in niscope.proto for FetchArrayMeasurement.

### DIFF
--- a/generated/niscope/niscope.proto
+++ b/generated/niscope/niscope.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SCOPE API metadata version 23.0.0f168
+// This file is generated from NI-SCOPE API metadata version 23.3.0d9999
 //---------------------------------------------------------------------
 // Proto file for the NI-SCOPE Metadata
 //---------------------------------------------------------------------
@@ -473,8 +473,8 @@ enum ExportableSignals {
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_ADVANCE_EVENT = 6;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_START_EVENT = 7;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_REF_EVENT = 10;
-  EXPORTABLE_SIGNALS_NISCOPE_VAL_REF_CLOCK = 100;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_5V_OUT = 13;
+  EXPORTABLE_SIGNALS_NISCOPE_VAL_REF_CLOCK = 100;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_SAMPLE_CLOCK = 101;
 }
 
@@ -1439,6 +1439,7 @@ message FetchArrayMeasurementRequest {
     ArrayMeasurement array_meas_function = 4;
     sint32 array_meas_function_raw = 5;
   }
+  sint32 meas_wfm_size = 6;
 }
 
 message FetchArrayMeasurementResponse {

--- a/generated/niscope/niscope.proto
+++ b/generated/niscope/niscope.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SCOPE API metadata version 23.3.0d9999
+// This file is generated from NI-SCOPE API metadata version 23.3.0d127
 //---------------------------------------------------------------------
 // Proto file for the NI-SCOPE Metadata
 //---------------------------------------------------------------------

--- a/generated/niscope/niscope.proto
+++ b/generated/niscope/niscope.proto
@@ -1440,6 +1440,7 @@ message FetchArrayMeasurementRequest {
     sint32 array_meas_function_raw = 5;
   }
   sint32 meas_wfm_size = 6;
+  bool info_only = 7;
 }
 
 message FetchArrayMeasurementResponse {

--- a/generated/niscope/niscope.proto
+++ b/generated/niscope/niscope.proto
@@ -1439,8 +1439,7 @@ message FetchArrayMeasurementRequest {
     ArrayMeasurement array_meas_function = 4;
     sint32 array_meas_function_raw = 5;
   }
-  sint32 meas_wfm_size = 6;
-  bool info_only = 7;
+  optional sint32 meas_wfm_size = 6;
 }
 
 message FetchArrayMeasurementResponse {

--- a/generated/niscope/niscope_client.cpp
+++ b/generated/niscope/niscope_client.cpp
@@ -1140,7 +1140,7 @@ fetch(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& 
 }
 
 FetchArrayMeasurementResponse
-fetch_array_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const simple_variant<ArrayMeasurement, pb::int32>& array_meas_function, const pb::int32& meas_wfm_size, const bool& info_only)
+fetch_array_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const simple_variant<ArrayMeasurement, pb::int32>& array_meas_function, const pb::int32& meas_wfm_size)
 {
   ::grpc::ClientContext context;
 
@@ -1157,7 +1157,6 @@ fetch_array_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, c
     request.set_array_meas_function_raw(*array_meas_function_raw_ptr);
   }
   request.set_meas_wfm_size(meas_wfm_size);
-  request.set_info_only(info_only);
 
   auto response = FetchArrayMeasurementResponse{};
 

--- a/generated/niscope/niscope_client.cpp
+++ b/generated/niscope/niscope_client.cpp
@@ -1140,7 +1140,7 @@ fetch(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& 
 }
 
 FetchArrayMeasurementResponse
-fetch_array_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const simple_variant<ArrayMeasurement, pb::int32>& array_meas_function, const pb::int32& meas_wfm_size)
+fetch_array_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const simple_variant<ArrayMeasurement, pb::int32>& array_meas_function, const pb::int32& meas_wfm_size, const bool& info_only)
 {
   ::grpc::ClientContext context;
 
@@ -1157,6 +1157,7 @@ fetch_array_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, c
     request.set_array_meas_function_raw(*array_meas_function_raw_ptr);
   }
   request.set_meas_wfm_size(meas_wfm_size);
+  request.set_info_only(info_only);
 
   auto response = FetchArrayMeasurementResponse{};
 

--- a/generated/niscope/niscope_client.cpp
+++ b/generated/niscope/niscope_client.cpp
@@ -1140,7 +1140,7 @@ fetch(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& 
 }
 
 FetchArrayMeasurementResponse
-fetch_array_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const simple_variant<ArrayMeasurement, pb::int32>& array_meas_function)
+fetch_array_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const simple_variant<ArrayMeasurement, pb::int32>& array_meas_function, const pb::int32& meas_wfm_size)
 {
   ::grpc::ClientContext context;
 
@@ -1156,6 +1156,7 @@ fetch_array_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, c
   else if (array_meas_function_raw_ptr) {
     request.set_array_meas_function_raw(*array_meas_function_raw_ptr);
   }
+  request.set_meas_wfm_size(meas_wfm_size);
 
   auto response = FetchArrayMeasurementResponse{};
 

--- a/generated/niscope/niscope_client.h
+++ b/generated/niscope/niscope_client.h
@@ -67,7 +67,7 @@ ExportAttributeConfigurationBufferResponse export_attribute_configuration_buffer
 ExportAttributeConfigurationFileResponse export_attribute_configuration_file(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& file_path);
 ExportSignalResponse export_signal(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<ExportableSignals, pb::int32>& signal, const std::string& signal_identifier, const simple_variant<ClockingTerminalValues, std::string>& output_terminal);
 FetchResponse fetch(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const pb::int32& num_samples);
-FetchArrayMeasurementResponse fetch_array_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const simple_variant<ArrayMeasurement, pb::int32>& array_meas_function, const pb::int32& meas_wfm_size, const bool& info_only);
+FetchArrayMeasurementResponse fetch_array_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const simple_variant<ArrayMeasurement, pb::int32>& array_meas_function, const pb::int32& meas_wfm_size);
 FetchBinary16Response fetch_binary16(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const pb::int32& num_samples);
 FetchBinary32Response fetch_binary32(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const pb::int32& num_samples);
 FetchBinary8Response fetch_binary8(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const pb::int32& num_samples);

--- a/generated/niscope/niscope_client.h
+++ b/generated/niscope/niscope_client.h
@@ -67,7 +67,7 @@ ExportAttributeConfigurationBufferResponse export_attribute_configuration_buffer
 ExportAttributeConfigurationFileResponse export_attribute_configuration_file(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& file_path);
 ExportSignalResponse export_signal(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<ExportableSignals, pb::int32>& signal, const std::string& signal_identifier, const simple_variant<ClockingTerminalValues, std::string>& output_terminal);
 FetchResponse fetch(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const pb::int32& num_samples);
-FetchArrayMeasurementResponse fetch_array_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const simple_variant<ArrayMeasurement, pb::int32>& array_meas_function);
+FetchArrayMeasurementResponse fetch_array_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const simple_variant<ArrayMeasurement, pb::int32>& array_meas_function, const pb::int32& meas_wfm_size);
 FetchBinary16Response fetch_binary16(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const pb::int32& num_samples);
 FetchBinary32Response fetch_binary32(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const pb::int32& num_samples);
 FetchBinary8Response fetch_binary8(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const pb::int32& num_samples);

--- a/generated/niscope/niscope_client.h
+++ b/generated/niscope/niscope_client.h
@@ -67,7 +67,7 @@ ExportAttributeConfigurationBufferResponse export_attribute_configuration_buffer
 ExportAttributeConfigurationFileResponse export_attribute_configuration_file(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& file_path);
 ExportSignalResponse export_signal(const StubPtr& stub, const nidevice_grpc::Session& vi, const simple_variant<ExportableSignals, pb::int32>& signal, const std::string& signal_identifier, const simple_variant<ClockingTerminalValues, std::string>& output_terminal);
 FetchResponse fetch(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const pb::int32& num_samples);
-FetchArrayMeasurementResponse fetch_array_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const simple_variant<ArrayMeasurement, pb::int32>& array_meas_function, const pb::int32& meas_wfm_size);
+FetchArrayMeasurementResponse fetch_array_measurement(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const simple_variant<ArrayMeasurement, pb::int32>& array_meas_function, const pb::int32& meas_wfm_size, const bool& info_only);
 FetchBinary16Response fetch_binary16(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const pb::int32& num_samples);
 FetchBinary32Response fetch_binary32(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const pb::int32& num_samples);
 FetchBinary8Response fetch_binary8(const StubPtr& stub, const nidevice_grpc::Session& vi, const std::string& channel_list, const double& timeout, const pb::int32& num_samples);

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -1157,7 +1157,7 @@ def is_get_last_error_output_param(parameter: dict) -> bool:
 
 
 def is_optional_param(parameter: dict) -> bool:
-    """Whether the parameter is marked is_optional"""
+    """Whether the parameter is marked is_optional."""
     return parameter.get("is_optional", False)
 
 

--- a/source/codegen/common_helpers.py
+++ b/source/codegen/common_helpers.py
@@ -580,8 +580,8 @@ def _has_strlen_bug(parameter: dict) -> bool:
     return has_size_mechanism_tag(parameter, "strlen-bug")
 
 
-def is_optional(parameter: dict) -> bool:
-    """Whether the given parameter is marked as optional."""
+def has_optional_size_tag(parameter: dict) -> bool:
+    """Whether the given parameter has a size mechanism tag "optional"."""
     return has_size_mechanism_tag(parameter, "optional")
 
 
@@ -1152,8 +1152,13 @@ def is_return_value(parameter: dict) -> bool:
 
 
 def is_get_last_error_output_param(parameter: dict) -> bool:
-    """Return True if pararameter is a get_last_error parameter."""
+    """Return True if parameter is a get_last_error parameter."""
     return "get_last_error" in parameter
+
+
+def is_optional_param(parameter: dict) -> bool:
+    """Whether the parameter is marked is_optional"""
+    return parameter.get("is_optional", False)
 
 
 def get_driver_api_params(parameters: List[dict]) -> List[dict]:

--- a/source/codegen/metadata/niscope/attributes.py
+++ b/source/codegen/metadata/niscope/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.3.0d9999
+# This file is generated from NI-SCOPE API metadata version 23.3.0d127
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niscope/attributes.py
+++ b/source/codegen/metadata/niscope/attributes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0f168
+# This file is generated from NI-SCOPE API metadata version 23.3.0d9999
 attributes = {
     1050002: {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niscope/config.py
+++ b/source/codegen/metadata/niscope/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0f168
+# This file is generated from NI-SCOPE API metadata version 23.3.0d9999
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.0.0f168',
+    'api_version': '23.3.0d9999',
     'c_function_prefix': 'niScope_',
     'c_header': 'niScopeCal.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/niscope/config.py
+++ b/source/codegen/metadata/niscope/config.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.3.0d9999
+# This file is generated from NI-SCOPE API metadata version 23.3.0d127
 config = {
     'additional_headers': {
         'custom/ivi_errors.h': [
             'service.cpp'
         ]
     },
-    'api_version': '23.3.0d9999',
+    'api_version': '23.3.0d127',
     'c_function_prefix': 'niScope_',
     'c_header': 'niScopeCal.h',
     'close_function': 'Close',

--- a/source/codegen/metadata/niscope/enums.py
+++ b/source/codegen/metadata/niscope/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.3.0d9999
+# This file is generated from NI-SCOPE API metadata version 23.3.0d127
 enums = {
     'AcquisitionStatus': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niscope/enums.py
+++ b/source/codegen/metadata/niscope/enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0f168
+# This file is generated from NI-SCOPE API metadata version 23.3.0d9999
 enums = {
     'AcquisitionStatus': {
         'codegen_method': 'public',
@@ -583,12 +583,12 @@ enums = {
                 'value': 10
             },
             {
-                'name': 'NISCOPE_VAL_REF_CLOCK',
-                'value': 100
-            },
-            {
                 'name': 'NISCOPE_VAL_5V_OUT',
                 'value': 13
+            },
+            {
+                'name': 'NISCOPE_VAL_REF_CLOCK',
+                'value': 100
             },
             {
                 'name': 'NISCOPE_VAL_SAMPLE_CLOCK',

--- a/source/codegen/metadata/niscope/functions.py
+++ b/source/codegen/metadata/niscope/functions.py
@@ -1658,6 +1658,14 @@ functions = {
                     'value': 'actual_num_wfms'
                 },
                 'type': 'struct niScope_wfmInfo[]'
+            },
+            {
+                'cppName': 'infoOnly',
+                'direction': 'in',
+                'grpc_type': 'bool',
+                'name': 'infoOnly',
+                'proto_only': True,
+                'type': 'bool'
             }
         ],
         'returns': 'ViStatus'

--- a/source/codegen/metadata/niscope/functions.py
+++ b/source/codegen/metadata/niscope/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.0.0f168
+# This file is generated from NI-SCOPE API metadata version 23.3.0d9999
 functions = {
     'Abort': {
         'codegen_method': 'public',
@@ -1634,7 +1634,6 @@ functions = {
                 'cppName': 'measWfmSize',
                 'direction': 'in',
                 'grpc_type': 'sint32',
-                'include_in_proto': False,
                 'name': 'measWfmSize',
                 'type': 'ViInt32'
             },

--- a/source/codegen/metadata/niscope/functions.py
+++ b/source/codegen/metadata/niscope/functions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# This file is generated from NI-SCOPE API metadata version 23.3.0d9999
+# This file is generated from NI-SCOPE API metadata version 23.3.0d127
 functions = {
     'Abort': {
         'codegen_method': 'public',

--- a/source/codegen/metadata/niscope/functions.py
+++ b/source/codegen/metadata/niscope/functions.py
@@ -1634,6 +1634,7 @@ functions = {
                 'cppName': 'measWfmSize',
                 'direction': 'in',
                 'grpc_type': 'sint32',
+                'is_optional': True,
                 'name': 'measWfmSize',
                 'type': 'ViInt32'
             },
@@ -1658,14 +1659,6 @@ functions = {
                     'value': 'actual_num_wfms'
                 },
                 'type': 'struct niScope_wfmInfo[]'
-            },
-            {
-                'cppName': 'infoOnly',
-                'direction': 'in',
-                'grpc_type': 'bool',
-                'name': 'infoOnly',
-                'proto_only': True,
-                'type': 'bool'
             }
         ],
         'returns': 'ViStatus'

--- a/source/codegen/metadata/niscope/niscope.proto
+++ b/source/codegen/metadata/niscope/niscope.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SCOPE API metadata version 23.0.0f168
+// This file is generated from NI-SCOPE API metadata version 23.3.0d9999
 //---------------------------------------------------------------------
 // Proto file for the NI-SCOPE Metadata
 //---------------------------------------------------------------------
@@ -473,8 +473,8 @@ enum ExportableSignals {
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_ADVANCE_EVENT = 6;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_START_EVENT = 7;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_READY_FOR_REF_EVENT = 10;
-  EXPORTABLE_SIGNALS_NISCOPE_VAL_REF_CLOCK = 100;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_5V_OUT = 13;
+  EXPORTABLE_SIGNALS_NISCOPE_VAL_REF_CLOCK = 100;
   EXPORTABLE_SIGNALS_NISCOPE_VAL_SAMPLE_CLOCK = 101;
 }
 
@@ -1439,6 +1439,7 @@ message FetchArrayMeasurementRequest {
     ArrayMeasurement array_meas_function = 4;
     sint32 array_meas_function_raw = 5;
   }
+  sint32 meas_wfm_size = 6;
 }
 
 message FetchArrayMeasurementResponse {

--- a/source/codegen/metadata/niscope/niscope.proto
+++ b/source/codegen/metadata/niscope/niscope.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-SCOPE API metadata version 23.3.0d9999
+// This file is generated from NI-SCOPE API metadata version 23.3.0d127
 //---------------------------------------------------------------------
 // Proto file for the NI-SCOPE Metadata
 //---------------------------------------------------------------------

--- a/source/codegen/metadata/niscope/niscope.proto
+++ b/source/codegen/metadata/niscope/niscope.proto
@@ -1440,6 +1440,7 @@ message FetchArrayMeasurementRequest {
     sint32 array_meas_function_raw = 5;
   }
   sint32 meas_wfm_size = 6;
+  bool info_only = 7;
 }
 
 message FetchArrayMeasurementResponse {

--- a/source/codegen/metadata/niscope/niscope.proto
+++ b/source/codegen/metadata/niscope/niscope.proto
@@ -1439,8 +1439,7 @@ message FetchArrayMeasurementRequest {
     ArrayMeasurement array_meas_function = 4;
     sint32 array_meas_function_raw = 5;
   }
-  sint32 meas_wfm_size = 6;
-  bool info_only = 7;
+  optional sint32 meas_wfm_size = 6;
 }
 
 message FetchArrayMeasurementResponse {

--- a/source/codegen/metadata_mutation.py
+++ b/source/codegen/metadata_mutation.py
@@ -193,7 +193,7 @@ def mark_non_proto_params(parameters):
                 if "determine_size_from" not in size_param:
                     size_param["determine_size_from"] = []
                 size_param["determine_size_from"].append(param["name"])
-                is_optional = common_helpers.is_optional(param)
+                is_optional = common_helpers.has_optional_size_tag(param)
                 if is_optional != size_param.get("linked_params_are_optional", is_optional):
                     raise Exception(
                         "Code generator does not support linked params that are a mix of optional and required",

--- a/source/codegen/metadata_validation.py
+++ b/source/codegen/metadata_validation.py
@@ -105,6 +105,7 @@ PARAM_SCHEMA = Schema(
         Optional("is_size_param"): bool,
         Optional("linked_params_are_optional"): bool,
         Optional("mapped-enum"): str,
+        Optional("is_optional"): bool,
     }
 )
 
@@ -302,6 +303,15 @@ def _validate_function(function_name: str, metadata: dict):
                             raise Exception(
                                 f"{metadata['config']['namespace_component']} allows duplicate resource handles in the session repository. Therefore, the handle we'd get for \"{parameter['name']}\" can't be mapped back to a Session to provide to the client!"
                             )
+                if common_helpers.is_optional_param(parameter):
+                    if common_helpers.is_enum(parameter):
+                        raise Exception(
+                            f"\"{parameter['name']}\" is marked optional and an enum which doesn't make sense!"
+                        )
+                    if function.get("codegen_method", "public") != "CustomCode":
+                        raise Exception(
+                            f"\"{parameter['name']}\" is marked optional but the function is not marked CustomCode!"
+                        )
     except Exception as e:
         raise Exception(f"Failed to validate function {function_name}") from e
 

--- a/source/codegen/proto_helpers.py
+++ b/source/codegen/proto_helpers.py
@@ -136,12 +136,14 @@ def get_message_parameter_definitions(parameters):
                 parameter_type = f'repeated {parameter["enum"]}'
             grpc_field_number = generate_parameter_field_number(parameter, used_indexes)
             is_get_last_error_output = common_helpers.is_get_last_error_output_param(parameter)
+            is_optional = common_helpers.is_optional_param(parameter)
             parameter_definitions.append(
                 {
                     "name": parameter_name,
                     "type": parameter_type,
                     "grpc_field_number": grpc_field_number,
                     "is_get_last_error_output": is_get_last_error_output,
+                    "is_optional": is_optional,
                 }
             )
     return parameter_definitions

--- a/source/codegen/templates/proto_helpers.mako
+++ b/source/codegen/templates/proto_helpers.mako
@@ -84,6 +84,8 @@ message ${common_helpers.snake_to_pascal(function)}Request {
     ${oneof_parameter["type"]} ${oneof_parameter["name"]} = ${oneof_parameter["grpc_field_number"]};
 %     endfor
   }
+%   elif common_helpers.is_optional_param(parameter):
+  optional ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]};
 %   else:
   ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]};
 %   endif
@@ -100,8 +102,10 @@ message ${common_helpers.snake_to_pascal(function)}Request {
 %>\
 message ${common_helpers.snake_to_pascal(function)}Response {
 % for parameter in response_parameters:
-% if (parameter.get("is_get_last_error_output", False)):
+% if parameter.get("is_get_last_error_output", False):
   ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]} [deprecated = true];
+% elif common_helpers.is_optional_param(parameter):
+  optional ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]};
 % else:
   ${parameter["type"]} ${parameter["name"]} = ${parameter["grpc_field_number"]};
 % endif

--- a/source/custom/niscope_service.custom.cpp
+++ b/source/custom/niscope_service.custom.cpp
@@ -228,8 +228,10 @@ void CheckStatus(int status)
         break;
     }
 
-    ViInt32 measurement_waveform_size;
-    CheckStatus(library_->ActualMeasWfmSize(vi, array_meas_function, &measurement_waveform_size));
+    ViInt32 measurement_waveform_size = request->meas_wfm_size();
+    if (measurement_waveform_size < 0) {
+      CheckStatus(library_->ActualMeasWfmSize(vi, array_meas_function, &measurement_waveform_size));
+    }
 
     ViInt32 num_waveforms;
     CheckStatus(library_->ActualNumWfms(vi, channel_list, &num_waveforms));

--- a/source/custom/niscope_service.custom.cpp
+++ b/source/custom/niscope_service.custom.cpp
@@ -228,11 +228,14 @@ void CheckStatus(int status)
         break;
     }
 
-    ViInt32 measurement_waveform_size = request->meas_wfm_size();
-    if (request->info_only()) {
-      measurement_waveform_size = 0;
+    // meas_wfm_size is marked optional in the proto file.
+    // If it was set to a non-negative value, use it.
+    // If it wasn't set or if it was set to a negative number, use the ActualMeasWfmSize.
+    ViInt32 measurement_waveform_size = -1;
+    if (request->has_meas_wfm_size()) {
+      measurement_waveform_size = request->meas_wfm_size();
     }
-    else if (measurement_waveform_size <= 0) {
+    if (measurement_waveform_size < 0) {
       CheckStatus(library_->ActualMeasWfmSize(vi, array_meas_function, &measurement_waveform_size));
     }
 

--- a/source/custom/niscope_service.custom.cpp
+++ b/source/custom/niscope_service.custom.cpp
@@ -229,7 +229,10 @@ void CheckStatus(int status)
     }
 
     ViInt32 measurement_waveform_size = request->meas_wfm_size();
-    if (measurement_waveform_size < 0) {
+    if (request->info_only()) {
+      measurement_waveform_size = 0;
+    }
+    else if (measurement_waveform_size <= 0) {
       CheckStatus(library_->ActualMeasWfmSize(vi, array_meas_function, &measurement_waveform_size));
     }
 

--- a/source/tests/system/niscope_driver_api_tests.cpp
+++ b/source/tests/system/niscope_driver_api_tests.cpp
@@ -299,6 +299,31 @@ TEST_F(NiScopeDriverApiTest, NiScopeFetchArrayMeasurement_SendRequestWithNegativ
   EXPECT_EQ(expected_num_waveforms, response.wfm_info_size());
 }
 
+TEST_F(NiScopeDriverApiTest, NiScopeFetchArrayMeasurement_SendRequestWithZeroWfmSize_FetchCompletesUsingZeroWfmSize)
+{
+  auto_setup();
+  initiate_acquisition();
+  const char* channel_list = "0";
+  const int32 expected_num_waveforms = get_actual_num_wfms(channel_list);
+  const niscope_grpc::ArrayMeasurement measurement_func = niscope_grpc::ArrayMeasurement::ARRAY_MEASUREMENT_NISCOPE_VAL_INVERSE;
+  const int32 zero_waveform_size = 0;
+  ::grpc::ClientContext context;
+  scope::FetchArrayMeasurementRequest request;
+  request.mutable_vi()->set_name(GetSessionName());
+  request.set_channel_list(channel_list);
+  request.set_timeout(10000);
+  request.set_array_meas_function(measurement_func);
+  request.set_meas_wfm_size(zero_waveform_size);
+  scope::FetchArrayMeasurementResponse response;
+
+  ::grpc::Status status = GetStub()->FetchArrayMeasurement(&context, request, &response);
+
+  EXPECT_TRUE(status.ok());
+  expect_api_success(response.status());
+  EXPECT_EQ(zero_waveform_size, response.meas_wfm_size());
+  EXPECT_EQ(expected_num_waveforms, response.wfm_info_size());
+}
+
 TEST_F(NiScopeDriverApiTest, NiScopeFetchArrayMeasurement_SendRequestWithMeasWfmSize_FetchCompletesWithCorrectSizes)
 {
   auto_setup();

--- a/source/tests/system/niscope_driver_api_tests.cpp
+++ b/source/tests/system/niscope_driver_api_tests.cpp
@@ -274,11 +274,10 @@ TEST_F(NiScopeDriverApiTest, NiScopeRead_SendRequest_ReadCompletesWithCorrectSiz
   EXPECT_EQ(expected_num_waveforms, response.wfm_info_size());
 }
 
-TEST_F(NiScopeDriverApiTest, NiScopeFetchArrayMeasurement_SendRequest_FetchCompletesWithCorrectSizes)
+TEST_F(NiScopeDriverApiTest, NiScopeFetchArrayMeasurement_SendRequestWithNegativeWfmSize_FetchCompletesUsingActualMeasurementWaveformSize)
 {
   auto_setup();
   initiate_acquisition();
-  const int32 expected_num_samples = 100000;
   const char* channel_list = "0";
   const int32 expected_num_waveforms = get_actual_num_wfms(channel_list);
   const niscope_grpc::ArrayMeasurement measurement_func = niscope_grpc::ArrayMeasurement::ARRAY_MEASUREMENT_NISCOPE_VAL_INVERSE;
@@ -289,6 +288,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeFetchArrayMeasurement_SendRequest_FetchCompl
   request.set_channel_list(channel_list);
   request.set_timeout(10000);
   request.set_array_meas_function(measurement_func);
+  request.set_meas_wfm_size(-1);
   scope::FetchArrayMeasurementResponse response;
 
   ::grpc::Status status = GetStub()->FetchArrayMeasurement(&context, request, &response);
@@ -296,6 +296,31 @@ TEST_F(NiScopeDriverApiTest, NiScopeFetchArrayMeasurement_SendRequest_FetchCompl
   EXPECT_TRUE(status.ok());
   expect_api_success(response.status());
   EXPECT_EQ(expected_num_waveforms * expected_waveform_size, response.meas_wfm_size());
+  EXPECT_EQ(expected_num_waveforms, response.wfm_info_size());
+}
+
+TEST_F(NiScopeDriverApiTest, NiScopeFetchArrayMeasurement_SendRequestWithMeasWfmSize_FetchCompletesWithCorrectSizes)
+{
+  auto_setup();
+  initiate_acquisition();
+  const char* channel_list = "0";
+  const int32 expected_num_waveforms = get_actual_num_wfms(channel_list);
+  const niscope_grpc::ArrayMeasurement measurement_func = niscope_grpc::ArrayMeasurement::ARRAY_MEASUREMENT_NISCOPE_VAL_INVERSE;
+  const int32 waveform_size = 42;
+  ::grpc::ClientContext context;
+  scope::FetchArrayMeasurementRequest request;
+  request.mutable_vi()->set_name(GetSessionName());
+  request.set_channel_list(channel_list);
+  request.set_timeout(10000);
+  request.set_array_meas_function(measurement_func);
+  request.set_meas_wfm_size(waveform_size);
+  scope::FetchArrayMeasurementResponse response;
+
+  ::grpc::Status status = GetStub()->FetchArrayMeasurement(&context, request, &response);
+
+  EXPECT_TRUE(status.ok());
+  expect_api_success(response.status());
+  EXPECT_EQ(expected_num_waveforms * waveform_size, response.meas_wfm_size());
   EXPECT_EQ(expected_num_waveforms, response.wfm_info_size());
 }
 

--- a/source/tests/system/niscope_driver_api_tests.cpp
+++ b/source/tests/system/niscope_driver_api_tests.cpp
@@ -323,7 +323,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeFetchArrayMeasurement_SendRequestWithoutWfmS
   EXPECT_EQ(expected_num_waveforms, response.wfm_info_size());
 }
 
-TEST_F(NiScopeDriverApiTest, NiScopeFetchArrayMeasurement_SendRequestWithZeroMeasWfmSize_FetchCompletesUsingActualMeasurementWaveformSize)
+TEST_F(NiScopeDriverApiTest, NiScopeFetchArrayMeasurement_SendRequestWithZeroMeasWfmSize_FetchCompletesWithZeroMeasurementWaveformSize)
 {
   auto_setup();
   initiate_acquisition();
@@ -331,7 +331,6 @@ TEST_F(NiScopeDriverApiTest, NiScopeFetchArrayMeasurement_SendRequestWithZeroMea
   const int32 expected_num_waveforms = get_actual_num_wfms(channel_list);
   const niscope_grpc::ArrayMeasurement measurement_func = niscope_grpc::ArrayMeasurement::ARRAY_MEASUREMENT_NISCOPE_VAL_INVERSE;
   const int32 zero_waveform_size = 0;
-  const int32 expected_waveform_size = get_actual_measurement_waveform_size(measurement_func);
   ::grpc::ClientContext context;
   scope::FetchArrayMeasurementRequest request;
   request.mutable_vi()->set_name(GetSessionName());
@@ -345,33 +344,7 @@ TEST_F(NiScopeDriverApiTest, NiScopeFetchArrayMeasurement_SendRequestWithZeroMea
 
   EXPECT_TRUE(status.ok());
   expect_api_success(response.status());
-  EXPECT_EQ(expected_num_waveforms * expected_waveform_size, response.meas_wfm_size());
-  EXPECT_EQ(expected_num_waveforms, response.wfm_info_size());
-}
-
-TEST_F(NiScopeDriverApiTest, NiScopeFetchArrayMeasurement_SendRequestWithInfoOnlyTrue_FetchCompletesUsingZeroWaveformSize)
-{
-  auto_setup();
-  initiate_acquisition();
-  const char* channel_list = "0";
-  const int32 expected_num_waveforms = get_actual_num_wfms(channel_list);
-  const niscope_grpc::ArrayMeasurement measurement_func = niscope_grpc::ArrayMeasurement::ARRAY_MEASUREMENT_NISCOPE_VAL_INVERSE;
-  const int32 waveform_size_to_discard_on_server = 42;
-  ::grpc::ClientContext context;
-  scope::FetchArrayMeasurementRequest request;
-  request.mutable_vi()->set_name(GetSessionName());
-  request.set_channel_list(channel_list);
-  request.set_timeout(10000);
-  request.set_array_meas_function(measurement_func);
-  request.set_meas_wfm_size(waveform_size_to_discard_on_server);
-  request.set_info_only(true);
-  scope::FetchArrayMeasurementResponse response;
-
-  ::grpc::Status status = GetStub()->FetchArrayMeasurement(&context, request, &response);
-
-  EXPECT_TRUE(status.ok());
-  expect_api_success(response.status());
-  EXPECT_EQ(0, response.meas_wfm_size());
+  EXPECT_EQ(zero_waveform_size, response.meas_wfm_size());
   EXPECT_EQ(expected_num_waveforms, response.wfm_info_size());
 }
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds `meas_wfm_size` to the `FetchArrayMeasurementRequest`.
Mark the new `meas_wfm_size` as `optional` in the proto request.

Updates custom service handler to
1. Use the request's `meas_wfm_size` was set to a non-negative value, use it.
2. If it wasn't set or if it was set to a negative number, get the size using `ActualMeasWfmSize`.

This makes it a backwards compatible change and provides the option for a 0-fetch request.

### Why should this Pull Request be merged?

[AB#2292398](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2292398)

While we were implementing the LV SCOPE APIs to go through grpc-device we found scenarios in their tests where they were passing in a different `meas_wfm_size` to `FetchArrayMeasurement` than what we'd get from calling `ActualMeasWfmSize`. We couldn't forward that `meas_wfm_size` input before since it wasn't exposed on the .proto file and thus we got incorrect behavior for these legitimate client scenarios.

### What testing has been done?

Build passes.
Scope system tests pass including new one exercising setting or not setting `meas_wfm_size`.
