### PR TITLE
Fix mypy violations in examples.

### DIFF
--- a/examples/nidaqmx/analog-input-every-n-samples.py
+++ b/examples/nidaqmx/analog-input-every-n-samples.py
@@ -169,7 +169,7 @@ async def _main():
             check_for_warning(stop_task_response)
 
         except grpc.RpcError as rpc_error:
-            error_message = rpc_error.details()
+            error_message = str(rpc_error.details() or "")
             for key, value in rpc_error.trailing_metadata() or []:  # type: ignore
                 if key == "ni-error":
                     details = value if isinstance(value, str) else value.decode("utf-8")

--- a/examples/nidaqmx/analog-input.py
+++ b/examples/nidaqmx/analog-input.py
@@ -114,7 +114,7 @@ try:
         f"({response.samps_per_chan_read} samples per channel)",
     )
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for key, value in rpc_error.trailing_metadata() or []:  # type: ignore
         if key == "ni-error":
             details = value if isinstance(value, str) else value.decode("utf-8")

--- a/examples/nidaqmx/analog-output.py
+++ b/examples/nidaqmx/analog-output.py
@@ -91,7 +91,7 @@ try:
     check_for_warning(stop_task_response)
     print(f"Output was successfully written to {PHYSICAL_CHANNEL}.")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for key, value in rpc_error.trailing_metadata() or []:  # type: ignore
         if key == "ni-error":
             details = value if isinstance(value, str) else value.decode("utf-8")

--- a/examples/nidaqmx/counter-input.py
+++ b/examples/nidaqmx/counter-input.py
@@ -89,7 +89,7 @@ try:
     check_for_warning(stop_task_response)
     print(f"Frequency: {response.value} Hz")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for key, value in rpc_error.trailing_metadata() or []:  # type: ignore
         if key == "ni-error":
             details = value if isinstance(value, str) else value.decode("utf-8")

--- a/examples/nidaqmx/counter-output.py
+++ b/examples/nidaqmx/counter-output.py
@@ -87,7 +87,7 @@ try:
     check_for_warning(stop_task_response)
     print(f"Output was successfully written to {COUNTER_NAME}.")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for key, value in rpc_error.trailing_metadata() or []:  # type: ignore
         if key == "ni-error":
             details = value if isinstance(value, str) else value.decode("utf-8")

--- a/examples/nidaqmx/digital-input.py
+++ b/examples/nidaqmx/digital-input.py
@@ -87,7 +87,7 @@ try:
     check_for_warning(stop_task_response)
     print(f"Data acquired: {hex(response.read_array[0])}")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for key, value in rpc_error.trailing_metadata() or []:  # type: ignore
         if key == "ni-error":
             details = value if isinstance(value, str) else value.decode("utf-8")

--- a/examples/nidaqmx/digital-output.py
+++ b/examples/nidaqmx/digital-output.py
@@ -88,7 +88,7 @@ try:
     check_for_warning(stop_task_response)
     print(f"Output was successfully written to {LINES}.")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for key, value in rpc_error.trailing_metadata() or []:  # type: ignore
         if key == "ni-error":
             details = value if isinstance(value, str) else value.decode("utf-8")

--- a/examples/nidaqmx/dsa-shared-timebase-and-trig-analog-input-and-output.py
+++ b/examples/nidaqmx/dsa-shared-timebase-and-trig-analog-input-and-output.py
@@ -526,7 +526,7 @@ async def _main():
             check_for_warning(stop_task_response)
 
         except grpc.RpcError as rpc_error:
-            error_message = rpc_error.details()
+            error_message = str(rpc_error.details() or "")
             for key, value in rpc_error.trailing_metadata() or []:  # type: ignore
                 if key == "ni-error":
                     details = value if isinstance(value, str) else value.decode("utf-8")

