### PR TITLE
Update niRFmxInstr to 23.8

### DIFF
--- a/generated/nirfmxinstr/nirfmxinstr.proto
+++ b/generated/nirfmxinstr/nirfmxinstr.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-RFMXINSTR API metadata version 22.5.0
+// This file is generated from NI-RFMXINSTR API metadata version 23.8.0
 //---------------------------------------------------------------------
 // Proto file for the NI-RFMXINSTR Metadata
 //---------------------------------------------------------------------
@@ -111,6 +111,7 @@ service NiRFmxInstr {
   rpc TimestampFromValues(TimestampFromValuesRequest) returns (TimestampFromValuesResponse);
   rpc ValuesFromTimestamp(ValuesFromTimestampRequest) returns (ValuesFromTimestampResponse);
   rpc WaitForAcquisitionComplete(WaitForAcquisitionCompleteRequest) returns (WaitForAcquisitionCompleteResponse);
+  rpc FetchRawIQData(FetchRawIQDataRequest) returns (FetchRawIQDataResponse);
 }
 
 enum NiRFmxInstrAttribute {
@@ -210,6 +211,7 @@ enum NiRFmxInstrAttribute {
   NIRFMXINSTR_ATTRIBUTE_SELF_CALIBRATION_VALIDITY_CHECK_TIME_INTERVAL = 118;
   NIRFMXINSTR_ATTRIBUTE_TEMPERATURE_READ_INTERVAL = 119;
   NIRFMXINSTR_ATTRIBUTE_THERMAL_CORRECTION_TEMPERATURE_RESOLUTION = 120;
+  NIRFMXINSTR_ATTRIBUTE_NUMBER_OF_RAW_IQ_RECORDS = 128;
 }
 
 enum ExportSignalSource {
@@ -1488,5 +1490,21 @@ message WaitForAcquisitionCompleteRequest {
 
 message WaitForAcquisitionCompleteResponse {
   int32 status = 1;
+}
+
+message FetchRawIQDataRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  double timeout = 3;
+  int32 records_to_fetch = 4;
+  int64 samples_to_read = 5;
+}
+
+message FetchRawIQDataResponse {
+  int32 status = 1;
+  double x0 = 2;
+  double dx = 3;
+  repeated nidevice_grpc.NIComplexNumberF32 data = 4;
+  int32 actual_array_size = 5;
 }
 

--- a/generated/nirfmxinstr/nirfmxinstr_client.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_client.cpp
@@ -1899,5 +1899,26 @@ wait_for_acquisition_complete(const StubPtr& stub, const nidevice_grpc::Session&
   return response;
 }
 
+FetchRawIQDataResponse
+fetch_raw_iq_data(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout, const pb::int32& records_to_fetch, const pb::int64& samples_to_read)
+{
+  ::grpc::ClientContext context;
+
+  auto request = FetchRawIQDataRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_timeout(timeout);
+  request.set_records_to_fetch(records_to_fetch);
+  request.set_samples_to_read(samples_to_read);
+
+  auto response = FetchRawIQDataResponse{};
+
+  raise_if_error(
+      stub->FetchRawIQData(&context, request, &response),
+      context);
+
+  return response;
+}
+
 
 } // namespace nirfmxinstr_grpc::experimental::client

--- a/generated/nirfmxinstr/nirfmxinstr_client.h
+++ b/generated/nirfmxinstr/nirfmxinstr_client.h
@@ -115,6 +115,7 @@ SetAttributeU8ArrayResponse set_attribute_u8_array(const StubPtr& stub, const ni
 TimestampFromValuesResponse timestamp_from_values(const StubPtr& stub, const pb::int64& seconds_since_1970, const double& fractional_seconds);
 ValuesFromTimestampResponse values_from_timestamp(const StubPtr& stub, const google::protobuf::Timestamp& timestamp);
 WaitForAcquisitionCompleteResponse wait_for_acquisition_complete(const StubPtr& stub, const nidevice_grpc::Session& instrument, const double& timeout);
+FetchRawIQDataResponse fetch_raw_iq_data(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout, const pb::int32& records_to_fetch, const pb::int64& samples_to_read);
 
 } // namespace nirfmxinstr_grpc::experimental::client
 

--- a/generated/nirfmxinstr/nirfmxinstr_compilation_test.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_compilation_test.cpp
@@ -472,4 +472,9 @@ int32 WaitForAcquisitionComplete(niRFmxInstrHandle instrumentHandle, float64 tim
   return RFmxInstr_WaitForAcquisitionComplete(instrumentHandle, timeout);
 }
 
+int32 FetchRawIQData(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, int32 recordsToFetch, int64 samplesToRead, float64* x0, float64* dx, NIComplexSingle data[], int32 arraySize, int32* actualArraySize, void* reserved)
+{
+  return RFmxInstr_FetchRawIQData(instrumentHandle, selectorString, timeout, recordsToFetch, samplesToRead, x0, dx, data, arraySize, actualArraySize, reserved);
+}
+
 }  // namespace nirfmxinstr_grpc

