### PR TITLE
Updated gRPC Device code for BT, LTE and SpecAn 24C2 Cycle RFmx APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Indicates the most recent driver version used to test builds of the current sour
 | NI-Digital Pattern Driver | 2023 Q1       | Not Supported | Not Supported |
 | NI-DMM                    | 2023 Q1       | 2023 Q1       | 2023 Q1       |
 | NI-FGEN                   | 2023 Q1       | 2023 Q1       | 2023 Q1       |
-| NI-RFmx Bluetooth         | 2024 Q1       | Not Supported | Not Supported |
+| NI-RFmx Bluetooth         | 2024 Q2       | Not Supported | Not Supported |
 | NI-RFmx CDMA2k            | 2023 Q1       | Not Supported | Not Supported |
 | NI-RFmx Demod             | 2023 Q1       | Not Supported | Not Supported |
 | NI-RFmx GSM               | 2023 Q1       | Not Supported | Not Supported |
-| NI-RFmx LTE               | 2024 Q1       | Not Supported | Not Supported |
+| NI-RFmx LTE               | 2024 Q2       | Not Supported | Not Supported |
 | NI-RFmx NR                | 2024 Q1       | Not Supported | Not Supported |
-| NI-RFmx SpecAn            | 2024 Q1       | Not Supported | Not Supported |
+| NI-RFmx SpecAn            | 2024 Q2       | Not Supported | Not Supported |
 | NI-RFmx TD-SCDMA          | 2023 Q1       | Not Supported | Not Supported |
 | NI-RFmx WCDMA             | 2023 Q1       | Not Supported | Not Supported |
 | NI-RFmx WLAN              | 2024 Q1       | Not Supported | Not Supported |

--- a/generated/nirfmxbluetooth/nirfmxbluetooth.proto
+++ b/generated/nirfmxbluetooth/nirfmxbluetooth.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-RFMXBLUETOOTH API metadata version 24.3.0
+// This file is generated from NI-RFMXBLUETOOTH API metadata version 24.5.0
 //---------------------------------------------------------------------
 // Proto file for the NI-RFMXBLUETOOTH Metadata
 //---------------------------------------------------------------------
