### PR TITLE
We must close the Find handle to avoid a leak.

### DIFF
--- a/source/custom/visa_service.custom.cpp
+++ b/source/custom/visa_service.custom.cpp
@@ -153,10 +153,12 @@ static ViStatus GetAttributeValue(ViObject vi, ViAttr attributeID, VisaService::
     for (ViUInt32 index = 1; index < return_count; ++index) {
       status = library_->FindNext(find_handle, descriptor);
       if (!status_ok(status)) {
+        library_->Close(find_handle);
         return ConvertApiErrorStatusForViSession(context, status, rsrc_manager_handle);
       }
       response->add_instrument_descriptor(descriptor);
     }
+    library_->Close(find_handle);
     response->set_status(status);
     return ::grpc::Status::OK;
   }


### PR DESCRIPTION
### What does this Pull Request accomplish?

Close the handle returned from `viFindRsrc` when we're done with it.

### Why should this Pull Request be merged?

This fixes a resource leak.

### What testing has been done?

`FindRsrc_OpensResourceManagerOnceAndClosesFindHandle`