### PR TITLE
Instr Save Load Configurations API grpvcc device code

### DIFF
--- a/generated/nirfmxinstr/nirfmxinstr.proto
+++ b/generated/nirfmxinstr/nirfmxinstr.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-RFMXINSTR API metadata version 23.8.0
+// This file is generated from NI-RFMXINSTR API metadata version 24.3.0
 //---------------------------------------------------------------------
 // Proto file for the NI-RFMXINSTR Metadata
 //---------------------------------------------------------------------
@@ -41,6 +41,7 @@ service NiRFmxInstr {
   rpc DisableCalibrationPlane(DisableCalibrationPlaneRequest) returns (DisableCalibrationPlaneResponse);
   rpc EnableCalibrationPlane(EnableCalibrationPlaneRequest) returns (EnableCalibrationPlaneResponse);
   rpc ExportSignal(ExportSignalRequest) returns (ExportSignalResponse);
+  rpc FetchRawIQData(FetchRawIQDataRequest) returns (FetchRawIQDataResponse);
   rpc GetAttributeF32(GetAttributeF32Request) returns (GetAttributeF32Response);
   rpc GetAttributeF32Array(GetAttributeF32ArrayRequest) returns (GetAttributeF32ArrayResponse);
   rpc GetAttributeF64(GetAttributeF64Request) returns (GetAttributeF64Response);
@@ -112,7 +113,7 @@ service NiRFmxInstr {
   rpc TimestampFromValues(TimestampFromValuesRequest) returns (TimestampFromValuesResponse);
   rpc ValuesFromTimestamp(ValuesFromTimestampRequest) returns (ValuesFromTimestampResponse);
   rpc WaitForAcquisitionComplete(WaitForAcquisitionCompleteRequest) returns (WaitForAcquisitionCompleteResponse);
-  rpc FetchRawIQData(FetchRawIQDataRequest) returns (FetchRawIQDataResponse);
+  rpc LoadConfigurations(LoadConfigurationsRequest) returns (LoadConfigurationsResponse);
 }
 
 enum NiRFmxInstrAttribute {
@@ -213,6 +214,7 @@ enum NiRFmxInstrAttribute {
   NIRFMXINSTR_ATTRIBUTE_TEMPERATURE_READ_INTERVAL = 119;
   NIRFMXINSTR_ATTRIBUTE_THERMAL_CORRECTION_TEMPERATURE_RESOLUTION = 120;
   NIRFMXINSTR_ATTRIBUTE_NUMBER_OF_RAW_IQ_RECORDS = 128;
+  NIRFMXINSTR_ATTRIBUTE_LOAD_OPTIONS = 129;
 }
 
 enum ExportSignalSource {
@@ -692,6 +694,22 @@ message ExportSignalRequest {
 
 message ExportSignalResponse {
   int32 status = 1;
+}
+
+message FetchRawIQDataRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  double timeout = 3;
+  int32 records_to_fetch = 4;
+  int64 samples_to_read = 5;
+}
+
+message FetchRawIQDataResponse {
+  int32 status = 1;
+  double x0 = 2;
+  double dx = 3;
+  repeated nidevice_grpc.NIComplexNumberF32 data = 4;
+  int32 actual_array_size = 5;
 }
 
 message GetAttributeF32Request {
@@ -1503,19 +1521,12 @@ message WaitForAcquisitionCompleteResponse {
   int32 status = 1;
 }
 
-message FetchRawIQDataRequest {
+message LoadConfigurationsRequest {
   nidevice_grpc.Session instrument = 1;
-  string selector_string = 2;
-  double timeout = 3;
-  int32 records_to_fetch = 4;
-  int64 samples_to_read = 5;
+  string file_path = 2;
 }
 
-message FetchRawIQDataResponse {
+message LoadConfigurationsResponse {
   int32 status = 1;
-  double x0 = 2;
-  double dx = 3;
-  repeated nidevice_grpc.NIComplexNumberF32 data = 4;
-  int32 actual_array_size = 5;
 }
 

--- a/generated/nirfmxinstr/nirfmxinstr.proto
+++ b/generated/nirfmxinstr/nirfmxinstr.proto
@@ -79,6 +79,7 @@ service NiRFmxInstr {
   rpc InitializeFromNIRFSASessionArray(InitializeFromNIRFSASessionArrayRequest) returns (InitializeFromNIRFSASessionArrayResponse);
   rpc IsSelfCalibrateValid(IsSelfCalibrateValidRequest) returns (IsSelfCalibrateValidResponse);
   rpc LoadAllConfigurations(LoadAllConfigurationsRequest) returns (LoadAllConfigurationsResponse);
+  rpc LoadConfigurations(LoadConfigurationsRequest) returns (LoadConfigurationsResponse);
   rpc LoadSParameterExternalAttenuationTableFromS2PFile(LoadSParameterExternalAttenuationTableFromS2PFileRequest) returns (LoadSParameterExternalAttenuationTableFromS2PFileResponse);
   rpc ResetAttribute(ResetAttributeRequest) returns (ResetAttributeResponse);
   rpc ResetDriver(ResetDriverRequest) returns (ResetDriverResponse);
@@ -113,7 +114,6 @@ service NiRFmxInstr {
   rpc TimestampFromValues(TimestampFromValuesRequest) returns (TimestampFromValuesResponse);
   rpc ValuesFromTimestamp(ValuesFromTimestampRequest) returns (ValuesFromTimestampResponse);
   rpc WaitForAcquisitionComplete(WaitForAcquisitionCompleteRequest) returns (WaitForAcquisitionCompleteResponse);
-  rpc LoadConfigurations(LoadConfigurationsRequest) returns (LoadConfigurationsResponse);
 }
 
 enum NiRFmxInstrAttribute {
@@ -214,7 +214,7 @@ enum NiRFmxInstrAttribute {
   NIRFMXINSTR_ATTRIBUTE_TEMPERATURE_READ_INTERVAL = 119;
   NIRFMXINSTR_ATTRIBUTE_THERMAL_CORRECTION_TEMPERATURE_RESOLUTION = 120;
   NIRFMXINSTR_ATTRIBUTE_NUMBER_OF_RAW_IQ_RECORDS = 128;
-  NIRFMXINSTR_ATTRIBUTE_LOAD_OPTIONS = 129;
+  NIRFMXINSTR_ATTRIBUTE_LOAD_OPTIONS = 163;
 }
 
 enum ExportSignalSource {
@@ -281,6 +281,7 @@ enum Personality {
   PERSONALITY_PULSE = 2048;
   PERSONALITY_SPECAN = 1;
   PERSONALITY_TDSCDMA = 64;
+  PERSONALITY_UWB = 8192;
   PERSONALITY_VNA = 4096;
   PERSONALITY_WCDMA = 16;
   PERSONALITY_WLAN = 512;
@@ -398,6 +399,8 @@ enum NiRFmxInstrInt32AttributeValues {
   NIRFMXINSTR_INT32_LO_SHARING_MODE_DISABLED = 0;
   NIRFMXINSTR_INT32_LO_SHARING_MODE_EXTERNAL_DAISY_CHAIN = 4;
   NIRFMXINSTR_INT32_LO_SHARING_MODE_EXTERNAL_STAR = 3;
+  NIRFMXINSTR_INT32_LOAD_OPTIONS_SKIP_NONE = 0;
+  NIRFMXINSTR_INT32_LOAD_OPTIONS_SKIP_RFINSTR = 1;
   NIRFMXINSTR_INT32_MECHANICAL_ATTENUATION_AUTO_FALSE = 0;
   NIRFMXINSTR_INT32_MECHANICAL_ATTENUATION_AUTO_TRUE = 1;
   NIRFMXINSTR_INT32_OPTIMIZE_PATH_FOR_SIGNAL_BANDWIDTH_DISABLED = 0;
@@ -1152,6 +1155,15 @@ message LoadAllConfigurationsResponse {
   int32 status = 1;
 }
 
+message LoadConfigurationsRequest {
+  nidevice_grpc.Session instrument = 1;
+  string file_path = 2;
+}
+
+message LoadConfigurationsResponse {
+  int32 status = 1;
+}
+
 message LoadSParameterExternalAttenuationTableFromS2PFileRequest {
   nidevice_grpc.Session instrument = 1;
   string selector_string = 2;
@@ -1518,15 +1530,6 @@ message WaitForAcquisitionCompleteRequest {
 }
 
 message WaitForAcquisitionCompleteResponse {
-  int32 status = 1;
-}
-
-message LoadConfigurationsRequest {
-  nidevice_grpc.Session instrument = 1;
-  string file_path = 2;
-}
-
-message LoadConfigurationsResponse {
   int32 status = 1;
 }
 

--- a/generated/nirfmxinstr/nirfmxinstr_client.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_client.cpp
@@ -1246,6 +1246,24 @@ load_all_configurations(const StubPtr& stub, const nidevice_grpc::Session& instr
   return response;
 }
 
+LoadConfigurationsResponse
+load_configurations(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& file_path)
+{
+  ::grpc::ClientContext context;
+
+  auto request = LoadConfigurationsRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_file_path(file_path);
+
+  auto response = LoadConfigurationsResponse{};
+
+  raise_if_error(
+      stub->LoadConfigurations(&context, request, &response),
+      context);
+
+  return response;
+}
+
 LoadSParameterExternalAttenuationTableFromS2PFileResponse
 load_s_parameter_external_attenuation_table_from_s2p_file(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::string& s2p_file_path, const simple_variant<SParameterOrientation, pb::int32>& s_parameter_orientation)
 {
@@ -1933,24 +1951,6 @@ wait_for_acquisition_complete(const StubPtr& stub, const nidevice_grpc::Session&
 
   raise_if_error(
       stub->WaitForAcquisitionComplete(&context, request, &response),
-      context);
-
-  return response;
-}
-
-LoadConfigurationsResponse
-load_configurations(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& file_path)
-{
-  ::grpc::ClientContext context;
-
-  auto request = LoadConfigurationsRequest{};
-  request.mutable_instrument()->CopyFrom(instrument);
-  request.set_file_path(file_path);
-
-  auto response = LoadConfigurationsResponse{};
-
-  raise_if_error(
-      stub->LoadConfigurations(&context, request, &response),
       context);
 
   return response;

--- a/generated/nirfmxinstr/nirfmxinstr_client.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_client.cpp
@@ -508,6 +508,27 @@ export_signal(const StubPtr& stub, const nidevice_grpc::Session& instrument, con
   return response;
 }
 
+FetchRawIQDataResponse
+fetch_raw_iq_data(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout, const pb::int32& records_to_fetch, const pb::int64& samples_to_read)
+{
+  ::grpc::ClientContext context;
+
+  auto request = FetchRawIQDataRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_timeout(timeout);
+  request.set_records_to_fetch(records_to_fetch);
+  request.set_samples_to_read(samples_to_read);
+
+  auto response = FetchRawIQDataResponse{};
+
+  raise_if_error(
+      stub->FetchRawIQData(&context, request, &response),
+      context);
+
+  return response;
+}
+
 GetAttributeF32Response
 get_attribute_f32(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& channel_name, const NiRFmxInstrAttribute& attribute_id)
 {
@@ -1917,22 +1938,19 @@ wait_for_acquisition_complete(const StubPtr& stub, const nidevice_grpc::Session&
   return response;
 }
 
-FetchRawIQDataResponse
-fetch_raw_iq_data(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout, const pb::int32& records_to_fetch, const pb::int64& samples_to_read)
+LoadConfigurationsResponse
+load_configurations(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& file_path)
 {
   ::grpc::ClientContext context;
 
-  auto request = FetchRawIQDataRequest{};
+  auto request = LoadConfigurationsRequest{};
   request.mutable_instrument()->CopyFrom(instrument);
-  request.set_selector_string(selector_string);
-  request.set_timeout(timeout);
-  request.set_records_to_fetch(records_to_fetch);
-  request.set_samples_to_read(samples_to_read);
+  request.set_file_path(file_path);
 
-  auto response = FetchRawIQDataResponse{};
+  auto response = LoadConfigurationsResponse{};
 
   raise_if_error(
-      stub->FetchRawIQData(&context, request, &response),
+      stub->LoadConfigurations(&context, request, &response),
       context);
 
   return response;

--- a/generated/nirfmxinstr/nirfmxinstr_client.h
+++ b/generated/nirfmxinstr/nirfmxinstr_client.h
@@ -83,6 +83,7 @@ InitializeFromNIRFSASessionResponse initialize_from_nirfsa_session(const StubPtr
 InitializeFromNIRFSASessionArrayResponse initialize_from_nirfsa_session_array(const StubPtr& stub, const std::vector<nidevice_grpc::Session>& nirfsa_sessions, const nidevice_grpc::SessionInitializationBehavior& initialization_behavior = nidevice_grpc::SESSION_INITIALIZATION_BEHAVIOR_UNSPECIFIED);
 IsSelfCalibrateValidResponse is_self_calibrate_valid(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string);
 LoadAllConfigurationsResponse load_all_configurations(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& file_path, const pb::int32& load_rf_instr_configuration);
+LoadConfigurationsResponse load_configurations(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& file_path);
 LoadSParameterExternalAttenuationTableFromS2PFileResponse load_s_parameter_external_attenuation_table_from_s2p_file(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::string& s2p_file_path, const simple_variant<SParameterOrientation, pb::int32>& s_parameter_orientation);
 ResetAttributeResponse reset_attribute(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& channel_name, const NiRFmxInstrAttribute& attribute_id);
 ResetDriverResponse reset_driver(const StubPtr& stub, const nidevice_grpc::Session& instrument);
@@ -117,7 +118,6 @@ SetAttributeU8ArrayResponse set_attribute_u8_array(const StubPtr& stub, const ni
 TimestampFromValuesResponse timestamp_from_values(const StubPtr& stub, const pb::int64& seconds_since_1970, const double& fractional_seconds);
 ValuesFromTimestampResponse values_from_timestamp(const StubPtr& stub, const google::protobuf::Timestamp& timestamp);
 WaitForAcquisitionCompleteResponse wait_for_acquisition_complete(const StubPtr& stub, const nidevice_grpc::Session& instrument, const double& timeout);
-LoadConfigurationsResponse load_configurations(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& file_path);
 
 } // namespace nirfmxinstr_grpc::experimental::client
 

--- a/generated/nirfmxinstr/nirfmxinstr_client.h
+++ b/generated/nirfmxinstr/nirfmxinstr_client.h
@@ -45,6 +45,7 @@ DeleteExternalAttenuationTableResponse delete_external_attenuation_table(const S
 DisableCalibrationPlaneResponse disable_calibration_plane(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string);
 EnableCalibrationPlaneResponse enable_calibration_plane(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string);
 ExportSignalResponse export_signal(const StubPtr& stub, const nidevice_grpc::Session& instrument, const simple_variant<ExportSignalSource, pb::int32>& export_signal_source, const simple_variant<OutputTerminal, std::string>& export_signal_output_terminal);
+FetchRawIQDataResponse fetch_raw_iq_data(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout, const pb::int32& records_to_fetch, const pb::int64& samples_to_read);
 GetAttributeF32Response get_attribute_f32(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& channel_name, const NiRFmxInstrAttribute& attribute_id);
 GetAttributeF32ArrayResponse get_attribute_f32_array(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& channel_name, const NiRFmxInstrAttribute& attribute_id);
 GetAttributeF64Response get_attribute_f64(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& channel_name, const NiRFmxInstrAttribute& attribute_id);
@@ -116,7 +117,7 @@ SetAttributeU8ArrayResponse set_attribute_u8_array(const StubPtr& stub, const ni
 TimestampFromValuesResponse timestamp_from_values(const StubPtr& stub, const pb::int64& seconds_since_1970, const double& fractional_seconds);
 ValuesFromTimestampResponse values_from_timestamp(const StubPtr& stub, const google::protobuf::Timestamp& timestamp);
 WaitForAcquisitionCompleteResponse wait_for_acquisition_complete(const StubPtr& stub, const nidevice_grpc::Session& instrument, const double& timeout);
-FetchRawIQDataResponse fetch_raw_iq_data(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout, const pb::int32& records_to_fetch, const pb::int64& samples_to_read);
+LoadConfigurationsResponse load_configurations(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& file_path);
 
 } // namespace nirfmxinstr_grpc::experimental::client
 

--- a/generated/nirfmxinstr/nirfmxinstr_compilation_test.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_compilation_test.cpp
@@ -122,6 +122,11 @@ int32 ExportSignal(niRFmxInstrHandle instrumentHandle, int32 exportSignalSource,
   return RFmxInstr_ExportSignal(instrumentHandle, exportSignalSource, exportSignalOutputTerminal);
 }
 
+int32 FetchRawIQData(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, int32 recordsToFetch, int64 samplesToRead, float64* x0, float64* dx, NIComplexSingle data[], int32 arraySize, int32* actualArraySize, void* reserved)
+{
+  return RFmxInstr_FetchRawIQData(instrumentHandle, selectorString, timeout, recordsToFetch, samplesToRead, x0, dx, data, arraySize, actualArraySize, reserved);
+}
+
 int32 GetAttributeF32(niRFmxInstrHandle instrumentHandle, char channelName[], int32 attributeID, float32* attrVal)
 {
   return RFmxInstr_GetAttributeF32(instrumentHandle, channelName, attributeID, attrVal);
@@ -477,9 +482,9 @@ int32 WaitForAcquisitionComplete(niRFmxInstrHandle instrumentHandle, float64 tim
   return RFmxInstr_WaitForAcquisitionComplete(instrumentHandle, timeout);
 }
 
-int32 FetchRawIQData(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, int32 recordsToFetch, int64 samplesToRead, float64* x0, float64* dx, NIComplexSingle data[], int32 arraySize, int32* actualArraySize, void* reserved)
+int32 LoadConfigurations(niRFmxInstrHandle instrumentHandle, char filePath[])
 {
-  return RFmxInstr_FetchRawIQData(instrumentHandle, selectorString, timeout, recordsToFetch, samplesToRead, x0, dx, data, arraySize, actualArraySize, reserved);
+  return RFmxInstr_LoadConfigurations(instrumentHandle, filePath);
 }
 
 }  // namespace nirfmxinstr_grpc

--- a/generated/nirfmxinstr/nirfmxinstr_compilation_test.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_compilation_test.cpp
@@ -312,6 +312,11 @@ int32 LoadAllConfigurations(niRFmxInstrHandle instrumentHandle, char filePath[],
   return RFmxInstr_LoadAllConfigurations(instrumentHandle, filePath, loadRFInstrConfiguration);
 }
 
+int32 LoadConfigurations(niRFmxInstrHandle instrumentHandle, char filePath[])
+{
+  return RFmxInstr_LoadConfigurations(instrumentHandle, filePath);
+}
+
 int32 LoadSParameterExternalAttenuationTableFromS2PFile(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char s2PFilePath[], int32 sParameterOrientation)
 {
   return RFmxInstr_LoadSParameterExternalAttenuationTableFromS2PFile(instrumentHandle, selectorString, tableName, s2PFilePath, sParameterOrientation);
@@ -480,11 +485,6 @@ int32 ValuesFromTimestamp(CVIAbsoluteTime timestamp, int64* secondsSince1970, fl
 int32 WaitForAcquisitionComplete(niRFmxInstrHandle instrumentHandle, float64 timeout)
 {
   return RFmxInstr_WaitForAcquisitionComplete(instrumentHandle, timeout);
-}
-
-int32 LoadConfigurations(niRFmxInstrHandle instrumentHandle, char filePath[])
-{
-  return RFmxInstr_LoadConfigurations(instrumentHandle, filePath);
 }
 
 }  // namespace nirfmxinstr_grpc

--- a/generated/nirfmxinstr/nirfmxinstr_library.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_library.cpp
@@ -88,6 +88,7 @@ NiRFmxInstrLibrary::NiRFmxInstrLibrary(std::shared_ptr<nidevice_grpc::SharedLibr
   function_pointers_.InitializeFromNIRFSASessionArray = reinterpret_cast<InitializeFromNIRFSASessionArrayPtr>(shared_library_->get_function_pointer("RFmxInstr_InitializeFromNIRFSASessionArray"));
   function_pointers_.IsSelfCalibrateValid = reinterpret_cast<IsSelfCalibrateValidPtr>(shared_library_->get_function_pointer("RFmxInstr_IsSelfCalibrateValid"));
   function_pointers_.LoadAllConfigurations = reinterpret_cast<LoadAllConfigurationsPtr>(shared_library_->get_function_pointer("RFmxInstr_LoadAllConfigurations"));
+  function_pointers_.LoadConfigurations = reinterpret_cast<LoadConfigurationsPtr>(shared_library_->get_function_pointer("RFmxInstr_LoadConfigurations"));
   function_pointers_.LoadSParameterExternalAttenuationTableFromS2PFile = reinterpret_cast<LoadSParameterExternalAttenuationTableFromS2PFilePtr>(shared_library_->get_function_pointer("RFmxInstr_LoadSParameterExternalAttenuationTableFromS2PFile"));
   function_pointers_.ResetAttribute = reinterpret_cast<ResetAttributePtr>(shared_library_->get_function_pointer("RFmxInstr_ResetAttribute"));
   function_pointers_.ResetDriver = reinterpret_cast<ResetDriverPtr>(shared_library_->get_function_pointer("RFmxInstr_ResetDriver"));
@@ -122,7 +123,6 @@ NiRFmxInstrLibrary::NiRFmxInstrLibrary(std::shared_ptr<nidevice_grpc::SharedLibr
   function_pointers_.TimestampFromValues = reinterpret_cast<TimestampFromValuesPtr>(shared_library_->get_function_pointer("RFmxInstr_TimestampFromValues"));
   function_pointers_.ValuesFromTimestamp = reinterpret_cast<ValuesFromTimestampPtr>(shared_library_->get_function_pointer("RFmxInstr_ValuesFromTimestamp"));
   function_pointers_.WaitForAcquisitionComplete = reinterpret_cast<WaitForAcquisitionCompletePtr>(shared_library_->get_function_pointer("RFmxInstr_WaitForAcquisitionComplete"));
-  function_pointers_.LoadConfigurations = reinterpret_cast<LoadConfigurationsPtr>(shared_library_->get_function_pointer("RFmxInstr_LoadConfigurations"));
 }
 
 NiRFmxInstrLibrary::~NiRFmxInstrLibrary()
@@ -624,6 +624,14 @@ int32 NiRFmxInstrLibrary::LoadAllConfigurations(niRFmxInstrHandle instrumentHand
   return function_pointers_.LoadAllConfigurations(instrumentHandle, filePath, loadRFInstrConfiguration);
 }
 
+int32 NiRFmxInstrLibrary::LoadConfigurations(niRFmxInstrHandle instrumentHandle, char filePath[])
+{
+  if (!function_pointers_.LoadConfigurations) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_LoadConfigurations.");
+  }
+  return function_pointers_.LoadConfigurations(instrumentHandle, filePath);
+}
+
 int32 NiRFmxInstrLibrary::LoadSParameterExternalAttenuationTableFromS2PFile(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char s2PFilePath[], int32 sParameterOrientation)
 {
   if (!function_pointers_.LoadSParameterExternalAttenuationTableFromS2PFile) {
@@ -894,14 +902,6 @@ int32 NiRFmxInstrLibrary::WaitForAcquisitionComplete(niRFmxInstrHandle instrumen
     throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_WaitForAcquisitionComplete.");
   }
   return function_pointers_.WaitForAcquisitionComplete(instrumentHandle, timeout);
-}
-
-int32 NiRFmxInstrLibrary::LoadConfigurations(niRFmxInstrHandle instrumentHandle, char filePath[])
-{
-  if (!function_pointers_.LoadConfigurations) {
-    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_LoadConfigurations.");
-  }
-  return function_pointers_.LoadConfigurations(instrumentHandle, filePath);
 }
 
 }  // namespace nirfmxinstr_grpc

--- a/generated/nirfmxinstr/nirfmxinstr_library.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_library.cpp
@@ -50,6 +50,7 @@ NiRFmxInstrLibrary::NiRFmxInstrLibrary(std::shared_ptr<nidevice_grpc::SharedLibr
   function_pointers_.DisableCalibrationPlane = reinterpret_cast<DisableCalibrationPlanePtr>(shared_library_->get_function_pointer("RFmxInstr_DisableCalibrationPlane"));
   function_pointers_.EnableCalibrationPlane = reinterpret_cast<EnableCalibrationPlanePtr>(shared_library_->get_function_pointer("RFmxInstr_EnableCalibrationPlane"));
   function_pointers_.ExportSignal = reinterpret_cast<ExportSignalPtr>(shared_library_->get_function_pointer("RFmxInstr_ExportSignal"));
+  function_pointers_.FetchRawIQData = reinterpret_cast<FetchRawIQDataPtr>(shared_library_->get_function_pointer("RFmxInstr_FetchRawIQData"));
   function_pointers_.GetAttributeF32 = reinterpret_cast<GetAttributeF32Ptr>(shared_library_->get_function_pointer("RFmxInstr_GetAttributeF32"));
   function_pointers_.GetAttributeF32Array = reinterpret_cast<GetAttributeF32ArrayPtr>(shared_library_->get_function_pointer("RFmxInstr_GetAttributeF32Array"));
   function_pointers_.GetAttributeF64 = reinterpret_cast<GetAttributeF64Ptr>(shared_library_->get_function_pointer("RFmxInstr_GetAttributeF64"));
@@ -121,7 +122,7 @@ NiRFmxInstrLibrary::NiRFmxInstrLibrary(std::shared_ptr<nidevice_grpc::SharedLibr
   function_pointers_.TimestampFromValues = reinterpret_cast<TimestampFromValuesPtr>(shared_library_->get_function_pointer("RFmxInstr_TimestampFromValues"));
   function_pointers_.ValuesFromTimestamp = reinterpret_cast<ValuesFromTimestampPtr>(shared_library_->get_function_pointer("RFmxInstr_ValuesFromTimestamp"));
   function_pointers_.WaitForAcquisitionComplete = reinterpret_cast<WaitForAcquisitionCompletePtr>(shared_library_->get_function_pointer("RFmxInstr_WaitForAcquisitionComplete"));
-  function_pointers_.FetchRawIQData = reinterpret_cast<FetchRawIQDataPtr>(shared_library_->get_function_pointer("RFmxInstr_FetchRawIQData"));
+  function_pointers_.LoadConfigurations = reinterpret_cast<LoadConfigurationsPtr>(shared_library_->get_function_pointer("RFmxInstr_LoadConfigurations"));
 }
 
 NiRFmxInstrLibrary::~NiRFmxInstrLibrary()
@@ -317,6 +318,14 @@ int32 NiRFmxInstrLibrary::ExportSignal(niRFmxInstrHandle instrumentHandle, int32
     throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_ExportSignal.");
   }
   return function_pointers_.ExportSignal(instrumentHandle, exportSignalSource, exportSignalOutputTerminal);
+}
+
+int32 NiRFmxInstrLibrary::FetchRawIQData(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, int32 recordsToFetch, int64 samplesToRead, float64* x0, float64* dx, NIComplexSingle data[], int32 arraySize, int32* actualArraySize, void* reserved)
+{
+  if (!function_pointers_.FetchRawIQData) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_FetchRawIQData.");
+  }
+  return function_pointers_.FetchRawIQData(instrumentHandle, selectorString, timeout, recordsToFetch, samplesToRead, x0, dx, data, arraySize, actualArraySize, reserved);
 }
 
 int32 NiRFmxInstrLibrary::GetAttributeF32(niRFmxInstrHandle instrumentHandle, char channelName[], int32 attributeID, float32* attrVal)
@@ -887,12 +896,12 @@ int32 NiRFmxInstrLibrary::WaitForAcquisitionComplete(niRFmxInstrHandle instrumen
   return function_pointers_.WaitForAcquisitionComplete(instrumentHandle, timeout);
 }
 
-int32 NiRFmxInstrLibrary::FetchRawIQData(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, int32 recordsToFetch, int64 samplesToRead, float64* x0, float64* dx, NIComplexSingle data[], int32 arraySize, int32* actualArraySize, void* reserved)
+int32 NiRFmxInstrLibrary::LoadConfigurations(niRFmxInstrHandle instrumentHandle, char filePath[])
 {
-  if (!function_pointers_.FetchRawIQData) {
-    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_FetchRawIQData.");
+  if (!function_pointers_.LoadConfigurations) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_LoadConfigurations.");
   }
-  return function_pointers_.FetchRawIQData(instrumentHandle, selectorString, timeout, recordsToFetch, samplesToRead, x0, dx, data, arraySize, actualArraySize, reserved);
+  return function_pointers_.LoadConfigurations(instrumentHandle, filePath);
 }
 
 }  // namespace nirfmxinstr_grpc

--- a/generated/nirfmxinstr/nirfmxinstr_library.h
+++ b/generated/nirfmxinstr/nirfmxinstr_library.h
@@ -82,6 +82,7 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
   int32 InitializeFromNIRFSASessionArray(uInt32 nirfsaSessions[], int32 numberOfNIRFSASessions, niRFmxInstrHandle* handleOut) override;
   int32 IsSelfCalibrateValid(niRFmxInstrHandle instrumentHandle, char selectorString[], int32* selfCalibrateValid, int32* validSteps) override;
   int32 LoadAllConfigurations(niRFmxInstrHandle instrumentHandle, char filePath[], int32 loadRFInstrConfiguration) override;
+  int32 LoadConfigurations(niRFmxInstrHandle instrumentHandle, char filePath[]) override;
   int32 LoadSParameterExternalAttenuationTableFromS2PFile(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char s2PFilePath[], int32 sParameterOrientation) override;
   int32 ResetAttribute(niRFmxInstrHandle instrumentHandle, char channelName[], int32 attributeID) override;
   int32 ResetDriver(niRFmxInstrHandle instrumentHandle) override;
@@ -116,7 +117,6 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
   int32 TimestampFromValues(int64 secondsSince1970, float64 fractionalSeconds, CVIAbsoluteTime* timestamp) override;
   int32 ValuesFromTimestamp(CVIAbsoluteTime timestamp, int64* secondsSince1970, float64* fractionalSeconds) override;
   int32 WaitForAcquisitionComplete(niRFmxInstrHandle instrumentHandle, float64 timeout) override;
-  int32 LoadConfigurations(niRFmxInstrHandle instrumentHandle, char filePath[]) override;
 
  private:
   using BuildCalibrationPlaneStringPtr = decltype(&RFmxInstr_BuildCalibrationPlaneString);
@@ -180,6 +180,7 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
   using InitializeFromNIRFSASessionArrayPtr = decltype(&RFmxInstr_InitializeFromNIRFSASessionArray);
   using IsSelfCalibrateValidPtr = decltype(&RFmxInstr_IsSelfCalibrateValid);
   using LoadAllConfigurationsPtr = decltype(&RFmxInstr_LoadAllConfigurations);
+  using LoadConfigurationsPtr = decltype(&RFmxInstr_LoadConfigurations);
   using LoadSParameterExternalAttenuationTableFromS2PFilePtr = decltype(&RFmxInstr_LoadSParameterExternalAttenuationTableFromS2PFile);
   using ResetAttributePtr = decltype(&RFmxInstr_ResetAttribute);
   using ResetDriverPtr = decltype(&RFmxInstr_ResetDriver);
@@ -214,7 +215,6 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
   using TimestampFromValuesPtr = decltype(&RFmxInstr_TimestampFromValues);
   using ValuesFromTimestampPtr = decltype(&RFmxInstr_ValuesFromTimestamp);
   using WaitForAcquisitionCompletePtr = decltype(&RFmxInstr_WaitForAcquisitionComplete);
-  using LoadConfigurationsPtr = decltype(&RFmxInstr_LoadConfigurations);
 
   typedef struct FunctionPointers {
     BuildCalibrationPlaneStringPtr BuildCalibrationPlaneString;
@@ -278,6 +278,7 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
     InitializeFromNIRFSASessionArrayPtr InitializeFromNIRFSASessionArray;
     IsSelfCalibrateValidPtr IsSelfCalibrateValid;
     LoadAllConfigurationsPtr LoadAllConfigurations;
+    LoadConfigurationsPtr LoadConfigurations;
     LoadSParameterExternalAttenuationTableFromS2PFilePtr LoadSParameterExternalAttenuationTableFromS2PFile;
     ResetAttributePtr ResetAttribute;
     ResetDriverPtr ResetDriver;
@@ -312,7 +313,6 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
     TimestampFromValuesPtr TimestampFromValues;
     ValuesFromTimestampPtr ValuesFromTimestamp;
     WaitForAcquisitionCompletePtr WaitForAcquisitionComplete;
-    LoadConfigurationsPtr LoadConfigurations;
   } FunctionLoadStatus;
 
   std::shared_ptr<nidevice_grpc::SharedLibraryInterface> shared_library_;

--- a/generated/nirfmxinstr/nirfmxinstr_library.h
+++ b/generated/nirfmxinstr/nirfmxinstr_library.h
@@ -44,6 +44,7 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
   int32 DisableCalibrationPlane(niRFmxInstrHandle instrumentHandle, char selectorString[]) override;
   int32 EnableCalibrationPlane(niRFmxInstrHandle instrumentHandle, char selectorString[]) override;
   int32 ExportSignal(niRFmxInstrHandle instrumentHandle, int32 exportSignalSource, char exportSignalOutputTerminal[]) override;
+  int32 FetchRawIQData(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, int32 recordsToFetch, int64 samplesToRead, float64* x0, float64* dx, NIComplexSingle data[], int32 arraySize, int32* actualArraySize, void* reserved) override;
   int32 GetAttributeF32(niRFmxInstrHandle instrumentHandle, char channelName[], int32 attributeID, float32* attrVal) override;
   int32 GetAttributeF32Array(niRFmxInstrHandle instrumentHandle, char channelName[], int32 attributeID, float32 attrVal[], int32 arraySize, int32* actualArraySize) override;
   int32 GetAttributeF64(niRFmxInstrHandle instrumentHandle, char channelName[], int32 attributeID, float64* attrVal) override;
@@ -115,7 +116,7 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
   int32 TimestampFromValues(int64 secondsSince1970, float64 fractionalSeconds, CVIAbsoluteTime* timestamp) override;
   int32 ValuesFromTimestamp(CVIAbsoluteTime timestamp, int64* secondsSince1970, float64* fractionalSeconds) override;
   int32 WaitForAcquisitionComplete(niRFmxInstrHandle instrumentHandle, float64 timeout) override;
-  int32 FetchRawIQData(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, int32 recordsToFetch, int64 samplesToRead, float64* x0, float64* dx, NIComplexSingle data[], int32 arraySize, int32* actualArraySize, void* reserved) override;
+  int32 LoadConfigurations(niRFmxInstrHandle instrumentHandle, char filePath[]) override;
 
  private:
   using BuildCalibrationPlaneStringPtr = decltype(&RFmxInstr_BuildCalibrationPlaneString);
@@ -141,6 +142,7 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
   using DisableCalibrationPlanePtr = decltype(&RFmxInstr_DisableCalibrationPlane);
   using EnableCalibrationPlanePtr = decltype(&RFmxInstr_EnableCalibrationPlane);
   using ExportSignalPtr = decltype(&RFmxInstr_ExportSignal);
+  using FetchRawIQDataPtr = decltype(&RFmxInstr_FetchRawIQData);
   using GetAttributeF32Ptr = decltype(&RFmxInstr_GetAttributeF32);
   using GetAttributeF32ArrayPtr = decltype(&RFmxInstr_GetAttributeF32Array);
   using GetAttributeF64Ptr = decltype(&RFmxInstr_GetAttributeF64);
@@ -212,7 +214,7 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
   using TimestampFromValuesPtr = decltype(&RFmxInstr_TimestampFromValues);
   using ValuesFromTimestampPtr = decltype(&RFmxInstr_ValuesFromTimestamp);
   using WaitForAcquisitionCompletePtr = decltype(&RFmxInstr_WaitForAcquisitionComplete);
-  using FetchRawIQDataPtr = decltype(&RFmxInstr_FetchRawIQData);
+  using LoadConfigurationsPtr = decltype(&RFmxInstr_LoadConfigurations);
 
   typedef struct FunctionPointers {
     BuildCalibrationPlaneStringPtr BuildCalibrationPlaneString;
@@ -238,6 +240,7 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
     DisableCalibrationPlanePtr DisableCalibrationPlane;
     EnableCalibrationPlanePtr EnableCalibrationPlane;
     ExportSignalPtr ExportSignal;
+    FetchRawIQDataPtr FetchRawIQData;
     GetAttributeF32Ptr GetAttributeF32;
     GetAttributeF32ArrayPtr GetAttributeF32Array;
     GetAttributeF64Ptr GetAttributeF64;
@@ -309,7 +312,7 @@ class NiRFmxInstrLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterface 
     TimestampFromValuesPtr TimestampFromValues;
     ValuesFromTimestampPtr ValuesFromTimestamp;
     WaitForAcquisitionCompletePtr WaitForAcquisitionComplete;
-    FetchRawIQDataPtr FetchRawIQData;
+    LoadConfigurationsPtr LoadConfigurations;
   } FunctionLoadStatus;
 
   std::shared_ptr<nidevice_grpc::SharedLibraryInterface> shared_library_;

--- a/generated/nirfmxinstr/nirfmxinstr_library_interface.h
+++ b/generated/nirfmxinstr/nirfmxinstr_library_interface.h
@@ -76,6 +76,7 @@ class NiRFmxInstrLibraryInterface {
   virtual int32 InitializeFromNIRFSASessionArray(uInt32 nirfsaSessions[], int32 numberOfNIRFSASessions, niRFmxInstrHandle* handleOut) = 0;
   virtual int32 IsSelfCalibrateValid(niRFmxInstrHandle instrumentHandle, char selectorString[], int32* selfCalibrateValid, int32* validSteps) = 0;
   virtual int32 LoadAllConfigurations(niRFmxInstrHandle instrumentHandle, char filePath[], int32 loadRFInstrConfiguration) = 0;
+  virtual int32 LoadConfigurations(niRFmxInstrHandle instrumentHandle, char filePath[]) = 0;
   virtual int32 LoadSParameterExternalAttenuationTableFromS2PFile(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char s2PFilePath[], int32 sParameterOrientation) = 0;
   virtual int32 ResetAttribute(niRFmxInstrHandle instrumentHandle, char channelName[], int32 attributeID) = 0;
   virtual int32 ResetDriver(niRFmxInstrHandle instrumentHandle) = 0;
@@ -110,7 +111,6 @@ class NiRFmxInstrLibraryInterface {
   virtual int32 TimestampFromValues(int64 secondsSince1970, float64 fractionalSeconds, CVIAbsoluteTime* timestamp) = 0;
   virtual int32 ValuesFromTimestamp(CVIAbsoluteTime timestamp, int64* secondsSince1970, float64* fractionalSeconds) = 0;
   virtual int32 WaitForAcquisitionComplete(niRFmxInstrHandle instrumentHandle, float64 timeout) = 0;
-  virtual int32 LoadConfigurations(niRFmxInstrHandle instrumentHandle, char filePath[]) = 0;
 };
 
 }  // namespace nirfmxinstr_grpc

--- a/generated/nirfmxinstr/nirfmxinstr_library_interface.h
+++ b/generated/nirfmxinstr/nirfmxinstr_library_interface.h
@@ -38,6 +38,7 @@ class NiRFmxInstrLibraryInterface {
   virtual int32 DisableCalibrationPlane(niRFmxInstrHandle instrumentHandle, char selectorString[]) = 0;
   virtual int32 EnableCalibrationPlane(niRFmxInstrHandle instrumentHandle, char selectorString[]) = 0;
   virtual int32 ExportSignal(niRFmxInstrHandle instrumentHandle, int32 exportSignalSource, char exportSignalOutputTerminal[]) = 0;
+  virtual int32 FetchRawIQData(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, int32 recordsToFetch, int64 samplesToRead, float64* x0, float64* dx, NIComplexSingle data[], int32 arraySize, int32* actualArraySize, void* reserved) = 0;
   virtual int32 GetAttributeF32(niRFmxInstrHandle instrumentHandle, char channelName[], int32 attributeID, float32* attrVal) = 0;
   virtual int32 GetAttributeF32Array(niRFmxInstrHandle instrumentHandle, char channelName[], int32 attributeID, float32 attrVal[], int32 arraySize, int32* actualArraySize) = 0;
   virtual int32 GetAttributeF64(niRFmxInstrHandle instrumentHandle, char channelName[], int32 attributeID, float64* attrVal) = 0;
@@ -109,7 +110,7 @@ class NiRFmxInstrLibraryInterface {
   virtual int32 TimestampFromValues(int64 secondsSince1970, float64 fractionalSeconds, CVIAbsoluteTime* timestamp) = 0;
   virtual int32 ValuesFromTimestamp(CVIAbsoluteTime timestamp, int64* secondsSince1970, float64* fractionalSeconds) = 0;
   virtual int32 WaitForAcquisitionComplete(niRFmxInstrHandle instrumentHandle, float64 timeout) = 0;
-  virtual int32 FetchRawIQData(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, int32 recordsToFetch, int64 samplesToRead, float64* x0, float64* dx, NIComplexSingle data[], int32 arraySize, int32* actualArraySize, void* reserved) = 0;
+  virtual int32 LoadConfigurations(niRFmxInstrHandle instrumentHandle, char filePath[]) = 0;
 };
 
 }  // namespace nirfmxinstr_grpc

--- a/generated/nirfmxinstr/nirfmxinstr_mock_library.h
+++ b/generated/nirfmxinstr/nirfmxinstr_mock_library.h
@@ -40,6 +40,7 @@ class NiRFmxInstrMockLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterf
   MOCK_METHOD(int32, DisableCalibrationPlane, (niRFmxInstrHandle instrumentHandle, char selectorString[]), (override));
   MOCK_METHOD(int32, EnableCalibrationPlane, (niRFmxInstrHandle instrumentHandle, char selectorString[]), (override));
   MOCK_METHOD(int32, ExportSignal, (niRFmxInstrHandle instrumentHandle, int32 exportSignalSource, char exportSignalOutputTerminal[]), (override));
+  MOCK_METHOD(int32, FetchRawIQData, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, int32 recordsToFetch, int64 samplesToRead, float64* x0, float64* dx, NIComplexSingle data[], int32 arraySize, int32* actualArraySize, void* reserved), (override));
   MOCK_METHOD(int32, GetAttributeF32, (niRFmxInstrHandle instrumentHandle, char channelName[], int32 attributeID, float32* attrVal), (override));
   MOCK_METHOD(int32, GetAttributeF32Array, (niRFmxInstrHandle instrumentHandle, char channelName[], int32 attributeID, float32 attrVal[], int32 arraySize, int32* actualArraySize), (override));
   MOCK_METHOD(int32, GetAttributeF64, (niRFmxInstrHandle instrumentHandle, char channelName[], int32 attributeID, float64* attrVal), (override));
@@ -111,7 +112,7 @@ class NiRFmxInstrMockLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterf
   MOCK_METHOD(int32, TimestampFromValues, (int64 secondsSince1970, float64 fractionalSeconds, CVIAbsoluteTime* timestamp), (override));
   MOCK_METHOD(int32, ValuesFromTimestamp, (CVIAbsoluteTime timestamp, int64* secondsSince1970, float64* fractionalSeconds), (override));
   MOCK_METHOD(int32, WaitForAcquisitionComplete, (niRFmxInstrHandle instrumentHandle, float64 timeout), (override));
-  MOCK_METHOD(int32, FetchRawIQData, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, int32 recordsToFetch, int64 samplesToRead, float64* x0, float64* dx, NIComplexSingle data[], int32 arraySize, int32* actualArraySize, void* reserved), (override));
+  MOCK_METHOD(int32, LoadConfigurations, (niRFmxInstrHandle instrumentHandle, char filePath[]), (override));
 };
 
 }  // namespace unit

--- a/generated/nirfmxinstr/nirfmxinstr_mock_library.h
+++ b/generated/nirfmxinstr/nirfmxinstr_mock_library.h
@@ -78,6 +78,7 @@ class NiRFmxInstrMockLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterf
   MOCK_METHOD(int32, InitializeFromNIRFSASessionArray, (uInt32 nirfsaSessions[], int32 numberOfNIRFSASessions, niRFmxInstrHandle* handleOut), (override));
   MOCK_METHOD(int32, IsSelfCalibrateValid, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32* selfCalibrateValid, int32* validSteps), (override));
   MOCK_METHOD(int32, LoadAllConfigurations, (niRFmxInstrHandle instrumentHandle, char filePath[], int32 loadRFInstrConfiguration), (override));
+  MOCK_METHOD(int32, LoadConfigurations, (niRFmxInstrHandle instrumentHandle, char filePath[]), (override));
   MOCK_METHOD(int32, LoadSParameterExternalAttenuationTableFromS2PFile, (niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char s2PFilePath[], int32 sParameterOrientation), (override));
   MOCK_METHOD(int32, ResetAttribute, (niRFmxInstrHandle instrumentHandle, char channelName[], int32 attributeID), (override));
   MOCK_METHOD(int32, ResetDriver, (niRFmxInstrHandle instrumentHandle), (override));
@@ -112,7 +113,6 @@ class NiRFmxInstrMockLibrary : public nirfmxinstr_grpc::NiRFmxInstrLibraryInterf
   MOCK_METHOD(int32, TimestampFromValues, (int64 secondsSince1970, float64 fractionalSeconds, CVIAbsoluteTime* timestamp), (override));
   MOCK_METHOD(int32, ValuesFromTimestamp, (CVIAbsoluteTime timestamp, int64* secondsSince1970, float64* fractionalSeconds), (override));
   MOCK_METHOD(int32, WaitForAcquisitionComplete, (niRFmxInstrHandle instrumentHandle, float64 timeout), (override));
-  MOCK_METHOD(int32, LoadConfigurations, (niRFmxInstrHandle instrumentHandle, char filePath[]), (override));
 };
 
 }  // namespace unit

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -2317,6 +2317,30 @@ namespace nirfmxinstr_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxInstrService::LoadConfigurations(::grpc::ServerContext* context, const LoadConfigurationsRequest* request, LoadConfigurationsResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
+      auto file_path_mbcs = convert_from_grpc<std::string>(request->file_path());
+      char* file_path = (char*)file_path_mbcs.c_str();
+      auto status = library_->LoadConfigurations(instrument, file_path);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiRFmxInstrService::LoadSParameterExternalAttenuationTableFromS2PFile(::grpc::ServerContext* context, const LoadSParameterExternalAttenuationTableFromS2PFileRequest* request, LoadSParameterExternalAttenuationTableFromS2PFileResponse* response)
   {
     if (context->IsCancelled()) {
@@ -3307,30 +3331,6 @@ namespace nirfmxinstr_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       float64 timeout = request->timeout();
       auto status = library_->WaitForAcquisitionComplete(instrument, timeout);
-      if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
-      }
-      response->set_status(status);
-      return ::grpc::Status::OK;
-    }
-    catch (nidevice_grpc::NonDriverException& ex) {
-      return ex.GetStatus();
-    }
-  }
-
-  //---------------------------------------------------------------------
-  //---------------------------------------------------------------------
-  ::grpc::Status NiRFmxInstrService::LoadConfigurations(::grpc::ServerContext* context, const LoadConfigurationsRequest* request, LoadConfigurationsResponse* response)
-  {
-    if (context->IsCancelled()) {
-      return ::grpc::Status::CANCELLED;
-    }
-    try {
-      auto instrument_grpc_session = request->instrument();
-      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
-      auto file_path_mbcs = convert_from_grpc<std::string>(request->file_path());
-      char* file_path = (char*)file_path_mbcs.c_str();
-      auto status = library_->LoadConfigurations(instrument, file_path);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
       }

--- a/generated/nirfmxinstr/nirfmxinstr_service.cpp
+++ b/generated/nirfmxinstr/nirfmxinstr_service.cpp
@@ -844,6 +844,60 @@ namespace nirfmxinstr_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxInstrService::FetchRawIQData(::grpc::ServerContext* context, const FetchRawIQDataRequest* request, FetchRawIQDataResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
+      auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
+      char* selector_string = (char*)selector_string_mbcs.c_str();
+      float64 timeout = request->timeout();
+      int32 records_to_fetch = request->records_to_fetch();
+      int64 samples_to_read = request->samples_to_read();
+      auto reserved = nullptr;
+      float64 x0 {};
+      float64 dx {};
+      int32 actual_array_size {};
+      while (true) {
+        auto status = library_->FetchRawIQData(instrument, selector_string, timeout, records_to_fetch, samples_to_read, &x0, &dx, nullptr, 0, &actual_array_size, reserved);
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+        }
+        std::vector<NIComplexSingle> data(actual_array_size, NIComplexSingle());
+        auto array_size = actual_array_size;
+        status = library_->FetchRawIQData(instrument, selector_string, timeout, records_to_fetch, samples_to_read, &x0, &dx, data.data(), array_size, &actual_array_size, reserved);
+        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
+          // buffer is now too small, try again
+          continue;
+        }
+        if (!status_ok(status)) {
+          return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+        }
+        response->set_status(status);
+        response->set_x0(x0);
+        response->set_dx(dx);
+        convert_to_grpc(data, response->mutable_data());
+        {
+          auto shrunk_size = actual_array_size;
+          auto current_size = response->mutable_data()->size();
+          if (shrunk_size != current_size) {
+            response->mutable_data()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
+          }
+        }
+        response->set_actual_array_size(actual_array_size);
+        return ::grpc::Status::OK;
+      }
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiRFmxInstrService::GetAttributeF32(::grpc::ServerContext* context, const GetAttributeF32Request* request, GetAttributeF32Response* response)
   {
     if (context->IsCancelled()) {
@@ -3266,7 +3320,7 @@ namespace nirfmxinstr_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
-  ::grpc::Status NiRFmxInstrService::FetchRawIQData(::grpc::ServerContext* context, const FetchRawIQDataRequest* request, FetchRawIQDataResponse* response)
+  ::grpc::Status NiRFmxInstrService::LoadConfigurations(::grpc::ServerContext* context, const LoadConfigurationsRequest* request, LoadConfigurationsResponse* response)
   {
     if (context->IsCancelled()) {
       return ::grpc::Status::CANCELLED;
@@ -3274,44 +3328,14 @@ namespace nirfmxinstr_grpc {
     try {
       auto instrument_grpc_session = request->instrument();
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
-      auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
-      char* selector_string = (char*)selector_string_mbcs.c_str();
-      float64 timeout = request->timeout();
-      int32 records_to_fetch = request->records_to_fetch();
-      int64 samples_to_read = request->samples_to_read();
-      float64 x0 {};
-      float64 dx {};
-      int32 actual_array_size {};
-      auto reserved = nullptr;
-      while (true) {
-        auto status = library_->FetchRawIQData(instrument, selector_string, timeout, records_to_fetch, samples_to_read, &x0, &dx, nullptr, 0, &actual_array_size, &reserved);
-        if (!status_ok(status)) {
-          return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
-        }
-        std::vector<NIComplexSingle> data(actual_array_size, NIComplexSingle());
-        auto array_size = actual_array_size;
-        status = library_->FetchRawIQData(instrument, selector_string, timeout, records_to_fetch, samples_to_read, &x0, &dx, data.data(), array_size, &actual_array_size, &reserved);
-        if (status == kErrorReadBufferTooSmall || status == kWarningCAPIStringTruncatedToFitBuffer) {
-          // buffer is now too small, try again
-          continue;
-        }
-        if (!status_ok(status)) {
-          return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
-        }
-        response->set_status(status);
-        response->set_x0(x0);
-        response->set_dx(dx);
-        convert_to_grpc(data, response->mutable_data());
-        {
-          auto shrunk_size = actual_array_size;
-          auto current_size = response->mutable_data()->size();
-          if (shrunk_size != current_size) {
-            response->mutable_data()->DeleteSubrange(shrunk_size, current_size - shrunk_size);
-          }
-        }
-        response->set_actual_array_size(actual_array_size);
-        return ::grpc::Status::OK;
+      auto file_path_mbcs = convert_from_grpc<std::string>(request->file_path());
+      char* file_path = (char*)file_path_mbcs.c_str();
+      auto status = library_->LoadConfigurations(instrument, file_path);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
       }
+      response->set_status(status);
+      return ::grpc::Status::OK;
     }
     catch (nidevice_grpc::NonDriverException& ex) {
       return ex.GetStatus();

--- a/generated/nirfmxinstr/nirfmxinstr_service.h
+++ b/generated/nirfmxinstr/nirfmxinstr_service.h
@@ -105,6 +105,7 @@ public:
   ::grpc::Status InitializeFromNIRFSASessionArray(::grpc::ServerContext* context, const InitializeFromNIRFSASessionArrayRequest* request, InitializeFromNIRFSASessionArrayResponse* response) override;
   ::grpc::Status IsSelfCalibrateValid(::grpc::ServerContext* context, const IsSelfCalibrateValidRequest* request, IsSelfCalibrateValidResponse* response) override;
   ::grpc::Status LoadAllConfigurations(::grpc::ServerContext* context, const LoadAllConfigurationsRequest* request, LoadAllConfigurationsResponse* response) override;
+  ::grpc::Status LoadConfigurations(::grpc::ServerContext* context, const LoadConfigurationsRequest* request, LoadConfigurationsResponse* response) override;
   ::grpc::Status LoadSParameterExternalAttenuationTableFromS2PFile(::grpc::ServerContext* context, const LoadSParameterExternalAttenuationTableFromS2PFileRequest* request, LoadSParameterExternalAttenuationTableFromS2PFileResponse* response) override;
   ::grpc::Status ResetAttribute(::grpc::ServerContext* context, const ResetAttributeRequest* request, ResetAttributeResponse* response) override;
   ::grpc::Status ResetDriver(::grpc::ServerContext* context, const ResetDriverRequest* request, ResetDriverResponse* response) override;
@@ -139,7 +140,6 @@ public:
   ::grpc::Status TimestampFromValues(::grpc::ServerContext* context, const TimestampFromValuesRequest* request, TimestampFromValuesResponse* response) override;
   ::grpc::Status ValuesFromTimestamp(::grpc::ServerContext* context, const ValuesFromTimestampRequest* request, ValuesFromTimestampResponse* response) override;
   ::grpc::Status WaitForAcquisitionComplete(::grpc::ServerContext* context, const WaitForAcquisitionCompleteRequest* request, WaitForAcquisitionCompleteResponse* response) override;
-  ::grpc::Status LoadConfigurations(::grpc::ServerContext* context, const LoadConfigurationsRequest* request, LoadConfigurationsResponse* response) override;
 private:
   LibrarySharedPtr library_;
   ResourceRepositorySharedPtr session_repository_;

--- a/generated/nirfmxinstr/nirfmxinstr_service.h
+++ b/generated/nirfmxinstr/nirfmxinstr_service.h
@@ -67,6 +67,7 @@ public:
   ::grpc::Status DisableCalibrationPlane(::grpc::ServerContext* context, const DisableCalibrationPlaneRequest* request, DisableCalibrationPlaneResponse* response) override;
   ::grpc::Status EnableCalibrationPlane(::grpc::ServerContext* context, const EnableCalibrationPlaneRequest* request, EnableCalibrationPlaneResponse* response) override;
   ::grpc::Status ExportSignal(::grpc::ServerContext* context, const ExportSignalRequest* request, ExportSignalResponse* response) override;
+  ::grpc::Status FetchRawIQData(::grpc::ServerContext* context, const FetchRawIQDataRequest* request, FetchRawIQDataResponse* response) override;
   ::grpc::Status GetAttributeF32(::grpc::ServerContext* context, const GetAttributeF32Request* request, GetAttributeF32Response* response) override;
   ::grpc::Status GetAttributeF32Array(::grpc::ServerContext* context, const GetAttributeF32ArrayRequest* request, GetAttributeF32ArrayResponse* response) override;
   ::grpc::Status GetAttributeF64(::grpc::ServerContext* context, const GetAttributeF64Request* request, GetAttributeF64Response* response) override;
@@ -138,7 +139,7 @@ public:
   ::grpc::Status TimestampFromValues(::grpc::ServerContext* context, const TimestampFromValuesRequest* request, TimestampFromValuesResponse* response) override;
   ::grpc::Status ValuesFromTimestamp(::grpc::ServerContext* context, const ValuesFromTimestampRequest* request, ValuesFromTimestampResponse* response) override;
   ::grpc::Status WaitForAcquisitionComplete(::grpc::ServerContext* context, const WaitForAcquisitionCompleteRequest* request, WaitForAcquisitionCompleteResponse* response) override;
-  ::grpc::Status FetchRawIQData(::grpc::ServerContext* context, const FetchRawIQDataRequest* request, FetchRawIQDataResponse* response) override;
+  ::grpc::Status LoadConfigurations(::grpc::ServerContext* context, const LoadConfigurationsRequest* request, LoadConfigurationsResponse* response) override;
 private:
   LibrarySharedPtr library_;
   ResourceRepositorySharedPtr session_repository_;

--- a/imports/include/niRFmxInstr.h
+++ b/imports/include/niRFmxInstr.h
@@ -214,6 +214,7 @@ typedef union CVIAbsoluteTime { CVITime cviTime; unsigned int u32Data[4]; } CVIA
 #define RFMXINSTR_ATTR_NUMBER_OF_RAW_IQ_RECORDS                            0x00000080
 #define RFMXINSTR_ATTR_LO_SHARING_MODE                                     0x00000044
 #define RFMXINSTR_ATTR_NUMBER_OF_LO_SHARING_GROUPS                         0x00000061
+#define RFMXINSTR_ATTR_LOAD_OPTIONS                                        0x000000A3
 
 
 /* -- Values for binary attributes -- */
@@ -390,6 +391,7 @@ typedef union CVIAbsoluteTime { CVITime cviTime; unsigned int u32Data[4]; } CVIA
 #define RFMXINSTR_VAL_PERSONALITY_WLAN                                     (1 << 9)
 #define RFMXINSTR_VAL_PERSONALITY_VNA                                      (1 << 12)
 #define RFMXINSTR_VAL_PERSONALITY_PULSE                                    (1 << 11)
+#define RFMXINSTR_VAL_PERSONALITY_UWB                                      (1 << 13)
 #define RFMXINSTR_VAL_PERSONALITY_ALL                                      0x7FFFFFFF
 
 /* -- Values for Overflow Error Reporting -- */
@@ -444,6 +446,10 @@ typedef union CVIAbsoluteTime { CVITime cviTime; unsigned int u32Data[4]; } CVIA
 #define RFMXINSTR_VAL_LO_SHARING_MODE_DISABLED                             0
 #define RFMXINSTR_VAL_LO_SHARING_MODE_EXTERNAL_STAR                        3
 #define RFMXINSTR_VAL_LO_SHARING_MODE_EXTERNAL_DAISY_CHAIN                 4
+
+// Values for RFMXINSTR_ATTR_LOAD_OPTIONS
+#define RFMXINSTR_VAL_LOAD_OPTIONS_SKIP_NONE                               0
+#define RFMXINSTR_VAL_LOAD_OPTIONS_SKIP_RFINSTR                            1
 
 /*****************************************************************************/
 /*= Macros for checking for errors.                                 ======== */
@@ -639,10 +645,9 @@ extern "C"
       niRFmxInstrHandle instrumentHandle,
       char filePath[]);
 
-   int32 __stdcall RFmxInstr_LoadAllConfigurations(
+   int32 __stdcall RFmxInstr_LoadConfigurations(
       niRFmxInstrHandle instrumentHandle,
-      char filePath[],
-      int32 loadRFInstrConfiguration);
+      char filePath[]);
 
    int32 __stdcall RFmxInstr_ResetEntireSession(
       niRFmxInstrHandle instrumentHandle);
@@ -2036,7 +2041,22 @@ int32 __stdcall RFmxInstr_FetchRawIQData(
       char selectorString[],
       int32 attrVal
    );
-   
+
+   int32 __stdcall RFmxInstr_GetLoadOptions(
+       niRFmxInstrHandle instrumentHandle,
+       char selectorString[],
+       int32 attrVal[],
+       int32 arraySize,
+       int32* actualArraySize
+   );
+
+   int32 __stdcall RFmxInstr_SetLoadOptions(
+       niRFmxInstrHandle instrumentHandle,
+       char selectorString[],
+       int32 attrVal[],
+       int32 arraySize
+   );
+
 #ifdef __cplusplus
 }
 #endif
@@ -2085,6 +2105,12 @@ extern "C"
        niRFmxInstrHandle instrumentHandle,
        char channelName[],
        int32 attrVal
+   );
+
+   int32 __stdcall RFmxInstr_LoadAllConfigurations(
+      niRFmxInstrHandle instrumentHandle,
+      char filePath[],
+      int32 loadRFInstrConfiguration
    );
   
 #ifdef __cplusplus

--- a/source/codegen/metadata/nirfmxinstr/attributes.py
+++ b/source/codegen/metadata/nirfmxinstr/attributes.py
@@ -516,5 +516,11 @@ attributes = {
         'access': 'read-write',
         'name': 'NUMBER_OF_RAW_IQ_RECORDS',
         'type': 'int32'
+    },
+    163: {
+        'access': 'read-write',
+        'enum': 'LoadOptions',
+        'name': 'LOAD_OPTIONS',
+        'type': 'int32[]'
     }
 }

--- a/source/codegen/metadata/nirfmxinstr/config.py
+++ b/source/codegen/metadata/nirfmxinstr/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 config = {
-    'api_version': '23.8.0',
+    'api_version': '24.3.0',
     'c_header': 'niRFmxInstr.h',
     'c_function_prefix': 'RFmxInstr_',
     'service_class_prefix': 'NiRFmxInstr',

--- a/source/codegen/metadata/nirfmxinstr/enums.py
+++ b/source/codegen/metadata/nirfmxinstr/enums.py
@@ -375,6 +375,18 @@ enums = {
             }
         ]
     },
+    'LoadOptions': {
+        'values': [
+            {
+                'name': 'SKIP_NONE',
+                'value': 0
+            },
+            {
+                'name': 'SKIP_RFINSTR',
+                'value': 1
+            }
+        ]
+    },
     'MechanicalAttenuationAuto': {
         'values': [
             {
@@ -537,6 +549,10 @@ enums = {
             {
                 'name': 'TDSCDMA',
                 'value': 64
+            },
+            {
+                'name': 'UWB',
+                'value': 8192
             },
             {
                 'name': 'VNA',

--- a/source/codegen/metadata/nirfmxinstr/functions.py
+++ b/source/codegen/metadata/nirfmxinstr/functions.py
@@ -1975,13 +1975,13 @@ functions = {
     'LoadConfigurations': {
         'parameters': [
             {
-                'direction': 'out',
+                'direction': 'in',
                 'grpc_name': 'instrument',
                 'name': 'instrumentHandle',
                 'type': 'niRFmxInstrHandle'
             },
             {
-                'direction': 'out',
+                'direction': 'in',
                 'name': 'filePath',
                 'type': 'char[]'
             }

--- a/source/codegen/metadata/nirfmxinstr/functions.py
+++ b/source/codegen/metadata/nirfmxinstr/functions.py
@@ -615,6 +615,75 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'FetchRawIQData': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'timeout',
+                'type': 'float64'
+            },
+            {
+                'direction': 'in',
+                'name': 'recordsToFetch',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'name': 'samplesToRead',
+                'type': 'int64'
+            },
+            {
+                'direction': 'out',
+                'name': 'x0',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'dx',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'data',
+                'size': {
+                    'mechanism': 'ivi-dance-with-a-twist',
+                    'value': 'arraySize',
+                    'value_twist': 'actualArraySize'
+                },
+                'type': 'NIComplexSingle[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'arraySize',
+                'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'name': 'actualArraySize',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'hardcoded_value': 'nullptr',
+                'include_in_proto': False,
+                'name': 'reserved',
+                'pointer': True,
+                'type': 'void'
+            }
+        ],
+        'returns': 'int32'
+    },
     'GetAttributeF32': {
         'parameters': [
             {
@@ -1903,6 +1972,22 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'LoadConfigurations': {
+        'parameters': [
+            {
+                'direction': 'out',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'out',
+                'name': 'filePath',
+                'type': 'char[]'
+            }
+        ],
+        'returns': 'int32'
+    },
     'LoadSParameterExternalAttenuationTableFromS2PFile': {
         'parameters': [
             {
@@ -2798,74 +2883,6 @@ functions = {
                 'direction': 'in',
                 'name': 'timeout',
                 'type': 'float64'
-            }
-        ],
-        'returns': 'int32'
-    },
-    'FetchRawIQData': {
-        'parameters': [
-            {
-                'direction': 'in',
-                'grpc_name': 'instrument',
-                'name': 'instrumentHandle',
-                'type': 'niRFmxInstrHandle'
-            },
-            {
-                'direction': 'in',
-                'name': 'selectorString',
-                'type': 'char[]'
-            },
-            {
-                'direction': 'in',
-                'name': 'timeout',
-                'type': 'float64'
-            },
-            {
-                'direction': 'in',
-                'name': 'recordsToFetch',
-                'type': 'int32'
-            },
-            {
-                'direction': 'in',
-                'name': 'samplesToRead',
-                'type': 'int64'
-            },
-            {
-                'direction': 'out',
-                'name': 'x0',
-                'type': 'float64'
-            },
-            {
-                'direction': 'out',
-                'name': 'dx',
-                'type': 'float64'
-            },
-            {
-                'direction': 'out',
-                'name': 'data',
-                'size': {
-                    'mechanism': 'ivi-dance-with-a-twist',
-                    'value': 'arraySize',
-                    'value_twist': 'actualArraySize'
-                },
-                'type': 'NIComplexSingle[]'
-            },
-            {
-                'direction': 'in',
-                'name': 'arraySize',
-                'type': 'int32'
-            },
-            {
-                'direction': 'out',
-                'name': 'actualArraySize',
-                'type': 'int32'
-            },
-            {
-                'direction': 'out',
-                'hardcoded_value': 'nullptr',
-                'include_in_proto': False,
-                'name': 'reserved',
-                'type': 'void'
             }
         ],
         'returns': 'int32'


### PR DESCRIPTION
What does this Pull Request accomplish?
Updates niRFmxInstr in grpc-device to 24.3
Updates the Grpc Device Code for SaveLoadConfigurations API.
Updates the Grpc Device Code for LoadOptions attribute.

Why should this Pull Request be merged?
Updated to match the upcoming release of niRFmxInstr 24.3.0

What testing has been done?
Manually inspected generated files..
Manually inspected nirfmxInstr.proto file
