### PR TITLE
Adding private APIs to configure attenuation tables in RFmx Instr

### DIFF
--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted.proto
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted.proto
@@ -13,6 +13,7 @@ option csharp_namespace = "NationalInstruments.Grpc.NiRFmxInstrRestricted";
 
 package nirfmxinstr_restricted_grpc;
 
+import "nidevice.proto";
 import "session.proto";
 
 service NiRFmxInstrRestricted {
@@ -52,6 +53,11 @@ service NiRFmxInstrRestricted {
   rpc UnregisterSpecialClientSnapshotInterest(UnregisterSpecialClientSnapshotInterestRequest) returns (UnregisterSpecialClientSnapshotInterestResponse);
   rpc GetSFPSessionAccessEnabled(GetSFPSessionAccessEnabledRequest) returns (GetSFPSessionAccessEnabledResponse);
   rpc CreateDefaultSignalConfiguration(CreateDefaultSignalConfigurationRequest) returns (CreateDefaultSignalConfigurationResponse);
+  rpc LoadExternalAttenuationTable(LoadExternalAttenuationTableRequest) returns (LoadExternalAttenuationTableResponse);
+  rpc DefineExternalAttenuationTable(DefineExternalAttenuationTableRequest) returns (DefineExternalAttenuationTableResponse);
+  rpc CfgSParameterExternalAttenuationTableFrequencies(CfgSParameterExternalAttenuationTableFrequenciesRequest) returns (CfgSParameterExternalAttenuationTableFrequenciesResponse);
+  rpc CfgSParameterExternalAttenuationTableSParameter(CfgSParameterExternalAttenuationTableSParameterRequest) returns (CfgSParameterExternalAttenuationTableSParameterResponse);
+  rpc DefineSParameterExternalAttenuationTable(DefineSParameterExternalAttenuationTableRequest) returns (DefineSParameterExternalAttenuationTableResponse);
 }
 
 message ConvertForPowerUnitsUtilityRequest {
@@ -433,6 +439,63 @@ message CreateDefaultSignalConfigurationRequest {
 }
 
 message CreateDefaultSignalConfigurationResponse {
+  int32 status = 1;
+}
+
+message LoadExternalAttenuationTableRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  string table_name = 3;
+  string file_path = 4;
+}
+
+message LoadExternalAttenuationTableResponse {
+  int32 status = 1;
+}
+
+message DefineExternalAttenuationTableRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  string table_name = 3;
+  int32 number_of_points = 4;
+}
+
+message DefineExternalAttenuationTableResponse {
+  int32 status = 1;
+}
+
+message CfgSParameterExternalAttenuationTableFrequenciesRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  string table_name = 3;
+  repeated double s_parameter_frequencies = 4;
+}
+
+message CfgSParameterExternalAttenuationTableFrequenciesResponse {
+  int32 status = 1;
+}
+
+message CfgSParameterExternalAttenuationTableSParameterRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  string table_name = 3;
+  repeated nidevice_grpc.NIComplexNumber s_parameters = 4;
+  int32 s_parameter_orientation = 5;
+}
+
+message CfgSParameterExternalAttenuationTableSParameterResponse {
+  int32 status = 1;
+}
+
+message DefineSParameterExternalAttenuationTableRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  string table_name = 3;
+  int32 number_of_frequency_points = 4;
+  int32 number_of_ports = 5;
+}
+
+message DefineSParameterExternalAttenuationTableResponse {
   int32 status = 1;
 }
 

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.cpp
@@ -675,5 +675,107 @@ create_default_signal_configuration(const StubPtr& stub, const nidevice_grpc::Se
   return response;
 }
 
