### PR TITLE
Update niRFmxBT to 23.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Indicates the most recent driver version used to test builds of the current sour
 | NI-Digital Pattern Driver | 2023 Q1 | Not Supported | Not Supported |
 | NI-DMM                    | 2023 Q1 | 2023 Q1       | 2023 Q1       |
 | NI-FGEN                   | 2023 Q1 | 2023 Q1       | 2023 Q1       |
-| NI-RFmx Bluetooth         | 2022 Q3 | Not Supported | Not Supported |
+| NI-RFmx Bluetooth         | 2023 Q4 | Not Supported | Not Supported |
 | NI-RFmx LTE               | 2022 Q3 | Not Supported | Not Supported |
 | NI-RFmx NR                | 2023 Q3 | Not Supported | Not Supported |
 | NI-RFmx SpecAn            | 2023 Q3 | Not Supported | Not Supported |

--- a/generated/nirfmxbluetooth/nirfmxbluetooth.proto
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-RFMXBLUETOOTH API metadata version 21.0.0
+// This file is generated from NI-RFMXBLUETOOTH API metadata version 23.8.0
 //---------------------------------------------------------------------
 // Proto file for the NI-RFMXBLUETOOTH Metadata
 //---------------------------------------------------------------------
@@ -93,6 +93,8 @@ service NiRFmxBluetooth {
   rpc Initiate(InitiateRequest) returns (InitiateResponse);
   rpc ModAccCfgAveraging(ModAccCfgAveragingRequest) returns (ModAccCfgAveragingResponse);
   rpc ModAccCfgBurstSynchronizationType(ModAccCfgBurstSynchronizationTypeRequest) returns (ModAccCfgBurstSynchronizationTypeResponse);
+  rpc ModAccFetchCSDetrendedPhaseTrace(ModAccFetchCSDetrendedPhaseTraceRequest) returns (ModAccFetchCSDetrendedPhaseTraceResponse);
+  rpc ModAccFetchCSToneTrace(ModAccFetchCSToneTraceRequest) returns (ModAccFetchCSToneTraceResponse);
   rpc ModAccFetchConstellationTrace(ModAccFetchConstellationTraceRequest) returns (ModAccFetchConstellationTraceResponse);
   rpc ModAccFetchDEVM(ModAccFetchDEVMRequest) returns (ModAccFetchDEVMResponse);
   rpc ModAccFetchDEVMMagnitudeError(ModAccFetchDEVMMagnitudeErrorRequest) returns (ModAccFetchDEVMMagnitudeErrorResponse);
@@ -179,6 +181,10 @@ enum NiRFmxBluetoothAttribute {
   NIRFMXBLUETOOTH_ATTRIBUTE_CTE_LENGTH = 11534381;
   NIRFMXBLUETOOTH_ATTRIBUTE_CTE_SLOT_DURATION = 11534382;
   NIRFMXBLUETOOTH_ATTRIBUTE_CTE_NUMBER_OF_TRANSMIT_SLOTS = 11534383;
+  NIRFMXBLUETOOTH_ATTRIBUTE_CHANNEL_SOUNDING_PACKET_FORMAT = 11534384;
+  NIRFMXBLUETOOTH_ATTRIBUTE_CHANNEL_SOUNDING_SYNC_SEQUENCE = 11534385;
+  NIRFMXBLUETOOTH_ATTRIBUTE_CHANNEL_SOUNDING_PHASE_MEASUREMENT_PERIOD = 11534386;
+  NIRFMXBLUETOOTH_ATTRIBUTE_CHANNEL_SOUNDING_TONE_EXTENSION_SLOT = 11534387;
   NIRFMXBLUETOOTH_ATTRIBUTE_REFERENCE_LEVEL_HEADROOM = 11538428;
   NIRFMXBLUETOOTH_ATTRIBUTE_SELECTED_PORTS = 11538429;
   NIRFMXBLUETOOTH_ATTRIBUTE_IQ_POWER_EDGE_TRIGGER_LEVEL_TYPE = 11538431;
@@ -257,6 +263,8 @@ enum NiRFmxBluetoothAttribute {
   NIRFMXBLUETOOTH_ATTRIBUTE_MODACC_RESULTS_AVERAGE_RMS_PHASE_ERROR_MEAN = 11550767;
   NIRFMXBLUETOOTH_ATTRIBUTE_MODACC_RESULTS_PEAK_RMS_PHASE_ERROR_MAXIMUM = 11550768;
   NIRFMXBLUETOOTH_ATTRIBUTE_MODACC_RESULTS_LE_INITIAL_FREQUENCY_ERROR_MAXIMUM = 11550769;
+  NIRFMXBLUETOOTH_ATTRIBUTE_MODACC_RESULTS_CLOCK_DRIFT_MEAN = 11550770;
+  NIRFMXBLUETOOTH_ATTRIBUTE_MODACC_RESULTS_PREAMBLE_START_TIME_MEAN = 11550771;
   NIRFMXBLUETOOTH_ATTRIBUTE_ACP_MEASUREMENT_ENABLED = 11554816;
   NIRFMXBLUETOOTH_ATTRIBUTE_ACP_OFFSET_CHANNEL_MODE = 11554818;
   NIRFMXBLUETOOTH_ATTRIBUTE_ACP_NUMBER_OF_OFFSETS = 11554819;
@@ -379,6 +387,7 @@ enum PacketType {
   PACKET_TYPE_3_EV3 = 14;
   PACKET_TYPE_3_EV5 = 15;
   PACKET_TYPE_LE = 16;
+  PACKET_TYPE_LE_CS = 17;
 }
 
 enum PayloadBitPattern {
@@ -438,6 +447,15 @@ enum NiRFmxBluetoothInt32AttributeValues {
   NIRFMXBLUETOOTH_INT32_ACP_RESULTS_MEASUREMENT_STATUS_FAIL = 0;
   NIRFMXBLUETOOTH_INT32_ACP_RESULTS_MEASUREMENT_STATUS_NOT_APPLICABLE = -1;
   NIRFMXBLUETOOTH_INT32_ACP_RESULTS_MEASUREMENT_STATUS_PASS = 1;
+  NIRFMXBLUETOOTH_INT32_CHANNEL_SOUNDING_PACKET_FORMAT_SYNC = 0;
+  NIRFMXBLUETOOTH_INT32_CHANNEL_SOUNDING_PACKET_FORMAT_CS_TONE = 1;
+  NIRFMXBLUETOOTH_INT32_CHANNEL_SOUNDING_PACKET_FORMAT_CS_TONE_AFTER_SYNC = 2;
+  NIRFMXBLUETOOTH_INT32_CHANNEL_SOUNDING_PACKET_FORMAT_CS_TONE_BEFORE_SYNC = 3;
+  NIRFMXBLUETOOTH_INT32_CHANNEL_SOUNDING_SYNC_SEQUENCE_NONE = 0;
+  NIRFMXBLUETOOTH_INT32_CHANNEL_SOUNDING_SYNC_SEQUENCE_SOUNDING_SEQUENCE_32_BIT = 1;
+  NIRFMXBLUETOOTH_INT32_CHANNEL_SOUNDING_SYNC_SEQUENCE_SOUNDING_SEQUENCE_96_BIT = 2;
+  NIRFMXBLUETOOTH_INT32_CHANNEL_SOUNDING_TONE_EXTENSION_SLOT_DISABLED = 0;
+  NIRFMXBLUETOOTH_INT32_CHANNEL_SOUNDING_TONE_EXTENSION_SLOT_ENABLED = 1;
   NIRFMXBLUETOOTH_INT32_DIGITAL_EDGE_TRIGGER_EDGE_RISING = 0;
   NIRFMXBLUETOOTH_INT32_DIGITAL_EDGE_TRIGGER_EDGE_FALLING = 1;
   NIRFMXBLUETOOTH_INT32_DIRECTION_FINDING_MODE_DISABLED = 0;
@@ -480,6 +498,7 @@ enum NiRFmxBluetoothInt32AttributeValues {
   NIRFMXBLUETOOTH_INT32_PACKET_TYPE_3_EV3 = 14;
   NIRFMXBLUETOOTH_INT32_PACKET_TYPE_3_EV5 = 15;
   NIRFMXBLUETOOTH_INT32_PACKET_TYPE_LE = 16;
+  NIRFMXBLUETOOTH_INT32_PACKET_TYPE_LE_CS = 17;
   NIRFMXBLUETOOTH_INT32_PAYLOAD_BIT_PATTERN_STANDARD_DEFINED = 0;
   NIRFMXBLUETOOTH_INT32_PAYLOAD_BIT_PATTERN_11110000 = 1;
   NIRFMXBLUETOOTH_INT32_PAYLOAD_BIT_PATTERN_10101010 = 2;
@@ -1426,6 +1445,35 @@ message ModAccCfgBurstSynchronizationTypeRequest {
 
 message ModAccCfgBurstSynchronizationTypeResponse {
   int32 status = 1;
+}
+
+message ModAccFetchCSDetrendedPhaseTraceRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  double timeout = 3;
+}
+
+message ModAccFetchCSDetrendedPhaseTraceResponse {
+  int32 status = 1;
+  double x0 = 2;
+  double dx = 3;
+  repeated float cs_detrended_phase = 4;
+  int32 actual_array_size = 5;
+}
+
+message ModAccFetchCSToneTraceRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  double timeout = 3;
+}
+
+message ModAccFetchCSToneTraceResponse {
+  int32 status = 1;
+  double x0 = 2;
+  double dx = 3;
+  repeated float cs_tone_amplitude = 4;
+  repeated float cs_tone_phase = 5;
+  int32 actual_array_size = 6;
 }
 
 message ModAccFetchConstellationTraceRequest {

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_client.cpp
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_client.cpp
@@ -1597,6 +1597,44 @@ mod_acc_cfg_burst_synchronization_type(const StubPtr& stub, const nidevice_grpc:
   return response;
 }
 
+ModAccFetchCSDetrendedPhaseTraceResponse
+mod_acc_fetch_cs_detrended_phase_trace(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout)
+{
+  ::grpc::ClientContext context;
+
+  auto request = ModAccFetchCSDetrendedPhaseTraceRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_timeout(timeout);
+
+  auto response = ModAccFetchCSDetrendedPhaseTraceResponse{};
+
+  raise_if_error(
+      stub->ModAccFetchCSDetrendedPhaseTrace(&context, request, &response),
+      context);
+
+  return response;
+}
+
+ModAccFetchCSToneTraceResponse
+mod_acc_fetch_cs_tone_trace(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout)
+{
+  ::grpc::ClientContext context;
+
+  auto request = ModAccFetchCSToneTraceRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_timeout(timeout);
+
+  auto response = ModAccFetchCSToneTraceResponse{};
+
+  raise_if_error(
+      stub->ModAccFetchCSToneTrace(&context, request, &response),
+      context);
+
+  return response;
+}
+
 ModAccFetchConstellationTraceResponse
 mod_acc_fetch_constellation_trace(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout)
 {

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_client.h
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_client.h
@@ -98,6 +98,8 @@ InitializeFromNIRFSASessionResponse initialize_from_nirfsa_session(const StubPtr
 InitiateResponse initiate(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& result_name);
 ModAccCfgAveragingResponse mod_acc_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<ModAccAveragingEnabled, pb::int32>& averaging_enabled, const pb::int32& averaging_count);
 ModAccCfgBurstSynchronizationTypeResponse mod_acc_cfg_burst_synchronization_type(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<ModAccBurstSynchronizationType, pb::int32>& burst_synchronization_type);
+ModAccFetchCSDetrendedPhaseTraceResponse mod_acc_fetch_cs_detrended_phase_trace(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout);
+ModAccFetchCSToneTraceResponse mod_acc_fetch_cs_tone_trace(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout);
 ModAccFetchConstellationTraceResponse mod_acc_fetch_constellation_trace(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout);
 ModAccFetchDEVMResponse mod_acc_fetch_devm(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout);
 ModAccFetchDEVMMagnitudeErrorResponse mod_acc_fetch_devm_magnitude_error(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout);

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_compilation_test.cpp
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_compilation_test.cpp
@@ -387,6 +387,16 @@ int32 ModAccCfgBurstSynchronizationType(niRFmxInstrHandle instrumentHandle, char
   return RFmxBT_ModAccCfgBurstSynchronizationType(instrumentHandle, selectorString, burstSynchronizationType);
 }
 
+int32 ModAccFetchCSDetrendedPhaseTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 csDetrendedPhase[], int32 arraySize, int32* actualArraySize)
+{
+  return RFmxBT_ModAccFetchCSDetrendedPhaseTrace(instrumentHandle, selectorString, timeout, x0, dx, csDetrendedPhase, arraySize, actualArraySize);
+}
+
+int32 ModAccFetchCSToneTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 csToneAmplitude[], float32 csTonePhase[], int32 arraySize, int32* actualArraySize)
+{
+  return RFmxBT_ModAccFetchCSToneTrace(instrumentHandle, selectorString, timeout, x0, dx, csToneAmplitude, csTonePhase, arraySize, actualArraySize);
+}
+
 int32 ModAccFetchConstellationTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, NIComplexSingle constellation[], int32 arraySize, int32* actualArraySize)
 {
   return RFmxBT_ModAccFetchConstellationTrace(instrumentHandle, selectorString, timeout, constellation, arraySize, actualArraySize);

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_library.cpp
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_library.cpp
@@ -103,6 +103,8 @@ NiRFmxBluetoothLibrary::NiRFmxBluetoothLibrary(std::shared_ptr<nidevice_grpc::Sh
   function_pointers_.Initiate = reinterpret_cast<InitiatePtr>(shared_library_->get_function_pointer("RFmxBT_Initiate"));
   function_pointers_.ModAccCfgAveraging = reinterpret_cast<ModAccCfgAveragingPtr>(shared_library_->get_function_pointer("RFmxBT_ModAccCfgAveraging"));
   function_pointers_.ModAccCfgBurstSynchronizationType = reinterpret_cast<ModAccCfgBurstSynchronizationTypePtr>(shared_library_->get_function_pointer("RFmxBT_ModAccCfgBurstSynchronizationType"));
+  function_pointers_.ModAccFetchCSDetrendedPhaseTrace = reinterpret_cast<ModAccFetchCSDetrendedPhaseTracePtr>(shared_library_->get_function_pointer("RFmxBT_ModAccFetchCSDetrendedPhaseTrace"));
+  function_pointers_.ModAccFetchCSToneTrace = reinterpret_cast<ModAccFetchCSToneTracePtr>(shared_library_->get_function_pointer("RFmxBT_ModAccFetchCSToneTrace"));
   function_pointers_.ModAccFetchConstellationTrace = reinterpret_cast<ModAccFetchConstellationTracePtr>(shared_library_->get_function_pointer("RFmxBT_ModAccFetchConstellationTrace"));
   function_pointers_.ModAccFetchDEVM = reinterpret_cast<ModAccFetchDEVMPtr>(shared_library_->get_function_pointer("RFmxBT_ModAccFetchDEVM"));
   function_pointers_.ModAccFetchDEVMMagnitudeError = reinterpret_cast<ModAccFetchDEVMMagnitudeErrorPtr>(shared_library_->get_function_pointer("RFmxBT_ModAccFetchDEVMMagnitudeError"));
@@ -777,6 +779,22 @@ int32 NiRFmxBluetoothLibrary::ModAccCfgBurstSynchronizationType(niRFmxInstrHandl
     throw nidevice_grpc::LibraryLoadException("Could not find RFmxBT_ModAccCfgBurstSynchronizationType.");
   }
   return function_pointers_.ModAccCfgBurstSynchronizationType(instrumentHandle, selectorString, burstSynchronizationType);
+}
+
+int32 NiRFmxBluetoothLibrary::ModAccFetchCSDetrendedPhaseTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 csDetrendedPhase[], int32 arraySize, int32* actualArraySize)
+{
+  if (!function_pointers_.ModAccFetchCSDetrendedPhaseTrace) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxBT_ModAccFetchCSDetrendedPhaseTrace.");
+  }
+  return function_pointers_.ModAccFetchCSDetrendedPhaseTrace(instrumentHandle, selectorString, timeout, x0, dx, csDetrendedPhase, arraySize, actualArraySize);
+}
+
+int32 NiRFmxBluetoothLibrary::ModAccFetchCSToneTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 csToneAmplitude[], float32 csTonePhase[], int32 arraySize, int32* actualArraySize)
+{
+  if (!function_pointers_.ModAccFetchCSToneTrace) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxBT_ModAccFetchCSToneTrace.");
+  }
+  return function_pointers_.ModAccFetchCSToneTrace(instrumentHandle, selectorString, timeout, x0, dx, csToneAmplitude, csTonePhase, arraySize, actualArraySize);
 }
 
 int32 NiRFmxBluetoothLibrary::ModAccFetchConstellationTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, NIComplexSingle constellation[], int32 arraySize, int32* actualArraySize)

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_library.h
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_library.h
@@ -97,6 +97,8 @@ class NiRFmxBluetoothLibrary : public nirfmxbluetooth_grpc::NiRFmxBluetoothLibra
   int32 Initiate(niRFmxInstrHandle instrumentHandle, char selectorString[], char resultName[]);
   int32 ModAccCfgAveraging(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 averagingEnabled, int32 averagingCount);
   int32 ModAccCfgBurstSynchronizationType(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 burstSynchronizationType);
