### PR TITLE
tests: Refactor driver error assertions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,11 @@ include_directories(
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
+if(MSVC)
+  # Set __cplusplus accurately so that gtest can print std::optional.
+  # See https://github.com/google/googletest/issues/4226 for more info.
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
+endif()
 
 #----------------------------------------------------------------------
 # Include generated *.pb.h files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,11 +68,6 @@ include_directories(
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-if(MSVC)
-  # Set __cplusplus accurately so that gtest can print std::optional.
-  # See https://github.com/google/googletest/issues/4226 for more info.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:__cplusplus")
-endif()
 
 #----------------------------------------------------------------------
 # Include generated *.pb.h files

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -1087,18 +1087,12 @@ TEST_F(NiDAQmxDriverApiTests, GetScaledUnitsAsDouble_Fails)
       ScaleStringAttribute::SCALE_ATTRIBUTE_SCALED_UNITS,
       UNITS);
 
-  EXPECT_THROW({
-    try {
-      client::get_scale_attribute_double(
-          stub(),
-          SCALE_NAME,
-          (ScaleDoubleAttribute)ScaleStringAttribute::SCALE_ATTRIBUTE_SCALED_UNITS);
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, SPECIFIED_ATTRIBUTE_NOT_VALID_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    client::get_scale_attribute_double(
+      stub(),
+      SCALE_NAME,
+      (ScaleDoubleAttribute)ScaleStringAttribute::SCALE_ATTRIBUTE_SCALED_UNITS);
+  }, SPECIFIED_ATTRIBUTE_NOT_VALID_ERROR);
 }
 
 TEST_F(NiDAQmxDriverApiTests, SetScaledUnits_GetScaledUnits_ReturnsAttribute)
@@ -1168,18 +1162,12 @@ TEST_F(NiDAQmxDriverApiTests, AOVoltageChannel_WriteAODataWithOutOfRangeValue_Re
   create_ao_voltage_chan(AO_MIN, AO_MAX);
 
   start_task();
-  EXPECT_THROW({
-    try {
-      auto write_data = generate_random_data(AO_MIN, AO_MAX, 100);
-      write_data[80] += AO_MAX;
-      WriteAnalogF64Response write_response;
-      write_analog_f64(write_data, write_response);
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, INVALID_AO_DATA_WRITE_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    auto write_data = generate_random_data(AO_MIN, AO_MAX, 100);
+    write_data[80] += AO_MAX;
+    WriteAnalogF64Response write_response;
+    write_analog_f64(write_data, write_response);
+  }, INVALID_AO_DATA_WRITE_ERROR);
   stop_task();
 }
 
@@ -1510,32 +1498,20 @@ TEST_F(NiDAQmxDriverApiTests, AIVoltageChannel_WaitForValidTimestamp_ReturnsErro
 {
   create_ai_voltage_chan(0.0, 1.0);
 
-  EXPECT_THROW({
-    try {
-      auto response = WaitForValidTimestampResponse{};
-      auto status = wait_for_valid_timestamp(response);
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, WAIT_FOR_VALID_TIMESTAMP_NOT_SUPPORTED_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    auto response = WaitForValidTimestampResponse{};
+    auto status = wait_for_valid_timestamp(response);
+  }, WAIT_FOR_VALID_TIMESTAMP_NOT_SUPPORTED_ERROR);
 }
 
 TEST_F(NiDAQmxDriverApiTests, AIVoltageChannel_CfgTimeStartTrig_ReturnsError)
 {
   create_ai_voltage_chan(0.0, 1.0);
 
-  EXPECT_THROW({
-    try {
-      auto response = CfgTimeStartTrigResponse{};
-      cfg_time_start_trig(response);
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, INVALID_ATTRIBUTE_VALUE_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    auto response = CfgTimeStartTrigResponse{};
+    cfg_time_start_trig(response);
+  }, INVALID_ATTRIBUTE_VALUE_ERROR);
 }
 
 TEST_F(NiDAQmxDriverApiTests, LoadedVoltageTask_ReadAIData_ReturnsDataInExpectedRange)
@@ -1569,29 +1545,17 @@ TEST_F(NiDAQmxDriverApiTests, SelfCal_Succeeds)
 
 TEST_F(NiDAQmxDriverApiTests, AddNetworkDeviceWithInvalidIP_ErrorRetrievingNetworkDeviceProperties)
 {
-  EXPECT_THROW({
-    try {
-      auto response = AddNetworkDeviceResponse{};
-      add_network_device("0.0.0.0", response);
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, RETRIEVING_NETWORK_DEVICE_PROPERTIES_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    auto response = AddNetworkDeviceResponse{};
+    add_network_device("0.0.0.0", response);
+  }, RETRIEVING_NETWORK_DEVICE_PROPERTIES_ERROR);
 }
 
 TEST_F(NiDAQmxDriverApiTests, ConfigureTEDSOnNonTEDSChannel_ErrorTEDSSensorNotDetected)
 {
-  EXPECT_THROW({
-    try {
-      client::configure_teds(stub(), AI_CHANNEL, "");
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, TEDS_SENSOR_NOT_DETECTED_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    client::configure_teds(stub(), AI_CHANNEL, "");
+  }, TEDS_SENSOR_NOT_DETECTED_ERROR);
 }
 
 TEST_F(NiDAQmxDriverApiTests, HardwareTimedTask_WaitForNextSampleClock_Succeeds)
@@ -1616,16 +1580,10 @@ TEST_F(NiDAQmxDriverApiTests, HardwareTimedTask_WaitForNextSampleClock_Succeeds)
 
 TEST_F(NiDAQmxDriverApiTests, ConnectBogusTerms_FailsWithInvalidRoutingError)
 {
-  EXPECT_THROW({
-    try {
-      auto response = ConnectTermsResponse{};
-      connect_terms("ABC", "123", response);
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, INVALID_TERM_ROUTING_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    auto response = ConnectTermsResponse{};
+    connect_terms("ABC", "123", response);
+  }, INVALID_TERM_ROUTING_ERROR);
 }
 
 TEST_F(NiDAQmxDriverApiTests, DOWatchdogTask_StartTaskAndWatchdogTask_Succeeds)
@@ -1653,15 +1611,9 @@ TEST_F(NiDAQmxDriverApiTests, DOWatchdogTask_StartTaskAndWatchdogTask_Succeeds)
 
 TEST_F(NiDAQmxDriverApiTests, AutoConfigureCDAQSyncConnections_ReturnsNotSupportedError)
 {
-  EXPECT_THROW({
-    try {
-      client::auto_configure_cdaq_sync_connections(stub(), DEVICE_NAME, 1.0);
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, DEVICE_DOES_NOT_SUPPORT_CDAQ_SYNC_CONNECTIONS_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    client::auto_configure_cdaq_sync_connections(stub(), DEVICE_NAME, 1.0);
+  }, DEVICE_DOES_NOT_SUPPORT_CDAQ_SYNC_CONNECTIONS_ERROR);
 }
 
 TEST_F(NiDAQmxDriverApiTests, DIChannel_GetSetResetInputBufferSize_UpdatesBufferSize)
@@ -1878,28 +1830,16 @@ TEST_F(NiDAQmxDriverApiTests, AIChannel_ReconfigureSampQuantSampsPerChan_Updates
 
 TEST_F(NiDAQmxDriverApiTests, SetWrongCategoryAttribute_ReturnsNotValidError)
 {
-  EXPECT_THROW({
-    try {
-      client::get_device_attribute_bool(stub(), DEVICE_NAME, ScaleDoubleAttribute::SCALE_ATTRIBUTE_LIN_SLOPE);
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, SPECIFIED_ATTRIBUTE_NOT_VALID_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    client::get_device_attribute_bool(stub(), DEVICE_NAME, ScaleDoubleAttribute::SCALE_ATTRIBUTE_LIN_SLOPE);
+  }, SPECIFIED_ATTRIBUTE_NOT_VALID_ERROR);
 }
 
 TEST_F(NiDAQmxDriverApiTests, SetWrongDataTypeAttribute_ReturnsNotValidError)
 {
-  EXPECT_THROW({
-    try {
-      client::get_device_attribute_bool(stub(), DEVICE_NAME, DeviceStringAttribute::DEVICE_ATTRIBUTE_AO_PHYSICAL_CHANS);
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, SPECIFIED_ATTRIBUTE_NOT_VALID_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    client::get_device_attribute_bool(stub(), DEVICE_NAME, DeviceStringAttribute::DEVICE_ATTRIBUTE_AO_PHYSICAL_CHANS);
+  }, SPECIFIED_ATTRIBUTE_NOT_VALID_ERROR);
 }
 
 }  // namespace

--- a/source/tests/system/nidcpower_session_tests.cpp
+++ b/source/tests/system/nidcpower_session_tests.cpp
@@ -118,15 +118,10 @@ TEST_F(NiDCPowerSessionTest, InitializeSessionWithDeviceAndNoSessionName_Creates
 
 TEST_F(NiDCPowerSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     dcpower::InitializeWithChannelsResponse response;
     call_initialize_with_channels(kTestInvalidRsrc, "", "", &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRsrc);
-    EXPECT_STRNE("", ex.what());
-  }
+  }, kInvalidRsrc);
 }
 
 TEST_F(NiDCPowerSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
@@ -152,32 +147,22 @@ TEST_F(NiDCPowerSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionEr
   nidevice_grpc::Session session;
   session.set_name("");
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR({
     ::grpc::ClientContext context;
     dcpower::CloseRequest request;
     request.mutable_vi()->set_name(session.name());
     dcpower::CloseResponse response;
     auto status = GetStub()->Close(&context, request, &response);
     nidevice_grpc::experimental::client::raise_if_error(status, context);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidDCPowerSession);
-    EXPECT_THAT(ex.what(), HasSubstr(kInvalidDCPowerSessionMessage));
-  }
+  }, kInvalidDCPowerSession, kInvalidDCPowerSessionMessage);
 }
 
 TEST_F(NiDCPowerSessionTest, InitWithErrorFromDriver_ReturnsDriverErrorWithUserErrorMessage)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR({
     dcpower::InitializeWithChannelsResponse initialize_response;
     call_initialize_with_channels(kTestInvalidRsrc, "", "", &initialize_response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRsrc);
-    EXPECT_STREQ(kViErrorResourceNotFoundMessage, ex.what());
-  }
+  }, kInvalidRsrc, kViErrorResourceNotFoundMessage);
 }
 
 }  // namespace system

--- a/source/tests/system/nidigital_session_tests.cpp
+++ b/source/tests/system/nidigital_session_tests.cpp
@@ -98,15 +98,10 @@ TEST_F(NiDigitalSessionTest, InitializedSession_CloseSession_ClosesDriverSession
 
 TEST_F(NiDigitalSessionTest, InitWithErrorFromDriver_ReturnsDriverErrorWithUserErrorMessage)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR({
     digital::InitWithOptionsResponse init_response;
     auto status = call_init_with_options(kDigitalInvalidResourceName, "", "", &init_response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kDigitalRsrcNotFound);
-    EXPECT_STREQ(kDigitalRsrcNotFoundMessage, ex.what());
-  }
+  }, kDigitalRsrcNotFound, kDigitalRsrcNotFoundMessage);
 }
 
 }  // namespace system

--- a/source/tests/system/nidmm_session_tests.cpp
+++ b/source/tests/system/nidmm_session_tests.cpp
@@ -123,32 +123,22 @@ TEST_F(NiDmmSessionTest, InvalidSession_CloseSession_ReturnsInvalidSesssionError
   nidevice_grpc::Session session;
   session.set_name("");
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR({
     ::grpc::ClientContext context;
     dmm::CloseRequest request;
     request.mutable_vi()->set_name(session.name());
     dmm::CloseResponse response;
     ::grpc::Status status = GetStub()->Close(&context, request, &response);
     nidevice_grpc::experimental::client::raise_if_error(status, context);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidDmmSession);
-    EXPECT_THAT(ex.what(), HasSubstr(kInvalidDmmSessionMessage));
-  }
+  }, kInvalidDmmSession, kInvalidDmmSessionMessage);
 }
 
 TEST_F(NiDmmSessionTest, InitWithErrorFromDriver_ReturnsDriverErrorWithUserErrorMessage)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR({
     dmm::InitWithOptionsResponse init_response;
     call_init_with_options(kInvalidRsrc, "", "", &init_response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kViErrorDmmRsrcNFound);
-    EXPECT_STREQ(kViErrorDmmRsrcNFoundMessage, ex.what());
-  }
+  }, kViErrorDmmRsrcNFound, kViErrorDmmRsrcNFoundMessage);
 }
 
 }  // namespace system

