### PR TITLE
Fix the validate_linux_rt.py script.

### DIFF
--- a/source/codegen/validate_linux_rt.py
+++ b/source/codegen/validate_linux_rt.py
@@ -64,8 +64,6 @@ def _need_linux_rt_feed_update(metadata_dir: str, changed_files: Set[str]) -> bo
         and not load_metadata(f"{metadata_dir}/{driver}/")["config"].get("linux_rt_support", False)
     ]
     non_rt_driver_changes = set()
-    print(f"\nNon-RT Drivers\n")
-    pprint(non_rt_drivers)
     for non_rt_driver in non_rt_drivers:
         non_rt_driver_changes |= _get_non_rt_driver_changes(non_rt_driver, remaining_changes)
     _print_changed_files("Changes related to drivers not supported on RT:", non_rt_driver_changes)

--- a/source/codegen/validate_linux_rt.py
+++ b/source/codegen/validate_linux_rt.py
@@ -22,6 +22,14 @@ def _get_test_changes(changed_files: Set[str]) -> Set[str]:
     return set(fnmatch.filter(changed_files, "source/tests/*"))
 
 
+def _get_import_changes(changed_files: Set[str]) -> Set[str]:
+    return set(fnmatch.filter(changed_files, "imports/*"))
+
+
+def _get_markdown_changes(changed_files: Set[str]) -> Set[str]:
+    return set(fnmatch.filter(changed_files, "*.md"))
+
+
 def _get_non_rt_driver_changes(driver_name: str, changed_files: Set[str]) -> Set[str]:
     files_affecting_linux_rt = [
         f"generated/{driver_name}/*",
@@ -39,16 +47,25 @@ def _need_linux_rt_feed_update(metadata_dir: str, changed_files: Set[str]) -> bo
     codegen_changes = _get_codegen_changes(changed_files)
     _print_changed_files("Codegen changes not affecting RT:", codegen_changes)
     remaining_changes = changed_files - codegen_changes
-    test_changes = _get_test_changes(changed_files)
+    test_changes = _get_test_changes(remaining_changes)
     _print_changed_files("Test related changes not affecting RT:", test_changes)
     remaining_changes -= test_changes
+    import_changes = _get_import_changes(remaining_changes)
+    _print_changed_files("Import related changes not affecting RT:", import_changes)
+    remaining_changes -= import_changes
+    markdown_changes = _get_markdown_changes(remaining_changes)
+    _print_changed_files("Markdown changes not affecting RT:", markdown_changes)
+    remaining_changes -= markdown_changes
 
     non_rt_drivers = [
         driver
         for driver in os.listdir(metadata_dir)
-        if not load_metadata(f"{metadata_dir}/{driver}/")["config"]["linux_rt_support"]
+        if os.path.isdir(os.path.join(metadata_dir, driver))
+        and not load_metadata(f"{metadata_dir}/{driver}/")["config"].get("linux_rt_support", False)
     ]
     non_rt_driver_changes = set()
+    print(f"\nNon-RT Drivers\n")
+    pprint(non_rt_drivers)
     for non_rt_driver in non_rt_drivers:
         non_rt_driver_changes |= _get_non_rt_driver_changes(non_rt_driver, remaining_changes)
     _print_changed_files("Changes related to drivers not supported on RT:", non_rt_driver_changes)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes the validate_linux_rt.py script.

### Why should this Pull Request be merged?

 It was brought up that it failed last time it ran for the 2.0 release: https://github.com/ni/grpc-device/actions/workflows/validate_linux_rt.yml

### What testing has been done?

Ran `git diff --name-only v1.5.1..v2.0.0 | python .\source\codegen\validate_linux_rt.py source/codegen/metadata` locally.

Before: Failed with same error reported in GitHub action.
After: Passed and suggested that the Linux RT Feed needs updating.
