### PR TITLE
tests: Fix task leaks in nidaqmx system tests

### DIFF
--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -1474,15 +1474,9 @@ TEST_F(NiDAQmxDriverApiTests, ChannelWithDoneEventRegisteredTwice_RunCompleteFin
   read_stream(reader_context1, *reader1, response1);
 
   EXPECT_EQ(DAQMX_SUCCESS, response1.status());
-  EXPECT_THROW({
-    try {
-      read_stream(reader_context2, *reader2, response2);
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, DONE_EVENT_ALREADY_REGISTERED_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    read_stream(reader_context2, *reader2, response2);
+  }, DONE_EVENT_ALREADY_REGISTERED_ERROR);
 }
 
 TEST_F(NiDAQmxDriverApiTests, EveryNSamplesEventRegisteredWithWrongEventType_ReadStream_NotSupportedByDeviceErrorReceived)
@@ -1493,15 +1487,9 @@ TEST_F(NiDAQmxDriverApiTests, EveryNSamplesEventRegisteredWithWrongEventType_Rea
   auto reader = register_every_n_samples_event(reader_context, N_SAMPLES, EveryNSamplesEventType::EVERY_N_SAMPLES_EVENT_TYPE_TRANSFERRED_FROM_BUFFER);
 
   RegisterEveryNSamplesEventResponse response;
-  EXPECT_THROW({
-    try {
-      read_stream(reader_context, *reader, response);
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, EVERY_N_SAMPS_TRANSFERRED_FROM_BUFFER_EVENT_NOT_SUPPORTED_BY_DEVICE_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    read_stream(reader_context, *reader, response);
+  }, EVERY_N_SAMPS_TRANSFERRED_FROM_BUFFER_EVENT_NOT_SUPPORTED_BY_DEVICE_ERROR);
 }
 
 TEST_F(NiDAQmxDriverApiTests, EveryNSamplesEventRegisteredWithWrongEventType_Finish_NotSupportedByDeviceErrorReceived)
@@ -1511,16 +1499,10 @@ TEST_F(NiDAQmxDriverApiTests, EveryNSamplesEventRegisteredWithWrongEventType_Fin
   ::grpc::ClientContext reader_context;
   auto reader = register_every_n_samples_event(reader_context, N_SAMPLES, EveryNSamplesEventType::EVERY_N_SAMPLES_EVENT_TYPE_TRANSFERRED_FROM_BUFFER);
 
-  EXPECT_THROW({
-    try {
-      auto status = reader->Finish();
-      client::raise_if_error(status, reader_context);
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, EVERY_N_SAMPS_TRANSFERRED_FROM_BUFFER_EVENT_NOT_SUPPORTED_BY_DEVICE_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    auto status = reader->Finish();
+    client::raise_if_error(status, reader_context);
+  }, EVERY_N_SAMPS_TRANSFERRED_FROM_BUFFER_EVENT_NOT_SUPPORTED_BY_DEVICE_ERROR);
 }
 
 TEST_F(NiDAQmxDriverApiTests, EveryNSamplesEventRegisteredWithWrongEventType_Cancel_NoErrors)
@@ -1637,15 +1619,9 @@ TEST_F(NiDAQmxDriverApiTests, AsyncEveryNSamplesEventRegisteredWithWrongEventTyp
   bool finish_completed = try_get_next_completion_without_blocking(completion_queue, finish_completion);
   EXPECT_TRUE(finish_completed);
   ASSERT_EQ(Completion(FINISH_TAG, true), finish_completion);
-  EXPECT_THROW({
-    try {
-      client::raise_if_error(status, reader_context);
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, EVERY_N_SAMPS_TRANSFERRED_FROM_BUFFER_EVENT_NOT_SUPPORTED_BY_DEVICE_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    client::raise_if_error(status, reader_context);
+  }, EVERY_N_SAMPS_TRANSFERRED_FROM_BUFFER_EVENT_NOT_SUPPORTED_BY_DEVICE_ERROR);
 }
 
 TEST_F(NiDAQmxDriverApiTests, AIVoltageChannel_ConfigureInputBuffer_Succeeds)

--- a/source/tests/system/nidaqmx_session_tests.cpp
+++ b/source/tests/system/nidaqmx_session_tests.cpp
@@ -50,9 +50,10 @@ TEST_F(NiDAQmxSessionTests, CreateTask_ClearTask_Succeeds)
 {
   CreateTaskResponse create_response;
   auto create_status = create_task("", create_response);
+  auto task_name = create_response.task().name();
 
   ClearTaskResponse clear_response;
-  auto clear_status = clear_task("", clear_response);
+  auto clear_status = clear_task(task_name, clear_response);
 
   EXPECT_TRUE(create_status.ok());
   EXPECT_TRUE(clear_status.ok());

--- a/source/tests/utilities/scope_exit.h
+++ b/source/tests/utilities/scope_exit.h
@@ -1,0 +1,47 @@
+#ifndef SCOPE_EXIT
+#define SCOPE_EXIT
+
+// A basic implementation of std::experimental::scope_exit
+template <typename Fn>
+class scope_exit
+{
+public:
+  explicit scope_exit(Fn&& fn) noexcept
+    : fn_(std::move(fn)),
+      active_(true)
+  {
+  }
+
+  scope_exit(scope_exit&& that) noexcept
+    : fn_(std::move(that.fn_)),
+      active_(that.active_)
+  {
+    that.release();
+  }
+
+  scope_exit(const scope_exit&) = delete;
+
+  ~scope_exit()
+  {
+    if (active_) {
+      fn_();
+    }
+  }
+
+  void release() noexcept
+  {
+    active_ = false;
+  }
+
+private:
+  Fn fn_;
+  bool active_;
+};
+
+template <typename Fn>
+auto make_scope_exit(Fn&& fn) noexcept -> scope_exit<decltype(fn)>
+{
+  return scope_exit<decltype(fn)>(std::move(fn));
+}
+
+#endif

--- a/source/tests/utilities/scope_exit.h
+++ b/source/tests/utilities/scope_exit.h
@@ -39,9 +39,9 @@ private:
 };
 
 template <typename Fn>
-auto make_scope_exit(Fn&& fn) noexcept -> scope_exit<decltype(fn)>
+scope_exit<Fn> make_scope_exit(Fn&& fn) noexcept
 {
-  return scope_exit<decltype(fn)>(std::move(fn));
+  return scope_exit<Fn>(std::move(fn));
 }
 
 #endif

--- a/source/tests/utilities/scope_exit.h
+++ b/source/tests/utilities/scope_exit.h
@@ -20,6 +20,7 @@ public:
   }
 
   scope_exit(const scope_exit&) = delete;
+  scope_exit& operator=(const scope_exit&) = delete;
 
   ~scope_exit()
   {


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fix task leak in `DOWatchdogTask_StartTaskAndWatchdogTask_Succeeds` by using `scope_exit` to call `clear_task`.

Fix task leak in `CreateTask_ClearTask_Succeeds` by passing the returned task name to `clear_task`, not "". 

Fix build errors by retrofitting new event tests to use `EXPECT_THROW_DRIVER_ERROR`.

### Why should this Pull Request be merged?

Partially fixes https://github.com/ni/grpc-device/issues/936: it fixes the leaks, but leaking a session should not crash during shutdown.

### What testing has been done?

`SystemTestsRunner --gtest_filter="*DAQmx*"`
- Windows: no shutdown crash.
- Linux: shutdown crashes in nisyscfg now (#938)