### PR TITLE
Multi driver example to show RFmx Analysis Only (AO) mode in action

### DIFF
--- a/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
+++ b/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
@@ -179,7 +179,7 @@ try:
             )
         )
     )
-    ###### Configure RFSG Settigs ######
+    ###### Configure RFSG Settings ######
     raise_if_error(
         rfsgclient.SetAttributeViReal64(
             nirfsg_types.SetAttributeViReal64Request(

--- a/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
+++ b/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
@@ -96,13 +96,9 @@ def raise_if_error(response):
             )
         )
         if response.status < 0:
-            raise RuntimeError(
-                f"Error: {error_response.error_description or response.status}"
-            )
+            raise RuntimeError(f"Error: {error_response.error_description or response.status}")
         else:
-            sys.stderr.write(
-                f"Warning: {error_response.error_description or response.status}\n"
-            )
+            sys.stderr.write(f"Warning: {error_response.error_description or response.status}\n")
     return response
 
 
@@ -222,9 +218,7 @@ try:
         )
     )
     raise_if_error(
-        rfsgclient.WriteScript(
-            nirfsg_types.WriteScriptRequest(vi=rfsgsession, script=rfsg_script)
-        )
+        rfsgclient.WriteScript(nirfsg_types.WriteScriptRequest(vi=rfsgsession, script=rfsg_script))
     )
     raise_if_error(
         rfsgclient.ExportSignal(
@@ -243,9 +237,7 @@ try:
     nr_subcarrier_spacing = 30e3
     nr_auto_resource_block_detection_enabled = True
     nr_pusch_modulation_type = nirfmxnr_types.NIRFMXNR_INT32_PUSCH_MODULATION_TYPE_QAM64
-    nr_measurement_length_unit = (
-        nirfmxnr_types.NIRFMXNR_INT32_MODACC_MEASUREMENT_LENGTH_UNIT_SLOT
-    )
+    nr_measurement_length_unit = nirfmxnr_types.NIRFMXNR_INT32_MODACC_MEASUREMENT_LENGTH_UNIT_SLOT
     nr_link_direction = nirfmxnr_types.NIRFMXNR_INT32_LINK_DIRECTION_UPLINK
     nr_measurement_offset = 0
     nr_measurement_length = 1
@@ -395,9 +387,7 @@ try:
     )
     raise_if_error(
         rfsaclient.ConfigureIQRate(
-            nirfsa_types.ConfigureIQRateRequest(
-                vi=rfsasession, iq_rate=minimum_sample_rate
-            )
+            nirfsa_types.ConfigureIQRateRequest(vi=rfsasession, iq_rate=minimum_sample_rate)
         )
     )
     print(f"Done")
@@ -424,9 +414,7 @@ try:
         )
 
         iq = [
-            nidevice_grpc.NIComplexNumberF32(
-                real=sample.real, imaginary=sample.imaginary
-            )
+            nidevice_grpc.NIComplexNumberF32(real=sample.real, imaginary=sample.imaginary)
             for sample in read_response.data
         ]
 
@@ -457,22 +445,18 @@ except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
-            value = (
-                entry.value
-                if isinstance(entry.value, str)
-                else entry.value.decode("utf-8")
-            )
+            value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")
             error_message += f"\nError status: {value}"
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {SERVER_ADDRESS}:{SERVER_PORT}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
     print(f"{error_message}")
 finally:
     if rfmxsession:
-        rfmxclient.Close(
-            nirfmxnr_types.CloseRequest(instrument=rfmxsession, force_destroy=True)
-        )
+        rfmxclient.Close(nirfmxnr_types.CloseRequest(instrument=rfmxsession, force_destroy=True))
     if rfsasession:
         rfsaclient.Close(nirfsa_types.CloseRequest(vi=rfsasession))
     raise_if_error(rfsgclient.Abort(nirfsg_types.AbortRequest(vi=rfsgsession)))

--- a/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
+++ b/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
@@ -147,7 +147,7 @@ try:
     file_path = r"C:\Users\Public\Documents\National Instruments\NI-RFmx\NR\Examples\C\Support\NR_FR1_UL_BW-100MHz_SCS-30kHz.tdms"
 
     print(f"Configuring RFmx NR, RFSG and RFSA settings...", end="")
-    ###### Configure RFSA Settigs ######
+    ###### Configure RFSA Settings ######
     raise_if_error(
         rfsaclient.ConfigureRefClock(
             nirfsa_types.ConfigureRefClockRequest(

--- a/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
+++ b/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
@@ -66,7 +66,7 @@ if len(sys.argv) >= 4:
     RESOURCE = sys.argv[3]
     OPTIONS = ""
 # Create a gRPC channel + client.
-# Use a larger buffer for the messages as we are transfering the raw data from instrument.
+# Use a larger buffer for the messages as we are transferring the raw data from instrument.
 # In this example up to 1.6M samples
 options = [("grpc.max_receive_message_length", 2**21)]
 channel = grpc.insecure_channel(f"{SERVER_ADDRESS}:{SERVER_PORT}", options=options)

--- a/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
+++ b/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
@@ -14,8 +14,11 @@ The gRPC API is built from the C API. RFmx NR documentation is installed with th
 
 Getting Started:
 
-To run this example, install "RFmx NR" on the server machine:
+To run this example, install "RFmx NR", "RFSA" and "RFSG" on the server machine:
   https://www.ni.com/en-us/support/downloads/software-products/download.rfmx-nr.html
+  https://www.ni.com/en-us/support/downloads/drivers/download.ni-rfsa.html
+  https://www.ni.com/en-us/support/downloads/drivers/download.ni-rfsg.html
+
 
 For instructions on how to use protoc to generate gRPC client interfaces, see our "Creating a gRPC
 Client" wiki page:
@@ -45,7 +48,7 @@ import nirfsa_pb2_grpc as grpc_nirfsa
 import nirfsg_pb2 as nirfsg_types
 import nirfsg_pb2_grpc as grpc_nirfsg
 
-SERVER_ADDRESS = "mercury07"
+SERVER_ADDRESS = "localhost"
 SERVER_PORT = "31763"
 RFMXSESSION_NAME = "RFmxNRSession"
 RFSASESSION_NAME = "RfsaSession"
@@ -247,7 +250,7 @@ try:
                 instrument=rfmxsession,
                 selector_string="",
                 attribute_id=nirfmxnr_types.NIRFMXNR_ATTRIBUTE_LINK_DIRECTION,
-                attr_val_raw=nr_link_direction,
+                attr_val=nr_link_direction,
             )
         )
     )
@@ -257,7 +260,7 @@ try:
                 instrument=rfmxsession,
                 selector_string="",
                 attribute_id=nirfmxnr_types.NIRFMXNR_ATTRIBUTE_FREQUENCY_RANGE,
-                attr_val_raw=nr_frequency_range,
+                attr_val=nr_frequency_range,
             )
         )
     )