+  int32 ModAccFetchCSDetrendedPhaseTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 csDetrendedPhase[], int32 arraySize, int32* actualArraySize);
+  int32 ModAccFetchCSToneTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 csToneAmplitude[], float32 csTonePhase[], int32 arraySize, int32* actualArraySize);
   int32 ModAccFetchConstellationTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, NIComplexSingle constellation[], int32 arraySize, int32* actualArraySize);
   int32 ModAccFetchDEVM(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* peakRMSDEVMMaximum, float64* peakDEVMMaximum, float64* ninetyninePercentDEVM);
   int32 ModAccFetchDEVMMagnitudeError(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* averageRMSMagnitudeErrorMean, float64* peakRMSMagnitudeErrorMaximum);
@@ -230,6 +232,8 @@ class NiRFmxBluetoothLibrary : public nirfmxbluetooth_grpc::NiRFmxBluetoothLibra
   using InitiatePtr = decltype(&RFmxBT_Initiate);
   using ModAccCfgAveragingPtr = decltype(&RFmxBT_ModAccCfgAveraging);
   using ModAccCfgBurstSynchronizationTypePtr = decltype(&RFmxBT_ModAccCfgBurstSynchronizationType);
+  using ModAccFetchCSDetrendedPhaseTracePtr = decltype(&RFmxBT_ModAccFetchCSDetrendedPhaseTrace);
+  using ModAccFetchCSToneTracePtr = decltype(&RFmxBT_ModAccFetchCSToneTrace);
   using ModAccFetchConstellationTracePtr = decltype(&RFmxBT_ModAccFetchConstellationTrace);
   using ModAccFetchDEVMPtr = decltype(&RFmxBT_ModAccFetchDEVM);
   using ModAccFetchDEVMMagnitudeErrorPtr = decltype(&RFmxBT_ModAccFetchDEVMMagnitudeError);
