### PR TITLE
Use Python 3.8 in validate_python workflow

### DIFF
--- a/.github/workflows/validate_python.yml
+++ b/.github/workflows/validate_python.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup python3
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7.x'
+        python-version: '3.8.x'
 
     - name: Install build dependencies
       run: python -m pip install -r python_build_requirements.txt

--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -62,7 +62,7 @@ def _validate_examples(
         _system("poetry new .")
         _system("poetry add grpcio")
         _system("poetry add --dev grpcio-tools mypy mypy-protobuf types-protobuf grpc-stubs")
-        _system('poetry add --dev black')
+        _system("poetry add --dev black")
         _system("poetry install")
 
         _stage_client_files(artifact_location, staging_dir)

--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -62,9 +62,7 @@ def _validate_examples(
         _system("poetry new .")
         _system("poetry add grpcio")
         _system("poetry add --dev grpcio-tools mypy mypy-protobuf types-protobuf grpc-stubs")
-        # black requires python >=3.6.2, so only ask it to be installed for python >=3.6.2, or else
-        # poetry can give a SolverProblemError and fail the "install" step
-        _system('poetry add --dev --python ">=3.6.2" black')
+        _system('poetry add --dev black')
         _system("poetry install")
 
         _stage_client_files(artifact_location, staging_dir)


### PR DESCRIPTION
### What does this Pull Request accomplish?

The validate_python workflow is erroring with `FAILED STEP (256): [poetry add --dev --python ">=3.6.2" black]` because [the latest release of black does not have a Python 3.7 wheel](https://pypi.org/simple/black/).
By bumping the version used to Python 3.8, this fixes the workflow.

### Why should this Pull Request be merged?

* PR Checks should always be able to pass with the code that's in main.
* Python has ended support of Python 3.7.

### What testing has been done?

PR Checks