### PR TITLE
custom: Allow server streaming RPCs to use ConvertApiErrorStatus functions

### DIFF
--- a/generated/nidaqmx/nidaqmx_service.h
+++ b/generated/nidaqmx/nidaqmx_service.h
@@ -434,7 +434,7 @@ public:
 private:
   NiDAQmxLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForTaskHandle(::grpc::ServerContext* context, int32_t status, TaskHandle task);
+  ::grpc::Status ConvertApiErrorStatusForTaskHandle(::grpc::ServerContextBase* context, int32_t status, TaskHandle task);
 
   NiDAQmxFeatureToggles feature_toggles_;
 };

--- a/generated/nidcpower/nidcpower_service.h
+++ b/generated/nidcpower/nidcpower_service.h
@@ -189,7 +189,7 @@ public:
 private:
   NiDCPowerLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi);
+  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi);
   void Copy(const std::vector<ViBoolean>& input, google::protobuf::RepeatedField<bool>* output);
 
   NiDCPowerFeatureToggles feature_toggles_;

--- a/generated/nidigitalpattern/nidigitalpattern_service.h
+++ b/generated/nidigitalpattern/nidigitalpattern_service.h
@@ -174,7 +174,7 @@ public:
 private:
   NiDigitalLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi);
+  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi);
   void Copy(const std::vector<ViBoolean>& input, google::protobuf::RepeatedField<bool>* output);
   template <typename TEnum>
   void CopyBytesToEnums(const std::string& input, google::protobuf::RepeatedField<TEnum>* output);

--- a/generated/nidmm/nidmm_service.h
+++ b/generated/nidmm/nidmm_service.h
@@ -131,7 +131,7 @@ public:
 private:
   NiDmmLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi);
+  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi);
   std::map<std::int32_t, double> nidmmreal64attributevaluesmapped_input_map_ { {1, 1e-06f},{2, 1e-05f},{3, 0.0001f},{4, 0.001f},{5, 1000000},{6, 10000000},{7, 10000000000.0f}, };
   std::map<double, std::int32_t> nidmmreal64attributevaluesmapped_output_map_ { {1e-06f, 1},{1e-05f, 2},{0.0001f, 3},{0.001f, 4},{1000000, 5},{10000000, 6},{10000000000.0f, 7}, };
 

--- a/generated/nifake/nifake_service.h
+++ b/generated/nifake/nifake_service.h
@@ -135,7 +135,7 @@ public:
 private:
   NiFakeLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi);
+  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi);
   void Copy(const std::vector<ViBoolean>& input, google::protobuf::RepeatedField<bool>* output);
   template <typename TEnum>
   void CopyBytesToEnums(const std::string& input, google::protobuf::RepeatedField<TEnum>* output);

--- a/generated/nifake_extension/nifake_extension_service.h
+++ b/generated/nifake_extension/nifake_extension_service.h
@@ -45,7 +45,7 @@ public:
 private:
   NiFakeExtensionLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi);
+  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi);
 
   NiFakeExtensionFeatureToggles feature_toggles_;
 };

--- a/generated/nifake_non_ivi/nifake_non_ivi_service.h
+++ b/generated/nifake_non_ivi/nifake_non_ivi_service.h
@@ -86,8 +86,8 @@ private:
   ResourceRepositorySharedPtr session_repository_;
   SecondarySessionHandleResourceRepositorySharedPtr secondary_session_handle_resource_repository_;
   FakeCrossDriverHandleResourceRepositorySharedPtr fake_cross_driver_handle_resource_repository_;
-  ::grpc::Status ConvertApiErrorStatusForFakeHandle(::grpc::ServerContext* context, int32_t status, FakeHandle handle);
-  ::grpc::Status ConvertApiErrorStatusForSecondarySessionHandle(::grpc::ServerContext* context, int32_t status, SecondarySessionHandle handle);
+  ::grpc::Status ConvertApiErrorStatusForFakeHandle(::grpc::ServerContextBase* context, int32_t status, FakeHandle handle);
+  ::grpc::Status ConvertApiErrorStatusForSecondarySessionHandle(::grpc::ServerContextBase* context, int32_t status, SecondarySessionHandle handle);
   std::map<std::int32_t, std::string> mobileosnames_input_map_ { {1, "Android"},{2, "iOS"},{3, "None"}, };
   std::map<std::string, std::int32_t> mobileosnames_output_map_ { {"Android", 1},{"iOS", 2},{"None", 3}, };
 

--- a/generated/nifgen/nifgen_service.h
+++ b/generated/nifgen/nifgen_service.h
@@ -175,7 +175,7 @@ public:
 private:
   NiFgenLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi);
+  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi);
   std::map<std::int32_t, std::string> nifgenstringattributevaluesmapped_input_map_ { {1, "ClkIn"},{2, "None"},{3, "OnboardRefClk"},{4, "PXI_Clk"},{5, "RTSI7"},{6, "ClkIn"},{7, "DDC_ClkIn"},{8, "OnboardClock"},{9, "PXI_Star"},{10, "PXI_Trig0"},{11, "PXI_Trig1"},{12, "PXI_Trig2"},{13, "PXI_Trig3"},{14, "PXI_Trig4"},{15, "PXI_Trig5"},{16, "PXI_Trig6"},{17, "PXI_Trig7"},{18, "ClkIn"},{19, "OnboardClock"}, };
   std::map<std::string, std::int32_t> nifgenstringattributevaluesmapped_output_map_ { {"ClkIn", 1},{"None", 2},{"OnboardRefClk", 3},{"PXI_Clk", 4},{"RTSI7", 5},{"ClkIn", 6},{"DDC_ClkIn", 7},{"OnboardClock", 8},{"PXI_Star", 9},{"PXI_Trig0", 10},{"PXI_Trig1", 11},{"PXI_Trig2", 12},{"PXI_Trig3", 13},{"PXI_Trig4", 14},{"PXI_Trig5", 15},{"PXI_Trig6", 16},{"PXI_Trig7", 17},{"ClkIn", 18},{"OnboardClock", 19}, };
 

--- a/generated/nimxlcterminaladaptor_restricted/nimxlcterminaladaptor_restricted_service.h
+++ b/generated/nimxlcterminaladaptor_restricted/nimxlcterminaladaptor_restricted_service.h
@@ -50,7 +50,7 @@ public:
 private:
   NimxlcTerminalAdaptorRestrictedLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForNimxlc_Session(::grpc::ServerContext* context, int32_t status, nimxlc_Session session);
