### PR TITLE
Remove VISA support NextRelease toggle

### DIFF
--- a/generated/visa/visa_service.cpp
+++ b/generated/visa/visa_service.cpp
@@ -1956,7 +1956,7 @@ namespace visa_grpc {
   VisaFeatureToggles::VisaFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)
     : is_enabled(
-        feature_toggles.is_feature_enabled("visa", CodeReadiness::kNextRelease))
+        feature_toggles.is_feature_enabled("visa", CodeReadiness::kRelease))
   {
   }
 } // namespace visa_grpc

--- a/source/codegen/metadata/visa/config.py
+++ b/source/codegen/metadata/visa/config.py
@@ -5,7 +5,6 @@ config = {
     'c_function_prefix': 'vi',
     'c_header': 'visa.h',
     'close_function': 'Close',
-    'code_readiness': 'NextRelease',
     'csharp_namespace': 'NationalInstruments.Grpc.Visa',
     'custom_header_suffix': '_attributes.h',
     'custom_types': [],


### PR DESCRIPTION
### What does this Pull Request accomplish?

Move VISA support in grpc-device to Release state

### Why should this Pull Request be merged?

NI-VISA gRPC support for MeasurementLink will be released in 2024Q1, align with grpc-device 2024Q1 release.

### What testing has been done?

Manual validation.
