### PR TITLE
Enable CalibrationOperationsRestrictedService by default

### DIFF
--- a/source/server/calibration_operations_restricted_service.cpp
+++ b/source/server/calibration_operations_restricted_service.cpp
@@ -8,7 +8,7 @@ namespace nidevice_restricted_grpc {
 CalibrationOperationsRestrictedFeatureToggles::CalibrationOperationsRestrictedFeatureToggles(
   const nidevice_grpc::FeatureToggles& feature_toggles)
   : is_enabled(
-      feature_toggles.is_feature_enabled("calibrationoperations_restricted", CodeReadiness::kNextRelease))
+      feature_toggles.is_feature_enabled("calibrationoperations_restricted", CodeReadiness::kRelease))
 {
 }
 


### PR DESCRIPTION
### What does this Pull Request accomplish?
- Changes CalibrationOperationsRestrictedService feature toggle from kNextRelease to kRelease.

### Why should this Pull Request be merged?
The CalibrationOperationsRestrictedService was completed in the first iteration of this cycle.  It hasn't had any issues since then and is ready to ship at the end of this cycle.

### What testing has been done?
- Reran calibration operation unit tests.
- Tested on a real device with a local debug build.
![image](https://github.com/ni/grpc-device/assets/77293599/ce834d88-9a80-42f0-910c-3d1b5c530dee)
