### PR TITLE
Stop running NiXnetLINDriverApiTests.ConvertFramesToFromSignalsFromEx…

### DIFF
--- a/.github/workflows/run_ubuntu_system_tests.yml
+++ b/.github/workflows/run_ubuntu_system_tests.yml
@@ -26,5 +26,5 @@ jobs:
         tar -xvzf ni-grpc-device-tests-linux-glibc2_31-x64.tar.gz
 
     - name: Run System Tests
-      run: ./SystemTestsRunner --gtest_filter=-NiRFSA*:NiRFSG*:NiDCPower*CalSelfCalibrate*
+      run: ./SystemTestsRunner --gtest_filter=-NiRFSA*:NiRFSG*:NiDCPower*CalSelfCalibrate*:NiXnetLINDriverApiTests.ConvertFramesToFromSignalsFromExample_CompareFrames_ValuesMatch
       timeout-minutes: 27


### PR DESCRIPTION
Stop running NiXnetLINDriverApiTests.ConvertFramesToFromSignalsFromExample_CompareFrames_ValuesMatch on Ubuntu

### What does this Pull Request accomplish?
Stop running NiXnetLINDriverApiTests.ConvertFramesToFromSignalsFromExample_CompareFrames_ValuesMatch on Ubuntu. Testing locally and internal NI ATS is not able to reproduce the issue seen when running the github actions. More debugging is needed on why this is happening there. So this does not because noise for PR reviews will will keep watching the test runs on the internal ATS while debugging more into why this is failing in the system used for running the system tests.

### Why should this Pull Request be merged?

Stop the Ubuntu tests from reporting the same test failure that appears to only be failing with the configuration used in the actions pipeline.

### What testing has been done?

Local testing and internal ATS testing. Discussed in internal BUG.