@@ -363,6 +367,8 @@ class NiRFmxBluetoothLibrary : public nirfmxbluetooth_grpc::NiRFmxBluetoothLibra
     InitiatePtr Initiate;
     ModAccCfgAveragingPtr ModAccCfgAveraging;
     ModAccCfgBurstSynchronizationTypePtr ModAccCfgBurstSynchronizationType;
+    ModAccFetchCSDetrendedPhaseTracePtr ModAccFetchCSDetrendedPhaseTrace;
+    ModAccFetchCSToneTracePtr ModAccFetchCSToneTrace;
     ModAccFetchConstellationTracePtr ModAccFetchConstellationTrace;
     ModAccFetchDEVMPtr ModAccFetchDEVM;
     ModAccFetchDEVMMagnitudeErrorPtr ModAccFetchDEVMMagnitudeError;

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_library_interface.h
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_library_interface.h
@@ -91,6 +91,8 @@ class NiRFmxBluetoothLibraryInterface {
   virtual int32 Initiate(niRFmxInstrHandle instrumentHandle, char selectorString[], char resultName[]) = 0;
   virtual int32 ModAccCfgAveraging(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 averagingEnabled, int32 averagingCount) = 0;
   virtual int32 ModAccCfgBurstSynchronizationType(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 burstSynchronizationType) = 0;
+  virtual int32 ModAccFetchCSDetrendedPhaseTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 csDetrendedPhase[], int32 arraySize, int32* actualArraySize) = 0;
+  virtual int32 ModAccFetchCSToneTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 csToneAmplitude[], float32 csTonePhase[], int32 arraySize, int32* actualArraySize) = 0;
   virtual int32 ModAccFetchConstellationTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, NIComplexSingle constellation[], int32 arraySize, int32* actualArraySize) = 0;
   virtual int32 ModAccFetchDEVM(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* peakRMSDEVMMaximum, float64* peakDEVMMaximum, float64* ninetyninePercentDEVM) = 0;
   virtual int32 ModAccFetchDEVMMagnitudeError(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* averageRMSMagnitudeErrorMean, float64* peakRMSMagnitudeErrorMaximum) = 0;

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_mock_library.h
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_mock_library.h
@@ -93,6 +93,8 @@ class NiRFmxBluetoothMockLibrary : public nirfmxbluetooth_grpc::NiRFmxBluetoothL
   MOCK_METHOD(int32, Initiate, (niRFmxInstrHandle instrumentHandle, char selectorString[], char resultName[]), (override));
   MOCK_METHOD(int32, ModAccCfgAveraging, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 averagingEnabled, int32 averagingCount), (override));
   MOCK_METHOD(int32, ModAccCfgBurstSynchronizationType, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 burstSynchronizationType), (override));
