### PR TITLE
Update all upload/download-artifact uses to v4

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -124,7 +124,7 @@ jobs:
         ThirdPartyNotices.txt
 
     - name: Upload Linux Server Binaries Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       with:
         name: ni-grpc-device-server-linux-glibc${{ matrix.config.glibc_version }}-x64
@@ -148,36 +148,28 @@ jobs:
         ThirdPartyNotices.txt
 
     - name: Upload Linux Test Binaries Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ runner.os == 'Linux' }}
       with:
         name: ni-grpc-device-tests-linux-glibc${{ matrix.config.glibc_version }}-x64
         path: ni-grpc-device-tests-linux-glibc${{ matrix.config.glibc_version }}-x64.tar.gz
         retention-days: 5
 
-    - name: Upload Windows Server Information Artifact
-      uses: actions/upload-artifact@v2
+    - name: Upload Windows Server Artifact
+      uses: actions/upload-artifact@v4
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}
       with:
         name: ni-grpc-device-server-windows-x64
         path: |
           LICENSE
           ThirdPartyNotices.txt
-        retention-days: 5
-
-    - name: Upload Windows Server Binaries Artifact
-      uses: actions/upload-artifact@v2
-      if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}
-      with:
-        name: ni-grpc-device-server-windows-x64
-        path: |
           build/RelWithDebInfo/ni_grpc_device_server.exe
           build/RelWithDebInfo/server_config.json
           build/RelWithDebInfo/server_capabilities.json
         retention-days: 5
 
     - name: Upload Windows Test Binaries Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ runner.os == 'Windows' }}
       with:
         name: ni-grpc-device-tests-windows-x64
@@ -198,7 +190,7 @@ jobs:
         retention-days: 5
 
     - name: Upload Windows Server Debug Symbols Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}
       with:
         name: ni-grpc-device-server-windows-x64-debug-symbols

--- a/.github/workflows/build_nilrt.yml
+++ b/.github/workflows/build_nilrt.yml
@@ -140,7 +140,7 @@ jobs:
         ThirdPartyNotices.txt
 
     - name: Upload Server Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases') }}
       with:
         name: ni-grpc-device-server-ni-linux-rt-x64
@@ -164,7 +164,7 @@ jobs:
         ThirdPartyNotices.txt
 
     - name: Upload Tests Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases') }}
       with:
         name: ni-grpc-device-tests-ni-linux-rt-x64

--- a/.github/workflows/create_client_artifacts.yml
+++ b/.github/workflows/create_client_artifacts.yml
@@ -47,7 +47,7 @@ jobs:
         tar -cvzf ni-grpc-device-client.tar.gz -C ${{ runner.temp }}/staging/ .
 
     - name: Upload Linux Client Files Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Linux') }}
       with:
         name: ni-grpc-device-client-Linux
@@ -55,7 +55,7 @@ jobs:
         retention-days: 5
 
     - name: Upload Windows Client Files Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}
       with:
         name: ni-grpc-device-client
@@ -64,7 +64,7 @@ jobs:
         retention-days: 5
 
     - name: Upload Windows Restricted Client Files Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/releases')) && (runner.os == 'Windows') }}
       with:
         name: ni-grpc-device-client-restricted

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ni-grpc-device-client
         path: downloads/ni-grpc-device-client
@@ -26,22 +26,22 @@ jobs:
         files: downloads/ni-grpc-device-client
         dest: downloads/artifacts/ni-grpc-device-client.zip
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ni-grpc-device-client-Linux
         path: downloads/artifacts
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ni-grpc-device-server-linux-glibc2_31-x64
         path: downloads/artifacts
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ni-grpc-device-server-ni-linux-rt-x64
         path: downloads/artifacts
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ni-grpc-device-server-windows-x64
         path: downloads/ni-grpc-device-server-windows-x64
@@ -51,7 +51,7 @@ jobs:
         files: downloads/ni-grpc-device-server-windows-x64
         dest: downloads/artifacts/ni-grpc-device-server-windows-x64.zip
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: ni-grpc-device-server-windows-x64-debug-symbols
         path: downloads/artifacts

--- a/.github/workflows/run_ubuntu_system_tests.yml
+++ b/.github/workflows/run_ubuntu_system_tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Download Tests Artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: ni-grpc-device-tests-linux-glibc2_31-x64
 

--- a/.github/workflows/run_win_system_tests.yml
+++ b/.github/workflows/run_win_system_tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Download Tests Artifact
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v4
       with:
         name: ni-grpc-device-tests-windows-x64
 


### PR DESCRIPTION
### What does this Pull Request accomplish?
fixes #1066

Use the latest version of download-artifacts away from deprecated versions.

### Why should this Pull Request be merged?

The older versions will be deprecated and latest version has possible speed improvements.

### What testing has been done?
- All downloads appear to be to a unique directory. If not this a new argument would be needed.
- All uploads updated to be unique since with v4 no merging is allowed.
- PR build and testing
