### PR TITLE
Update github hosted runners from ubuntu-18.04 to ubuntu-latest.

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -27,7 +27,7 @@ jobs:
           }
         - {
             name: "Ubuntu Build", artifact: "Linux.tar.xz",
-            os: ubuntu-18.04,
+            os: ubuntu-latest,
             build_type: "Release", cc: "gcc-9", cxx: "g++-9",
             cmake_platform: "",
             glibc_version: "2_27",

--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -27,7 +27,7 @@ jobs:
           }
         - {
             name: "Ubuntu Build", artifact: "Linux.tar.xz",
-            os: ubuntu-latest,
+            os: ubuntu-20.04,
             build_type: "Release", cc: "gcc-9", cxx: "g++-9",
             cmake_platform: "",
             glibc_version: "2_27",

--- a/.github/workflows/create_client_artifacts.yml
+++ b/.github/workflows/create_client_artifacts.yml
@@ -18,7 +18,7 @@ jobs:
           }
         - {
             name: "Linux Artifacts", artifact: "Linux.tar.xz",
-            os: ubuntu-18.04,
+            os: ubuntu-latest,
           }
 
     steps:

--- a/.github/workflows/create_client_artifacts.yml
+++ b/.github/workflows/create_client_artifacts.yml
@@ -18,7 +18,7 @@ jobs:
           }
         - {
             name: "Linux Artifacts", artifact: "Linux.tar.xz",
-            os: ubuntu-latest,
+            os: ubuntu-20.04,
           }
 
     steps:


### PR DESCRIPTION
### What does this Pull Request accomplish?

Updates two GitHub actions using `ubuntu-18.04` to use `ubuntu-20.04` instead.

### Why should this Pull Request be merged?

GitHub runners have deprecated ubuntu-18.04 so all actions using them will start failing today: https://github.com/actions/runner-images/issues/6002

### What testing has been done?

Trusting the build.