--- a/examples/nidcpower/measure-record.py
+++ b/examples/nidcpower/measure-record.py
@@ -202,7 +202,7 @@ try:
     print(f"Effective measurement rate : {1 / get_measure_record_delta_time.attribute_value}")
 
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nidigitalpattern/configure-voltage-levels-and-termination-voltage.py
+++ b/examples/nidigitalpattern/configure-voltage-levels-and-termination-voltage.py
@@ -240,7 +240,7 @@ try:
 
 # If NI-Digital Pattern Driver API throws an exception, print the error message
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nidmm/continuous-acquire-graph-multiple-points.py
+++ b/examples/nidmm/continuous-acquire-graph-multiple-points.py
@@ -196,7 +196,7 @@ try:
 
 # If NI-DMM API throws an exception, print the error message
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nifgen/basic-arbitrary-waveform.py
+++ b/examples/nifgen/basic-arbitrary-waveform.py
@@ -155,7 +155,7 @@ try:
 
 # If NI-FGEN API throws an exception, print the error message
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxbluetooth/acp-basic.py
+++ b/examples/nirfmxbluetooth/acp-basic.py
@@ -320,7 +320,7 @@ try:
             print(f"Lower Margin (dB)                    : {lower_margin[i]}")
             print(f"Upper Margin (dB)                    : {upper_margin[i]}\n")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxbluetooth/txp-basic.py
+++ b/examples/nirfmxbluetooth/txp-basic.py
@@ -335,7 +335,7 @@ try:
             f"Peak Absolute Power Deviation Maximum (%)[{i}]    : {transmit_slot_peak_absolute_power_deviation_maximum[i]}\n"
         )
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxcdma2k/acp.py
+++ b/examples/nirfmxcdma2k/acp.py
@@ -249,7 +249,7 @@ try:
         print(f"Lower Absolute Power (dBm)               : {upper_absolute_power[i]}")
         print(f"Upper Absolute Power (dBm)               : {lower_absolute_power[i]}")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxcdma2k/modacc.py
+++ b/examples/nirfmxcdma2k/modacc.py
@@ -240,7 +240,7 @@ try:
     print(f"I/Q Gain Imbalance (dB)           : {iq_gain_imbalance}")
     print(f"I/Q Quadrature Error (deg)        : {iq_quadrature_error}")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxgsm/evm.py
+++ b/examples/nirfmxgsm/evm.py
@@ -245,7 +245,7 @@ try:
         else:
             print(f"Slot {i}                          : tsc{detected_tsc[i]}")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxgsm/orfs.py
+++ b/examples/nirfmxgsm/orfs.py
@@ -311,7 +311,7 @@ try:
         print(f"Upper Absolute Power (dBm)          : {switch_upper_absolute_power[i]}")
         print(f"Upper Relative Power (dB)           : {switch_upper_relative_power[i]}")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxlte/acp-single-carrier.py
+++ b/examples/nirfmxlte/acp-single-carrier.py
@@ -316,7 +316,7 @@ try:
         print(f"Upper Absolute Power (dBm)   : {upper_absolute_power[i]}")
         print("------------------------------------------")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxlte/ul-modacc-single-carrier.py
+++ b/examples/nirfmxlte/ul-modacc-single-carrier.py
@@ -294,7 +294,7 @@ try:
     print(f"Mean IQ Quadrature Error (deg)       : {mean_iq_quadrature_error}")
     print(f"In Band Emission Margin (dB)         : {in_band_emission_margin}")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxnr/acp-single-carrier.py
+++ b/examples/nirfmxnr/acp-single-carrier.py
@@ -322,7 +322,7 @@ try:
         print(f"Upper Absolute Power (dBm or dBm/Hz)   : {upper_absolute_power[i]}")
         print("-------------------------------------------------\n")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxnr/txp-single-carrier.py
+++ b/examples/nirfmxnr/txp-single-carrier.py
@@ -248,7 +248,7 @@ try:
     print(f"Average Power Mean (dBm) : {avearge_power_mean}")
     print(f"Peak Power Maximum (dBm) : {peak_power_maximum}")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxspecan/acp-basic.py
