### PR TITLE
codegen: Support DAQmx event unregistration

### DIFF
--- a/generated/nidaqmx/nidaqmx.proto
+++ b/generated/nidaqmx/nidaqmx.proto
@@ -382,6 +382,9 @@ service NiDAQmx {
   rpc StopTask(StopTaskRequest) returns (StopTaskResponse);
   rpc TaskControl(TaskControlRequest) returns (TaskControlResponse);
   rpc TristateOutputTerm(TristateOutputTermRequest) returns (TristateOutputTermResponse);
+  rpc UnregisterDoneEvent(UnregisterDoneEventRequest) returns (UnregisterDoneEventResponse);
+  rpc UnregisterEveryNSamplesEvent(UnregisterEveryNSamplesEventRequest) returns (UnregisterEveryNSamplesEventResponse);
+  rpc UnregisterSignalEvent(UnregisterSignalEventRequest) returns (UnregisterSignalEventResponse);
   rpc UnreserveNetworkDevice(UnreserveNetworkDeviceRequest) returns (UnreserveNetworkDeviceResponse);
   rpc WaitForNextSampleClock(WaitForNextSampleClockRequest) returns (WaitForNextSampleClockResponse);
   rpc WaitForValidTimestamp(WaitForValidTimestampRequest) returns (WaitForValidTimestampResponse);
@@ -9925,6 +9928,38 @@ message TristateOutputTermRequest {
 }
 
 message TristateOutputTermResponse {
+  int32 status = 1;
+}
+
+message UnregisterDoneEventRequest {
+  nidevice_grpc.Session task = 1;
+}
+
+message UnregisterDoneEventResponse {
+  int32 status = 1;
+}
+
+message UnregisterEveryNSamplesEventRequest {
+  nidevice_grpc.Session task = 1;
+  oneof every_n_samples_event_type_enum {
+    EveryNSamplesEventType every_n_samples_event_type = 2;
+    int32 every_n_samples_event_type_raw = 3;
+  }
+}
+
+message UnregisterEveryNSamplesEventResponse {
+  int32 status = 1;
+}
+
+message UnregisterSignalEventRequest {
+  nidevice_grpc.Session task = 1;
+  oneof signal_id_enum {
+    Signal2 signal_id = 2;
+    int32 signal_id_raw = 3;
+  }
+}
+
+message UnregisterSignalEventResponse {
   int32 status = 1;
 }
 

--- a/generated/nidaqmx/nidaqmx_client.cpp
+++ b/generated/nidaqmx/nidaqmx_client.cpp
@@ -10420,6 +10420,73 @@ tristate_output_term(const StubPtr& stub, const std::string& output_terminal)
   return response;
 }
 