--- a/source/tests/system/nifgen_session_tests.cpp
+++ b/source/tests/system/nifgen_session_tests.cpp
@@ -117,32 +117,22 @@ TEST_F(NiFgenSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError
   nidevice_grpc::Session session;
   session.set_name("");
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR({
     ::grpc::ClientContext context;
     fgen::CloseRequest request;
     request.mutable_vi()->set_name(session.name());
     fgen::CloseResponse response;
     auto status = GetStub()->Close(&context, request, &response);
     nidevice_grpc::experimental::client::raise_if_error(status, context);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidFgenSession);
-    EXPECT_STREQ(kInvalidFgenSessionMessage, ex.what());
-  }
+  }, kInvalidFgenSession, kInvalidFgenSessionMessage);
 }
 
 TEST_F(NiFgenSessionTest, InitWithErrorFromDriver_ReturnsDriverErrorWithUserErrorMessage)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR({
     fgen::InitWithOptionsResponse initialize_response;
     call_init_with_options(kTestInvalidFgenRsrc, "", "", &initialize_response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidFgenRsrc);
-    EXPECT_THAT(ex.what(), HasSubstr(kViErrorFgenResourceNotFoundMessage));
-  }
+  }, kInvalidFgenRsrc, kViErrorFgenResourceNotFoundMessage);
 }
 
 }  // namespace system

