### PR TITLE
Avoid binary-breaking change in RFmx LTE

### DIFF
--- a/generated/nirfmxlte/nirfmxlte.proto
+++ b/generated/nirfmxlte/nirfmxlte.proto
@@ -2582,8 +2582,8 @@ message CfgPSSCHModulationTypeRequest {
   nidevice_grpc.Session instrument = 1;
   string selector_string = 2;
   oneof modulation_type_enum {
-    PsschModulationType modulation_type = 3;
-    int32 modulation_type_raw = 4;
+    int32 modulation_type_raw = 3;
+    PsschModulationType modulation_type = 4;
   }
 }
 

--- a/source/codegen/metadata/nirfmxlte/functions.py
+++ b/source/codegen/metadata/nirfmxlte/functions.py
@@ -2511,6 +2511,8 @@ functions = {
             {
                 'direction': 'in',
                 'enum': 'PsschModulationType',
+                'grpc_field_number': '4',
+                'grpc_raw_field_number': '3',
                 'name': 'modulationType',
                 'type': 'int32'
             }


### PR DESCRIPTION
### What does this Pull Request accomplish?

Avoids changing a field number in the RFmx LTE Proto from the previous release.

### Why should this Pull Request be merged?

Reverses the binary breaking change introduced in #1047 

### What testing has been done?

The build.