--- a/generated/nirfmxinstr/nirfmxinstr_library.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_library.cpp
@@ -120,6 +120,7 @@ NiRFmxInstrLibrary::NiRFmxInstrLibrary(std::shared_ptr<nidevice_grpc::SharedLibr
   function_pointers_.TimestampFromValues = reinterpret_cast<TimestampFromValuesPtr>(shared_library_->get_function_pointer("RFmxInstr_TimestampFromValues"));
   function_pointers_.ValuesFromTimestamp = reinterpret_cast<ValuesFromTimestampPtr>(shared_library_->get_function_pointer("RFmxInstr_ValuesFromTimestamp"));
   function_pointers_.WaitForAcquisitionComplete = reinterpret_cast<WaitForAcquisitionCompletePtr>(shared_library_->get_function_pointer("RFmxInstr_WaitForAcquisitionComplete"));
+  function_pointers_.FetchRawIQData = reinterpret_cast<FetchRawIQDataPtr>(shared_library_->get_function_pointer("RFmxInstr_FetchRawIQData"));
 }
 
 NiRFmxInstrLibrary::~NiRFmxInstrLibrary()
@@ -875,6 +876,14 @@ int32 NiRFmxInstrLibrary::WaitForAcquisitionComplete(niRFmxInstrHandle instrumen
     throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_WaitForAcquisitionComplete.");
   }
   return function_pointers_.WaitForAcquisitionComplete(instrumentHandle, timeout);
+}
+
+int32 NiRFmxInstrLibrary::FetchRawIQData(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, int32 recordsToFetch, int64 samplesToRead, float64* x0, float64* dx, NIComplexSingle data[], int32 arraySize, int32* actualArraySize, void* reserved)
+{
+  if (!function_pointers_.FetchRawIQData) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_FetchRawIQData.");
+  }
+  return function_pointers_.FetchRawIQData(instrumentHandle, selectorString, timeout, recordsToFetch, samplesToRead, x0, dx, data, arraySize, actualArraySize, reserved);
 }
 
 }  // namespace nirfmxinstr_grpc

--- a/generated/nirfmxinstr/nirfmxinstr_library.h
+++ b/generated/nirfmxinstr/nirfmxinstr_library.h
@@ -114,6 +114,7 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
   int32 TimestampFromValues(int64 secondsSince1970, float64 fractionalSeconds, CVIAbsoluteTime* timestamp);
   int32 ValuesFromTimestamp(CVIAbsoluteTime timestamp, int64* secondsSince1970, float64* fractionalSeconds);
   int32 WaitForAcquisitionComplete(niRFmxInstrHandle instrumentHandle, float64 timeout);
+  int32 FetchRawIQData(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, int32 recordsToFetch, int64 samplesToRead, float64* x0, float64* dx, NIComplexSingle data[], int32 arraySize, int32* actualArraySize, void* reserved);
 
  private:
   using BuildCalibrationPlaneStringPtr = decltype(&RFmxInstr_BuildCalibrationPlaneString);
@@ -209,6 +210,7 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
   using TimestampFromValuesPtr = decltype(&RFmxInstr_TimestampFromValues);
   using ValuesFromTimestampPtr = decltype(&RFmxInstr_ValuesFromTimestamp);
   using WaitForAcquisitionCompletePtr = decltype(&RFmxInstr_WaitForAcquisitionComplete);