+++ b/examples/nirfmxspecan/acp-basic.py
@@ -153,7 +153,7 @@ try:
     print(f"Offset ch1 Lower Relative Power(dB)     {off_ch1_lower_relative_power}")
     print(f"Offset ch1 Upper Relative Power(dB)     {off_ch1_upper_relative_power}")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxspecan/spectrum-basic.py
+++ b/examples/nirfmxspecan/spectrum-basic.py
@@ -156,7 +156,7 @@ try:
         f"max frequency: {_format_frequency(read_response.x0 + read_response.dx * (read_response.actual_array_size - 1))}: {read_response.spectrum[-1]:.1f} dBm"
     )
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxspecan/txp-basic.py
+++ b/examples/nirfmxspecan/txp-basic.py
@@ -156,7 +156,7 @@ try:
     print(f"Maximum Power(dBm)         {maximum_power}")
     print(f"Minimum Power(dBm)         {minimum_power}")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxtdscdma/acp.py
+++ b/examples/nirfmxtdscdma/acp.py
@@ -218,7 +218,7 @@ try:
         print(f"Upper Absolute Power (dBm)   : {upper_absolute_power[i]}")
         print("-------------------------------------------------")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxtdscdma/modacc.py
+++ b/examples/nirfmxtdscdma/modacc.py
@@ -274,7 +274,7 @@ try:
     print(f"RMS Midamble Magnitude Error  (%%)  : {rms_midamble_magnitude_error}")
     print(f"Midamble Power  (dBm)               : {midamble_power}")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxwcdma/acp-single-carrier.py
+++ b/examples/nirfmxwcdma/acp-single-carrier.py
@@ -282,7 +282,7 @@ try:
         print(f"Upper Absolute Power (dBm)     : {upper_absolute_power[i]}")
         print("-------------------------------------------------")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxwcdma/modacc-single-carrier.py
+++ b/examples/nirfmxwcdma/modacc-single-carrier.py
@@ -287,7 +287,7 @@ try:
     print(f"Peak RCDE Spreading Factor              : {peak_rcde_spreading_factor}")
     print(f"Peak RCDE Branch                        : {'Q' if peak_rcde_branch else 'I'}")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxwlan/ofdm-modacc.py
+++ b/examples/nirfmxwlan/ofdm-modacc.py
@@ -453,7 +453,7 @@ try:
     elif sig_b_crc_status == nirfmxwlan_types.OFDMMODACC_SIG_B_CRC_STATUS_PASS:
         print("SIG-B CRC Status                        : Pass")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfmxwlan/txp-basic.py
