### PR TITLE
Correcting enum values and maintaining backward compatability

### DIFF
--- a/generated/nirfmxspecan/nirfmxspecan.proto
+++ b/generated/nirfmxspecan/nirfmxspecan.proto
@@ -5350,12 +5350,12 @@ message IDPDCfgReferenceWaveformRequest {
   double dx = 4;
   repeated nidevice_grpc.NIComplexNumberF32 reference_waveform = 5;
   oneof idle_duration_present_enum {
-    IdpdReferenceWaveformIdleDurationPresent idle_duration_present = 6;
-    int32 idle_duration_present_raw = 7;
+    int32 idle_duration_present_raw = 6;
+    IdpdReferenceWaveformIdleDurationPresent idle_duration_present = 8;
   }
   oneof signal_type_enum {
-    IdpdSignalType signal_type = 8;
-    int32 signal_type_raw = 9;
+    int32 signal_type_raw = 7;
+    IdpdSignalType signal_type = 9;
   }
 }
 

--- a/source/codegen/metadata/nirfmxlte/functions_addon.py
+++ b/source/codegen/metadata/nirfmxlte/functions_addon.py
@@ -1,2 +1,26 @@
 functions_override_metadata = {
+    'CfgPSSCHModulationType': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'enum': 'PsschModulationType',
+                'grpc_field_number': '4',
+                'grpc_raw_field_number': '3',
+                'name': 'modulationType',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
 }

--- a/source/codegen/metadata/nirfmxspecan/functions.py
+++ b/source/codegen/metadata/nirfmxspecan/functions.py
@@ -6628,12 +6628,16 @@ functions = {
             {
                 'direction': 'in',
                 'enum': 'IdpdReferenceWaveformIdleDurationPresent',
+                'grpc_raw_field_number': '6',
+                'grpc_field_number': '8',
                 'name': 'idleDurationPresent',
                 'type': 'int32'
             },
             {
                 'direction': 'in',
                 'enum': 'IdpdSignalType',
+                'grpc_raw_field_number': '7',
+                'grpc_field_number': '9',
                 'name': 'signalType',
                 'type': 'int32'
             }

--- a/source/codegen/metadata/nirfmxspecan/functions_addon.py
+++ b/source/codegen/metadata/nirfmxspecan/functions_addon.py
@@ -1,2 +1,58 @@
 functions_override_metadata = {
+    'IDPDCfgReferenceWaveform': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'x0',
+                'type': 'float64'
+            },
+            {
+                'direction': 'in',
+                'name': 'dx',
+                'type': 'float64'
+            },
+            {
+                'direction': 'in',
+                'name': 'referenceWaveform',
+                'size': {
+                    'mechanism': 'len',
+                    'value': 'arraySize'
+                },
+                'type': 'NIComplexSingle[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'arraySize',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'enum': 'IdpdReferenceWaveformIdleDurationPresent',
+                'grpc_raw_field_number': '6',
+                'grpc_field_number': '8',
+                'name': 'idleDurationPresent',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'enum': 'IdpdSignalType',
+                'grpc_raw_field_number': '7',
+                'grpc_field_number': '9',
+                'name': 'signalType',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
 }


### PR DESCRIPTION
What does this Pull Request accomplish?
Avoids changing a field number in the RFmx LTE Proto from the previous release.
Avoids changing a field number in the RFmxSpecAn Proto from the previous release

Why should this Pull Request be merged?
Reverses the binary breaking change introduced in https://github.com/ni/grpc-device/pull/1047
Adding the special implementation in the functions_addon.py files of SpecAn and LTE to make sure correct code is generated in future.

What testing has been done?
The build.