--- a/source/tests/system/nirfmxbluetooth_session_tests.cpp
+++ b/source/tests/system/nirfmxbluetooth_session_tests.cpp
@@ -85,14 +85,10 @@ TEST_F(NiRFmxBluetoothSessionTest, InitializeSessionWithDeviceAndNoSessionName_C
 
 TEST_F(NiRFmxBluetoothSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxbluetooth::InitializeResponse response;
     auto status = call_initialize(kRFmxBTTestInvalidRsrc, "", "", &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRsrc);
-  }
+  }, kInvalidRsrc);
 }
 
 TEST_F(NiRFmxBluetoothSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
@@ -153,15 +149,11 @@ TEST_F(NiRFmxBluetoothSessionTest, CallInitializeTwiceWithSameSessionNameOnSameD
   EXPECT_TRUE(status_one.ok());
   EXPECT_EQ(0, close_response_one.status());
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     // Initialize was only called once in the driver since the second init call to the service found the Session by the same name and returned it.
     // Therefore if we try to close the session again the driver will respond that it's not a valid session (it's already been closed).
     call_close(session_two, false, &close_response_two);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxBTSession);
-  }
+  }, kInvalidRFmxBTSession);
 }
 
 TEST_F(NiRFmxBluetoothSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
@@ -169,14 +161,10 @@ TEST_F(NiRFmxBluetoothSessionTest, InvalidSession_CloseSession_ReturnsInvalidSes
   nidevice_grpc::Session session;
   session.set_name("");
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxbluetooth::CloseResponse response;
     call_close(session, false, &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxBTSession);
-  }
+  }, kInvalidRFmxBTSession);
 }
 
 }  // namespace

--- a/source/tests/system/nirfmxcdma2k_session_tests.cpp
+++ b/source/tests/system/nirfmxcdma2k_session_tests.cpp
@@ -85,14 +85,10 @@ TEST_F(NiRFmxCDMA2kSessionTest, InitializeSessionWithDeviceAndNoSessionName_Crea
 
 TEST_F(NiRFmxCDMA2kSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxcdma2k::InitializeResponse response;
     call_initialize(kRFmxCDMA2kTestInvalidRsrc, "", "", &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRsrc);
-  }
+  }, kInvalidRsrc);
 }
 
 TEST_F(NiRFmxCDMA2kSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
@@ -153,15 +149,12 @@ TEST_F(NiRFmxCDMA2kSessionTest, CallInitializeTwiceWithSameSessionNameOnSameDevi
   EXPECT_TRUE(status_one.ok());
   EXPECT_EQ(0, close_response_one.status());
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     // Initialize was only called once in the driver since the second init call to the service found the Session by the same name and returned it.
     // Therefore if we try to close the session again the driver will respond that it's not a valid session (it's already been closed).
     call_close(session_two, false, &close_response_two);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxCDMA2kSession);
-  }
+  }, kInvalidRFmxCDMA2kSession);
+
 }
 
 TEST_F(NiRFmxCDMA2kSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
@@ -169,14 +162,10 @@ TEST_F(NiRFmxCDMA2kSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessio
   nidevice_grpc::Session session;
   session.set_name("");
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxcdma2k::CloseResponse response;
     call_close(session, false, &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxCDMA2kSession);
-  }
+  }, kInvalidRFmxCDMA2kSession);
 }
 
 }  // namespace

--- a/source/tests/system/nirfmxdemod_session_tests.cpp
+++ b/source/tests/system/nirfmxdemod_session_tests.cpp
@@ -85,14 +85,10 @@ TEST_F(NiRFmxDemodSessionTest, InitializeSessionWithDeviceAndNoSessionName_Creat
 
 TEST_F(NiRFmxDemodSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxdemod::InitializeResponse response;
     call_initialize(kRFmxDemodTestInvalidRsrc, "", "", &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRsrc);
-  }
+  }, kInvalidRsrc);
 }
 
 TEST_F(NiRFmxDemodSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
@@ -153,15 +149,11 @@ TEST_F(NiRFmxDemodSessionTest, CallInitializeTwiceWithSameSessionNameOnSameDevic
   EXPECT_TRUE(status_one.ok());
   EXPECT_EQ(0, close_response_one.status());
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     // Initialize was only called once in the driver since the second init call to the service found the Session by the same name and returned it.
     // Therefore if we try to close the session again the driver will respond that it's not a valid session (it's already been closed).
     call_close(session_two, false, &close_response_two);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxDemodSession);
-  }
+  }, kInvalidRFmxDemodSession);
 }
 
 TEST_F(NiRFmxDemodSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
@@ -169,14 +161,10 @@ TEST_F(NiRFmxDemodSessionTest, InvalidSession_CloseSession_ReturnsInvalidSession
   nidevice_grpc::Session session;
   session.set_name("");
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxdemod::CloseResponse response;
     call_close(session, false, &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxDemodSession);
-  }
+  }, kInvalidRFmxDemodSession);
 }
 
 }  // namespace

--- a/source/tests/system/nirfmxgsm_session_tests.cpp
+++ b/source/tests/system/nirfmxgsm_session_tests.cpp
@@ -85,14 +85,10 @@ TEST_F(NiRFmxGSMSessionTest, InitializeSessionWithDeviceAndNoSessionName_Creates
 
 TEST_F(NiRFmxGSMSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxgsm::InitializeResponse response;
     call_initialize(kRFmxGSMTestInvalidRsrc, "", "", &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRsrc);
-  }
+  }, kInvalidRsrc);
 }
 
 TEST_F(NiRFmxGSMSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
@@ -153,15 +149,11 @@ TEST_F(NiRFmxGSMSessionTest, CallInitializeTwiceWithSameSessionNameOnSameDevice_
   EXPECT_TRUE(status_one.ok());
   EXPECT_EQ(0, close_response_one.status());
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     // Initialize was only called once in the driver since the second init call to the service found the Session by the same name and returned it.
     // Therefore if we try to close the session again the driver will respond that it's not a valid session (it's already been closed).
     call_close(session_two, false, &close_response_two);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxGSMSession);
-  }
+  }, kInvalidRFmxGSMSession);
 }
 
 TEST_F(NiRFmxGSMSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
@@ -169,14 +161,10 @@ TEST_F(NiRFmxGSMSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionEr
   nidevice_grpc::Session session;
   session.set_name("");
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxgsm::CloseResponse response;
     call_close(session, false, &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxGSMSession);
-  }
+  }, kInvalidRFmxGSMSession);
 }
 
 }  // namespace

--- a/source/tests/system/nirfmxlte_session_tests.cpp
+++ b/source/tests/system/nirfmxlte_session_tests.cpp
@@ -85,14 +85,10 @@ TEST_F(NiRFmxLTESessionTest, InitializeSessionWithDeviceAndNoSessionName_Creates
 
 TEST_F(NiRFmxLTESessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxlte::InitializeResponse response;
     call_initialize(kRFmxLTETestInvalidRsrc, "", "", &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRsrc);
-  }
+  }, kInvalidRsrc);
 }
 
 TEST_F(NiRFmxLTESessionTest, InitializedSession_CloseSession_ClosesDriverSession)
@@ -153,15 +149,11 @@ TEST_F(NiRFmxLTESessionTest, CallInitializeTwiceWithSameSessionNameOnSameDevice_
   EXPECT_TRUE(status_one.ok());
   EXPECT_EQ(0, close_response_one.status());
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     // Initialize was only called once in the driver since the second init call to the service found the Session by the same name and returned it.
     // Therefore if we try to close the session again the driver will respond that it's not a valid session (it's already been closed).
     call_close(session_two, false, &close_response_two);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxLTESession);
-  }
+  }, kInvalidRFmxLTESession);
 }
 
 TEST_F(NiRFmxLTESessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
@@ -169,14 +161,10 @@ TEST_F(NiRFmxLTESessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionEr
   nidevice_grpc::Session session;
   session.set_name("");
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxlte::CloseResponse response;
     call_close(session, false, &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxLTESession);
-  }
+  }, kInvalidRFmxLTESession);
 }
 
 }  // namespace

