### PR TITLE
Add CfgExternalAttenuationTableLosses function to nirfmxinstr_restricted

### DIFF
--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted.proto
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted.proto
@@ -60,6 +60,7 @@ service NiRFmxInstrRestricted {
   rpc DefineSParameterExternalAttenuationTable(DefineSParameterExternalAttenuationTableRequest) returns (DefineSParameterExternalAttenuationTableResponse);
   rpc SaveExternalAttenuationTable(SaveExternalAttenuationTableRequest) returns (SaveExternalAttenuationTableResponse);
   rpc CfgExternalAttenuationTableFrequencies(CfgExternalAttenuationTableFrequenciesRequest) returns (CfgExternalAttenuationTableFrequenciesResponse);
+  rpc CfgExternalAttenuationTableLosses(CfgExternalAttenuationTableLossesRequest) returns (CfgExternalAttenuationTableLossesResponse);
   rpc ReleaseLicense(ReleaseLicenseRequest) returns (ReleaseLicenseResponse);
 }
 
@@ -522,6 +523,17 @@ message CfgExternalAttenuationTableFrequenciesRequest {
 }
 
 message CfgExternalAttenuationTableFrequenciesResponse {
+  int32 status = 1;
+}
+
+message CfgExternalAttenuationTableLossesRequest {
+  nidevice_grpc.Session instrument = 1;
+  string selector_string = 2;
+  string table_name = 3;
+  repeated double external_attenuation = 4;
+}
+
+message CfgExternalAttenuationTableLossesResponse {
   int32 status = 1;
 }
 

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.cpp
@@ -818,6 +818,26 @@ cfg_external_attenuation_table_frequencies(const StubPtr& stub, const nidevice_g
   return response;
 }
 
+CfgExternalAttenuationTableLossesResponse
+cfg_external_attenuation_table_losses(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::vector<double>& external_attenuation)
+{
+  ::grpc::ClientContext context;
+
+  auto request = CfgExternalAttenuationTableLossesRequest{};
+  request.mutable_instrument()->CopyFrom(instrument);
+  request.set_selector_string(selector_string);
+  request.set_table_name(table_name);
+  copy_array(external_attenuation, request.mutable_external_attenuation());
+
+  auto response = CfgExternalAttenuationTableLossesResponse{};
+
+  raise_if_error(
+      stub->CfgExternalAttenuationTableLosses(&context, request, &response),
+      context);
+
+  return response;
+}
+
 ReleaseLicenseResponse
 release_license(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string)
 {

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_client.h
@@ -65,6 +65,7 @@ CfgSParameterExternalAttenuationTableSParameterResponse cfg_s_parameter_external
 DefineSParameterExternalAttenuationTableResponse define_s_parameter_external_attenuation_table(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const pb::int32& number_of_frequency_points, const pb::int32& number_of_ports);
 SaveExternalAttenuationTableResponse save_external_attenuation_table(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::string& file_path, const std::string& description);
 CfgExternalAttenuationTableFrequenciesResponse cfg_external_attenuation_table_frequencies(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::vector<double>& frequency);
+CfgExternalAttenuationTableLossesResponse cfg_external_attenuation_table_losses(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string, const std::string& table_name, const std::vector<double>& external_attenuation);
 ReleaseLicenseResponse release_license(const StubPtr& stub, const nidevice_grpc::Session& instrument, const std::string& selector_string);
 
 } // namespace nirfmxinstr_restricted_grpc::experimental::client

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.cpp
@@ -73,6 +73,7 @@ NiRFmxInstrRestrictedLibrary::NiRFmxInstrRestrictedLibrary(std::shared_ptr<nidev
   function_pointers_.DefineSParameterExternalAttenuationTable = reinterpret_cast<DefineSParameterExternalAttenuationTablePtr>(shared_library_->get_function_pointer("RFmxInstr_DefineSParameterExternalAttenuationTable"));
   function_pointers_.SaveExternalAttenuationTable = reinterpret_cast<SaveExternalAttenuationTablePtr>(shared_library_->get_function_pointer("RFmxInstr_SaveExternalAttenuationTable"));
   function_pointers_.CfgExternalAttenuationTableFrequencies = reinterpret_cast<CfgExternalAttenuationTableFrequenciesPtr>(shared_library_->get_function_pointer("RFmxInstr_CfgExternalAttenuationTableFrequencies"));
+  function_pointers_.CfgExternalAttenuationTableLosses = reinterpret_cast<CfgExternalAttenuationTableLossesPtr>(shared_library_->get_function_pointer("RFmxInstr_CfgExternalAttenuationTableLosses"));
   function_pointers_.ReleaseLicense = reinterpret_cast<ReleaseLicensePtr>(shared_library_->get_function_pointer("RFmxInstr_ReleaseLicense"));
 }
 
