### PR TITLE
Be accurate on glibc version linux is built with.

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -30,7 +30,7 @@ jobs:
             os: ubuntu-20.04,
             build_type: "Release", cc: "gcc-9", cxx: "g++-9",
             cmake_platform: "",
-            glibc_version: "2_27",
+            glibc_version: "2_31",
             cmake_number_of_jobs: "-j 2"
           }
 

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -33,7 +33,7 @@ jobs:
 
     - uses: actions/download-artifact@v3
       with:
-        name: ni-grpc-device-server-linux-glibc2_27-x64
+        name: ni-grpc-device-server-linux-glibc2_31-x64
         path: downloads/artifacts
 
     - uses: actions/download-artifact@v3

--- a/.github/workflows/run_ubuntu_system_tests.yml
+++ b/.github/workflows/run_ubuntu_system_tests.yml
@@ -17,13 +17,13 @@ jobs:
     - name: Download Tests Artifact
       uses: actions/download-artifact@v2
       with:
-        name: ni-grpc-device-tests-linux-glibc2_27-x64
+        name: ni-grpc-device-tests-linux-glibc2_31-x64
 
     - run: ls -R
 
     - name: Untar Test Build Files
       run: >-
-        tar -xvzf ni-grpc-device-tests-linux-glibc2_27-x64.tar.gz
+        tar -xvzf ni-grpc-device-tests-linux-glibc2_31-x64.tar.gz
 
     - name: Run System Tests
       run: ./SystemTestsRunner --gtest_filter=-NiRFSA*:NiRFSG*:NiDCPower*CalSelfCalibrate*


### PR DESCRIPTION
### What does this Pull Request accomplish?

Reflects the glibc version the Ubuntu 20.04 build uses (2.31) in the build output file names.

### Why should this Pull Request be merged?

Missed updating this in #901 

### What testing has been done?

Trusting the build.