### PR TITLE
Grpc - LoadReferenceWaveformFromTDMSFile

### DIFF
--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted.proto
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted.proto
@@ -17,6 +17,7 @@ import "nidevice.proto";
 import "session.proto";
 
 service NiRFmxSpecAnRestricted {
+  rpc AMPMLoadReferenceWaveformFromTDMSFile(AMPMLoadReferenceWaveformFromTDMSFileRequest) returns (AMPMLoadReferenceWaveformFromTDMSFileResponse);
   rpc CacheResult(CacheResultRequest) returns (CacheResultResponse);
   rpc IQFetchDataOverrideBehavior(IQFetchDataOverrideBehaviorRequest) returns (IQFetchDataOverrideBehaviorResponse);
 }
@@ -25,6 +26,35 @@ enum IQDeleteOnFetch {
   IQ_DELETE_ON_FETCH_DEFAULT = 0;
   IQ_DELETE_ON_FETCH_TRUE = 1;
   IQ_DELETE_ON_FETCH_FALSE = 2;
+}
+
+enum AmpmReferenceWaveformIdleDurationPresent {
+  AMPM_REFERENCE_WAVEFORM_IDLE_DURATION_PRESENT_FALSE = 0;
+  AMPM_REFERENCE_WAVEFORM_IDLE_DURATION_PRESENT_TRUE = 1;
+}
+
+enum AmpmSignalType {
+  AMPM_SIGNAL_TYPE_MODULATED = 0;
+  AMPM_SIGNAL_TYPE_TONES = 1;
+}
+
+message AMPMLoadReferenceWaveformFromTDMSFileRequest {
+  nidevice_grpc.Session instrument_handle = 1;
+  string selector_string = 2;
+  string waveform_file_path = 3;
+  oneof idle_duration_present_enum {
+    AmpmReferenceWaveformIdleDurationPresent idle_duration_present = 4;
+    int32 idle_duration_present_raw = 5;
+  }
+  oneof signal_type_enum {
+    AmpmSignalType signal_type = 6;
+    int32 signal_type_raw = 7;
+  }
+  int32 waveform_index = 8;
+}
+
+message AMPMLoadReferenceWaveformFromTDMSFileResponse {
+  int32 status = 1;
 }
 
 message CacheResultRequest {

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.cpp
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.cpp
@@ -17,6 +17,42 @@
 
 namespace nirfmxspecan_restricted_grpc::experimental::client {
 
+AMPMLoadReferenceWaveformFromTDMSFileResponse
+ampm_load_reference_waveform_from_tdms_file(const StubPtr& stub, const nidevice_grpc::Session& instrument_handle, const std::string& selector_string, const std::string& waveform_file_path, const simple_variant<AmpmReferenceWaveformIdleDurationPresent, pb::int32>& idle_duration_present, const simple_variant<AmpmSignalType, pb::int32>& signal_type, const pb::int32& waveform_index)
+{
+  ::grpc::ClientContext context;
+
+  auto request = AMPMLoadReferenceWaveformFromTDMSFileRequest{};
+  request.mutable_instrument_handle()->CopyFrom(instrument_handle);
+  request.set_selector_string(selector_string);
+  request.set_waveform_file_path(waveform_file_path);
+  const auto idle_duration_present_ptr = idle_duration_present.get_if<AmpmReferenceWaveformIdleDurationPresent>();
+  const auto idle_duration_present_raw_ptr = idle_duration_present.get_if<pb::int32>();
+  if (idle_duration_present_ptr) {
+    request.set_idle_duration_present(*idle_duration_present_ptr);
+  }
+  else if (idle_duration_present_raw_ptr) {
+    request.set_idle_duration_present_raw(*idle_duration_present_raw_ptr);
+  }
+  const auto signal_type_ptr = signal_type.get_if<AmpmSignalType>();
+  const auto signal_type_raw_ptr = signal_type.get_if<pb::int32>();
+  if (signal_type_ptr) {
+    request.set_signal_type(*signal_type_ptr);
+  }
+  else if (signal_type_raw_ptr) {
+    request.set_signal_type_raw(*signal_type_raw_ptr);
+  }
+  request.set_waveform_index(waveform_index);
+
+  auto response = AMPMLoadReferenceWaveformFromTDMSFileResponse{};
+
+  raise_if_error(
+      stub->AMPMLoadReferenceWaveformFromTDMSFile(&context, request, &response),
+      context);
+
+  return response;
+}
+
 CacheResultResponse
 cache_result(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const pb::int32& selector_string_out_size)
 {

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.h
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.h
@@ -22,6 +22,7 @@ using StubPtr = std::unique_ptr<NiRFmxSpecAnRestricted::Stub>;
 using namespace nidevice_grpc::experimental::client;
 
 
+AMPMLoadReferenceWaveformFromTDMSFileResponse ampm_load_reference_waveform_from_tdms_file(const StubPtr& stub, const nidevice_grpc::Session& instrument_handle, const std::string& selector_string, const std::string& waveform_file_path, const simple_variant<AmpmReferenceWaveformIdleDurationPresent, pb::int32>& idle_duration_present, const simple_variant<AmpmSignalType, pb::int32>& signal_type, const pb::int32& waveform_index);
 CacheResultResponse cache_result(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const pb::int32& selector_string_out_size);
 IQFetchDataOverrideBehaviorResponse iq_fetch_data_override_behavior(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout, const pb::int32& record_to_fetch, const pb::int64& samples_to_read, const simple_variant<IQDeleteOnFetch, pb::int32>& delete_on_fetch);
 

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_library.cpp
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_library.cpp
@@ -27,6 +27,7 @@ NiRFmxSpecAnRestrictedLibrary::NiRFmxSpecAnRestrictedLibrary(std::shared_ptr<nid
   if (!loaded) {
     return;
   }
+  function_pointers_.AMPMLoadReferenceWaveformFromTDMSFile = reinterpret_cast<AMPMLoadReferenceWaveformFromTDMSFilePtr>(shared_library_->get_function_pointer("RFmxSpecAn_AMPMLoadReferenceWaveformFromTDMSFile"));
   function_pointers_.CacheResult = reinterpret_cast<CacheResultPtr>(shared_library_->get_function_pointer("RFmxSpecAn_CacheResult"));
   function_pointers_.GetError = reinterpret_cast<GetErrorPtr>(shared_library_->get_function_pointer("RFmxSpecAn_GetError"));
   function_pointers_.GetErrorString = reinterpret_cast<GetErrorStringPtr>(shared_library_->get_function_pointer("RFmxSpecAn_GetErrorString"));
@@ -42,6 +43,14 @@ NiRFmxSpecAnRestrictedLibrary::~NiRFmxSpecAnRestrictedLibrary()
   return shared_library_->function_exists(functionName.c_str())
     ? ::grpc::Status::OK
     : ::grpc::Status(::grpc::NOT_FOUND, "Could not find the function " + functionName);
+}
+
+int32 NiRFmxSpecAnRestrictedLibrary::AMPMLoadReferenceWaveformFromTDMSFile(niRFmxInstrHandle instrumentHandle, char selectorString[], char waveformFilePath[], int32 idleDurationPresent, int32 signalType, int32 waveformIndex)
+{
+  if (!function_pointers_.AMPMLoadReferenceWaveformFromTDMSFile) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxSpecAn_AMPMLoadReferenceWaveformFromTDMSFile.");
+  }
+  return function_pointers_.AMPMLoadReferenceWaveformFromTDMSFile(instrumentHandle, selectorString, waveformFilePath, idleDurationPresent, signalType, waveformIndex);
 }
 
 int32 NiRFmxSpecAnRestrictedLibrary::CacheResult(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 selectorStringOutSize, char selectorStringOut[])

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_library.h
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_library.h
@@ -21,18 +21,21 @@ class NiRFmxSpecAnRestrictedLibrary : public nirfmxspecan_restricted_grpc::NiRFm
   virtual ~NiRFmxSpecAnRestrictedLibrary();
 
   ::grpc::Status check_function_exists(std::string functionName);
+  int32 AMPMLoadReferenceWaveformFromTDMSFile(niRFmxInstrHandle instrumentHandle, char selectorString[], char waveformFilePath[], int32 idleDurationPresent, int32 signalType, int32 waveformIndex) override;
   int32 CacheResult(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 selectorStringOutSize, char selectorStringOut[]) override;
   int32 GetError(niRFmxInstrHandle instrumentHandle, int32* errorCode, int32 errorDescriptionBufferSize, char errorDescription[]) override;
   int32 GetErrorString(niRFmxInstrHandle instrumentHandle, int32 errorCode, int32 errorDescriptionBufferSize, char errorDescription[]) override;
   int32 IQFetchDataOverrideBehavior(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, int32 recordToFetch, int64 samplesToRead, int32 deleteOnFetch, float64* t0, float64* dt, NIComplexSingle data[], int32 arraySize, int32* actualArraySize) override;
 
  private:
+  using AMPMLoadReferenceWaveformFromTDMSFilePtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], char waveformFilePath[], int32 idleDurationPresent, int32 signalType, int32 waveformIndex);
   using CacheResultPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 selectorStringOutSize, char selectorStringOut[]);
   using GetErrorPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, int32* errorCode, int32 errorDescriptionBufferSize, char errorDescription[]);
   using GetErrorStringPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, int32 errorCode, int32 errorDescriptionBufferSize, char errorDescription[]);
   using IQFetchDataOverrideBehaviorPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, int32 recordToFetch, int64 samplesToRead, int32 deleteOnFetch, float64* t0, float64* dt, NIComplexSingle data[], int32 arraySize, int32* actualArraySize);
 
   typedef struct FunctionPointers {
+    AMPMLoadReferenceWaveformFromTDMSFilePtr AMPMLoadReferenceWaveformFromTDMSFile;
     CacheResultPtr CacheResult;
     GetErrorPtr GetError;
     GetErrorStringPtr GetErrorString;

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_library_interface.h
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_library_interface.h
@@ -15,6 +15,7 @@ class NiRFmxSpecAnRestrictedLibraryInterface {
  public:
   virtual ~NiRFmxSpecAnRestrictedLibraryInterface() {}
 
+  virtual int32 AMPMLoadReferenceWaveformFromTDMSFile(niRFmxInstrHandle instrumentHandle, char selectorString[], char waveformFilePath[], int32 idleDurationPresent, int32 signalType, int32 waveformIndex) = 0;
   virtual int32 CacheResult(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 selectorStringOutSize, char selectorStringOut[]) = 0;
   virtual int32 GetError(niRFmxInstrHandle instrumentHandle, int32* errorCode, int32 errorDescriptionBufferSize, char errorDescription[]) = 0;
   virtual int32 GetErrorString(niRFmxInstrHandle instrumentHandle, int32 errorCode, int32 errorDescriptionBufferSize, char errorDescription[]) = 0;

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_mock_library.h
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_mock_library.h
@@ -17,6 +17,7 @@ namespace unit {
 
 class NiRFmxSpecAnRestrictedMockLibrary : public nirfmxspecan_restricted_grpc::NiRFmxSpecAnRestrictedLibraryInterface {
  public:
+  MOCK_METHOD(int32, AMPMLoadReferenceWaveformFromTDMSFile, (niRFmxInstrHandle instrumentHandle, char selectorString[], char waveformFilePath[], int32 idleDurationPresent, int32 signalType, int32 waveformIndex), (override));
   MOCK_METHOD(int32, CacheResult, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 selectorStringOutSize, char selectorStringOut[]), (override));
   MOCK_METHOD(int32, GetError, (niRFmxInstrHandle instrumentHandle, int32* errorCode, int32 errorDescriptionBufferSize, char errorDescription[]), (override));
   MOCK_METHOD(int32, GetErrorString, (niRFmxInstrHandle instrumentHandle, int32 errorCode, int32 errorDescriptionBufferSize, char errorDescription[]), (override));

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_service.cpp
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_service.cpp
@@ -46,6 +46,65 @@ namespace nirfmxspecan_restricted_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxSpecAnRestrictedService::AMPMLoadReferenceWaveformFromTDMSFile(::grpc::ServerContext* context, const AMPMLoadReferenceWaveformFromTDMSFileRequest* request, AMPMLoadReferenceWaveformFromTDMSFileResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_handle_grpc_session = request->instrument_handle();
+      niRFmxInstrHandle instrument_handle = session_repository_->access_session(instrument_handle_grpc_session.name());
+      auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
+      char* selector_string = (char*)selector_string_mbcs.c_str();
+      auto waveform_file_path_mbcs = convert_from_grpc<std::string>(request->waveform_file_path());
+      char* waveform_file_path = (char*)waveform_file_path_mbcs.c_str();
+      int32 idle_duration_present;
+      switch (request->idle_duration_present_enum_case()) {
+        case nirfmxspecan_restricted_grpc::AMPMLoadReferenceWaveformFromTDMSFileRequest::IdleDurationPresentEnumCase::kIdleDurationPresent: {
+          idle_duration_present = static_cast<int32>(request->idle_duration_present());
+          break;
+        }
+        case nirfmxspecan_restricted_grpc::AMPMLoadReferenceWaveformFromTDMSFileRequest::IdleDurationPresentEnumCase::kIdleDurationPresentRaw: {
+          idle_duration_present = static_cast<int32>(request->idle_duration_present_raw());
+          break;
+        }
+        case nirfmxspecan_restricted_grpc::AMPMLoadReferenceWaveformFromTDMSFileRequest::IdleDurationPresentEnumCase::IDLE_DURATION_PRESENT_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for idle_duration_present was not specified or out of range");
+          break;
+        }
+      }
+
+      int32 signal_type;
+      switch (request->signal_type_enum_case()) {
+        case nirfmxspecan_restricted_grpc::AMPMLoadReferenceWaveformFromTDMSFileRequest::SignalTypeEnumCase::kSignalType: {
+          signal_type = static_cast<int32>(request->signal_type());
+          break;
+        }
+        case nirfmxspecan_restricted_grpc::AMPMLoadReferenceWaveformFromTDMSFileRequest::SignalTypeEnumCase::kSignalTypeRaw: {
+          signal_type = static_cast<int32>(request->signal_type_raw());
+          break;
+        }
+        case nirfmxspecan_restricted_grpc::AMPMLoadReferenceWaveformFromTDMSFileRequest::SignalTypeEnumCase::SIGNAL_TYPE_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for signal_type was not specified or out of range");
+          break;
+        }
+      }
+
+      int32 waveform_index = request->waveform_index();
+      auto status = library_->AMPMLoadReferenceWaveformFromTDMSFile(instrument_handle, selector_string, waveform_file_path, idle_duration_present, signal_type, waveform_index);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument_handle);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiRFmxSpecAnRestrictedService::CacheResult(::grpc::ServerContext* context, const CacheResultRequest* request, CacheResultResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_service.h
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_service.h
@@ -42,6 +42,7 @@ public:
     const NiRFmxSpecAnRestrictedFeatureToggles& feature_toggles = {});
   virtual ~NiRFmxSpecAnRestrictedService();
 
+  ::grpc::Status AMPMLoadReferenceWaveformFromTDMSFile(::grpc::ServerContext* context, const AMPMLoadReferenceWaveformFromTDMSFileRequest* request, AMPMLoadReferenceWaveformFromTDMSFileResponse* response) override;
   ::grpc::Status CacheResult(::grpc::ServerContext* context, const CacheResultRequest* request, CacheResultResponse* response) override;
   ::grpc::Status IQFetchDataOverrideBehavior(::grpc::ServerContext* context, const IQFetchDataOverrideBehaviorRequest* request, IQFetchDataOverrideBehaviorResponse* response) override;
 private:

--- a/generated/nirfmxwlan_restricted/nirfmxwlan_restricted.proto
+++ b/generated/nirfmxwlan_restricted/nirfmxwlan_restricted.proto
@@ -18,6 +18,7 @@ import "session.proto";
 service NiRFmxWLANRestricted {
   rpc GetChannelList(GetChannelListRequest) returns (GetChannelListResponse);
   rpc OFDMModAccFetchCommonPilotErrorTraceIndB(OFDMModAccFetchCommonPilotErrorTraceIndBRequest) returns (OFDMModAccFetchCommonPilotErrorTraceIndBResponse);
+  rpc OFDMModAccLoad1ReferenceWaveformFromTDMSFile(OFDMModAccLoad1ReferenceWaveformFromTDMSFileRequest) returns (OFDMModAccLoad1ReferenceWaveformFromTDMSFileResponse);
   rpc OFDMModAccNoiseCalibrate(OFDMModAccNoiseCalibrateRequest) returns (OFDMModAccNoiseCalibrateResponse);
 }
 
@@ -47,6 +48,17 @@ message OFDMModAccFetchCommonPilotErrorTraceIndBResponse {
   repeated float common_pilot_error_magnitude = 4;
   repeated float common_pilot_error_phase = 5;
   int32 actual_array_size = 6;
+}
+
+message OFDMModAccLoad1ReferenceWaveformFromTDMSFileRequest {
+  nidevice_grpc.Session instrument_handle = 1;
+  string selector_string = 2;
+  string waveform_file_path = 3;
+  int32 waveform_index = 4;
+}
+
+message OFDMModAccLoad1ReferenceWaveformFromTDMSFileResponse {
+  int32 status = 1;
 }
 
 message OFDMModAccNoiseCalibrateRequest {

--- a/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_client.cpp
+++ b/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_client.cpp
@@ -55,6 +55,26 @@ ofdm_mod_acc_fetch_common_pilot_error_trace_ind_b(const StubPtr& stub, const nid
   return response;
 }
 
+OFDMModAccLoad1ReferenceWaveformFromTDMSFileResponse
+ofdm_mod_acc_load1_reference_waveform_from_tdms_file(const StubPtr& stub, const nidevice_grpc::Session& instrument_handle, const std::string& selector_string, const std::string& waveform_file_path, const pb::int32& waveform_index)
+{
+  ::grpc::ClientContext context;
+
+  auto request = OFDMModAccLoad1ReferenceWaveformFromTDMSFileRequest{};
+  request.mutable_instrument_handle()->CopyFrom(instrument_handle);
+  request.set_selector_string(selector_string);
+  request.set_waveform_file_path(waveform_file_path);
+  request.set_waveform_index(waveform_index);
+
+  auto response = OFDMModAccLoad1ReferenceWaveformFromTDMSFileResponse{};
+
+  raise_if_error(
+      stub->OFDMModAccLoad1ReferenceWaveformFromTDMSFile(&context, request, &response),
+      context);
+
+  return response;
+}
+
 OFDMModAccNoiseCalibrateResponse
 ofdm_mod_acc_noise_calibrate(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const pb::int32& shared_lo_connection)
 {

--- a/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_client.h
+++ b/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_client.h
@@ -24,6 +24,7 @@ using namespace nidevice_grpc::experimental::client;
 
 GetChannelListResponse get_channel_list(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const pb::int32& wlan_band);
 OFDMModAccFetchCommonPilotErrorTraceIndBResponse ofdm_mod_acc_fetch_common_pilot_error_trace_ind_b(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout);
+OFDMModAccLoad1ReferenceWaveformFromTDMSFileResponse ofdm_mod_acc_load1_reference_waveform_from_tdms_file(const StubPtr& stub, const nidevice_grpc::Session& instrument_handle, const std::string& selector_string, const std::string& waveform_file_path, const pb::int32& waveform_index);
 OFDMModAccNoiseCalibrateResponse ofdm_mod_acc_noise_calibrate(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const pb::int32& shared_lo_connection);
 
 } // namespace nirfmxwlan_restricted_grpc::experimental::client

--- a/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_library.cpp
+++ b/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_library.cpp
@@ -31,6 +31,7 @@ NiRFmxWLANRestrictedLibrary::NiRFmxWLANRestrictedLibrary(std::shared_ptr<nidevic
   function_pointers_.GetError = reinterpret_cast<GetErrorPtr>(shared_library_->get_function_pointer("RFmxWLAN_GetError"));
   function_pointers_.GetErrorString = reinterpret_cast<GetErrorStringPtr>(shared_library_->get_function_pointer("RFmxWLAN_GetErrorString"));
   function_pointers_.OFDMModAccFetchCommonPilotErrorTraceIndB = reinterpret_cast<OFDMModAccFetchCommonPilotErrorTraceIndBPtr>(shared_library_->get_function_pointer("RFmxWLAN_OFDMModAccFetchCommonPilotErrorTraceIndB"));
+  function_pointers_.OFDMModAccLoad1ReferenceWaveformFromTDMSFile = reinterpret_cast<OFDMModAccLoad1ReferenceWaveformFromTDMSFilePtr>(shared_library_->get_function_pointer("RFmxWLAN_OFDMModAccLoad1ReferenceWaveformFromTDMSFile"));
   function_pointers_.OFDMModAccNoiseCalibrate = reinterpret_cast<OFDMModAccNoiseCalibratePtr>(shared_library_->get_function_pointer("RFmxWLAN_OFDMModAccNoiseCalibrate"));
 }
 
@@ -75,6 +76,14 @@ int32 NiRFmxWLANRestrictedLibrary::OFDMModAccFetchCommonPilotErrorTraceIndB(niRF
     throw nidevice_grpc::LibraryLoadException("Could not find RFmxWLAN_OFDMModAccFetchCommonPilotErrorTraceIndB.");
   }
   return function_pointers_.OFDMModAccFetchCommonPilotErrorTraceIndB(instrumentHandle, selectorString, timeout, x0, dx, commonPilotErrorMagnitude, commonPilotErrorPhase, arraySize, actualArraySize);
+}
+
+int32 NiRFmxWLANRestrictedLibrary::OFDMModAccLoad1ReferenceWaveformFromTDMSFile(niRFmxInstrHandle instrumentHandle, char selectorString[], char waveformFilePath[], int32 waveformIndex)
+{
+  if (!function_pointers_.OFDMModAccLoad1ReferenceWaveformFromTDMSFile) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxWLAN_OFDMModAccLoad1ReferenceWaveformFromTDMSFile.");
+  }
+  return function_pointers_.OFDMModAccLoad1ReferenceWaveformFromTDMSFile(instrumentHandle, selectorString, waveformFilePath, waveformIndex);
 }
 
 int32 NiRFmxWLANRestrictedLibrary::OFDMModAccNoiseCalibrate(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 sharedLOConnection)

