### PR TITLE
Use EXPECT_NEAR in NiRFmxLTEDriverApiTest to mitigate intermittent te…

### DIFF
--- a/source/tests/system/nirfmxlte_driver_api_tests.cpp
+++ b/source/tests/system/nirfmxlte_driver_api_tests.cpp
@@ -319,7 +319,10 @@ TEST_F(NiRFmxLTEDriverApiTests, NBIotAcpFromExample_FetchData_DataLooksReasonabl
   EXPECT_EQ(2, acp_fetch_offset_measurement_array_response.upper_absolute_power().size());
   EXPECT_GT(0.0, acp_fetch_offset_measurement_array_response.upper_absolute_power(0));
   EXPECT_LT(0.0, acp_fetch_component_carrier_measurement_response.absolute_power());
-  EXPECT_EQ(0.0, acp_fetch_component_carrier_measurement_response.relative_power());
+  // There have been intermittent instances where the relative_power returned
+  // isn't absolutely 0.0 from the driver. When this happens it doesn't appear to affect
+  // any of the other tests.
+  EXPECT_NEAR(0.0, acp_fetch_component_carrier_measurement_response.relative_power(), 0.001);
   EXPECT_LT(0.0, acp_fetch_absolute_powers_trace_response.x0());
   EXPECT_LT(0.0, acp_fetch_absolute_powers_trace_response.dx());
   EXPECT_EQ(2, acp_fetch_absolute_powers_trace_response.absolute_powers_trace_size());


### PR DESCRIPTION
…st failure

### What does this Pull Request accomplish?
Mitigate intermittent test failure of `NiRFmxLTEDriverApiTests.NBIotAcpFromExample_FetchData_DataLooksReasonable`.
It appears that the driver will sometimes report a value near 0 but not exactly zero. Using EXPECT_NEAR should help with this.  When the value is not absolutely zero this does not appear to affect the reliability of the other test values.

Note: I was never able to reproduce the error myself.

```
[ RUN      ] NiRFmxLTEDriverApiTests.NBIotAcpFromExample_FetchData_DataLooksReasonable
D:\a\grpc-device\grpc-device\source\tests\system\nirfmxlte_driver_api_tests.cpp(322): error: Expected equality of these values:
  0.0
    Which is: 0
  acp_fetch_component_carrier_measurement_response.relative_power()
    Which is: 7.62939e-06
```

### Why should this Pull Request be merged?

Close #929 

### What testing has been done?

Compiled and ran tests myself.