+  using FetchRawIQDataPtr = decltype(&RFmxInstr_FetchRawIQData);
 
   typedef struct FunctionPointers {
     BuildCalibrationPlaneStringPtr BuildCalibrationPlaneString;
@@ -304,6 +306,7 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
     TimestampFromValuesPtr TimestampFromValues;
     ValuesFromTimestampPtr ValuesFromTimestamp;
     WaitForAcquisitionCompletePtr WaitForAcquisitionComplete;
+    FetchRawIQDataPtr FetchRawIQData;
   } FunctionLoadStatus;
 
   std::shared_ptr<nidevice_grpc::SharedLibraryInterface> shared_library_;

--- a/generated/nirfmxinstr/nirfmxinstr_library_interface.h
+++ b/generated/nirfmxinstr/nirfmxinstr_library_interface.h
@@ -108,6 +108,7 @@ class NiRFmxInstrLibraryInterface {
   virtual int32 TimestampFromValues(int64 secondsSince1970, float64 fractionalSeconds, CVIAbsoluteTime* timestamp) = 0;
   virtual int32 ValuesFromTimestamp(CVIAbsoluteTime timestamp, int64* secondsSince1970, float64* fractionalSeconds) = 0;
   virtual int32 WaitForAcquisitionComplete(niRFmxInstrHandle instrumentHandle, float64 timeout) = 0;
+  virtual int32 FetchRawIQData(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, int32 recordsToFetch, int64 samplesToRead, float64* x0, float64* dx, NIComplexSingle data[], int32 arraySize, int32* actualArraySize, void* reserved) = 0;
 };
 
 }  // namespace nirfmxinstr_grpc

--- a/generated/nirfmxinstr/nirfmxinstr_mock_library.h
+++ b/generated/nirfmxinstr/nirfmxinstr_mock_library.h
@@ -110,6 +110,7 @@ class NiRFmxInstrMockLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterf
   MOCK_METHOD(int32, TimestampFromValues, (int64 secondsSince1970, float64 fractionalSeconds, CVIAbsoluteTime* timestamp), (override));
   MOCK_METHOD(int32, ValuesFromTimestamp, (CVIAbsoluteTime timestamp, int64* secondsSince1970, float64* fractionalSeconds), (override));
   MOCK_METHOD(int32, WaitForAcquisitionComplete, (niRFmxInstrHandle instrumentHandle, float64 timeout), (override));