+UnregisterDoneEventResponse
+unregister_done_event(const StubPtr& stub, const nidevice_grpc::Session& task)
+{
+  ::grpc::ClientContext context;
+
+  auto request = UnregisterDoneEventRequest{};
+  request.mutable_task()->CopyFrom(task);
+
+  auto response = UnregisterDoneEventResponse{};
+
+  raise_if_error(
+      stub->UnregisterDoneEvent(&context, request, &response),
+      context);
+
+  return response;
+}
+
+UnregisterEveryNSamplesEventResponse
+unregister_every_n_samples_event(const StubPtr& stub, const nidevice_grpc::Session& task, const simple_variant<EveryNSamplesEventType, pb::int32>& every_n_samples_event_type)
+{
+  ::grpc::ClientContext context;
+
+  auto request = UnregisterEveryNSamplesEventRequest{};
+  request.mutable_task()->CopyFrom(task);
+  const auto every_n_samples_event_type_ptr = every_n_samples_event_type.get_if<EveryNSamplesEventType>();
+  const auto every_n_samples_event_type_raw_ptr = every_n_samples_event_type.get_if<pb::int32>();
+  if (every_n_samples_event_type_ptr) {
+    request.set_every_n_samples_event_type(*every_n_samples_event_type_ptr);
+  }
+  else if (every_n_samples_event_type_raw_ptr) {
+    request.set_every_n_samples_event_type_raw(*every_n_samples_event_type_raw_ptr);
+  }
+
+  auto response = UnregisterEveryNSamplesEventResponse{};
+
+  raise_if_error(
+      stub->UnregisterEveryNSamplesEvent(&context, request, &response),
+      context);
+
+  return response;
+}
+
+UnregisterSignalEventResponse
+unregister_signal_event(const StubPtr& stub, const nidevice_grpc::Session& task, const simple_variant<Signal2, pb::int32>& signal_id)
+{
+  ::grpc::ClientContext context;
+
+  auto request = UnregisterSignalEventRequest{};
+  request.mutable_task()->CopyFrom(task);
+  const auto signal_id_ptr = signal_id.get_if<Signal2>();
+  const auto signal_id_raw_ptr = signal_id.get_if<pb::int32>();
+  if (signal_id_ptr) {
+    request.set_signal_id(*signal_id_ptr);
+  }
+  else if (signal_id_raw_ptr) {
+    request.set_signal_id_raw(*signal_id_raw_ptr);
+  }
+
+  auto response = UnregisterSignalEventResponse{};
+
+  raise_if_error(
+      stub->UnregisterSignalEvent(&context, request, &response),
+      context);
+
+  return response;
+}
+
 UnreserveNetworkDeviceResponse
 unreserve_network_device(const StubPtr& stub, const std::string& device_name)
 {

--- a/generated/nidaqmx/nidaqmx_client.h
+++ b/generated/nidaqmx/nidaqmx_client.h
@@ -387,6 +387,9 @@ StartTaskResponse start_task(const StubPtr& stub, const nidevice_grpc::Session& 
 StopTaskResponse stop_task(const StubPtr& stub, const nidevice_grpc::Session& task);
 TaskControlResponse task_control(const StubPtr& stub, const nidevice_grpc::Session& task, const simple_variant<TaskControlAction, pb::int32>& action);
 TristateOutputTermResponse tristate_output_term(const StubPtr& stub, const std::string& output_terminal);
+UnregisterDoneEventResponse unregister_done_event(const StubPtr& stub, const nidevice_grpc::Session& task);
+UnregisterEveryNSamplesEventResponse unregister_every_n_samples_event(const StubPtr& stub, const nidevice_grpc::Session& task, const simple_variant<EveryNSamplesEventType, pb::int32>& every_n_samples_event_type);
+UnregisterSignalEventResponse unregister_signal_event(const StubPtr& stub, const nidevice_grpc::Session& task, const simple_variant<Signal2, pb::int32>& signal_id);
 UnreserveNetworkDeviceResponse unreserve_network_device(const StubPtr& stub, const std::string& device_name);
 WaitForNextSampleClockResponse wait_for_next_sample_clock(const StubPtr& stub, const nidevice_grpc::Session& task, const double& timeout);
 WaitForValidTimestampResponse wait_for_valid_timestamp(const StubPtr& stub, const nidevice_grpc::Session& task, const simple_variant<TimestampEvent, pb::int32>& timestamp_event, const double& timeout);

--- a/generated/nidaqmx/nidaqmx_compilation_test.cpp
+++ b/generated/nidaqmx/nidaqmx_compilation_test.cpp
@@ -1832,6 +1832,21 @@ int32 TristateOutputTerm(const char outputTerminal[])
   return DAQmxTristateOutputTerm(outputTerminal);
 }
 
+int32 UnregisterDoneEvent(TaskHandle task, uInt32 options, DAQmxDoneEventCallbackPtr callbackFunction, void* callbackData)
+{
+  return DAQmxRegisterDoneEvent(task, options, callbackFunction, callbackData);
+}
+
+int32 UnregisterEveryNSamplesEvent(TaskHandle task, int32 everyNSamplesEventType, uInt32 nSamples, uInt32 options, DAQmxEveryNSamplesEventCallbackPtr callbackFunction, void* callbackData)
+{
+  return DAQmxRegisterEveryNSamplesEvent(task, everyNSamplesEventType, nSamples, options, callbackFunction, callbackData);
+}
+
+int32 UnregisterSignalEvent(TaskHandle task, int32 signalID, uInt32 options, DAQmxSignalEventCallbackPtr callbackFunction, void* callbackData)
+{
+  return DAQmxRegisterSignalEvent(task, signalID, options, callbackFunction, callbackData);
+}
+
 int32 UnreserveNetworkDevice(const char deviceName[])
 {
   return DAQmxUnreserveNetworkDevice(deviceName);

--- a/generated/nidaqmx/nidaqmx_library.cpp
+++ b/generated/nidaqmx/nidaqmx_library.cpp
@@ -387,6 +387,9 @@ NiDAQmxLibrary::NiDAQmxLibrary() : shared_library_(kLibraryName)
   function_pointers_.StopTask = reinterpret_cast<StopTaskPtr>(shared_library_.get_function_pointer("DAQmxStopTask"));
   function_pointers_.TaskControl = reinterpret_cast<TaskControlPtr>(shared_library_.get_function_pointer("DAQmxTaskControl"));
   function_pointers_.TristateOutputTerm = reinterpret_cast<TristateOutputTermPtr>(shared_library_.get_function_pointer("DAQmxTristateOutputTerm"));
+  function_pointers_.UnregisterDoneEvent = reinterpret_cast<UnregisterDoneEventPtr>(shared_library_.get_function_pointer("DAQmxRegisterDoneEvent"));
+  function_pointers_.UnregisterEveryNSamplesEvent = reinterpret_cast<UnregisterEveryNSamplesEventPtr>(shared_library_.get_function_pointer("DAQmxRegisterEveryNSamplesEvent"));
+  function_pointers_.UnregisterSignalEvent = reinterpret_cast<UnregisterSignalEventPtr>(shared_library_.get_function_pointer("DAQmxRegisterSignalEvent"));
   function_pointers_.UnreserveNetworkDevice = reinterpret_cast<UnreserveNetworkDevicePtr>(shared_library_.get_function_pointer("DAQmxUnreserveNetworkDevice"));
   function_pointers_.WaitForNextSampleClock = reinterpret_cast<WaitForNextSampleClockPtr>(shared_library_.get_function_pointer("DAQmxWaitForNextSampleClock"));
   function_pointers_.WaitForValidTimestamp = reinterpret_cast<WaitForValidTimestampPtr>(shared_library_.get_function_pointer("DAQmxWaitForValidTimestamp"));
@@ -3350,6 +3353,30 @@ int32 NiDAQmxLibrary::TristateOutputTerm(const char outputTerminal[])
     throw nidevice_grpc::LibraryLoadException("Could not find DAQmxTristateOutputTerm.");
   }
   return function_pointers_.TristateOutputTerm(outputTerminal);
+}
+
+int32 NiDAQmxLibrary::UnregisterDoneEvent(TaskHandle task, uInt32 options, DAQmxDoneEventCallbackPtr callbackFunction, void* callbackData)
+{
+  if (!function_pointers_.UnregisterDoneEvent) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxRegisterDoneEvent.");
+  }
+  return function_pointers_.UnregisterDoneEvent(task, options, callbackFunction, callbackData);
+}
+
+int32 NiDAQmxLibrary::UnregisterEveryNSamplesEvent(TaskHandle task, int32 everyNSamplesEventType, uInt32 nSamples, uInt32 options, DAQmxEveryNSamplesEventCallbackPtr callbackFunction, void* callbackData)
+{
+  if (!function_pointers_.UnregisterEveryNSamplesEvent) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxRegisterEveryNSamplesEvent.");
+  }
+  return function_pointers_.UnregisterEveryNSamplesEvent(task, everyNSamplesEventType, nSamples, options, callbackFunction, callbackData);
+}
+
+int32 NiDAQmxLibrary::UnregisterSignalEvent(TaskHandle task, int32 signalID, uInt32 options, DAQmxSignalEventCallbackPtr callbackFunction, void* callbackData)
+{
+  if (!function_pointers_.UnregisterSignalEvent) {
+    throw nidevice_grpc::LibraryLoadException("Could not find DAQmxRegisterSignalEvent.");
+  }
+  return function_pointers_.UnregisterSignalEvent(task, signalID, options, callbackFunction, callbackData);
 }
 
 int32 NiDAQmxLibrary::UnreserveNetworkDevice(const char deviceName[])

