### PR TITLE
examples: Check for DAQmx event registration errors

### DIFF
--- a/examples/nidaqmx/analog-input-every-n-samples-aio.py
+++ b/examples/nidaqmx/analog-input-every-n-samples-aio.py
@@ -62,6 +62,11 @@ async def _main():
                     f"{warning_message.error_string}\nWarning status: {response.status}\n"
                 )
 
+        async def check_for_stream_error(stream: grpc.aio.UnaryStreamCall) -> None:
+            """Raise an exception if the stream was closed with an error."""
+            if stream.done() and await stream.code() != grpc.StatusCode.OK:
+                _ = await stream.read()
+
         try:
             create_task_response = await client.CreateTask(nidaqmx_types.CreateTaskRequest())
             task = create_task_response.task
@@ -98,20 +103,16 @@ async def _main():
             )
 
             # Wait for initial_metadata and check for stream errors to ensure that the callback is
-            # registered before starting the task.
+            # registered successfully before starting the task.
             await every_n_samples_stream.initial_metadata()
-            if every_n_samples_stream.done():
-                every_n_samples_response = await every_n_samples_stream.read()
-                check_for_warning(every_n_samples_response)
+            await check_for_stream_error(every_n_samples_stream)
 
             done_event_stream = client.RegisterDoneEvent(
                 nidaqmx_types.RegisterDoneEventRequest(task=task)
             )
 
             await done_event_stream.initial_metadata()
-            if done_event_stream.done():
-                done_response = await done_event_stream.read()
-                check_for_warning(done_response)
+            await check_for_stream_error(done_event_stream)
 
             start_task_response = await client.StartTask(nidaqmx_types.StartTaskRequest(task=task))
             check_for_warning(start_task_response)

--- a/examples/nidaqmx/analog-input-every-n-samples-aio.py
+++ b/examples/nidaqmx/analog-input-every-n-samples-aio.py
@@ -62,7 +62,7 @@ async def _main():
                     f"{warning_message.error_string}\nWarning status: {response.status}\n"
                 )
 
-        async def check_for_stream_error(stream: grpc.aio.UnaryStreamCall) -> None:
+        async def check_for_stream_error(stream):
             """Raise an exception if the stream was closed with an error."""
             if stream.done() and await stream.code() != grpc.StatusCode.OK:
                 _ = await stream.read()

--- a/examples/nidaqmx/analog-input-every-n-samples-aio.py
+++ b/examples/nidaqmx/analog-input-every-n-samples-aio.py
@@ -97,15 +97,21 @@ async def _main():
                 )
             )
 
-            # Wait for initial_metadata to ensure that the callback is registered before starting
-            # the task.
+            # Wait for initial_metadata and check for stream errors to ensure that the callback is
+            # registered before starting the task.
             await every_n_samples_stream.initial_metadata()
+            if every_n_samples_stream.done():
+                every_n_samples_response = await every_n_samples_stream.read()
+                check_for_warning(every_n_samples_response)
 
             done_event_stream = client.RegisterDoneEvent(
                 nidaqmx_types.RegisterDoneEventRequest(task=task)
             )
 
             await done_event_stream.initial_metadata()
+            if done_event_stream.done():
+                done_response = await done_event_stream.read()
+                check_for_warning(done_response)
 
             start_task_response = await client.StartTask(nidaqmx_types.StartTaskRequest(task=task))
             check_for_warning(start_task_response)

--- a/examples/nidaqmx/analog-input-every-n-samples.py
+++ b/examples/nidaqmx/analog-input-every-n-samples.py
@@ -64,7 +64,7 @@ def _main():
                     f"{warning_message.error_string}\nWarning status: {response.status}\n"
                 )
 
-        def check_for_stream_error(stream: grpc.Future) -> None:
+        def check_for_stream_error(stream):
             """Raise an exception if the stream was closed with an error."""
             if stream.done() and stream.exception() is not None:
                 raise stream.exception()

--- a/examples/nidaqmx/analog-input-every-n-samples.py
+++ b/examples/nidaqmx/analog-input-every-n-samples.py
@@ -99,15 +99,21 @@ def _main():
                 )
             )
 
-            # Wait for initial_metadata to ensure that the callback is registered before starting
-            # the task.
+            # Wait for initial_metadata and check for stream errors to ensure that the callback is
+            # registered before starting the task.
             every_n_samples_stream.initial_metadata()
+            if every_n_samples_stream.done():
+                every_n_samples_response = next(every_n_samples_stream)
+                check_for_warning(every_n_samples_response)
 
             done_event_stream = client.RegisterDoneEvent(
                 nidaqmx_types.RegisterDoneEventRequest(task=task)
             )
 
             done_event_stream.initial_metadata()
+            if done_event_stream.done():
+                done_response = next(done_event_stream)
+                check_for_warning(done_response)
 
             start_task_response = client.StartTask(nidaqmx_types.StartTaskRequest(task=task))
             check_for_warning(start_task_response)

--- a/examples/nidaqmx/analog-input-every-n-samples.py
+++ b/examples/nidaqmx/analog-input-every-n-samples.py
@@ -64,6 +64,11 @@ def _main():
                     f"{warning_message.error_string}\nWarning status: {response.status}\n"
                 )
 
+        def check_for_stream_error(stream: grpc.Future) -> None:
+            """Raise an exception if the stream was closed with an error."""
+            if stream.done() and stream.exception() is not None:
+                raise stream.exception()
+
         try:
             create_task_response = client.CreateTask(nidaqmx_types.CreateTaskRequest())
             task = create_task_response.task
@@ -100,20 +105,16 @@ def _main():
             )
 
             # Wait for initial_metadata and check for stream errors to ensure that the callback is
-            # registered before starting the task.
+            # registered successfully before starting the task.
             every_n_samples_stream.initial_metadata()
-            if every_n_samples_stream.done():
-                every_n_samples_response = next(every_n_samples_stream)
-                check_for_warning(every_n_samples_response)
+            check_for_stream_error(every_n_samples_stream)
 
             done_event_stream = client.RegisterDoneEvent(
                 nidaqmx_types.RegisterDoneEventRequest(task=task)
             )
 
             done_event_stream.initial_metadata()
-            if done_event_stream.done():
-                done_response = next(done_event_stream)
-                check_for_warning(done_response)
+            check_for_stream_error(done_event_stream)
 
             start_task_response = client.StartTask(nidaqmx_types.StartTaskRequest(task=task))
             check_for_warning(start_task_response)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Change the DAQmx event examples to explicitly check for stream errors after waiting for initial metadata.
If the stream was closed with an error, it is "done" and reading a response will throw an exception.

### Why should this Pull Request be merged?

Demonstrates how to benefit from #927 

### What testing has been done?

Tested examples as written.

Tested error handling by changing `EVERY_N_SAMPLES_EVENT_TYPE_ACQUIRED_INTO_BUFFER` to `EVERY_N_SAMPLES_EVENT_TYPE_TRANSFERRED_FROM_BUFFER` and adding a `return` after the error check to prevent the worker thread/async task from being started.