--- a/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
+++ b/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
@@ -1,0 +1,484 @@
+r"""Demostration on how to use RFSA, RFSG and RFmx in Analysis Only mode.
+
+This example shows how to generate a TDMS waveform using RFSG, to capture the raw IQ data using
+RFSA and to demodulate it using RFmx Analysis Only mode.
+
+The gRPC API is built from the C API. NI-RFSG documentation is installed with the driver at:
+  C:\Program Files (x86)\IVI Foundation\IVI\Drivers\niRFSG\documentation\English\RFSG.chm
+
+The gRPC API is built from the C API. NI-RFSA documentation is installed with the driver at:
+  C:\Program Files (x86)\IVI Foundation\IVI\Drivers\niRFSG\documentation\English\RFSA.chm
+
+The gRPC API is built from the C API. RFmx NR documentation is installed with the driver at:
+  C:\Program Files (x86)\National Instruments\RFmx\NR\Documentation\rfmxnrcvi.chm
+
+Getting Started:
+
+To run this example, install "RFmx NR" on the server machine:
+  https://www.ni.com/en-us/support/downloads/software-products/download.rfmx-nr.html
+
+For instructions on how to use protoc to generate gRPC client interfaces, see our "Creating a gRPC
+Client" wiki page:
+  https://github.com/ni/grpc-device/wiki/Creating-a-gRPC-Client
+
+Refer to the NI-RFmxNR gRPC Wiki for the latest C Function Reference:
+  https://github.com/ni/grpc-device/wiki/NI-RFmxNR-C-Function-Reference
+
+Running from command line:
+
+Server machine's IP address, port number, and physical channel name can be passed as separate
+command line arguments.
+  > python rfsa-rfsg-NR-analysis-only-modacc.py <server_address> <port_number> <resource_name>
+If they are not passed in as command line arguments, then by default the server address will be
+"localhost:31763", with "SimulatedDevice" as the resource name.
+"""
+
+import sys
+
+import os
+
+sys.path.append(os.getcwd())
+
+import grpc
+import nidevice_pb2 as nidevice_grpc
+import nirfmxinstr_pb2 as nirfmxinstr_types
+import nirfmxnr_pb2 as nirfmxnr_types
+import nirfmxnr_pb2_grpc as grpc_nirfmxnr
+import nirfsa_pb2 as nirfsa_types
+import nirfsa_pb2_grpc as grpc_nirfsa
+import nirfsg_pb2 as nirfsg_types
+import nirfsg_pb2_grpc as grpc_nirfsg
+
+SERVER_ADDRESS = "mercury07"
+SERVER_PORT = "31763"
+RFMXSESSION_NAME = "RFmxNRSession"
+RFSASESSION_NAME = "RfsaSession"
+RFSGSESSION_NAME = "RfsgSession"
+
+# Resource name and options for a simulated 5663 client.
+RESOURCE = "5840_1"
+RFMXOPTIONS = "AnalysisOnly=1"
+RFSAOPTIONS = "DriverSetup=SFPSessionAccess:1"
+RFSGOPTIONS = ""
+
+# Read in cmd args
+if len(sys.argv) >= 2:
+    SERVER_ADDRESS = sys.argv[1]
+if len(sys.argv) >= 3:
+    SERVER_PORT = sys.argv[2]
+if len(sys.argv) >= 4:
+    RESOURCE = sys.argv[3]
+    OPTIONS = ""
+# Create a gRPC channel + client.
+# Use a larger buffer for the messages as we are transfering the raw data from instrument.
+# In this example up to 1.6M samples
+options = [("grpc.max_receive_message_length", 2**21)]
+channel = grpc.insecure_channel(f"{SERVER_ADDRESS}:{SERVER_PORT}", options=options)
+rfmxclient = grpc_nirfmxnr.NiRFmxNRStub(channel)
+rfsaclient = grpc_nirfsa.NiRFSAStub(channel)
+rfsgclient = grpc_nirfsg.NiRFSGStub(channel)
+rfsgsession = None
+rfmxsession = None
+rfsasession = None
+
+
+def raise_if_initialization_error(response):
+    """Raise an exception if an error was returned from Initialize."""
+    if response.status < 0:
+        raise RuntimeError(f"Error: {response.error_message or response.status}")
+    if response.status > 0:
+        sys.stderr.write(f"Warning: {response.error_message or response.status}\n")
+    return response
+
+
+def raise_if_error(response):
+    """Raise an exception if an error was returned."""
+    if response.status != 0:
+        error_response = rfmxclient.GetError(
+            nirfmxnr_types.GetErrorRequest(
+                instrument=rfmxsession,
+            )
+        )
+        if response.status < 0:
+            raise RuntimeError(
+                f"Error: {error_response.error_description or response.status}"
+            )
+        else:
+            sys.stderr.write(
+                f"Warning: {error_response.error_description or response.status}\n"
+            )
+    return response
+
+
+try:
+    print(f"Initializing Instruments...", end="")
+    initialize_response = raise_if_initialization_error(
+        rfmxclient.Initialize(
+            nirfmxnr_types.InitializeRequest(
+                session_name=RFMXSESSION_NAME,
+                resource_name=RESOURCE,
+                option_string=RFMXOPTIONS,
+            )
+        )
+    )
+    rfmxsession = initialize_response.instrument
+
+    initialize_response = raise_if_initialization_error(
+        rfsaclient.InitWithOptions(
+            nirfsa_types.InitWithOptionsRequest(
+                session_name=RFSASESSION_NAME,
+                resource_name=RESOURCE,
+                option_string=RFSAOPTIONS,
+            )
+        )
+    )
+    rfsasession = initialize_response.vi
+
+    initialize_response = raise_if_initialization_error(
+        rfsgclient.InitWithOptions(
+            nirfsg_types.InitWithOptionsRequest(
+                session_name=RFSGSESSION_NAME,
+                resource_name=RESOURCE,
+                option_string=RFSGOPTIONS,
+            )
+        )
+    )
+    rfsgsession = initialize_response.vi
+    print("Done")
+
+    center_frequency = 3.5e9
+    reference_level_dbm = 0
+    power_level_dbm = -10
+    rfsg_script = "script GenerateWaveform  repeat forever generate waveform end repeat end script"
+    rfsg_waveform_name = "waveform"
+    # The following waveform is installed with RFmx NR
+    file_path = r"C:\Users\Public\Documents\National Instruments\NI-RFmx\NR\Examples\C\Support\NR_FR1_UL_BW-100MHz_SCS-30kHz.tdms"
+
+    print(f"Configuring RFmx NR, RFSG and RFSA settings...", end="")
+    ###### Configure RFSA Settigs ######
+    raise_if_error(
+        rfsaclient.ConfigureRefClock(
+            nirfsa_types.ConfigureRefClockRequest(
+                vi=rfsasession,
+                clock_source_mapped=nirfsa_types.RefClockSource.REF_CLOCK_SOURCE_ONBOARD_CLOCK,
+                ref_clock_rate=10e6,
+            )
+        )
+    )
+    raise_if_error(
+        rfsaclient.ConfigureReferenceLevel(
+            nirfsa_types.ConfigureReferenceLevelRequest(
+                vi=rfsasession, reference_level=reference_level_dbm
+            )
+        )
+    )
+    raise_if_error(
+        rfsaclient.ConfigureAcquisitionType(
+            nirfsa_types.ConfigureAcquisitionTypeRequest(
+                vi=rfsasession,
+                acquisition_type=nirfsa_types.AcquisitionType.ACQUISITION_TYPE_IQ,
+            )
+        )
+    )
+    raise_if_error(
+        rfsaclient.ConfigureIQCarrierFrequency(
+            nirfsa_types.ConfigureIQCarrierFrequencyRequest(
+                vi=rfsasession, carrier_frequency=center_frequency
+            )
+        )
+    )
+    ###### Configure RFSG Settigs ######
+    raise_if_error(
+        rfsgclient.SetAttributeViReal64(
+            nirfsg_types.SetAttributeViReal64Request(
+                vi=rfsgsession,
+                channel_name="",
+                attribute_id=nirfsg_types.NIRFSG_ATTRIBUTE_POWER_LEVEL,
+                value_raw=power_level_dbm,
+            )
+        )
+    )
+    raise_if_error(
+        rfsgclient.SetAttributeViReal64(
+            nirfsg_types.SetAttributeViReal64Request(
+                vi=rfsgsession,
+                channel_name="",
+                attribute_id=nirfsg_types.NIRFSG_ATTRIBUTE_FREQUENCY,
+                value_raw=center_frequency,
+            )
+        )
+    )
+    raise_if_error(
+        rfsgclient.ConfigureGenerationMode(
+            nirfsg_types.ConfigureGenerationModeRequest(
+                vi=rfsgsession, generation_mode=nirfsg_types.GENERATION_MODE_SCRIPT
+            )
+        )
+    )
+    raise_if_error(
+        rfsgclient.ReadAndDownloadWaveformFromFileTDMS(
+            nirfsg_types.ReadAndDownloadWaveformFromFileTDMSRequest(
+                vi=rfsgsession,
+                waveform_name=rfsg_waveform_name,
+                file_path=str(file_path),
+                waveform_index=0,
+            )
+        )
+    )
+    raise_if_error(
+        rfsgclient.WriteScript(
+            nirfsg_types.WriteScriptRequest(vi=rfsgsession, script=rfsg_script)
+        )
+    )
+    raise_if_error(
+        rfsgclient.ExportSignal(
+            nirfsg_types.ExportSignalRequest(
+                vi=rfsgsession,
+                signal=nirfsg_types.ROUTED_SIGNAL_MARKER_EVENT,
+                signal_identifier_mapped=nirfsg_types.SIGNAL_IDENTIFIER_MARKER0,
+                output_terminal_mapped=nirfsg_types.OUTPUT_SIGNAL_PXI_TRIG1,
+            )
+        )
+    )
+
+    ###### Configure NR Settigs ######
+    nr_frequency_range = nirfmxnr_types.NIRFMXNR_INT32_FREQUENCY_RANGE_RANGE1
+    nr_carrier_bandwidth = 100e6
+    nr_subcarrier_spacing = 30e3
+    nr_auto_resource_block_detection_enabled = True
+    nr_pusch_modulation_type = nirfmxnr_types.NIRFMXNR_INT32_PUSCH_MODULATION_TYPE_QAM64
+    nr_measurement_length_unit = (
+        nirfmxnr_types.NIRFMXNR_INT32_MODACC_MEASUREMENT_LENGTH_UNIT_SLOT
+    )
+    nr_link_direction = nirfmxnr_types.NIRFMXNR_INT32_LINK_DIRECTION_UPLINK
+    nr_measurement_offset = 0
+    nr_measurement_length = 1
+    raise_if_error(
+        rfmxclient.SetAttributeI32(
+            nirfmxnr_types.SetAttributeI32Request(
+                instrument=rfmxsession,
+                selector_string="",
+                attribute_id=nirfmxnr_types.NIRFMXNR_ATTRIBUTE_LINK_DIRECTION,
+                attr_val_raw=nr_link_direction,
+            )
+        )
+    )
+    raise_if_error(
+        rfmxclient.SetAttributeI32(
+            nirfmxnr_types.SetAttributeI32Request(
+                instrument=rfmxsession,
+                selector_string="",
+                attribute_id=nirfmxnr_types.NIRFMXNR_ATTRIBUTE_FREQUENCY_RANGE,
+                attr_val_raw=nr_frequency_range,
+            )
+        )
+    )
+    raise_if_error(
+        rfmxclient.SetAttributeF64(
+            nirfmxnr_types.SetAttributeF64Request(
+                instrument=rfmxsession,
+                selector_string="",
+                attribute_id=nirfmxnr_types.NIRFMXNR_ATTRIBUTE_COMPONENT_CARRIER_BANDWIDTH,
+                attr_val=nr_carrier_bandwidth,
+            )
+        )
+    )
+    raise_if_error(
+        rfmxclient.SetAttributeF64(
+            nirfmxnr_types.SetAttributeF64Request(
+                instrument=rfmxsession,
+                selector_string="",
+                attribute_id=nirfmxnr_types.NIRFMXNR_ATTRIBUTE_BANDWIDTH_PART_SUBCARRIER_SPACING,
+                attr_val=nr_subcarrier_spacing,
+            )
+        )
+    )
+    raise_if_error(
+        rfmxclient.SetAttributeI32(
+            nirfmxnr_types.SetAttributeI32Request(
+                instrument=rfmxsession,
+                selector_string="",
+                attribute_id=nirfmxnr_types.NIRFMXNR_ATTRIBUTE_PUSCH_MODULATION_TYPE,
+                attr_val=nr_pusch_modulation_type,
+            )
+        )
+    )
+    raise_if_error(
+        rfmxclient.SetAttributeI32(
+            nirfmxnr_types.SetAttributeI32Request(
+                instrument=rfmxsession,
+                selector_string="",
+                attribute_id=nirfmxnr_types.NIRFMXNR_ATTRIBUTE_MODACC_MEASUREMENT_LENGTH_UNIT,
+                attr_val=nr_measurement_length_unit,
+            )
+        )
+    )
+    raise_if_error(
+        rfmxclient.SetAttributeF64(
+            nirfmxnr_types.SetAttributeF64Request(
+                instrument=rfmxsession,
+                selector_string="",
+                attribute_id=nirfmxnr_types.NIRFMXNR_ATTRIBUTE_MODACC_MEASUREMENT_OFFSET,
+                attr_val=nr_measurement_offset,
+            )
+        )
+    )
+    raise_if_error(
+        rfmxclient.SetAttributeF64(
+            nirfmxnr_types.SetAttributeF64Request(
+                instrument=rfmxsession,
+                selector_string="",
+                attribute_id=nirfmxnr_types.NIRFMXNR_ATTRIBUTE_MODACC_MEASUREMENT_LENGTH,
+                attr_val=nr_measurement_length,
+            )
+        )
+    )
+    raise_if_error(
+        rfmxclient.SelectMeasurements(
+            nirfmxnr_types.SelectMeasurementsRequest(
+                instrument=rfmxsession,
+                selector_string="",
+                measurements=nirfmxnr_types.MEASUREMENT_TYPES_MODACC,
+                enable_all_traces=False,
+            )
+        )
+    )
+    raise_if_error(
+        rfmxclient.Commit(
+            nirfmxnr_types.CommitRequest(
+                instrument=rfmxsession,
+                selector_string="",
+            )
+        )
+    )
+    # Once commit is called, the recommended acquisition settings can be queried
+    response = rfmxclient.GetAttributeF64(
+        nirfmxinstr_types.GetAttributeF64Request(
+            instrument=rfmxsession,
+            channel_name="",
+            attribute_id=nirfmxinstr_types.NIRFMXINSTR_ATTRIBUTE_RECOMMENDED_IQ_MINIMUM_SAMPLE_RATE,
+        )
+    )
+    minimum_sample_rate = response.attr_val
+    response = rfmxclient.GetAttributeF64(
+        nirfmxinstr_types.GetAttributeF64Request(
+            instrument=rfmxsession,
+            channel_name="",
+            attribute_id=nirfmxinstr_types.NIRFMXINSTR_ATTRIBUTE_RECOMMENDED_IQ_ACQUISITION_TIME,
+        )
+    )
+    acquisition_time = response.attr_val
+    number_of_samples = acquisition_time * minimum_sample_rate
+    response = rfmxclient.GetAttributeF64(
+        nirfmxinstr_types.GetAttributeF64Request(
+            instrument=rfmxsession,
+            channel_name="",
+            attribute_id=nirfmxinstr_types.NIRFMXINSTR_ATTRIBUTE_RECOMMENDED_IQ_PRE_TRIGGER_TIME,
+        )
+    )
+    pre_trigger_time = response.attr_val
+    number_of_pre_samples = pre_trigger_time * minimum_sample_rate
+    response = rfmxclient.GetAttributeI32(
+        nirfmxinstr_types.GetAttributeI32Request(
+            instrument=rfmxsession,
+            channel_name="",
+            attribute_id=nirfmxinstr_types.NIRFMXINSTR_ATTRIBUTE_RECOMMENDED_NUMBER_OF_RECORDS,
+        )
+    )
+    number_of_records = response.attr_val
+
+    # Configure RFSA Acquisition Settings
+    raise_if_error(
+        rfsaclient.ConfigureNumberOfSamples(
+            nirfsa_types.ConfigureNumberOfSamplesRequest(
+                vi=rfsasession,
+                number_of_samples_is_finite=True,
+                samples_per_record=int(number_of_samples),
+            )
+        )
+    )
+    raise_if_error(
+        rfsaclient.ConfigureIQRate(
+            nirfsa_types.ConfigureIQRateRequest(
+                vi=rfsasession, iq_rate=minimum_sample_rate
+            )
+        )
+    )
+    print(f"Done")
+    print(f"Starting Generation...", end="")
+    raise_if_error(rfsgclient.Initiate(nirfsg_types.InitiateRequest(vi=rfsgsession)))
+    print("Generating")
+    print("Starting Acquisition and Analysis Loop:")
+
+    ###### Start Acquisition and AO Analyze ######
+    read_response = raise_if_error(
+        rfsaclient.Initiate(nirfsa_types.InitiateRequest(vi=rfsasession))
+    )
+    for record in range(number_of_records):
+        read_response = raise_if_error(
+            rfsaclient.FetchIQSingleRecordComplexF32(
+                nirfsa_types.FetchIQSingleRecordComplexF32Request(
+                    vi=rfsasession,
+                    channel_list="",
+                    record_number=record,
+                    number_of_samples=int(number_of_samples),
+                    timeout=10.0,
+                )
+            )
+        )
+
+        iq = [
+            nidevice_grpc.NIComplexNumberF32(
+                real=sample.real, imaginary=sample.imaginary
+            )
+            for sample in read_response.data
+        ]
+
+        ###### Feed IQ Data to Analysis Only ######
+        raise_if_error(
+            rfmxclient.AnalyzeIQ1Waveform(
+                nirfmxnr_types.AnalyzeIQ1WaveformRequest(
+                    instrument=rfmxsession,
+                    selector_string="",
+                    result_name="",
+                    x0=read_response.wfm_info.relative_initial_x,
+                    dx=read_response.wfm_info.x_increment,
+                    iq=iq,
+                    reset=True,
+                )
+            )
+        )
+    ###### Fetch ModAcc results ######
+    modacc_fetch_measurement = raise_if_error(
+        rfmxclient.ModAccFetchCompositeEVM(
+            nirfmxnr_types.ModAccFetchCompositeEVMRequest(
+                instrument=rfmxsession, selector_string="", timeout=10.0
+            )
+        )
+    )
+    print(modacc_fetch_measurement)
+except grpc.RpcError as rpc_error:
+    error_message = rpc_error.details()
+    for entry in rpc_error.trailing_metadata() or []:
+        if entry.key == "ni-error":
+            value = (
+                entry.value
+                if isinstance(entry.value, str)
+                else entry.value.decode("utf-8")
+            )
+            error_message += f"\nError status: {value}"
+    if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
+        error_message = f"Failed to connect to server on {SERVER_ADDRESS}:{SERVER_PORT}"
+    elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
+        error_message = "The operation is not implemented or is not supported/enabled in this service"
+    print(f"{error_message}")
+finally:
+    if rfmxsession:
+        rfmxclient.Close(
+            nirfmxnr_types.CloseRequest(instrument=rfmxsession, force_destroy=True)
+        )
+    if rfsasession:
+        rfsaclient.Close(nirfsa_types.CloseRequest(vi=rfsasession))
+    raise_if_error(rfsgclient.Abort(nirfsg_types.AbortRequest(vi=rfsgsession)))
+    if rfsgsession:
+        rfsgclient.Close(nirfsg_types.CloseRequest(vi=rfsgsession))