+  ::grpc::Status ConvertApiErrorStatusForNimxlc_Session(::grpc::ServerContextBase* context, int32_t status, nimxlc_Session session);
 
   NimxlcTerminalAdaptorRestrictedFeatureToggles feature_toggles_;
 };

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_service.h
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_service.h
@@ -178,7 +178,7 @@ private:
   NiRFmxBluetoothLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
   ViSessionResourceRepositorySharedPtr vi_session_resource_repository_;
-  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle);
+  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle);
   std::map<std::int32_t, std::string> frequencyreferencesource_input_map_ { {1, "OnboardClock"},{2, "RefIn"},{3, "PXI_Clk"},{4, "ClkIn"}, };
   std::map<std::string, std::int32_t> frequencyreferencesource_output_map_ { {"OnboardClock", 1},{"RefIn", 2},{"PXI_Clk", 3},{"ClkIn", 4}, };
   std::map<std::int32_t, std::string> nirfmxbluetoothstringattributevaluesmapped_input_map_ { {1, "PFI0"},{2, "PFI1"},{3, "PXI_Trig0"},{4, "PXI_Trig1"},{5, "PXI_Trig2"},{6, "PXI_Trig3"},{7, "PXI_Trig4"},{8, "PXI_Trig5"},{9, "PXI_Trig6"},{10, "PXI_Trig7"},{11, "PXI_STAR"},{12, "PXIe_DStarB"},{13, "TimerEvent"}, };

--- a/generated/nirfmxcdma2k/nirfmxcdma2k_service.h
+++ b/generated/nirfmxcdma2k/nirfmxcdma2k_service.h
@@ -208,7 +208,7 @@ private:
   NiRFmxCDMA2kLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
   ViSessionResourceRepositorySharedPtr vi_session_resource_repository_;
-  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle);
+  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle);
   std::map<std::int32_t, std::string> digitaledgetriggersource_input_map_ { {1, "PFI0"},{2, "PFI1"},{3, "PXI_Trig0"},{4, "PXI_Trig1"},{5, "PXI_Trig2"},{6, "PXI_Trig3"},{7, "PXI_Trig4"},{8, "PXI_Trig5"},{9, "PXI_Trig6"},{10, "PXI_Trig7"},{11, "PXI_STAR"},{12, "PXIe_DStarB"},{13, "TimerEvent"}, };
   std::map<std::string, std::int32_t> digitaledgetriggersource_output_map_ { {"PFI0", 1},{"PFI1", 2},{"PXI_Trig0", 3},{"PXI_Trig1", 4},{"PXI_Trig2", 5},{"PXI_Trig3", 6},{"PXI_Trig4", 7},{"PXI_Trig5", 8},{"PXI_Trig6", 9},{"PXI_Trig7", 10},{"PXI_STAR", 11},{"PXIe_DStarB", 12},{"TimerEvent", 13}, };
   std::map<std::int32_t, std::string> frequencyreferencesource_input_map_ { {1, "OnboardClock"},{2, "RefIn"},{3, "PXI_Clk"},{4, "ClkIn"}, };

--- a/generated/nirfmxdemod/nirfmxdemod_service.h
+++ b/generated/nirfmxdemod/nirfmxdemod_service.h
@@ -190,7 +190,7 @@ private:
   NiRFmxDemodLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
   ViSessionResourceRepositorySharedPtr vi_session_resource_repository_;
-  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle);
+  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle);
   std::map<std::int32_t, std::string> digitaledgetriggersource_input_map_ { {1, "PFI0"},{2, "PFI1"},{3, "PXI_STAR"},{4, "PXI_Trig0"},{5, "PXI_Trig1"},{6, "PXI_Trig2"},{7, "PXI_Trig3"},{8, "PXI_Trig4"},{9, "PXI_Trig5"},{10, "PXI_Trig6"},{11, "PXI_Trig7"},{12, "PXIe_DStarB"},{13, "TimerEvent"}, };
   std::map<std::string, std::int32_t> digitaledgetriggersource_output_map_ { {"PFI0", 1},{"PFI1", 2},{"PXI_STAR", 3},{"PXI_Trig0", 4},{"PXI_Trig1", 5},{"PXI_Trig2", 6},{"PXI_Trig3", 7},{"PXI_Trig4", 8},{"PXI_Trig5", 9},{"PXI_Trig6", 10},{"PXI_Trig7", 11},{"PXIe_DStarB", 12},{"TimerEvent", 13}, };
   std::map<std::int32_t, std::string> frequencyreferencesource_input_map_ { {1, "OnboardClock"},{2, "RefIn"},{3, "PXI_Clk"},{4, "ClkIn"}, };

--- a/generated/nirfmxgsm/nirfmxgsm_service.h
+++ b/generated/nirfmxgsm/nirfmxgsm_service.h
@@ -164,7 +164,7 @@ private:
   NiRFmxGSMLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
   ViSessionResourceRepositorySharedPtr vi_session_resource_repository_;
-  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle);
+  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle);
   std::map<std::int32_t, std::string> digitaledgetriggersource_input_map_ { {1, "PFI0"},{2, "PFI1"},{3, "PXI_Trig0"},{4, "PXI_Trig1"},{5, "PXI_Trig2"},{6, "PXI_Trig3"},{7, "PXI_Trig4"},{8, "PXI_Trig5"},{9, "PXI_Trig6"},{10, "PXI_Trig7"},{11, "PXI_STAR"},{12, "PXIe_DStarB"},{13, "TimerEvent"}, };
   std::map<std::string, std::int32_t> digitaledgetriggersource_output_map_ { {"PFI0", 1},{"PFI1", 2},{"PXI_Trig0", 3},{"PXI_Trig1", 4},{"PXI_Trig2", 5},{"PXI_Trig3", 6},{"PXI_Trig4", 7},{"PXI_Trig5", 8},{"PXI_Trig6", 9},{"PXI_Trig7", 10},{"PXI_STAR", 11},{"PXIe_DStarB", 12},{"TimerEvent", 13}, };
   std::map<std::int32_t, std::string> frequencyreferencesource_input_map_ { {1, "OnboardClock"},{2, "RefIn"},{3, "PXI_Clk"},{4, "ClkIn"}, };

--- a/generated/nirfmxinstr/nirfmxinstr_service.h
+++ b/generated/nirfmxinstr/nirfmxinstr_service.h
@@ -140,7 +140,7 @@ private:
   NiRFmxInstrLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
   ViSessionResourceRepositorySharedPtr vi_session_resource_repository_;
