### PR TITLE
Add remaining missing attenuation table functions to RFmxInstr

### DIFF
--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted.proto
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted.proto
@@ -58,6 +58,9 @@ service NiRFmxInstrRestricted {
   rpc CfgSParameterExternalAttenuationTableFrequencies(CfgSParameterExternalAttenuationTableFrequenciesRequest) returns (CfgSParameterExternalAttenuationTableFrequenciesResponse);
   rpc CfgSParameterExternalAttenuationTableSParameter(CfgSParameterExternalAttenuationTableSParameterRequest) returns (CfgSParameterExternalAttenuationTableSParameterResponse);
   rpc DefineSParameterExternalAttenuationTable(DefineSParameterExternalAttenuationTableRequest) returns (DefineSParameterExternalAttenuationTableResponse);
+  rpc SaveExternalAttenuationTable(SaveExternalAttenuationTableRequest) returns (SaveExternalAttenuationTableResponse);
+  rpc CfgExternalAttenuationTableFrequencies(CfgExternalAttenuationTableFrequenciesRequest) returns (CfgExternalAttenuationTableFrequenciesResponse);
+  rpc CfgExternalAttenuationTable(CfgExternalAttenuationTableRequest) returns (CfgExternalAttenuationTableResponse);
 }
 
 message ConvertForPowerUnitsUtilityRequest {
@@ -496,6 +499,41 @@ message DefineSParameterExternalAttenuationTableRequest {
 }
 
 message DefineSParameterExternalAttenuationTableResponse {
+  int32 status = 1;
+}
+
+message SaveExternalAttenuationTableRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  string table_name = 3;
+  string file_path = 4;
+  string description = 5;
+}
+
+message SaveExternalAttenuationTableResponse {
+  int32 status = 1;
+}
+
+message CfgExternalAttenuationTableFrequenciesRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  string table_name = 3;
+  repeated double frequency = 4;
+}
+
+message CfgExternalAttenuationTableFrequenciesResponse {
+  int32 status = 1;
+}
+
+message CfgExternalAttenuationTableRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  string table_name = 3;
+  repeated double frequency = 4;
+  repeated double external_attenuation = 5;
+}
+
+message CfgExternalAttenuationTableResponse {
   int32 status = 1;
 }
 

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.cpp
@@ -777,5 +777,67 @@ define_s_parameter_external_attenuation_table(const StubPtr& stub, const nidevic
   return response;
 }
 