--- a/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
+++ b/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
@@ -35,10 +35,6 @@ If they are not passed in as command line arguments, then by default the server 
 
 import sys
 
-import os
-
-sys.path.append(os.getcwd())
-
 import grpc
 import nidevice_pb2 as nidevice_grpc
 import nirfmxinstr_pb2 as nirfmxinstr_types

--- a/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
+++ b/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
@@ -234,7 +234,7 @@ try:
         )
     )
 
-    ###### Configure NR Settigs ######
+    ###### Configure NR Settings ######
     nr_frequency_range = nirfmxnr_types.NIRFMXNR_INT32_FREQUENCY_RANGE_RANGE1
     nr_carrier_bandwidth = 100e6
     nr_subcarrier_spacing = 30e3

--- a/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
+++ b/examples/nirf/rfsa-rfsg-NR-analysis-only-modacc.py
@@ -1,4 +1,4 @@
-r"""Demostration on how to use RFSA, RFSG and RFmx in Analysis Only mode.
+r"""Demonstration on how to use RFSA, RFSG and RFmx in Analysis Only mode.
 
 This example shows how to generate a TDMS waveform using RFSG, to capture the raw IQ data using
 RFSA and to demodulate it using RFmx Analysis Only mode.

--- a/examples/nirfsg/rfsg-multitone-example.py
+++ b/examples/nirfsg/rfsg-multitone-example.py
@@ -1,0 +1,295 @@
+"""Generate any number and power of tones.
+At least one tone needs to be at 0 dB. Use Power level to set the power of all the tones relative to their selected power.
+The minimum separation is mandated by a variable below. A smaller number needs more samples to meet the needs.
+The maximum separation is mandated by the instrument used.
+
+Gerardo orozco
+RF Systems R&D Semiconductor
+National Instruments
+
+The gRPC API is built from the C API. NI-RFSG documentation is installed with the driver at:
+  C:\Program Files (x86)\IVI Foundation\IVI\Drivers\niRFSG\documentation\English\RFSG.chm
+
+Getting Started:
+
+To run this example, install "NI-RFSG Driver" on the server machine:
+  https://www.ni.com/en-us/support/downloads/drivers/download.ni-rfsg.html
+
+For instructions on how to use protoc to generate gRPC client interfaces, see our "Creating a gRPC
+Client" wiki page:
+  https://github.com/ni/grpc-device/wiki/Creating-a-gRPC-Client
+
+Refer to the NI-RFSG gRPC Wiki for the latest C Function Reference:
+  https://github.com/ni/grpc-device/wiki/NI-RFSG-C-Function-Reference
+
+Running from command line:
+
+Server machine's IP address, port number, and physical channel name can be passed as separate
+command line arguments.
+  > python getting-started-single-tone-generation.py <server_address> <port_number> <resource_name>
+If they are not passed in as command line arguments, then by default the server address will be
+"localhost:31763", with "SimulatedRFSG" as the physical channel name.
+"""  # noqa: W505
+
+import sys
+import math
+import numpy as np
+
+import os
+sys.path.append(os.getcwd())
+
+import grpc
+import nirfsg_pb2 as nirfsg_types
+import nirfsg_pb2_grpc as grpc_nirfsg
+import nidevice_pb2 as nidevice_grpc
+
+
+SERVER_ADDRESS = "mercury07"
+SERVER_PORT = "31763"
+SESSION_NAME = "NI-RFSG-Session"
+
+# Resource name, channel name and options for a simulated 5841 client.
+RESOURCE = "5840_1"
+OPTIONS = ""
+
+# Read in cmd args
+if len(sys.argv) >= 2:
+    SERVER_ADDRESS = sys.argv[1]
+if len(sys.argv) >= 3:
+    SERVER_PORT = sys.argv[2]
+if len(sys.argv) >= 4:
+    RESOURCE = sys.argv[3]
+    OPTIONS = ""
+
+# Create a gRPC channel + client.
+channel = grpc.insecure_channel(f"{SERVER_ADDRESS}:{SERVER_PORT}")
+client = grpc_nirfsg.NiRFSGStub(channel)
+vi = None
+
+
+def check_for_warning(response, vi):
+    """Print to console if the status indicates a warning."""
+    if response.status > 0:
+        warning_message = client.ErrorMessage(
+            nirfsg_types.ErrorMessageRequest(vi=vi, error_code=response.status)
+        )
+        sys.stderr.write(f"{warning_message.error_message}\nWarning status: {response.status}\n")
+
+
+class Tone:
+    def __init__(self,offsetHz, gaindB):
+        self.offsetHz = offsetHz
+        self.gaindB = gaindB
+    def __repr__(self):
+        return 'Offset: {0} Hz and Gain: {1} dB'.format(self.offsetHz,self.gaindB)
+
+def gcd(my_list):
+    result = my_list[0]
+    for x in my_list[1:]:
+        if result < x:
+            temp = result
+            result = x
+            x = temp
+        while x != 0:
+            temp = x
+            x = result % x
+            result = temp
+    return result
+
+
+try:
+    response = client.InitWithOptions(
+        nirfsg_types.InitWithOptionsRequest(
+            session_name=SESSION_NAME, resource_name=RESOURCE, option_string=OPTIONS
+        )
+    )
+    vi = response.vi
+    #Tones to Generate
+
+    #Documentation
+    #Tones power is relative to the generated power.
+
+    #Test Cases
+    #Tones = [Tone(0, 0)]
+    #Tones = [Tone(-1E6, 0), Tone(1E6, 0)]
+    Tones = [Tone(-1E6, 0), Tone(1E6, 0), Tone(-5E6, 0), Tone(5E6, 0), Tone(-10E6, 0), Tone(10E6, 0)]
+    #Tones = [Tone(-1E6, 0), Tone(1E6, -5), Tone(2.5E6, -10), Tone(3.9E6, -20), Tone(-10E6, 0)]
+    #Tones = [Tone(100E3, 0), Tone(-835E3, -6)]
+    #Tones = [Tone(10E6, -3), Tone(-100.1E6, -6)]
+    #Tones = [Tone(1E6, 2.45), Tone(-50E6, -6)]
+    #Tones = [Tone(499E6, 0), Tone(-499E6, -6)]
+    #Tones = [Tone(1E6, 0), Tone(-50E6, -6)] + [Tone(499E6, 0), Tone(-499E6, -6)]
+    #Tones = [Tone(0, 0), Tone(-835E3, -6)]
+    #Tones = [Tone(2501200001-3e9, 0), Tone(3405200000-3e9, 0), Tone(3305300000-3e9, 0)]
+
+    #Error Test Cases
+    #Tones = [Tone(0, -6)]
+    #Tones = [Tone(100E6, -10), Tone(-100E6, -10)]
+    #Tones = [Tone(1E9, 0), Tone(-100.1E6, -6)]
+    #Tones = [Tone(100E6, -20)]
+    #Tones = [Tone(1, 0), Tone(10E6, -6)]
+
+    minSamplingRateHz = 4e6
+    minFrequencyStepHz = 5000
+    minWaveformSize = 100000
+    print(Tones)
+
+
+    # Define the instrument and RF parameters
+    print("Setting measurement parameters.. ", end='')
+    centerFrequency = 3e9
+    rfsgPowerLevel_dBm = -10
+    rfsgResourceName = '5840_1'    
+    rfsgSelectedPorts = ""                                              
+    rfsgWaveformName = "wfm"
+    rfsg_script = 'script GenerateWaveform repeat forever generate wfm end repeat end script'
+    rfsgExternalAttenuation = 0.0
+    rfsgFrequencyReferenceSource = nirfsg_types.REF_CLOCK_SOURCE_ONBOARD_CLOCK
+    rfsgAutomaticSharedLO = nirfsg_types.NIRFSG_INT32_ENABLE_VALUES_DISABLE
+    SamplingRateHz = max([abs(tone.offsetHz) for tone in Tones] + [minSamplingRateHz]) * 2.5 #Max rate 2.5x the max offset
+    #Greatest common denominator of the tones we need to make it divisible by Sampling Rate so we add it to the list it and then we divide it by a minimum resolution
+    FrequencyStepHz = max(gcd([abs(tone.offsetHz) for tone in Tones] + [SamplingRateHz])/minFrequencyStepHz, SamplingRateHz/minWaveformSize) 
+    #Sum all the tones power for scaling on the SG power
+    TonesPower = 10*math.log(sum([math.pow(10,tone.gaindB/10) for tone in Tones]),10)
+    print("FrequencyStep = {} Hz and Sampling Frequency = {} Hz and Tone Total Power = {}".format(FrequencyStepHz, SamplingRateHz, TonesPower))
+
+    client.SetAttributeViString(nirfsg_types.SetAttributeViStringRequest(vi=vi, 
+                                channel_name="", 
+                                attribute_id=nirfsg_types.NIRFSG_ATTRIBUTE_SELECTED_PORTS, 
+                                value_raw = rfsgSelectedPorts)
+                                )
+
+    
+    # We wante the TONES to be at a specific power, for that reason, we adjust our generator power to the desired power + whatever the tones constructive interference
+    # This was computed above as the "tones power"
+    client.SetAttributeViReal64(nirfsg_types.SetAttributeViReal64Request(
+                            vi = vi,
+                            channel_name = "",
+                            attribute_id = nirfsg_types.NIRFSG_ATTRIBUTE_POWER_LEVEL,
+                            value_raw = rfsgPowerLevel_dBm + TonesPower)
+                            )
+
+    client.SetAttributeViReal64(nirfsg_types.SetAttributeViReal64Request(
+                            vi = vi,
+                            channel_name = "",
+                            attribute_id = nirfsg_types.NIRFSG_ATTRIBUTE_EXTERNAL_GAIN,
+                            value_raw = -rfsgExternalAttenuation)
+                            )
+    
+    client.SetAttributeViReal64(nirfsg_types.SetAttributeViReal64Request(
+                            vi = vi,
+                            channel_name = "",
+                            attribute_id = nirfsg_types.NIRFSG_ATTRIBUTE_FREQUENCY,
+                            value_raw = centerFrequency)
+                            )
+
+    #Coarce Settings
+    for item in Tones:
+        item.offsetHz = np.floor(item.offsetHz/FrequencyStepHz)*FrequencyStepHz
+        print(item)
+
+
+    #Init initial waveform
+    waveform = np.full(int(1/FrequencyStepHz * SamplingRateHz), 0+0j)
+    Buffer = np.full(int(1/FrequencyStepHz * SamplingRateHz), 1+0j)
+    #Create Tones on waveform
+    for item in Tones:
+        phaseDrif = item.offsetHz/SamplingRateHz * 2 * np.pi
+        OffsetWaveform = [1*np.exp(i*phaseDrif*1j) for i in np.arange(0,len(waveform))]
+        waveform = waveform + np.array(OffsetWaveform) * math.pow(10,item.gaindB/20)
+
+    
+    # Waveform needs to normalize as we will use Peak Power Mode. This is easier to integrate with other pieces of code as it's the same mode.
+    # This means that what we write magnitude (sqrt(I^2 + Q^2)) be larger than 1. 1 is the maximum and corresponds to the peak power setting.
+    # If the power is set to -10 dBm, then a 1 means that the instantaneous power will be at -10 dBm.
+    # To normalize, we divide all numbers by the peak to average ratio. If the signal has gaps, then we should not use that section to compute power.
+    
+    waveform_papr = 10*math.log(np.max(np.square(abs(waveform)))/np.mean(np.square(abs(waveform))), 10)
+    waveformNorm = waveform/math.pow(10,waveform_papr/10)
+    print(f"Previous max value is: {np.max(abs(waveform))} average value is: {np.mean(abs(waveform))} and new max value is: {np.max(abs(waveformNorm))} and PAPR: {waveform_papr}")
+    # convert to NI complex datatype
+    iqNI = [nidevice_grpc.NIComplexNumberF32(real = sample.real, imaginary = sample.imag) for sample in waveformNorm]
+    
+    client.ConfigurePowerLevelType(nirfsg_types.ConfigurePowerLevelTypeRequest(
+                            vi = vi,
+                            power_level_type = nirfsg_types.POWER_LEVEL_TYPE_PEAK_POWER)
+                            )
+
+    client.WriteArbWaveformComplexF32(nirfsg_types.WriteArbWaveformComplexF32Request(
+                            vi = vi,
+                            waveform_name = 'wfm',
+                            wfm_data = iqNI,
+                            more_data_pending = False)
+                            )
+    client.SetAttributeViReal64(nirfsg_types.SetAttributeViReal64Request(
+                            vi = vi,
+                            channel_name = 'waveform::wfm',
+                            attribute_id = nirfsg_types.NIRFSG_ATTRIBUTE_WAVEFORM_IQ_RATE,
+                            value_raw = SamplingRateHz)
+                            )
+    
+    # Example of how to set/get parameters of a waveform, the channel_name needs to have the prefix waveform:: before the name of the waveform
+    client.SetAttributeViReal64(nirfsg_types.SetAttributeViReal64Request(
+                            vi = vi,
+                            channel_name = 'waveform::wfm',
+                            attribute_id = nirfsg_types.NIRFSG_ATTRIBUTE_WAVEFORM_PAPR,
+                            value_raw = waveform_papr)
+                            )
+
+    response = client.GetAttributeViReal64(nirfsg_types.GetAttributeViReal64Request(
+                            vi = vi,
+                            channel_name = 'waveform::wfm',
+                            attribute_id = nirfsg_types.NIRFSG_ATTRIBUTE_WAVEFORM_PAPR)
+                            )
+    waveform_papr = response.value
+    # The runtime scaling is to help reduce the chance of overflow the DAC by reducing the signal a little bit more. The driver compensates for this reduction and no need to compensate for this.
+    runtimeScaling = 1.5
+    client.SetAttributeViReal64(nirfsg_types.SetAttributeViReal64Request(
+                            vi = vi,
+                            channel_name = 'waveform::wfm',
+                            attribute_id = nirfsg_types.NIRFSG_ATTRIBUTE_WAVEFORM_RUNTIME_SCALING,
+                            value_raw = -runtimeScaling)
+                            )
+    client.SetAttributeViReal64(nirfsg_types.SetAttributeViReal64Request(
+                            vi = vi,
+                            channel_name = 'waveform::wfm',
+                            attribute_id = nirfsg_types.NIRFSG_ATTRIBUTE_WAVEFORM_SIGNAL_BANDWIDTH,
+                            value_raw = 8E6)
+                            )
+
+    client.ConfigureGenerationMode(nirfsg_types.ConfigureGenerationModeRequest(
+                            vi = vi,
+                            generation_mode = nirfsg_types.GENERATION_MODE_SCRIPT)
+                            )
+
+    client.WriteScript(nirfsg_types.WriteScriptRequest(
+                            vi = vi,
+                            script = rfsg_script)
+                            )
+
+    initiate_response = client.Initiate(nirfsg_types.InitiateRequest(vi=vi))
+    check_for_warning(initiate_response, vi)
+    print("Generating tone...")
+    input("Press Any Key to Stop Generation")
+
+    client.Abort(nirfsg_types.AbortRequest(vi=vi))
+
+except grpc.RpcError as rpc_error:
+    error_message = rpc_error.details()
+    for entry in rpc_error.trailing_metadata() or []:
+        if entry.key == "ni-error":
+            value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")
+            error_message += f"\nError status: {value}"
+    if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
+        error_message = f"Failed to connect to server on {SERVER_ADDRESS}:{SERVER_PORT}"
+    elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
+    print(f"{error_message}")
+finally:
+    if vi:
+        client.ConfigureOutputEnabled(
+            nirfsg_types.ConfigureOutputEnabledRequest(output_enabled=False)
+        )
+        client.Close(nirfsg_types.CloseRequest(vi=vi))