-  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle);
+  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle);
   std::map<std::int32_t, std::string> frequencyreferencesource_input_map_ { {1, "OnboardClock"},{2, "RefIn"},{3, "PXI_Clk"},{4, "ClkIn"},{5, "RefIn2"},{6, "PXI_ClkMaster"}, };
   std::map<std::string, std::int32_t> frequencyreferencesource_output_map_ { {"OnboardClock", 1},{"RefIn", 2},{"PXI_Clk", 3},{"ClkIn", 4},{"RefIn2", 5},{"PXI_ClkMaster", 6}, };
   std::map<std::int32_t, std::string> nirfmxinstrstringattributevaluesmapped_input_map_ { {1, "PFI0"},{2, "PFI1"},{3, "PXI_Trig0"},{4, "PXI_Trig1"},{5, "PXI_Trig2"},{6, "PXI_Trig3"},{7, "PXI_Trig4"},{8, "PXI_Trig5"},{9, "PXI_Trig6"},{10, "PXI_Trig7"},{11, "PXI_STAR"},{12, "PXIe_DStarB"},{13, "TimerEvent"},{14, ""},{15, "RefOut"},{16, "RefOut2"},{17, "ClkOut"},{18, ""},{19, "OnboardClock"},{20, "RefIn"},{21, "PXI_Clk"},{22, "ClkIn"},{23, "RefIn2"},{24, "PXI_ClkMaster"},{25, "Automatic_SG_SA_Shared"},{26, "LO_In"},{27, "None"},{28, "Onboard"},{29, "Secondary"},{30, "SG_SA_Shared"},{31, "PFI0"},{32, "PFI1"},{33, "PXI_Trig0"},{34, "PXI_Trig1"},{35, "PXI_Trig2"},{36, "PXI_Trig3"},{37, "PXI_Trig4"},{38, "PXI_Trig5"},{39, "PXI_Trig6"},{40, "PXI_Trig7"},{41, "PXI_STAR"},{42, "PXIe_DStarC"},{43, "PXIe_DStarB"},{44, "TimerEvent"}, };

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.h
@@ -78,7 +78,7 @@ public:
 private:
   NiRFmxInstrRestrictedLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrument);
+  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrument);
 
   NiRFmxInstrRestrictedFeatureToggles feature_toggles_;
 };

--- a/generated/nirfmxlte/nirfmxlte_service.h
+++ b/generated/nirfmxlte/nirfmxlte_service.h
@@ -333,7 +333,7 @@ private:
   NiRFmxLTELibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
   ViSessionResourceRepositorySharedPtr vi_session_resource_repository_;
-  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle);
+  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle);
   std::map<std::int32_t, std::string> digitaledgetriggersource_input_map_ { {1, "PFI0"},{2, "PFI1"},{3, "PXI_Trig0"},{4, "PXI_Trig1"},{5, "PXI_Trig2"},{6, "PXI_Trig3"},{7, "PXI_Trig4"},{8, "PXI_Trig5"},{9, "PXI_Trig6"},{10, "PXI_Trig7"},{11, "PXI_STAR"},{12, "PXIe_DStarB"},{13, "TimerEvent"}, };
   std::map<std::string, std::int32_t> digitaledgetriggersource_output_map_ { {"PFI0", 1},{"PFI1", 2},{"PXI_Trig0", 3},{"PXI_Trig1", 4},{"PXI_Trig2", 5},{"PXI_Trig3", 6},{"PXI_Trig4", 7},{"PXI_Trig5", 8},{"PXI_Trig6", 9},{"PXI_Trig7", 10},{"PXI_STAR", 11},{"PXIe_DStarB", 12},{"TimerEvent", 13}, };
   std::map<std::int32_t, std::string> frequencyreferencesource_input_map_ { {1, "OnboardClock"},{2, "RefIn"},{3, "PXI_Clk"},{4, "ClkIn"}, };

--- a/generated/nirfmxnr/nirfmxnr_service.h
+++ b/generated/nirfmxnr/nirfmxnr_service.h
@@ -267,7 +267,7 @@ private:
   NiRFmxNRLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
   ViSessionResourceRepositorySharedPtr vi_session_resource_repository_;
-  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle);
+  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle);
   std::map<std::int32_t, std::string> digitaledgetriggersource_input_map_ { {1, "PFI0"},{2, "PFI1"},{3, "PXI_Trig0"},{4, "PXI_Trig1"},{5, "PXI_Trig2"},{6, "PXI_Trig3"},{7, "PXI_Trig4"},{8, "PXI_Trig5"},{9, "PXI_Trig6"},{10, "PXI_Trig7"},{11, "PXI_STAR"},{12, "PXIe_DStarB"},{13, "TimerEvent"}, };
   std::map<std::string, std::int32_t> digitaledgetriggersource_output_map_ { {"PFI0", 1},{"PFI1", 2},{"PXI_Trig0", 3},{"PXI_Trig1", 4},{"PXI_Trig2", 5},{"PXI_Trig3", 6},{"PXI_Trig4", 7},{"PXI_Trig5", 8},{"PXI_Trig6", 9},{"PXI_Trig7", 10},{"PXI_STAR", 11},{"PXIe_DStarB", 12},{"TimerEvent", 13}, };
   std::map<std::int32_t, std::string> frequencyreferencesource_input_map_ { {1, "OnboardClock"},{2, "RefIn"},{3, "PXI_Clk"},{4, "ClkIn"},{5, "RefIn2"},{6, "PXI_Clk_Master"}, };

--- a/generated/nirfmxspecan/nirfmxspecan_service.h
+++ b/generated/nirfmxspecan/nirfmxspecan_service.h
@@ -462,7 +462,7 @@ private:
   NiRFmxSpecAnLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
   ViSessionResourceRepositorySharedPtr vi_session_resource_repository_;
-  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle);
+  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle);
   std::map<std::int32_t, std::string> digitaledgetriggersource_input_map_ { {1, "PFI0"},{2, "PFI1"},{3, "PXI_Trig0"},{4, "PXI_Trig1"},{5, "PXI_Trig2"},{6, "PXI_Trig3"},{7, "PXI_Trig4"},{8, "PXI_Trig5"},{9, "PXI_Trig6"},{10, "PXI_Trig7"},{11, "PXI_STAR"},{12, "PXIe_DStarB"},{13, "TimerEvent"}, };
   std::map<std::string, std::int32_t> digitaledgetriggersource_output_map_ { {"PFI0", 1},{"PFI1", 2},{"PXI_Trig0", 3},{"PXI_Trig1", 4},{"PXI_Trig2", 5},{"PXI_Trig3", 6},{"PXI_Trig4", 7},{"PXI_Trig5", 8},{"PXI_Trig6", 9},{"PXI_Trig7", 10},{"PXI_STAR", 11},{"PXIe_DStarB", 12},{"TimerEvent", 13}, };
   std::map<std::int32_t, std::string> frequencyreferencesource_input_map_ { {1, "OnboardClock"},{2, "RefIn"},{3, "PXI_Clk"},{4, "ClkIn"}, };

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_service.h
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_service.h
@@ -46,7 +46,7 @@ public:
 private:
   NiRFmxSpecAnRestrictedLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle);
