### PR TITLE
Add SetRuntimeEnvironment to all MI Driver and NI-Fake library classes

### DIFF
--- a/generated/nidcpower/nidcpower_library.cpp
+++ b/generated/nidcpower/nidcpower_library.cpp
@@ -169,6 +169,7 @@ NiDCPowerLibrary::NiDCPowerLibrary() : shared_library_(kLibraryName)
   function_pointers_.UnlockSession = reinterpret_cast<UnlockSessionPtr>(shared_library_.get_function_pointer("niDCPower_UnlockSession"));
   function_pointers_.WaitForEvent = reinterpret_cast<WaitForEventPtr>(shared_library_.get_function_pointer("niDCPower_WaitForEvent"));
   function_pointers_.WaitForEventWithChannels = reinterpret_cast<WaitForEventWithChannelsPtr>(shared_library_.get_function_pointer("niDCPower_WaitForEventWithChannels"));
+  function_pointers_.SetRuntimeEnvironment = reinterpret_cast<SetRuntimeEnvironmentPtr>(shared_library_.get_function_pointer("niDCPower_SetRuntimeEnvironment"));
 }
 
 NiDCPowerLibrary::~NiDCPowerLibrary()
@@ -1364,6 +1365,14 @@ ViStatus NiDCPowerLibrary::WaitForEventWithChannels(ViSession vi, ViConstString 
     throw nidevice_grpc::LibraryLoadException("Could not find niDCPower_WaitForEventWithChannels.");
   }
   return function_pointers_.WaitForEventWithChannels(vi, channelName, eventId, timeout);
+}
+
+ViStatus NiDCPowerLibrary::SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2)
+{
+  if (!function_pointers_.SetRuntimeEnvironment) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niDCPower_SetRuntimeEnvironment.");
+  }
+  return function_pointers_.SetRuntimeEnvironment(environment, environmentVersion, reserved1, reserved2);
 }
 
 }  // namespace nidcpower_grpc

--- a/generated/nidcpower/nidcpower_library.h
+++ b/generated/nidcpower/nidcpower_library.h
@@ -166,6 +166,7 @@ class NiDCPowerLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
   ViStatus UnlockSession(ViSession vi, ViBoolean* callerHasLock);
   ViStatus WaitForEvent(ViSession vi, ViInt32 eventId, ViReal64 timeout);
   ViStatus WaitForEventWithChannels(ViSession vi, ViConstString channelName, ViInt32 eventId, ViReal64 timeout);
+  ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2);
 
  private:
   using AbortPtr = decltype(&niDCPower_Abort);
@@ -316,6 +317,7 @@ class NiDCPowerLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
   using UnlockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using WaitForEventPtr = decltype(&niDCPower_WaitForEvent);
   using WaitForEventWithChannelsPtr = decltype(&niDCPower_WaitForEventWithChannels);
+  using SetRuntimeEnvironmentPtr = ViStatus (*)(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2);
 
   typedef struct FunctionPointers {
     AbortPtr Abort;
@@ -466,6 +468,7 @@ class NiDCPowerLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
     UnlockSessionPtr UnlockSession;
     WaitForEventPtr WaitForEvent;
     WaitForEventWithChannelsPtr WaitForEventWithChannels;
+    SetRuntimeEnvironmentPtr SetRuntimeEnvironment;
   } FunctionLoadStatus;
 
   nidevice_grpc::SharedLibrary shared_library_;

--- a/generated/nidcpower/nidcpower_library_interface.h
+++ b/generated/nidcpower/nidcpower_library_interface.h
@@ -163,6 +163,7 @@ class NiDCPowerLibraryInterface {
   virtual ViStatus UnlockSession(ViSession vi, ViBoolean* callerHasLock) = 0;
   virtual ViStatus WaitForEvent(ViSession vi, ViInt32 eventId, ViReal64 timeout) = 0;
   virtual ViStatus WaitForEventWithChannels(ViSession vi, ViConstString channelName, ViInt32 eventId, ViReal64 timeout) = 0;
+  virtual ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2) = 0;
 };
 
 }  // namespace nidcpower_grpc

--- a/generated/nidcpower/nidcpower_mock_library.h
+++ b/generated/nidcpower/nidcpower_mock_library.h
@@ -165,6 +165,7 @@ class NiDCPowerMockLibrary : public nidcpower_grpc::NiDCPowerLibraryInterface {
   MOCK_METHOD(ViStatus, UnlockSession, (ViSession vi, ViBoolean* callerHasLock), (override));
   MOCK_METHOD(ViStatus, WaitForEvent, (ViSession vi, ViInt32 eventId, ViReal64 timeout), (override));
   MOCK_METHOD(ViStatus, WaitForEventWithChannels, (ViSession vi, ViConstString channelName, ViInt32 eventId, ViReal64 timeout), (override));
+  MOCK_METHOD(ViStatus, SetRuntimeEnvironment, (ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2), (override));
 };
 
 }  // namespace unit

--- a/generated/nidigitalpattern/nidigitalpattern_library.cpp
+++ b/generated/nidigitalpattern/nidigitalpattern_library.cpp
@@ -153,6 +153,7 @@ NiDigitalLibrary::NiDigitalLibrary() : shared_library_(kLibraryName)
   function_pointers_.WriteSourceWaveformDataFromFileTDMS = reinterpret_cast<WriteSourceWaveformDataFromFileTDMSPtr>(shared_library_.get_function_pointer("niDigital_WriteSourceWaveformDataFromFileTDMS"));
   function_pointers_.WriteSourceWaveformSiteUniqueU32 = reinterpret_cast<WriteSourceWaveformSiteUniqueU32Ptr>(shared_library_.get_function_pointer("niDigital_WriteSourceWaveformSiteUniqueU32"));
   function_pointers_.WriteStatic = reinterpret_cast<WriteStaticPtr>(shared_library_.get_function_pointer("niDigital_WriteStatic"));