--- a/examples/nirfsg/rfsg-multitone-example.py
+++ b/examples/nirfsg/rfsg-multitone-example.py
@@ -38,7 +38,7 @@ import nirfsg_pb2_grpc as grpc_nirfsg
 import numpy as np
 
 
-SERVER_ADDRESS = "mercury07"
+SERVER_ADDRESS = "localhost"
 SERVER_PORT = "31763"
 SESSION_NAME = "NI-RFSG-Session"
 
@@ -176,7 +176,7 @@ try:
         )
     )
 
-    # We wante the tones to be at a specific power, for that reason, we adjust
+    # We want the tones to be at a specific power, for that reason, we adjust
     # generator power to the desired power + whatever the tones constructive
     # interference. This was computed above as the "tones power"
     client.SetAttributeViReal64(
@@ -206,7 +206,7 @@ try:
         )
     )
 
-    # Coarce Settings
+    # Coerce Settings
     for item in tones:
         item.offset_hz = np.floor(item.offset_hz / frequency_step_hz) * frequency_step_hz
         print(item)

--- a/examples/nirfsg/rfsg-multitone-example.py
+++ b/examples/nirfsg/rfsg-multitone-example.py
@@ -66,9 +66,7 @@ def check_for_warning(response, vi):
         warning_message = client.ErrorMessage(
             nirfsg_types.ErrorMessageRequest(vi=vi, error_code=response.status)
         )