+  MOCK_METHOD(int32, FetchRawIQData, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, int32 recordsToFetch, int64 samplesToRead, float64* x0, float64* dx, NIComplexSingle data[], int32 arraySize, int32* actualArraySize, void* reserved), (override));
 };
 
 }  // namespace unit

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -3219,6 +3219,60 @@ namespace nirfmxinstr_grpc {
     }
   }
 
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxInstrService::FetchRawIQData(::grpc::ServerContext* context, const FetchRawIQDataRequest* request, FetchRawIQDataResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
+      auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
+      char* selector_string = (char*)selector_string_mbcs.c_str();
+      float64 timeout = request->timeout();
+      int32 records_to_fetch = request->records_to_fetch();
+      int64 samples_to_read = request->samples_to_read();
+      auto reserved = nullptr;
+      float64 x0 {};
+      float64 dx {};
+      int32 actual_array_size {};
+      while (true) {
+        auto status = library_->FetchRawIQData(instrument, selector_string, timeout, records_to_fetch, samples_to_read, &x0, &dx, nullptr, 0, &actual_array_size, reserved);
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+        }
+        std::vector<NIComplexSingle> data(actual_array_size, NIComplexSingle());
+        auto array_size = actual_array_size;
+        status = library_->FetchRawIQData(instrument, selector_string, timeout, records_to_fetch, samples_to_read, &x0, &dx, data.data(), array_size, &actual_array_size, reserved);
+        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
+          // buffer is now too small, try again
+          continue;
+        }
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+        }
+        response->set_status(status);
+        response->set_x0(x0);
+        response->set_dx(dx);
+        convert_to_grpc(data, response->mutable_data());
+        {
+          auto shrunk_size = actual_array_size;
+          auto current_size = response->mutable_data()->size();
+          if (shrunk_size != current_size) {
+            response->mutable_data()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
+          }
+        }
+        response->set_actual_array_size(actual_array_size);
+        return ::grpc::Status::OK;
+      }
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
 
   NiRFmxInstrFeatureToggles::NiRFmxInstrFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -3234,18 +3234,18 @@ namespace nirfmxinstr_grpc {
       float64 timeout = request->timeout();
       int32 records_to_fetch = request->records_to_fetch();
       int64 samples_to_read = request->samples_to_read();
-      auto reserved = nullptr;
       float64 x0 {};
       float64 dx {};
       int32 actual_array_size {};
+      auto reserved = nullptr;
       while (true) {
-        auto status = library_->FetchRawIQData(instrument, selector_string, timeout, records_to_fetch, samples_to_read, &x0, &dx, nullptr, 0, &actual_array_size, reserved);
+        auto status = library_->FetchRawIQData(instrument, selector_string, timeout, records_to_fetch, samples_to_read, &x0, &dx, nullptr, 0, &actual_array_size, &reserved);
         if (!status_ok(status)) {
           return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
         }
         std::vector<NIComplexSingle> data(actual_array_size, NIComplexSingle());
         auto array_size = actual_array_size;
-        status = library_->FetchRawIQData(instrument, selector_string, timeout, records_to_fetch, samples_to_read, &x0, &dx, data.data(), array_size, &actual_array_size, reserved);
+        status = library_->FetchRawIQData(instrument, selector_string, timeout, records_to_fetch, samples_to_read, &x0, &dx, data.data(), array_size, &actual_array_size, &reserved);
         if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
           // buffer is now too small, try again
           continue;

--- a/generated/nirfmxinstr/nirfmxinstr_service.h
+++ b/generated/nirfmxinstr/nirfmxinstr_service.h
@@ -137,6 +137,7 @@ public:
   ::grpc::Status TimestampFromValues(::grpc::ServerContext* context, const TimestampFromValuesRequest* request, TimestampFromValuesResponse* response) override;
   ::grpc::Status ValuesFromTimestamp(::grpc::ServerContext* context, const ValuesFromTimestampRequest* request, ValuesFromTimestampResponse* response) override;
   ::grpc::Status WaitForAcquisitionComplete(::grpc::ServerContext* context, const WaitForAcquisitionCompleteRequest* request, WaitForAcquisitionCompleteResponse* response) override;
+  ::grpc::Status FetchRawIQData(::grpc::ServerContext* context, const FetchRawIQDataRequest* request, FetchRawIQDataResponse* response) override;
 private:
   LibrarySharedPtr library_;
   ResourceRepositorySharedPtr session_repository_;

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted.proto
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-RFMXINSTR-RESTRICTED API metadata version 21.0.0
+// This file is generated from NI-RFMXINSTR-RESTRICTED API metadata version 23.8.0
 //---------------------------------------------------------------------
 // Proto file for the NI-RFMXINSTR-RESTRICTED Metadata
 //---------------------------------------------------------------------
@@ -51,6 +51,7 @@ service NiRFmxInstrRestricted {
   rpc SetIOTraceStatus(SetIOTraceStatusRequest) returns (SetIOTraceStatusResponse);
   rpc UnregisterSpecialClientSnapshotInterest(UnregisterSpecialClientSnapshotInterestRequest) returns (UnregisterSpecialClientSnapshotInterestResponse);
   rpc GetSFPSessionAccessEnabled(GetSFPSessionAccessEnabledRequest) returns (GetSFPSessionAccessEnabledResponse);
+  rpc CreateDefaultSignalConfiguration(CreateDefaultSignalConfigurationRequest) returns (CreateDefaultSignalConfigurationResponse);
 }
 
 message ConvertForPowerUnitsUtilityRequest {
@@ -423,5 +424,15 @@ message GetSFPSessionAccessEnabledRequest {
 message GetSFPSessionAccessEnabledResponse {
   int32 status = 1;
   int32 is_sfp_session_access_enabled = 2;
+}
+
+message CreateDefaultSignalConfigurationRequest {
+  nidevice_grpc.Session instrument = 1;
+  string signal_name = 2;
+  int32 personality_id = 3;
+}
+
+message CreateDefaultSignalConfigurationResponse {
+  int32 status = 1;
 }
 

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.cpp
@@ -656,5 +656,24 @@ get_sfp_session_access_enabled(const StubPtr& stub, const std::string& option_st
   return response;
 }
 
+CreateDefaultSignalConfigurationResponse
+create_default_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& signal_name, const pb::int32& personality_id)
+{
+  ::grpc::ClientContext context;
+
+  auto request = CreateDefaultSignalConfigurationRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_signal_name(signal_name);
+  request.set_personality_id(personality_id);
+
+  auto response = CreateDefaultSignalConfigurationResponse{};
+
+  raise_if_error(
+      stub->CreateDefaultSignalConfiguration(&context, request, &response),
+      context);
+
+  return response;
+}
+
 
 } // namespace nirfmxinstr_restricted_grpc::experimental::client

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.h
@@ -57,6 +57,7 @@ SetForceAllTracesEnabledResponse set_force_all_traces_enabled(const StubPtr& stu
 SetIOTraceStatusResponse set_io_trace_status(const StubPtr& stub, const nidevice_grpc::Session& instrument, const pb::int32& io_trace_status);
 UnregisterSpecialClientSnapshotInterestResponse unregister_special_client_snapshot_interest(const StubPtr& stub, const std::string& resource_name);
 GetSFPSessionAccessEnabledResponse get_sfp_session_access_enabled(const StubPtr& stub, const std::string& option_string);
+CreateDefaultSignalConfigurationResponse create_default_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& signal_name, const pb::int32& personality_id);
 
 } // namespace nirfmxinstr_restricted_grpc::experimental::client
 

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.cpp
@@ -65,6 +65,7 @@ NiRFmxInstrRestrictedLibrary::NiRFmxInstrRestrictedLibrary(std::shared_ptr<nidev
   function_pointers_.SetIOTraceStatus = reinterpret_cast<SetIOTraceStatusPtr>(shared_library_->get_function_pointer("RFmxInstr_SetIOTraceStatus"));
   function_pointers_.UnregisterSpecialClientSnapshotInterest = reinterpret_cast<UnregisterSpecialClientSnapshotInterestPtr>(shared_library_->get_function_pointer("RFmxInstr_UnregisterSpecialClientSnapshotInterest"));
   function_pointers_.GetSFPSessionAccessEnabled = reinterpret_cast<GetSFPSessionAccessEnabledPtr>(shared_library_->get_function_pointer("RFmxInstr_GetSFPSessionAccessEnabled"));
+  function_pointers_.CreateDefaultSignalConfiguration = reinterpret_cast<CreateDefaultSignalConfigurationPtr>(shared_library_->get_function_pointer("RFmxInstr_CreateDefaultSignalConfiguration"));
 }
 
 NiRFmxInstrRestrictedLibrary::~NiRFmxInstrRestrictedLibrary()
@@ -380,6 +381,14 @@ int32 NiRFmxInstrRestrictedLibrary::GetSFPSessionAccessEnabled(char optionString
     throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_GetSFPSessionAccessEnabled.");
   }
   return function_pointers_.GetSFPSessionAccessEnabled(optionString, isSFPSessionAccessEnabled);
+}
+
+int32 NiRFmxInstrRestrictedLibrary::CreateDefaultSignalConfiguration(niRFmxInstrHandle instrumentHandle, char signalName[], int32 personalityID)
+{
+  if (!function_pointers_.CreateDefaultSignalConfiguration) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_CreateDefaultSignalConfiguration.");
+  }
+  return function_pointers_.CreateDefaultSignalConfiguration(instrumentHandle, signalName, personalityID);
 }
 
 }  // namespace nirfmxinstr_restricted_grpc

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.h
@@ -59,6 +59,7 @@ class NiRFmxInstrRestrictedLibrary : public nirfmxinstr_restricted_grpc::NiRFmxI
   int32 SetIOTraceStatus(niRFmxInstrHandle instrumentHandle, int32 IOTraceStatus);
   int32 UnregisterSpecialClientSnapshotInterest(char resourceName[]);
   int32 GetSFPSessionAccessEnabled(char optionString[], int32* isSFPSessionAccessEnabled);