@@ -432,6 +432,7 @@ enum PacketType {
   PACKET_TYPE_3_EV5 = 15;
   PACKET_TYPE_LE = 16;
   PACKET_TYPE_LE_CS = 17;
+  PACKET_TYPE_LE_HDT = 18;
 }
 
 enum PayloadBitPattern {
@@ -562,6 +563,7 @@ enum NiRFmxBluetoothInt32AttributeValues {
   NIRFMXBLUETOOTH_INT32_PACKET_TYPE_3_EV5 = 15;
   NIRFMXBLUETOOTH_INT32_PACKET_TYPE_LE = 16;
   NIRFMXBLUETOOTH_INT32_PACKET_TYPE_LE_CS = 17;
+  NIRFMXBLUETOOTH_INT32_PACKET_TYPE_LE_HDT = 18;
   NIRFMXBLUETOOTH_INT32_PAYLOAD_BIT_PATTERN_STANDARD_DEFINED = 0;
   NIRFMXBLUETOOTH_INT32_PAYLOAD_BIT_PATTERN_11110000 = 1;
   NIRFMXBLUETOOTH_INT32_PAYLOAD_BIT_PATTERN_10101010 = 2;

--- a/generated/nirfmxlte/nirfmxlte.proto
+++ b/generated/nirfmxlte/nirfmxlte.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-RFMXLTE API metadata version 24.3.0
+// This file is generated from NI-RFMXLTE API metadata version 24.5.0
 //---------------------------------------------------------------------
 // Proto file for the NI-RFMXLTE Metadata
 //---------------------------------------------------------------------
@@ -304,6 +304,10 @@ service NiRFmxLTE {
   rpc SlotPhaseFetchSamplePhaseErrorLinearFitTrace(SlotPhaseFetchSamplePhaseErrorLinearFitTraceRequest) returns (SlotPhaseFetchSamplePhaseErrorLinearFitTraceResponse);
   rpc SlotPowerCfgMeasurementInterval(SlotPowerCfgMeasurementIntervalRequest) returns (SlotPowerCfgMeasurementIntervalResponse);
   rpc SlotPowerFetchPowers(SlotPowerFetchPowersRequest) returns (SlotPowerFetchPowersResponse);
+  rpc TXPCfgAveraging(TXPCfgAveragingRequest) returns (TXPCfgAveragingResponse);
+  rpc TXPCfgMeasurementOffsetAndInterval(TXPCfgMeasurementOffsetAndIntervalRequest) returns (TXPCfgMeasurementOffsetAndIntervalResponse);
+  rpc TXPFetchMeasurement(TXPFetchMeasurementRequest) returns (TXPFetchMeasurementResponse);
+  rpc TXPFetchPowerTrace(TXPFetchPowerTraceRequest) returns (TXPFetchPowerTraceResponse);
   rpc WaitForAcquisitionComplete(WaitForAcquisitionCompleteRequest) returns (WaitForAcquisitionCompleteResponse);
   rpc WaitForMeasurementComplete(WaitForMeasurementCompleteRequest) returns (WaitForMeasurementCompleteResponse);
 }
@@ -694,6 +698,15 @@ enum NiRFmxLTEAttribute {
   NIRFMXLTE_ATTRIBUTE_TRANSMITTER_ARCHITECTURE = 3198978;
   NIRFMXLTE_ATTRIBUTE_LIMITED_CONFIGURATION_CHANGE = 3198979;
   NIRFMXLTE_ATTRIBUTE_CENTER_FREQUENCY_FOR_LIMITS = 3198980;
+  NIRFMXLTE_ATTRIBUTE_TXP_MEASUREMENT_ENABLED = 3203072;
+  NIRFMXLTE_ATTRIBUTE_TXP_MEASUREMENT_OFFSET = 3203074;
+  NIRFMXLTE_ATTRIBUTE_TXP_MEASUREMENT_INTERVAL = 3203075;
+  NIRFMXLTE_ATTRIBUTE_TXP_AVERAGING_ENABLED = 3203076;
+  NIRFMXLTE_ATTRIBUTE_TXP_AVERAGING_COUNT = 3203077;
+  NIRFMXLTE_ATTRIBUTE_TXP_ALL_TRACES_ENABLED = 3203079;
+  NIRFMXLTE_ATTRIBUTE_TXP_NUMBER_OF_ANALYSIS_THREADS = 3203080;
+  NIRFMXLTE_ATTRIBUTE_TXP_RESULTS_AVERAGE_POWER_MEAN = 3203082;
+  NIRFMXLTE_ATTRIBUTE_TXP_RESULTS_PEAK_POWER_MAXIMUM = 3203083;
 }
 
 enum AcpAveragingEnabled {
@@ -944,6 +957,7 @@ enum MeasurementTypes {
   MEASUREMENT_TYPES_PVT = 32;
   MEASUREMENT_TYPES_SLOTPHASE = 64;
   MEASUREMENT_TYPES_SLOTPOWER = 128;
+  MEASUREMENT_TYPES_TXP = 256;
 }
 
 enum MechanicalAttenuationAuto {
@@ -1152,6 +1166,11 @@ enum SlotPhaseSynchronizationMode {
 enum TriggerMinimumQuietTimeMode {
   TRIGGER_MINIMUM_QUIET_TIME_MODE_MANUAL = 0;
   TRIGGER_MINIMUM_QUIET_TIME_MODE_AUTO = 1;
+}
+
+enum TxpAveragingEnabled {
+  TXP_AVERAGING_ENABLED_FALSE = 0;
+  TXP_AVERAGING_ENABLED_TRUE = 1;
 }
 
 enum UplinkDownlinkConfiguration {
@@ -1487,6 +1506,8 @@ enum NiRFmxLTEInt32AttributeValues {
   NIRFMXLTE_INT32_TRIGGER_TYPE_DIGITAL_EDGE = 1;
   NIRFMXLTE_INT32_TRIGGER_TYPE_IQ_POWER_EDGE = 2;
   NIRFMXLTE_INT32_TRIGGER_TYPE_SOFTWARE = 3;
+  NIRFMXLTE_INT32_TXP_AVERAGING_ENABLED_FALSE = 0;
+  NIRFMXLTE_INT32_TXP_AVERAGING_ENABLED_TRUE = 1;
   NIRFMXLTE_INT32_UPLINK_DOWNLINK_CONFIGURATION_0 = 0;
   NIRFMXLTE_INT32_UPLINK_DOWNLINK_CONFIGURATION_1 = 1;
   NIRFMXLTE_INT32_UPLINK_DOWNLINK_CONFIGURATION_2 = 2;
@@ -2582,8 +2603,8 @@ message CfgPSSCHModulationTypeRequest {
   nidevice_grpc.Session instrument = 1;
   string selector_string = 2;
   oneof modulation_type_enum {
-    int32 modulation_type_raw = 3;
-    PsschModulationType modulation_type = 4;
+    PsschModulationType modulation_type = 3;
+    int32 modulation_type_raw = 4;
   }
 }
 
@@ -5131,6 +5152,57 @@ message SlotPowerFetchPowersResponse {
   repeated double subframe_power = 2;
   repeated double subframe_power_delta = 3;
   int32 actual_array_size = 4;
+}
+
+message TXPCfgAveragingRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  oneof averaging_enabled_enum {
+    TxpAveragingEnabled averaging_enabled = 3;
+    int32 averaging_enabled_raw = 4;
+  }
+  int32 averaging_count = 5;
+}
+
+message TXPCfgAveragingResponse {
+  int32 status = 1;
+}
+
+message TXPCfgMeasurementOffsetAndIntervalRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  double measurement_offset = 3;
+  double measurement_interval = 4;
+}
+
+message TXPCfgMeasurementOffsetAndIntervalResponse {
+  int32 status = 1;
+}
+
+message TXPFetchMeasurementRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  double timeout = 3;
+}
+
+message TXPFetchMeasurementResponse {
+  int32 status = 1;
+  double average_power_mean = 2;
+  double peak_power_maximum = 3;
+}
+
+message TXPFetchPowerTraceRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  double timeout = 3;
+}
+
+message TXPFetchPowerTraceResponse {
+  int32 status = 1;
+  double x0 = 2;
+  double dx = 3;
+  repeated float power = 4;
+  int32 actual_array_size = 5;
 }
 
 message WaitForAcquisitionCompleteRequest {

--- a/generated/nirfmxlte/nirfmxlte.proto
+++ b/generated/nirfmxlte/nirfmxlte.proto
@@ -2603,8 +2603,8 @@ message CfgPSSCHModulationTypeRequest {
   nidevice_grpc.Session instrument = 1;
   string selector_string = 2;
   oneof modulation_type_enum {
-    PsschModulationType modulation_type = 3;
-    int32 modulation_type_raw = 4;
+    int32 modulation_type_raw = 3;
+    PsschModulationType modulation_type = 4;
   }
 }
 

--- a/generated/nirfmxlte/nirfmxlte_client.cpp
+++ b/generated/nirfmxlte/nirfmxlte_client.cpp
@@ -6079,6 +6079,91 @@ slot_power_fetch_powers(const StubPtr& stub, const nidevice_grpc::Session& instr
   return response;
 }
 
+TXPCfgAveragingResponse
+txp_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<TxpAveragingEnabled, pb::int32>& averaging_enabled, const pb::int32& averaging_count)
+{
+  ::grpc::ClientContext context;
+
+  auto request = TXPCfgAveragingRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  const auto averaging_enabled_ptr = averaging_enabled.get_if<TxpAveragingEnabled>();
+  const auto averaging_enabled_raw_ptr = averaging_enabled.get_if<pb::int32>();
+  if (averaging_enabled_ptr) {
+    request.set_averaging_enabled(*averaging_enabled_ptr);
+  }
+  else if (averaging_enabled_raw_ptr) {
+    request.set_averaging_enabled_raw(*averaging_enabled_raw_ptr);
+  }
+  request.set_averaging_count(averaging_count);
+
+  auto response = TXPCfgAveragingResponse{};
+
+  raise_if_error(
+      stub->TXPCfgAveraging(&context, request, &response),
+      context);
+
+  return response;
+}
+
+TXPCfgMeasurementOffsetAndIntervalResponse
+txp_cfg_measurement_offset_and_interval(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& measurement_offset, const double& measurement_interval)
+{
+  ::grpc::ClientContext context;
+
+  auto request = TXPCfgMeasurementOffsetAndIntervalRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_measurement_offset(measurement_offset);
+  request.set_measurement_interval(measurement_interval);
+
+  auto response = TXPCfgMeasurementOffsetAndIntervalResponse{};
+
+  raise_if_error(
+      stub->TXPCfgMeasurementOffsetAndInterval(&context, request, &response),
+      context);
+
+  return response;
+}
+
+TXPFetchMeasurementResponse
+txp_fetch_measurement(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout)
+{
+  ::grpc::ClientContext context;
+
+  auto request = TXPFetchMeasurementRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_timeout(timeout);
+
+  auto response = TXPFetchMeasurementResponse{};
+
+  raise_if_error(
+      stub->TXPFetchMeasurement(&context, request, &response),
+      context);
+
+  return response;
+}
+
+TXPFetchPowerTraceResponse
+txp_fetch_power_trace(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout)
+{
+  ::grpc::ClientContext context;
+
+  auto request = TXPFetchPowerTraceRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_timeout(timeout);
+
+  auto response = TXPFetchPowerTraceResponse{};
+
+  raise_if_error(
+      stub->TXPFetchPowerTrace(&context, request, &response),
+      context);
+
+  return response;
+}
+
 WaitForAcquisitionCompleteResponse
 wait_for_acquisition_complete(const StubPtr& stub, const nidevice_grpc::Session& instrument, const double& timeout)
 {

--- a/generated/nirfmxlte/nirfmxlte_client.h
+++ b/generated/nirfmxlte/nirfmxlte_client.h
@@ -309,6 +309,10 @@ SlotPhaseFetchSamplePhaseErrorResponse slot_phase_fetch_sample_phase_error(const
 SlotPhaseFetchSamplePhaseErrorLinearFitTraceResponse slot_phase_fetch_sample_phase_error_linear_fit_trace(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout);
 SlotPowerCfgMeasurementIntervalResponse slot_power_cfg_measurement_interval(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const pb::int32& measurement_offset, const pb::int32& measurement_length);
 SlotPowerFetchPowersResponse slot_power_fetch_powers(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout);
+TXPCfgAveragingResponse txp_cfg_averaging(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<TxpAveragingEnabled, pb::int32>& averaging_enabled, const pb::int32& averaging_count);
+TXPCfgMeasurementOffsetAndIntervalResponse txp_cfg_measurement_offset_and_interval(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& measurement_offset, const double& measurement_interval);
+TXPFetchMeasurementResponse txp_fetch_measurement(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout);
+TXPFetchPowerTraceResponse txp_fetch_power_trace(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout);
 WaitForAcquisitionCompleteResponse wait_for_acquisition_complete(const StubPtr& stub, const nidevice_grpc::Session& instrument, const double& timeout);
 WaitForMeasurementCompleteResponse wait_for_measurement_complete(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout);
 

--- a/generated/nirfmxlte/nirfmxlte_compilation_test.cpp
+++ b/generated/nirfmxlte/nirfmxlte_compilation_test.cpp
@@ -1442,6 +1442,26 @@ int32 SlotPowerFetchPowers(niRFmxInstrHandle instrumentHandle, char selectorStri
   return RFmxLTE_SlotPowerFetchPowers(instrumentHandle, selectorString, timeout, subframePower, subframePowerDelta, arraySize, actualArraySize);
 }
 
+int32 TXPCfgAveraging(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 averagingEnabled, int32 averagingCount)
+{
+  return RFmxLTE_TXPCfgAveraging(instrumentHandle, selectorString, averagingEnabled, averagingCount);
+}
+
+int32 TXPCfgMeasurementOffsetAndInterval(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 measurementOffset, float64 measurementInterval)
+{
+  return RFmxLTE_TXPCfgMeasurementOffsetAndInterval(instrumentHandle, selectorString, measurementOffset, measurementInterval);
+}
+
+int32 TXPFetchMeasurement(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* averagePowerMean, float64* peakPowerMaximum)
+{
+  return RFmxLTE_TXPFetchMeasurement(instrumentHandle, selectorString, timeout, averagePowerMean, peakPowerMaximum);
+}
+
+int32 TXPFetchPowerTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 power[], int32 arraySize, int32* actualArraySize)
+{
+  return RFmxLTE_TXPFetchPowerTrace(instrumentHandle, selectorString, timeout, x0, dx, power, arraySize, actualArraySize);
+}
+
 int32 WaitForAcquisitionComplete(niRFmxInstrHandle instrumentHandle, float64 timeout)
 {
   return RFmxLTE_WaitForAcquisitionComplete(instrumentHandle, timeout);

--- a/generated/nirfmxlte/nirfmxlte_library.cpp
+++ b/generated/nirfmxlte/nirfmxlte_library.cpp
@@ -314,6 +314,10 @@ NiRFmxLTELibrary::NiRFmxLTELibrary(std::shared_ptr<nidevice_grpc::SharedLibraryI
   function_pointers_.SlotPhaseFetchSamplePhaseErrorLinearFitTrace = reinterpret_cast<SlotPhaseFetchSamplePhaseErrorLinearFitTracePtr>(shared_library_->get_function_pointer("RFmxLTE_SlotPhaseFetchSamplePhaseErrorLinearFitTrace"));
   function_pointers_.SlotPowerCfgMeasurementInterval = reinterpret_cast<SlotPowerCfgMeasurementIntervalPtr>(shared_library_->get_function_pointer("RFmxLTE_SlotPowerCfgMeasurementInterval"));
   function_pointers_.SlotPowerFetchPowers = reinterpret_cast<SlotPowerFetchPowersPtr>(shared_library_->get_function_pointer("RFmxLTE_SlotPowerFetchPowers"));
+  function_pointers_.TXPCfgAveraging = reinterpret_cast<TXPCfgAveragingPtr>(shared_library_->get_function_pointer("RFmxLTE_TXPCfgAveraging"));
+  function_pointers_.TXPCfgMeasurementOffsetAndInterval = reinterpret_cast<TXPCfgMeasurementOffsetAndIntervalPtr>(shared_library_->get_function_pointer("RFmxLTE_TXPCfgMeasurementOffsetAndInterval"));
+  function_pointers_.TXPFetchMeasurement = reinterpret_cast<TXPFetchMeasurementPtr>(shared_library_->get_function_pointer("RFmxLTE_TXPFetchMeasurement"));
+  function_pointers_.TXPFetchPowerTrace = reinterpret_cast<TXPFetchPowerTracePtr>(shared_library_->get_function_pointer("RFmxLTE_TXPFetchPowerTrace"));
   function_pointers_.WaitForAcquisitionComplete = reinterpret_cast<WaitForAcquisitionCompletePtr>(shared_library_->get_function_pointer("RFmxLTE_WaitForAcquisitionComplete"));
   function_pointers_.WaitForMeasurementComplete = reinterpret_cast<WaitForMeasurementCompletePtr>(shared_library_->get_function_pointer("RFmxLTE_WaitForMeasurementComplete"));
 }
@@ -2623,6 +2627,38 @@ int32 NiRFmxLTELibrary::SlotPowerFetchPowers(niRFmxInstrHandle instrumentHandle,
     throw nidevice_grpc::LibraryLoadException("Could not find RFmxLTE_SlotPowerFetchPowers.");
   }
   return function_pointers_.SlotPowerFetchPowers(instrumentHandle, selectorString, timeout, subframePower, subframePowerDelta, arraySize, actualArraySize);
+}
+
+int32 NiRFmxLTELibrary::TXPCfgAveraging(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 averagingEnabled, int32 averagingCount)
+{
+  if (!function_pointers_.TXPCfgAveraging) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxLTE_TXPCfgAveraging.");
+  }
+  return function_pointers_.TXPCfgAveraging(instrumentHandle, selectorString, averagingEnabled, averagingCount);
+}
+
+int32 NiRFmxLTELibrary::TXPCfgMeasurementOffsetAndInterval(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 measurementOffset, float64 measurementInterval)
+{
+  if (!function_pointers_.TXPCfgMeasurementOffsetAndInterval) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxLTE_TXPCfgMeasurementOffsetAndInterval.");
+  }
+  return function_pointers_.TXPCfgMeasurementOffsetAndInterval(instrumentHandle, selectorString, measurementOffset, measurementInterval);
+}
+
+int32 NiRFmxLTELibrary::TXPFetchMeasurement(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* averagePowerMean, float64* peakPowerMaximum)
+{
+  if (!function_pointers_.TXPFetchMeasurement) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxLTE_TXPFetchMeasurement.");
+  }
+  return function_pointers_.TXPFetchMeasurement(instrumentHandle, selectorString, timeout, averagePowerMean, peakPowerMaximum);
+}
+
+int32 NiRFmxLTELibrary::TXPFetchPowerTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 power[], int32 arraySize, int32* actualArraySize)
+{
+  if (!function_pointers_.TXPFetchPowerTrace) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxLTE_TXPFetchPowerTrace.");
+  }
+  return function_pointers_.TXPFetchPowerTrace(instrumentHandle, selectorString, timeout, x0, dx, power, arraySize, actualArraySize);
 }
 
 int32 NiRFmxLTELibrary::WaitForAcquisitionComplete(niRFmxInstrHandle instrumentHandle, float64 timeout)

--- a/generated/nirfmxlte/nirfmxlte_library.h
+++ b/generated/nirfmxlte/nirfmxlte_library.h
@@ -308,6 +308,10 @@ class NiRFmxLTELibrary : public nirfmxlte_grpc::NiRFmxLTELibraryInterface {
   int32 SlotPhaseFetchSamplePhaseErrorLinearFitTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 samplePhaseErrorLinearFit[], int32 arraySize, int32* actualArraySize) override;
   int32 SlotPowerCfgMeasurementInterval(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 measurementOffset, int32 measurementLength) override;
   int32 SlotPowerFetchPowers(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64 subframePower[], float64 subframePowerDelta[], int32 arraySize, int32* actualArraySize) override;