-        sys.stderr.write(
-            f"{warning_message.error_message}\nWarning status: {response.status}\n"
-        )
+        sys.stderr.write(f"{warning_message.error_message}\nWarning status: {response.status}\n")
 
 
 class Tone:
@@ -154,14 +152,11 @@ try:
     rfsg_frequency_reference_source = nirfsg_types.REF_CLOCK_SOURCE_ONBOARD_CLOCK
     rfsg_automatic_shared_lo = nirfsg_types.NIRFSG_INT32_ENABLE_VALUES_DISABLE
     # Max rate 2.5x the max offset
-    sampling_rate_hz = (
-        max([abs(tone.offset_hz) for tone in tones] + [min_sampling_rate_hz]) * 2.5
-    )
+    sampling_rate_hz = max([abs(tone.offset_hz) for tone in tones] + [min_sampling_rate_hz]) * 2.5
     # Greatest common denominator of the tones we need to make it divisible by Sampling Rate
     # thus we add it to the list it and then we divide it by a minimum resolution
     frequency_step_hz = max(
-        gcd([abs(tone.offset_hz) for tone in tones] + [sampling_rate_hz])
-        / min_frequency_step_hz,
+        gcd([abs(tone.offset_hz) for tone in tones] + [sampling_rate_hz]) / min_frequency_step_hz,
         sampling_rate_hz / min_waveform_size,
     )
     # Sum all the tones power for scaling on the SG power