+  int32 CreateDefaultSignalConfiguration(niRFmxInstrHandle instrumentHandle, char signalName[], int32 personalityID);
 
  private:
   using ConvertForPowerUnitsUtilityPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, float64 referenceOrTriggerLevelIn, int32 inputPowerUnits, int32 outputPowerUnits, int32 terminalConfiguration, float64 bandwidth, float64* referenceOrTriggerLevelOut);
@@ -99,6 +100,7 @@ class NiRFmxInstrRestrictedLibrary : public nirfmxinstr_restricted_grpc::NiRFmxI
   using SetIOTraceStatusPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, int32 IOTraceStatus);
   using UnregisterSpecialClientSnapshotInterestPtr = int32 (*)(char resourceName[]);
   using GetSFPSessionAccessEnabledPtr = int32 (*)(char optionString[], int32* isSFPSessionAccessEnabled);
+  using CreateDefaultSignalConfigurationPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char signalName[], int32 personalityID);
 
   typedef struct FunctionPointers {
     ConvertForPowerUnitsUtilityPtr ConvertForPowerUnitsUtility;
@@ -139,6 +141,7 @@ class NiRFmxInstrRestrictedLibrary : public nirfmxinstr_restricted_grpc::NiRFmxI
     SetIOTraceStatusPtr SetIOTraceStatus;
     UnregisterSpecialClientSnapshotInterestPtr UnregisterSpecialClientSnapshotInterest;
     GetSFPSessionAccessEnabledPtr GetSFPSessionAccessEnabled;
+    CreateDefaultSignalConfigurationPtr CreateDefaultSignalConfiguration;
   } FunctionLoadStatus;
 
   std::shared_ptr<nidevice_grpc::SharedLibraryInterface> shared_library_;

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library_interface.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library_interface.h
@@ -53,6 +53,7 @@ class NiRFmxInstrRestrictedLibraryInterface {
   virtual int32 SetIOTraceStatus(niRFmxInstrHandle instrumentHandle, int32 IOTraceStatus) = 0;
   virtual int32 UnregisterSpecialClientSnapshotInterest(char resourceName[]) = 0;
   virtual int32 GetSFPSessionAccessEnabled(char optionString[], int32* isSFPSessionAccessEnabled) = 0;
+  virtual int32 CreateDefaultSignalConfiguration(niRFmxInstrHandle instrumentHandle, char signalName[], int32 personalityID) = 0;
 };
 
 }  // namespace nirfmxinstr_restricted_grpc

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_mock_library.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_mock_library.h
@@ -55,6 +55,7 @@ class NiRFmxInstrRestrictedMockLibrary : public nirfmxinstr_restricted_grpc::NiR
   MOCK_METHOD(int32, SetIOTraceStatus, (niRFmxInstrHandle instrumentHandle, int32 IOTraceStatus), (override));
   MOCK_METHOD(int32, UnregisterSpecialClientSnapshotInterest, (char resourceName[]), (override));
   MOCK_METHOD(int32, GetSFPSessionAccessEnabled, (char optionString[], int32* isSFPSessionAccessEnabled), (override));
