### PR TITLE
Update sync_github_issues_to_azdo.yml to new owning squad

### DIFF
--- a/.github/workflows/sync_github_issues_to_azdo.yml
+++ b/.github/workflows/sync_github_issues_to_azdo.yml
@@ -15,7 +15,7 @@ jobs:
           github_token: "${{ secrets.GH_REPO_TOKEN }}"
           ado_organization: "ni"
           ado_project: "DevCentral"
-          ado_area_path: "DevCentral\\Product RnD\\PlatformSW\\Test System SW\\CBS\\HW Config"
+          ado_area_path: "DevCentral\\Product RnD\\PlatformSW\\Platform HW and Drivers\\Drivers\\Customer Facing"
           ado_wit: "Bug"
           ado_new_state: "New"
           ado_active_state: "Active"


### PR DESCRIPTION
### What does this Pull Request accomplish?

Changes the area path for syncing Issues to Bugs in AzDo to reflect the new grpc-device owning squad.

### Why should this Pull Request be merged?

Driver team Customer Facing squad should have Bugs assigned to them.

### What testing has been done?

None. I'll make a fake Issue to make sure it syncs to the right spot after this is merged to main.
