### PR TITLE
Lock down black to 23.3.0

### DIFF
--- a/source/codegen/validate_examples.py
+++ b/source/codegen/validate_examples.py
@@ -62,7 +62,7 @@ def _validate_examples(
         _system("poetry new .")
         _system("poetry add grpcio")
         _system("poetry add --dev grpcio-tools mypy mypy-protobuf types-protobuf grpc-stubs")
-        _system("poetry add --dev black")
+        _system("poetry add --dev black==23.3.0")
         _system("poetry install")
 
         _stage_client_files(artifact_location, staging_dir)


### PR DESCRIPTION
### What does this Pull Request accomplish?

Locks down black to 23.3.0

### Why should this Pull Request be merged?

Pulling latest version of black is breaking validate_python step
https://dev.azure.com/ni/DevCentral/_workitems/edit/2640696

### What testing has been done?
None, step within PR should complete with this change