@@ -453,6 +454,14 @@ int32 NiRFmxInstrRestrictedLibrary::CfgExternalAttenuationTableFrequencies(niRFm
     throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_CfgExternalAttenuationTableFrequencies.");
   }
   return function_pointers_.CfgExternalAttenuationTableFrequencies(instrumentHandle, selectorString, tableName, frequency, arraySize);
+}
+
+int32 NiRFmxInstrRestrictedLibrary::CfgExternalAttenuationTableLosses(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 externalAttenuation[], int32 arraySize)
+{
+  if (!function_pointers_.CfgExternalAttenuationTableLosses) {
+    throw nidevice_grpc::LibraryLoadException("Could not find RFmxInstr_CfgExternalAttenuationTableLosses.");
+  }
+  return function_pointers_.CfgExternalAttenuationTableLosses(instrumentHandle, selectorString, tableName, externalAttenuation, arraySize);
 }
 
 int32 NiRFmxInstrRestrictedLibrary::ReleaseLicense(niRFmxInstrHandle instrumentHandle, char selectorString[])

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library.h
@@ -67,6 +67,7 @@ class NiRFmxInstrRestrictedLibrary : public nirfmxinstr_restricted_grpc::NiRFmxI
   int32 DefineSParameterExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfFrequencyPoints, int32 numberOfPorts) override;
   int32 SaveExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char filePath[], char description[]) override;
   int32 CfgExternalAttenuationTableFrequencies(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 frequency[], int32 arraySize) override;
+  int32 CfgExternalAttenuationTableLosses(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 externalAttenuation[], int32 arraySize) override;
   int32 ReleaseLicense(niRFmxInstrHandle instrumentHandle, char selectorString[]) override;
 
  private:
@@ -116,6 +117,7 @@ class NiRFmxInstrRestrictedLibrary : public nirfmxinstr_restricted_grpc::NiRFmxI
   using DefineSParameterExternalAttenuationTablePtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfFrequencyPoints, int32 numberOfPorts);
   using SaveExternalAttenuationTablePtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char filePath[], char description[]);
   using CfgExternalAttenuationTableFrequenciesPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 frequency[], int32 arraySize);
+  using CfgExternalAttenuationTableLossesPtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 externalAttenuation[], int32 arraySize);
   using ReleaseLicensePtr = int32 (*)(niRFmxInstrHandle instrumentHandle, char selectorString[]);
 
   typedef struct FunctionPointers {
@@ -165,6 +167,7 @@ class NiRFmxInstrRestrictedLibrary : public nirfmxinstr_restricted_grpc::NiRFmxI
     DefineSParameterExternalAttenuationTablePtr DefineSParameterExternalAttenuationTable;
     SaveExternalAttenuationTablePtr SaveExternalAttenuationTable;
     CfgExternalAttenuationTableFrequenciesPtr CfgExternalAttenuationTableFrequencies;
+    CfgExternalAttenuationTableLossesPtr CfgExternalAttenuationTableLosses;
     ReleaseLicensePtr ReleaseLicense;
   } FunctionLoadStatus;
 

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library_interface.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_library_interface.h
@@ -61,6 +61,7 @@ class NiRFmxInstrRestrictedLibraryInterface {
   virtual int32 DefineSParameterExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfFrequencyPoints, int32 numberOfPorts) = 0;
   virtual int32 SaveExternalAttenuationTable(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char filePath[], char description[]) = 0;
   virtual int32 CfgExternalAttenuationTableFrequencies(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 frequency[], int32 arraySize) = 0;
+  virtual int32 CfgExternalAttenuationTableLosses(niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 externalAttenuation[], int32 arraySize) = 0;
   virtual int32 ReleaseLicense(niRFmxInstrHandle instrumentHandle, char selectorString[]) = 0;
 };
 

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_mock_library.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_mock_library.h
@@ -63,6 +63,7 @@ class NiRFmxInstrRestrictedMockLibrary : public nirfmxinstr_restricted_grpc::NiR
   MOCK_METHOD(int32, DefineSParameterExternalAttenuationTable, (niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], int32 numberOfFrequencyPoints, int32 numberOfPorts), (override));
   MOCK_METHOD(int32, SaveExternalAttenuationTable, (niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], char filePath[], char description[]), (override));
   MOCK_METHOD(int32, CfgExternalAttenuationTableFrequencies, (niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 frequency[], int32 arraySize), (override));