+SaveExternalAttenuationTableResponse
+save_external_attenuation_table(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::string& file_path, const std::string& description)
+{
+  ::grpc::ClientContext context;
+
+  auto request = SaveExternalAttenuationTableRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_table_name(table_name);
+  request.set_file_path(file_path);
+  request.set_description(description);
+
+  auto response = SaveExternalAttenuationTableResponse{};
+
+  raise_if_error(
+      stub->SaveExternalAttenuationTable(&context, request, &response),
+      context);
+
+  return response;
+}
+
+CfgExternalAttenuationTableFrequenciesResponse
+cfg_external_attenuation_table_frequencies(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::vector<double>& frequency)
+{
+  ::grpc::ClientContext context;
+
+  auto request = CfgExternalAttenuationTableFrequenciesRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_table_name(table_name);
+  copy_array(frequency, request.mutable_frequency());
+
+  auto response = CfgExternalAttenuationTableFrequenciesResponse{};
+
+  raise_if_error(
+      stub->CfgExternalAttenuationTableFrequencies(&context, request, &response),
+      context);
+
+  return response;
+}
+
+CfgExternalAttenuationTableResponse
+cfg_external_attenuation_table(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::vector<double>& frequency, const std::vector<double>& external_attenuation)
+{
+  ::grpc::ClientContext context;
+
+  auto request = CfgExternalAttenuationTableRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_table_name(table_name);
+  copy_array(frequency, request.mutable_frequency());
+  copy_array(external_attenuation, request.mutable_external_attenuation());
+
+  auto response = CfgExternalAttenuationTableResponse{};
+
+  raise_if_error(
+      stub->CfgExternalAttenuationTable(&context, request, &response),
+      context);
+
+  return response;
+}
+
 
 } // namespace nirfmxinstr_restricted_grpc::experimental::client

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.h
@@ -63,6 +63,9 @@ DefineExternalAttenuationTableResponse define_external_attenuation_table(const S
 CfgSParameterExternalAttenuationTableFrequenciesResponse cfg_s_parameter_external_attenuation_table_frequencies(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::vector<double>& s_parameter_frequencies);
 CfgSParameterExternalAttenuationTableSParameterResponse cfg_s_parameter_external_attenuation_table_s_parameter(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::vector<nidevice_grpc::NIComplexNumber>& s_parameters, const pb::int32& s_parameter_orientation);
 DefineSParameterExternalAttenuationTableResponse define_s_parameter_external_attenuation_table(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const pb::int32& number_of_frequency_points, const pb::int32& number_of_ports);
+SaveExternalAttenuationTableResponse save_external_attenuation_table(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::string& file_path, const std::string& description);
+CfgExternalAttenuationTableFrequenciesResponse cfg_external_attenuation_table_frequencies(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::vector<double>& frequency);
+CfgExternalAttenuationTableResponse cfg_external_attenuation_table(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::vector<double>& frequency, const std::vector<double>& external_attenuation);
 
 } // namespace nirfmxinstr_restricted_grpc::experimental::client
 

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.cpp
@@ -71,6 +71,9 @@ NiRFmxInstrRestrictedLibrary::NiRFmxInstrRestrictedLibrary(std::shared_ptr<nidev
   function_pointers_.CfgSParameterExternalAttenuationTableFrequencies = reinterpret_cast<CfgSParameterExternalAttenuationTableFrequenciesPtr>(shared_library_->get_function_pointer("RFmxInstr_CfgSParameterExternalAttenuationTableFrequencies"));
   function_pointers_.CfgSParameterExternalAttenuationTableSParameter = reinterpret_cast<CfgSParameterExternalAttenuationTableSParameterPtr>(shared_library_->get_function_pointer("RFmxInstr_CfgSParameterExternalAttenuationTableSParameter"));
   function_pointers_.DefineSParameterExternalAttenuationTable = reinterpret_cast<DefineSParameterExternalAttenuationTablePtr>(shared_library_->get_function_pointer("RFmxInstr_DefineSParameterExternalAttenuationTable"));
+  function_pointers_.SaveExternalAttenuationTable = reinterpret_cast<SaveExternalAttenuationTablePtr>(shared_library_->get_function_pointer("RFmxInstr_SaveExternalAttenuationTable"));
+  function_pointers_.CfgExternalAttenuationTableFrequencies = reinterpret_cast<CfgExternalAttenuationTableFrequenciesPtr>(shared_library_->get_function_pointer("RFmxInstr_CfgExternalAttenuationTableFrequencies"));
+  function_pointers_.CfgExternalAttenuationTable = reinterpret_cast<CfgExternalAttenuationTablePtr>(shared_library_->get_function_pointer("RFmxInstr_CfgExternalAttenuationTable"));
 }
 
 NiRFmxInstrRestrictedLibrary::~NiRFmxInstrRestrictedLibrary()
@@ -434,6 +437,30 @@ int32 NiRFmxInstrRestrictedLibrary::DefineSParameterExternalAttenuationTable(niR
     throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_DefineSParameterExternalAttenuationTable.");
   }
   return function_pointers_.DefineSParameterExternalAttenuationTable(instrumentHandle, selectorString, tableName, numberOfFrequencyPoints, numberOfPorts);