+  function_pointers_.SetRuntimeEnvironment = reinterpret_cast<SetRuntimeEnvironmentPtr>(shared_library_.get_function_pointer("niDigital_SetRuntimeEnvironment"));
 }
 
 NiDigitalLibrary::~NiDigitalLibrary()
@@ -1220,6 +1221,14 @@ ViStatus NiDigitalLibrary::WriteStatic(ViSession vi, ViConstString channelList, 
     throw nidevice_grpc::LibraryLoadException("Could not find niDigital_WriteStatic.");
   }
   return function_pointers_.WriteStatic(vi, channelList, state);
+}
+
+ViStatus NiDigitalLibrary::SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2)
+{
+  if (!function_pointers_.SetRuntimeEnvironment) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niDigital_SetRuntimeEnvironment.");
+  }
+  return function_pointers_.SetRuntimeEnvironment(environment, environmentVersion, reserved1, reserved2);
 }
 
 }  // namespace nidigitalpattern_grpc

--- a/generated/nidigitalpattern/nidigitalpattern_library.h
+++ b/generated/nidigitalpattern/nidigitalpattern_library.h
@@ -150,6 +150,7 @@ class NiDigitalLibrary : public nidigitalpattern_grpc::NiDigitalLibraryInterface
   ViStatus WriteSourceWaveformDataFromFileTDMS(ViSession vi, ViConstString waveformName, ViConstString waveformFilePath);
   ViStatus WriteSourceWaveformSiteUniqueU32(ViSession vi, ViConstString siteList, ViConstString waveformName, ViInt32 numWaveforms, ViInt32 samplesPerWaveform, ViUInt32 waveformData[1]);
   ViStatus WriteStatic(ViSession vi, ViConstString channelList, ViUInt8 state);
+  ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2);
 
  private:
   using AbortPtr = decltype(&niDigital_Abort);
@@ -284,6 +285,7 @@ class NiDigitalLibrary : public nidigitalpattern_grpc::NiDigitalLibraryInterface
   using WriteSourceWaveformDataFromFileTDMSPtr = decltype(&niDigital_WriteSourceWaveformDataFromFileTDMS);
   using WriteSourceWaveformSiteUniqueU32Ptr = decltype(&niDigital_WriteSourceWaveformSiteUniqueU32);
   using WriteStaticPtr = decltype(&niDigital_WriteStatic);
+  using SetRuntimeEnvironmentPtr = ViStatus (*)(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2);
 
   typedef struct FunctionPointers {
     AbortPtr Abort;
@@ -418,6 +420,7 @@ class NiDigitalLibrary : public nidigitalpattern_grpc::NiDigitalLibraryInterface
     WriteSourceWaveformDataFromFileTDMSPtr WriteSourceWaveformDataFromFileTDMS;
     WriteSourceWaveformSiteUniqueU32Ptr WriteSourceWaveformSiteUniqueU32;
     WriteStaticPtr WriteStatic;
+    SetRuntimeEnvironmentPtr SetRuntimeEnvironment;
   } FunctionLoadStatus;
 
   nidevice_grpc::SharedLibrary shared_library_;

--- a/generated/nidigitalpattern/nidigitalpattern_library_interface.h
+++ b/generated/nidigitalpattern/nidigitalpattern_library_interface.h
@@ -147,6 +147,7 @@ class NiDigitalLibraryInterface {
   virtual ViStatus WriteSourceWaveformDataFromFileTDMS(ViSession vi, ViConstString waveformName, ViConstString waveformFilePath) = 0;
   virtual ViStatus WriteSourceWaveformSiteUniqueU32(ViSession vi, ViConstString siteList, ViConstString waveformName, ViInt32 numWaveforms, ViInt32 samplesPerWaveform, ViUInt32 waveformData[1]) = 0;
   virtual ViStatus WriteStatic(ViSession vi, ViConstString channelList, ViUInt8 state) = 0;
+  virtual ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2) = 0;
 };
 
 }  // namespace nidigitalpattern_grpc

--- a/generated/nidigitalpattern/nidigitalpattern_mock_library.h
+++ b/generated/nidigitalpattern/nidigitalpattern_mock_library.h
@@ -149,6 +149,7 @@ class NiDigitalMockLibrary : public nidigitalpattern_grpc::NiDigitalLibraryInter
   MOCK_METHOD(ViStatus, WriteSourceWaveformDataFromFileTDMS, (ViSession vi, ViConstString waveformName, ViConstString waveformFilePath), (override));
   MOCK_METHOD(ViStatus, WriteSourceWaveformSiteUniqueU32, (ViSession vi, ViConstString siteList, ViConstString waveformName, ViInt32 numWaveforms, ViInt32 samplesPerWaveform, ViUInt32 waveformData[1]), (override));
   MOCK_METHOD(ViStatus, WriteStatic, (ViSession vi, ViConstString channelList, ViUInt8 state), (override));
+  MOCK_METHOD(ViStatus, SetRuntimeEnvironment, (ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2), (override));
 };
 
 }  // namespace unit

--- a/generated/nidmm/nidmm_library.cpp
+++ b/generated/nidmm/nidmm_library.cpp
@@ -110,6 +110,7 @@ NiDmmLibrary::NiDmmLibrary() : shared_library_(kLibraryName)
   function_pointers_.SetAttributeViSession = reinterpret_cast<SetAttributeViSessionPtr>(shared_library_.get_function_pointer("niDMM_SetAttributeViSession"));
   function_pointers_.SetAttributeViString = reinterpret_cast<SetAttributeViStringPtr>(shared_library_.get_function_pointer("niDMM_SetAttributeViString"));
   function_pointers_.UnlockSession = reinterpret_cast<UnlockSessionPtr>(shared_library_.get_function_pointer("niDMM_UnlockSession"));
