### PR TITLE
Fix missing "grpc name" from two RFmx restricted functions

### DIFF
--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted.proto
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted.proto
@@ -39,7 +39,7 @@ enum AmpmSignalType {
 }
 
 message AMPMLoadReferenceWaveformFromTDMSFileRequest {
-  nidevice_grpc.Session instrument_handle = 1;
+  nidevice_grpc.Session instrument = 1;
   string selector_string = 2;
   string waveform_file_path = 3;
   oneof idle_duration_present_enum {

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.cpp
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.cpp
@@ -18,12 +18,12 @@
 namespace nirfmxspecan_restricted_grpc::experimental::client {
 
 AMPMLoadReferenceWaveformFromTDMSFileResponse
-ampm_load_reference_waveform_from_tdms_file(const StubPtr& stub, const nidevice_grpc::Session& instrument_handle, const std::string& selector_string, const std::string& waveform_file_path, const simple_variant<AmpmReferenceWaveformIdleDurationPresent, pb::int32>& idle_duration_present, const simple_variant<AmpmSignalType, pb::int32>& signal_type, const pb::int32& waveform_index)
+ampm_load_reference_waveform_from_tdms_file(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& waveform_file_path, const simple_variant<AmpmReferenceWaveformIdleDurationPresent, pb::int32>& idle_duration_present, const simple_variant<AmpmSignalType, pb::int32>& signal_type, const pb::int32& waveform_index)
 {
   ::grpc::ClientContext context;
 
   auto request = AMPMLoadReferenceWaveformFromTDMSFileRequest{};
-  request.mutable_instrument_handle()->CopyFrom(instrument_handle);
+  request.mutable_instrument()->CopyFrom(instrument);
   request.set_selector_string(selector_string);
   request.set_waveform_file_path(waveform_file_path);
   const auto idle_duration_present_ptr = idle_duration_present.get_if<AmpmReferenceWaveformIdleDurationPresent>();

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.h
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_client.h
@@ -22,7 +22,7 @@ using StubPtr = std::unique_ptr<NiRFmxSpecAnRestricted::Stub>;
 using namespace nidevice_grpc::experimental::client;
 
 
-AMPMLoadReferenceWaveformFromTDMSFileResponse ampm_load_reference_waveform_from_tdms_file(const StubPtr& stub, const nidevice_grpc::Session& instrument_handle, const std::string& selector_string, const std::string& waveform_file_path, const simple_variant<AmpmReferenceWaveformIdleDurationPresent, pb::int32>& idle_duration_present, const simple_variant<AmpmSignalType, pb::int32>& signal_type, const pb::int32& waveform_index);
+AMPMLoadReferenceWaveformFromTDMSFileResponse ampm_load_reference_waveform_from_tdms_file(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& waveform_file_path, const simple_variant<AmpmReferenceWaveformIdleDurationPresent, pb::int32>& idle_duration_present, const simple_variant<AmpmSignalType, pb::int32>& signal_type, const pb::int32& waveform_index);
 CacheResultResponse cache_result(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const pb::int32& selector_string_out_size);
 IQFetchDataOverrideBehaviorResponse iq_fetch_data_override_behavior(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout, const pb::int32& record_to_fetch, const pb::int64& samples_to_read, const simple_variant<IQDeleteOnFetch, pb::int32>& delete_on_fetch);
 

--- a/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_service.cpp
+++ b/generated/nirfmxspecan_restricted/nirfmxspecan_restricted_service.cpp
@@ -52,8 +52,8 @@ namespace nirfmxspecan_restricted_grpc {
       return ::grpc::Status::CANCELLED;
     }
     try {
-      auto instrument_handle_grpc_session = request->instrument_handle();
-      niRFmxInstrHandle instrument_handle = session_repository_->access_session(instrument_handle_grpc_session.name());
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
       char* selector_string = (char*)selector_string_mbcs.c_str();
       auto waveform_file_path_mbcs = convert_from_grpc<std::string>(request->waveform_file_path());
@@ -91,9 +91,9 @@ namespace nirfmxspecan_restricted_grpc {
       }
 
       int32 waveform_index = request->waveform_index();
-      auto status = library_->AMPMLoadReferenceWaveformFromTDMSFile(instrument_handle, selector_string, waveform_file_path, idle_duration_present, signal_type, waveform_index);
+      auto status = library_->AMPMLoadReferenceWaveformFromTDMSFile(instrument, selector_string, waveform_file_path, idle_duration_present, signal_type, waveform_index);
       if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument_handle);
+        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
       }
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/generated/nirfmxwlan_restricted/nirfmxwlan_restricted.proto
+++ b/generated/nirfmxwlan_restricted/nirfmxwlan_restricted.proto
@@ -51,7 +51,7 @@ message OFDMModAccFetchCommonPilotErrorTraceIndBResponse {
 }
 
 message OFDMModAccLoad1ReferenceWaveformFromTDMSFileRequest {
-  nidevice_grpc.Session instrument_handle = 1;
+  nidevice_grpc.Session instrument = 1;
   string selector_string = 2;
   string waveform_file_path = 3;
   int32 waveform_index = 4;

--- a/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_client.cpp
+++ b/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_client.cpp
@@ -56,12 +56,12 @@ ofdm_mod_acc_fetch_common_pilot_error_trace_ind_b(const StubPtr& stub, const nid
 }
 
 OFDMModAccLoad1ReferenceWaveformFromTDMSFileResponse
-ofdm_mod_acc_load1_reference_waveform_from_tdms_file(const StubPtr& stub, const nidevice_grpc::Session& instrument_handle, const std::string& selector_string, const std::string& waveform_file_path, const pb::int32& waveform_index)
+ofdm_mod_acc_load1_reference_waveform_from_tdms_file(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& waveform_file_path, const pb::int32& waveform_index)
 {
   ::grpc::ClientContext context;
 
   auto request = OFDMModAccLoad1ReferenceWaveformFromTDMSFileRequest{};
-  request.mutable_instrument_handle()->CopyFrom(instrument_handle);
+  request.mutable_instrument()->CopyFrom(instrument);
   request.set_selector_string(selector_string);
   request.set_waveform_file_path(waveform_file_path);
   request.set_waveform_index(waveform_index);

--- a/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_client.h
+++ b/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_client.h
@@ -24,7 +24,7 @@ using namespace nidevice_grpc::experimental::client;
 
 GetChannelListResponse get_channel_list(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const pb::int32& wlan_band);
 OFDMModAccFetchCommonPilotErrorTraceIndBResponse ofdm_mod_acc_fetch_common_pilot_error_trace_ind_b(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout);
-OFDMModAccLoad1ReferenceWaveformFromTDMSFileResponse ofdm_mod_acc_load1_reference_waveform_from_tdms_file(const StubPtr& stub, const nidevice_grpc::Session& instrument_handle, const std::string& selector_string, const std::string& waveform_file_path, const pb::int32& waveform_index);
+OFDMModAccLoad1ReferenceWaveformFromTDMSFileResponse ofdm_mod_acc_load1_reference_waveform_from_tdms_file(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& waveform_file_path, const pb::int32& waveform_index);
 OFDMModAccNoiseCalibrateResponse ofdm_mod_acc_noise_calibrate(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const pb::int32& shared_lo_connection);
 
 } // namespace nirfmxwlan_restricted_grpc::experimental::client

--- a/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_service.cpp
+++ b/generated/nirfmxwlan_restricted/nirfmxwlan_restricted_service.cpp
@@ -144,16 +144,16 @@ namespace nirfmxwlan_restricted_grpc {
       return ::grpc::Status::CANCELLED;
     }
     try {
-      auto instrument_handle_grpc_session = request->instrument_handle();
-      niRFmxInstrHandle instrument_handle = session_repository_->access_session(instrument_handle_grpc_session.name());
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
       char* selector_string = (char*)selector_string_mbcs.c_str();
       auto waveform_file_path_mbcs = convert_from_grpc<std::string>(request->waveform_file_path());
       char* waveform_file_path = (char*)waveform_file_path_mbcs.c_str();
       int32 waveform_index = request->waveform_index();
-      auto status = library_->OFDMModAccLoad1ReferenceWaveformFromTDMSFile(instrument_handle, selector_string, waveform_file_path, waveform_index);
+      auto status = library_->OFDMModAccLoad1ReferenceWaveformFromTDMSFile(instrument, selector_string, waveform_file_path, waveform_index);
       if (!status_ok(status)) {
-        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument_handle);
+        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
       }
       response->set_status(status);
       return ::grpc::Status::OK;

--- a/source/codegen/metadata/nirfmxspecan_restricted/functions.py
+++ b/source/codegen/metadata/nirfmxspecan_restricted/functions.py
@@ -3,6 +3,7 @@ functions = {
         'parameters': [
             {
                 'direction': 'in',
+                'grpc_name': 'instrument',
                 'name': 'instrumentHandle',
                 'type': 'niRFmxInstrHandle'
             },

--- a/source/codegen/metadata/nirfmxwlan_restricted/functions.py
+++ b/source/codegen/metadata/nirfmxwlan_restricted/functions.py
@@ -177,6 +177,7 @@ functions = {
         'parameters': [
             {
                 'direction': 'in',
+                'grpc_name': 'instrument',
                 'name': 'instrumentHandle',
                 'type': 'niRFmxInstrHandle'
             },


### PR DESCRIPTION
### What does this Pull Request accomplish?

Two RFmx functions that were added recently don't comply with the grpc instrument name. This causes issues with automated tooling like in this PR https://dev.azure.com/ni/DevCentral/_git/ni-central/pullrequest/620589

### Why should this Pull Request be merged?

The rest of the RFmx API follows this grpc name convention. 

### What testing has been done?

Visually inspected the generated proto file for the expected session name adjustment.
