### PR TITLE
tests: Report more error info in MI/sync/tclk driver API tests

### DIFF
--- a/source/tests/system/nidigital_driver_api_tests.cpp
+++ b/source/tests/system/nidigital_driver_api_tests.cpp
@@ -8,6 +8,7 @@
 
 #include "device_server.h"
 #include "nidigitalpattern/nidigitalpattern_client.h"
+#include "tests/utilities/test_helpers.h"
 
 #define EXPECT_SUCCESS(status)               \
   EXPECT_TRUE((status).ok());                \
@@ -86,10 +87,11 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     digital::InitWithOptionsResponse response;
 
     ::grpc::Status status = GetStub()->InitWithOptions(&context, request, &response);
+    nidevice_grpc::experimental::client::raise_if_error(status, context);
     driver_session_ = std::make_unique<nidevice_grpc::Session>(response.vi());
 
-    ASSERT_TRUE(status.ok());
-    ASSERT_EQ(kDigitalDriverApiSuccess, response.status());
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(kDigitalDriverApiSuccess, response.status());
   }
 
   void initialize_multi_instrument_driver_session()
@@ -104,10 +106,11 @@ class NiDigitalDriverApiTest : public ::testing::Test {
     digital::InitWithOptionsResponse response;
 
     ::grpc::Status status = GetStub()->InitWithOptions(&context, request, &response);
+    nidevice_grpc::experimental::client::raise_if_error(status, context);
     multi_instrument_driver_session_ = std::make_unique<nidevice_grpc::Session>(response.vi());
 
-    ASSERT_TRUE(status.ok());
-    ASSERT_EQ(kDigitalDriverApiSuccess, response.status());
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(kDigitalDriverApiSuccess, response.status());
   }
 
   void close_driver_session()

--- a/source/tests/system/nidmm_driver_api_tests.cpp
+++ b/source/tests/system/nidmm_driver_api_tests.cpp
@@ -3,6 +3,7 @@
 #include "device_server.h"
 #include "nidmm/nidmm_client.h"
 #include "nidmm/nidmm_library.h"
