### PR TITLE
Update README to make default address binding more apparent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you're looking to build the grpc-device repo locally, look at the [Getting St
 
 ## Running the gRPC Server
 
-The server's startup configuration is set by specifying port and security settings in a JSON configuration file. A default configuration file named `server_config.json` with an insecure configuration (no SSL/TLS) is located in the same directory as the server executable. For more information on SSL/TLS related security settings refer to the [SSL/TLS Support section](#ssltls-support). The location of the server binary is not important as long as the user has proper permissions in the chosen directory.
+The server's startup configuration is set by specifying port and security settings in a JSON configuration file. A default configuration file named `server_config.json` with an insecure configuration (no SSL/TLS) bound to localhost is located in the same directory as the server executable. For more information on SSL/TLS related security settings refer to the [SSL/TLS Support section](#ssltls-support). For more information on address binding refer to the [Bind Address Support section](#bind-address-support). The location of the server binary is not important as long as the user has proper permissions in the chosen directory.
 
 There are two ways to start the server:
 


### PR DESCRIPTION
### What does this Pull Request accomplish?
Updates description of the default server_config.json to include binding to localhost behavior.

### Why should this Pull Request be merged?
Makes the default localhost binding more obvious.  Hopefully this will avoid issues similar to [this Teams thread](https://teams.microsoft.com/l/message/19:658a48f1bcd240dc9c56f5eb35761898@thread.tacv2/1684528217399?tenantId=87ba1f9a-44cd-43a6-b008-6fdb45a5204e&groupId=22cecbce-4450-4339-bbf5-85ade50ab7fb&parentMessageId=1684528217399&teamName=gRPC&channelName=grpc-device&createdTime=1684528217399) in the future.

### What testing has been done?
None.