+}
+
+int32 NiRFmxInstrRestrictedLibrary::SaveExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char filePath[], char description[])
+{
+  if (!function_pointers_.SaveExternalAttenuationTable) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_SaveExternalAttenuationTable.");
+  }
+  return function_pointers_.SaveExternalAttenuationTable(instrumentHandle, selectorString, tableName, filePath, description);
+}
+
+int32 NiRFmxInstrRestrictedLibrary::CfgExternalAttenuationTableFrequencies(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 frequency[], int32 arraySize)
+{
+  if (!function_pointers_.CfgExternalAttenuationTableFrequencies) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_CfgExternalAttenuationTableFrequencies.");
+  }
+  return function_pointers_.CfgExternalAttenuationTableFrequencies(instrumentHandle, selectorString, tableName, frequency, arraySize);
+}
+
+int32 NiRFmxInstrRestrictedLibrary::CfgExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 frequency[], float64 externalAttenuation[], int32 arraySize)
+{
+  if (!function_pointers_.CfgExternalAttenuationTable) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_CfgExternalAttenuationTable.");
+  }
+  return function_pointers_.CfgExternalAttenuationTable(instrumentHandle, selectorString, tableName, frequency, externalAttenuation, arraySize);
 }
 
 }  // namespace nirfmxinstr_restricted_grpc

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.h
@@ -65,6 +65,9 @@ class NiRFmxInstrRestrictedLibrary : public nirfmxinstr_restricted_grpc::NiRFmxI
   int32 CfgSParameterExternalAttenuationTableFrequencies(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 sParameterFrequencies[], int32 sParameterFrequenciesArraySize) override;
   int32 CfgSParameterExternalAttenuationTableSParameter(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], NIComplexDouble sParameters[], int32 sParameterTableSize, int32 sParameterOrientation) override;
   int32 DefineSParameterExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfFrequencyPoints, int32 numberOfPorts) override;
+  int32 SaveExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char filePath[], char description[]) override;
+  int32 CfgExternalAttenuationTableFrequencies(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 frequency[], int32 arraySize) override;
+  int32 CfgExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 frequency[], float64 externalAttenuation[], int32 arraySize) override;
 
  private:
   using ConvertForPowerUnitsUtilityPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, float64 referenceOrTriggerLevelIn, int32 inputPowerUnits, int32 outputPowerUnits, int32 terminalConfiguration, float64 bandwidth, float64* referenceOrTriggerLevelOut);
@@ -111,6 +114,9 @@ class NiRFmxInstrRestrictedLibrary : public nirfmxinstr_restricted_grpc::NiRFmxI
   using CfgSParameterExternalAttenuationTableFrequenciesPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 sParameterFrequencies[], int32 sParameterFrequenciesArraySize);
   using CfgSParameterExternalAttenuationTableSParameterPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], NIComplexDouble sParameters[], int32 sParameterTableSize, int32 sParameterOrientation);
   using DefineSParameterExternalAttenuationTablePtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfFrequencyPoints, int32 numberOfPorts);
+  using SaveExternalAttenuationTablePtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char filePath[], char description[]);
+  using CfgExternalAttenuationTableFrequenciesPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 frequency[], int32 arraySize);
+  using CfgExternalAttenuationTablePtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 frequency[], float64 externalAttenuation[], int32 arraySize);
 
   typedef struct FunctionPointers {
     ConvertForPowerUnitsUtilityPtr ConvertForPowerUnitsUtility;
@@ -157,6 +163,9 @@ class NiRFmxInstrRestrictedLibrary : public nirfmxinstr_restricted_grpc::NiRFmxI
     CfgSParameterExternalAttenuationTableFrequenciesPtr CfgSParameterExternalAttenuationTableFrequencies;
     CfgSParameterExternalAttenuationTableSParameterPtr CfgSParameterExternalAttenuationTableSParameter;
     DefineSParameterExternalAttenuationTablePtr DefineSParameterExternalAttenuationTable;
+    SaveExternalAttenuationTablePtr SaveExternalAttenuationTable;
+    CfgExternalAttenuationTableFrequenciesPtr CfgExternalAttenuationTableFrequencies;
+    CfgExternalAttenuationTablePtr CfgExternalAttenuationTable;
   } FunctionLoadStatus;
 
   std::shared_ptr<nidevice_grpc::SharedLibraryInterface> shared_library_;

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library_interface.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library_interface.h
@@ -59,6 +59,9 @@ class NiRFmxInstrRestrictedLibraryInterface {
   virtual int32 CfgSParameterExternalAttenuationTableFrequencies(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 sParameterFrequencies[], int32 sParameterFrequenciesArraySize) = 0;
   virtual int32 CfgSParameterExternalAttenuationTableSParameter(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], NIComplexDouble sParameters[], int32 sParameterTableSize, int32 sParameterOrientation) = 0;
   virtual int32 DefineSParameterExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfFrequencyPoints, int32 numberOfPorts) = 0;