+LoadExternalAttenuationTableResponse
+load_external_attenuation_table(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::string& file_path)
+{
+  ::grpc::ClientContext context;
+
+  auto request = LoadExternalAttenuationTableRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_table_name(table_name);
+  request.set_file_path(file_path);
+
+  auto response = LoadExternalAttenuationTableResponse{};
+
+  raise_if_error(
+      stub->LoadExternalAttenuationTable(&context, request, &response),
+      context);
+
+  return response;
+}
+
+DefineExternalAttenuationTableResponse
+define_external_attenuation_table(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const pb::int32& number_of_points)
+{
+  ::grpc::ClientContext context;
+
+  auto request = DefineExternalAttenuationTableRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_table_name(table_name);
+  request.set_number_of_points(number_of_points);
+
+  auto response = DefineExternalAttenuationTableResponse{};
+
+  raise_if_error(
+      stub->DefineExternalAttenuationTable(&context, request, &response),
+      context);
+
+  return response;
+}
+
+CfgSParameterExternalAttenuationTableFrequenciesResponse
+cfg_s_parameter_external_attenuation_table_frequencies(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::vector<double>& s_parameter_frequencies)
+{
+  ::grpc::ClientContext context;
+
+  auto request = CfgSParameterExternalAttenuationTableFrequenciesRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_table_name(table_name);
+  copy_array(s_parameter_frequencies, request.mutable_s_parameter_frequencies());
+
+  auto response = CfgSParameterExternalAttenuationTableFrequenciesResponse{};
+
+  raise_if_error(
+      stub->CfgSParameterExternalAttenuationTableFrequencies(&context, request, &response),
+      context);
+
+  return response;
+}
+
+CfgSParameterExternalAttenuationTableSParameterResponse
+cfg_s_parameter_external_attenuation_table_s_parameter(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::vector<nidevice_grpc::NIComplexNumber>& s_parameters, const pb::int32& s_parameter_orientation)
+{
+  ::grpc::ClientContext context;
+
+  auto request = CfgSParameterExternalAttenuationTableSParameterRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_table_name(table_name);
+  copy_array(s_parameters, request.mutable_s_parameters());
+  request.set_s_parameter_orientation(s_parameter_orientation);
+
+  auto response = CfgSParameterExternalAttenuationTableSParameterResponse{};
+
+  raise_if_error(
+      stub->CfgSParameterExternalAttenuationTableSParameter(&context, request, &response),
+      context);
+
+  return response;
+}
+
+DefineSParameterExternalAttenuationTableResponse
+define_s_parameter_external_attenuation_table(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const pb::int32& number_of_frequency_points, const pb::int32& number_of_ports)
+{
+  ::grpc::ClientContext context;
+
+  auto request = DefineSParameterExternalAttenuationTableRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_table_name(table_name);
+  request.set_number_of_frequency_points(number_of_frequency_points);
+  request.set_number_of_ports(number_of_ports);
+
+  auto response = DefineSParameterExternalAttenuationTableResponse{};
+
+  raise_if_error(
+      stub->DefineSParameterExternalAttenuationTable(&context, request, &response),
+      context);
+
+  return response;
+}
+
 
 } // namespace nirfmxinstr_restricted_grpc::experimental::client

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.h
@@ -58,6 +58,11 @@ SetIOTraceStatusResponse set_io_trace_status(const StubPtr& stub, const nidevice
 UnregisterSpecialClientSnapshotInterestResponse unregister_special_client_snapshot_interest(const StubPtr& stub, const std::string& resource_name);
 GetSFPSessionAccessEnabledResponse get_sfp_session_access_enabled(const StubPtr& stub, const std::string& option_string);
 CreateDefaultSignalConfigurationResponse create_default_signal_configuration(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& signal_name, const pb::int32& personality_id);
+LoadExternalAttenuationTableResponse load_external_attenuation_table(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::string& file_path);
+DefineExternalAttenuationTableResponse define_external_attenuation_table(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const pb::int32& number_of_points);
+CfgSParameterExternalAttenuationTableFrequenciesResponse cfg_s_parameter_external_attenuation_table_frequencies(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::vector<double>& s_parameter_frequencies);
+CfgSParameterExternalAttenuationTableSParameterResponse cfg_s_parameter_external_attenuation_table_s_parameter(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::vector<nidevice_grpc::NIComplexNumber>& s_parameters, const pb::int32& s_parameter_orientation);
+DefineSParameterExternalAttenuationTableResponse define_s_parameter_external_attenuation_table(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const pb::int32& number_of_frequency_points, const pb::int32& number_of_ports);
 
 } // namespace nirfmxinstr_restricted_grpc::experimental::client
 

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.cpp
@@ -66,6 +66,11 @@ NiRFmxInstrRestrictedLibrary::NiRFmxInstrRestrictedLibrary(std::shared_ptr<nidev
   function_pointers_.UnregisterSpecialClientSnapshotInterest = reinterpret_cast<UnregisterSpecialClientSnapshotInterestPtr>(shared_library_->get_function_pointer("RFmxInstr_UnregisterSpecialClientSnapshotInterest"));
   function_pointers_.GetSFPSessionAccessEnabled = reinterpret_cast<GetSFPSessionAccessEnabledPtr>(shared_library_->get_function_pointer("RFmxInstr_GetSFPSessionAccessEnabled"));
   function_pointers_.CreateDefaultSignalConfiguration = reinterpret_cast<CreateDefaultSignalConfigurationPtr>(shared_library_->get_function_pointer("RFmxInstr_CreateDefaultSignalConfiguration"));
+  function_pointers_.LoadExternalAttenuationTable = reinterpret_cast<LoadExternalAttenuationTablePtr>(shared_library_->get_function_pointer("RFmxInstr_LoadExternalAttenuationTable"));
+  function_pointers_.DefineExternalAttenuationTable = reinterpret_cast<DefineExternalAttenuationTablePtr>(shared_library_->get_function_pointer("RFmxInstr_DefineExternalAttenuationTable"));
+  function_pointers_.CfgSParameterExternalAttenuationTableFrequencies = reinterpret_cast<CfgSParameterExternalAttenuationTableFrequenciesPtr>(shared_library_->get_function_pointer("RFmxInstr_CfgSParameterExternalAttenuationTableFrequencies"));
+  function_pointers_.CfgSParameterExternalAttenuationTableSParameter = reinterpret_cast<CfgSParameterExternalAttenuationTableSParameterPtr>(shared_library_->get_function_pointer("RFmxInstr_CfgSParameterExternalAttenuationTableSParameter"));
+  function_pointers_.DefineSParameterExternalAttenuationTable = reinterpret_cast<DefineSParameterExternalAttenuationTablePtr>(shared_library_->get_function_pointer("RFmxInstr_DefineSParameterExternalAttenuationTable"));
 }
 
 NiRFmxInstrRestrictedLibrary::~NiRFmxInstrRestrictedLibrary()