+  MOCK_METHOD(int32, CreateDefaultSignalConfiguration, (niRFmxInstrHandle instrumentHandle, char signalName[], int32 personalityID), (override));
 };
 
 }  // namespace unit

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
@@ -1092,6 +1092,31 @@ namespace nirfmxinstr_restricted_grpc {
     }
   }
 
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxInstrRestrictedService::CreateDefaultSignalConfiguration(::grpc::ServerContext* context, const CreateDefaultSignalConfigurationRequest* request, CreateDefaultSignalConfigurationResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
+      auto signal_name_mbcs = convert_from_grpc<std::string>(request->signal_name());
+      char* signal_name = (char*)signal_name_mbcs.c_str();
+      int32 personality_id = request->personality_id();
+      auto status = library_->CreateDefaultSignalConfiguration(instrument, signal_name, personality_id);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
 
   NiRFmxInstrRestrictedFeatureToggles::NiRFmxInstrRestrictedFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.h
@@ -77,6 +77,7 @@ public:
   ::grpc::Status SetIOTraceStatus(::grpc::ServerContext* context, const SetIOTraceStatusRequest* request, SetIOTraceStatusResponse* response) override;
   ::grpc::Status UnregisterSpecialClientSnapshotInterest(::grpc::ServerContext* context, const UnregisterSpecialClientSnapshotInterestRequest* request, UnregisterSpecialClientSnapshotInterestResponse* response) override;
   ::grpc::Status GetSFPSessionAccessEnabled(::grpc::ServerContext* context, const GetSFPSessionAccessEnabledRequest* request, GetSFPSessionAccessEnabledResponse* response) override;
+  ::grpc::Status CreateDefaultSignalConfiguration(::grpc::ServerContext* context, const CreateDefaultSignalConfigurationRequest* request, CreateDefaultSignalConfigurationResponse* response) override;
 private:
   LibrarySharedPtr library_;
   ResourceRepositorySharedPtr session_repository_;

--- a/imports/include/niRFmxInstr.h
+++ b/imports/include/niRFmxInstr.h
@@ -211,6 +211,7 @@ typedef union CVIAbsoluteTime { CVITime cviTime; unsigned int u32Data[4]; } CVIA
 #define RFMXINSTR_ATTR_DONE_EVENT_TERMINAL_NAME                            0x00000074
 #define RFMXINSTR_ATTR_TEMPERATURE_READ_INTERVAL                           0x00000077
 #define RFMXINSTR_ATTR_THERMAL_CORRECTION_TEMPERATURE_RESOLUTION           0x00000078
+#define RFMXINSTR_ATTR_NUMBER_OF_RAW_IQ_RECORDS                            0x00000080
 #define RFMXINSTR_ATTR_LO_SHARING_MODE                                     0x00000044
 #define RFMXINSTR_ATTR_NUMBER_OF_LO_SHARING_GROUPS                         0x00000061
 
@@ -1964,6 +1965,11 @@ extern "C"
       float64 attrVal
    );
 