+  virtual int32 SaveExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char filePath[], char description[]) = 0;
+  virtual int32 CfgExternalAttenuationTableFrequencies(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 frequency[], int32 arraySize) = 0;
+  virtual int32 CfgExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 frequency[], float64 externalAttenuation[], int32 arraySize) = 0;
 };
 
 }  // namespace nirfmxinstr_restricted_grpc

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_mock_library.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_mock_library.h
@@ -61,6 +61,9 @@ class NiRFmxInstrRestrictedMockLibrary : public nirfmxinstr_restricted_grpc::NiR
   MOCK_METHOD(int32, CfgSParameterExternalAttenuationTableFrequencies, (niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 sParameterFrequencies[], int32 sParameterFrequenciesArraySize), (override));
   MOCK_METHOD(int32, CfgSParameterExternalAttenuationTableSParameter, (niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], NIComplexDouble sParameters[], int32 sParameterTableSize, int32 sParameterOrientation), (override));
   MOCK_METHOD(int32, DefineSParameterExternalAttenuationTable, (niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfFrequencyPoints, int32 numberOfPorts), (override));
+  MOCK_METHOD(int32, SaveExternalAttenuationTable, (niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char filePath[], char description[]), (override));
+  MOCK_METHOD(int32, CfgExternalAttenuationTableFrequencies, (niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 frequency[], int32 arraySize), (override));
+  MOCK_METHOD(int32, CfgExternalAttenuationTable, (niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 frequency[], float64 externalAttenuation[], int32 arraySize), (override));
 };
 
 }  // namespace unit

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
@@ -1257,6 +1257,104 @@ namespace nirfmxinstr_restricted_grpc {
     }
   }
 
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxInstrRestrictedService::SaveExternalAttenuationTable(::grpc::ServerContext* context, const SaveExternalAttenuationTableRequest* request, SaveExternalAttenuationTableResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
+      auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
+      char* selector_string = (char*)selector_string_mbcs.c_str();
+      auto table_name_mbcs = convert_from_grpc<std::string>(request->table_name());
+      char* table_name = (char*)table_name_mbcs.c_str();
+      auto file_path_mbcs = convert_from_grpc<std::string>(request->file_path());
+      char* file_path = (char*)file_path_mbcs.c_str();
+      auto description_mbcs = convert_from_grpc<std::string>(request->description());
+      char* description = (char*)description_mbcs.c_str();
+      auto status = library_->SaveExternalAttenuationTable(instrument, selector_string, table_name, file_path, description);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxInstrRestrictedService::CfgExternalAttenuationTableFrequencies(::grpc::ServerContext* context, const CfgExternalAttenuationTableFrequenciesRequest* request, CfgExternalAttenuationTableFrequenciesResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
+      auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
+      char* selector_string = (char*)selector_string_mbcs.c_str();
+      auto table_name_mbcs = convert_from_grpc<std::string>(request->table_name());
+      char* table_name = (char*)table_name_mbcs.c_str();
+      auto frequency = const_cast<float64*>(request->frequency().data());
+      int32 array_size = static_cast<int32>(request->frequency().size());
+      auto status = library_->CfgExternalAttenuationTableFrequencies(instrument, selector_string, table_name, frequency, array_size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxInstrRestrictedService::CfgExternalAttenuationTable(::grpc::ServerContext* context, const CfgExternalAttenuationTableRequest* request, CfgExternalAttenuationTableResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
+      auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
+      char* selector_string = (char*)selector_string_mbcs.c_str();
+      auto table_name_mbcs = convert_from_grpc<std::string>(request->table_name());
+      char* table_name = (char*)table_name_mbcs.c_str();
+      auto frequency = const_cast<float64*>(request->frequency().data());
+      auto external_attenuation = const_cast<float64*>(request->external_attenuation().data());
+      auto array_size_determine_from_sizes = std::array<int, 2>
+      {
+        request->frequency_size(),
+        request->external_attenuation_size()
+      };
+      const auto array_size_size_calculation = calculate_linked_array_size(array_size_determine_from_sizes, false);
+
+      if (array_size_size_calculation.match_state == MatchState::MISMATCH) {
+        return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The sizes of linked repeated fields [frequency, external_attenuation] do not match");
+      }
+      auto array_size = array_size_size_calculation.size;
+
+      auto status = library_->CfgExternalAttenuationTable(instrument, selector_string, table_name, frequency, external_attenuation, array_size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
 
   NiRFmxInstrRestrictedFeatureToggles::NiRFmxInstrRestrictedFeatureToggles(
     const nidevice_grpc::FeatureToggles& feature_toggles)

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.h
@@ -83,6 +83,9 @@ public:
   ::grpc::Status CfgSParameterExternalAttenuationTableFrequencies(::grpc::ServerContext* context, const CfgSParameterExternalAttenuationTableFrequenciesRequest* request, CfgSParameterExternalAttenuationTableFrequenciesResponse* response) override;
   ::grpc::Status CfgSParameterExternalAttenuationTableSParameter(::grpc::ServerContext* context, const CfgSParameterExternalAttenuationTableSParameterRequest* request, CfgSParameterExternalAttenuationTableSParameterResponse* response) override;
   ::grpc::Status DefineSParameterExternalAttenuationTable(::grpc::ServerContext* context, const DefineSParameterExternalAttenuationTableRequest* request, DefineSParameterExternalAttenuationTableResponse* response) override;
+  ::grpc::Status SaveExternalAttenuationTable(::grpc::ServerContext* context, const SaveExternalAttenuationTableRequest* request, SaveExternalAttenuationTableResponse* response) override;
+  ::grpc::Status CfgExternalAttenuationTableFrequencies(::grpc::ServerContext* context, const CfgExternalAttenuationTableFrequenciesRequest* request, CfgExternalAttenuationTableFrequenciesResponse* response) override;
+  ::grpc::Status CfgExternalAttenuationTable(::grpc::ServerContext* context, const CfgExternalAttenuationTableRequest* request, CfgExternalAttenuationTableResponse* response) override;
 private:
   LibrarySharedPtr library_;
   ResourceRepositorySharedPtr session_repository_;

--- a/source/codegen/metadata/nirfmxinstr_restricted/functions.py
+++ b/source/codegen/metadata/nirfmxinstr_restricted/functions.py
@@ -1391,5 +1391,115 @@ functions = {
             }
         ],
         'returns': 'int32'
+    },
+    'SaveExternalAttenuationTable': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'tableName',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'filePath',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'description',
+                'type': 'char[]'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'CfgExternalAttenuationTableFrequencies': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'tableName',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'frequency',
+                'size': {
+                    'mechanism': 'len',
+                    'value': 'arraySize'
+                },
+                'type': 'float64[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'arraySize',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'CfgExternalAttenuationTable': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'tableName',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'frequency',
+                'size': {
+                    'mechanism': 'len',
+                    'value': 'arraySize'
+                },
+                'type': 'float64[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'externalAttenuation',
+                'size': {
+                    'mechanism': 'len',
+                    'value': 'arraySize'
+                },
+                'type': 'float64[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'arraySize',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
     }
 }


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add missing functions to configure attenuation tables in RFmx Instr - Restricted

### Why should this Pull Request be merged?

This PR adds gRPC support for some  RFmx instr functions that don't have gRPC support

### What testing has been done?

Built server and verified codegen.