@@ -389,6 +394,46 @@ int32 NiRFmxInstrRestrictedLibrary::CreateDefaultSignalConfiguration(niRFmxInstr
     throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_CreateDefaultSignalConfiguration.");
   }
   return function_pointers_.CreateDefaultSignalConfiguration(instrumentHandle, signalName, personalityID);
+}
+
+int32 NiRFmxInstrRestrictedLibrary::LoadExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char filePath[])
+{
+  if (!function_pointers_.LoadExternalAttenuationTable) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_LoadExternalAttenuationTable.");
+  }
+  return function_pointers_.LoadExternalAttenuationTable(instrumentHandle, selectorString, tableName, filePath);
+}
+
+int32 NiRFmxInstrRestrictedLibrary::DefineExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfPoints)
+{
+  if (!function_pointers_.DefineExternalAttenuationTable) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_DefineExternalAttenuationTable.");
+  }
+  return function_pointers_.DefineExternalAttenuationTable(instrumentHandle, selectorString, tableName, numberOfPoints);
+}
+
+int32 NiRFmxInstrRestrictedLibrary::CfgSParameterExternalAttenuationTableFrequencies(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 sParameterFrequencies[], int32 sParameterFrequenciesArraySize)
+{
+  if (!function_pointers_.CfgSParameterExternalAttenuationTableFrequencies) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_CfgSParameterExternalAttenuationTableFrequencies.");
+  }
+  return function_pointers_.CfgSParameterExternalAttenuationTableFrequencies(instrumentHandle, selectorString, tableName, sParameterFrequencies, sParameterFrequenciesArraySize);
+}
+
+int32 NiRFmxInstrRestrictedLibrary::CfgSParameterExternalAttenuationTableSParameter(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], NIComplexDouble sParameters[], int32 sParameterTableSize, int32 sParameterOrientation)
+{
+  if (!function_pointers_.CfgSParameterExternalAttenuationTableSParameter) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_CfgSParameterExternalAttenuationTableSParameter.");
+  }
+  return function_pointers_.CfgSParameterExternalAttenuationTableSParameter(instrumentHandle, selectorString, tableName, sParameters, sParameterTableSize, sParameterOrientation);
+}
+
+int32 NiRFmxInstrRestrictedLibrary::DefineSParameterExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfFrequencyPoints, int32 numberOfPorts)
+{
+  if (!function_pointers_.DefineSParameterExternalAttenuationTable) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_DefineSParameterExternalAttenuationTable.");
+  }
+  return function_pointers_.DefineSParameterExternalAttenuationTable(instrumentHandle, selectorString, tableName, numberOfFrequencyPoints, numberOfPorts);
 }
 
 }  // namespace nirfmxinstr_restricted_grpc

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.h
@@ -60,6 +60,11 @@ class NiRFmxInstrRestrictedLibrary : public nirfmxinstr_restricted_grpc::NiRFmxI
   int32 UnregisterSpecialClientSnapshotInterest(char resourceName[]) override;
   int32 GetSFPSessionAccessEnabled(char optionString[], int32* isSFPSessionAccessEnabled) override;
   int32 CreateDefaultSignalConfiguration(niRFmxInstrHandle instrumentHandle, char signalName[], int32 personalityID) override;