@@ -221,9 +216,7 @@ try:
     # Create tones on waveform
     for item in tones:
         phase_drif = item.offset_hz / sampling_rate_hz * 2 * np.pi
-        offset_waveform = [
-            1 * np.exp(i * phase_drif * 1j) for i in np.arange(0, len(waveform))
-        ]
+        offset_waveform = [1 * np.exp(i * phase_drif * 1j) for i in np.arange(0, len(waveform))]
         waveform = waveform + np.array(offset_waveform) * math.pow(10, item.gain_db / 20)
     # Waveform needs to normalize as we will use Peak Power Mode. This is easier to
     #  integrate with other pieces of code as it's the same mode.
@@ -325,9 +318,7 @@ except grpc.RpcError as rpc_error:
     error_message = rpc_error.details()
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
-            value = (
-                entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")
-            )
+            value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")
             error_message += f"\nError status: {value}"
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {SERVER_ADDRESS}:{SERVER_PORT}"

--- a/examples/nirfsg/rfsg-multitone-example.py
+++ b/examples/nirfsg/rfsg-multitone-example.py
@@ -82,13 +82,13 @@ class Tone:
         """Construct each tone using a relative offset in Hz and relative power in dBc."""
         self.offset_hz = offset_hz
         self.gain_db = gain_db