+  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle);
 
   NiRFmxSpecAnRestrictedFeatureToggles feature_toggles_;
 };

--- a/generated/nirfmxtdscdma/nirfmxtdscdma_service.h
+++ b/generated/nirfmxtdscdma/nirfmxtdscdma_service.h
@@ -218,7 +218,7 @@ private:
   NiRFmxTDSCDMALibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
   ViSessionResourceRepositorySharedPtr vi_session_resource_repository_;
-  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle);
+  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle);
   std::map<std::int32_t, std::string> digitaledgetriggersource_input_map_ { {1, "PFI0"},{2, "PFI1"},{3, "PXI_Trig0"},{4, "PXI_Trig1"},{5, "PXI_Trig2"},{6, "PXI_Trig3"},{7, "PXI_Trig4"},{8, "PXI_Trig5"},{9, "PXI_Trig6"},{10, "PXI_Trig7"},{11, "PXI_STAR"},{12, "PXIe_DStarB"},{13, "TimerEvent"}, };
   std::map<std::string, std::int32_t> digitaledgetriggersource_output_map_ { {"PFI0", 1},{"PFI1", 2},{"PXI_Trig0", 3},{"PXI_Trig1", 4},{"PXI_Trig2", 5},{"PXI_Trig3", 6},{"PXI_Trig4", 7},{"PXI_Trig5", 8},{"PXI_Trig6", 9},{"PXI_Trig7", 10},{"PXI_STAR", 11},{"PXIe_DStarB", 12},{"TimerEvent", 13}, };
   std::map<std::int32_t, std::string> frequencyreferencesource_input_map_ { {1, "OnboardClock"},{2, "RefIn"},{3, "PXI_Clk"},{4, "ClkIn"}, };

--- a/generated/nirfmxwcdma/nirfmxwcdma_service.h
+++ b/generated/nirfmxwcdma/nirfmxwcdma_service.h
@@ -233,7 +233,7 @@ private:
   NiRFmxWCDMALibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
   ViSessionResourceRepositorySharedPtr vi_session_resource_repository_;
-  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle);
+  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle);
   std::map<std::int32_t, std::string> digitaledgetriggersource_input_map_ { {1, "PFI0"},{2, "PFI1"},{3, "PXI_Trig0"},{4, "PXI_Trig1"},{5, "PXI_Trig2"},{6, "PXI_Trig3"},{7, "PXI_Trig4"},{8, "PXI_Trig5"},{9, "PXI_Trig6"},{10, "PXI_Trig7"},{11, "PXI_STAR"},{12, "PXIe_DStarB"},{13, "TimerEvent"}, };
   std::map<std::string, std::int32_t> digitaledgetriggersource_output_map_ { {"PFI0", 1},{"PFI1", 2},{"PXI_Trig0", 3},{"PXI_Trig1", 4},{"PXI_Trig2", 5},{"PXI_Trig3", 6},{"PXI_Trig4", 7},{"PXI_Trig5", 8},{"PXI_Trig6", 9},{"PXI_Trig7", 10},{"PXI_STAR", 11},{"PXIe_DStarB", 12},{"TimerEvent", 13}, };
   std::map<std::int32_t, std::string> frequencyreferencesource_input_map_ { {1, "OnboardClock"},{2, "RefIn"},{3, "PXI_Clk"},{4, "ClkIn"}, };

--- a/generated/nirfmxwlan/nirfmxwlan_service.h
+++ b/generated/nirfmxwlan/nirfmxwlan_service.h
@@ -280,7 +280,7 @@ private:
   NiRFmxWLANLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
   ViSessionResourceRepositorySharedPtr vi_session_resource_repository_;
-  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle);
+  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle);
   std::map<std::int32_t, std::string> frequencyreferencesource_input_map_ { {1, "OnboardClock"},{2, "RefIn"},{3, "PXI_Clk"},{4, "ClkIn"}, };
   std::map<std::string, std::int32_t> frequencyreferencesource_output_map_ { {"OnboardClock", 1},{"RefIn", 2},{"PXI_Clk", 3},{"ClkIn", 4}, };
   std::map<std::int32_t, std::string> nirfmxwlanstringattributevaluesmapped_input_map_ { {1, "PFI0"},{2, "PFI1"},{3, "PXI_Trig0"},{4, "PXI_Trig1"},{5, "PXI_Trig2"},{6, "PXI_Trig3"},{7, "PXI_Trig4"},{8, "PXI_Trig5"},{9, "PXI_Trig6"},{10, "PXI_Trig7"},{11, "PXI_STAR"},{12, "PXIe_DStarB"},{13, "TimerEvent"}, };

--- a/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_service.h
+++ b/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_service.h
@@ -47,7 +47,7 @@ public:
 private:
   NiRFmxWLANRestrictedLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle);
+  ::grpc::Status ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle);
 
   NiRFmxWLANRestrictedFeatureToggles feature_toggles_;
 };

--- a/generated/nirfsa/nirfsa_service.h
+++ b/generated/nirfsa/nirfsa_service.h
@@ -147,7 +147,7 @@ public:
 private:
   NiRFSALibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi);
+  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi);
   std::map<std::int32_t, std::string> digitaledgetriggersource_input_map_ { {1, "PFI0"},{2, "PFI1"},{3, "PXI_Trig0"},{4, "PXI_Trig1"},{5, "PXI_Trig2"},{6, "PXI_Trig3"},{7, "PXI_Trig4"},{8, "PXI_Trig5"},{9, "PXI_Trig6"},{10, "PXI_Trig7"},{11, "PXI_STAR"},{12, "PXI_Trig0"},{13, "PXI_Trig1"},{14, "PXI_Trig2"},{15, "PXI_Trig3"},{16, "PXI_Trig4"},{17, "PXI_Trig5"},{18, "PXI_Trig6"},{19, "PXI_Trig7"},{20, "TimerEvent"}, };
   std::map<std::string, std::int32_t> digitaledgetriggersource_output_map_ { {"PFI0", 1},{"PFI1", 2},{"PXI_Trig0", 3},{"PXI_Trig1", 4},{"PXI_Trig2", 5},{"PXI_Trig3", 6},{"PXI_Trig4", 7},{"PXI_Trig5", 8},{"PXI_Trig6", 9},{"PXI_Trig7", 10},{"PXI_STAR", 11},{"PXI_Trig0", 12},{"PXI_Trig1", 13},{"PXI_Trig2", 14},{"PXI_Trig3", 15},{"PXI_Trig4", 16},{"PXI_Trig5", 17},{"PXI_Trig6", 18},{"PXI_Trig7", 19},{"TimerEvent", 20}, };
   std::map<std::int32_t, std::string> exportterminal_input_map_ { {1, ""},{2, "PFI0"},{3, "PFI1"},{4, "PXI_Trig0"},{5, "PXI_Trig1"},{6, "PXI_Trig2"},{7, "PXI_Trig3"},{8, "PXI_Trig4"},{9, "PXI_Trig5"},{10, "PXI_Trig6"},{11, "PXI_Trig7"},{12, "PXI_STAR"},{13, "PXIe_DStarC"},{14, "RefOut"},{15, "RefOut2"},{16, "ClkOut"}, };