+  int32 TXPCfgAveraging(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 averagingEnabled, int32 averagingCount) override;
+  int32 TXPCfgMeasurementOffsetAndInterval(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 measurementOffset, float64 measurementInterval) override;
+  int32 TXPFetchMeasurement(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* averagePowerMean, float64* peakPowerMaximum) override;
+  int32 TXPFetchPowerTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 power[], int32 arraySize, int32* actualArraySize) override;
   int32 WaitForAcquisitionComplete(niRFmxInstrHandle instrumentHandle, float64 timeout) override;
   int32 WaitForMeasurementComplete(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout) override;
 
@@ -599,6 +603,10 @@ class NiRFmxLTELibrary : public nirfmxlte_grpc::NiRFmxLTELibraryInterface {
   using SlotPhaseFetchSamplePhaseErrorLinearFitTracePtr = decltype(&RFmxLTE_SlotPhaseFetchSamplePhaseErrorLinearFitTrace);
   using SlotPowerCfgMeasurementIntervalPtr = decltype(&RFmxLTE_SlotPowerCfgMeasurementInterval);
   using SlotPowerFetchPowersPtr = decltype(&RFmxLTE_SlotPowerFetchPowers);
+  using TXPCfgAveragingPtr = decltype(&RFmxLTE_TXPCfgAveraging);
+  using TXPCfgMeasurementOffsetAndIntervalPtr = decltype(&RFmxLTE_TXPCfgMeasurementOffsetAndInterval);
+  using TXPFetchMeasurementPtr = decltype(&RFmxLTE_TXPFetchMeasurement);
+  using TXPFetchPowerTracePtr = decltype(&RFmxLTE_TXPFetchPowerTrace);
   using WaitForAcquisitionCompletePtr = decltype(&RFmxLTE_WaitForAcquisitionComplete);
   using WaitForMeasurementCompletePtr = decltype(&RFmxLTE_WaitForMeasurementComplete);
 
@@ -890,6 +898,10 @@ class NiRFmxLTELibrary : public nirfmxlte_grpc::NiRFmxLTELibraryInterface {
     SlotPhaseFetchSamplePhaseErrorLinearFitTracePtr SlotPhaseFetchSamplePhaseErrorLinearFitTrace;
     SlotPowerCfgMeasurementIntervalPtr SlotPowerCfgMeasurementInterval;
     SlotPowerFetchPowersPtr SlotPowerFetchPowers;
+    TXPCfgAveragingPtr TXPCfgAveraging;
+    TXPCfgMeasurementOffsetAndIntervalPtr TXPCfgMeasurementOffsetAndInterval;
+    TXPFetchMeasurementPtr TXPFetchMeasurement;
+    TXPFetchPowerTracePtr TXPFetchPowerTrace;
     WaitForAcquisitionCompletePtr WaitForAcquisitionComplete;
     WaitForMeasurementCompletePtr WaitForMeasurementComplete;
   } FunctionLoadStatus;

--- a/generated/nirfmxlte/nirfmxlte_library_interface.h
+++ b/generated/nirfmxlte/nirfmxlte_library_interface.h
@@ -302,6 +302,10 @@ class NiRFmxLTELibraryInterface {
   virtual int32 SlotPhaseFetchSamplePhaseErrorLinearFitTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 samplePhaseErrorLinearFit[], int32 arraySize, int32* actualArraySize) = 0;
   virtual int32 SlotPowerCfgMeasurementInterval(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 measurementOffset, int32 measurementLength) = 0;
   virtual int32 SlotPowerFetchPowers(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64 subframePower[], float64 subframePowerDelta[], int32 arraySize, int32* actualArraySize) = 0;
+  virtual int32 TXPCfgAveraging(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 averagingEnabled, int32 averagingCount) = 0;
+  virtual int32 TXPCfgMeasurementOffsetAndInterval(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 measurementOffset, float64 measurementInterval) = 0;
+  virtual int32 TXPFetchMeasurement(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* averagePowerMean, float64* peakPowerMaximum) = 0;
+  virtual int32 TXPFetchPowerTrace(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 power[], int32 arraySize, int32* actualArraySize) = 0;
   virtual int32 WaitForAcquisitionComplete(niRFmxInstrHandle instrumentHandle, float64 timeout) = 0;
   virtual int32 WaitForMeasurementComplete(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout) = 0;
 };

--- a/generated/nirfmxlte/nirfmxlte_mock_library.h
+++ b/generated/nirfmxlte/nirfmxlte_mock_library.h
@@ -304,6 +304,10 @@ class NiRFmxLTEMockLibrary : public nirfmxlte_grpc::NiRFmxLTELibraryInterface {
   MOCK_METHOD(int32, SlotPhaseFetchSamplePhaseErrorLinearFitTrace, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 samplePhaseErrorLinearFit[], int32 arraySize, int32* actualArraySize), (override));
   MOCK_METHOD(int32, SlotPowerCfgMeasurementInterval, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 measurementOffset, int32 measurementLength), (override));
   MOCK_METHOD(int32, SlotPowerFetchPowers, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64 subframePower[], float64 subframePowerDelta[], int32 arraySize, int32* actualArraySize), (override));
+  MOCK_METHOD(int32, TXPCfgAveraging, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 averagingEnabled, int32 averagingCount), (override));
+  MOCK_METHOD(int32, TXPCfgMeasurementOffsetAndInterval, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 measurementOffset, float64 measurementInterval), (override));
+  MOCK_METHOD(int32, TXPFetchMeasurement, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* averagePowerMean, float64* peakPowerMaximum), (override));
+  MOCK_METHOD(int32, TXPFetchPowerTrace, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* x0, float64* dx, float32 power[], int32 arraySize, int32* actualArraySize), (override));
   MOCK_METHOD(int32, WaitForAcquisitionComplete, (niRFmxInstrHandle instrumentHandle, float64 timeout), (override));
   MOCK_METHOD(int32, WaitForMeasurementComplete, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout), (override));
 };

--- a/generated/nirfmxlte/nirfmxlte_service.h
+++ b/generated/nirfmxlte/nirfmxlte_service.h
@@ -331,6 +331,10 @@ public:
   ::grpc::Status SlotPhaseFetchSamplePhaseErrorLinearFitTrace(::grpc::ServerContext* context, const SlotPhaseFetchSamplePhaseErrorLinearFitTraceRequest* request, SlotPhaseFetchSamplePhaseErrorLinearFitTraceResponse* response) override;
   ::grpc::Status SlotPowerCfgMeasurementInterval(::grpc::ServerContext* context, const SlotPowerCfgMeasurementIntervalRequest* request, SlotPowerCfgMeasurementIntervalResponse* response) override;
   ::grpc::Status SlotPowerFetchPowers(::grpc::ServerContext* context, const SlotPowerFetchPowersRequest* request, SlotPowerFetchPowersResponse* response) override;
+  ::grpc::Status TXPCfgAveraging(::grpc::ServerContext* context, const TXPCfgAveragingRequest* request, TXPCfgAveragingResponse* response) override;
+  ::grpc::Status TXPCfgMeasurementOffsetAndInterval(::grpc::ServerContext* context, const TXPCfgMeasurementOffsetAndIntervalRequest* request, TXPCfgMeasurementOffsetAndIntervalResponse* response) override;
+  ::grpc::Status TXPFetchMeasurement(::grpc::ServerContext* context, const TXPFetchMeasurementRequest* request, TXPFetchMeasurementResponse* response) override;
+  ::grpc::Status TXPFetchPowerTrace(::grpc::ServerContext* context, const TXPFetchPowerTraceRequest* request, TXPFetchPowerTraceResponse* response) override;
   ::grpc::Status WaitForAcquisitionComplete(::grpc::ServerContext* context, const WaitForAcquisitionCompleteRequest* request, WaitForAcquisitionCompleteResponse* response) override;
   ::grpc::Status WaitForMeasurementComplete(::grpc::ServerContext* context, const WaitForMeasurementCompleteRequest* request, WaitForMeasurementCompleteResponse* response) override;
 private:

--- a/generated/nirfmxspecan/nirfmxspecan.proto
+++ b/generated/nirfmxspecan/nirfmxspecan.proto
@@ -5368,12 +5368,12 @@ message IDPDCfgReferenceWaveformRequest {
   double dx = 4;
   repeated nidevice_grpc.NIComplexNumberF32 reference_waveform = 5;
   oneof idle_duration_present_enum {
-    IdpdReferenceWaveformIdleDurationPresent idle_duration_present = 6;
-    int32 idle_duration_present_raw = 7;
+    int32 idle_duration_present_raw = 6;
+    IdpdReferenceWaveformIdleDurationPresent idle_duration_present = 8;
   }
   oneof signal_type_enum {
-    IdpdSignalType signal_type = 8;
-    int32 signal_type_raw = 9;
+    int32 signal_type_raw = 7;
+    IdpdSignalType signal_type = 9;
   }
 }
 

--- a/generated/nirfmxspecan/nirfmxspecan.proto
+++ b/generated/nirfmxspecan/nirfmxspecan.proto
@@ -1,6 +1,6 @@
 
 //---------------------------------------------------------------------
-// This file is generated from NI-RFMXSPECAN API metadata version 24.3.0
+// This file is generated from NI-RFMXSPECAN API metadata version 24.5.0
 //---------------------------------------------------------------------
 // Proto file for the NI-RFMXSPECAN Metadata
 //---------------------------------------------------------------------