--- a/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_library.h
+++ b/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_library.h
@@ -25,6 +25,7 @@ class NiRFmxWLANRestrictedLibrary : public nirfmxwlan_restricted_grpc::NiRFmxWLA
   int32 GetError(niRFmxInstrHandle instrumentHandle, int32* errorCode, int32 errorDescriptionBufferSize, char errorDescription[]) override;
   int32 GetErrorString(niRFmxInstrHandle instrumentHandle, int32 errorCode, int32 errorDescriptionBufferSize, char errorDescription[]) override;
   int32 OFDMModAccFetchCommonPilotErrorTraceIndB(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 commonPilotErrorMagnitude[], float32 commonPilotErrorPhase[], int32 arraySize, int32* actualArraySize) override;
+  int32 OFDMModAccLoad1ReferenceWaveformFromTDMSFile(niRFmxInstrHandle instrumentHandle, char selectorString[], char waveformFilePath[], int32 waveformIndex) override;
   int32 OFDMModAccNoiseCalibrate(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 sharedLOConnection) override;
 
  private:
@@ -32,6 +33,7 @@ class NiRFmxWLANRestrictedLibrary : public nirfmxwlan_restricted_grpc::NiRFmxWLA
   using GetErrorPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, int32* errorCode, int32 errorDescriptionBufferSize, char errorDescription[]);
   using GetErrorStringPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, int32 errorCode, int32 errorDescriptionBufferSize, char errorDescription[]);
   using OFDMModAccFetchCommonPilotErrorTraceIndBPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 commonPilotErrorMagnitude[], float32 commonPilotErrorPhase[], int32 arraySize, int32* actualArraySize);