--- a/generated/nirfsg/nirfsg_service.h
+++ b/generated/nirfsg/nirfsg_service.h
@@ -153,7 +153,7 @@ public:
 private:
   NiRFSGLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi);
+  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi);
   std::map<std::int32_t, std::string> digitaledgeconfigurationliststeptriggersource_input_map_ { {1, "PFI0"},{2, "PFI1"},{3, "PFI2"},{4, "PFI3"},{5, "PXI_Trig0"},{6, "PXI_Trig1"},{7, "PXI_Trig2"},{8, "PXI_Trig3"},{9, "PXI_Trig4"},{10, "PXI_Trig5"},{11, "PXI_Trig6"},{12, "PXI_Trig7"},{13, "PXI_STAR"},{14, "Marker0Event"},{15, "Marker1Event"},{16, "Marker2Event"},{17, "Marker3Event"},{18, "TimerEvent"},{19, "TrigIn"}, };
   std::map<std::string, std::int32_t> digitaledgeconfigurationliststeptriggersource_output_map_ { {"PFI0", 1},{"PFI1", 2},{"PFI2", 3},{"PFI3", 4},{"PXI_Trig0", 5},{"PXI_Trig1", 6},{"PXI_Trig2", 7},{"PXI_Trig3", 8},{"PXI_Trig4", 9},{"PXI_Trig5", 10},{"PXI_Trig6", 11},{"PXI_Trig7", 12},{"PXI_STAR", 13},{"Marker0Event", 14},{"Marker1Event", 15},{"Marker2Event", 16},{"Marker3Event", 17},{"TimerEvent", 18},{"TrigIn", 19}, };
   std::map<std::int32_t, std::string> digitaledgescripttriggeridentifier_input_map_ { {1, "scriptTrigger0"},{2, "scriptTrigger1"},{3, "scriptTrigger2"},{4, "scriptTrigger3"}, };

--- a/generated/niscope/niscope_service.h
+++ b/generated/niscope/niscope_service.h
@@ -134,7 +134,7 @@ public:
 private:
   NiScopeLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi);
+  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi);
   std::map<std::int32_t, std::string> clockingterminalvalues_input_map_ { {1, "VAL_NO_SOURCE"},{2, "VAL_RTSI_CLOCK"},{3, "VAL_EXTERNAL"},{4, "VAL_PFI_0"},{5, "VAL_PFI_1"},{6, "VAL_PFI_2"},{7, "VAL_CLK_IN"},{8, "VAL_CLK_OUT"},{9, "VAL_INTERNAL10MHZ_OSC"},{10, "VAL_PXI_CLK"},{11, "VAL_PXI_CLK10"},{12, "VAL_PXI_CLK100"},{13, "VAL_PXIE_DSTAR_A"},{14, "VAL_AUX_0_CLK_IN"},{15, "VAL_AUX_0_CLK_OUT"},{16, "VAL_ONBOARD_CONFIGURABLE_RATE_CLK"}, };
   std::map<std::string, std::int32_t> clockingterminalvalues_output_map_ { {"VAL_NO_SOURCE", 1},{"VAL_RTSI_CLOCK", 2},{"VAL_EXTERNAL", 3},{"VAL_PFI_0", 4},{"VAL_PFI_1", 5},{"VAL_PFI_2", 6},{"VAL_CLK_IN", 7},{"VAL_CLK_OUT", 8},{"VAL_INTERNAL10MHZ_OSC", 9},{"VAL_PXI_CLK", 10},{"VAL_PXI_CLK10", 11},{"VAL_PXI_CLK100", 12},{"VAL_PXIE_DSTAR_A", 13},{"VAL_AUX_0_CLK_IN", 14},{"VAL_AUX_0_CLK_OUT", 15},{"VAL_ONBOARD_CONFIGURABLE_RATE_CLK", 16}, };
   std::map<std::int32_t, double> niscopereal64attributevaluesmapped_input_map_ { {1, 50.0f},{2, 75.0f},{3, 1000000.0f},{4, 0.0f},{5, -1.0f},{6, 20000000.0f},{7, 100000000.0f},{8, 20000000.0f},{9, 100000000.0f}, };

--- a/generated/niscope_restricted/niscope_restricted_service.h
+++ b/generated/niscope_restricted/niscope_restricted_service.h
@@ -45,7 +45,7 @@ public:
 private:
   NiScopeRestrictedLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi);
+  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi);
 
   NiScopeRestrictedFeatureToggles feature_toggles_;
 };

--- a/generated/niswitch/niswitch_service.h
+++ b/generated/niswitch/niswitch_service.h
@@ -104,7 +104,7 @@ public:
 private:
   NiSwitchLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi);
+  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi);
 
   NiSwitchFeatureToggles feature_toggles_;
 };

--- a/generated/nisync/nisync_service.h
+++ b/generated/nisync/nisync_service.h
@@ -114,7 +114,7 @@ public:
 private:
   NiSyncLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi);
+  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi);
 
   NiSyncFeatureToggles feature_toggles_;
 };

--- a/generated/nitclk/nitclk_service.h
+++ b/generated/nitclk/nitclk_service.h
@@ -59,7 +59,7 @@ public:
 private:
   NiTClkLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
-  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession session_number);
+  ::grpc::Status ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession session_number);
 
   NiTClkFeatureToggles feature_toggles_;
 };

--- a/generated/nixnet/nixnet_service.h
+++ b/generated/nixnet/nixnet_service.h
@@ -105,8 +105,8 @@ private:
   NiXnetLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
   nxDatabaseRef_tResourceRepositorySharedPtr nx_database_ref_t_resource_repository_;
