### PR TITLE
Add workflow_dispatch to allow manual trigger of the CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
       - 'releases/**'
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 jobs:
   cancel_builds:
@@ -15,12 +16,12 @@ jobs:
   validate_python:
     uses: ./.github/workflows/validate_python.yml
   build_desktop:
-    needs: 
+    needs:
       - validate_imported_protos
       - validate_python
     uses: ./.github/workflows/build_cmake.yml
   build_nilrt:
-    needs: 
+    needs:
       - validate_imported_protos
       - validate_python
     uses: ./.github/workflows/build_nilrt.yml


### PR DESCRIPTION
### What does this Pull Request accomplish?

 Allow manual trigger of the CI build
- For public repositories, users must have write permissions to manually run a workflow. This typically includes the repository owner and collaborators.

### Why should this Pull Request be merged?

Need a manual trigger of the CI build

### What testing has been done?

None.
