### PR TITLE
Update GSM/WCDMA metadata (to use bitfield_as_enum_array)

### DIFF
--- a/generated/nirfmxgsm/nirfmxgsm.proto
+++ b/generated/nirfmxgsm/nirfmxgsm.proto
@@ -1726,10 +1726,8 @@ message ResetToDefaultResponse {
 message SelectMeasurementsRequest {
   nidevice_grpc.Session instrument = 1;
   string selector_string = 2;
-  oneof measurements_enum {
-    MeasurementTypes measurements = 3;
-    uint32 measurements_raw = 4;
-  }
+  repeated MeasurementTypes measurements_array = 3;
+  uint32 measurements_raw = 4;
   bool enable_all_traces = 5;
 }
 

--- a/generated/nirfmxgsm/nirfmxgsm_client.cpp
+++ b/generated/nirfmxgsm/nirfmxgsm_client.cpp
@@ -1994,21 +1994,14 @@ reset_to_default(const StubPtr& stub, const nidevice_grpc::Session& instrument, 
 }
 
 SelectMeasurementsResponse
-select_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<MeasurementTypes, pb::uint32>& measurements, const bool& enable_all_traces)
+select_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<std::vector<MeasurementTypes>, std::int32_t>& measurements, const bool& enable_all_traces)
 {
   ::grpc::ClientContext context;
 
   auto request = SelectMeasurementsRequest{};
   request.mutable_instrument()->CopyFrom(instrument);
   request.set_selector_string(selector_string);
-  const auto measurements_ptr = measurements.get_if<MeasurementTypes>();
-  const auto measurements_raw_ptr = measurements.get_if<pb::uint32>();
-  if (measurements_ptr) {
-    request.set_measurements(*measurements_ptr);
-  }
-  else if (measurements_raw_ptr) {
-    request.set_measurements_raw(*measurements_raw_ptr);
-  }
+  request.set_measurements_raw(copy_bitfield_as_enum_array(measurements));
   request.set_enable_all_traces(enable_all_traces);
 
   auto response = SelectMeasurementsResponse{};

--- a/generated/nirfmxgsm/nirfmxgsm_client.h
+++ b/generated/nirfmxgsm/nirfmxgsm_client.h
@@ -115,7 +115,7 @@ PVTFetchSlotMeasurementResponse pvt_fetch_slot_measurement(const StubPtr& stub, 
 PVTFetchSlotMeasurementArrayResponse pvt_fetch_slot_measurement_array(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout);
 ResetAttributeResponse reset_attribute(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const NiRFmxGSMAttribute& attribute_id);
 ResetToDefaultResponse reset_to_default(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string);
-SelectMeasurementsResponse select_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<MeasurementTypes, pb::uint32>& measurements, const bool& enable_all_traces);
+SelectMeasurementsResponse select_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<std::vector<MeasurementTypes>, std::int32_t>& measurements, const bool& enable_all_traces);
 SendSoftwareEdgeTriggerResponse send_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& instrument);
 SetAttributeF32Response set_attribute_f32(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const NiRFmxGSMAttribute& attribute_id, const float& attr_val);
 SetAttributeF32ArrayResponse set_attribute_f32_array(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const NiRFmxGSMAttribute& attribute_id, const std::vector<float>& attr_val);

--- a/generated/nirfmxgsm/nirfmxgsm_service.cpp
+++ b/generated/nirfmxgsm/nirfmxgsm_service.cpp
@@ -3588,21 +3588,9 @@ namespace nirfmxgsm_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
       char* selector_string = (char*)selector_string_mbcs.c_str();
-      uInt32 measurements;
-      switch (request->measurements_enum_case()) {
-        case nirfmxgsm_grpc::SelectMeasurementsRequest::MeasurementsEnumCase::kMeasurements: {
-          measurements = static_cast<uInt32>(request->measurements());
-          break;
-        }
-        case nirfmxgsm_grpc::SelectMeasurementsRequest::MeasurementsEnumCase::kMeasurementsRaw: {
-          measurements = static_cast<uInt32>(request->measurements_raw());
-          break;
-        }
-        case nirfmxgsm_grpc::SelectMeasurementsRequest::MeasurementsEnumCase::MEASUREMENTS_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for measurements was not specified or out of range");
-          break;
-        }
-      }
+      const auto measurements = nidevice_grpc::converters::convert_bitfield_as_enum_array_input(
+        request->measurements_array(),
+        request->measurements_raw());
 
       int32 enable_all_traces = request->enable_all_traces();
       auto status = library_->SelectMeasurements(instrument, selector_string, measurements, enable_all_traces);