+++ b/examples/nirfmxwlan/txp-basic.py
@@ -230,7 +230,7 @@ try:
     print(f"Average Power Mean (dBm)          : {average_power_mean}")
     print(f"Peak Power Maximum (dBm)          : {peak_power_maximum}")
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfsa/getting-started-iq.py
+++ b/examples/nirfsa/getting-started-iq.py
@@ -120,7 +120,7 @@ try:
 
 
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfsa/getting-started-spectrum.py
+++ b/examples/nirfsa/getting-started-spectrum.py
@@ -137,7 +137,7 @@ try:
 
 
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfsg/getting-started-single-tone-generation.py
+++ b/examples/nirfsg/getting-started-single-tone-generation.py
@@ -88,7 +88,7 @@ try:
     print("Generating tone...")
     time.sleep(2)
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfsg/reference-clock.py
+++ b/examples/nirfsg/reference-clock.py
@@ -90,7 +90,7 @@ try:
     # Check the generation status
     client.CheckGenerationStatus(nirfsg_types.CheckGenerationStatusRequest(vi=vi))
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nirfsg/rfsg-multitone-example.py
+++ b/examples/nirfsg/rfsg-multitone-example.py
@@ -315,7 +315,7 @@ try:
 
     client.Abort(nirfsg_types.AbortRequest(vi=vi))
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/niscope/fetch-continuous.py
+++ b/examples/niscope/fetch-continuous.py
@@ -166,7 +166,7 @@ try:
 
 # If NI-SCOPE API throws an exception, print the error message.
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/niscope/fetch.py
+++ b/examples/niscope/fetch.py
@@ -126,7 +126,7 @@ try:
 
 # If NI-SCOPE API throws an exception, print the error message.
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/niscope/graph-measurement.py
+++ b/examples/niscope/graph-measurement.py
@@ -185,7 +185,7 @@ try:
         pass
 
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/niscope/plot-read-waveform.py
+++ b/examples/niscope/plot-read-waveform.py
@@ -133,7 +133,7 @@ try:
     print(values)
 
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/niswitch/controlling-an-individual-relay.py
+++ b/examples/niswitch/controlling-an-individual-relay.py
@@ -93,7 +93,7 @@ try:
 
 # If NI-SWITCH API throws an exception, print the error message
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/niswitch/software-scanning.py
+++ b/examples/niswitch/software-scanning.py
@@ -127,7 +127,7 @@ try:
 
 # If NI-SWITCH API throws an exception, print the error message
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nitclk/multi-device-configured-acquisition-tclk.py
+++ b/examples/nitclk/multi-device-configured-acquisition-tclk.py
@@ -293,7 +293,7 @@ try:
         print("Actual Record Length = %f\n" % record_length_result.record_length)
 
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nitclk/synchronize-tclk.py
+++ b/examples/nitclk/synchronize-tclk.py
@@ -126,7 +126,7 @@ try:
 
 # If NI-FGEN API throws an exception, print the error message.
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nixnet/can-signal-single-point-output.py
+++ b/examples/nixnet/can-signal-single-point-output.py
@@ -110,7 +110,7 @@ try:
         i = i + 1
 
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nixnet/ethernet-frame-stream-input-reader.py
+++ b/examples/nixnet/ethernet-frame-stream-input-reader.py
@@ -173,7 +173,7 @@ try:
     print("Frame capture stopped.\n")
 
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nixnet/flexray-signal-single-point-input.py
+++ b/examples/nixnet/flexray-signal-single-point-input.py
@@ -122,7 +122,7 @@ try:
         i = i + 1
 
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/nixnet/lin-signal-single-point-output.py
+++ b/examples/nixnet/lin-signal-single-point-output.py
@@ -134,7 +134,7 @@ try:
         i = i + 1
 
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/session/session-reservation.py
+++ b/examples/session/session-reservation.py
@@ -149,7 +149,7 @@ try:
 
 # If NI-SCOPE API or Session API throws an exception, print the error message.
 except grpc.RpcError as rpc_error:
-    error_message = rpc_error.details()
+    error_message = str(rpc_error.details() or "")
     for entry in rpc_error.trailing_metadata() or []:
         if entry.key == "ni-error":
             value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")

--- a/examples/session/session-utilities.py
+++ b/examples/session/session-utilities.py
@@ -54,7 +54,7 @@ def main(args):
 
     # If the API throws an exception, print the error message.
     except grpc.RpcError as rpc_error:
-        error_message = rpc_error.details()
+        error_message = str(rpc_error.details() or "")
         for entry in rpc_error.trailing_metadata() or []:
             if entry.key == "ni-error":
                 value = entry.value if isinstance(entry.value, str) else entry.value.decode("utf-8")


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes recent mypy violations popping up for examples. I think this is because mypy bumped to version 1.2.0 and is catching a scenario it previously missed.

The specific failure was complaining that the left operand of a concatenate could be None.

See this [failed validate_python step](https://github.com/ni/grpc-device/actions/runs/4639441570/jobs/8210400991) in a recent PR ci.yml run.

### Why should this Pull Request be merged?

Fixes build by making validate_python.yml pass.

### What testing has been done?

Ran the `python source/codegen/validate_examples.py -e "nidaqmx"` script locally and it now passes with these changes.
Also the `validate_python` step run in this PR's ci.yml run should validate it as well.