+  using OFDMModAccLoad1ReferenceWaveformFromTDMSFilePtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], char waveformFilePath[], int32 waveformIndex);
   using OFDMModAccNoiseCalibratePtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 sharedLOConnection);
 
   typedef struct FunctionPointers {
@@ -39,6 +41,7 @@ class NiRFmxWLANRestrictedLibrary : public nirfmxwlan_restricted_grpc::NiRFmxWLA
     GetErrorPtr GetError;
     GetErrorStringPtr GetErrorString;
     OFDMModAccFetchCommonPilotErrorTraceIndBPtr OFDMModAccFetchCommonPilotErrorTraceIndB;
+    OFDMModAccLoad1ReferenceWaveformFromTDMSFilePtr OFDMModAccLoad1ReferenceWaveformFromTDMSFile;
     OFDMModAccNoiseCalibratePtr OFDMModAccNoiseCalibrate;
   } FunctionLoadStatus;
 

--- a/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_library_interface.h
+++ b/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_library_interface.h
@@ -19,6 +19,7 @@ class NiRFmxWLANRestrictedLibraryInterface {
   virtual int32 GetError(niRFmxInstrHandle instrumentHandle, int32* errorCode, int32 errorDescriptionBufferSize, char errorDescription[]) = 0;
   virtual int32 GetErrorString(niRFmxInstrHandle instrumentHandle, int32 errorCode, int32 errorDescriptionBufferSize, char errorDescription[]) = 0;
   virtual int32 OFDMModAccFetchCommonPilotErrorTraceIndB(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 commonPilotErrorMagnitude[], float32 commonPilotErrorPhase[], int32 arraySize, int32* actualArraySize) = 0;
+  virtual int32 OFDMModAccLoad1ReferenceWaveformFromTDMSFile(niRFmxInstrHandle instrumentHandle, char selectorString[], char waveformFilePath[], int32 waveformIndex) = 0;
   virtual int32 OFDMModAccNoiseCalibrate(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 sharedLOConnection) = 0;
 };
 