-        
+
     def __repr__(self):
-        """Returns formatted string to repreesent the  Tones."""
-        return 'Offset: {0} Hz and Gain: {1} dB'.format(self.offset_hz,self.gain_db)
+        """Make a string with Tones information."""
+        return 'Offset: {0} Hz and Gain: {1} dB'.format(self.offset_hz, self.gain_db)
 
 def gcd(my_list):
-    """Computes the greatest common denominator.
+    """Return the greatest common denominator.
 
     Given a list of numbers find the smallest number that can divide them all.
     """

--- a/examples/nirfsg/rfsg-multitone-example.py
+++ b/examples/nirfsg/rfsg-multitone-example.py
@@ -149,9 +149,7 @@ try:
     rfsg_resource_name = "5840_1"
     rfsg_selected_ports = ""
     rfsg_waveform_name = "wfm"
-    rfsg_script = (
-        "script GenerateWaveform repeat forever generate wfm end repeat end script"
-    )
+    rfsg_script = "script GenerateWaveform repeat forever generate wfm end repeat end script"
     rfsg_external_attenuation = 0.0
     rfsg_frequency_reference_source = nirfsg_types.REF_CLOCK_SOURCE_ONBOARD_CLOCK
     rfsg_automatic_shared_lo = nirfsg_types.NIRFSG_INT32_ENABLE_VALUES_DISABLE
@@ -167,9 +165,7 @@ try:
         sampling_rate_hz / min_waveform_size,
     )
     # Sum all the tones power for scaling on the SG power
-    tones_power = 10 * math.log(
-        sum([math.pow(10, tone.gain_db / 10) for tone in tones]), 10
-    )
+    tones_power = 10 * math.log(sum([math.pow(10, tone.gain_db / 10) for tone in tones]), 10)
     print(
         "FrequencyStep = {} Hz and Sampling Frequency = {} Hz and Tone Total Power = {}".format(
             frequency_step_hz, sampling_rate_hz, tones_power
@@ -217,9 +213,7 @@ try:
 
     # Coarce Settings
     for item in tones:
-        item.offset_hz = (
-            np.floor(item.offset_hz / frequency_step_hz) * frequency_step_hz
-        )
+        item.offset_hz = np.floor(item.offset_hz / frequency_step_hz) * frequency_step_hz
         print(item)
     # Init initial waveform
     waveform = np.full(int(1 / frequency_step_hz * sampling_rate_hz), 0 + 0j)
@@ -230,9 +224,7 @@ try:
         offset_waveform = [
             1 * np.exp(i * phase_drif * 1j) for i in np.arange(0, len(waveform))
         ]
-        waveform = waveform + np.array(offset_waveform) * math.pow(
-            10, item.gain_db / 20
-        )
+        waveform = waveform + np.array(offset_waveform) * math.pow(10, item.gain_db / 20)
     # Waveform needs to normalize as we will use Peak Power Mode. This is easier to
     #  integrate with other pieces of code as it's the same mode.
     # This means that what we write magnitude (sqrt(I^2 + Q^2)) be larger than 1. 1 is
@@ -334,15 +326,15 @@ except grpc.RpcError as rpc_error:
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = (
-                entry.value
-                if isinstance(entry.value, str)
-                else entry.value.decode("utf-8")
+                entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")
             )
             error_message += f"\nError status: {value}"
     if rpc_error.code() == grpc.StatusCode.UNAVAILABLE:
         error_message = f"Failed to connect to server on {SERVER_ADDRESS}:{SERVER_PORT}"
     elif rpc_error.code() == grpc.StatusCode.UNIMPLEMENTED:
-        error_message = "The operation is not implemented or is not supported/enabled in this service"
+        error_message = (
+            "The operation is not implemented or is not supported/enabled in this service"
+        )
     print(f"{error_message}")
 finally:
     if vi:

--- a/examples/nirfsg/rfsg-multitone-example.py
+++ b/examples/nirfsg/rfsg-multitone-example.py
@@ -85,7 +85,7 @@ class Tone:
 
     def __repr__(self):
         """Make a string with Tones information."""
-        return 'Offset: {0} Hz and Gain: {1} dB'.format(self.offset_hz, self.gain_db)
+        return "Offset: {0} Hz and Gain: {1} dB".format(self.offset_hz, self.gain_db)
 
 def gcd(my_list):
     """Return the greatest common denominator.

--- a/examples/nirfsg/rfsg-multitone-example.py
+++ b/examples/nirfsg/rfsg-multitone-example.py
@@ -1,4 +1,4 @@
-r"""Generate any number and power of tones using RFSG
+r"""Generate any number and power of tones using RFSG.
 
 At least one tone needs to be at 0 dB. Use Power level to set the power of all the tones relative to their selected power.
 The minimum separation is mandated by a variable below. A smaller number needs more samples to meet the needs.
@@ -31,8 +31,6 @@ If they are not passed in as command line arguments, then by default the server 
 import math
 import os
 import sys
-
-sys.path.append(os.getcwd())
 
 import grpc
 import nidevice_pb2 as nidevice_grpc
@@ -74,7 +72,7 @@ def check_for_warning(response, vi):
 
 
 class Tone:
-    """Class definition for Tones
+    """Class definition for tones.
 
     Define the tone with relative offset from the carrier frequency in Hz (relative to the
      generator center frequency).
@@ -86,12 +84,13 @@ class Tone:
         self.offset_hz = offset_hz
         self.gain_db = gain_db
     def __repr__(self):
-        """Used when using the print method so it displays nicer the Tones values."""
+        """Used when using the print method so it displays nicer the tones values."""
         return 'Offset: {0} Hz and Gain: {1} dB'.format(self.offset_hz,self.gain_db)
 
 def gcd(my_list):
-    """Greatest common denominator. Given a list of numbers find the smallest
-     number that can divide them all."""
+    """Greatest common denominator. 
+    Given a list of numbers find the smallest number that can divide them all.
+    """
     result = my_list[0]
     for x in my_list[1:]:
         if result < x:
@@ -112,30 +111,28 @@ try:
         )
     )
     vi = response.vi
-    #Tones to Generate
-
-    #Documentation
-    #Tones power is relative to the generated power.
+    #tones to Generate
+    #tones power is relative to the generated power.
 
     #Test Cases