+  function_pointers_.SetRuntimeEnvironment = reinterpret_cast<SetRuntimeEnvironmentPtr>(shared_library_.get_function_pointer("niDMM_SetRuntimeEnvironment"));
 }
 
 NiDmmLibrary::~NiDmmLibrary()
@@ -833,6 +834,14 @@ ViStatus NiDmmLibrary::UnlockSession(ViSession vi, ViBoolean* callerHasLock)
     throw nidevice_grpc::LibraryLoadException("Could not find niDMM_UnlockSession.");
   }
   return function_pointers_.UnlockSession(vi, callerHasLock);
+}
+
+ViStatus NiDmmLibrary::SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2)
+{
+  if (!function_pointers_.SetRuntimeEnvironment) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niDMM_SetRuntimeEnvironment.");
+  }
+  return function_pointers_.SetRuntimeEnvironment(environment, environmentVersion, reserved1, reserved2);
 }
 
 }  // namespace nidmm_grpc

--- a/generated/nidmm/nidmm_library.h
+++ b/generated/nidmm/nidmm_library.h
@@ -107,6 +107,7 @@ class NiDmmLibrary : public nidmm_grpc::NiDmmLibraryInterface {
   ViStatus SetAttributeViSession(ViSession vi, ViConstString channelName, ViAttr attributeId, ViSession attributeValue);
   ViStatus SetAttributeViString(ViSession vi, ViConstString channelName, ViAttr attributeId, ViString attributeValue);
   ViStatus UnlockSession(ViSession vi, ViBoolean* callerHasLock);
+  ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2);
 
  private:
   using AbortPtr = decltype(&niDMM_Abort);
@@ -198,6 +199,7 @@ class NiDmmLibrary : public nidmm_grpc::NiDmmLibraryInterface {
   using SetAttributeViSessionPtr = decltype(&niDMM_SetAttributeViSession);
   using SetAttributeViStringPtr = decltype(&niDMM_SetAttributeViString);
   using UnlockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
+  using SetRuntimeEnvironmentPtr = ViStatus (*)(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2);
 
   typedef struct FunctionPointers {
     AbortPtr Abort;
@@ -289,6 +291,7 @@ class NiDmmLibrary : public nidmm_grpc::NiDmmLibraryInterface {
     SetAttributeViSessionPtr SetAttributeViSession;
     SetAttributeViStringPtr SetAttributeViString;
     UnlockSessionPtr UnlockSession;
+    SetRuntimeEnvironmentPtr SetRuntimeEnvironment;
   } FunctionLoadStatus;
 
   nidevice_grpc::SharedLibrary shared_library_;

--- a/generated/nidmm/nidmm_library_interface.h
+++ b/generated/nidmm/nidmm_library_interface.h
@@ -104,6 +104,7 @@ class NiDmmLibraryInterface {
   virtual ViStatus SetAttributeViSession(ViSession vi, ViConstString channelName, ViAttr attributeId, ViSession attributeValue) = 0;
   virtual ViStatus SetAttributeViString(ViSession vi, ViConstString channelName, ViAttr attributeId, ViString attributeValue) = 0;
   virtual ViStatus UnlockSession(ViSession vi, ViBoolean* callerHasLock) = 0;
+  virtual ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2) = 0;
 };
 
 }  // namespace nidmm_grpc

--- a/generated/nidmm/nidmm_mock_library.h
+++ b/generated/nidmm/nidmm_mock_library.h
@@ -106,6 +106,7 @@ class NiDmmMockLibrary : public nidmm_grpc::NiDmmLibraryInterface {
   MOCK_METHOD(ViStatus, SetAttributeViSession, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViSession attributeValue), (override));
   MOCK_METHOD(ViStatus, SetAttributeViString, (ViSession vi, ViConstString channelName, ViAttr attributeId, ViString attributeValue), (override));
   MOCK_METHOD(ViStatus, UnlockSession, (ViSession vi, ViBoolean* callerHasLock), (override));
+  MOCK_METHOD(ViStatus, SetRuntimeEnvironment, (ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2), (override));
 };
 
 }  // namespace unit

--- a/generated/nifake/nifake_library.cpp
+++ b/generated/nifake/nifake_library.cpp
@@ -114,6 +114,7 @@ NiFakeLibrary::NiFakeLibrary() : shared_library_(kLibraryName)
   function_pointers_.ViUInt8ArrayInputFunction = reinterpret_cast<ViUInt8ArrayInputFunctionPtr>(shared_library_.get_function_pointer("niFake_ViUInt8ArrayInputFunction"));
   function_pointers_.ViUInt8ArrayOutputFunction = reinterpret_cast<ViUInt8ArrayOutputFunctionPtr>(shared_library_.get_function_pointer("niFake_ViUInt8ArrayOutputFunction"));
   function_pointers_.WriteWaveform = reinterpret_cast<WriteWaveformPtr>(shared_library_.get_function_pointer("niFake_WriteWaveform"));
+  function_pointers_.SetRuntimeEnvironment = reinterpret_cast<SetRuntimeEnvironmentPtr>(shared_library_.get_function_pointer("niFake_SetRuntimeEnvironment"));
 }
 
 NiFakeLibrary::~NiFakeLibrary()
@@ -869,6 +870,14 @@ ViStatus NiFakeLibrary::WriteWaveform(ViSession vi, ViInt32 numberOfSamples, ViR
     throw nidevice_grpc::LibraryLoadException("Could not find niFake_WriteWaveform.");
   }
   return function_pointers_.WriteWaveform(vi, numberOfSamples, waveform);