--- a/source/tests/system/nirfmxnr_session_tests.cpp
+++ b/source/tests/system/nirfmxnr_session_tests.cpp
@@ -85,14 +85,10 @@ TEST_F(NiRFmxNRSessionTest, InitializeSessionWithDeviceAndNoSessionName_CreatesD
 
 TEST_F(NiRFmxNRSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxnr::InitializeResponse response;
     call_initialize(kRFmxNRTestInvalidRsrc, "", "", &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRsrc);
-  }
+  }, kInvalidRsrc);
 }
 
 TEST_F(NiRFmxNRSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
@@ -153,15 +149,11 @@ TEST_F(NiRFmxNRSessionTest, CallInitializeTwiceWithSameSessionNameOnSameDevice_C
   EXPECT_TRUE(status_one.ok());
   EXPECT_EQ(0, close_response_one.status());
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     // Initialize was only called once in the driver since the second init call to the service found the Session by the same name and returned it.
     // Therefore if we try to close the session again the driver will respond that it's not a valid session (it's already been closed).
     call_close(session_two, false, &close_response_two);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxNRSession);
-  }
+  }, kInvalidRFmxNRSession);
 }
 
 TEST_F(NiRFmxNRSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
@@ -169,14 +161,10 @@ TEST_F(NiRFmxNRSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionErr
   nidevice_grpc::Session session;
   session.set_name("");
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxnr::CloseResponse response;
     call_close(session, false, &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxNRSession);
-  }
+  }, kInvalidRFmxNRSession);
 }
 
 }  // namespace

--- a/source/tests/system/nirfmxspecan_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxspecan_driver_api_tests.cpp
@@ -647,13 +647,9 @@ TEST_P(NiRFmxSpecAnDriverApiConflictingResourceInitTests, InitializeResource_Ini
   const auto session1 = init_session(stub(), PXI_5663, std::get<0>(GetParam()));
   EXPECT_VALID_DRIVER_SESSION(session1);
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     init(stub(), PXI_5663, std::get<1>(GetParam()));
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, DEVICE_IN_USE_ERROR);
-  }
+  }, DEVICE_IN_USE_ERROR);
 }
 
 TEST_P(NiRFmxSpecAnDriverApiConflictingResourceInitTests, InitializeAndCloseResource_InitializeResourceThatWouldHaveConflicted_Succeeds)

--- a/source/tests/system/nirfmxspecan_session_tests.cpp
+++ b/source/tests/system/nirfmxspecan_session_tests.cpp
@@ -95,28 +95,24 @@ TEST_F(NiRFmxSpecAnSessionTest, InitializedSession_CloseSession_ClosesDriverSess
 // afterwards will fail to get the error_message if the request is handled on a different thread.
 TEST_F(NiRFmxSpecAnSessionTest, InitWithErrorFromDriver_ReturnsDriverErrorWithUserErrorMessage)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR({
     rfmxspecan::InitializeResponse init_response;
     call_initialize(kRFmxSpecAnTestInvalidRsrc, "", "", &init_response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRsrc);
-    EXPECT_STREQ(kRFmxSpecAnErrorResourceNotFoundMessage, ex.what());
-  }
+  }, kInvalidRsrc, kRFmxSpecAnErrorResourceNotFoundMessage);
 }
 
 TEST_F(NiRFmxSpecAnSessionTest, InitWithErrorFromDriver_ReinitSuccessfully_ErrorMessageIsEmpty)
 {
-  try {
-    rfmxspecan::InitializeResponse failed_init_response;
-    call_initialize(kRFmxSpecAnTestInvalidRsrc, "", "", &failed_init_response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    EXPECT_EQ(::grpc::StatusCode::UNKNOWN, ex.StatusCode());
-    EXPECT_STREQ(kRFmxSpecAnErrorResourceNotFoundMessage, ex.what());
-  }
+  EXPECT_THROW({
+    try {
+      rfmxspecan::InitializeResponse failed_init_response;
+      call_initialize(kRFmxSpecAnTestInvalidRsrc, "", "", &failed_init_response);
+    }
+    catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
+      EXPECT_EQ(::grpc::StatusCode::UNKNOWN, ex.StatusCode());
+      EXPECT_STREQ(kRFmxSpecAnErrorResourceNotFoundMessage, ex.what());
+    }
+  }, nidevice_grpc::experimental::client::grpc_driver_error);
 
   rfmxspecan::InitializeResponse successful_init_response;
   auto status_two = call_initialize(kRFmxSpecAnTestRsrc, kRFmxSpecAnOptionsString, kRFmxSpecAnTestSession, &successful_init_response);
@@ -131,7 +127,7 @@ TEST_F(NiRFmxSpecAnSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessio
   nidevice_grpc::Session session;
   session.set_name("");
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     ::grpc::ClientContext context;
     rfmxspecan::CloseRequest request;
     request.mutable_instrument()->set_name(session.name());
@@ -139,11 +135,7 @@ TEST_F(NiRFmxSpecAnSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessio
     rfmxspecan::CloseResponse response;
     ::grpc::Status status = GetStub()->Close(&context, request, &response);
     nidevice_grpc::experimental::client::raise_if_error(status, context);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxSpecAnSession);
-  }
+  }, kInvalidRFmxSpecAnSession);
 }
 
 }  // namespace system

--- a/source/tests/system/nirfmxspecan_session_tests.cpp
+++ b/source/tests/system/nirfmxspecan_session_tests.cpp
@@ -111,6 +111,7 @@ TEST_F(NiRFmxSpecAnSessionTest, InitWithErrorFromDriver_ReinitSuccessfully_Error
     catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
       EXPECT_EQ(::grpc::StatusCode::UNKNOWN, ex.StatusCode());
       EXPECT_STREQ(kRFmxSpecAnErrorResourceNotFoundMessage, ex.what());
+      throw;
     }
   }, nidevice_grpc::experimental::client::grpc_driver_error);
 

--- a/source/tests/system/nirfmxtdscdma_session_tests.cpp
+++ b/source/tests/system/nirfmxtdscdma_session_tests.cpp
@@ -85,14 +85,10 @@ TEST_F(NiRFmxTDSCDMASessionTest, InitializeSessionWithDeviceAndNoSessionName_Cre
 
 TEST_F(NiRFmxTDSCDMASessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxtdscdma::InitializeResponse response;
     call_initialize(kRFmxTDSCDMATestInvalidRsrc, "", "", &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRsrc);
-  }
+  }, kInvalidRsrc);
 }
 
 TEST_F(NiRFmxTDSCDMASessionTest, InitializedSession_CloseSession_ClosesDriverSession)
@@ -153,15 +149,11 @@ TEST_F(NiRFmxTDSCDMASessionTest, CallInitializeTwiceWithSameSessionNameOnSameDev
   EXPECT_TRUE(status_one.ok());
   EXPECT_EQ(0, close_response_one.status());
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     // Initialize was only called once in the driver since the second init call to the service found the Session by the same name and returned it.
     // Therefore if we try to close the session again the driver will respond that it's not a valid session (it's already been closed).
     call_close(session_two, false, &close_response_two);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxTDSCDMASession);
-  }
+  }, kInvalidRFmxTDSCDMASession);
 }
 
 TEST_F(NiRFmxTDSCDMASessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
@@ -169,14 +161,10 @@ TEST_F(NiRFmxTDSCDMASessionTest, InvalidSession_CloseSession_ReturnsInvalidSessi
   nidevice_grpc::Session session;
   session.set_name("");
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxtdscdma::CloseResponse response;
     call_close(session, false, &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxTDSCDMASession);
-  }
+  }, kInvalidRFmxTDSCDMASession);
 }
 
 }  // namespace

