### PR TITLE
Close VISA resource manager on server reset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,18 +491,28 @@ endif()
 
 # Link test executable against gtest
 add_executable(IntegrationTestsRunner
+    "imports/include/nierr_Status.cpp"
     "source/tests/utilities/run_all_tests.cpp"
     "source/tests/integration/ni_fake_service_tests_endtoend.cpp"
     "source/tests/integration/ni_fake_non_ivi_service_tests_endtoend.cpp"
     "source/tests/integration/session_utilities_service_tests.cpp"
     "source/tests/integration/session_utilities_service_tests_endtoend.cpp"
+    "source/tests/integration/visa_resource_manager_tests.cpp"
+    "source/server/calibration_operations_restricted_service_registrar.cpp"
+    "source/server/calibration_operations_restricted_service.cpp"
+    "source/server/core_services_registrar.cpp"
+    "source/server/debug_session_properties_restricted_service_registrar.cpp"
+    "source/server/debug_session_properties_restricted_service.cpp"
     "source/server/device_enumerator.cpp"
     "source/server/feature_toggles.cpp"
     "source/server/semaphore.cpp"
     "source/server/session_repository.cpp"
     "source/server/session_utilities_service.cpp"
+    "source/server/session_utilities_service_registrar.cpp"
     "source/server/shared_library.cpp"
     "source/server/software_enumerator.cpp"
+    "source/server/syscfg_library.cpp"
+    "source/server/syscfg_resource_accessor.cpp"
     "source/server/syscfg_session_handler.cpp"
     ${nidevice_proto_srcs}
     ${session_proto_srcs}
@@ -515,6 +525,7 @@ add_executable(IntegrationTestsRunner
     ${debugsessionproperties_restricted_grpc_srcs}
     ${calibrationoperations_restricted_proto_srcs}
     ${calibrationoperations_restricted_grpc_srcs}
+    ${nidriver_service_srcs}
     "${proto_srcs_dir}/nifake.pb.cc"
     "${proto_srcs_dir}/nifake.grpc.pb.cc"
     "${proto_srcs_dir}/nifake_non_ivi.pb.cc"

--- a/source/tests/integration/visa_resource_manager_tests.cpp
+++ b/source/tests/integration/visa_resource_manager_tests.cpp
@@ -1,18 +1,9 @@
-#include <grpcpp/impl/grpc_library.h>
-#include <gtest/gtest.h>
 #include <server/session_repository.h>
 #include "visa/visa_mock_library.h"
 #include "visa/visa_service.h"
 
-#include <array>
-#include <iostream>
-#include <nlohmann/json.hpp>
-#include <string>
-
-using namespace ::nlohmann;
+using namespace testing;
 using namespace visa_grpc;
-using testing::Invoke;
-using testing::WithArg;
 
 namespace ni {
 namespace tests {
@@ -23,8 +14,8 @@ static const char* test_descriptor = "fake::descriptor";
 void call_open(VisaService& service, const char* session_name)
 {
     ::grpc::ServerContext context;
-    visa_grpc::OpenRequest request;
-    visa_grpc::OpenResponse response;
+    OpenRequest request;
+    OpenResponse response;
     request.set_instrument_descriptor(test_descriptor);
     request.set_access_mode(visa_grpc::LOCK_STATE_NO_LOCK);
     request.set_session_name(session_name);
@@ -38,8 +29,8 @@ void call_open(VisaService& service, const char* session_name)
 void call_parse(VisaService& service)
 {
     ::grpc::ServerContext context;
-    visa_grpc::ParseRsrcRequest request;
-    visa_grpc::ParseRsrcResponse response;
+    ParseRsrcRequest request;
+    ParseRsrcResponse response;
     request.set_resource_name(test_descriptor);
 
     auto status = service.ParseRsrc(&context, &request, &response);
@@ -59,7 +50,7 @@ TEST(VisaResourceManagerTest, ParsePlusOpen_OpensResourceManagerOnce)
   auto library = std::make_shared<ni::tests::unit::VisaMockLibrary>();
   auto resource_repository = std::make_shared<nidevice_grpc::SessionResourceRepository<ViSession>>(session_repository);
   auto object_repository = std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViObject>>();
-  visa_grpc::VisaService service(library, resource_repository, object_repository);
+  VisaService service(library, resource_repository, object_repository);
 
   EXPECT_CALL(*library, OpenDefaultRM)
     .WillOnce(WithArg<0>(Invoke(SetSessionToOne)));
@@ -82,7 +73,7 @@ TEST(VisaResourceManagerTest, OpenTwoSessions_OpensResourceManagerOnce)
   auto library = std::make_shared<ni::tests::unit::VisaMockLibrary>();
   auto resource_repository = std::make_shared<nidevice_grpc::SessionResourceRepository<ViSession>>(session_repository);
   auto object_repository = std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViObject>>();
-  visa_grpc::VisaService service(library, resource_repository, object_repository);
+  VisaService service(library, resource_repository, object_repository);
 
   EXPECT_CALL(*library, OpenDefaultRM)
     .WillOnce(WithArg<0>(Invoke(SetSessionToOne)));
@@ -103,7 +94,7 @@ TEST(VisaResourceManagerTest, ResetServerWithOpenSession_OpenNewSession_OpensRes
   auto library = std::make_shared<ni::tests::unit::VisaMockLibrary>();
   auto resource_repository = std::make_shared<nidevice_grpc::SessionResourceRepository<ViSession>>(session_repository);
   auto object_repository = std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViObject>>();
-  visa_grpc::VisaService service(library, resource_repository, object_repository);
+  VisaService service(library, resource_repository, object_repository);
 
   EXPECT_CALL(*library, OpenDefaultRM)
     .Times(2)

--- a/source/tests/integration/visa_resource_manager_tests.cpp
+++ b/source/tests/integration/visa_resource_manager_tests.cpp
@@ -1,0 +1,125 @@
+#include <grpcpp/impl/grpc_library.h>
+#include <gtest/gtest.h>
+#include <server/session_repository.h>
+#include "visa/visa_mock_library.h"
+#include "visa/visa_service.h"
+
+#include <array>
+#include <iostream>
+#include <nlohmann/json.hpp>
+#include <string>
+
+using namespace ::nlohmann;
+using namespace visa_grpc;
+using testing::Invoke;
+using testing::WithArg;
+
+namespace ni {
+namespace tests {
+namespace integration {
+
+static const char* test_descriptor = "fake::descriptor";
+
+void call_open(VisaService& service, const char* session_name)
+{
+    ::grpc::ServerContext context;
+    visa_grpc::OpenRequest request;
+    visa_grpc::OpenResponse response;
+    request.set_instrument_descriptor(test_descriptor);
+    request.set_access_mode(visa_grpc::LOCK_STATE_NO_LOCK);
+    request.set_session_name(session_name);
+    request.set_open_timeout(0);
+
+    auto status = service.Open(&context, &request, &response);
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(0, response.status());
+}
+
+void call_parse(VisaService& service)
+{
+    ::grpc::ServerContext context;
+    visa_grpc::ParseRsrcRequest request;
+    visa_grpc::ParseRsrcResponse response;
+    request.set_resource_name(test_descriptor);
+
+    auto status = service.ParseRsrc(&context, &request, &response);
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(0, response.status());
+}
+
+ViStatus SetSessionToOne(ViSession* session)
+{
+  *session = (ViSession)1;
+  return VI_SUCCESS;
+}
+
+TEST(VisaResourceManagerTest, ParsePlusOpen_OpensResourceManagerOnce)
+{
+  auto session_repository = std::make_shared<nidevice_grpc::SessionRepository>();
+  auto library = std::make_shared<ni::tests::unit::VisaMockLibrary>();
+  auto resource_repository = std::make_shared<nidevice_grpc::SessionResourceRepository<ViSession>>(session_repository);
+  auto object_repository = std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViObject>>();
+  visa_grpc::VisaService service(library, resource_repository, object_repository);
+
+  EXPECT_CALL(*library, OpenDefaultRM)
+    .WillOnce(WithArg<0>(Invoke(SetSessionToOne)));
+  EXPECT_CALL(*library, ParseRsrc)
+    .Times(1);
+  EXPECT_CALL(*library, Open)
+    .Times(1);
+
+  call_parse(service);
+  call_open(service, "name2");
+
+  EXPECT_CALL(*library, Close)
+    .Times(2);
+  session_repository->reset_server();
+}
+
+TEST(VisaResourceManagerTest, OpenTwoSessions_OpensResourceManagerOnce)
+{
+  auto session_repository = std::make_shared<nidevice_grpc::SessionRepository>();
+  auto library = std::make_shared<ni::tests::unit::VisaMockLibrary>();
+  auto resource_repository = std::make_shared<nidevice_grpc::SessionResourceRepository<ViSession>>(session_repository);
+  auto object_repository = std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViObject>>();
+  visa_grpc::VisaService service(library, resource_repository, object_repository);
+
+  EXPECT_CALL(*library, OpenDefaultRM)
+    .WillOnce(WithArg<0>(Invoke(SetSessionToOne)));
+  EXPECT_CALL(*library, Open)
+    .Times(2);
+
+  call_open(service, "name1");
+  call_open(service, "name2");
+
+  EXPECT_CALL(*library, Close)
+    .Times(3);
+  session_repository->reset_server();
+}
+
+TEST(VisaResourceManagerTest, ResetServerWithOpenSession_OpenNewSession_OpensResourceManagerAgain)
+{
+  auto session_repository = std::make_shared<nidevice_grpc::SessionRepository>();
+  auto library = std::make_shared<ni::tests::unit::VisaMockLibrary>();
+  auto resource_repository = std::make_shared<nidevice_grpc::SessionResourceRepository<ViSession>>(session_repository);
+  auto object_repository = std::shared_ptr<nidevice_grpc::SessionResourceRepository<ViObject>>();
+  visa_grpc::VisaService service(library, resource_repository, object_repository);
+
+  EXPECT_CALL(*library, OpenDefaultRM)
+    .Times(2)
+    .WillRepeatedly(WithArg<0>(Invoke(SetSessionToOne)));
+  EXPECT_CALL(*library, Open)
+    .Times(2);
+  EXPECT_CALL(*library, Close)
+    .Times(4);
+
+  call_open(service, "name1");
+  session_repository->reset_server();
+
+  call_open(service, "name2");
+  session_repository->reset_server();
+}
+
+}  // namespace integration
+}  // namespace tests
+}  // namespace ni


### PR DESCRIPTION
### What does this Pull Request accomplish?

It closes the VISA resource manager when the server is reset.
- It does this by registering a fake session name (that really should be internal-only) that cleans up the static variable as well as closing the session.
- But it's lightweight enough that we don't need to worry about closing it in normal I/O session usage.

### Why should this Pull Request be merged?

The server being reset should clean up as much as possible.

### What testing has been done?

Added `visa_resource_manager_tests`
- Instantiating `OpenRequest`, `OpenResponse` etc. had the side effect of requiring many more .cpp files to be added to the integration test executable. Otherwise I got unresolved link errors.
![image](https://github.com/ni/grpc-device/assets/27234531/14cd46c7-18d8-4e20-9a60-d2252327e3c3)