@@ -393,6 +393,7 @@ service NiRFmxSpecAn {
   rpc SpectrumCfgDetector(SpectrumCfgDetectorRequest) returns (SpectrumCfgDetectorResponse);
   rpc SpectrumCfgFFT(SpectrumCfgFFTRequest) returns (SpectrumCfgFFTResponse);
   rpc SpectrumCfgFrequencyStartStop(SpectrumCfgFrequencyStartStopRequest) returns (SpectrumCfgFrequencyStartStopResponse);
+  rpc SpectrumCfgMeasurementMethod(SpectrumCfgMeasurementMethodRequest) returns (SpectrumCfgMeasurementMethodResponse);
   rpc SpectrumCfgNoiseCompensationEnabled(SpectrumCfgNoiseCompensationEnabledRequest) returns (SpectrumCfgNoiseCompensationEnabledResponse);
   rpc SpectrumCfgPowerUnits(SpectrumCfgPowerUnitsRequest) returns (SpectrumCfgPowerUnitsResponse);
   rpc SpectrumCfgRBWFilter(SpectrumCfgRBWFilterRequest) returns (SpectrumCfgRBWFilterResponse);
@@ -786,6 +787,11 @@ enum NiRFmxSpecAnAttribute {
   NIRFMXSPECAN_ATTRIBUTE_SPECTRUM_NOISE_CALIBRATION_AVERAGING_AUTO = 1085473;
   NIRFMXSPECAN_ATTRIBUTE_SPECTRUM_NOISE_CALIBRATION_MODE = 1085474;
   NIRFMXSPECAN_ATTRIBUTE_SPECTRUM_ANALYSIS_INPUT = 1085475;
+  NIRFMXSPECAN_ATTRIBUTE_SPECTRUM_FFT_OVERLAP_MODE = 1085476;
+  NIRFMXSPECAN_ATTRIBUTE_SPECTRUM_FFT_OVERLAP = 1085477;
+  NIRFMXSPECAN_ATTRIBUTE_SPECTRUM_FFT_OVERLAP_TYPE = 1085478;
+  NIRFMXSPECAN_ATTRIBUTE_SPECTRUM_MEASUREMENT_METHOD = 1085479;
+  NIRFMXSPECAN_ATTRIBUTE_SPECTRUM_SEQUENTIAL_FFT_SIZE = 1085480;
   NIRFMXSPECAN_ATTRIBUTE_SPUR_MEASUREMENT_ENABLED = 1089536;
   NIRFMXSPECAN_ATTRIBUTE_SPUR_NUMBER_OF_ANALYSIS_THREADS = 1089539;
   NIRFMXSPECAN_ATTRIBUTE_SPUR_NUMBER_OF_RANGES = 1089540;
@@ -2019,6 +2025,11 @@ enum SpectrumFftWindow {
   SPECTRUM_FFT_WINDOW_KAISER_BESSEL = 7;
 }
 
+enum SpectrumMeasurementMethod {
+  SPECTRUM_MEASUREMENT_METHOD_NORMAL = 0;
+  SPECTRUM_MEASUREMENT_METHOD_SEQUENTIAL_FFT = 2;
+}
+
 enum SpectrumNoiseCalibrationDataValid {
   SPECTRUM_NOISE_CALIBRATION_DATA_VALID_FALSE = 0;
   SPECTRUM_NOISE_CALIBRATION_DATA_VALID_TRUE = 1;
@@ -2710,6 +2721,11 @@ enum NiRFmxSpecAnInt32AttributeValues {
   NIRFMXSPECAN_INT32_SPECTRUM_DETECTOR_TYPE_AVERAGE_RMS = 5;
   NIRFMXSPECAN_INT32_SPECTRUM_DETECTOR_TYPE_AVERAGE_VOLTAGE = 6;
   NIRFMXSPECAN_INT32_SPECTRUM_DETECTOR_TYPE_AVERAGE_LOG = 7;
+  NIRFMXSPECAN_INT32_SPECTRUM_FFT_OVERLAP_MODE_DISABLED = 0;
+  NIRFMXSPECAN_INT32_SPECTRUM_FFT_OVERLAP_MODE_AUTOMATIC = 1;
+  NIRFMXSPECAN_INT32_SPECTRUM_FFT_OVERLAP_MODE_USER_DEFINED = 2;
+  NIRFMXSPECAN_INT32_SPECTRUM_FFT_OVERLAP_TYPE_RMS = 0;
+  NIRFMXSPECAN_INT32_SPECTRUM_FFT_OVERLAP_TYPE_MAX = 3;
   NIRFMXSPECAN_INT32_SPECTRUM_FFT_WINDOW_NONE = 0;
   NIRFMXSPECAN_INT32_SPECTRUM_FFT_WINDOW_FLAT_TOP = 1;
   NIRFMXSPECAN_INT32_SPECTRUM_FFT_WINDOW_HANNING = 2;
@@ -2718,6 +2734,8 @@ enum NiRFmxSpecAnInt32AttributeValues {
   NIRFMXSPECAN_INT32_SPECTRUM_FFT_WINDOW_BLACKMAN = 5;
   NIRFMXSPECAN_INT32_SPECTRUM_FFT_WINDOW_BLACKMAN_HARRIS = 6;
   NIRFMXSPECAN_INT32_SPECTRUM_FFT_WINDOW_KAISER_BESSEL = 7;
+  NIRFMXSPECAN_INT32_SPECTRUM_MEASUREMENT_METHOD_NORMAL = 0;
+  NIRFMXSPECAN_INT32_SPECTRUM_MEASUREMENT_METHOD_SEQUENTIAL_FFT = 2;
   NIRFMXSPECAN_INT32_SPECTRUM_MEASUREMENT_MODE_MEASURE = 0;
   NIRFMXSPECAN_INT32_SPECTRUM_MEASUREMENT_MODE_CALIBRATE_NOISE_FLOOR = 1;
   NIRFMXSPECAN_INT32_SPECTRUM_NOISE_CALIBRATION_AVERAGING_AUTO_FALSE = 0;
@@ -5350,12 +5368,12 @@ message IDPDCfgReferenceWaveformRequest {
   double dx = 4;
   repeated nidevice_grpc.NIComplexNumberF32 reference_waveform = 5;
   oneof idle_duration_present_enum {
-    int32 idle_duration_present_raw = 6;
-    IdpdReferenceWaveformIdleDurationPresent idle_duration_present = 8;
+    IdpdReferenceWaveformIdleDurationPresent idle_duration_present = 6;
+    int32 idle_duration_present_raw = 7;
   }
   oneof signal_type_enum {
-    int32 signal_type_raw = 7;
-    IdpdSignalType signal_type = 9;
+    IdpdSignalType signal_type = 8;
+    int32 signal_type_raw = 9;
   }
 }
 
@@ -5889,7 +5907,6 @@ message MarkerCfgYLocationResponse {
 message MarkerFetchFunctionValueRequest {
   nidevice_grpc.Session instrument = 1;
   string selector_string = 2;
-  double timeout = 3;
 }
 
 message MarkerFetchFunctionValueResponse {
@@ -7643,6 +7660,19 @@ message SpectrumCfgFrequencyStartStopRequest {
 }
 
 message SpectrumCfgFrequencyStartStopResponse {
+  int32 status = 1;
+}
+
+message SpectrumCfgMeasurementMethodRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  oneof measurement_method_enum {
+    SpectrumMeasurementMethod measurement_method = 3;
+    int32 measurement_method_raw = 4;
+  }
+}
+
+message SpectrumCfgMeasurementMethodResponse {
   int32 status = 1;
 }
 

--- a/generated/nirfmxspecan/nirfmxspecan_client.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_client.cpp
@@ -5294,14 +5294,13 @@ marker_cfg_y_location(const StubPtr& stub, const nidevice_grpc::Session& instrum
 }
 
 MarkerFetchFunctionValueResponse
-marker_fetch_function_value(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout)
+marker_fetch_function_value(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string)
 {
   ::grpc::ClientContext context;
 
   auto request = MarkerFetchFunctionValueRequest{};
   request.mutable_instrument()->CopyFrom(instrument);
   request.set_selector_string(selector_string);
-  request.set_timeout(timeout);
 
   auto response = MarkerFetchFunctionValueResponse{};
 
@@ -8349,6 +8348,32 @@ spectrum_cfg_frequency_start_stop(const StubPtr& stub, const nidevice_grpc::Sess
 
   raise_if_error(
       stub->SpectrumCfgFrequencyStartStop(&context, request, &response),
+      context);
+
+  return response;
+}
+
+SpectrumCfgMeasurementMethodResponse
+spectrum_cfg_measurement_method(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<SpectrumMeasurementMethod, pb::int32>& measurement_method)
+{
+  ::grpc::ClientContext context;
+
+  auto request = SpectrumCfgMeasurementMethodRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  const auto measurement_method_ptr = measurement_method.get_if<SpectrumMeasurementMethod>();
+  const auto measurement_method_raw_ptr = measurement_method.get_if<pb::int32>();
+  if (measurement_method_ptr) {
+    request.set_measurement_method(*measurement_method_ptr);
+  }
+  else if (measurement_method_raw_ptr) {
+    request.set_measurement_method_raw(*measurement_method_raw_ptr);
+  }
+
+  auto response = SpectrumCfgMeasurementMethodResponse{};
+
+  raise_if_error(
+      stub->SpectrumCfgMeasurementMethod(&context, request, &response),
       context);
 
   return response;

--- a/generated/nirfmxspecan/nirfmxspecan_client.h
+++ b/generated/nirfmxspecan/nirfmxspecan_client.h
@@ -260,7 +260,7 @@ MarkerCfgTraceResponse marker_cfg_trace(const StubPtr& stub, const nidevice_grpc
 MarkerCfgTypeResponse marker_cfg_type(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<MarkerType, pb::int32>& marker_type);
 MarkerCfgXLocationResponse marker_cfg_x_location(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& marker_x_location);
 MarkerCfgYLocationResponse marker_cfg_y_location(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& marker_y_location);
-MarkerFetchFunctionValueResponse marker_fetch_function_value(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& timeout);
+MarkerFetchFunctionValueResponse marker_fetch_function_value(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string);
 MarkerFetchXYResponse marker_fetch_xy(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string);
 MarkerNextPeakResponse marker_next_peak(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<MarkerNextPeak, pb::int32>& next_peak);
 MarkerPeakSearchResponse marker_peak_search(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string);
@@ -398,6 +398,7 @@ SpectrumCfgAveragingResponse spectrum_cfg_averaging(const StubPtr& stub, const n
 SpectrumCfgDetectorResponse spectrum_cfg_detector(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<SpectrumDetectorType, pb::int32>& detector_type, const pb::int32& detector_points);
 SpectrumCfgFFTResponse spectrum_cfg_fft(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<SpectrumFftWindow, pb::int32>& fft_window, const double& fft_padding);
 SpectrumCfgFrequencyStartStopResponse spectrum_cfg_frequency_start_stop(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const double& start_frequency, const double& stop_frequency);
+SpectrumCfgMeasurementMethodResponse spectrum_cfg_measurement_method(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<SpectrumMeasurementMethod, pb::int32>& measurement_method);
 SpectrumCfgNoiseCompensationEnabledResponse spectrum_cfg_noise_compensation_enabled(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<SpectrumNoiseCompensationEnabled, pb::int32>& noise_compensation_enabled);
 SpectrumCfgPowerUnitsResponse spectrum_cfg_power_units(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<SpectrumPowerUnits, pb::int32>& spectrum_power_units);
 SpectrumCfgRBWFilterResponse spectrum_cfg_rbw_filter(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const simple_variant<SpectrumRbwAutoBandwidth, pb::int32>& rbw_auto, const double& rbw, const simple_variant<SpectrumRbwFilterType, pb::int32>& rbw_filter_type);

--- a/generated/nirfmxspecan/nirfmxspecan_compilation_test.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_compilation_test.cpp
@@ -1197,9 +1197,9 @@ int32 MarkerCfgYLocation(niRFmxInstrHandle instrumentHandle, char selectorString
   return RFmxSpecAn_MarkerCfgYLocation(instrumentHandle, selectorString, markerYLocation);
 }
 
-int32 MarkerFetchFunctionValue(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* functionValue)
+int32 MarkerFetchFunctionValue(niRFmxInstrHandle instrumentHandle, char selectorString[], float64* functionValue)
 {
-  return RFmxSpecAn_MarkerFetchFunctionValue(instrumentHandle, selectorString, timeout, functionValue);
+  return RFmxSpecAn_MarkerFetchFunctionValue(instrumentHandle, selectorString, functionValue);
 }
 
 int32 MarkerFetchXY(niRFmxInstrHandle instrumentHandle, char selectorString[], float64* markerXLocation, float64* markerYLocation)
@@ -1885,6 +1885,11 @@ int32 SpectrumCfgFFT(niRFmxInstrHandle instrumentHandle, char selectorString[], 
 int32 SpectrumCfgFrequencyStartStop(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 startFrequency, float64 stopFrequency)
 {
   return RFmxSpecAn_SpectrumCfgFrequencyStartStop(instrumentHandle, selectorString, startFrequency, stopFrequency);
+}
+
+int32 SpectrumCfgMeasurementMethod(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 measurementMethod)
+{
+  return RFmxSpecAn_SpectrumCfgMeasurementMethod(instrumentHandle, selectorString, measurementMethod);
 }
 
 int32 SpectrumCfgNoiseCompensationEnabled(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 noiseCompensationEnabled)

--- a/generated/nirfmxspecan/nirfmxspecan_library.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_library.cpp
@@ -403,6 +403,7 @@ NiRFmxSpecAnLibrary::NiRFmxSpecAnLibrary(std::shared_ptr<nidevice_grpc::SharedLi
   function_pointers_.SpectrumCfgDetector = reinterpret_cast<SpectrumCfgDetectorPtr>(shared_library_->get_function_pointer("RFmxSpecAn_SpectrumCfgDetector"));
   function_pointers_.SpectrumCfgFFT = reinterpret_cast<SpectrumCfgFFTPtr>(shared_library_->get_function_pointer("RFmxSpecAn_SpectrumCfgFFT"));
   function_pointers_.SpectrumCfgFrequencyStartStop = reinterpret_cast<SpectrumCfgFrequencyStartStopPtr>(shared_library_->get_function_pointer("RFmxSpecAn_SpectrumCfgFrequencyStartStop"));
+  function_pointers_.SpectrumCfgMeasurementMethod = reinterpret_cast<SpectrumCfgMeasurementMethodPtr>(shared_library_->get_function_pointer("RFmxSpecAn_SpectrumCfgMeasurementMethod"));
   function_pointers_.SpectrumCfgNoiseCompensationEnabled = reinterpret_cast<SpectrumCfgNoiseCompensationEnabledPtr>(shared_library_->get_function_pointer("RFmxSpecAn_SpectrumCfgNoiseCompensationEnabled"));
   function_pointers_.SpectrumCfgPowerUnits = reinterpret_cast<SpectrumCfgPowerUnitsPtr>(shared_library_->get_function_pointer("RFmxSpecAn_SpectrumCfgPowerUnits"));
   function_pointers_.SpectrumCfgRBWFilter = reinterpret_cast<SpectrumCfgRBWFilterPtr>(shared_library_->get_function_pointer("RFmxSpecAn_SpectrumCfgRBWFilter"));
@@ -2371,12 +2372,12 @@ int32 NiRFmxSpecAnLibrary::MarkerCfgYLocation(niRFmxInstrHandle instrumentHandle
   return function_pointers_.MarkerCfgYLocation(instrumentHandle, selectorString, markerYLocation);
 }
 
-int32 NiRFmxSpecAnLibrary::MarkerFetchFunctionValue(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* functionValue)
+int32 NiRFmxSpecAnLibrary::MarkerFetchFunctionValue(niRFmxInstrHandle instrumentHandle, char selectorString[], float64* functionValue)
 {
   if (!function_pointers_.MarkerFetchFunctionValue) {
     throw nidevice_grpc::LibraryLoadException("Could not find RFmxSpecAn_MarkerFetchFunctionValue.");
   }
-  return function_pointers_.MarkerFetchFunctionValue(instrumentHandle, selectorString, timeout, functionValue);
+  return function_pointers_.MarkerFetchFunctionValue(instrumentHandle, selectorString, functionValue);
 }
 
 int32 NiRFmxSpecAnLibrary::MarkerFetchXY(niRFmxInstrHandle instrumentHandle, char selectorString[], float64* markerXLocation, float64* markerYLocation)
@@ -3473,6 +3474,14 @@ int32 NiRFmxSpecAnLibrary::SpectrumCfgFrequencyStartStop(niRFmxInstrHandle instr
     throw nidevice_grpc::LibraryLoadException("Could not find RFmxSpecAn_SpectrumCfgFrequencyStartStop.");
   }
   return function_pointers_.SpectrumCfgFrequencyStartStop(instrumentHandle, selectorString, startFrequency, stopFrequency);
+}
+
+int32 NiRFmxSpecAnLibrary::SpectrumCfgMeasurementMethod(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 measurementMethod)
+{
+  if (!function_pointers_.SpectrumCfgMeasurementMethod) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxSpecAn_SpectrumCfgMeasurementMethod.");
+  }
+  return function_pointers_.SpectrumCfgMeasurementMethod(instrumentHandle, selectorString, measurementMethod);
 }
 
 int32 NiRFmxSpecAnLibrary::SpectrumCfgNoiseCompensationEnabled(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 noiseCompensationEnabled)

--- a/generated/nirfmxspecan/nirfmxspecan_library.h
+++ b/generated/nirfmxspecan/nirfmxspecan_library.h
@@ -259,7 +259,7 @@ class NiRFmxSpecAnLibrary : public nirfmxspecan_grpc::NiRFmxSpecAnLibraryInterfa
   int32 MarkerCfgType(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 markerType) override;
   int32 MarkerCfgXLocation(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 markerXLocation) override;
   int32 MarkerCfgYLocation(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 markerYLocation) override;
-  int32 MarkerFetchFunctionValue(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* functionValue) override;
+  int32 MarkerFetchFunctionValue(niRFmxInstrHandle instrumentHandle, char selectorString[], float64* functionValue) override;
   int32 MarkerFetchXY(niRFmxInstrHandle instrumentHandle, char selectorString[], float64* markerXLocation, float64* markerYLocation) override;
   int32 MarkerNextPeak(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 nextPeak, int32* nextPeakFound) override;
   int32 MarkerPeakSearch(niRFmxInstrHandle instrumentHandle, char selectorString[], int32* numberOfPeaks) override;
@@ -397,6 +397,7 @@ class NiRFmxSpecAnLibrary : public nirfmxspecan_grpc::NiRFmxSpecAnLibraryInterfa
   int32 SpectrumCfgDetector(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 detectorType, int32 detectorPoints) override;
   int32 SpectrumCfgFFT(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 fftWindow, float64 fftPadding) override;
   int32 SpectrumCfgFrequencyStartStop(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 startFrequency, float64 stopFrequency) override;
+  int32 SpectrumCfgMeasurementMethod(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 measurementMethod) override;
   int32 SpectrumCfgNoiseCompensationEnabled(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 noiseCompensationEnabled) override;
   int32 SpectrumCfgPowerUnits(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 spectrumPowerUnits) override;
   int32 SpectrumCfgRBWFilter(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 rbwAuto, float64 rbw, int32 rbwFilterType) override;
@@ -826,6 +827,7 @@ class NiRFmxSpecAnLibrary : public nirfmxspecan_grpc::NiRFmxSpecAnLibraryInterfa
   using SpectrumCfgDetectorPtr = decltype(&RFmxSpecAn_SpectrumCfgDetector);
   using SpectrumCfgFFTPtr = decltype(&RFmxSpecAn_SpectrumCfgFFT);
   using SpectrumCfgFrequencyStartStopPtr = decltype(&RFmxSpecAn_SpectrumCfgFrequencyStartStop);
+  using SpectrumCfgMeasurementMethodPtr = decltype(&RFmxSpecAn_SpectrumCfgMeasurementMethod);
   using SpectrumCfgNoiseCompensationEnabledPtr = decltype(&RFmxSpecAn_SpectrumCfgNoiseCompensationEnabled);
   using SpectrumCfgPowerUnitsPtr = decltype(&RFmxSpecAn_SpectrumCfgPowerUnits);
   using SpectrumCfgRBWFilterPtr = decltype(&RFmxSpecAn_SpectrumCfgRBWFilter);
@@ -1255,6 +1257,7 @@ class NiRFmxSpecAnLibrary : public nirfmxspecan_grpc::NiRFmxSpecAnLibraryInterfa
     SpectrumCfgDetectorPtr SpectrumCfgDetector;
     SpectrumCfgFFTPtr SpectrumCfgFFT;
     SpectrumCfgFrequencyStartStopPtr SpectrumCfgFrequencyStartStop;
+    SpectrumCfgMeasurementMethodPtr SpectrumCfgMeasurementMethod;
     SpectrumCfgNoiseCompensationEnabledPtr SpectrumCfgNoiseCompensationEnabled;
     SpectrumCfgPowerUnitsPtr SpectrumCfgPowerUnits;
     SpectrumCfgRBWFilterPtr SpectrumCfgRBWFilter;

--- a/generated/nirfmxspecan/nirfmxspecan_library_interface.h
+++ b/generated/nirfmxspecan/nirfmxspecan_library_interface.h
@@ -253,7 +253,7 @@ class NiRFmxSpecAnLibraryInterface {
   virtual int32 MarkerCfgType(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 markerType) = 0;
   virtual int32 MarkerCfgXLocation(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 markerXLocation) = 0;
   virtual int32 MarkerCfgYLocation(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 markerYLocation) = 0;
-  virtual int32 MarkerFetchFunctionValue(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* functionValue) = 0;
+  virtual int32 MarkerFetchFunctionValue(niRFmxInstrHandle instrumentHandle, char selectorString[], float64* functionValue) = 0;
   virtual int32 MarkerFetchXY(niRFmxInstrHandle instrumentHandle, char selectorString[], float64* markerXLocation, float64* markerYLocation) = 0;
   virtual int32 MarkerNextPeak(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 nextPeak, int32* nextPeakFound) = 0;
   virtual int32 MarkerPeakSearch(niRFmxInstrHandle instrumentHandle, char selectorString[], int32* numberOfPeaks) = 0;
@@ -391,6 +391,7 @@ class NiRFmxSpecAnLibraryInterface {
   virtual int32 SpectrumCfgDetector(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 detectorType, int32 detectorPoints) = 0;
   virtual int32 SpectrumCfgFFT(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 fftWindow, float64 fftPadding) = 0;
   virtual int32 SpectrumCfgFrequencyStartStop(niRFmxInstrHandle instrumentHandle, char selectorString[], float64 startFrequency, float64 stopFrequency) = 0;
+  virtual int32 SpectrumCfgMeasurementMethod(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 measurementMethod) = 0;
   virtual int32 SpectrumCfgNoiseCompensationEnabled(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 noiseCompensationEnabled) = 0;
   virtual int32 SpectrumCfgPowerUnits(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 spectrumPowerUnits) = 0;
   virtual int32 SpectrumCfgRBWFilter(niRFmxInstrHandle instrumentHandle, char selectorString[], int32 rbwAuto, float64 rbw, int32 rbwFilterType) = 0;

--- a/generated/nirfmxspecan/nirfmxspecan_mock_library.h
+++ b/generated/nirfmxspecan/nirfmxspecan_mock_library.h
@@ -255,7 +255,7 @@ class NiRFmxSpecAnMockLibrary : public nirfmxspecan_grpc::NiRFmxSpecAnLibraryInt
   MOCK_METHOD(int32, MarkerCfgType, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 markerType), (override));
   MOCK_METHOD(int32, MarkerCfgXLocation, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 markerXLocation), (override));
   MOCK_METHOD(int32, MarkerCfgYLocation, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 markerYLocation), (override));
-  MOCK_METHOD(int32, MarkerFetchFunctionValue, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 timeout, float64* functionValue), (override));
+  MOCK_METHOD(int32, MarkerFetchFunctionValue, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64* functionValue), (override));
   MOCK_METHOD(int32, MarkerFetchXY, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64* markerXLocation, float64* markerYLocation), (override));
   MOCK_METHOD(int32, MarkerNextPeak, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 nextPeak, int32* nextPeakFound), (override));
   MOCK_METHOD(int32, MarkerPeakSearch, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32* numberOfPeaks), (override));
@@ -393,6 +393,7 @@ class NiRFmxSpecAnMockLibrary : public nirfmxspecan_grpc::NiRFmxSpecAnLibraryInt
   MOCK_METHOD(int32, SpectrumCfgDetector, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 detectorType, int32 detectorPoints), (override));
   MOCK_METHOD(int32, SpectrumCfgFFT, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 fftWindow, float64 fftPadding), (override));
   MOCK_METHOD(int32, SpectrumCfgFrequencyStartStop, (niRFmxInstrHandle instrumentHandle, char selectorString[], float64 startFrequency, float64 stopFrequency), (override));
+  MOCK_METHOD(int32, SpectrumCfgMeasurementMethod, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 measurementMethod), (override));
   MOCK_METHOD(int32, SpectrumCfgNoiseCompensationEnabled, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 noiseCompensationEnabled), (override));
   MOCK_METHOD(int32, SpectrumCfgPowerUnits, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 spectrumPowerUnits), (override));
   MOCK_METHOD(int32, SpectrumCfgRBWFilter, (niRFmxInstrHandle instrumentHandle, char selectorString[], int32 rbwAuto, float64 rbw, int32 rbwFilterType), (override));

