### PR TITLE
Add new executable flag to check if main or release version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,6 +425,13 @@ if(WIN32)
   )
 endif()
 
+execute_process(
+  COMMAND git rev-parse --abbrev-ref HEAD
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_BRANCH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
 # Generate version header file
 # This file requires product name and version info that mako does not know, but CMake does
 configure_file(

--- a/generated/version.h
+++ b/generated/version.h
@@ -5,7 +5,6 @@ namespace nidevice_grpc {
 
 static constexpr const char* kNiDeviceGrpcFileVersion = "2.5.0.0";
 static constexpr const char* kNiDeviceGrpcOriginalFileName = "ni_grpc_device_server.exe";
-static constexpr const char* kNiDeviceGrpcBranchName = "users/christag-ni/noteDevWithCommand";
 
 }
 

--- a/generated/version.h
+++ b/generated/version.h
@@ -5,6 +5,7 @@ namespace nidevice_grpc {
 
 static constexpr const char* kNiDeviceGrpcFileVersion = "2.5.0.0";
 static constexpr const char* kNiDeviceGrpcOriginalFileName = "ni_grpc_device_server.exe";
+static constexpr const char* kNiDeviceGrpcBranchName = "users/christag-ni/noteDevWithCommand";
 
 }
 

--- a/source/server/core_server.cpp
+++ b/source/server/core_server.cpp
@@ -17,6 +17,8 @@
   #include "windows/console_ctrl_handler.h"
 #endif
 
+#include "version.h"
+
 using FeatureState = nidevice_grpc::FeatureToggles::FeatureState;
 
 struct ServerConfiguration {
@@ -183,6 +185,17 @@ Options parse_options(int argc, char** argv)
 #endif
     if (strcmp("--help", argv[i]) == 0 || strcmp("-h", argv[i]) == 0) {
       nidevice_grpc::logging::log(nidevice_grpc::logging::Level_Info, usage);
+      exit(EXIT_SUCCESS);
+    }
+    else if (strcmp("--version", argv[i]) == 0) {
+      std::string string_kNiDeviceGrpcBranchName(nidevice_grpc::kNiDeviceGrpcBranchName);
+      if (string_kNiDeviceGrpcBranchName.rfind("releases", 0) == 0) {
+        nidevice_grpc::logging::log(nidevice_grpc::logging::Level_Info, nidevice_grpc::kNiDeviceGrpcFileVersion);
+      }
+      else {
+        nidevice_grpc::logging::log(nidevice_grpc::logging::Level_Info, nidevice_grpc::kNiDeviceGrpcFileVersion);
+        nidevice_grpc::logging::log(nidevice_grpc::logging::Level_Info, "dev");
+      }
       exit(EXIT_SUCCESS);
     }
     else if (i == argc - 1) {

--- a/source/server/version.h.in
+++ b/source/server/version.h.in
@@ -5,6 +5,7 @@ namespace nidevice_grpc {
 
 static constexpr const char* kNiDeviceGrpcFileVersion = "@PROJECT_VERSION_MAJOR@.@PROJECT_VERSION_MINOR@.@PROJECT_VERSION_PATCH@.0";
 static constexpr const char* kNiDeviceGrpcOriginalFileName = "ni_grpc_device_server.exe";
+static constexpr const char* kNiDeviceGrpcBranchName = "@GIT_BRANCH@";
 
 }
 


### PR DESCRIPTION
### What does this Pull Request accomplish?

This PR adds new command line functionality by allowing clients to see if their executable version is from a main or release branch. 

### Why should this Pull Request be merged?

To be able to easily determine if clients' version of ni_grpc_device_server is from a main or release branch

### What testing has been done?

When the branch is from main (name doesn't begin with 'releases')
![image](https://github.com/ni/grpc-device/assets/122389095/805449d8-8991-4274-a73f-41412999b5a6)

When it is a release version (begins with 'releases')
![image](https://github.com/ni/grpc-device/assets/122389095/1f494c84-90e0-4308-9f5e-0eeaf997b209)

Closes #828 