--- a/source/tests/system/nirfmxwcdma_session_tests.cpp
+++ b/source/tests/system/nirfmxwcdma_session_tests.cpp
@@ -85,14 +85,10 @@ TEST_F(NiRFmxWCDMASessionTest, InitializeSessionWithDeviceAndNoSessionName_Creat
 
 TEST_F(NiRFmxWCDMASessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxwcdma::InitializeResponse response;
     call_initialize(kRFmxWCDMATestInvalidRsrc, "", "", &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRsrc);
-  }
+  }, kInvalidRsrc);
 }
 
 TEST_F(NiRFmxWCDMASessionTest, InitializedSession_CloseSession_ClosesDriverSession)
@@ -153,15 +149,11 @@ TEST_F(NiRFmxWCDMASessionTest, CallInitializeTwiceWithSameSessionNameOnSameDevic
   EXPECT_TRUE(status_one.ok());
   EXPECT_EQ(0, close_response_one.status());
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     // Initialize was only called once in the driver since the second init call to the service found the Session by the same name and returned it.
     // Therefore if we try to close the session again the driver will respond that it's not a valid session (it's already been closed).
     call_close(session_two, false, &close_response_two);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxWCDMASession);
-  }
+  }, kInvalidRFmxWCDMASession);
 }
 
 TEST_F(NiRFmxWCDMASessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
@@ -169,14 +161,10 @@ TEST_F(NiRFmxWCDMASessionTest, InvalidSession_CloseSession_ReturnsInvalidSession
   nidevice_grpc::Session session;
   session.set_name("");
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxwcdma::CloseResponse response;
     call_close(session, false, &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxWCDMASession);
-  }
+  }, kInvalidRFmxWCDMASession);
 }
 
 }  // namespace

--- a/source/tests/system/nirfmxwlan_session_tests.cpp
+++ b/source/tests/system/nirfmxwlan_session_tests.cpp
@@ -85,14 +85,10 @@ TEST_F(NiRFmxWLANSessionTest, InitializeSessionWithDeviceAndNoSessionName_Create
 
 TEST_F(NiRFmxWLANSessionTest, InitializeSessionWithoutDevice_ReturnsDriverError)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxwlan::InitializeResponse response;
     call_initialize(kRFmxWLANTestInvalidRsrc, "", "", &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRsrc);
-  }
+  }, kInvalidRsrc);
 }
 
 TEST_F(NiRFmxWLANSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
@@ -140,14 +136,10 @@ TEST_F(NiRFmxWLANSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionE
   nidevice_grpc::Session session;
   session.set_name("");
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     rfmxwlan::CloseResponse response;
     call_close(session, false, &response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxWLANSession);
-  }
+  }, kInvalidRFmxWLANSession);
 }
 
 TEST_F(NiRFmxWLANSessionTest, CallInitializeTwiceWithSameSessionNameOnSameDevice_CloseSessionTwice_SecondCloseReturnsInvalidSessionError)
@@ -168,15 +160,11 @@ TEST_F(NiRFmxWLANSessionTest, CallInitializeTwiceWithSameSessionNameOnSameDevice
   EXPECT_TRUE(status_one.ok());
   EXPECT_EQ(0, close_response_one.status());
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     // Initialize was only called once in the driver since the second init call to the service found the Session by the same name and returned it.
     // Therefore if we try to close the session again the driver will respond that it's not a valid session (it's already been closed).
     call_close(session_two, false, &close_response_two);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFmxWLANSession);
-  }
+  }, kInvalidRFmxWLANSession);
 }
 
 }  // namespace

--- a/source/tests/system/nirfsa_driver_api_tests.cpp
+++ b/source/tests/system/nirfsa_driver_api_tests.cpp
@@ -501,6 +501,7 @@ TEST_F(NiRFSADriverApiTests, CreateConfigurationListWithInvalidAttribute_Reports
     }
     catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
       EXPECT_RFSA_ERROR(IVI_ATTRIBUTE_NOT_SUPPORTED_ERROR, "Attribute or property not supported.", ex, session);
+      throw;
     }
   }, nidevice_grpc::experimental::client::grpc_driver_error);
 }

--- a/source/tests/system/nirfsa_driver_api_tests.cpp
+++ b/source/tests/system/nirfsa_driver_api_tests.cpp
@@ -84,8 +84,7 @@ class NiRFSADriverApiTests : public Test {
 
   void EXPECT_RFSA_ERROR(int32_t expected_error, const std::string& message_substring, const nidevice_grpc::experimental::client::grpc_driver_error& ex, const nidevice_grpc::Session& session)
   {
-    expect_driver_error(ex, expected_error);
-    EXPECT_THAT(ex.what(), HasSubstr(message_substring));
+    EXPECT_DRIVER_ERROR_WITH_SUBSTR(ex, expected_error, message_substring);
     clear_error(session);
   }
 
@@ -121,14 +120,9 @@ TEST_F(NiRFSADriverApiTests, Init_Close_Succeeds)
 
 TEST_F(NiRFSADriverApiTests, InitWithErrorFromDriver_ReturnsDriverErrorWithUserErrorMessage)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR({
     client::init_with_options(stub(), "", false, false, "");
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, -200220);
-    EXPECT_STREQ("Device identifier is invalid.", ex.what());
-  }
+  }, -200220, "Device identifier is invalid.");
 }
 
 MATCHER(IsNonDefaultComplexArray, "")
@@ -496,18 +490,19 @@ TEST_F(NiRFSADriverApiTests, CreateConfigurationListWithInvalidAttribute_Reports
   const auto LIST_NAME = "MyList";
   auto session = init_session(stub(), PXI_5663E);
 
-  try {
-    client::create_configuration_list(
-        stub(),
-        session,
-        LIST_NAME,
-        {NiRFSAAttribute::NIRFSA_ATTRIBUTE_EXTERNAL_GAIN, NiRFSAAttribute::NIRFSA_ATTRIBUTE_NOTCH_FILTER_ENABLED},
-        true);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    EXPECT_RFSA_ERROR(IVI_ATTRIBUTE_NOT_SUPPORTED_ERROR, "Attribute or property not supported.", ex, session);
-  }
+  EXPECT_THROW({
+    try {
+      client::create_configuration_list(
+          stub(),
+          session,
+          LIST_NAME,
+          {NiRFSAAttribute::NIRFSA_ATTRIBUTE_EXTERNAL_GAIN, NiRFSAAttribute::NIRFSA_ATTRIBUTE_NOTCH_FILTER_ENABLED},
+          true);
+    }
+    catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
+      EXPECT_RFSA_ERROR(IVI_ATTRIBUTE_NOT_SUPPORTED_ERROR, "Attribute or property not supported.", ex, session);
+    }
+  }, nidevice_grpc::experimental::client::grpc_driver_error);
 }
 
 TEST_F(NiRFSADriverApiTests, GetScalingCoefficients_ReturnsCoefficients)

