### PR TITLE
Users/phindman/enable cdma2k feature toggle

### DIFF
--- a/generated/nirfmxcdma2k/nirfmxcdma2k_service.cpp
+++ b/generated/nirfmxcdma2k/nirfmxcdma2k_service.cpp
@@ -6094,7 +6094,7 @@ namespace nirfmxcdma2k_grpc {
   NiRFmxCDMA2kFeatureToggles::NiRFmxCDMA2kFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("nirfmxcdma2k", CodeReadiness::kNextRelease))
+        feature_toggles.is_feature_enabled("nirfmxcdma2k", CodeReadiness::kRelease))
   {
   }
 } // namespace nirfmxcdma2k_grpc

--- a/generated/nirfmxtdscdma/nirfmxtdscdma_service.cpp
+++ b/generated/nirfmxtdscdma/nirfmxtdscdma_service.cpp
@@ -6499,7 +6499,7 @@ namespace nirfmxtdscdma_grpc {
   NiRFmxTDSCDMAFeatureToggles::NiRFmxTDSCDMAFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("nirfmxtdscdma", CodeReadiness::kNextRelease))
+        feature_toggles.is_feature_enabled("nirfmxtdscdma", CodeReadiness::kRelease))
   {
   }
 } // namespace nirfmxtdscdma_grpc

--- a/source/codegen/metadata/nirfmxcdma2k/config.py
+++ b/source/codegen/metadata/nirfmxcdma2k/config.py
@@ -27,7 +27,7 @@ config = {
         "NIComplexSingle": "nidevice_grpc.NIComplexNumberF32",
         "NIComplexDouble": "nidevice_grpc.NIComplexNumber",
     },
-    'code_readiness': 'NextRelease',
+    'code_readiness': 'Release',
     'feature_toggles': {},
     'driver_name': 'NI-rfmxcdma2k',
     'extra_errors_used': [

--- a/source/codegen/metadata/nirfmxtdscdma/config.py
+++ b/source/codegen/metadata/nirfmxtdscdma/config.py
@@ -27,7 +27,7 @@ config = {
         "NIComplexSingle": "nidevice_grpc.NIComplexNumberF32",
         "NIComplexDouble": "nidevice_grpc.NIComplexNumber",
     },
-    'code_readiness': 'NextRelease',
+    'code_readiness': 'Release',
     'feature_toggles': {},
     'driver_name': 'NI-rfmxtdscdma',
     'extra_errors_used': [


### PR DESCRIPTION
### What does this Pull Request accomplish?

Enables the `nirfmxcdma2k` and `nirfmxtdscdma` services so that they will be available in the next release of `grpc-device`.

### Why should this Pull Request be merged?

The planned dev work for these services is complete.  Closes [AB#2362972](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2362972) and [AB#2316716](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2316716) 

### What testing has been done?

I demonstrated the functionality of these two personalities to Gerardo Orozco earlier this week using the corresponding python examples.