-  ::grpc::Status ConvertApiErrorStatusForNxSessionRef_t(::grpc::ServerContext* context, int32_t status, nxSessionRef_t session);
-  ::grpc::Status ConvertApiErrorStatusForNxDatabaseRef_t(::grpc::ServerContext* context, int32_t status, nxDatabaseRef_t session);
+  ::grpc::Status ConvertApiErrorStatusForNxSessionRef_t(::grpc::ServerContextBase* context, int32_t status, nxSessionRef_t session);
+  ::grpc::Status ConvertApiErrorStatusForNxDatabaseRef_t(::grpc::ServerContextBase* context, int32_t status, nxDatabaseRef_t session);
   std::map<std::int32_t, std::int32_t> dbpropertyvalue_input_map_ { {0, 0},{1, 0},{2, 1},{3, 2},{4, 4294967294},{5, 0},{6, 1},{7, 2},{8, 3},{9, 0},{10, 1},{11, 1},{12, 2},{13, 3},{14, 4},{15, 0},{16, 1},{17, 2},{18, 0},{19, 1},{20, 0},{21, 1},{22, 2},{23, 3},{24, 2},{25, 3},{26, 4},{27, 5},{28, 6},{29, 0},{30, 1},{31, 2},{32, 0},{33, 1},{34, 2},{35, 3}, };
   std::map<std::int32_t, std::int32_t> dbpropertyvalue_output_map_ { {0, 0},{0, 1},{1, 2},{2, 3},{4294967294, 4},{0, 5},{1, 6},{2, 7},{3, 8},{0, 9},{1, 10},{1, 11},{2, 12},{3, 13},{4, 14},{0, 15},{1, 16},{2, 17},{0, 18},{1, 19},{0, 20},{1, 21},{2, 22},{3, 23},{2, 24},{3, 25},{4, 26},{5, 27},{6, 28},{0, 29},{1, 30},{2, 31},{0, 32},{1, 33},{2, 34},{3, 35}, };
   std::map<std::int32_t, std::int32_t> enetflags_input_map_ { {0, 0},{1, 2147483648},{2, 1073741824},{3, 8388608},{4, 65536}, };

--- a/generated/nixnetsocket/nixnetsocket_service.h
+++ b/generated/nixnetsocket/nixnetsocket_service.h
@@ -78,8 +78,8 @@ private:
   NiXnetSocketLibraryInterface* library_;
   ResourceRepositorySharedPtr session_repository_;
   nxIpStackRef_tResourceRepositorySharedPtr nx_ip_stack_ref_t_resource_repository_;
-  ::grpc::Status ConvertApiErrorStatusForNxSOCKET(::grpc::ServerContext* context, int32_t status, nxSOCKET socket);
-  ::grpc::Status ConvertApiErrorStatusForNxIpStackRef_t(::grpc::ServerContext* context, int32_t status, nxIpStackRef_t socket);
+  ::grpc::Status ConvertApiErrorStatusForNxSOCKET(::grpc::ServerContextBase* context, int32_t status, nxSOCKET socket);
+  ::grpc::Status ConvertApiErrorStatusForNxIpStackRef_t(::grpc::ServerContextBase* context, int32_t status, nxIpStackRef_t socket);
 
   NiXnetSocketFeatureToggles feature_toggles_;
 };

--- a/source/codegen/templates/service.h.mako
+++ b/source/codegen/templates/service.h.mako
@@ -100,7 +100,7 @@ private:
 <%
   cpp_handle_type = resource_handle_type[0].upper() + resource_handle_type[1:]
 %>\
-  ::grpc::Status ConvertApiErrorStatusFor${cpp_handle_type}(::grpc::ServerContext* context, int32_t status, ${resource_handle_type} ${config["session_handle_parameter_name"]});
+  ::grpc::Status ConvertApiErrorStatusFor${cpp_handle_type}(::grpc::ServerContextBase* context, int32_t status, ${resource_handle_type} ${config["session_handle_parameter_name"]});
 % endfor
 % if common_helpers.has_viboolean_array_param(functions):
   void Copy(const std::vector<ViBoolean>& input, google::protobuf::RepeatedField<bool>* output);

--- a/source/custom/nidaqmx_service.custom.cpp
+++ b/source/custom/nidaqmx_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nidaqmx_grpc {
 
-::grpc::Status NiDAQmxService::ConvertApiErrorStatusForTaskHandle(::grpc::ServerContext* context, int32_t status, TaskHandle task)
+::grpc::Status NiDAQmxService::ConvertApiErrorStatusForTaskHandle(::grpc::ServerContextBase* context, int32_t status, TaskHandle task)
 {
   // This implementation assumes this method is always called on the same thread where the error occurred.
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nidcpower_service.custom.cpp
+++ b/source/custom/nidcpower_service.custom.cpp
@@ -103,7 +103,7 @@ static void CheckStatus(int status)
   }
 }
 
-::grpc::Status NiDCPowerService::ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi)
+::grpc::Status NiDCPowerService::ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi)
 {
   static_assert(nidevice_grpc::kMaxGrpcErrorDescriptionSize >= 256, "ErrorMessage expects a minimum buffer size.");
   ViStatus error_code{};

--- a/source/custom/nidigitalpattern_service.custom.cpp
+++ b/source/custom/nidigitalpattern_service.custom.cpp
@@ -12,7 +12,7 @@ inline bool status_ok(int32 status)
   return status >= 0;
 }
 
-::grpc::Status NiDigitalService::ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi)
+::grpc::Status NiDigitalService::ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi)
 {
   static_assert(nidevice_grpc::kMaxGrpcErrorDescriptionSize >= 256, "ErrorMessage expects a minimum buffer size.");
   ViStatus error_code{};

--- a/source/custom/nidmm_service.custom.cpp
+++ b/source/custom/nidmm_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nidmm_grpc {
 
-::grpc::Status NiDmmService::ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi)
+::grpc::Status NiDmmService::ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi)
 {
   ViStatus error_code{};
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nifake_extension_service.custom.cpp
+++ b/source/custom/nifake_extension_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nifake_extension_grpc {
 
-::grpc::Status NiFakeExtensionService::ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi)
+::grpc::Status NiFakeExtensionService::ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi)
 {
   std::string description = "In a real service, you'd look up the error message here.";
   return nidevice_grpc::ApiErrorAndDescriptionToStatus(context, status, description);

--- a/source/custom/nifake_non_ivi_service.custom.cpp
+++ b/source/custom/nifake_non_ivi_service.custom.cpp
@@ -51,14 +51,14 @@ namespace nifake_non_ivi_grpc {
       request->stop());
 }
 
-::grpc::Status NiFakeNonIviService::ConvertApiErrorStatusForFakeHandle(::grpc::ServerContext* context, int32_t status, FakeHandle handle)
+::grpc::Status NiFakeNonIviService::ConvertApiErrorStatusForFakeHandle(::grpc::ServerContextBase* context, int32_t status, FakeHandle handle)
 {
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');
   library_->GetLatestErrorMessage(&description[0], nidevice_grpc::kMaxGrpcErrorDescriptionSize);
   return nidevice_grpc::ApiErrorAndDescriptionToStatus(context, status, description);
 }
 
