### PR TITLE
Switch some nifgen tests to use 5433 to help with intermittent failures

### DIFF
--- a/source/tests/system/nifgen_driver_api_tests.cpp
+++ b/source/tests/system/nifgen_driver_api_tests.cpp
@@ -62,7 +62,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
     fgen::InitializeWithChannelsRequest request;
     request.set_channel_name("");
     request.set_resource_name("FakeDevice");
-    request.set_option_string("Simulate=1, DriverSetup=Model:5433;BoardType:PXI");
+    request.set_option_string("Simulate=1, DriverSetup=Model:5441;BoardType:PXI");
     request.set_reset_device(false);
     fgen::InitializeWithChannelsResponse response;
 

--- a/source/tests/system/nifgen_driver_api_tests.cpp
+++ b/source/tests/system/nifgen_driver_api_tests.cpp
@@ -62,7 +62,7 @@ class NiFgenDriverApiTest : public ::testing::Test {
     fgen::InitializeWithChannelsRequest request;
     request.set_channel_name("");
     request.set_resource_name("FakeDevice");
-    request.set_option_string("Simulate=1, DriverSetup=Model:5441;BoardType:PXI");
+    request.set_option_string("Simulate=1, DriverSetup=Model:5433;BoardType:PXI");
     request.set_reset_device(false);
     fgen::InitializeWithChannelsResponse response;
 

--- a/source/tests/system/nifgen_session_tests.cpp
+++ b/source/tests/system/nifgen_session_tests.cpp
@@ -17,7 +17,7 @@ const int kInvalidFgenSession = -1074130544;
 const char* kViErrorFgenResourceNotFoundMessage = "Insufficient location information or resource not present in the system.\n\nInvalid Identifier: ";
 const char* kInvalidFgenSessionMessage = "The session handle is not valid.";
 const char* kTestFgenRsrc = "FakeDevice";
-const char* kFgenOptionsString = "Simulate=1, DriverSetup=Model:5421; BoardType:PXI";
+const char* kFgenOptionsString = "Simulate=1, DriverSetup=Model:5433; BoardType:PXI";
 const char* kFgenTestSession = "SessionName";
 const char* kTestInvalidFgenRsrc = "";
 

--- a/source/tests/system/nifgen_session_tests.cpp
+++ b/source/tests/system/nifgen_session_tests.cpp
@@ -17,7 +17,7 @@ const int kInvalidFgenSession = -1074130544;
 const char* kViErrorFgenResourceNotFoundMessage = "Insufficient location information or resource not present in the system.\n\nInvalid Identifier: ";
 const char* kInvalidFgenSessionMessage = "The session handle is not valid.";
 const char* kTestFgenRsrc = "FakeDevice";
-const char* kFgenOptionsString = "Simulate=1, DriverSetup=Model:5433; BoardType:PXI";
+const char* kFgenOptionsString = "Simulate=1, DriverSetup=Model:5433 (2CH); BoardType:PXI";
 const char* kFgenTestSession = "SessionName";
 const char* kTestInvalidFgenRsrc = "";
 


### PR DESCRIPTION
### What does this Pull Request accomplish?
NiFgenSessionTests has had tests fail with the following. Using a 5433 is expected to help mitigate these issues as it uses a different process to create its simulated devices.
```
unknown file: Failure
C++ exception with description "MAX:  (Hex 0x80040303) Internal error: The requested object was not found in the configuration database. Please note the steps you performed that led to this error and contact technical support at http://ni.com/support.

Component Name: 
File Name: 
Line Number: 0

Status Code: -2147220733" thrown in the test body.
```


### Why should this Pull Request be merged?

Close #951 

### What testing has been done?

Ran all tests locally with no failures.