+}
+
+ViStatus NiFakeLibrary::SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2)
+{
+  if (!function_pointers_.SetRuntimeEnvironment) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFake_SetRuntimeEnvironment.");
+  }
+  return function_pointers_.SetRuntimeEnvironment(environment, environmentVersion, reserved1, reserved2);
 }
 
 }  // namespace nifake_grpc

--- a/generated/nifake/nifake_library.h
+++ b/generated/nifake/nifake_library.h
@@ -111,6 +111,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   ViStatus ViUInt8ArrayInputFunction(ViSession vi, ViInt32 numberOfElements, ViUInt8 anArray[]);
   ViStatus ViUInt8ArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViUInt8 anArray[]);
   ViStatus WriteWaveform(ViSession vi, ViInt32 numberOfSamples, ViReal64 waveform[]);
+  ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2);
 
  private:
   using AbortPtr = decltype(&niFake_Abort);
@@ -206,6 +207,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
   using ViUInt8ArrayInputFunctionPtr = decltype(&niFake_ViUInt8ArrayInputFunction);
   using ViUInt8ArrayOutputFunctionPtr = decltype(&niFake_ViUInt8ArrayOutputFunction);
   using WriteWaveformPtr = decltype(&niFake_WriteWaveform);
+  using SetRuntimeEnvironmentPtr = ViStatus (*)(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2);
 
   typedef struct FunctionPointers {
     AbortPtr Abort;
@@ -301,6 +303,7 @@ class NiFakeLibrary : public nifake_grpc::NiFakeLibraryInterface {
     ViUInt8ArrayInputFunctionPtr ViUInt8ArrayInputFunction;
     ViUInt8ArrayOutputFunctionPtr ViUInt8ArrayOutputFunction;
     WriteWaveformPtr WriteWaveform;
+    SetRuntimeEnvironmentPtr SetRuntimeEnvironment;
   } FunctionLoadStatus;
 
   nidevice_grpc::SharedLibrary shared_library_;

--- a/generated/nifake/nifake_library_interface.h
+++ b/generated/nifake/nifake_library_interface.h
@@ -108,6 +108,7 @@ class NiFakeLibraryInterface {
   virtual ViStatus ViUInt8ArrayInputFunction(ViSession vi, ViInt32 numberOfElements, ViUInt8 anArray[]) = 0;
   virtual ViStatus ViUInt8ArrayOutputFunction(ViSession vi, ViInt32 numberOfElements, ViUInt8 anArray[]) = 0;
   virtual ViStatus WriteWaveform(ViSession vi, ViInt32 numberOfSamples, ViReal64 waveform[]) = 0;
+  virtual ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2) = 0;
 };
 
 }  // namespace nifake_grpc

--- a/generated/nifake/nifake_mock_library.h
+++ b/generated/nifake/nifake_mock_library.h
@@ -110,6 +110,7 @@ class NiFakeMockLibrary : public nifake_grpc::NiFakeLibraryInterface {
   MOCK_METHOD(ViStatus, ViUInt8ArrayInputFunction, (ViSession vi, ViInt32 numberOfElements, ViUInt8 anArray[]), (override));
   MOCK_METHOD(ViStatus, ViUInt8ArrayOutputFunction, (ViSession vi, ViInt32 numberOfElements, ViUInt8 anArray[]), (override));
   MOCK_METHOD(ViStatus, WriteWaveform, (ViSession vi, ViInt32 numberOfSamples, ViReal64 waveform[]), (override));
+  MOCK_METHOD(ViStatus, SetRuntimeEnvironment, (ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2), (override));
 };
 
 }  // namespace unit

--- a/generated/nifgen/nifgen_library.cpp
+++ b/generated/nifgen/nifgen_library.cpp
@@ -154,6 +154,7 @@ NiFgenLibrary::NiFgenLibrary() : shared_library_(kLibraryName)
   function_pointers_.WriteScript = reinterpret_cast<WriteScriptPtr>(shared_library_.get_function_pointer("niFgen_WriteScript"));
   function_pointers_.WriteWaveform = reinterpret_cast<WriteWaveformPtr>(shared_library_.get_function_pointer("niFgen_WriteWaveform"));
   function_pointers_.WriteWaveformComplexF64 = reinterpret_cast<WriteWaveformComplexF64Ptr>(shared_library_.get_function_pointer("niFgen_WriteWaveformComplexF64"));
+  function_pointers_.SetRuntimeEnvironment = reinterpret_cast<SetRuntimeEnvironmentPtr>(shared_library_.get_function_pointer("niFgen_SetRuntimeEnvironment"));
 }
 
 NiFgenLibrary::~NiFgenLibrary()
@@ -1229,6 +1230,14 @@ ViStatus NiFgenLibrary::WriteWaveformComplexF64(ViSession vi, ViConstString chan
     throw nidevice_grpc::LibraryLoadException("Could not find niFgen_WriteWaveformComplexF64.");
   }
   return function_pointers_.WriteWaveformComplexF64(vi, channelName, numberOfSamples, data, waveformHandle);
+}
+
+ViStatus NiFgenLibrary::SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2)
+{
+  if (!function_pointers_.SetRuntimeEnvironment) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niFgen_SetRuntimeEnvironment.");
+  }
+  return function_pointers_.SetRuntimeEnvironment(environment, environmentVersion, reserved1, reserved2);
 }
 
 }  // namespace nifgen_grpc

--- a/generated/nifgen/nifgen_library.h
+++ b/generated/nifgen/nifgen_library.h
@@ -151,6 +151,7 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   ViStatus WriteScript(ViSession vi, ViConstString channelName, ViConstString script);
   ViStatus WriteWaveform(ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 size, ViReal64 data[]);
   ViStatus WriteWaveformComplexF64(ViSession vi, ViConstString channelName, ViInt32 numberOfSamples, NIComplexNumber_struct data[], ViInt32 waveformHandle);
+  ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2);
 
  private:
   using AbortGenerationPtr = decltype(&niFgen_AbortGeneration);