--- a/generated/nirfmxspecan/nirfmxspecan_service.cpp
+++ b/generated/nirfmxspecan/nirfmxspecan_service.cpp
@@ -9245,9 +9245,8 @@ namespace nirfmxspecan_grpc {
       niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
       auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
       char* selector_string = (char*)selector_string_mbcs.c_str();
-      float64 timeout = request->timeout();
       float64 function_value {};
-      auto status = library_->MarkerFetchFunctionValue(instrument, selector_string, timeout, &function_value);
+      auto status = library_->MarkerFetchFunctionValue(instrument, selector_string, &function_value);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
       }
@@ -14459,6 +14458,46 @@ namespace nirfmxspecan_grpc {
       float64 start_frequency = request->start_frequency();
       float64 stop_frequency = request->stop_frequency();
       auto status = library_->SpectrumCfgFrequencyStartStop(instrument, selector_string, start_frequency, stop_frequency);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxSpecAnService::SpectrumCfgMeasurementMethod(::grpc::ServerContext* context, const SpectrumCfgMeasurementMethodRequest* request, SpectrumCfgMeasurementMethodResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
+      auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
+      char* selector_string = (char*)selector_string_mbcs.c_str();
+      int32 measurement_method;
+      switch (request->measurement_method_enum_case()) {
+        case nirfmxspecan_grpc::SpectrumCfgMeasurementMethodRequest::MeasurementMethodEnumCase::kMeasurementMethod: {
+          measurement_method = static_cast<int32>(request->measurement_method());
+          break;
+        }
+        case nirfmxspecan_grpc::SpectrumCfgMeasurementMethodRequest::MeasurementMethodEnumCase::kMeasurementMethodRaw: {
+          measurement_method = static_cast<int32>(request->measurement_method_raw());
+          break;
+        }
+        case nirfmxspecan_grpc::SpectrumCfgMeasurementMethodRequest::MeasurementMethodEnumCase::MEASUREMENT_METHOD_ENUM_NOT_SET: {
+          return ::grpc::Status(::grpc::INVALID_ARGUMENT, "The value for measurement_method was not specified or out of range");
+          break;
+        }
+      }
+
+      auto status = library_->SpectrumCfgMeasurementMethod(instrument, selector_string, measurement_method);
       if (!status_ok(status)) {
         return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
       }

--- a/generated/nirfmxspecan/nirfmxspecan_service.h
+++ b/generated/nirfmxspecan/nirfmxspecan_service.h
@@ -420,6 +420,7 @@ public:
   ::grpc::Status SpectrumCfgDetector(::grpc::ServerContext* context, const SpectrumCfgDetectorRequest* request, SpectrumCfgDetectorResponse* response) override;
   ::grpc::Status SpectrumCfgFFT(::grpc::ServerContext* context, const SpectrumCfgFFTRequest* request, SpectrumCfgFFTResponse* response) override;
   ::grpc::Status SpectrumCfgFrequencyStartStop(::grpc::ServerContext* context, const SpectrumCfgFrequencyStartStopRequest* request, SpectrumCfgFrequencyStartStopResponse* response) override;
+  ::grpc::Status SpectrumCfgMeasurementMethod(::grpc::ServerContext* context, const SpectrumCfgMeasurementMethodRequest* request, SpectrumCfgMeasurementMethodResponse* response) override;
   ::grpc::Status SpectrumCfgNoiseCompensationEnabled(::grpc::ServerContext* context, const SpectrumCfgNoiseCompensationEnabledRequest* request, SpectrumCfgNoiseCompensationEnabledResponse* response) override;
   ::grpc::Status SpectrumCfgPowerUnits(::grpc::ServerContext* context, const SpectrumCfgPowerUnitsRequest* request, SpectrumCfgPowerUnitsResponse* response) override;
   ::grpc::Status SpectrumCfgRBWFilter(::grpc::ServerContext* context, const SpectrumCfgRBWFilterRequest* request, SpectrumCfgRBWFilterResponse* response) override;

--- a/imports/include/niRFmxBT.h
+++ b/imports/include/niRFmxBT.h
@@ -233,6 +233,7 @@
 #define RFMXBT_VAL_PACKET_TYPE_3_EV5                                                              15
 #define RFMXBT_VAL_PACKET_TYPE_LE                                                                 16
 #define RFMXBT_VAL_PACKET_TYPE_LE_CS                                                              17
+#define RFMXBT_VAL_PACKET_TYPE_LE_HDT                                                             18
 
 // Values for RFMXBT_ATTR_PAYLOAD_BIT_PATTERN
 #define RFMXBT_VAL_PAYLOAD_BIT_PATTERN_STANDARD_DEFINED                                           0

--- a/imports/include/niRFmxLTE.h
+++ b/imports/include/niRFmxLTE.h
@@ -397,6 +397,15 @@
 #define RFMXLTE_ATTR_SLOTPOWER_COMMON_CLOCK_SOURCE_ENABLED                                  0x0030b005
 #define RFMXLTE_ATTR_SLOTPOWER_SPECTRUM_INVERTED                                            0x0030b006
 #define RFMXLTE_ATTR_SLOTPOWER_ALL_TRACES_ENABLED                                           0x0030b00a
+#define RFMXLTE_ATTR_TXP_MEASUREMENT_ENABLED                                                0x0030e000
+#define RFMXLTE_ATTR_TXP_MEASUREMENT_OFFSET                                                 0x0030e002
+#define RFMXLTE_ATTR_TXP_MEASUREMENT_INTERVAL                                               0x0030e003
+#define RFMXLTE_ATTR_TXP_AVERAGING_ENABLED                                                  0x0030e004
+#define RFMXLTE_ATTR_TXP_AVERAGING_COUNT                                                    0x0030e005
+#define RFMXLTE_ATTR_TXP_ALL_TRACES_ENABLED                                                 0x0030e007
+#define RFMXLTE_ATTR_TXP_NUMBER_OF_ANALYSIS_THREADS                                         0x0030e008
+#define RFMXLTE_ATTR_TXP_RESULTS_AVERAGE_POWER_MEAN                                         0x0030e00a
+#define RFMXLTE_ATTR_TXP_RESULTS_PEAK_POWER_MAXIMUM                                         0x0030e00b
 #define RFMXLTE_ATTR_AUTO_LEVEL_INITIAL_REFERENCE_LEVEL                                     0x0030d000
 #define RFMXLTE_ATTR_ACQUISITION_BANDWIDTH_OPTIMIZATION_ENABLED                             0x0030d001
 #define RFMXLTE_ATTR_TRANSMITTER_ARCHITECTURE                                               0x0030d002
@@ -979,6 +988,10 @@
 #define RFMXLTE_VAL_SLOTPOWER_SPECTRUM_INVERTED_FALSE                                              0
 #define RFMXLTE_VAL_SLOTPOWER_SPECTRUM_INVERTED_TRUE                                               1
 
+// Values for RFMXLTE_ATTR_TXP_AVERAGING_ENABLED
+#define RFMXLTE_VAL_TXP_AVERAGING_ENABLED_FALSE                                                    0
+#define RFMXLTE_VAL_TXP_AVERAGING_ENABLED_TRUE                                                     1
+
 // Values for RFMXLTE_ATTR_ACQUISITION_BANDWIDTH_OPTIMIZATION_ENABLED
 #define RFMXLTE_VAL_ACQUISITION_BANDWIDTH_OPTIMIZATION_ENABLED_FALSE                               0
 #define RFMXLTE_VAL_ACQUISITION_BANDWIDTH_OPTIMIZATION_ENABLED_TRUE                                1
@@ -1022,6 +1035,7 @@
 #define RFMXLTE_VAL_PVT                                                                            1<<5
 #define RFMXLTE_VAL_SLOTPHASE                                                                      1<<6
 #define RFMXLTE_VAL_SLOTPOWER                                                                      1<<7
+#define RFMXLTE_VAL_TXP                                                                            1<<8
 
 // Values for AcpNoiseCalibrationDataValid
 #define RFMXLTE_VAL_ACP_NOISE_CALIBRATION_DATA_VALID_FALSE                                         0
@@ -2241,6 +2255,20 @@ int32 __stdcall RFmxLTE_SlotPowerCfgMeasurementInterval(
    char selectorString[],
    int32 measurementOffset,
    int32 measurementLength
+);
+
+int32 __stdcall RFmxLTE_TXPCfgAveraging(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 averagingEnabled,
+   int32 averagingCount
+);
+
+int32 __stdcall RFmxLTE_TXPCfgMeasurementOffsetAndInterval(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   float64 measurementOffset,
+   float64 measurementInterval
 );
 
 int32 __stdcall RFmxLTE_ModAccFetchNPUSCHConstellationTrace(
@@ -3585,6 +3613,25 @@ int32 __stdcall RFmxLTE_SlotPowerFetchPowers(
    float64 subframePowerDelta[],
    int32 arraySize,
    int32* actualArraySize
+);
+
+int32 __stdcall RFmxLTE_TXPFetchPowerTrace(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   float64 timeout,
+   float64* x0,
+   float64* dx,
+   float32 power[],
+   int32 arraySize,
+   int32* actualArraySize
+);
+
+int32 __stdcall RFmxLTE_TXPFetchMeasurement(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   float64 timeout,
+   float64* averagePowerMean,
+   float64* peakPowerMaximum
 );
 
 int32 __stdcall RFmxLTE_GetSelectedPorts(
@@ -7429,6 +7476,102 @@ int32 __stdcall RFmxLTE_SlotPowerSetAllTracesEnabled(
    niRFmxInstrHandle instrumentHandle,
    char selectorString[],
    int32 attrVal
+);
+
+int32 __stdcall RFmxLTE_TXPGetMeasurementEnabled(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 *attrVal
+);
+
+int32 __stdcall RFmxLTE_TXPSetMeasurementEnabled(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 attrVal
+);
+
+int32 __stdcall RFmxLTE_TXPGetMeasurementOffset(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   float64 *attrVal
+);
+
+int32 __stdcall RFmxLTE_TXPSetMeasurementOffset(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   float64 attrVal
+);
+
+int32 __stdcall RFmxLTE_TXPGetMeasurementInterval(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   float64 *attrVal
+);
+
+int32 __stdcall RFmxLTE_TXPSetMeasurementInterval(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   float64 attrVal
+);
+
+int32 __stdcall RFmxLTE_TXPGetAveragingEnabled(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 *attrVal
+);
+
+int32 __stdcall RFmxLTE_TXPSetAveragingEnabled(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 attrVal
+);
+
+int32 __stdcall RFmxLTE_TXPGetAveragingCount(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 *attrVal
+);
+
+int32 __stdcall RFmxLTE_TXPSetAveragingCount(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 attrVal
+);
+
+int32 __stdcall RFmxLTE_TXPGetAllTracesEnabled(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 *attrVal
+);
+
+int32 __stdcall RFmxLTE_TXPSetAllTracesEnabled(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 attrVal
+);
+
+int32 __stdcall RFmxLTE_TXPGetNumberOfAnalysisThreads(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 *attrVal
+);
+
+int32 __stdcall RFmxLTE_TXPSetNumberOfAnalysisThreads(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 attrVal
+);
+
+int32 __stdcall RFmxLTE_TXPGetResultsAveragePowerMean(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   float64 *attrVal
+);
+
+int32 __stdcall RFmxLTE_TXPGetResultsPeakPowerMaximum(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   float64 *attrVal
 );
 
 #ifdef __cplusplus

--- a/imports/include/niRFmxSpecAn.h
+++ b/imports/include/niRFmxSpecAn.h
@@ -328,7 +328,12 @@
 #define RFMXSPECAN_ATTR_SPECTRUM_MEASUREMENT_MODE                                      0x0010901e
 #define RFMXSPECAN_ATTR_SPECTRUM_FFT_WINDOW                                            0x00109009
 #define RFMXSPECAN_ATTR_SPECTRUM_FFT_PADDING                                           0x0010900a
+#define RFMXSPECAN_ATTR_SPECTRUM_FFT_OVERLAP_MODE                                      0x00109024
+#define RFMXSPECAN_ATTR_SPECTRUM_FFT_OVERLAP                                           0x00109025
+#define RFMXSPECAN_ATTR_SPECTRUM_FFT_OVERLAP_TYPE                                      0x00109026
 #define RFMXSPECAN_ATTR_SPECTRUM_AMPLITUDE_CORRECTION_TYPE                             0x00109017
+#define RFMXSPECAN_ATTR_SPECTRUM_MEASUREMENT_METHOD                                    0x00109027
+#define RFMXSPECAN_ATTR_SPECTRUM_SEQUENTIAL_FFT_SIZE                                   0x00109028
 #define RFMXSPECAN_ATTR_SPECTRUM_ANALYSIS_INPUT                                        0x00109023
 #define RFMXSPECAN_ATTR_SPECTRUM_NUMBER_OF_ANALYSIS_THREADS                            0x00109002
 #define RFMXSPECAN_ATTR_SPECTRUM_RESULTS_PEAK_AMPLITUDE                                0x00109012
@@ -1263,9 +1268,22 @@
 #define RFMXSPECAN_VAL_SPECTRUM_FFT_WINDOW_BLACKMAN_HARRIS                                            6
 #define RFMXSPECAN_VAL_SPECTRUM_FFT_WINDOW_KAISER_BESSEL                                              7
 
+// Values for RFMXSPECAN_ATTR_SPECTRUM_FFT_OVERLAP_MODE
+#define RFMXSPECAN_VAL_SPECTRUM_FFT_OVERLAP_MODE_DISABLED                                             0
+#define RFMXSPECAN_VAL_SPECTRUM_FFT_OVERLAP_MODE_AUTOMATIC                                            1
+#define RFMXSPECAN_VAL_SPECTRUM_FFT_OVERLAP_MODE_USER_DEFINED                                         2
+
+// Values for RFMXSPECAN_ATTR_SPECTRUM_FFT_OVERLAP_TYPE
+#define RFMXSPECAN_VAL_SPECTRUM_FFT_OVERLAP_TYPE_RMS                                                  0
+#define RFMXSPECAN_VAL_SPECTRUM_FFT_OVERLAP_TYPE_MAX                                                  3
+
 // Values for RFMXSPECAN_ATTR_SPECTRUM_AMPLITUDE_CORRECTION_TYPE
 #define RFMXSPECAN_VAL_SPECTRUM_AMPLITUDE_CORRECTION_TYPE_RF_CENTER_FREQUENCY                         0
 #define RFMXSPECAN_VAL_SPECTRUM_AMPLITUDE_CORRECTION_TYPE_SPECTRUM_FREQUENCY_BIN                      1
+
+// Values for RFMXSPECAN_ATTR_SPECTRUM_MEASUREMENT_METHOD
+#define RFMXSPECAN_VAL_SPECTRUM_MEASUREMENT_METHOD_NORMAL                                             0
+#define RFMXSPECAN_VAL_SPECTRUM_MEASUREMENT_METHOD_SEQUENTIAL_FFT                                     2
 
 // Values for RFMXSPECAN_ATTR_SPECTRUM_ANALYSIS_INPUT
 #define RFMXSPECAN_VAL_SPECTRUM_ANALYSIS_INPUT_IQ                                                     0
@@ -3848,6 +3866,12 @@ int32 __stdcall RFmxSpecAn_SpectrumCfgVBWFilter(
    float64 VBWToRBWRatio
 );
 
+int32 __stdcall RFmxSpecAn_SpectrumCfgMeasurementMethod(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 measurementMethod
+);
+
 int32 __stdcall RFmxSpecAn_AMPMCfgAMToAMCurveFit(
    niRFmxInstrHandle instrumentHandle,
    char selectorString[],
@@ -4300,8 +4324,8 @@ int32 __stdcall RFmxSpecAn_IQFetchDataSplit(
    int64 samplesToRead,
    float64* t0,
    float64* dt,
-   float32 I[],
-   float32 Q[],
+   float32 dataI[],
+   float32 dataQ[],
    int32 arraySize,
    int32* actualArraySize
 );
@@ -5671,7 +5695,6 @@ int32 __stdcall RFmxSpecAn_MarkerFetchXY(
 int32 __stdcall RFmxSpecAn_MarkerFetchFunctionValue(
    niRFmxInstrHandle instrumentHandle,
    char selectorString[],
-   float64 timeout,
    float64* functionValue
 );
 
@@ -8925,6 +8948,42 @@ int32 __stdcall RFmxSpecAn_SpectrumSetFFTPadding(
    float64 attrVal
 );
 
+int32 __stdcall RFmxSpecAn_SpectrumGetFFTOverlapMode(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 *attrVal
+);
+
+int32 __stdcall RFmxSpecAn_SpectrumSetFFTOverlapMode(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 attrVal
+);
+
+int32 __stdcall RFmxSpecAn_SpectrumGetFFTOverlap(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   float64 *attrVal
+);
+
+int32 __stdcall RFmxSpecAn_SpectrumSetFFTOverlap(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   float64 attrVal
+);
+
+int32 __stdcall RFmxSpecAn_SpectrumGetFFTOverlapType(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 *attrVal
+);
+
+int32 __stdcall RFmxSpecAn_SpectrumSetFFTOverlapType(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 attrVal
+);
+
 int32 __stdcall RFmxSpecAn_SpectrumGetAmplitudeCorrectionType(
    niRFmxInstrHandle instrumentHandle,
    char selectorString[],
@@ -8932,6 +8991,30 @@ int32 __stdcall RFmxSpecAn_SpectrumGetAmplitudeCorrectionType(
 );
 
 int32 __stdcall RFmxSpecAn_SpectrumSetAmplitudeCorrectionType(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 attrVal
+);
+
+int32 __stdcall RFmxSpecAn_SpectrumGetMeasurementMethod(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 *attrVal
+);
+
+int32 __stdcall RFmxSpecAn_SpectrumSetMeasurementMethod(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 attrVal
+);
+
+int32 __stdcall RFmxSpecAn_SpectrumGetSequentialFFTSize(
+   niRFmxInstrHandle instrumentHandle,
+   char selectorString[],
+   int32 *attrVal
+);
+
+int32 __stdcall RFmxSpecAn_SpectrumSetSequentialFFTSize(
    niRFmxInstrHandle instrumentHandle,
    char selectorString[],
    int32 attrVal

--- a/source/codegen/metadata/nirfmxbluetooth/config.py
+++ b/source/codegen/metadata/nirfmxbluetooth/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 config = {
-    'api_version': '24.3.0',
+    'api_version': '24.5.0',
     'c_header': 'niRFmxBT.h',
     'c_function_prefix': 'RFmxBT_',
     'service_class_prefix': 'NiRFmxBluetooth',

--- a/source/codegen/metadata/nirfmxbluetooth/enums.py
+++ b/source/codegen/metadata/nirfmxbluetooth/enums.py
@@ -481,6 +481,10 @@ enums = {
             {
                 'name': 'LE_CS',
                 'value': 17
+            },
+            {
+                'name': 'LE_HDT',
+                'value': 18
             }
         ]
     },

--- a/source/codegen/metadata/nirfmxlte/__init__.py
+++ b/source/codegen/metadata/nirfmxlte/__init__.py
@@ -1,4 +1,5 @@
 from .functions import functions
+from .functions_addon import functions_override_metadata
 from .attributes import attributes
 from .enums import enums
 from .config import config
@@ -9,3 +10,5 @@ metadata = {
     "enums": enums,
     "config": config
 }
+
+metadata['functions'].update(functions_override_metadata)

--- a/source/codegen/metadata/nirfmxlte/attributes.py
+++ b/source/codegen/metadata/nirfmxlte/attributes.py
@@ -2043,5 +2043,51 @@ attributes = {
         'access': 'read-write',
         'name': 'CENTER_FREQUENCY_FOR_LIMITS',
         'type': 'float64'
+    },
+    3203072: {
+        'access': 'read-write',
+        'name': 'TXP_MEASUREMENT_ENABLED',
+        'type': 'int32'
+    },
+    3203074: {
+        'access': 'read-write',
+        'name': 'TXP_MEASUREMENT_OFFSET',
+        'type': 'float64'
+    },
+    3203075: {
+        'access': 'read-write',
+        'name': 'TXP_MEASUREMENT_INTERVAL',
+        'type': 'float64'
+    },
+    3203076: {
+        'access': 'read-write',
+        'enum': 'TxpAveragingEnabled',
+        'name': 'TXP_AVERAGING_ENABLED',
+        'type': 'int32'
+    },
+    3203077: {
+        'access': 'read-write',
+        'name': 'TXP_AVERAGING_COUNT',
+        'type': 'int32'
+    },
+    3203079: {
+        'access': 'read-write',
+        'name': 'TXP_ALL_TRACES_ENABLED',
+        'type': 'int32'
+    },
+    3203080: {
+        'access': 'read-write',
+        'name': 'TXP_NUMBER_OF_ANALYSIS_THREADS',
+        'type': 'int32'
+    },
+    3203082: {
+        'access': 'read-write',
+        'name': 'TXP_RESULTS_AVERAGE_POWER_MEAN',
+        'type': 'float64'
+    },
+    3203083: {
+        'access': 'read-write',
+        'name': 'TXP_RESULTS_PEAK_POWER_MAXIMUM',
+        'type': 'float64'
     }
 }

--- a/source/codegen/metadata/nirfmxlte/config.py
+++ b/source/codegen/metadata/nirfmxlte/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 config = {
-    'api_version': '24.3.0',
+    'api_version': '24.5.0',
     'c_header': 'niRFmxLTE.h',
     'c_function_prefix': 'RFmxLTE_',
     'service_class_prefix': 'NiRFmxLTE',

--- a/source/codegen/metadata/nirfmxlte/enums.py
+++ b/source/codegen/metadata/nirfmxlte/enums.py
@@ -992,6 +992,10 @@ enums = {
             {
                 'name': 'SLOTPOWER',
                 'value': 128
+            },
+            {
+                'name': 'TXP',
+                'value': 256
             }
         ]
     },
@@ -1913,6 +1917,18 @@ enums = {
             {
                 'name': 'SOFTWARE',
                 'value': 3
+            }
+        ]
+    },
+    'TxpAveragingEnabled': {
+        'values': [
+            {
+                'name': 'FALSE',
+                'value': 0
+            },
+            {
+                'name': 'TRUE',
+                'value': 1
             }
         ]
     },

--- a/source/codegen/metadata/nirfmxlte/functions.py
+++ b/source/codegen/metadata/nirfmxlte/functions.py
@@ -2511,8 +2511,6 @@ functions = {
             {
                 'direction': 'in',
                 'enum': 'PsschModulationType',
-                'grpc_field_number': '4',
-                'grpc_raw_field_number': '3',
                 'name': 'modulationType',
                 'type': 'int32'
             }
@@ -10283,6 +10281,141 @@ functions = {
                     'value_twist': 'actualArraySize'
                 },
                 'type': 'float64[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'arraySize',
+                'type': 'int32'
+            },
+            {
+                'direction': 'out',
+                'name': 'actualArraySize',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'TXPCfgAveraging': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'enum': 'TxpAveragingEnabled',
+                'name': 'averagingEnabled',
+                'type': 'int32'
+            },
+            {
+                'direction': 'in',
+                'name': 'averagingCount',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'TXPCfgMeasurementOffsetAndInterval': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'measurementOffset',
+                'type': 'float64'
+            },
+            {
+                'direction': 'in',
+                'name': 'measurementInterval',
+                'type': 'float64'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'TXPFetchMeasurement': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'timeout',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'averagePowerMean',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'peakPowerMaximum',
+                'type': 'float64'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'TXPFetchPowerTrace': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'timeout',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'x0',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'dx',
+                'type': 'float64'
+            },
+            {
+                'direction': 'out',
+                'name': 'power',
+                'size': {
+                    'mechanism': 'ivi-dance-with-a-twist',
+                    'value': 'arraySize',
+                    'value_twist': 'actualArraySize'
+                },
+                'type': 'float32[]'
             },
             {
                 'direction': 'in',

--- a/source/codegen/metadata/nirfmxspecan/__init__.py
+++ b/source/codegen/metadata/nirfmxspecan/__init__.py
@@ -1,4 +1,5 @@
 from .functions import functions
+from .functions_addon import functions_override_metadata
 from .attributes import attributes
 from .enums import enums
 from .config import config
@@ -9,3 +10,5 @@ metadata = {
     "enums": enums,
     "config": config
 }
+
+metadata['functions'].update(functions_override_metadata)

--- a/source/codegen/metadata/nirfmxspecan/attributes.py
+++ b/source/codegen/metadata/nirfmxspecan/attributes.py
@@ -1807,6 +1807,34 @@ attributes = {
         'name': 'SPECTRUM_ANALYSIS_INPUT',
         'type': 'int32'
     },
+    1085476: {
+        'access': 'read-write',
+        'enum': 'SpectrumFftOverlapMode',
+        'name': 'SPECTRUM_FFT_OVERLAP_MODE',
+        'type': 'int32'
+    },
+    1085477: {
+        'access': 'read-write',
+        'name': 'SPECTRUM_FFT_OVERLAP',
+        'type': 'float64'
+    },
+    1085478: {
+        'access': 'read-write',
+        'enum': 'SpectrumFftOverlapType',
+        'name': 'SPECTRUM_FFT_OVERLAP_TYPE',
+        'type': 'int32'
+    },
+    1085479: {
+        'access': 'read-write',
+        'enum': 'SpectrumMeasurementMethod',
+        'name': 'SPECTRUM_MEASUREMENT_METHOD',
+        'type': 'int32'
+    },
+    1085480: {
+        'access': 'read-write',
+        'name': 'SPECTRUM_SEQUENTIAL_FFT_SIZE',
+        'type': 'int32'
+    },
     1089536: {
         'access': 'read-write',
         'name': 'SPUR_MEASUREMENT_ENABLED',

--- a/source/codegen/metadata/nirfmxspecan/config.py
+++ b/source/codegen/metadata/nirfmxspecan/config.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 config = {
-    'api_version': '24.3.0',
+    'api_version': '24.5.0',
     'c_header': 'niRFmxSpecAn.h',
     'c_function_prefix': 'RFmxSpecAn_',
     'service_class_prefix': 'NiRFmxSpecAn',

--- a/source/codegen/metadata/nirfmxspecan/enums.py
+++ b/source/codegen/metadata/nirfmxspecan/enums.py
@@ -3257,6 +3257,34 @@ enums = {
             }
         ]
     },
+    'SpectrumFftOverlapMode': {
+        'values': [
+            {
+                'name': 'DISABLED',
+                'value': 0
+            },
+            {
+                'name': 'AUTOMATIC',
+                'value': 1
+            },
+            {
+                'name': 'USER_DEFINED',
+                'value': 2
+            }
+        ]
+    },
+    'SpectrumFftOverlapType': {
+        'values': [
+            {
+                'name': 'RMS',
+                'value': 0
+            },
+            {
+                'name': 'MAX',
+                'value': 3
+            }
+        ]
+    },
     'SpectrumFftWindow': {
         'values': [
             {
@@ -3290,6 +3318,18 @@ enums = {
             {
                 'name': 'KAISER_BESSEL',
                 'value': 7
+            }
+        ]
+    },
+    'SpectrumMeasurementMethod': {
+        'values': [
+            {
+                'name': 'NORMAL',
+                'value': 0
+            },
+            {
+                'name': 'SEQUENTIAL_FFT',
+                'value': 2
             }
         ]
     },

--- a/source/codegen/metadata/nirfmxspecan/functions.py
+++ b/source/codegen/metadata/nirfmxspecan/functions.py
@@ -6628,16 +6628,12 @@ functions = {
             {
                 'direction': 'in',
                 'enum': 'IdpdReferenceWaveformIdleDurationPresent',
-                'grpc_raw_field_number': '6',
-                'grpc_field_number': '8',
                 'name': 'idleDurationPresent',
                 'type': 'int32'
             },
             {
                 'direction': 'in',
                 'enum': 'IdpdSignalType',
-                'grpc_raw_field_number': '7',
-                'grpc_field_number': '9',
                 'name': 'signalType',
                 'type': 'int32'
             }
@@ -8069,11 +8065,6 @@ functions = {
                 'direction': 'in',
                 'name': 'selectorString',
                 'type': 'char[]'
-            },
-            {
-                'direction': 'in',
-                'name': 'timeout',
-                'type': 'float64'
             },
             {
                 'direction': 'out',
@@ -13010,6 +13001,28 @@ functions = {
                 'direction': 'in',
                 'name': 'stopFrequency',
                 'type': 'float64'
+            }
+        ],
+        'returns': 'int32'
+    },
+    'SpectrumCfgMeasurementMethod': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'enum': 'SpectrumMeasurementMethod',
+                'name': 'measurementMethod',
+                'type': 'int32'
             }
         ],
         'returns': 'int32'


### PR DESCRIPTION
### What does this Pull Request accomplish?
Updates niRFmxSpecAn in grpc-device-scrapigen to 24.5.0
Updates niRFmxLTE in grpc-device-scrapigen to 24.5.0
Updates niRFmxBT in grpc-device-scrapigen to 24.5.0
Updates the gRPC Scrapigen Device Code for SpecAn APIs which are created for the specific feature request from the customer: Addition of Sequential FFT to Spectrum measurement with configurable overlap type property.
Updates the gRPC Scrapigen Device Code for LTE TXP measurement APIs, attributes and enums.
Updates the gRPC Scrapigen Device Code for new BT enum value for an attribute.

Why should this Pull Request be merged?
Updated to match the upcoming release of niRFmxSpecAn 24.5.0
Updated to match the upcoming release of niRFmxLTE 24.5.0
Updated to match the upcoming release of niRFmxBT 24.5.0

What testing has been done?
Manually inspected generated files.
Copied files from grpc-device-scrapigen/out/rfmxspecan/export/ to grpc-device/source/codegen/metadata/nirfmxspecan/ and built grpc-device successfully.
Manually inspected nirfmxspecan.proto file.
Copied files from grpc-device-scrapigen/out/rfmxlte/export/ to grpc-device/source/codegen/metadata/nirfmxlte/ and built grpc-device successfully.
Manually inspected nirfmxlte.proto file.
Copied files from grpc-device-scrapigen\out\rfmxbluetooth\export to grpc-device/source/codegen/metadata/ nirfmxbluetooth / and built grpc-device successfully.
Manually inspected nirfmxbluetooth.proto file.

### Breaking Changes
RFmx SpecAn: removing `timeout` field from `MarkerFetchFunctionValueRequest` to match Driver API. Technically breaking for grpc-device but this method was busted in grpc-device in the previous release because the C API never released with the timeout parameter, and those changes weren’t carried over to grpc-device.