--- a/source/tests/system/nirfsg_session_tests.cpp
+++ b/source/tests/system/nirfsg_session_tests.cpp
@@ -104,15 +104,10 @@ TEST_F(NiRFSGSessionTest, InitializedSession_CloseSession_ClosesDriverSession)
 
 TEST_F(NiRFSGSessionTest, InitWithErrorFromDriver_ReturnsDriverErrorWithUserErrorMessage)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR({
     rfsg::InitWithOptionsResponse init_response;
     call_init_with_options(kRFSGTestInvalidRsrc, "", "", &init_response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRsrc);
-    EXPECT_STREQ(kRFSGErrorResourceNotFoundMessage, ex.what());
-  }
+  }, kInvalidRsrc, kRFSGErrorResourceNotFoundMessage);
 }
 
 TEST_F(NiRFSGSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError)
@@ -120,18 +115,14 @@ TEST_F(NiRFSGSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionError
   nidevice_grpc::Session session;
   session.set_name("");
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     ::grpc::ClientContext context;
     rfsg::CloseRequest request;
     request.mutable_vi()->set_name(session.name());
     rfsg::CloseResponse response;
     auto status = GetStub()->Close(&context, request, &response);
     nidevice_grpc::experimental::client::raise_if_error(status, context);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidRFSGSession);
-  }
+  }, kInvalidRFSGSession);
 }
 
 }  // namespace system

--- a/source/tests/system/niscope_session_tests.cpp
+++ b/source/tests/system/niscope_session_tests.cpp
@@ -113,32 +113,22 @@ TEST_F(NiScopeSessionTest, InvalidSession_CloseSession_ReturnsInvalidSesssionErr
   nidevice_grpc::Session session;
   session.set_name("");
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR({
     ::grpc::ClientContext context;
     scope::CloseRequest request;
     request.mutable_vi()->set_name(session.name());
     scope::CloseResponse response;
     ::grpc::Status status = GetStub()->Close(&context, request, &response);
     nidevice_grpc::experimental::client::raise_if_error(status, context);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidScopeSession);
-    EXPECT_STREQ(kInvalidScopeSessionMessage, ex.what());
-  }
+  }, kInvalidScopeSession, kInvalidScopeSessionMessage);
 }
 
 TEST_F(NiScopeSessionTest, InitWithErrorFromDriver_ReturnsDriverErrorWithUserErrorMessage)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR({
     scope::InitWithOptionsResponse init_response;
     call_init_with_options(kInvalidResourceName, "", "", &init_response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kViErrorRsrcNFound);
-    EXPECT_STREQ(kViErrorRsrcNFoundMessage, ex.what());
-  }
+  }, kViErrorRsrcNFound, kViErrorRsrcNFoundMessage);
 }
 
 }  // namespace system

--- a/source/tests/system/niswitch_session_tests.cpp
+++ b/source/tests/system/niswitch_session_tests.cpp
@@ -115,32 +115,22 @@ TEST_F(NiSwitchSessionTest, InvalidSession_CloseSession_ReturnsInvalidSessionErr
   nidevice_grpc::Session session;
   session.set_name("");
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR({
     ::grpc::ClientContext context;
     niswitch::CloseRequest request;
     request.mutable_vi()->set_name(session.name());
     niswitch::CloseResponse response;
     auto status = GetStub()->Close(&context, request, &response);
     nidevice_grpc::experimental::client::raise_if_error(status, context);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kInvalidSwitchSession);
-    EXPECT_THAT(ex.what(), ::testing::HasSubstr(kInvalidSwitchSessionMessage));
-  }
+  }, kInvalidSwitchSession, kInvalidSwitchSessionMessage);
 }
 
 TEST_F(NiSwitchSessionTest, InitWithErrorFromDriver_ReturnsDriverErrorWithUserErrorMessage)
 {
-  try {
+  EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR({
     niswitch::InitWithTopologyResponse init_response;
     call_init_with_topology(kInvalidRsrcName, "", "", &init_response);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, kViErrorRsrcNotFound);
-    EXPECT_STREQ(kViErrorRsrcNotFoundMessage, ex.what());
-  }
+  }, kViErrorRsrcNotFound, kViErrorRsrcNotFoundMessage);
 }
 
 }  // namespace system

--- a/source/tests/system/nixnetsocket_driver_api_tests.cpp
+++ b/source/tests/system/nixnetsocket_driver_api_tests.cpp
@@ -294,6 +294,7 @@ TEST_F(NiXnetSocketNoHardwareTests, InitWithInvalidIpStack_Close_ReturnsAndSetsE
     catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
       EXPECT_DRIVER_ERROR_WITH_SUBSTR(ex, GENERIC_NXSOCKET_ERROR, INVALID_SOCKET_MESSAGE);
       EXPECT_XNET_ERROR_NUMBER(INVALID_SOCKET_ERROR, ex);
+      throw;
     }
   }, nidevice_grpc::experimental::client::grpc_driver_error);
 }
@@ -313,6 +314,7 @@ TEST_F(NiXnetSocketNoHardwareTests, InitWithInvalidIpStack_Bind_ReturnsAndSetsEx
     catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
       EXPECT_DRIVER_ERROR_WITH_SUBSTR(ex, GENERIC_NXSOCKET_ERROR, INVALID_SOCKET_MESSAGE);
       EXPECT_XNET_ERROR_NUMBER(INVALID_SOCKET_ERROR, ex);
+      throw;
     }
   }, nidevice_grpc::experimental::client::grpc_driver_error);
 }
@@ -354,6 +356,7 @@ TEST_F(NiXnetSocketNoHardwareTests, InvalidSocket_Select_ReturnsAndSetsExpectedE
     catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
       EXPECT_DRIVER_ERROR_WITH_SUBSTR(ex, GENERIC_NXSOCKET_ERROR, INVALID_SOCKET_MESSAGE);
       EXPECT_XNET_ERROR_NUMBER(INVALID_SOCKET_ERROR, ex);
+      throw;
     }
   }, nidevice_grpc::experimental::client::grpc_driver_error);
 }

--- a/source/tests/system/nixnetsocket_driver_api_tests.cpp
+++ b/source/tests/system/nixnetsocket_driver_api_tests.cpp
@@ -287,15 +287,15 @@ TEST_F(NiXnetSocketNoHardwareTests, InitWithInvalidIpStack_Close_ReturnsAndSetsE
   SocketResponse invalid_socket;
   invalid_socket.mutable_socket()->set_name("");
 
-  try {
-    client::close(stub(), invalid_socket.socket());
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, GENERIC_NXSOCKET_ERROR);
-    EXPECT_XNET_ERROR_NUMBER(INVALID_SOCKET_ERROR, ex);
-    EXPECT_THAT(ex.what(), HasSubstr(INVALID_SOCKET_MESSAGE));
-  }
+  EXPECT_THROW({
+    try {
+      client::close(stub(), invalid_socket.socket());
+    }
+    catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
+      EXPECT_DRIVER_ERROR_WITH_SUBSTR(ex, GENERIC_NXSOCKET_ERROR, INVALID_SOCKET_MESSAGE);
+      EXPECT_XNET_ERROR_NUMBER(INVALID_SOCKET_ERROR, ex);
+    }
+  }, nidevice_grpc::experimental::client::grpc_driver_error);
 }
 
 TEST_F(NiXnetSocketNoHardwareTests, InitWithInvalidIpStack_Bind_ReturnsAndSetsExpectedErrors)