-    #Tones = [Tone(0, 0)]
-    #Tones = [Tone(-1E6, 0), Tone(1E6, 0)]
-    tones = [Tone(-1E6, 0), Tone(1E6, 0), Tone(-5E6, 0), Tone(5E6, 0), Tone(-10E6, 0), Tone(10E6, 0)]
-    #Tones = [Tone(-1E6, 0), Tone(1E6, -5), Tone(2.5E6, -10), Tone(3.9E6, -20), Tone(-10E6, 0)]
-    #Tones = [Tone(100E3, 0), Tone(-835E3, -6)]
-    #Tones = [Tone(10E6, -3), Tone(-100.1E6, -6)]
-    #Tones = [Tone(1E6, 2.45), Tone(-50E6, -6)]
-    #Tones = [Tone(499E6, 0), Tone(-499E6, -6)]
-    #Tones = [Tone(1E6, 0), Tone(-50E6, -6)] + [Tone(499E6, 0), Tone(-499E6, -6)]
-    #Tones = [Tone(0, 0), Tone(-835E3, -6)]
-    #Tones = [Tone(2501200001-3e9, 0), Tone(3405200000-3e9, 0), Tone(3305300000-3e9, 0)]
+    #tones = [Tone(0, 0)]
+    tones = [Tone(-1E6, 0), Tone(1E6, 0)]
+    #tones = [Tone(-1E6, 0), Tone(1E6, 0), Tone(-5E6, 0), Tone(5E6, 0), Tone(-10E6, 0), Tone(10E6, 0)]
+    #tones = [Tone(-1E6, 0), Tone(1E6, -5), Tone(2.5E6, -10), Tone(3.9E6, -20), Tone(-10E6, 0)]
+    #tones = [Tone(100E3, 0), Tone(-835E3, -6)]
+    #tones = [Tone(10E6, -3), Tone(-100.1E6, -6)]
+    #tones = [Tone(1E6, 2.45), Tone(-50E6, -6)]
+    #tones = [Tone(499E6, 0), Tone(-499E6, -6)]
+    #tones = [Tone(1E6, 0), Tone(-50E6, -6)] + [Tone(499E6, 0), Tone(-499E6, -6)]
+    #tones = [Tone(0, 0), Tone(-835E3, -6)]
+    #tones = [Tone(2501200001-3e9, 0), Tone(3405200000-3e9, 0), Tone(3305300000-3e9, 0)]
 
     #Error Test Cases
-    #Tones = [Tone(0, -6)]
-    #Tones = [Tone(100E6, -10), Tone(-100E6, -10)]
-    #Tones = [Tone(1E9, 0), Tone(-100.1E6, -6)]
-    #Tones = [Tone(100E6, -20)]
-    #Tones = [Tone(1, 0), Tone(10E6, -6)]
+    #tones = [Tone(0, -6)]
+    #tones = [Tone(100E6, -10), Tone(-100E6, -10)]
+    #tones = [Tone(1E9, 0), Tone(-100.1E6, -6)]
+    #tones = [Tone(100E6, -20)]
+    #tones = [Tone(1, 0), Tone(10E6, -6)]
 
     min_sampling_rate_hz = 4e6
     min_frequency_step_hz = 5000
@@ -170,7 +167,7 @@ try:
                                 )
 
     
-    # We wante the TONES to be at a specific power, for that reason, we adjust 
+    # We wante the tones to be at a specific power, for that reason, we adjust 
     # generator power to the desired power + whatever the tones constructive
     # interference. This was computed above as the "tones power"
     client.SetAttributeViReal64(nirfsg_types.SetAttributeViReal64Request(
@@ -203,7 +200,7 @@ try:
     #Init initial waveform
     waveform = np.full(int(1/frequency_step_hz * sampling_rate_hz), 0+0j)
     buffer = np.full(int(1/frequency_step_hz * sampling_rate_hz), 1+0j)
-    #Create Tones on waveform
+    #Create tones on waveform
     for item in tones:
         phase_drif = item.offset_hz/sampling_rate_hz * 2 * np.pi
         offset_waveform = [1*np.exp(i*phase_drif*1j) for i in np.arange(0,len(waveform))]

--- a/examples/nirfsg/rfsg-multitone-example.py
+++ b/examples/nirfsg/rfsg-multitone-example.py
@@ -29,7 +29,6 @@ If they are not passed in as command line arguments, then by default the server 
 """  # noqa: W505
 
 import math
-import os
 import sys
 
 import grpc
@@ -79,16 +78,17 @@ class Tone:
     Relative power level in dBc (relative to the generator defined power level).
     """
 
-    def __init__(self,offset_hz, gain_db):
+    def __init__(self, offset_hz, gain_db):
         """Construct each tone using a relative offset in Hz and relative power in dBc."""
         self.offset_hz = offset_hz
         self.gain_db = gain_db
     def __repr__(self):
-        """Used when using the print method so it displays nicer the tones values."""
+        """Returns a formatted string to repreesent the  Tones."""
         return 'Offset: {0} Hz and Gain: {1} dB'.format(self.offset_hz,self.gain_db)
 
 def gcd(my_list):
     """Greatest common denominator. 
+
     Given a list of numbers find the smallest number that can divide them all.
     """
     result = my_list[0]
@@ -117,7 +117,7 @@ try:
     #Test Cases
     #tones = [Tone(0, 0)]
     tones = [Tone(-1E6, 0), Tone(1E6, 0)]
-    #tones = [Tone(-1E6, 0), Tone(1E6, 0), Tone(-5E6, 0), Tone(5E6, 0), Tone(-10E6, 0), Tone(10E6, 0)]
+    #tones = [Tone(-1E6, 0), Tone(1E6, 0), Tone(-5E6, 0), Tone(5E6, 0), Tone(-10E6, 0)]
     #tones = [Tone(-1E6, 0), Tone(1E6, -5), Tone(2.5E6, -10), Tone(3.9E6, -20), Tone(-10E6, 0)]
     #tones = [Tone(100E3, 0), Tone(-835E3, -6)]
     #tones = [Tone(10E6, -3), Tone(-100.1E6, -6)]

--- a/examples/nirfsg/rfsg-multitone-example.py
+++ b/examples/nirfsg/rfsg-multitone-example.py
@@ -271,14 +271,14 @@ try:
         )
     )
 
-    response = client.GetAttributeViReal64(
+    response_papr = client.GetAttributeViReal64(
         nirfsg_types.GetAttributeViReal64Request(
             vi=vi,
             channel_name="waveform::wfm",
             attribute_id=nirfsg_types.NIRFSG_ATTRIBUTE_WAVEFORM_PAPR,
         )
     )
-    waveform_papr = response.value
+    waveform_papr = response_papr.value
     # The runtime scaling is to help reduce the chance of overflow the DAC by reducing
     #  the signal a bit more (1.5 dB). The driver compensates for this reduction and
     #  no need to compensate for this.

--- a/examples/nirfsg/rfsg-multitone-example.py
+++ b/examples/nirfsg/rfsg-multitone-example.py
@@ -87,6 +87,7 @@ class Tone:
         """Make a string with Tones information."""
         return "Offset: {0} Hz and Gain: {1} dB".format(self.offset_hz, self.gain_db)
 
+
 def gcd(my_list):
     """Return the greatest common denominator.
 

--- a/examples/nirfsg/rfsg-multitone-example.py
+++ b/examples/nirfsg/rfsg-multitone-example.py
@@ -82,12 +82,13 @@ class Tone:
         """Construct each tone using a relative offset in Hz and relative power in dBc."""
         self.offset_hz = offset_hz
         self.gain_db = gain_db
+        
     def __repr__(self):
-        """Returns a formatted string to repreesent the  Tones."""
+        """Returns formatted string to repreesent the  Tones."""
         return 'Offset: {0} Hz and Gain: {1} dB'.format(self.offset_hz,self.gain_db)
 
 def gcd(my_list):
-    """Greatest common denominator. 
+    """Computes the greatest common denominator.
 
     Given a list of numbers find the smallest number that can divide them all.
     """

--- a/source/codegen/stage_client_files.py
+++ b/source/codegen/stage_client_files.py
@@ -39,6 +39,10 @@ class _ArtifactReadiness:
         if "session" == module_name:
             return True
 
+        # Special case for multidriver examples for RF located in this folder
+        if module_name in ["session", "nirf"]:
+            return True
+
         if module_name not in self._module_to_readiness:
             raise KeyError(f"No module config.py metadata for module_name: {module_path}")
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

This example shows customers how to use RFSA/RFSG and RFmx NR to fully make use of Analysis Only feature of RFmx which means that the raw data is acquired by the raw RFSA driver and feed into RFmx to get the results. Feeding the data into RFmx can be done in a machine with no hardware.

### Why should this Pull Request be merged?

Shows examples to use gRPC for more complex scenarios. We include some of these examples in RFmx

### What testing has been done?

Ran example directly in my computer. Will polish the code to get it into the NI python standards.