--- a/generated/nidaqmx/nidaqmx_library.h
+++ b/generated/nidaqmx/nidaqmx_library.h
@@ -384,6 +384,9 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   int32 StopTask(TaskHandle task);
   int32 TaskControl(TaskHandle task, int32 action);
   int32 TristateOutputTerm(const char outputTerminal[]);
+  int32 UnregisterDoneEvent(TaskHandle task, uInt32 options, DAQmxDoneEventCallbackPtr callbackFunction, void* callbackData);
+  int32 UnregisterEveryNSamplesEvent(TaskHandle task, int32 everyNSamplesEventType, uInt32 nSamples, uInt32 options, DAQmxEveryNSamplesEventCallbackPtr callbackFunction, void* callbackData);
+  int32 UnregisterSignalEvent(TaskHandle task, int32 signalID, uInt32 options, DAQmxSignalEventCallbackPtr callbackFunction, void* callbackData);
   int32 UnreserveNetworkDevice(const char deviceName[]);
   int32 WaitForNextSampleClock(TaskHandle task, float64 timeout, bool32* isLate);
   int32 WaitForValidTimestamp(TaskHandle task, int32 timestampEvent, float64 timeout, CVIAbsoluteTime* timestamp);
@@ -776,6 +779,9 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   using StopTaskPtr = decltype(&DAQmxStopTask);
   using TaskControlPtr = decltype(&DAQmxTaskControl);
   using TristateOutputTermPtr = decltype(&DAQmxTristateOutputTerm);
+  using UnregisterDoneEventPtr = decltype(&DAQmxRegisterDoneEvent);
+  using UnregisterEveryNSamplesEventPtr = decltype(&DAQmxRegisterEveryNSamplesEvent);
+  using UnregisterSignalEventPtr = decltype(&DAQmxRegisterSignalEvent);
   using UnreserveNetworkDevicePtr = decltype(&DAQmxUnreserveNetworkDevice);
   using WaitForNextSampleClockPtr = decltype(&DAQmxWaitForNextSampleClock);
   using WaitForValidTimestampPtr = decltype(&DAQmxWaitForValidTimestamp);
@@ -1168,6 +1174,9 @@ class NiDAQmxLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
     StopTaskPtr StopTask;
     TaskControlPtr TaskControl;
     TristateOutputTermPtr TristateOutputTerm;
+    UnregisterDoneEventPtr UnregisterDoneEvent;
+    UnregisterEveryNSamplesEventPtr UnregisterEveryNSamplesEvent;
+    UnregisterSignalEventPtr UnregisterSignalEvent;
     UnreserveNetworkDevicePtr UnreserveNetworkDevice;
     WaitForNextSampleClockPtr WaitForNextSampleClock;
     WaitForValidTimestampPtr WaitForValidTimestamp;