@@ -306,15 +306,15 @@ TEST_F(NiXnetSocketNoHardwareTests, InitWithInvalidIpStack_Bind_ReturnsAndSetsEx
   sock_addr.mutable_ipv4()->mutable_addr()->set_addr(0x7F000001);
   sock_addr.mutable_ipv4()->set_port(31764);
 
-  try {
-    client::bind(stub(), invalid_socket.socket(), sock_addr);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, GENERIC_NXSOCKET_ERROR);
-    EXPECT_XNET_ERROR_NUMBER(INVALID_SOCKET_ERROR, ex);
-    EXPECT_THAT(ex.what(), HasSubstr(INVALID_SOCKET_MESSAGE));
-  }
+  EXPECT_THROW({
+    try {
+      client::bind(stub(), invalid_socket.socket(), sock_addr);
+    }
+    catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
+      EXPECT_DRIVER_ERROR_WITH_SUBSTR(ex, GENERIC_NXSOCKET_ERROR, INVALID_SOCKET_MESSAGE);
+      EXPECT_XNET_ERROR_NUMBER(INVALID_SOCKET_ERROR, ex);
+    }
+  }, nidevice_grpc::experimental::client::grpc_driver_error);
 }
 
 TEST_F(NiXnetSocketNoHardwareTests, SocketAndEmptySet_IsSet_ReturnsFalse)
@@ -347,15 +347,15 @@ TEST_F(NiXnetSocketNoHardwareTests, InvalidSocket_Select_ReturnsAndSetsExpectedE
   duration.set_seconds(1);
   duration.set_nanos(500000);
 
-  try {
-    client::select(stub(), {invalid_socket.socket()}, {invalid_socket.socket()}, {}, duration);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, GENERIC_NXSOCKET_ERROR);
-    EXPECT_XNET_ERROR_NUMBER(INVALID_SOCKET_ERROR, ex);
-    EXPECT_THAT(ex.what(), HasSubstr(INVALID_SOCKET_MESSAGE));
-  }
+  EXPECT_THROW({
+    try {
+      client::select(stub(), {invalid_socket.socket()}, {invalid_socket.socket()}, {}, duration);
+    }
+    catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
+      EXPECT_DRIVER_ERROR_WITH_SUBSTR(ex, GENERIC_NXSOCKET_ERROR, INVALID_SOCKET_MESSAGE);
+      EXPECT_XNET_ERROR_NUMBER(INVALID_SOCKET_ERROR, ex);
+    }
+  }, nidevice_grpc::experimental::client::grpc_driver_error);
 }
 
 TEST_F(NiXnetSocketNoHardwareTests, InvalidEmptyConfigJson_IpStackCreate_ReturnsInvalidInterfaceNameError)
@@ -363,13 +363,9 @@ TEST_F(NiXnetSocketNoHardwareTests, InvalidEmptyConfigJson_IpStackCreate_Returns
   constexpr auto TEST_CONFIG = "{}";
   constexpr auto JSON_OBJECT_MISSING_VALUE = -13017;
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     client::ip_stack_create(stub(), "", "{}");
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, JSON_OBJECT_MISSING_VALUE);
-  }
+  }, JSON_OBJECT_MISSING_VALUE);
 }
 
 TEST_F(NiXnetSocketNoHardwareTests, ValidConfigJsonForMissingDevice_IpStackCreate_ReturnsInvalidInterfaceNameError)
@@ -377,13 +373,9 @@ TEST_F(NiXnetSocketNoHardwareTests, ValidConfigJsonForMissingDevice_IpStackCreat
   const auto TEST_CONFIG = create_simple_config("ENET6");
   constexpr auto INVALID_INTERFACE_NAME = -1074384758;
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR({
     client::ip_stack_create(stub(), "", TEST_CONFIG);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, INVALID_INTERFACE_NAME);
-  }
+  }, INVALID_INTERFACE_NAME);
 }
 
 TEST_F(NiXnetSocketNoHardwareTests, StackAlreadyExistsError_StrErrR_ReturnsExpectedMessage)
@@ -400,14 +392,9 @@ TEST_F(NiXnetSocketNoHardwareTests, StackAlreadyExistsError_StrErrRWithZeroBuffe
 {
   constexpr auto STACK_ALREADY_EXISTS = static_cast<int32_t>(0xFFFFCD24);
 
-  try {
+  EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR({
     client::str_err_r(stub(), STACK_ALREADY_EXISTS, 0);
-    FAIL() << "We shouldn't get here.";
-  }
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {
-    expect_driver_error(ex, GENERIC_NXSOCKET_ERROR);
-    EXPECT_STREQ("Unknown", ex.what());
-  }
+  }, GENERIC_NXSOCKET_ERROR, "Unknown");
 }
 
 TEST_F(NiXnetSocketLoopbackTests, IPv4LocalhostAddress_AToNAndPToNRoundtrip_ReturnsCorrectAddr)

--- a/source/tests/system/rfmx_macros.h
+++ b/source/tests/system/rfmx_macros.h
@@ -42,14 +42,7 @@
   })((session_), (response_))
 
 #define EXPECT_ERROR(expected_error_, message_substring_, session_, response_call_) \
-  try {                                                                             \
-    response_call_;                                                                 \
-    FAIL() << "We shouldn't get here.";                                             \
-  }                                                                                 \
-  catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {        \
-    expect_driver_error(ex, expected_error_);                                       \
-    EXPECT_THAT(ex.what(), HasSubstr(message_substring_));                          \
-  }
+  EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR(response_call_, expected_error_, message_substring_)
 
 #define EXPECT_WARNING(expected_warning_, message_substring_, session_, response_)               \
   ([this](auto expected_warning, const auto& message_substring, auto& session, auto& response) { \

--- a/source/tests/unit/session_repository_tests.cpp
+++ b/source/tests/unit/session_repository_tests.cpp
@@ -61,22 +61,20 @@ TEST(SessionRepositoryTests, NoSessions_AddSessionWithAttachToExistingBehavior_E
   std::string session_name = "session_name";
   nidevice_grpc::SessionRepository session_repository;
 
-  EXPECT_THROW(
-      {
-        try {
-          session_repository.add_session(
-              session_name,
-              []() { return 0; },
-              NULL,
-              nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_ATTACH_TO_EXISTING);
-        }
-        catch (const nidevice_grpc::NonDriverException& e) {
-          auto exception_status = e.GetStatus();
-          EXPECT_EQ(::grpc::StatusCode::FAILED_PRECONDITION, exception_status.error_code());
-          throw e;
-        }
-      },
-      nidevice_grpc::NonDriverException);
+  EXPECT_THROW({
+    try {
+      session_repository.add_session(
+          session_name,
+          []() { return 0; },
+          NULL,
+          nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_ATTACH_TO_EXISTING);
+    }
+    catch (const nidevice_grpc::NonDriverException& e) {
+      auto exception_status = e.GetStatus();
+      EXPECT_EQ(::grpc::StatusCode::FAILED_PRECONDITION, exception_status.error_code());
+      throw e;
+    }
+  }, nidevice_grpc::NonDriverException);
 }
 
 TEST(SessionRepositoryTests, AddNamedSession_StoresSessionWithGivenIdAndName)

--- a/source/tests/unit/session_repository_tests.cpp
+++ b/source/tests/unit/session_repository_tests.cpp
@@ -72,7 +72,7 @@ TEST(SessionRepositoryTests, NoSessions_AddSessionWithAttachToExistingBehavior_E
     catch (const nidevice_grpc::NonDriverException& e) {
       auto exception_status = e.GetStatus();
       EXPECT_EQ(::grpc::StatusCode::FAILED_PRECONDITION, exception_status.error_code());
-      throw e;
+      throw;
     }
   }, nidevice_grpc::NonDriverException);
 }