@@ -286,6 +287,7 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   using WriteScriptPtr = decltype(&niFgen_WriteScript);
   using WriteWaveformPtr = decltype(&niFgen_WriteWaveform);
   using WriteWaveformComplexF64Ptr = decltype(&niFgen_WriteWaveformComplexF64);
+  using SetRuntimeEnvironmentPtr = ViStatus (*)(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2);
 
   typedef struct FunctionPointers {
     AbortGenerationPtr AbortGeneration;
@@ -421,6 +423,7 @@ class NiFgenLibrary : public nifgen_grpc::NiFgenLibraryInterface {
     WriteScriptPtr WriteScript;
     WriteWaveformPtr WriteWaveform;
     WriteWaveformComplexF64Ptr WriteWaveformComplexF64;
+    SetRuntimeEnvironmentPtr SetRuntimeEnvironment;
   } FunctionLoadStatus;
 
   nidevice_grpc::SharedLibrary shared_library_;

--- a/generated/nifgen/nifgen_library_interface.h
+++ b/generated/nifgen/nifgen_library_interface.h
@@ -148,6 +148,7 @@ class NiFgenLibraryInterface {
   virtual ViStatus WriteScript(ViSession vi, ViConstString channelName, ViConstString script) = 0;
   virtual ViStatus WriteWaveform(ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 size, ViReal64 data[]) = 0;
   virtual ViStatus WriteWaveformComplexF64(ViSession vi, ViConstString channelName, ViInt32 numberOfSamples, NIComplexNumber_struct data[], ViInt32 waveformHandle) = 0;
+  virtual ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2) = 0;
 };
 
 }  // namespace nifgen_grpc

--- a/generated/nifgen/nifgen_mock_library.h
+++ b/generated/nifgen/nifgen_mock_library.h
@@ -150,6 +150,7 @@ class NiFgenMockLibrary : public nifgen_grpc::NiFgenLibraryInterface {
   MOCK_METHOD(ViStatus, WriteScript, (ViSession vi, ViConstString channelName, ViConstString script), (override));
   MOCK_METHOD(ViStatus, WriteWaveform, (ViSession vi, ViConstString channelName, ViInt32 waveformHandle, ViInt32 size, ViReal64 data[]), (override));
   MOCK_METHOD(ViStatus, WriteWaveformComplexF64, (ViSession vi, ViConstString channelName, ViInt32 numberOfSamples, NIComplexNumber_struct data[], ViInt32 waveformHandle), (override));
+  MOCK_METHOD(ViStatus, SetRuntimeEnvironment, (ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2), (override));
 };
 
 }  // namespace unit

--- a/generated/niscope/niscope_library.cpp
+++ b/generated/niscope/niscope_library.cpp
@@ -113,6 +113,7 @@ NiScopeLibrary::NiScopeLibrary() : shared_library_(kLibraryName)
   function_pointers_.SetAttributeViSession = reinterpret_cast<SetAttributeViSessionPtr>(shared_library_.get_function_pointer("niScope_SetAttributeViSession"));
   function_pointers_.SetAttributeViString = reinterpret_cast<SetAttributeViStringPtr>(shared_library_.get_function_pointer("niScope_SetAttributeViString"));
   function_pointers_.UnlockSession = reinterpret_cast<UnlockSessionPtr>(shared_library_.get_function_pointer("niScope_UnlockSession"));
+  function_pointers_.SetRuntimeEnvironment = reinterpret_cast<SetRuntimeEnvironmentPtr>(shared_library_.get_function_pointer("niScope_SetRuntimeEnvironment"));
 }
 
 NiScopeLibrary::~NiScopeLibrary()
@@ -860,6 +861,14 @@ ViStatus NiScopeLibrary::UnlockSession(ViSession vi, ViBoolean* callerHasLock)
     throw nidevice_grpc::LibraryLoadException("Could not find niScope_UnlockSession.");
   }
   return function_pointers_.UnlockSession(vi, callerHasLock);
+}
+
+ViStatus NiScopeLibrary::SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2)
+{
+  if (!function_pointers_.SetRuntimeEnvironment) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niScope_SetRuntimeEnvironment.");
+  }
+  return function_pointers_.SetRuntimeEnvironment(environment, environmentVersion, reserved1, reserved2);
 }
 
 }  // namespace niscope_grpc

--- a/generated/niscope/niscope_library.h
+++ b/generated/niscope/niscope_library.h
@@ -110,6 +110,7 @@ class NiScopeLibrary : public niscope_grpc::NiScopeLibraryInterface {
   ViStatus SetAttributeViSession(ViSession vi, ViConstString channelList, ViAttr attributeId, ViSession value);
   ViStatus SetAttributeViString(ViSession vi, ViConstString channelList, ViAttr attributeId, ViConstString value);
   ViStatus UnlockSession(ViSession vi, ViBoolean* callerHasLock);
+  ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2);
 
  private:
   using AbortPtr = decltype(&niScope_Abort);
@@ -204,6 +205,7 @@ class NiScopeLibrary : public niscope_grpc::NiScopeLibraryInterface {
   using SetAttributeViSessionPtr = decltype(&niScope_SetAttributeViSession);
   using SetAttributeViStringPtr = decltype(&niScope_SetAttributeViString);
   using UnlockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
+  using SetRuntimeEnvironmentPtr = ViStatus (*)(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2);
 
   typedef struct FunctionPointers {
     AbortPtr Abort;
@@ -298,6 +300,7 @@ class NiScopeLibrary : public niscope_grpc::NiScopeLibraryInterface {
     SetAttributeViSessionPtr SetAttributeViSession;
     SetAttributeViStringPtr SetAttributeViString;
     UnlockSessionPtr UnlockSession;
+    SetRuntimeEnvironmentPtr SetRuntimeEnvironment;
   } FunctionLoadStatus;
 
   nidevice_grpc::SharedLibrary shared_library_;

--- a/generated/niscope/niscope_library_interface.h
+++ b/generated/niscope/niscope_library_interface.h
@@ -107,6 +107,7 @@ class NiScopeLibraryInterface {
   virtual ViStatus SetAttributeViSession(ViSession vi, ViConstString channelList, ViAttr attributeId, ViSession value) = 0;
   virtual ViStatus SetAttributeViString(ViSession vi, ViConstString channelList, ViAttr attributeId, ViConstString value) = 0;
   virtual ViStatus UnlockSession(ViSession vi, ViBoolean* callerHasLock) = 0;
+  virtual ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2) = 0;
 };
 
 }  // namespace niscope_grpc