-::grpc::Status NiFakeNonIviService::ConvertApiErrorStatusForSecondarySessionHandle(::grpc::ServerContext* context, int32_t status, SecondarySessionHandle handle)
+::grpc::Status NiFakeNonIviService::ConvertApiErrorStatusForSecondarySessionHandle(::grpc::ServerContextBase* context, int32_t status, SecondarySessionHandle handle)
 {
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');
   library_->GetLatestErrorMessage(&description[0], nidevice_grpc::kMaxGrpcErrorDescriptionSize);

--- a/source/custom/nifake_service.custom.cpp
+++ b/source/custom/nifake_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nifake_grpc {
 
-::grpc::Status NiFakeService::ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi)
+::grpc::Status NiFakeService::ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi)
 {
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');
   library_->ErrorMessage(vi, status, &description[0]);

--- a/source/custom/nifgen_service.custom.cpp
+++ b/source/custom/nifgen_service.custom.cpp
@@ -38,7 +38,7 @@ namespace nifgen_grpc {
   }
 }
 
-::grpc::Status NiFgenService::ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi)
+::grpc::Status NiFgenService::ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi)
 {
   static_assert(nidevice_grpc::kMaxGrpcErrorDescriptionSize >= 256, "ErrorMessage expects a minimum buffer size.");
   ViStatus error_code{};

--- a/source/custom/nimxlcterminaladaptor_restricted_service.custom.cpp
+++ b/source/custom/nimxlcterminaladaptor_restricted_service.custom.cpp
@@ -107,7 +107,7 @@ class TerminalContainerPtr {
   }
 }
 
-::grpc::Status NimxlcTerminalAdaptorRestrictedService::ConvertApiErrorStatusForNimxlc_Session(::grpc::ServerContext* context, int32_t status, nimxlc_Session session)
+::grpc::Status NimxlcTerminalAdaptorRestrictedService::ConvertApiErrorStatusForNimxlc_Session(::grpc::ServerContextBase* context, int32_t status, nimxlc_Session session)
 {
   std::string description;
   auto metadata = context->client_metadata();

--- a/source/custom/nirfmxbluetooth_service.custom.cpp
+++ b/source/custom/nirfmxbluetooth_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nirfmxbluetooth_grpc {
 
-::grpc::Status NiRFmxBluetoothService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle)
+::grpc::Status NiRFmxBluetoothService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle)
 {
   ViStatus error_code{};
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nirfmxcdma2k_service.custom.cpp
+++ b/source/custom/nirfmxcdma2k_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nirfmxcdma2k_grpc {
 
-::grpc::Status NiRFmxCDMA2kService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle)
+::grpc::Status NiRFmxCDMA2kService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle)
 {
   ViStatus error_code{};
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nirfmxdemod_service.custom.cpp
+++ b/source/custom/nirfmxdemod_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nirfmxdemod_grpc {
 
-::grpc::Status NiRFmxDemodService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle)
+::grpc::Status NiRFmxDemodService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle)
 {
   ViStatus error_code{};
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nirfmxgsm_service.custom.cpp
+++ b/source/custom/nirfmxgsm_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nirfmxgsm_grpc {
 
-::grpc::Status NiRFmxGSMService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle)
+::grpc::Status NiRFmxGSMService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle)
 {
   ViStatus error_code{};
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nirfmxinstr_restricted_service.custom.cpp
+++ b/source/custom/nirfmxinstr_restricted_service.custom.cpp
@@ -11,7 +11,7 @@ inline bool status_ok(int32 status)
 
 //---------------------------------------------------------------------
 //---------------------------------------------------------------------
-::grpc::Status NiRFmxInstrRestrictedService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle)
+::grpc::Status NiRFmxInstrRestrictedService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle)
 {
   int32 error_code{};
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nirfmxinstr_service.custom.cpp
+++ b/source/custom/nirfmxinstr_service.custom.cpp
@@ -116,7 +116,7 @@ const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;
   }
 }
 
-::grpc::Status NiRFmxInstrService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle)
+::grpc::Status NiRFmxInstrService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle)
 {
   int32 error_code{};
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nirfmxlte_service.custom.cpp
+++ b/source/custom/nirfmxlte_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nirfmxlte_grpc {
 
-::grpc::Status NiRFmxLTEService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle)
+::grpc::Status NiRFmxLTEService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle)
 {
   ViStatus error_code{};
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nirfmxnr_service.custom.cpp
+++ b/source/custom/nirfmxnr_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nirfmxnr_grpc {
 
-::grpc::Status NiRFmxNRService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle)
+::grpc::Status NiRFmxNRService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle)
 {
   int32 error_code{};
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nirfmxspecan_restricted_service.custom.cpp
+++ b/source/custom/nirfmxspecan_restricted_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nirfmxspecan_restricted_grpc {
 
-::grpc::Status NiRFmxSpecAnRestrictedService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle)
+::grpc::Status NiRFmxSpecAnRestrictedService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle)
 {
   ViStatus error_code{};
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nirfmxspecan_service.custom.cpp
+++ b/source/custom/nirfmxspecan_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nirfmxspecan_grpc {
 
-::grpc::Status NiRFmxSpecAnService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle)
+::grpc::Status NiRFmxSpecAnService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle)
 {
   ViStatus error_code{};
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nirfmxtdscdma_service.custom.cpp
+++ b/source/custom/nirfmxtdscdma_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nirfmxtdscdma_grpc {
 
-::grpc::Status NiRFmxTDSCDMAService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle)
+::grpc::Status NiRFmxTDSCDMAService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle)
 {
   ViStatus error_code{};
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nirfmxwcdma_service.custom.cpp
+++ b/source/custom/nirfmxwcdma_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nirfmxwcdma_grpc {
 
-::grpc::Status NiRFmxWCDMAService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle)
+::grpc::Status NiRFmxWCDMAService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle)
 {
   ViStatus error_code{};
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nirfmxwlan_restricted_service.custom.cpp
+++ b/source/custom/nirfmxwlan_restricted_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nirfmxwlan_restricted_grpc {
 
-::grpc::Status NiRFmxWLANRestrictedService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle)
+::grpc::Status NiRFmxWLANRestrictedService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle)
 {
   ViStatus error_code{};
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nirfmxwlan_service.custom.cpp
+++ b/source/custom/nirfmxwlan_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nirfmxwlan_grpc {
 
-::grpc::Status NiRFmxWLANService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContext* context, int32_t status, niRFmxInstrHandle instrumentHandle)
+::grpc::Status NiRFmxWLANService::ConvertApiErrorStatusForNiRFmxInstrHandle(::grpc::ServerContextBase* context, int32_t status, niRFmxInstrHandle instrumentHandle)
 {
   int32 error_code{};
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nirfsa_service.custom.cpp
+++ b/source/custom/nirfsa_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nirfsa_grpc {
 
-::grpc::Status NiRFSAService::ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi)
+::grpc::Status NiRFSAService::ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi)
 {
   static_assert(nidevice_grpc::kMaxGrpcErrorDescriptionSize >= 1024, "ErrorMessage expects a minimum buffer size.");
   ViStatus error_code{};

--- a/source/custom/nirfsg_service.custom.cpp
+++ b/source/custom/nirfsg_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nirfsg_grpc {
 
-::grpc::Status NiRFSGService::ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi)
+::grpc::Status NiRFSGService::ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi)
 {
   static_assert(nidevice_grpc::kMaxGrpcErrorDescriptionSize >= 1024, "ErrorMessage expects a minimum buffer size.");
   ViStatus error_code{};

--- a/source/custom/niscope_restricted_service.custom.cpp
+++ b/source/custom/niscope_restricted_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace niscope_restricted_grpc {
 
-::grpc::Status NiScopeRestrictedService::ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi)
+::grpc::Status NiScopeRestrictedService::ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi)
 {
   ViStatus error_code{};
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/niscope_service.custom.cpp
+++ b/source/custom/niscope_service.custom.cpp
@@ -563,7 +563,7 @@ void CheckStatus(int status)
   }
 }
 