+  int32 LoadExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char filePath[]) override;
+  int32 DefineExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfPoints) override;
+  int32 CfgSParameterExternalAttenuationTableFrequencies(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 sParameterFrequencies[], int32 sParameterFrequenciesArraySize) override;
+  int32 CfgSParameterExternalAttenuationTableSParameter(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], NIComplexDouble sParameters[], int32 sParameterTableSize, int32 sParameterOrientation) override;
+  int32 DefineSParameterExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfFrequencyPoints, int32 numberOfPorts) override;
 
  private:
   using ConvertForPowerUnitsUtilityPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, float64 referenceOrTriggerLevelIn, int32 inputPowerUnits, int32 outputPowerUnits, int32 terminalConfiguration, float64 bandwidth, float64* referenceOrTriggerLevelOut);
@@ -101,6 +106,11 @@ class NiRFmxInstrRestrictedLibrary : public nirfmxinstr_restricted_grpc::NiRFmxI
   using UnregisterSpecialClientSnapshotInterestPtr = int32 (*)(char resourceName[]);
   using GetSFPSessionAccessEnabledPtr = int32 (*)(char optionString[], int32* isSFPSessionAccessEnabled);
   using CreateDefaultSignalConfigurationPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char signalName[], int32 personalityID);
+  using LoadExternalAttenuationTablePtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char filePath[]);
+  using DefineExternalAttenuationTablePtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfPoints);
+  using CfgSParameterExternalAttenuationTableFrequenciesPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 sParameterFrequencies[], int32 sParameterFrequenciesArraySize);
+  using CfgSParameterExternalAttenuationTableSParameterPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], NIComplexDouble sParameters[], int32 sParameterTableSize, int32 sParameterOrientation);
+  using DefineSParameterExternalAttenuationTablePtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfFrequencyPoints, int32 numberOfPorts);
 
   typedef struct FunctionPointers {
     ConvertForPowerUnitsUtilityPtr ConvertForPowerUnitsUtility;
@@ -142,6 +152,11 @@ class NiRFmxInstrRestrictedLibrary : public nirfmxinstr_restricted_grpc::NiRFmxI
     UnregisterSpecialClientSnapshotInterestPtr UnregisterSpecialClientSnapshotInterest;
     GetSFPSessionAccessEnabledPtr GetSFPSessionAccessEnabled;
     CreateDefaultSignalConfigurationPtr CreateDefaultSignalConfiguration;
+    LoadExternalAttenuationTablePtr LoadExternalAttenuationTable;
+    DefineExternalAttenuationTablePtr DefineExternalAttenuationTable;
+    CfgSParameterExternalAttenuationTableFrequenciesPtr CfgSParameterExternalAttenuationTableFrequencies;
+    CfgSParameterExternalAttenuationTableSParameterPtr CfgSParameterExternalAttenuationTableSParameter;
+    DefineSParameterExternalAttenuationTablePtr DefineSParameterExternalAttenuationTable;
   } FunctionLoadStatus;
 
   std::shared_ptr<nidevice_grpc::SharedLibraryInterface> shared_library_;

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library_interface.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library_interface.h
@@ -54,6 +54,11 @@ class NiRFmxInstrRestrictedLibraryInterface {
   virtual int32 UnregisterSpecialClientSnapshotInterest(char resourceName[]) = 0;
   virtual int32 GetSFPSessionAccessEnabled(char optionString[], int32* isSFPSessionAccessEnabled) = 0;
   virtual int32 CreateDefaultSignalConfiguration(niRFmxInstrHandle instrumentHandle, char signalName[], int32 personalityID) = 0;
+  virtual int32 LoadExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char filePath[]) = 0;
+  virtual int32 DefineExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfPoints) = 0;
+  virtual int32 CfgSParameterExternalAttenuationTableFrequencies(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 sParameterFrequencies[], int32 sParameterFrequenciesArraySize) = 0;
+  virtual int32 CfgSParameterExternalAttenuationTableSParameter(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], NIComplexDouble sParameters[], int32 sParameterTableSize, int32 sParameterOrientation) = 0;
+  virtual int32 DefineSParameterExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfFrequencyPoints, int32 numberOfPorts) = 0;
 };
 
 }  // namespace nirfmxinstr_restricted_grpc

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_mock_library.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_mock_library.h
@@ -56,6 +56,11 @@ class NiRFmxInstrRestrictedMockLibrary : public nirfmxinstr_restricted_grpc::NiR
   MOCK_METHOD(int32, UnregisterSpecialClientSnapshotInterest, (char resourceName[]), (override));
   MOCK_METHOD(int32, GetSFPSessionAccessEnabled, (char optionString[], int32* isSFPSessionAccessEnabled), (override));
   MOCK_METHOD(int32, CreateDefaultSignalConfiguration, (niRFmxInstrHandle instrumentHandle, char signalName[], int32 personalityID), (override));