@@ -157,25 +157,23 @@ TEST(SessionRepositoryTests, NamedSessionAdded_AddSessionWithSameNameWithInitial
       NULL);
 
   bool init_called = false;
-  EXPECT_THROW(
-      {
-        try {
-          session_repository.add_session(
-              session_name,
-              [init_called]() mutable {
-                init_called = true;
-                return 0;
-              },
-              NULL,
-              nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_INITIALIZE_NEW);
-        }
-        catch (const nidevice_grpc::NonDriverException& e) {
-          auto exception_status = e.GetStatus();
-          EXPECT_EQ(::grpc::StatusCode::ALREADY_EXISTS, exception_status.error_code());
-          throw e;
-        }
-      },
-      nidevice_grpc::NonDriverException);
+  EXPECT_THROW({
+    try {
+      session_repository.add_session(
+          session_name,
+          [init_called]() mutable {
+            init_called = true;
+            return 0;
+          },
+          NULL,
+          nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_INITIALIZE_NEW);
+    }
+    catch (const nidevice_grpc::NonDriverException& e) {
+      auto exception_status = e.GetStatus();
+      EXPECT_EQ(::grpc::StatusCode::ALREADY_EXISTS, exception_status.error_code());
+      throw;
+    }
+  }, nidevice_grpc::NonDriverException);
 }
 
 TEST(SessionRepositoryTests, NamedSessionAdded_ResetServer_RemovesSession)

--- a/source/tests/unit/session_resource_repository_tests.cpp
+++ b/source/tests/unit/session_resource_repository_tests.cpp
@@ -253,21 +253,19 @@ TEST(SessionResourceRepositoryTests, AddSessionResource_AddSessionWithSameNameFr
   const int32_t kErrorCode = 9999;
   using MockInitDelegate = ::testing::MockFunction<std::tuple<int32_t, int32_t>(void)>;
   MockInitDelegate mock_init;
-  EXPECT_THROW(
-      {
-        try {
-          result = other_resource_repository.add_session(
-              kTestResource,
-              mock_init.AsStdFunction(),
-              [](int32_t handle) { FAIL() << "Unexpected Cleanup"; });
-        }
-        catch (const nidevice_grpc::SessionException& ex) {
-          const std::string expected_message("The session name \"" + kTestResource + "\" is being used by a different driver.");
-          EXPECT_STREQ(expected_message.c_str(), ex.what());
-          throw;
-        }
-      },
-      nidevice_grpc::SessionException);
+  EXPECT_THROW({
+    try {
+      result = other_resource_repository.add_session(
+          kTestResource,
+          mock_init.AsStdFunction(),
+          [](int32_t handle) { FAIL() << "Unexpected Cleanup"; });
+    }
+    catch (const nidevice_grpc::SessionException& ex) {
+      const std::string expected_message("The session name \"" + kTestResource + "\" is being used by a different driver.");
+      EXPECT_STREQ(expected_message.c_str(), ex.what());
+      throw;
+    }
+  }, nidevice_grpc::SessionException);
 }
 
 template <typename TResource>

--- a/source/tests/utilities/test_helpers.h
+++ b/source/tests/utilities/test_helpers.h
@@ -1,21 +1,74 @@
 #ifndef TEST_HELPERS
 #define TEST_HELPERS
 
-#include <gtest/gtest.h>  // For EXPECT matchers
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <optional>
 
 #include "client_helpers.h"
 
-inline void expect_driver_error(const nidevice_grpc::experimental::client::grpc_driver_error& ex, int32_t expected_error)
+#define EXPECT_THROW_DRIVER_ERROR(statement_, expected_error_)                 \
+  EXPECT_THROW({                                                               \
+    try {                                                                      \
+      statement_;                                                              \
+    }                                                                          \
+    catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) { \
+      EXPECT_DRIVER_ERROR(ex, expected_error_);                                \
+      throw;                                                                   \
+    }                                                                          \
+  }, nidevice_grpc::experimental::client::grpc_driver_error)
+
+#define EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR(statement_, expected_error_, message_substring_) \
+  EXPECT_THROW({                                                                               \
+    try {                                                                                      \
+      statement_;                                                                              \
+    }                                                                                          \
+    catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) {                 \
+      EXPECT_DRIVER_ERROR_WITH_SUBSTR(ex, expected_error_, message_substring_);                \
+      throw;                                                                                   \
+    }                                                                                          \
+  }, nidevice_grpc::experimental::client::grpc_driver_error)
+
+#define EXPECT_DRIVER_ERROR(exception_, expected_error_)             \
+  do {                                                               \
+    EXPECT_EQ(::grpc::StatusCode::UNKNOWN, exception_.StatusCode()); \
+    EXPECT_LT(expected_error_, 0);                                   \
+    auto driver_error = get_driver_error(exception_);                \
+    EXPECT_THAT(driver_error, ::testing::Optional(expected_error_)); \
+  } while(false)
+
+#define EXPECT_DRIVER_ERROR_WITH_SUBSTR(exception_, expected_error_, message_substring_) \
+  do {                                                                                   \
+    EXPECT_DRIVER_ERROR(exception_, expected_error_);                                    \
+    EXPECT_THAT(exception_.what(), ::testing::HasSubstr(message_substring_));            \
+  } while(false)
+
+inline std::optional<int> get_driver_error(const std::multimap<std::string, std::string>& metadata)
 {
-  EXPECT_EQ(::grpc::StatusCode::UNKNOWN, ex.StatusCode());
-  EXPECT_LT(expected_error, 0);
-  std::string actual_error = "";
-  auto iterator = ex.Trailers().find("ni-error");
-  if (iterator != ex.Trailers().end())
+  auto iterator = metadata.find("ni-error");
+  if (iterator != metadata.end())
   {
-    actual_error = iterator->second;
+    return std::stoi(iterator->second);
   }
-  EXPECT_EQ(expected_error, std::stoi(actual_error));
+  return std::nullopt;
+}
+
+inline std::optional<int> get_driver_error(const std::multimap<grpc::string_ref, grpc::string_ref>& metadata)
+{
+  auto iterator = metadata.find("ni-error");
+  if (iterator != metadata.end())
+  {
+    // grpc::string_ref is not NUL-terminated, so make a copy.
+    std::string value(iterator->second.begin(), iterator->second.end());
+    return std::stoi(value);
+  }
+  return std::nullopt;
+}
+
+inline std::optional<int> get_driver_error(const nidevice_grpc::experimental::client::grpc_driver_error& ex)
+{
+  return get_driver_error(ex.Trailers());
 }
 
 #endif


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add new assertion macros and helper functions to `test_helpers.h`:
- `EXPECT_THROW_DRIVER_ERROR`
- `EXPECT_THROW_DRIVER_ERROR_WITH_SUBSTR`
- `EXPECT_DRIVER_ERROR`
  - Replaces `expect_driver_error` helper function
- `EXPECT_DRIVER_ERROR_WITH_SUBSTR`
- `get_driver_error()`:
  - Accepts both gRPC metadata multimap types and `grpc_driver_error` exception
  - Returns `int`.
  - If the `ni-error` key is not found, `get_driver_error()` fails the test and returns 0.

### Why should this Pull Request be merged?

Reduce boilerplate and increase consistency in tests.

### What testing has been done?

Built on Windows and Linux. 
Ran DAQmx tests on Windows.
