### PR TITLE
Update timeout to 50 minutes

### DIFF
--- a/.github/workflows/run_win_system_tests.yml
+++ b/.github/workflows/run_win_system_tests.yml
@@ -25,4 +25,4 @@ jobs:
     - name: Run System Tests
       run: .\SystemTestsRunner.exe
       working-directory: ./build/Release
-      timeout-minutes: 27
+      timeout-minutes: 50


### PR DESCRIPTION
### What does this Pull Request accomplish?

Fixes #952

### Why should this Pull Request be merged?

With the increase in number of  devices supported by grpc-device, we need to update our test timeouts to avoid running into the limit.

### What testing has been done?
PR builds