--- a/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_mock_library.h
+++ b/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_mock_library.h
@@ -21,6 +21,7 @@ class NiRFmxWLANRestrictedMockLibrary : public nirfmxwlan_restricted_grpc::NiRFm
   MOCK_METHOD(int32, GetError, (niRFmxInstrHandle instrumentHandle, int32* errorCode, int32 errorDescriptionBufferSize, char errorDescription[]), (override));
   MOCK_METHOD(int32, GetErrorString, (niRFmxInstrHandle instrumentHandle, int32 errorCode, int32 errorDescriptionBufferSize, char errorDescription[]), (override));
   MOCK_METHOD(int32, OFDMModAccFetchCommonPilotErrorTraceIndB, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 commonPilotErrorMagnitude[], float32 commonPilotErrorPhase[], int32 arraySize, int32* actualArraySize), (override));
+  MOCK_METHOD(int32, OFDMModAccLoad1ReferenceWaveformFromTDMSFile, (niRFmxInstrHandle instrumentHandle, char selectorString[], char waveformFilePath[], int32 waveformIndex), (override));
   MOCK_METHOD(int32, OFDMModAccNoiseCalibrate, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 sharedLOConnection), (override));
 };
 

--- a/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_service.cpp
+++ b/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_service.cpp
@@ -138,6 +138,33 @@ namespace nirfmxwlan_restricted_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxWLANRestrictedService::OFDMModAccLoad1ReferenceWaveformFromTDMSFile(::grpc::ServerContext* context, const OFDMModAccLoad1ReferenceWaveformFromTDMSFileRequest* request, OFDMModAccLoad1ReferenceWaveformFromTDMSFileResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_handle_grpc_session = request->instrument_handle();
+      niRFmxInstrHandle instrument_handle = session_repository_->access_session(instrument_handle_grpc_session.name());
+      auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
+      char* selector_string = (char*)selector_string_mbcs.c_str();
+      auto waveform_file_path_mbcs = convert_from_grpc<std::string>(request->waveform_file_path());
+      char* waveform_file_path = (char*)waveform_file_path_mbcs.c_str();
+      int32 waveform_index = request->waveform_index();
+      auto status = library_->OFDMModAccLoad1ReferenceWaveformFromTDMSFile(instrument_handle, selector_string, waveform_file_path, waveform_index);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument_handle);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiRFmxWLANRestrictedService::OFDMModAccNoiseCalibrate(::grpc::ServerContext* context, const OFDMModAccNoiseCalibrateRequest* request, OFDMModAccNoiseCalibrateResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_service.h
+++ b/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_service.h
@@ -44,6 +44,7 @@ public:
 
   ::grpc::Status GetChannelList(::grpc::ServerContext* context, const GetChannelListRequest* request, GetChannelListResponse* response) override;
   ::grpc::Status OFDMModAccFetchCommonPilotErrorTraceIndB(::grpc::ServerContext* context, const OFDMModAccFetchCommonPilotErrorTraceIndBRequest* request, OFDMModAccFetchCommonPilotErrorTraceIndBResponse* response) override;
+  ::grpc::Status OFDMModAccLoad1ReferenceWaveformFromTDMSFile(::grpc::ServerContext* context, const OFDMModAccLoad1ReferenceWaveformFromTDMSFileRequest* request, OFDMModAccLoad1ReferenceWaveformFromTDMSFileResponse* response) override;
   ::grpc::Status OFDMModAccNoiseCalibrate(::grpc::ServerContext* context, const OFDMModAccNoiseCalibrateRequest* request, OFDMModAccNoiseCalibrateResponse* response) override;
 private:
   LibrarySharedPtr library_;

--- a/source/codegen/metadata/nirfmxspecan_restricted/enums.py
+++ b/source/codegen/metadata/nirfmxspecan_restricted/enums.py
@@ -14,5 +14,29 @@ enums = {
                 'value': 2
             }
         ]