--- a/generated/nirfmxwcdma/nirfmxwcdma.proto
+++ b/generated/nirfmxwcdma/nirfmxwcdma.proto
@@ -3084,10 +3084,8 @@ message SEMFetchUpperOffsetPowerArrayResponse {
 message SelectMeasurementsRequest {
   nidevice_grpc.Session instrument = 1;
   string selector_string = 2;
-  oneof measurements_enum {
-    MeasurementTypes measurements = 3;
-    uint32 measurements_raw = 4;
-  }
+  repeated MeasurementTypes measurements_array = 3;
+  uint32 measurements_raw = 4;
   bool enable_all_traces = 5;
 }
 

--- a/generated/nirfmxwcdma/nirfmxwcdma_client.cpp
+++ b/generated/nirfmxwcdma/nirfmxwcdma_client.cpp
@@ -3297,21 +3297,14 @@ sem_fetch_upper_offset_power_array(const StubPtr& stub, const nidevice_grpc::Ses
 }
 
 SelectMeasurementsResponse
-select_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<MeasurementTypes, pb::uint32>& measurements, const bool& enable_all_traces)
+select_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<std::vector<MeasurementTypes>, std::int32_t>& measurements, const bool& enable_all_traces)
 {
   ::grpc::ClientContext context;
 
   auto request = SelectMeasurementsRequest{};
   request.mutable_instrument()->CopyFrom(instrument);
   request.set_selector_string(selector_string);
-  const auto measurements_ptr = measurements.get_if<MeasurementTypes>();
-  const auto measurements_raw_ptr = measurements.get_if<pb::uint32>();
-  if (measurements_ptr) {
-    request.set_measurements(*measurements_ptr);
-  }
-  else if (measurements_raw_ptr) {
-    request.set_measurements_raw(*measurements_raw_ptr);
-  }
+  request.set_measurements_raw(copy_bitfield_as_enum_array(measurements));
   request.set_enable_all_traces(enable_all_traces);
 
   auto response = SelectMeasurementsResponse{};

--- a/generated/nirfmxwcdma/nirfmxwcdma_client.h
+++ b/generated/nirfmxwcdma/nirfmxwcdma_client.h
@@ -177,7 +177,7 @@ SEMFetchUpperOffsetMarginResponse sem_fetch_upper_offset_margin(const StubPtr& s
 SEMFetchUpperOffsetMarginArrayResponse sem_fetch_upper_offset_margin_array(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout);
 SEMFetchUpperOffsetPowerResponse sem_fetch_upper_offset_power(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout);
 SEMFetchUpperOffsetPowerArrayResponse sem_fetch_upper_offset_power_array(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout);
-SelectMeasurementsResponse select_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<MeasurementTypes, pb::uint32>& measurements, const bool& enable_all_traces);
+SelectMeasurementsResponse select_measurements(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<std::vector<MeasurementTypes>, std::int32_t>& measurements, const bool& enable_all_traces);
 SendSoftwareEdgeTriggerResponse send_software_edge_trigger(const StubPtr& stub, const nidevice_grpc::Session& instrument);
 SetAttributeF32Response set_attribute_f32(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const NiRFmxWCDMAAttribute& attribute_id, const float& attr_val);
 SetAttributeF32ArrayResponse set_attribute_f32_array(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const NiRFmxWCDMAAttribute& attribute_id, const std::vector<float>& attr_val);

--- a/generated/nirfmxwcdma/nirfmxwcdma_service.cpp
+++ b/generated/nirfmxwcdma/nirfmxwcdma_service.cpp
@@ -6130,21 +6130,9 @@ namespace nirfmxwcdma_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
       char* selector_string = (char*)selector_string_mbcs.c_str();
-      uInt32 measurements;
-      switch (request->measurements_enum_case()) {
-        case nirfmxwcdma_grpc::SelectMeasurementsRequest::MeasurementsEnumCase::kMeasurements: {
-          measurements = static_cast<uInt32>(request->measurements());
-          break;
-        }
-        case nirfmxwcdma_grpc::SelectMeasurementsRequest::MeasurementsEnumCase::kMeasurementsRaw: {
-          measurements = static_cast<uInt32>(request->measurements_raw());
-          break;
-        }
-        case nirfmxwcdma_grpc::SelectMeasurementsRequest::MeasurementsEnumCase::MEASUREMENTS_ENUM_NOT_SET: {
-          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for measurements was not specified or out of range");
-          break;
-        }
-      }
+      const auto measurements = nidevice_grpc::converters::convert_bitfield_as_enum_array_input(
+        request->measurements_array(),
+        request->measurements_raw());
 
       int32 enable_all_traces = request->enable_all_traces();
       auto status = library_->SelectMeasurements(instrument, selector_string, measurements, enable_all_traces);

--- a/source/codegen/metadata/nirfmxgsm/functions.py
+++ b/source/codegen/metadata/nirfmxgsm/functions.py
@@ -3158,8 +3158,8 @@ functions = {
                 'type': 'char[]'
             },
             {
+                'bitfield_as_enum_array': 'MeasurementTypes',
                 'direction': 'in',
-                'enum': 'MeasurementTypes',
                 'name': 'measurements',
                 'type': 'uInt32'
             },

--- a/source/codegen/metadata/nirfmxwcdma/functions.py
+++ b/source/codegen/metadata/nirfmxwcdma/functions.py
@@ -5924,8 +5924,8 @@ functions = {
                 'type': 'char[]'
             },
             {
+                'bitfield_as_enum_array': 'MeasurementTypes',
                 'direction': 'in',
-                'enum': 'MeasurementTypes',
                 'name': 'measurements',
                 'type': 'uInt32'
             },


### PR DESCRIPTION
### What does this Pull Request accomplish?

Updates the GSM and WCDMA metadata from scrapigen.  In particular, these updates simply make these services use `bitfield_as_enum_array` for the `measurements` parameter of the `SelectMeasurements` function.

### Why should this Pull Request be merged?

This is how these kinds of parameters should be implemented.

### What testing has been done?

Local build and ran RFmxGSM and RFmxWCDMA system tests:
![image](https://user-images.githubusercontent.com/77023184/218141017-723e0338-a1fe-48e0-83c1-e9b24c2bdac5.png)