+  MOCK_METHOD(int32, ModAccFetchCSDetrendedPhaseTrace, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 csDetrendedPhase[], int32 arraySize, int32* actualArraySize), (override));
+  MOCK_METHOD(int32, ModAccFetchCSToneTrace, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 csToneAmplitude[], float32 csTonePhase[], int32 arraySize, int32* actualArraySize), (override));
   MOCK_METHOD(int32, ModAccFetchConstellationTrace, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, NIComplexSingle constellation[], int32 arraySize, int32* actualArraySize), (override));
   MOCK_METHOD(int32, ModAccFetchDEVM, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* peakRMSDEVMMaximum, float64* peakDEVMMaximum, float64* ninetyninePercentDEVM), (override));
   MOCK_METHOD(int32, ModAccFetchDEVMMagnitudeError, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* averageRMSMagnitudeErrorMean, float64* peakRMSMagnitudeErrorMaximum), (override));

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_service.cpp
@@ -2773,6 +2773,99 @@ namespace nirfmxbluetooth_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxBluetoothService::ModAccFetchCSDetrendedPhaseTrace(::grpc::ServerContext* context, const ModAccFetchCSDetrendedPhaseTraceRequest* request, ModAccFetchCSDetrendedPhaseTraceResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
+      auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
+      char* selector_string = (char*)selector_string_mbcs.c_str();
+      float64 timeout = request->timeout();
+      float64 x0 {};
+      float64 dx {};
+      int32 actual_array_size {};
+      while (true) {
+        auto status = library_->ModAccFetchCSDetrendedPhaseTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, 0, &actual_array_size);
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+        }
+        response->mutable_cs_detrended_phase()->Resize(actual_array_size, 0);
+        float32* cs_detrended_phase = response->mutable_cs_detrended_phase()->mutable_data();
+        auto array_size = actual_array_size;
+        status = library_->ModAccFetchCSDetrendedPhaseTrace(instrument, selector_string, timeout, &x0, &dx, cs_detrended_phase, array_size, &actual_array_size);
+        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
+          // buffer is now too small, try again
+          continue;
+        }
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+        }
+        response->set_status(status);
+        response->set_x0(x0);
+        response->set_dx(dx);
+        response->mutable_cs_detrended_phase()->Resize(actual_array_size, 0);
+        response->set_actual_array_size(actual_array_size);
+        return ::grpc::Status::OK;
+      }
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxBluetoothService::ModAccFetchCSToneTrace(::grpc::ServerContext* context, const ModAccFetchCSToneTraceRequest* request, ModAccFetchCSToneTraceResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
+      auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
+      char* selector_string = (char*)selector_string_mbcs.c_str();
+      float64 timeout = request->timeout();
+      float64 x0 {};
+      float64 dx {};
+      int32 actual_array_size {};
+      while (true) {
+        auto status = library_->ModAccFetchCSToneTrace(instrument, selector_string, timeout, &x0, &dx, nullptr, nullptr, 0, &actual_array_size);
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+        }
+        response->mutable_cs_tone_amplitude()->Resize(actual_array_size, 0);
+        float32* cs_tone_amplitude = response->mutable_cs_tone_amplitude()->mutable_data();
+        response->mutable_cs_tone_phase()->Resize(actual_array_size, 0);
+        float32* cs_tone_phase = response->mutable_cs_tone_phase()->mutable_data();
+        auto array_size = actual_array_size;
+        status = library_->ModAccFetchCSToneTrace(instrument, selector_string, timeout, &x0, &dx, cs_tone_amplitude, cs_tone_phase, array_size, &actual_array_size);
+        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
+          // buffer is now too small, try again
+          continue;
+        }
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+        }
+        response->set_status(status);
+        response->set_x0(x0);
+        response->set_dx(dx);
+        response->mutable_cs_tone_amplitude()->Resize(actual_array_size, 0);
+        response->mutable_cs_tone_phase()->Resize(actual_array_size, 0);
+        response->set_actual_array_size(actual_array_size);
+        return ::grpc::Status::OK;
+      }
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiRFmxBluetoothService::ModAccFetchConstellationTrace(::grpc::ServerContext* context, const ModAccFetchConstellationTraceRequest* request, ModAccFetchConstellationTraceResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nirfmxbluetooth/nirfmxbluetooth_service.h
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth_service.h
@@ -120,6 +120,8 @@ public:
   ::grpc::Status Initiate(::grpc::ServerContext* context, const InitiateRequest* request, InitiateResponse* response) override;
   ::grpc::Status ModAccCfgAveraging(::grpc::ServerContext* context, const ModAccCfgAveragingRequest* request, ModAccCfgAveragingResponse* response) override;
   ::grpc::Status ModAccCfgBurstSynchronizationType(::grpc::ServerContext* context, const ModAccCfgBurstSynchronizationTypeRequest* request, ModAccCfgBurstSynchronizationTypeResponse* response) override;
+  ::grpc::Status ModAccFetchCSDetrendedPhaseTrace(::grpc::ServerContext* context, const ModAccFetchCSDetrendedPhaseTraceRequest* request, ModAccFetchCSDetrendedPhaseTraceResponse* response) override;
+  ::grpc::Status ModAccFetchCSToneTrace(::grpc::ServerContext* context, const ModAccFetchCSToneTraceRequest* request, ModAccFetchCSToneTraceResponse* response) override;
   ::grpc::Status ModAccFetchConstellationTrace(::grpc::ServerContext* context, const ModAccFetchConstellationTraceRequest* request, ModAccFetchConstellationTraceResponse* response) override;
   ::grpc::Status ModAccFetchDEVM(::grpc::ServerContext* context, const ModAccFetchDEVMRequest* request, ModAccFetchDEVMResponse* response) override;
   ::grpc::Status ModAccFetchDEVMMagnitudeError(::grpc::ServerContext* context, const ModAccFetchDEVMMagnitudeErrorRequest* request, ModAccFetchDEVMMagnitudeErrorResponse* response) override;

--- a/imports/include/niRFmxBT.h
+++ b/imports/include/niRFmxBT.h
@@ -45,6 +45,10 @@
 #define RFMXBT_ATTR_CTE_LENGTH                                                                     0x00b0002d
 #define RFMXBT_ATTR_CTE_SLOT_DURATION                                                              0x00b0002e
 #define RFMXBT_ATTR_CTE_NUMBER_OF_TRANSMIT_SLOTS                                                   0x00b0002f
+#define RFMXBT_ATTR_CHANNEL_SOUNDING_PACKET_FORMAT                                                 0x00b00030
+#define RFMXBT_ATTR_CHANNEL_SOUNDING_SYNC_SEQUENCE                                                 0x00b00031
+#define RFMXBT_ATTR_CHANNEL_SOUNDING_PHASE_MEASUREMENT_PERIOD                                      0x00b00032
+#define RFMXBT_ATTR_CHANNEL_SOUNDING_TONE_EXTENSION_SLOT                                           0x00b00033
 #define RFMXBT_ATTR_CHANNEL_NUMBER                                                                 0x00b00017
 #define RFMXBT_ATTR_DETECTED_PACKET_TYPE                                                           0x00b00019
 #define RFMXBT_ATTR_DETECTED_DATA_RATE                                                             0x00b0002a
@@ -89,6 +93,8 @@
 #define RFMXBT_ATTR_MODACC_RESULTS_AVERAGE_RMS_PHASE_ERROR_MEAN                                    0x00b0402f
 #define RFMXBT_ATTR_MODACC_RESULTS_PEAK_RMS_PHASE_ERROR_MAXIMUM                                    0x00b04030
 #define RFMXBT_ATTR_MODACC_RESULTS_IQ_ORIGIN_OFFSET_MEAN                                           0x00b04023
+#define RFMXBT_ATTR_MODACC_RESULTS_CLOCK_DRIFT_MEAN                                                0x00b04032
+#define RFMXBT_ATTR_MODACC_RESULTS_PREAMBLE_START_TIME_MEAN                                        0x00b04033
 #define RFMXBT_ATTR_ACP_MEASUREMENT_ENABLED                                                        0x00b05000
 #define RFMXBT_ATTR_ACP_OFFSET_CHANNEL_MODE                                                        0x00b05002
 #define RFMXBT_ATTR_ACP_NUMBER_OF_OFFSETS                                                          0x00b05003
@@ -201,6 +207,7 @@
 #define RFMXBT_VAL_PACKET_TYPE_3_EV3                                                              14
 #define RFMXBT_VAL_PACKET_TYPE_3_EV5                                                              15
 #define RFMXBT_VAL_PACKET_TYPE_LE                                                                 16
+#define RFMXBT_VAL_PACKET_TYPE_LE_CS                                                              17
 
 // Values for RFMXBT_ATTR_PAYLOAD_BIT_PATTERN
 #define RFMXBT_VAL_PAYLOAD_BIT_PATTERN_STANDARD_DEFINED                                           0
@@ -293,6 +300,21 @@
 #define RFMXBT_VAL_BR                                                                             0
 #define RFMXBT_VAL_EDR                                                                            0
 #define RFMXBT_VAL_LE                                                                             1
+
+// Values for RFMXBT_ATTR_CHANNEL_SOUNDING_PACKET_FORMAT
+#define RFMXBT_VAL_CHANNEL_SOUNDING_PACKET_FORMAT_SYNC                                            0
+#define RFMXBT_VAL_CHANNEL_SOUNDING_PACKET_FORMAT_CS_TONE                                         1
+#define RFMXBT_VAL_CHANNEL_SOUNDING_PACKET_FORMAT_CS_TONE_AFTER_SYNC                              2
+#define RFMXBT_VAL_CHANNEL_SOUNDING_PACKET_FORMAT_CS_TONE_BEFORE_SYNC                             3
+
+// Values for RFMXBT_ATTR_CHANNEL_SOUNDING_SYNC_SEQUENCE
+#define RFMXBT_VAL_CHANNEL_SOUNDING_SYNC_SEQUENCE_NONE                                            0
+#define RFMXBT_VAL_CHANNEL_SOUNDING_SYNC_SEQUENCE_SOUNDING_SEQUENCE_32_BIT                        1
+#define RFMXBT_VAL_CHANNEL_SOUNDING_SYNC_SEQUENCE_SOUNDING_SEQUENCE_96_BIT                        2
+
+// Values for RFMXBT_ATTR_CHANNEL_SOUNDING_TONE_EXTENSION_SLOT
+#define RFMXBT_VAL_CHANNEL_SOUNDING_TONE_EXTENSION_SLOT_DISABLED                                  0
+#define RFMXBT_VAL_CHANNEL_SOUNDING_TONE_EXTENSION_SLOT_ENABLED                                   1
 
 /* ---------------- RFmxBT APIs ------------------ */
 
@@ -1148,6 +1170,29 @@ int32 __stdcall RFmxBT_ModAccFetchConstellationTraceSplit(
    int32* actualArraySize
 );
 
+int32 __stdcall RFmxBT_ModAccFetchCSDetrendedPhaseTrace(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   float64 timeout,
+   float64* x0,
+   float64* dx,
+   float32 CSDetrendedPhase[],
+   int32 arraySize,
+   int32* actualArraySize
+);
+
+int32 __stdcall RFmxBT_ModAccFetchCSToneTrace(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   float64 timeout,
+   float64* x0,
+   float64* dx,
+   float32 CSToneAmplitude[],
+   float32 CSTonePhase[],
+   int32 arraySize,
+   int32* actualArraySize
+);
+
 int32 __stdcall RFmxBT_ModAccFetchDemodulatedBitTrace(
    niRFmxInstrHandle instrumentHandle,
    char selectorString[],
@@ -1649,6 +1694,54 @@ int32 __stdcall RFmxBT_GetCTENumberOfTransmitSlots(
    int32 *attrVal
 );
 
+int32 __stdcall RFmxBT_GetChannelSoundingPacketFormat(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 *attrVal
+);
+
+int32 __stdcall RFmxBT_SetChannelSoundingPacketFormat(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 attrVal
+);
+
+int32 __stdcall RFmxBT_GetChannelSoundingSyncSequence(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 *attrVal
+);
+
+int32 __stdcall RFmxBT_SetChannelSoundingSyncSequence(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 attrVal
+);
+
+int32 __stdcall RFmxBT_GetChannelSoundingPhaseMeasurementPeriod(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   float64 *attrVal
+);
+
+int32 __stdcall RFmxBT_SetChannelSoundingPhaseMeasurementPeriod(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   float64 attrVal
+);
+
+int32 __stdcall RFmxBT_GetChannelSoundingToneExtensionSlot(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 *attrVal
+);
+
+int32 __stdcall RFmxBT_SetChannelSoundingToneExtensionSlot(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 attrVal
+);
+
 int32 __stdcall RFmxBT_GetChannelNumber(
    niRFmxInstrHandle instrumentHandle,
    char selectorString[],
@@ -1992,6 +2085,18 @@ int32 __stdcall RFmxBT_ModAccGetResultsPeakRMSPhaseErrorMaximum(
 );
 
 int32 __stdcall RFmxBT_ModAccGetResultsIQOriginOffsetMean(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   float64 *attrVal
+);
+
+int32 __stdcall RFmxBT_ModAccGetResultsClockDriftMean(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   float64 *attrVal
+);
+
+int32 __stdcall RFmxBT_ModAccGetResultsPreambleStartTimeMean(
    niRFmxInstrHandle instrumentHandle,
    char selectorString[],
    float64 *attrVal

--- a/source/codegen/metadata/nirfmxbluetooth/attributes.py
+++ b/source/codegen/metadata/nirfmxbluetooth/attributes.py
@@ -144,6 +144,29 @@ attributes = {
         'name': 'CTE_NUMBER_OF_TRANSMIT_SLOTS',
         'type': 'int32'
     },
+    11534384: {
+        'access': 'read-write',
+        'enum': 'ChannelSoundingPacketFormat',
+        'name': 'CHANNEL_SOUNDING_PACKET_FORMAT',
+        'type': 'int32'
+    },
+    11534385: {
+        'access': 'read-write',
+        'enum': 'ChannelSoundingSyncSequence',
+        'name': 'CHANNEL_SOUNDING_SYNC_SEQUENCE',
+        'type': 'int32'
+    },
+    11534386: {
+        'access': 'read-write',
+        'name': 'CHANNEL_SOUNDING_PHASE_MEASUREMENT_PERIOD',
+        'type': 'float64'
+    },
+    11534387: {
+        'access': 'read-write',
+        'enum': 'ChannelSoundingToneExtensionSlot',
+        'name': 'CHANNEL_SOUNDING_TONE_EXTENSION_SLOT',
+        'type': 'int32'
+    },
     11538428: {
         'access': 'read-write',
         'name': 'REFERENCE_LEVEL_HEADROOM',
@@ -540,6 +563,16 @@ attributes = {
     11550769: {
         'access': 'read-write',
         'name': 'MODACC_RESULTS_LE_INITIAL_FREQUENCY_ERROR_MAXIMUM',
+        'type': 'float64'
+    },
+    11550770: {
+        'access': 'read-write',
+        'name': 'MODACC_RESULTS_CLOCK_DRIFT_MEAN',
+        'type': 'float64'
+    },
+    11550771: {
+        'access': 'read-write',
+        'name': 'MODACC_RESULTS_PREAMBLE_START_TIME_MEAN',
         'type': 'float64'
     },
     11554816: {

--- a/source/codegen/metadata/nirfmxbluetooth/config.py
+++ b/source/codegen/metadata/nirfmxbluetooth/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 config = {
-    'api_version': '21.0.0',
+    'api_version': '23.8.0',
     'c_header': 'niRFmxBT.h',
     'c_function_prefix': 'RFmxBT_',
     'service_class_prefix': 'NiRFmxBluetooth',

--- a/source/codegen/metadata/nirfmxbluetooth/enums.py
+++ b/source/codegen/metadata/nirfmxbluetooth/enums.py
@@ -55,6 +55,54 @@ enums = {
             }
         ]
     },
+    'ChannelSoundingPacketFormat': {
+        'values': [
+            {
+                'name': 'SYNC',
+                'value': 0
+            },
+            {
+                'name': 'CS_TONE',
+                'value': 1
+            },
+            {
+                'name': 'CS_TONE_AFTER_SYNC',
+                'value': 2
+            },
+            {
+                'name': 'CS_TONE_BEFORE_SYNC',
+                'value': 3
+            }
+        ]
+    },
+    'ChannelSoundingSyncSequence': {
+        'values': [
+            {
+                'name': 'NONE',
+                'value': 0
+            },
+            {
+                'name': 'SOUNDING_SEQUENCE_32_BIT',
+                'value': 1
+            },
+            {
+                'name': 'SOUNDING_SEQUENCE_96_BIT',
+                'value': 2
+            }
+        ]
+    },
+    'ChannelSoundingToneExtensionSlot': {
+        'values': [
+            {
+                'name': 'DISABLED',
+                'value': 0
+            },
+            {
+                'name': 'ENABLED',
+                'value': 1
+            }
+        ]
+    },
     'DigitalEdgeTriggerEdge': {
         'values': [
             {
@@ -377,6 +425,10 @@ enums = {
             {
                 'name': 'LE',
                 'value': 16
+            },
+            {
+                'name': 'LE_CS',
+                'value': 17
             }
         ]
     },

--- a/source/codegen/metadata/nirfmxbluetooth/functions.py
+++ b/source/codegen/metadata/nirfmxbluetooth/functions.py
@@ -2377,6 +2377,118 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'ModAccFetchCSDetrendedPhaseTrace': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'timeout',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'x0',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'dx',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'csDetrendedPhase',
+                'size': {
+                    'mechanism': 'ivi-dance-with-a-twist',
+                    'value': 'arraySize',
+                    'value_twist': 'actualArraySize'
+                },
+                'type': 'float32[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'arraySize',
+                'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'name': 'actualArraySize',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'ModAccFetchCSToneTrace': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'timeout',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'x0',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'dx',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'csToneAmplitude',
+                'size': {
+                    'mechanism': 'ivi-dance-with-a-twist',
+                    'value': 'arraySize',
+                    'value_twist': 'actualArraySize'
+                },
+                'type': 'float32[]'
+            },
+            {
+                'direction': 'out',
+                'name': 'csTonePhase',
+                'size': {
+                    'mechanism': 'ivi-dance-with-a-twist',
+                    'value': 'arraySize',
+                    'value_twist': 'actualArraySize'
+                },
+                'type': 'float32[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'arraySize',
+                'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'name': 'actualArraySize',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
     'ModAccFetchConstellationTrace': {
         'parameters': [
             {


### PR DESCRIPTION
### What does this Pull Request accomplish?

Updates niRFmxBT support to 23.8 API.

This adds the following:

**Methods**
RFmxBT_ModAccFetchCSDetrendedPhaseTrace
RFmxBT_ModAccFetchCSToneTrace

**Attributes**
RFMXBT_ATTR_CHANNEL_SOUNDING_PACKET_FORMAT
RFMXBT_ATTR_CHANNEL_SOUNDING_SYNC_SEQUENCE
RFMXBT_ATTR_CHANNEL_SOUNDING_PHASE_MEASUREMENT_PERIOD 
RFMXBT_ATTR_CHANNEL_SOUNDING_TONE_EXTENSION_SLOT
RFMXBT_ATTR_MODACC_RESULTS_CLOCK_DRIFT_MEAN
RFMXBT_ATTR_MODACC_RESULTS_PREAMBLE_START_TIME_MEAN 

**Enums Values**
RFMXBT_VAL_PACKET_TYPE_LE_CS

RFMXBT_VAL_CHANNEL_SOUNDING_PACKET_FORMAT_SYNC
RFMXBT_VAL_CHANNEL_SOUNDING_PACKET_FORMAT_CS_TONE
RFMXBT_VAL_CHANNEL_SOUNDING_PACKET_FORMAT_CS_TONE_AFTER_SYNC
RFMXBT_VAL_CHANNEL_SOUNDING_PACKET_FORMAT_CS_TONE_BEFORE_SYNC

RFMXBT_VAL_CHANNEL_SOUNDING_SYNC_SEQUENCE_NONE
RFMXBT_VAL_CHANNEL_SOUNDING_SYNC_SEQUENCE_SOUNDING_SEQUENCE_32_BIT
RFMXBT_VAL_CHANNEL_SOUNDING_SYNC_SEQUENCE_SOUNDING_SEQUENCE_96_BIT

RFMXBT_VAL_CHANNEL_SOUNDING_TONE_EXTENSION_SLOT_DISABLED
RFMXBT_VAL_CHANNEL_SOUNDING_TONE_EXTENSION_SLOT_ENABLED 

### Why should this Pull Request be merged?

https://dev.azure.com/ni/DevCentral/_workitems/edit/2500448

### What testing has been done?

Locally built grpc-device.