+    },
+    'AmpmReferenceWaveformIdleDurationPresent': {
+        'values': [
+            {
+                'name': 'FALSE',
+                'value': 0
+            },
+            {
+                'name': 'TRUE',
+                'value': 1
+            }
+        ]
+    },
+    'AmpmSignalType': {
+        'values': [
+            {
+                'name': 'MODULATED',
+                'value': 0
+            },
+            {
+                'name': 'TONES',
+                'value': 1
+            }
+        ]
     }
 }

--- a/source/codegen/metadata/nirfmxspecan_restricted/functions.py
+++ b/source/codegen/metadata/nirfmxspecan_restricted/functions.py
@@ -1,4 +1,41 @@
 functions = {
+    'AMPMLoadReferenceWaveformFromTDMSFile': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'waveformFilePath',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'enum': 'AmpmReferenceWaveformIdleDurationPresent',
+                'name': 'idleDurationPresent',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'enum': 'AmpmSignalType',
+                'name': 'signalType',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'name': 'waveformIndex',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
     'CacheResult': {
         'parameters': [
             {

--- a/source/codegen/metadata/nirfmxwlan_restricted/functions.py
+++ b/source/codegen/metadata/nirfmxwlan_restricted/functions.py
@@ -173,6 +173,31 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'OFDMModAccLoad1ReferenceWaveformFromTDMSFile': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'waveformFilePath',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'waveformIndex',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
     'OFDMModAccNoiseCalibrate': {
         'parameters': [
             {


### PR DESCRIPTION
### What does this Pull Request accomplish?

Added Grpc device support for newly added private API -  LoadReferenceWaveformFromTDMSFile
It has been implemented for 2 personalities for RFmx

### Why should this Pull Request be merged?

To support new APIs

### What testing has been done?

Manually inspected generated files.
Manually inspected nirfmxspecan.proto  & nirfmxwlan.proto file.