-::grpc::Status NiScopeService::ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi)
+::grpc::Status NiScopeService::ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi)
 {
   ViStatus error_code{};
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/niswitch_service.custom.cpp
+++ b/source/custom/niswitch_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace niswitch_grpc {
 
-::grpc::Status NiSwitchService::ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi)
+::grpc::Status NiSwitchService::ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi)
 {
   static_assert(nidevice_grpc::kMaxGrpcErrorDescriptionSize >= 256, "ErrorMessage expects a minimum buffer size.");
   ViStatus error_code{};

--- a/source/custom/nisync_service.custom.cpp
+++ b/source/custom/nisync_service.custom.cpp
@@ -39,7 +39,7 @@ using nidevice_grpc::converters::convert_from_grpc;
   }
 }
 
-::grpc::Status NiSyncService::ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession vi)
+::grpc::Status NiSyncService::ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession vi)
 {
   static_assert(nidevice_grpc::kMaxGrpcErrorDescriptionSize >= 256, "ErrorMessage expects a minimum buffer size.");
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nitclk_service.custom.cpp
+++ b/source/custom/nitclk_service.custom.cpp
@@ -6,7 +6,7 @@ namespace nitclk_grpc {
 const auto kErrorReadBufferTooSmall = -200229;
 const auto kWarningCAPIStringTruncatedToFitBuffer = 200026;
 
-::grpc::Status NiTClkService::ConvertApiErrorStatusForViSession(::grpc::ServerContext* context, int32_t status, ViSession session_number)
+::grpc::Status NiTClkService::ConvertApiErrorStatusForViSession(::grpc::ServerContextBase* context, int32_t status, ViSession session_number)
 {
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');
   library_->GetExtendedErrorInfo(&description[0], nidevice_grpc::kMaxGrpcErrorDescriptionSize);

--- a/source/custom/nixnet_service.custom.cpp
+++ b/source/custom/nixnet_service.custom.cpp
@@ -1198,7 +1198,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
   }
 }
 
-::grpc::Status NiXnetService::ConvertApiErrorStatusForNxSessionRef_t(::grpc::ServerContext* context, int32_t status, nxSessionRef_t session)
+::grpc::Status NiXnetService::ConvertApiErrorStatusForNxSessionRef_t(::grpc::ServerContextBase* context, int32_t status, nxSessionRef_t session)
 {
   static_assert(nidevice_grpc::kMaxGrpcErrorDescriptionSize >= 2048, "StatusToString expects a minimum buffer size.");
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');
@@ -1206,7 +1206,7 @@ u32 GetLinDiagnosticScheduleChangeValue(const WriteStateRequest* request)
   return nidevice_grpc::ApiErrorAndDescriptionToStatus(context, status, description);
 }
 
-::grpc::Status NiXnetService::ConvertApiErrorStatusForNxDatabaseRef_t(::grpc::ServerContext* context, int32_t status, nxDatabaseRef_t session)
+::grpc::Status NiXnetService::ConvertApiErrorStatusForNxDatabaseRef_t(::grpc::ServerContextBase* context, int32_t status, nxDatabaseRef_t session)
 {
   static_assert(nidevice_grpc::kMaxGrpcErrorDescriptionSize >= 2048, "StatusToString expects a minimum buffer size.");
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');

--- a/source/custom/nixnetsocket_service.custom.cpp
+++ b/source/custom/nixnetsocket_service.custom.cpp
@@ -2,7 +2,7 @@
 
 namespace nixnetsocket_grpc {
 
-::grpc::Status NiXnetSocketService::ConvertApiErrorStatusForNxSOCKET(::grpc::ServerContext* context, int32_t status, nxSOCKET socket)
+::grpc::Status NiXnetSocketService::ConvertApiErrorStatusForNxSOCKET(::grpc::ServerContextBase* context, int32_t status, nxSOCKET socket)
 {
   // This implementation assumes this method is always called on the same thread where the error occurred.
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');
@@ -13,7 +13,7 @@ namespace nixnetsocket_grpc {
   return nidevice_grpc::ApiErrorAndDescriptionToStatus(context, status, description);
 }
 
-::grpc::Status NiXnetSocketService::ConvertApiErrorStatusForNxIpStackRef_t(::grpc::ServerContext* context, int32_t status, nxIpStackRef_t socket)
+::grpc::Status NiXnetSocketService::ConvertApiErrorStatusForNxIpStackRef_t(::grpc::ServerContextBase* context, int32_t status, nxIpStackRef_t socket)
 {
   // This implementation assumes this method is always called on the same thread where the error occurred.
   std::string description(nidevice_grpc::kMaxGrpcErrorDescriptionSize, '\0');


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update `ConvertApiErrorStatusForTaskHandle`, `ConvertApiErrorStatusForViSession`, etc. to take `::grpc::ServerContextBase*` rather than `::grpc::ServerContext*`. This allows server streaming RPCs to call it, passing in a `::grpc::CallbackServerContext*`.

### Why should this Pull Request be merged?

This is part of the fix for #924 

### What testing has been done?

Tested the complete fix with Python examples and new/updated C++ test cases. 