### PR TITLE
Return supported event types when opening a session

### DIFF
--- a/generated/visa/visa.proto
+++ b/generated/visa/visa.proto
@@ -915,6 +915,7 @@ message OpenResponse {
   int32 status = 1;
   nidevice_grpc.Session vi = 2;
   bool new_session_initialized = 3;
+  repeated EventType supported_events = 4;
 }
 
 message Out16Request {

--- a/source/codegen/metadata/visa/functions.py
+++ b/source/codegen/metadata/visa/functions.py
@@ -1005,6 +1005,13 @@ functions = {
                 'name': 'newSessionInitialized',
                 'proto_only': True,
                 'type': 'bool'
+            },
+            {
+                'direction': 'out',
+                'grpc_type': 'repeated EventType',
+                'name': 'supportedEvents',
+                'proto_only': True,
+                'type': 'ViEvent'
             }
         ],
         'returns': 'ViStatus'

--- a/source/custom/visa_service.custom.cpp
+++ b/source/custom/visa_service.custom.cpp
@@ -262,12 +262,11 @@ static ViStatus GetAttributeValue(ViObject vi, ViAttr attributeID, VisaService::
     ViSession vi = session_repository_->access_session(grpc_device_session_name);
     if (library->GetAttribute(vi, VI_ATTR_NUM_SUP_EVENTS, &numEvents) == VI_SUCCESS && numEvents > 0) {
       // NI-VISA writes the events followed by an extra "-1" value that we don't need.
-      EventType* events = new EventType[numEvents + 1];
-      library->GetAttribute(vi, VI_ATTR_SUP_EVENTS, events);
+      std::vector<EventType> events(numEvents+1);
+      library->GetAttribute(vi, VI_ATTR_SUP_EVENTS, events.data());
       for (ViUInt16 i = 0; i < numEvents; ++i) {
         response->add_supported_events(events[i]);
       }
-      delete[] events;
     }
 
     response->set_status(status);

--- a/source/tests/integration/visa_resource_manager_tests.cpp
+++ b/source/tests/integration/visa_resource_manager_tests.cpp
@@ -71,9 +71,9 @@ TEST(VisaResourceManagerTest, ParsePlusOpen_OpensResourceManagerOnce)
     .Times(1);
   EXPECT_CALL(*library, Open)
     .Times(1);
-  EXPECT_CALL(*library, GetAttribute(_, 0x3FFF019CUL, _))
+  EXPECT_CALL(*library, GetAttribute(_, static_cast<ViAttr>(0x3FFF019CUL), _))
     .WillOnce(WithArg<2>(Invoke(SetNumberEventsToOne)));
-  EXPECT_CALL(*library, GetAttribute(_, 0x3FFF019DUL, _))
+  EXPECT_CALL(*library, GetAttribute(_, static_cast<ViAttr>(0x3FFF019DUL), _))
     .WillOnce(WithArg<2>(Invoke(SetEventTypeToTrigger)));
 
   call_parse(service);

--- a/source/tests/integration/visa_resource_manager_tests.cpp
+++ b/source/tests/integration/visa_resource_manager_tests.cpp
@@ -51,9 +51,9 @@ ViStatus SetNumberEventsToOne(void* attributeValue)
   return VI_SUCCESS;
 }
 
-ViStatus SetEventTypeToTrigger(void* attributeValue)
+ViStatus SetEventTypeToServiceRequest(void* attributeValue)
 {
-  *(ViEventType*)attributeValue = VI_EVENT_TRIG;
+  *(ViEventType*)attributeValue = VI_EVENT_SERVICE_REQ;
   return VI_SUCCESS;
 }
 
@@ -74,12 +74,12 @@ TEST(VisaResourceManagerTest, ParsePlusOpen_OpensResourceManagerOnce)
   EXPECT_CALL(*library, GetAttribute(_, static_cast<ViAttr>(0x3FFF019CUL), _))
     .WillOnce(WithArg<2>(Invoke(SetNumberEventsToOne)));
   EXPECT_CALL(*library, GetAttribute(_, static_cast<ViAttr>(0x3FFF019DUL), _))
-    .WillOnce(WithArg<2>(Invoke(SetEventTypeToTrigger)));
+    .WillOnce(WithArg<2>(Invoke(SetEventTypeToServiceRequest)));
 
   call_parse(service);
   auto response = call_open(service, "name2");
   EXPECT_EQ(1, response.supported_events_size());
-  EXPECT_EQ(VI_EVENT_TRIG, response.supported_events(0));
+  EXPECT_EQ(VI_EVENT_SERVICE_REQ, response.supported_events(0));
 
   EXPECT_CALL(*library, Close)
     .Times(2);


### PR DESCRIPTION
### What does this Pull Request accomplish?

- It includes the supported events for a newly-opened session as part of the "Open" response.
- This copies the latest output from scrapigen. The update is in a pending PR there.

### Why should this Pull Request be merged?

The VISA client needs to know which event types are supported for a given session.

### What testing has been done?

- Built and walked through it in the debugger.
- I updated the integration tests to account for the new library calls. Added both success and failure cases.