--- a/generated/nidaqmx/nidaqmx_library_interface.h
+++ b/generated/nidaqmx/nidaqmx_library_interface.h
@@ -374,6 +374,9 @@ class NiDAQmxLibraryInterface {
   virtual int32 StopTask(TaskHandle task) = 0;
   virtual int32 TaskControl(TaskHandle task, int32 action) = 0;
   virtual int32 TristateOutputTerm(const char outputTerminal[]) = 0;
+  virtual int32 UnregisterDoneEvent(TaskHandle task, uInt32 options, DAQmxDoneEventCallbackPtr callbackFunction, void* callbackData) = 0;
+  virtual int32 UnregisterEveryNSamplesEvent(TaskHandle task, int32 everyNSamplesEventType, uInt32 nSamples, uInt32 options, DAQmxEveryNSamplesEventCallbackPtr callbackFunction, void* callbackData) = 0;
+  virtual int32 UnregisterSignalEvent(TaskHandle task, int32 signalID, uInt32 options, DAQmxSignalEventCallbackPtr callbackFunction, void* callbackData) = 0;
   virtual int32 UnreserveNetworkDevice(const char deviceName[]) = 0;
   virtual int32 WaitForNextSampleClock(TaskHandle task, float64 timeout, bool32* isLate) = 0;
   virtual int32 WaitForValidTimestamp(TaskHandle task, int32 timestampEvent, float64 timeout, CVIAbsoluteTime* timestamp) = 0;

--- a/generated/nidaqmx/nidaqmx_mock_library.h
+++ b/generated/nidaqmx/nidaqmx_mock_library.h
@@ -376,6 +376,9 @@ class NiDAQmxMockLibrary : public nidaqmx_grpc::NiDAQmxLibraryInterface {
   MOCK_METHOD(int32, StopTask, (TaskHandle task), (override));
   MOCK_METHOD(int32, TaskControl, (TaskHandle task, int32 action), (override));
   MOCK_METHOD(int32, TristateOutputTerm, (const char outputTerminal[]), (override));
+  MOCK_METHOD(int32, UnregisterDoneEvent, (TaskHandle task, uInt32 options, DAQmxDoneEventCallbackPtr callbackFunction, void* callbackData), (override));
+  MOCK_METHOD(int32, UnregisterEveryNSamplesEvent, (TaskHandle task, int32 everyNSamplesEventType, uInt32 nSamples, uInt32 options, DAQmxEveryNSamplesEventCallbackPtr callbackFunction, void* callbackData), (override));
+  MOCK_METHOD(int32, UnregisterSignalEvent, (TaskHandle task, int32 signalID, uInt32 options, DAQmxSignalEventCallbackPtr callbackFunction, void* callbackData), (override));
   MOCK_METHOD(int32, UnreserveNetworkDevice, (const char deviceName[]), (override));
   MOCK_METHOD(int32, WaitForNextSampleClock, (TaskHandle task, float64 timeout, bool32* isLate), (override));
   MOCK_METHOD(int32, WaitForValidTimestamp, (TaskHandle task, int32 timestampEvent, float64 timeout, CVIAbsoluteTime* timestamp), (override));

--- a/generated/nidaqmx/nidaqmx_service.cpp
+++ b/generated/nidaqmx/nidaqmx_service.cpp
@@ -18118,6 +18118,114 @@ namespace nidaqmx_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::UnregisterDoneEvent(::grpc::ServerContext* context, const UnregisterDoneEventRequest* request, UnregisterDoneEventResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto task_grpc_session = request->task();
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
+      auto options = 0U;
+      auto callback_function = nullptr;
+      auto callback_data = nullptr;
+      auto status = library_->UnregisterDoneEvent(task, options, callback_function, callback_data);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::UnregisterEveryNSamplesEvent(::grpc::ServerContext* context, const UnregisterEveryNSamplesEventRequest* request, UnregisterEveryNSamplesEventResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto task_grpc_session = request->task();
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
+      int32 every_n_samples_event_type;
+      switch (request->every_n_samples_event_type_enum_case()) {
+        case nidaqmx_grpc::UnregisterEveryNSamplesEventRequest::EveryNSamplesEventTypeEnumCase::kEveryNSamplesEventType: {
+          every_n_samples_event_type = static_cast<int32>(request->every_n_samples_event_type());
+          break;
+        }
+        case nidaqmx_grpc::UnregisterEveryNSamplesEventRequest::EveryNSamplesEventTypeEnumCase::kEveryNSamplesEventTypeRaw: {
+          every_n_samples_event_type = static_cast<int32>(request->every_n_samples_event_type_raw());
+          break;
+        }
+        case nidaqmx_grpc::UnregisterEveryNSamplesEventRequest::EveryNSamplesEventTypeEnumCase::EVERY_N_SAMPLES_EVENT_TYPE_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for every_n_samples_event_type was not specified or out of range");
+          break;
+        }
+      }
+
+      auto n_samples = 0U;
+      auto options = 0U;
+      auto callback_function = nullptr;
+      auto callback_data = nullptr;
+      auto status = library_->UnregisterEveryNSamplesEvent(task, every_n_samples_event_type, n_samples, options, callback_function, callback_data);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiDAQmxService::UnregisterSignalEvent(::grpc::ServerContext* context, const UnregisterSignalEventRequest* request, UnregisterSignalEventResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto task_grpc_session = request->task();
+      TaskHandle task = session_repository_->access_session(task_grpc_session.name());
+      int32 signal_id;
+      switch (request->signal_id_enum_case()) {
+        case nidaqmx_grpc::UnregisterSignalEventRequest::SignalIdEnumCase::kSignalId: {
+          signal_id = static_cast<int32>(request->signal_id());
+          break;
+        }
+        case nidaqmx_grpc::UnregisterSignalEventRequest::SignalIdEnumCase::kSignalIdRaw: {
+          signal_id = static_cast<int32>(request->signal_id_raw());
+          break;
+        }
+        case nidaqmx_grpc::UnregisterSignalEventRequest::SignalIdEnumCase::SIGNAL_ID_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for signal_id was not specified or out of range");
+          break;
+        }
+      }
+
+      auto options = 0U;
+      auto callback_function = nullptr;
+      auto callback_data = nullptr;
+      auto status = library_->UnregisterSignalEvent(task, signal_id, options, callback_function, callback_data);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForTaskHandle(context, status, task);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiDAQmxService::UnreserveNetworkDevice(::grpc::ServerContext* context, const UnreserveNetworkDeviceRequest* request, UnreserveNetworkDeviceResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nidaqmx/nidaqmx_service.h
+++ b/generated/nidaqmx/nidaqmx_service.h
@@ -407,6 +407,9 @@ public:
   ::grpc::Status StopTask(::grpc::ServerContext* context, const StopTaskRequest* request, StopTaskResponse* response) override;
   ::grpc::Status TaskControl(::grpc::ServerContext* context, const TaskControlRequest* request, TaskControlResponse* response) override;
   ::grpc::Status TristateOutputTerm(::grpc::ServerContext* context, const TristateOutputTermRequest* request, TristateOutputTermResponse* response) override;
+  ::grpc::Status UnregisterDoneEvent(::grpc::ServerContext* context, const UnregisterDoneEventRequest* request, UnregisterDoneEventResponse* response) override;
+  ::grpc::Status UnregisterEveryNSamplesEvent(::grpc::ServerContext* context, const UnregisterEveryNSamplesEventRequest* request, UnregisterEveryNSamplesEventResponse* response) override;
+  ::grpc::Status UnregisterSignalEvent(::grpc::ServerContext* context, const UnregisterSignalEventRequest* request, UnregisterSignalEventResponse* response) override;
   ::grpc::Status UnreserveNetworkDevice(::grpc::ServerContext* context, const UnreserveNetworkDeviceRequest* request, UnreserveNetworkDeviceResponse* response) override;
   ::grpc::Status WaitForNextSampleClock(::grpc::ServerContext* context, const WaitForNextSampleClockRequest* request, WaitForNextSampleClockResponse* response) override;
   ::grpc::Status WaitForValidTimestamp(::grpc::ServerContext* context, const WaitForValidTimestampRequest* request, WaitForValidTimestampResponse* response) override;

--- a/source/codegen/metadata/nidaqmx/functions.py
+++ b/source/codegen/metadata/nidaqmx/functions.py
@@ -22941,6 +22941,223 @@ functions = {
         'python_description': 'Sets a terminal to high-impedance state. If you connect an external signal to a terminal on the I/O connector, the terminal must be in high-impedance state. Otherwise, the device could double-drive the terminal and damage the hardware. If you use this function on a terminal in an active route, the function fails and returns an error.',
         'returns': 'int32'
     },
+    'UnregisterDoneEvent': {
+        'calling_convention': 'StdCall',
+        'cname': 'DAQmxRegisterDoneEvent',
+        'handle_parameter': {
+            'ctypes_data_type': 'lib_importer.task_handle',
+            'cvi_name': 'taskHandle',
+            'python_accessor': 'self._handle'
+        },
+        'parameters': [
+            {
+                'ctypes_data_type': 'ctypes.TaskHandle',
+                'direction': 'in',
+                'is_optional_in_python': False,
+                'name': 'task',
+                'python_data_type': 'TaskHandle',
+                'python_description': '',
+                'python_type_annotation': 'TaskHandle',
+                'type': 'TaskHandle'
+            },
+            {
+                'ctypes_data_type': 'ctypes.c_uint',
+                'direction': 'in',
+                'hardcoded_value': '0U',
+                'include_in_proto': False,
+                'is_optional_in_python': False,
+                'name': 'options',
+                'python_data_type': 'int',
+                'python_description': '',
+                'python_type_annotation': 'int',
+                'type': 'uInt32'
+            },
+            {
+                'ctypes_data_type': None,
+                'direction': 'in',
+                'hardcoded_value': 'nullptr',
+                'include_in_proto': False,
+                'is_optional_in_python': False,
+                'name': 'callbackFunction',
+                'python_data_type': 'DAQmxDoneEventCallbackPtr',
+                'python_description': '',
+                'python_type_annotation': 'nidaqmx.constants.DAQmxDoneEventCallbackPtr',
+                'type': 'DAQmxDoneEventCallbackPtr'
+            },
+            {
+                'ctypes_data_type': 'ctypes.c_void_p',
+                'direction': 'in',
+                'hardcoded_value': 'nullptr',
+                'include_in_proto': False,
+                'is_optional_in_python': False,
+                'name': 'callbackData',
+                'pointer': True,
+                'python_data_type': 'dynamic',
+                'python_description': '',
+                'python_type_annotation': 'dynamic',
+                'type': 'void'
+            }
+        ],
+        'python_class_name': 'Task',
+        'python_codegen_method': 'CustomCode',
+        'returns': 'int32'
+    },
+    'UnregisterEveryNSamplesEvent': {
+        'calling_convention': 'StdCall',
+        'cname': 'DAQmxRegisterEveryNSamplesEvent',
+        'handle_parameter': {
+            'ctypes_data_type': 'lib_importer.task_handle',
+            'cvi_name': 'taskHandle',
+            'python_accessor': 'self._handle'
+        },
+        'parameters': [
+            {
+                'ctypes_data_type': 'ctypes.TaskHandle',
+                'direction': 'in',
+                'is_optional_in_python': False,
+                'name': 'task',
+                'python_data_type': 'TaskHandle',
+                'python_description': '',
+                'python_type_annotation': 'TaskHandle',
+                'type': 'TaskHandle'
+            },
+            {
+                'ctypes_data_type': 'ctypes.c_int',
+                'direction': 'in',
+                'enum': 'EveryNSamplesEventType',
+                'is_optional_in_python': False,
+                'name': 'everyNSamplesEventType',
+                'python_data_type': 'EveryNSamplesEventType',
+                'python_description': '',
+                'python_type_annotation': 'nidaqmx.constants.EveryNSamplesEventType',
+                'type': 'int32'
+            },
+            {
+                'ctypes_data_type': 'ctypes.c_uint',
+                'direction': 'in',
+                'hardcoded_value': '0U',
+                'include_in_proto': False,
+                'is_optional_in_python': False,
+                'name': 'nSamples',
+                'python_data_type': 'int',
+                'python_description': '',
+                'python_type_annotation': 'int',
+                'type': 'uInt32'
+            },
+            {
+                'ctypes_data_type': 'ctypes.c_uint',
+                'direction': 'in',
+                'hardcoded_value': '0U',
+                'include_in_proto': False,
+                'is_optional_in_python': False,
+                'name': 'options',
+                'python_data_type': 'int',
+                'python_description': '',
+                'python_type_annotation': 'int',
+                'type': 'uInt32'
+            },
+            {
+                'ctypes_data_type': None,
+                'direction': 'in',
+                'hardcoded_value': 'nullptr',
+                'include_in_proto': False,
+                'is_optional_in_python': False,
+                'name': 'callbackFunction',
+                'python_data_type': 'DAQmxEveryNSamplesEventCallbackPtr',
+                'python_description': '',
+                'python_type_annotation': 'nidaqmx.constants.DAQmxEveryNSamplesEventCallbackPtr',
+                'type': 'DAQmxEveryNSamplesEventCallbackPtr'
+            },
+            {
+                'ctypes_data_type': 'ctypes.c_void_p',
+                'direction': 'in',
+                'hardcoded_value': 'nullptr',
+                'include_in_proto': False,
+                'is_optional_in_python': False,
+                'name': 'callbackData',
+                'pointer': True,
+                'python_data_type': 'dynamic',
+                'python_description': '',
+                'python_type_annotation': 'dynamic',
+                'type': 'void'
+            }
+        ],
+        'python_class_name': 'Task',
+        'python_codegen_method': 'CustomCode',
+        'returns': 'int32'
+    },
+    'UnregisterSignalEvent': {
+        'calling_convention': 'StdCall',
+        'cname': 'DAQmxRegisterSignalEvent',
+        'handle_parameter': {
+            'ctypes_data_type': 'lib_importer.task_handle',
+            'cvi_name': 'taskHandle',
+            'python_accessor': 'self._handle'
+        },
+        'parameters': [
+            {
+                'ctypes_data_type': 'ctypes.TaskHandle',
+                'direction': 'in',
+                'is_optional_in_python': False,
+                'name': 'task',
+                'python_data_type': 'TaskHandle',
+                'python_description': '',
+                'python_type_annotation': 'TaskHandle',
+                'type': 'TaskHandle'
+            },
+            {
+                'ctypes_data_type': 'ctypes.c_int',
+                'direction': 'in',
+                'enum': 'Signal2',
+                'is_optional_in_python': False,
+                'name': 'signalID',
+                'python_data_type': 'Signal',
+                'python_description': '',
+                'python_type_annotation': 'nidaqmx.constants.Signal',
+                'type': 'int32'
+            },
+            {
+                'ctypes_data_type': 'ctypes.c_uint',
+                'direction': 'in',
+                'hardcoded_value': '0U',
+                'include_in_proto': False,
+                'is_optional_in_python': False,
+                'name': 'options',
+                'python_data_type': 'int',
+                'python_description': '',
+                'python_type_annotation': 'int',
+                'type': 'uInt32'
+            },
+            {
+                'ctypes_data_type': None,
+                'direction': 'in',
+                'hardcoded_value': 'nullptr',
+                'include_in_proto': False,
+                'is_optional_in_python': False,
+                'name': 'callbackFunction',
+                'python_data_type': 'DAQmxSignalEventCallbackPtr',
+                'python_description': '',
+                'python_type_annotation': 'nidaqmx.constants.DAQmxSignalEventCallbackPtr',
+                'type': 'DAQmxSignalEventCallbackPtr'
+            },
+            {
+                'ctypes_data_type': 'ctypes.c_void_p',
+                'direction': 'in',
+                'hardcoded_value': 'nullptr',
+                'include_in_proto': False,
+                'is_optional_in_python': False,
+                'name': 'callbackData',
+                'pointer': True,
+                'python_data_type': 'dynamic',
+                'python_description': '',
+                'python_type_annotation': 'dynamic',
+                'type': 'void'
+            }
+        ],
+        'python_class_name': 'Task',
+        'python_codegen_method': 'CustomCode',
+        'returns': 'int32'
+    },
     'UnreserveNetworkDevice': {
         'calling_convention': 'StdCall',
         'handle_parameter': {

--- a/source/codegen/metadata/nidaqmx/functions.py
+++ b/source/codegen/metadata/nidaqmx/functions.py
@@ -22973,6 +22973,21 @@ functions = {
                 'type': 'uInt32'
             },
             {
+                'callback_params': [
+                    {
+                        'ctypes_data_type': 'lib_importer.task_handle',
+                        'direction': 'out',
+                        'include_in_proto': False,
+                        'name': 'task',
+                        'type': 'TaskHandle'
+                    },
+                    {
+                        'ctypes_data_type': 'ctypes.c_int',
+                        'direction': 'out',
+                        'name': 'status',
+                        'type': 'int32'
+                    }
+                ],
                 'ctypes_data_type': None,
                 'direction': 'in',
                 'hardcoded_value': 'nullptr',
@@ -22985,6 +23000,7 @@ functions = {
                 'type': 'DAQmxDoneEventCallbackPtr'
             },
             {
+                'callback_token': True,
                 'ctypes_data_type': 'ctypes.c_void_p',
                 'direction': 'in',
                 'hardcoded_value': 'nullptr',
@@ -23057,6 +23073,28 @@ functions = {
                 'type': 'uInt32'
             },
             {
+                'callback_params': [
+                    {
+                        'ctypes_data_type': 'lib_importer.task_handle',
+                        'direction': 'out',
+                        'include_in_proto': False,
+                        'name': 'task',
+                        'type': 'TaskHandle'
+                    },
+                    {
+                        'ctypes_data_type': 'ctypes.c_int',
+                        'direction': 'out',
+                        'enum': 'EveryNSamplesEventType',
+                        'name': 'everyNSamplesEventType',
+                        'type': 'int32'
+                    },
+                    {
+                        'ctypes_data_type': 'ctypes.c_uint',
+                        'direction': 'out',
+                        'name': 'nSamples',
+                        'type': 'uInt32'
+                    }
+                ],
                 'ctypes_data_type': None,
                 'direction': 'in',
                 'hardcoded_value': 'nullptr',
@@ -23069,6 +23107,7 @@ functions = {
                 'type': 'DAQmxEveryNSamplesEventCallbackPtr'
             },
             {
+                'callback_token': True,
                 'ctypes_data_type': 'ctypes.c_void_p',
                 'direction': 'in',
                 'hardcoded_value': 'nullptr',
@@ -23129,6 +23168,21 @@ functions = {
                 'type': 'uInt32'
             },
             {
+                'callback_params': [
+                    {
+                        'ctypes_data_type': 'lib_importer.task_handle',
+                        'direction': 'out',
+                        'include_in_proto': False,
+                        'name': 'task',
+                        'type': 'TaskHandle'
+                    },
+                    {
+                        'ctypes_data_type': 'ctypes.c_int',
+                        'direction': 'out',
+                        'name': 'signalID',
+                        'type': 'int32'
+                    }
+                ],
                 'ctypes_data_type': None,
                 'direction': 'in',
                 'hardcoded_value': 'nullptr',
@@ -23141,6 +23195,7 @@ functions = {
                 'type': 'DAQmxSignalEventCallbackPtr'
             },
             {
+                'callback_token': True,
                 'ctypes_data_type': 'ctypes.c_void_p',
                 'direction': 'in',
                 'hardcoded_value': 'nullptr',

--- a/source/codegen/proto_helpers.py
+++ b/source/codegen/proto_helpers.py
@@ -238,9 +238,9 @@ def get_parameters(function):
     default_status_param = {"name": "status", "type": "int32", "grpc_type": "int32"}
     output_parameters = [default_status_param]
 
-    callback_parameters = _get_callback_output_params(function)
+    if common_helpers.has_async_streaming_response(function):
+        callback_parameters = _get_callback_output_params(function)
 
-    if callback_parameters:
         if any((p for p in callback_parameters if p["name"] == "status")):
             # if the callback provides a status, it can override default_status_param.
             output_parameters = callback_parameters

--- a/source/codegen/service_helpers.py
+++ b/source/codegen/service_helpers.py
@@ -97,15 +97,16 @@ def _create_standard_arg(parameter):
     parameter_name = common_helpers.get_cpp_local_name(parameter)
     is_array = common_helpers.is_array(parameter["type"])
     is_output = common_helpers.is_output_parameter(parameter)
+    is_hardcoded = "hardcoded_value" in parameter
     if is_output and common_helpers.is_string_arg(parameter):
         type_without_brackets = common_helpers.get_underlying_type_name(parameter["type"])
         return f"({type_without_brackets}*){parameter_name}.data(), "
     elif _is_array_that_requires_conversion(parameter):
         # Converted arrays are allocated into a std::vector. Access the C array via data().
         return f"{parameter_name}.data(), "
-    elif "callback_params" in parameter:
+    elif "callback_params" in parameter and not is_hardcoded:
         return f"CallbackRouter::handle_callback, "
-    elif "callback_token" in parameter:
+    elif "callback_token" in parameter and not is_hardcoded:
         return f"handler->token(), "
     elif is_size_param_passed_by_ptr(parameter):
         return f"&{parameter_name}_copy, "

--- a/source/codegen/templates/service_helpers.mako
+++ b/source/codegen/templates/service_helpers.mako
@@ -293,13 +293,13 @@ ${initialize_bitfield_as_enum_array_param(function_name, parameter)}
 ${initialize_enum_array_input_param(function_name, parameter)}
 % elif common_helpers.is_enum(parameter):
 ${initialize_enum_input_param(function_name, parameter)}
+% elif 'hardcoded_value' in parameter:
+${initialize_hardcoded_parameter(parameter)}
 % elif 'callback_token' in parameter or 'callback_params' in parameter: ## pass
 % elif "determine_size_from" in parameter:
 ${initialize_len_input_param(parameter, parameters)}
 % elif common_helpers.is_two_dimension_array_param(parameter):
 ${initialize_two_dimension_input_param(function_name, parameter, parameters)}
-% elif 'hardcoded_value' in parameter:
-${initialize_hardcoded_parameter(parameter)}
 % elif service_helpers.is_size_param_passed_by_ptr(parameter):
 ${initialize_pointer_input_parameter(parameter)}
 % else:

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -489,7 +489,7 @@ class NiDAQmxDriverApiTests : public Test {
   {
     RegisterSignalEventRequest request;
     set_request_session_name(request);
-    request.set_signal_id(Signal2::SIGNAL2_SAMPLE_CLOCK);
+    request.set_signal_id(signal_id);
     return stub()->RegisterSignalEvent(&context, request);
   }
 

--- a/source/tests/system/nidaqmx_driver_api_tests.cpp
+++ b/source/tests/system/nidaqmx_driver_api_tests.cpp
@@ -1469,15 +1469,9 @@ TEST_F(NiDAQmxDriverApiTests, ChannelWithDoneEventRegisteredTwice_RunCompleteFin
   read_stream(reader_context1, *reader1, response1);
 
   EXPECT_EQ(DAQMX_SUCCESS, response1.status());
-  EXPECT_THROW({
-    try {
-      read_stream(reader_context2, *reader2, response2);
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, DONE_EVENT_ALREADY_REGISTERED_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    read_stream(reader_context2, *reader2, response2);
+  }, DONE_EVENT_ALREADY_REGISTERED_ERROR);
 }
 
 TEST_F(NiDAQmxDriverApiTests, EveryNSamplesEventRegisteredWithWrongEventType_ReadStream_NotSupportedByDeviceErrorReceived)
@@ -1488,15 +1482,9 @@ TEST_F(NiDAQmxDriverApiTests, EveryNSamplesEventRegisteredWithWrongEventType_Rea
   auto reader = register_every_n_samples_event(reader_context, N_SAMPLES, EveryNSamplesEventType::EVERY_N_SAMPLES_EVENT_TYPE_TRANSFERRED_FROM_BUFFER);
 
   RegisterEveryNSamplesEventResponse response;
-  EXPECT_THROW({
-    try {
-      read_stream(reader_context, *reader, response);
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, EVERY_N_SAMPS_TRANSFERRED_FROM_BUFFER_EVENT_NOT_SUPPORTED_BY_DEVICE_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    read_stream(reader_context, *reader, response);
+  }, EVERY_N_SAMPS_TRANSFERRED_FROM_BUFFER_EVENT_NOT_SUPPORTED_BY_DEVICE_ERROR);
 }
 
 TEST_F(NiDAQmxDriverApiTests, EveryNSamplesEventRegisteredWithWrongEventType_Finish_NotSupportedByDeviceErrorReceived)
@@ -1506,16 +1494,10 @@ TEST_F(NiDAQmxDriverApiTests, EveryNSamplesEventRegisteredWithWrongEventType_Fin
   ::grpc::ClientContext reader_context;
   auto reader = register_every_n_samples_event(reader_context, N_SAMPLES, EveryNSamplesEventType::EVERY_N_SAMPLES_EVENT_TYPE_TRANSFERRED_FROM_BUFFER);
 
-  EXPECT_THROW({
-    try {
-      auto status = reader->Finish();
-      client::raise_if_error(status, reader_context);
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, EVERY_N_SAMPS_TRANSFERRED_FROM_BUFFER_EVENT_NOT_SUPPORTED_BY_DEVICE_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    auto status = reader->Finish();
+    client::raise_if_error(status, reader_context);
+  }, EVERY_N_SAMPS_TRANSFERRED_FROM_BUFFER_EVENT_NOT_SUPPORTED_BY_DEVICE_ERROR);
 }
 
 TEST_F(NiDAQmxDriverApiTests, EveryNSamplesEventRegisteredWithWrongEventType_Cancel_NoErrors)
@@ -1632,15 +1614,9 @@ TEST_F(NiDAQmxDriverApiTests, AsyncEveryNSamplesEventRegisteredWithWrongEventTyp
   bool finish_completed = try_get_next_completion_without_blocking(completion_queue, finish_completion);
   EXPECT_TRUE(finish_completed);
   ASSERT_EQ(Completion(FINISH_TAG, true), finish_completion);
-  EXPECT_THROW({
-    try {
-      client::raise_if_error(status, reader_context);
-    }
-    catch (const client::grpc_driver_error& ex) {
-      expect_driver_error(ex, EVERY_N_SAMPS_TRANSFERRED_FROM_BUFFER_EVENT_NOT_SUPPORTED_BY_DEVICE_ERROR);
-      throw;
-    }
-  }, client::grpc_driver_error);
+  EXPECT_THROW_DRIVER_ERROR({
+    client::raise_if_error(status, reader_context);
+  }, EVERY_N_SAMPS_TRANSFERRED_FROM_BUFFER_EVENT_NOT_SUPPORTED_BY_DEVICE_ERROR);
 }
 
 TEST_F(NiDAQmxDriverApiTests, AIVoltageChannel_ConfigureInputBuffer_Succeeds)

--- a/source/tests/utilities/test_helpers.h
+++ b/source/tests/utilities/test_helpers.h
@@ -28,6 +28,17 @@
     }                                                                                          \
   }, nidevice_grpc::experimental::client::grpc_driver_error)
 
+#define EXPECT_THROW_GRPC_CANCELLED(statement_)                                \
+  EXPECT_THROW({                                                               \
+    try {                                                                      \
+      statement_;                                                              \
+    }                                                                          \
+    catch (const nidevice_grpc::experimental::client::grpc_driver_error& ex) { \
+      EXPECT_EQ(::grpc::CANCELLED, ex.StatusCode());                           \
+      throw;                                                                   \
+    }                                                                          \
+  }, nidevice_grpc::experimental::client::grpc_driver_error)
+
 #define EXPECT_DRIVER_ERROR(exception_, expected_error_)             \
   do {                                                               \
     EXPECT_EQ(::grpc::StatusCode::UNKNOWN, exception_.StatusCode()); \


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add new RPCs to support DAQmx event unregistration:
- `UnregisterDoneEvent`
- `UnregisterEveryNSamplesEvent`
- `UnregisterSignalEvent`

Unregistering a DAQmx event configures the DAQmx task to stop producing the event. This allows test applications to enable/disable events without clearing and re-creating the task, which is required for sharing tasks between multiple MeasurementLink measurement services. It also allows test applications to unregister and reregister the same event with different settings, such as varying the every N samples interval or changing the signal event type. 

Events cannot be unregistered while the task is in the running state. The task must be in the verified, reserved, or committed states.

Canceling the event stream does not automatically unregister the event. If it did, canceling the event stream while the task is running would produce an error, but it would have no way to report the error because the stream is canceled. After the event stream is canceled, the NI gRPC Device Server ignores any additional events produced by DAQmx.

Unregistering an event does not automatically close or cancel the corresponding event stream at this time. The test application is currently responsible for canceling the event reader after unregistering the event. However, test architects are encouraged to handle stream closure/cancellation as well as stream errors.

### Why should this Pull Request be merged?

Fixes #925 

Required to fix AB#2395984: GrpcStubInterpreter does not unregister events with DAQmx

### What testing has been done?

Ran DAQmx system tests on Windows and Linux.
Ran nidaqmx-python tests on Windows with https://github.com/ni/nidaqmx-python/pull/377