+#include "tests/utilities/test_helpers.h"
 
 namespace ni {
 namespace tests {
@@ -60,6 +61,7 @@ class NiDmmDriverApiTest : public ::testing::Test {
     dmm::InitWithOptionsResponse response;
 
     ::grpc::Status status = GetStub()->InitWithOptions(&context, request, &response);
+    nidevice_grpc::experimental::client::raise_if_error(status, context);
     driver_session_ = std::make_unique<nidevice_grpc::Session>(response.vi());
 
     EXPECT_TRUE(status.ok());

--- a/source/tests/system/nifgen_driver_api_tests.cpp
+++ b/source/tests/system/nifgen_driver_api_tests.cpp
@@ -2,6 +2,7 @@
 
 #include "device_server.h"
 #include "nifgen/nifgen_client.h"
+#include "tests/utilities/test_helpers.h"
 #include "waveform_helpers.h"
 
 namespace ni {
@@ -66,9 +67,10 @@ class NiFgenDriverApiTest : public ::testing::Test {
     fgen::InitializeWithChannelsResponse response;
 
     ::grpc::Status status = GetStub()->InitializeWithChannels(&context, request, &response);
+    nidevice_grpc::experimental::client::raise_if_error(status, context);
     driver_session_ = std::make_unique<nidevice_grpc::Session>(response.vi());
 
-    ASSERT_TRUE(status.ok());
+    EXPECT_TRUE(status.ok());
     expect_api_success(response.status());
   }
 

--- a/source/tests/system/niscope_driver_api_tests.cpp
+++ b/source/tests/system/niscope_driver_api_tests.cpp
@@ -2,6 +2,7 @@
 
 #include "device_server.h"
 #include "niscope/niscope_client.h"
+#include "tests/utilities/test_helpers.h"
 
 namespace ni {
 namespace tests {
@@ -61,10 +62,11 @@ class NiScopeDriverApiTest : public ::testing::Test {
     scope::InitWithOptionsResponse response;
 
     ::grpc::Status status = GetStub()->InitWithOptions(&context, request, &response);
+    nidevice_grpc::experimental::client::raise_if_error(status, context);
     driver_session_ = std::make_unique<nidevice_grpc::Session>(response.vi());
 
-    ASSERT_TRUE(status.ok());
-    ASSERT_EQ(kScopeDriverApiSuccess, response.status());
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(kScopeDriverApiSuccess, response.status());
   }
 
   void close_driver_session()

--- a/source/tests/system/niswitch_driver_api_tests.cpp
+++ b/source/tests/system/niswitch_driver_api_tests.cpp
@@ -2,6 +2,7 @@
 
 #include "device_server.h"
 #include "niswitch/niswitch_client.h"
+#include "tests/utilities/test_helpers.h"
 
 namespace ni {
 namespace tests {
@@ -85,10 +86,11 @@ class NiSwitchDriverApiTest : public ::testing::Test {
     niswitch::InitWithTopologyResponse response;
 
     ::grpc::Status status = GetStub()->InitWithTopology(&context, request, &response);
+    nidevice_grpc::experimental::client::raise_if_error(status, context);
     driver_session_ = std::make_unique<nidevice_grpc::Session>(response.vi());
 
-    ASSERT_TRUE(status.ok());
-    ASSERT_EQ(kSwitchDriverApiSuccess, response.status());
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(kSwitchDriverApiSuccess, response.status());
   }
 
   void close_driver_session()

--- a/source/tests/system/nisync_driver_api_tests.cpp
+++ b/source/tests/system/nisync_driver_api_tests.cpp
@@ -3,6 +3,7 @@
 #include "device_server.h"
 #include "enumerate_devices.h"
 #include "nisync/nisync_client.h"
+#include "tests/utilities/test_helpers.h"
 
 namespace ni {
 namespace tests {
@@ -512,8 +513,8 @@ class NiSyncDriverApiTest : public ::testing::Test {
         timeNanoseconds,
         timeFractionalNanoseconds,
         &viStatus);
-    ASSERT_TRUE(grpcStatus.ok());
-    ASSERT_EQ(VI_SUCCESS, viStatus);
+    EXPECT_TRUE(grpcStatus.ok());
+    EXPECT_EQ(VI_SUCCESS, viStatus);
   }
 
   ::grpc::Status call_ClearFutureTimeEvents(
@@ -610,8 +611,8 @@ class NiSyncDriverApiTest : public ::testing::Test {
   {
     int32 viStatus;
     auto grpcStatus = call_EnableTimeStampTrigger(terminal, activeEdge, &viStatus);
-    ASSERT_TRUE(grpcStatus.ok());
-    ASSERT_EQ(VI_SUCCESS, viStatus);
+    EXPECT_TRUE(grpcStatus.ok());
+    EXPECT_EQ(VI_SUCCESS, viStatus);
   }
 
   ::grpc::Status call_ReadTriggerTimeStamp(

--- a/source/tests/system/nitclk_driver_api_tests.cpp
+++ b/source/tests/system/nitclk_driver_api_tests.cpp
@@ -3,6 +3,7 @@
 #include "device_server.h"
 #include "niscope/niscope_client.h"
 #include "nitclk/nitclk_client.h"
+#include "tests/utilities/test_helpers.h"
 
 namespace ni {
 namespace tests {
@@ -68,10 +69,11 @@ class NiTClkDriverApiTest : public ::testing::Test {
     scope::InitWithOptionsResponse response;
 
     ::grpc::Status status = GetScopeStub()->InitWithOptions(&context, request, &response);
+    nidevice_grpc::experimental::client::raise_if_error(status, context);
     scope_session_ = std::make_unique<nidevice_grpc::Session>(response.vi());
 
-    ASSERT_TRUE(status.ok());
-    ASSERT_EQ(kScopeDriverApiSuccess, response.status());
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(kScopeDriverApiSuccess, response.status());
   }
 
   void close_scope_session()


### PR DESCRIPTION
### What does this Pull Request accomplish?

In `initialize_driver_session()`, use `client::raise_if_error()`, which throws an exception that includes the full error message.

Change `ASSERT_*` to `EXPECT_*` in some helper functions so that they print more failure output instead of returning. `ASSERT_*` returns from the current function, so calling it in a helper function doesn't terminate the current test.

### Why should this Pull Request be merged?

When initialize_driver_session fails, it doesn't print any useful information about the error:
```
[ RUN      ] NiFgenDriverApiTest.AllocateNamedWaveform_WriteNamedWaveformF64_WaveformWrittenSuccessfully
/home/runner/work/grpc-device/grpc-device/source/tests/system/nifgen_driver_api_tests.cpp:71: Failure
Value of: status.ok()
  Actual: false
Expected: true
/home/runner/work/grpc-device/grpc-device/source/tests/system/nifgen_driver_api_tests.cpp:101: Failure
Value of: status.ok()
  Actual: false
Expected: true
[  FAILED  ] NiFgenDriverApiTest.AllocateNamedWaveform_WriteNamedWaveformF64_WaveformWrittenSuccessfully (81 ms)
```

### What testing has been done?

Ran nidmm, nidigital, nifgen, niscope, niswitch, and nitclk tests on my test machine. (They passed.)