--- a/generated/niscope/niscope_mock_library.h
+++ b/generated/niscope/niscope_mock_library.h
@@ -109,6 +109,7 @@ class NiScopeMockLibrary : public niscope_grpc::NiScopeLibraryInterface {
   MOCK_METHOD(ViStatus, SetAttributeViSession, (ViSession vi, ViConstString channelList, ViAttr attributeId, ViSession value), (override));
   MOCK_METHOD(ViStatus, SetAttributeViString, (ViSession vi, ViConstString channelList, ViAttr attributeId, ViConstString value), (override));
   MOCK_METHOD(ViStatus, UnlockSession, (ViSession vi, ViBoolean* callerHasLock), (override));
+  MOCK_METHOD(ViStatus, SetRuntimeEnvironment, (ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2), (override));
 };
 
 }  // namespace unit

--- a/generated/niswitch/niswitch_library.cpp
+++ b/generated/niswitch/niswitch_library.cpp
@@ -83,6 +83,7 @@ NiSwitchLibrary::NiSwitchLibrary() : shared_library_(kLibraryName)
   function_pointers_.UnlockSession = reinterpret_cast<UnlockSessionPtr>(shared_library_.get_function_pointer("niSwitch_UnlockSession"));
   function_pointers_.WaitForDebounce = reinterpret_cast<WaitForDebouncePtr>(shared_library_.get_function_pointer("niSwitch_WaitForDebounce"));
   function_pointers_.WaitForScanComplete = reinterpret_cast<WaitForScanCompletePtr>(shared_library_.get_function_pointer("niSwitch_WaitForScanComplete"));
+  function_pointers_.SetRuntimeEnvironment = reinterpret_cast<SetRuntimeEnvironmentPtr>(shared_library_.get_function_pointer("niSwitch_SetRuntimeEnvironment"));
 }
 
 NiSwitchLibrary::~NiSwitchLibrary()
@@ -590,6 +591,14 @@ ViStatus NiSwitchLibrary::WaitForScanComplete(ViSession vi, ViInt32 maximumTimeM
     throw nidevice_grpc::LibraryLoadException("Could not find niSwitch_WaitForScanComplete.");
   }
   return function_pointers_.WaitForScanComplete(vi, maximumTimeMs);
+}
+
+ViStatus NiSwitchLibrary::SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2)
+{
+  if (!function_pointers_.SetRuntimeEnvironment) {
+    throw nidevice_grpc::LibraryLoadException("Could not find niSwitch_SetRuntimeEnvironment.");
+  }
+  return function_pointers_.SetRuntimeEnvironment(environment, environmentVersion, reserved1, reserved2);
 }
 
 }  // namespace niswitch_grpc

--- a/generated/niswitch/niswitch_library.h
+++ b/generated/niswitch/niswitch_library.h
@@ -80,6 +80,7 @@ class NiSwitchLibrary : public niswitch_grpc::NiSwitchLibraryInterface {
   ViStatus UnlockSession(ViSession vi, ViBoolean* callerHasLock);
   ViStatus WaitForDebounce(ViSession vi, ViInt32 maximumTimeMs);
   ViStatus WaitForScanComplete(ViSession vi, ViInt32 maximumTimeMs);
+  ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2);
 
  private:
   using AbortScanPtr = decltype(&niSwitch_AbortScan);
@@ -144,6 +145,7 @@ class NiSwitchLibrary : public niswitch_grpc::NiSwitchLibraryInterface {
   using UnlockSessionPtr = ViStatus (*)(ViSession vi, ViBoolean* callerHasLock);
   using WaitForDebouncePtr = decltype(&niSwitch_WaitForDebounce);
   using WaitForScanCompletePtr = decltype(&niSwitch_WaitForScanComplete);
+  using SetRuntimeEnvironmentPtr = ViStatus (*)(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2);
 
   typedef struct FunctionPointers {
     AbortScanPtr AbortScan;
@@ -208,6 +210,7 @@ class NiSwitchLibrary : public niswitch_grpc::NiSwitchLibraryInterface {
     UnlockSessionPtr UnlockSession;
     WaitForDebouncePtr WaitForDebounce;
     WaitForScanCompletePtr WaitForScanComplete;
+    SetRuntimeEnvironmentPtr SetRuntimeEnvironment;
   } FunctionLoadStatus;
 
   nidevice_grpc::SharedLibrary shared_library_;

--- a/generated/niswitch/niswitch_library_interface.h
+++ b/generated/niswitch/niswitch_library_interface.h
@@ -77,6 +77,7 @@ class NiSwitchLibraryInterface {
   virtual ViStatus UnlockSession(ViSession vi, ViBoolean* callerHasLock) = 0;
   virtual ViStatus WaitForDebounce(ViSession vi, ViInt32 maximumTimeMs) = 0;
   virtual ViStatus WaitForScanComplete(ViSession vi, ViInt32 maximumTimeMs) = 0;
+  virtual ViStatus SetRuntimeEnvironment(ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2) = 0;
 };
 
 }  // namespace niswitch_grpc

--- a/generated/niswitch/niswitch_mock_library.h
+++ b/generated/niswitch/niswitch_mock_library.h
@@ -79,6 +79,7 @@ class NiSwitchMockLibrary : public niswitch_grpc::NiSwitchLibraryInterface {
   MOCK_METHOD(ViStatus, UnlockSession, (ViSession vi, ViBoolean* callerHasLock), (override));
   MOCK_METHOD(ViStatus, WaitForDebounce, (ViSession vi, ViInt32 maximumTimeMs), (override));
   MOCK_METHOD(ViStatus, WaitForScanComplete, (ViSession vi, ViInt32 maximumTimeMs), (override));
+  MOCK_METHOD(ViStatus, SetRuntimeEnvironment, (ViConstString environment, ViConstString environmentVersion, ViConstString reserved1, ViConstString reserved2), (override));
 };
 
 }  // namespace unit