+   int32 __stdcall RFmxInstr_GetNumberOfRawIQRecords(
+       niRFmxInstrHandle instrumentHandle,
+       char selectorString[],
+       int32* attrVal
+   );
    int32 __stdcall RFmxInstr_GetSParameterExternalAttenuationType(
       niRFmxInstrHandle instrumentHandle,
       char selectorString[],
@@ -2043,7 +2049,34 @@ extern "C"
        char channelName[],
        int32 attrVal
    );
+   int32 __stdcall RFmxInstr_FetchRawIQData(
+       niRFmxInstrHandle instrumentHandle,
+       char selectorString[],
+       float64 timeout,
+       int32 recordsToFetch,
+       int64 samplesToRead,
+       float64* x0,
+       float64* dx,
+       NIComplexSingle data[],
+       int32 arraySize,
+       int32* actualArraySize,
+       void* reserved
+   );
 
+   int32 __stdcall RFmxInstr_FetchRawIQDataSplit(
+       niRFmxInstrHandle instrumentHandle,
+       char selectorString[],
+       float64 timeout,
+       int32 recordsToFetch,
+       int64 samplesToRead,
+       float64* x0,
+       float64* dx,
+       float32 I[],
+       float32 Q[],
+       int32 arraySize,
+       int32* actualArraySize,
+       void* reserved
+   );
 #ifdef __cplusplus
 }
 #endif

--- a/source/codegen/metadata/nirfmxinstr/attributes.py
+++ b/source/codegen/metadata/nirfmxinstr/attributes.py
@@ -511,5 +511,10 @@ attributes = {
         'access': 'read-write',
         'name': 'THERMAL_CORRECTION_TEMPERATURE_RESOLUTION',
         'type': 'float64'
+    },
+    128: {
+        'access': 'read-write',
+        'name': 'NUMBER_OF_RAW_IQ_RECORDS',
+        'type': 'int32'
     }
 }