+  MOCK_METHOD(int32, LoadExternalAttenuationTable, (niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char filePath[]), (override));
+  MOCK_METHOD(int32, DefineExternalAttenuationTable, (niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfPoints), (override));
+  MOCK_METHOD(int32, CfgSParameterExternalAttenuationTableFrequencies, (niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 sParameterFrequencies[], int32 sParameterFrequenciesArraySize), (override));
+  MOCK_METHOD(int32, CfgSParameterExternalAttenuationTableSParameter, (niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], NIComplexDouble sParameters[], int32 sParameterTableSize, int32 sParameterOrientation), (override));
+  MOCK_METHOD(int32, DefineSParameterExternalAttenuationTable, (niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfFrequencyPoints, int32 numberOfPorts), (override));
 };
 
 }  // namespace unit

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
@@ -1117,6 +1117,146 @@ namespace nirfmxinstr_restricted_grpc {
     }
   }
 
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxInstrRestrictedService::LoadExternalAttenuationTable(::grpc::ServerContext* context, const LoadExternalAttenuationTableRequest* request, LoadExternalAttenuationTableResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
+      auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
+      char* selector_string = (char*)selector_string_mbcs.c_str();
+      auto table_name_mbcs = convert_from_grpc<std::string>(request->table_name());
+      char* table_name = (char*)table_name_mbcs.c_str();
+      auto file_path_mbcs = convert_from_grpc<std::string>(request->file_path());
+      char* file_path = (char*)file_path_mbcs.c_str();
+      auto status = library_->LoadExternalAttenuationTable(instrument, selector_string, table_name, file_path);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxInstrRestrictedService::DefineExternalAttenuationTable(::grpc::ServerContext* context, const DefineExternalAttenuationTableRequest* request, DefineExternalAttenuationTableResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
+      auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
+      char* selector_string = (char*)selector_string_mbcs.c_str();
+      auto table_name_mbcs = convert_from_grpc<std::string>(request->table_name());
+      char* table_name = (char*)table_name_mbcs.c_str();
+      int32 number_of_points = request->number_of_points();
+      auto status = library_->DefineExternalAttenuationTable(instrument, selector_string, table_name, number_of_points);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxInstrRestrictedService::CfgSParameterExternalAttenuationTableFrequencies(::grpc::ServerContext* context, const CfgSParameterExternalAttenuationTableFrequenciesRequest* request, CfgSParameterExternalAttenuationTableFrequenciesResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
+      auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
+      char* selector_string = (char*)selector_string_mbcs.c_str();
+      auto table_name_mbcs = convert_from_grpc<std::string>(request->table_name());
+      char* table_name = (char*)table_name_mbcs.c_str();
+      auto s_parameter_frequencies = const_cast<float64*>(request->s_parameter_frequencies().data());
+      int32 s_parameter_frequencies_array_size = static_cast<int32>(request->s_parameter_frequencies().size());
+      auto status = library_->CfgSParameterExternalAttenuationTableFrequencies(instrument, selector_string, table_name, s_parameter_frequencies, s_parameter_frequencies_array_size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxInstrRestrictedService::CfgSParameterExternalAttenuationTableSParameter(::grpc::ServerContext* context, const CfgSParameterExternalAttenuationTableSParameterRequest* request, CfgSParameterExternalAttenuationTableSParameterResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
+      auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
+      char* selector_string = (char*)selector_string_mbcs.c_str();
+      auto table_name_mbcs = convert_from_grpc<std::string>(request->table_name());
+      char* table_name = (char*)table_name_mbcs.c_str();
+      auto s_parameters = convert_from_grpc<NIComplexDouble>(request->s_parameters());
+      int32 s_parameter_table_size = static_cast<int32>(request->s_parameters().size());
+      int32 s_parameter_orientation = request->s_parameter_orientation();
+      auto status = library_->CfgSParameterExternalAttenuationTableSParameter(instrument, selector_string, table_name, s_parameters.data(), s_parameter_table_size, s_parameter_orientation);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxInstrRestrictedService::DefineSParameterExternalAttenuationTable(::grpc::ServerContext* context, const DefineSParameterExternalAttenuationTableRequest* request, DefineSParameterExternalAttenuationTableResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
+      auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
+      char* selector_string = (char*)selector_string_mbcs.c_str();
+      auto table_name_mbcs = convert_from_grpc<std::string>(request->table_name());
+      char* table_name = (char*)table_name_mbcs.c_str();
+      int32 number_of_frequency_points = request->number_of_frequency_points();
+      int32 number_of_ports = request->number_of_ports();
+      auto status = library_->DefineSParameterExternalAttenuationTable(instrument, selector_string, table_name, number_of_frequency_points, number_of_ports);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
 
   NiRFmxInstrRestrictedFeatureToggles::NiRFmxInstrRestrictedFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.h
@@ -78,6 +78,11 @@ public:
   ::grpc::Status UnregisterSpecialClientSnapshotInterest(::grpc::ServerContext* context, const UnregisterSpecialClientSnapshotInterestRequest* request, UnregisterSpecialClientSnapshotInterestResponse* response) override;
   ::grpc::Status GetSFPSessionAccessEnabled(::grpc::ServerContext* context, const GetSFPSessionAccessEnabledRequest* request, GetSFPSessionAccessEnabledResponse* response) override;
   ::grpc::Status CreateDefaultSignalConfiguration(::grpc::ServerContext* context, const CreateDefaultSignalConfigurationRequest* request, CreateDefaultSignalConfigurationResponse* response) override;
+  ::grpc::Status LoadExternalAttenuationTable(::grpc::ServerContext* context, const LoadExternalAttenuationTableRequest* request, LoadExternalAttenuationTableResponse* response) override;
+  ::grpc::Status DefineExternalAttenuationTable(::grpc::ServerContext* context, const DefineExternalAttenuationTableRequest* request, DefineExternalAttenuationTableResponse* response) override;
+  ::grpc::Status CfgSParameterExternalAttenuationTableFrequencies(::grpc::ServerContext* context, const CfgSParameterExternalAttenuationTableFrequenciesRequest* request, CfgSParameterExternalAttenuationTableFrequenciesResponse* response) override;
+  ::grpc::Status CfgSParameterExternalAttenuationTableSParameter(::grpc::ServerContext* context, const CfgSParameterExternalAttenuationTableSParameterRequest* request, CfgSParameterExternalAttenuationTableSParameterResponse* response) override;
+  ::grpc::Status DefineSParameterExternalAttenuationTable(::grpc::ServerContext* context, const DefineSParameterExternalAttenuationTableRequest* request, DefineSParameterExternalAttenuationTableResponse* response) override;
 private:
   LibrarySharedPtr library_;
   ResourceRepositorySharedPtr session_repository_;

--- a/source/codegen/metadata/nirfmxinstr_restricted/functions.py
+++ b/source/codegen/metadata/nirfmxinstr_restricted/functions.py
@@ -1233,5 +1233,163 @@ functions = {
             }
         ],
         'returns': 'int32'
+    },
+    'LoadExternalAttenuationTable': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'tableName',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'filePath',
+                'type': 'char[]'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'DefineExternalAttenuationTable': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'tableName',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'numberOfPoints',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'CfgSParameterExternalAttenuationTableFrequencies': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'tableName',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'sParameterFrequencies',
+                'size': {
+                    'mechanism': 'len',
+                    'value': 'sParameterFrequenciesArraySize'
+                },
+                'type': 'float64[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'sParameterFrequenciesArraySize',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'CfgSParameterExternalAttenuationTableSParameter': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'tableName',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'sParameters',
+                'size': {
+                    'mechanism': 'len',
+                    'value': 'sParameterTableSize'
+                },
+                'type': 'NIComplexDouble[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'sParameterTableSize',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'name': 'sParameterOrientation',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'DefineSParameterExternalAttenuationTable': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'tableName',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'numberOfFrequencyPoints',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'name': 'numberOfPorts',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
     }
 }


### PR DESCRIPTION
### What does this Pull Request accomplish?

Expose, in grpc-device, the existing private APIs in RFmxInstr to create and configure attenuation tables.

### Why should this Pull Request be merged?

We have a use case for using these private APIs, but they are currently not exposed through NI's gRPC server.

### What testing has been done?

Simple program that calls these APIs throws a NotImplemented exception with the currently release server. No errors thrown after these changes.
