### PR TITLE
Add targets for generating proto and service files for each driver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,8 @@ foreach(api ${nidrivers})
     ${gen_command}
     COMMENT "Generating proto file and service for ${api}"
     DEPENDS ${proto_dependencies})
+  add_custom_target(generate_proto_and_service_target_for_${api}
+    DEPENDS ${output_files})
 endforeach()
 
 add_custom_command(


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add targets for generating proto and service files for each driver, so that cmake could just generate proto and service file without building everything.

### Why should this Pull Request be merged?

grpc-device could be used as a utility to generate proto files for driver, e.g. nidaqmx gRPC client will need the proto file with the latest daqmx source files, just generating the proto file without building everything else saves some build time.

### What testing has been done?

Built.