--- a/source/codegen/metadata/nirfmxinstr/config.py
+++ b/source/codegen/metadata/nirfmxinstr/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 config = {
-    'api_version': '22.5.0',
+    'api_version': '23.8.0',
     'c_header': 'niRFmxInstr.h',
     'c_function_prefix': 'RFmxInstr_',
     'service_class_prefix': 'NiRFmxInstr',

--- a/source/codegen/metadata/nirfmxinstr/functions.py
+++ b/source/codegen/metadata/nirfmxinstr/functions.py
@@ -2831,11 +2831,10 @@ functions = {
                 'type': 'int32'
             },
             {
-                'direction': 'in',
+                'direction': 'out',
                 'hardcoded_value': 'nullptr',
                 'include_in_proto': False,
                 'name': 'reserved',
-                'pointer': True,
                 'type': 'void'
             }
         ],

--- a/source/codegen/metadata/nirfmxinstr/functions.py
+++ b/source/codegen/metadata/nirfmxinstr/functions.py
@@ -2771,5 +2771,74 @@ functions = {
             }
         ],
         'returns': 'int32'
+    },
+    'FetchRawIQData': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'timeout',
+                'type': 'float64'
+            },
+            {
+                'direction': 'in',
+                'name': 'recordsToFetch',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'name': 'samplesToRead',
+                'type': 'int64'
+            },
+            {
+                'direction': 'out',
+                'name': 'x0',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'dx',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'data',
+                'size': {
+                    'mechanism': 'ivi-dance-with-a-twist',
+                    'value': 'arraySize',
+                    'value_twist': 'actualArraySize'
+                },
+                'type': 'NIComplexSingle[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'arraySize',
+                'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'name': 'actualArraySize',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'hardcoded_value': 'nullptr',
+                'include_in_proto': False,
+                'name': 'reserved',
+                'pointer': True,
+                'type': 'void'
+            }
+        ],
+        'returns': 'int32'
     }
 }

--- a/source/codegen/metadata/nirfmxinstr_restricted/config.py
+++ b/source/codegen/metadata/nirfmxinstr_restricted/config.py
@@ -2,7 +2,7 @@
 config = {
     "code_readiness": "Release",
     "is_restricted": True,
-    'api_version': '21.0.0',
+    'api_version': '23.8.0',
     'c_header': 'niRFmxInstr.h',
     'c_function_prefix': 'RFmxInstr_',
     'service_class_prefix': 'NiRFmxInstrRestricted',

--- a/source/codegen/metadata/nirfmxinstr_restricted/functions.py
+++ b/source/codegen/metadata/nirfmxinstr_restricted/functions.py
@@ -1048,7 +1048,7 @@ functions = {
         ],
         'returns': 'int32'
     },
-'LoadConfigurationsFromJSON': {
+    'LoadConfigurationsFromJSON': {
         'parameters': [
             {
                 'direction': 'in',
@@ -1199,7 +1199,7 @@ functions = {
         'returns': 'int32'
     },
     'GetSFPSessionAccessEnabled': {
-	'parameters': [
+        'parameters': [
             {
                 'direction': 'in',
                 'name': 'optionString',
@@ -1210,7 +1210,28 @@ functions = {
                 'name': 'isSFPSessionAccessEnabled',
                 'type': 'int32'
             }
-	],
-	'returns': 'int32'
+        ],
+        'returns': 'int32'
+    },
+    'CreateDefaultSignalConfiguration': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'signalName',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'personalityID',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
     }
 }


### PR DESCRIPTION
### What does this Pull Request accomplish?

Updates niRFmxInstr support to 23.8 API.

This adds the following:

**Attributes:**
RFMXINSTR_ATTR_NUMBER_OF_RAW_IQ_RECORDS

**Functions:**
RFmxInstr_FetchRawIQData
RFmxInstr_CreateDefaultSignalConfiguration (under restricted proto)

### Why should this Pull Request be merged?

https://dev.azure.com/ni/DevCentral/_workitems/edit/2486799

### What testing has been done?

Locally built grpc-device.