--- a/source/codegen/metadata/nidcpower/__init__.py
+++ b/source/codegen/metadata/nidcpower/__init__.py
@@ -1,6 +1,9 @@
 from .functions import functions
+from .functions_addon import functions_override_metadata
 from .attributes import attributes
+from .attributes_addon import attributes_override_metadata
 from .enums import enums
+from .enums_addon import enums_override_metadata
 from .config import config
 
 metadata = {
@@ -9,3 +12,7 @@ metadata = {
     "enums" : enums,
     "config" : config
 }
+
+metadata['functions'].update(functions_override_metadata)
+metadata['attributes'].update(attributes_override_metadata)
+metadata['enums'].update(enums_override_metadata)

--- a/source/codegen/metadata/nidcpower/functions_addon.py
+++ b/source/codegen/metadata/nidcpower/functions_addon.py
@@ -2,4 +2,38 @@
 # Changes to the metadata should be made here, because functions.py is generated thus any changes get overwritten.
 
 functions_override_metadata = {
+    'SetRuntimeEnvironment': {
+        'codegen_method': 'private',
+        'parameters': [
+            {
+                'cppName': 'environment',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'environment',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'environmentVersion',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'environmentVersion',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'reserved1',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'reserved1',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'reserved2',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'reserved2',
+                'type': 'ViConstString'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
 }

--- a/source/codegen/metadata/nidigitalpattern/__init__.py
+++ b/source/codegen/metadata/nidigitalpattern/__init__.py
@@ -1,7 +1,10 @@
 from .functions import functions
+from .functions_addon import functions_override_metadata
 from .functions_addon import functions_validation_suppressions
 from .attributes import attributes
+from .attributes_addon import attributes_override_metadata
 from .enums import enums
+from .enums_addon import enums_override_metadata
 from .config import config
 
 metadata = {
@@ -11,3 +14,7 @@ metadata = {
     "enums" : enums,
     "config" : config
 }
+
+metadata['functions'].update(functions_override_metadata)
+metadata['attributes'].update(attributes_override_metadata)
+metadata['enums'].update(enums_override_metadata)

--- a/source/codegen/metadata/nidigitalpattern/functions_addon.py
+++ b/source/codegen/metadata/nidigitalpattern/functions_addon.py
@@ -2,6 +2,40 @@
 # Changes to the metadata should be made here, because functions.py is generated thus any changes get overwritten.
 
 functions_override_metadata = {
+    'SetRuntimeEnvironment': {
+        'codegen_method': 'private',
+        'parameters': [
+            {
+                'cppName': 'environment',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'environment',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'environmentVersion',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'environmentVersion',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'reserved1',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'reserved1',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'reserved2',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'reserved2',
+                'type': 'ViConstString'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
 }
 
 functions_validation_suppressions = {

--- a/source/codegen/metadata/nidmm/__init__.py
+++ b/source/codegen/metadata/nidmm/__init__.py
@@ -1,6 +1,9 @@
 from .functions import functions
+from .functions_addon import functions_override_metadata
 from .attributes import attributes
+from .attributes_addon import attributes_override_metadata
 from .enums import enums
+from .enums_addon import enums_override_metadata
 from .config import config
 
 metadata = {
@@ -9,3 +12,7 @@ metadata = {
     "enums" : enums,
     "config" : config
 }
+
+metadata['functions'].update(functions_override_metadata)
+metadata['attributes'].update(attributes_override_metadata)
+metadata['enums'].update(enums_override_metadata)

--- a/source/codegen/metadata/nidmm/functions_addon.py
+++ b/source/codegen/metadata/nidmm/functions_addon.py
@@ -2,6 +2,40 @@
 # Changes to the metadata should be made here, because functions.py is generated thus any changes get overwritten.
 
 functions_override_metadata = {
+    'SetRuntimeEnvironment': {
+        'codegen_method': 'private',
+        'parameters': [
+            {
+                'cppName': 'environment',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'environment',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'environmentVersion',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'environmentVersion',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'reserved1',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'reserved1',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'reserved2',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'reserved2',
+                'type': 'ViConstString'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
 }
 
 

--- a/source/codegen/metadata/nifake/__init__.py
+++ b/source/codegen/metadata/nifake/__init__.py
@@ -1,7 +1,10 @@
 from .functions import functions
+from .functions_addon import functions_override_metadata
 from .functions_addon import functions_validation_suppressions
 from .attributes import attributes
+from .attributes_addon import attributes_override_metadata
 from .enums import enums
+from .enums_addon import enums_override_metadata
 from .config import config
 
 metadata = {
@@ -11,3 +14,7 @@ metadata = {
     "enums" : enums,
     "config" : config
 }
+
+metadata['functions'].update(functions_override_metadata)
+metadata['attributes'].update(attributes_override_metadata)
+metadata['enums'].update(enums_override_metadata)

--- a/source/codegen/metadata/nifake/functions_addon.py
+++ b/source/codegen/metadata/nifake/functions_addon.py
@@ -2,6 +2,40 @@
 # Changes to the metadata should be made here, because functions.py is generated thus any changes get overwritten.
 
 functions_override_metadata = {
+    'SetRuntimeEnvironment': {
+        'codegen_method': 'private',
+        'parameters': [
+            {
+                'cppName': 'environment',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'environment',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'environmentVersion',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'environmentVersion',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'reserved1',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'reserved1',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'reserved2',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'reserved2',
+                'type': 'ViConstString'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
 }
 
 functions_validation_suppressions = {

--- a/source/codegen/metadata/nifgen/__init__.py
+++ b/source/codegen/metadata/nifgen/__init__.py
@@ -1,6 +1,9 @@
 from .functions import functions
+from .functions_addon import functions_override_metadata
 from .attributes import attributes
+from .attributes_addon import attributes_override_metadata
 from .enums import enums
+from .enums_addon import enums_override_metadata
 from .enums_addon import enums_validation_suppressions
 from .config import config
 
@@ -10,4 +13,8 @@ metadata = {
     "enums" : enums,
     "enums_validation_suppressions": enums_validation_suppressions,
     "config" : config
-} 
+}
+
+metadata['functions'].update(functions_override_metadata)
+metadata['attributes'].update(attributes_override_metadata)
+metadata['enums'].update(enums_override_metadata)

--- a/source/codegen/metadata/nifgen/functions_addon.py
+++ b/source/codegen/metadata/nifgen/functions_addon.py
@@ -2,6 +2,40 @@
 # Changes to the metadata should be made here, because functions.py is generated thus any changes get overwritten.
 
 functions_override_metadata = {
+    'SetRuntimeEnvironment': {
+        'codegen_method': 'private',
+        'parameters': [
+            {
+                'cppName': 'environment',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'environment',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'environmentVersion',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'environmentVersion',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'reserved1',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'reserved1',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'reserved2',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'reserved2',
+                'type': 'ViConstString'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
 }
 
 

--- a/source/codegen/metadata/niscope/__init__.py
+++ b/source/codegen/metadata/niscope/__init__.py
@@ -1,6 +1,9 @@
 from .functions import functions
+from .functions_addon import functions_override_metadata
 from .attributes import attributes
+from .attributes_addon import attributes_override_metadata
 from .enums import enums
+from .enums_addon import enums_override_metadata
 from .enums_addon import enums_validation_suppressions
 from .config import config
 
@@ -11,3 +14,7 @@ metadata = {
     "enums_validation_suppressions": enums_validation_suppressions,
     "config" : config
 }
+
+metadata['functions'].update(functions_override_metadata)
+metadata['attributes'].update(attributes_override_metadata)
+metadata['enums'].update(enums_override_metadata)

--- a/source/codegen/metadata/niscope/functions_addon.py
+++ b/source/codegen/metadata/niscope/functions_addon.py
@@ -2,4 +2,38 @@
 # Changes to the metadata should be made here, because functions.py is generated thus any changes get overwritten.
 
 functions_override_metadata = {
+    'SetRuntimeEnvironment': {
+        'codegen_method': 'private',
+        'parameters': [
+            {
+                'cppName': 'environment',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'environment',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'environmentVersion',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'environmentVersion',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'reserved1',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'reserved1',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'reserved2',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'reserved2',
+                'type': 'ViConstString'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
 }

--- a/source/codegen/metadata/niswitch/__init__.py
+++ b/source/codegen/metadata/niswitch/__init__.py
@@ -1,6 +1,9 @@
 from .functions import functions
+from .functions_addon import functions_override_metadata
 from .attributes import attributes
+from .attributes_addon import attributes_override_metadata
 from .enums import enums
+from .enums_addon import enums_override_metadata
 from .config import config
 
 metadata = {
@@ -9,3 +12,7 @@ metadata = {
     "enums" : enums,
     "config" : config
 }
+
+metadata['functions'].update(functions_override_metadata)
+metadata['attributes'].update(attributes_override_metadata)
+metadata['enums'].update(enums_override_metadata)

--- a/source/codegen/metadata/niswitch/functions_addon.py
+++ b/source/codegen/metadata/niswitch/functions_addon.py
@@ -2,6 +2,40 @@
 # Changes to the metadata should be made here, because functions.py is generated thus any changes get overwritten.
 
 functions_override_metadata = {
+    'SetRuntimeEnvironment': {
+        'codegen_method': 'private',
+        'parameters': [
+            {
+                'cppName': 'environment',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'environment',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'environmentVersion',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'environmentVersion',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'reserved1',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'reserved1',
+                'type': 'ViConstString'
+            },
+            {
+                'cppName': 'reserved2',
+                'direction': 'in',
+                'grpc_type': 'string',
+                'name': 'reserved2',
+                'type': 'ViConstString'
+            }
+        ],
+        'returns': 'ViStatus'
+    },
 }
 
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add SetRuntimeEnvironment to the library classes for all MI Drivers and NI-Fake

Implemented via the following changes:
* Update `source/codegen/metadata/<driver>/functions_addon.py` to privately add the SetRuntimeEnvironment function for all MI drivers and NI-Fake
* Update `source/codegen/metadata/<driver>/__init__.py` so that the new metadata will be merged. I merged metadata for attributes, functions and enums. config_addon.py had overrides that were not in use, so I did not merge them. They are most likely copy-pasta from nimi-python.
* Regenerate

Although I could include use official metadata exports, now that internal metadata is updated, that may include other changes. This way is more surgical.

Partially addresses #960

### Why should this Pull Request be merged?

As developers, we want to know how much nigrpc_device_server is used and which versions.
Adding SetRuntimeEnvironment to our library classes is the first step. It's already been tested for NI-DCPower via #962  

### What testing has been done?

Tested NI-DCPower via #962 