+  MOCK_METHOD(int32, CfgExternalAttenuationTableLosses, (niRFmxInstrHandle instrumentHandle, char selectorString[], char tableName[], float64 externalAttenuation[], int32 arraySize), (override));
   MOCK_METHOD(int32, ReleaseLicense, (niRFmxInstrHandle instrumentHandle, char selectorString[]), (override));
 };
 

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.cpp
@@ -1317,6 +1317,34 @@ namespace nirfmxinstr_restricted_grpc {
 
   //---------------------------------------------------------------------
   //---------------------------------------------------------------------
+  ::grpc::Status NiRFmxInstrRestrictedService::CfgExternalAttenuationTableLosses(::grpc::ServerContext* context, const CfgExternalAttenuationTableLossesRequest* request, CfgExternalAttenuationTableLossesResponse* response)
+  {
+    if (context->IsCancelled()) {
+      return ::grpc::Status::CANCELLED;
+    }
+    try {
+      auto instrument_grpc_session = request->instrument();
+      niRFmxInstrHandle instrument = session_repository_->access_session(instrument_grpc_session.name());
+      auto selector_string_mbcs = convert_from_grpc<std::string>(request->selector_string());
+      char* selector_string = (char*)selector_string_mbcs.c_str();
+      auto table_name_mbcs = convert_from_grpc<std::string>(request->table_name());
+      char* table_name = (char*)table_name_mbcs.c_str();
+      auto external_attenuation = const_cast<float64*>(request->external_attenuation().data());
+      int32 array_size = static_cast<int32>(request->external_attenuation().size());
+      auto status = library_->CfgExternalAttenuationTableLosses(instrument, selector_string, table_name, external_attenuation, array_size);
+      if (!status_ok(status)) {
+        return ConvertApiErrorStatusForNiRFmxInstrHandle(context, status, instrument);
+      }
+      response->set_status(status);
+      return ::grpc::Status::OK;
+    }
+    catch (nidevice_grpc::NonDriverException& ex) {
+      return ex.GetStatus();
+    }
+  }
+
+  //---------------------------------------------------------------------
+  //---------------------------------------------------------------------
   ::grpc::Status NiRFmxInstrRestrictedService::ReleaseLicense(::grpc::ServerContext* context, const ReleaseLicenseRequest* request, ReleaseLicenseResponse* response)
   {
     if (context->IsCancelled()) {

--- a/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.h
+++ b/generated/nirfmxinstr_restricted/nirfmxinstr_restricted_service.h
@@ -85,6 +85,7 @@ public:
   ::grpc::Status DefineSParameterExternalAttenuationTable(::grpc::ServerContext* context, const DefineSParameterExternalAttenuationTableRequest* request, DefineSParameterExternalAttenuationTableResponse* response) override;
   ::grpc::Status SaveExternalAttenuationTable(::grpc::ServerContext* context, const SaveExternalAttenuationTableRequest* request, SaveExternalAttenuationTableResponse* response) override;
   ::grpc::Status CfgExternalAttenuationTableFrequencies(::grpc::ServerContext* context, const CfgExternalAttenuationTableFrequenciesRequest* request, CfgExternalAttenuationTableFrequenciesResponse* response) override;
+  ::grpc::Status CfgExternalAttenuationTableLosses(::grpc::ServerContext* context, const CfgExternalAttenuationTableLossesRequest* request, CfgExternalAttenuationTableLossesResponse* response) override;
   ::grpc::Status ReleaseLicense(::grpc::ServerContext* context, const ReleaseLicenseRequest* request, ReleaseLicenseResponse* response) override;
 private:
   LibrarySharedPtr library_;

--- a/source/codegen/metadata/nirfmxinstr_restricted/functions.py
+++ b/source/codegen/metadata/nirfmxinstr_restricted/functions.py
@@ -1458,6 +1458,41 @@ functions = {
         ],
         'returns': 'int32'
     },
+    'CfgExternalAttenuationTableLosses': {
+        'parameters': [
+            {
+                'direction': 'in',
+                'grpc_name': 'instrument',
+                'name': 'instrumentHandle',
+                'type': 'niRFmxInstrHandle'
+            },
+            {
+                'direction': 'in',
+                'name': 'selectorString',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'tableName',
+                'type': 'char[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'externalAttenuation',
+                'size': {
+                    'mechanism': 'len',
+                    'value': 'arraySize'
+                },
+                'type': 'float64[]'
+            },
+            {
+                'direction': 'in',
+                'name': 'arraySize',
+                'type': 'int32'
+            }
+        ],
+        'returns': 'int32'
+    },
     'ReleaseLicense': {
         'parameters': [
             {


### PR DESCRIPTION
### What does this Pull Request accomplish?

Add private CfgExternalAttenuationTableLosses function to nirfmxinstr_restricted.

### Why should this Pull Request be merged?

Similar to https://github.com/ni/grpc-device/pull/1056. Add the last attenuation table function in nirfmxinstr_restricted

### What testing has been done?

No testing
